### PR TITLE
Fix Fatal error on Class 'Illuminate\Filesystem' load

### DIFF
--- a/src/Illuminate/Workbench/Starter.php
+++ b/src/Illuminate/Workbench/Starter.php
@@ -13,7 +13,7 @@ class Starter {
 	{
 		$finder = $finder ?: new \Symfony\Component\Finder\Finder;
 
-		$files = $files ?: new \Illuminate\Filesystem;
+		$files = $files ?: new \Illuminate\Filesystem\Filesystem;
 
 		// We will use the finder to locate all "autoload.php" files in the workbench
 		// directory, then we will include them each so that they are able to load


### PR DESCRIPTION
Fix Fatal error on Class 'Illuminate\Filesystem' not found in /vendor/laravel/framework/src/Illuminate/Workbench/Starter.php on line 16
