### PR TITLE
Typo and Iterator namespace reference

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -203,7 +203,7 @@ class Filesystem {
 
 		if ($glob === false) return array();
 
-		// To get the appropriate files, we'll simply glob the direectory and filter
+		// To get the appropriate files, we'll simply glob the directory and filter
 		// out any "files" that are not truly files so we do not end up with any
 		// directories in our list, but only true files within the directory.
 		return array_filter($glob, function($file)
@@ -288,7 +288,7 @@ class Filesystem {
 	{
 		if ( ! $this->isDirectory($directory)) return;
 
-		$items = new \FilesystemIterator($directory);
+		$items = new FilesystemIterator($directory);
 
 		foreach ($items as $item)
 		{


### PR DESCRIPTION
Cleaning up a minor typo and inconsistent reference to iterator.
