### PR TITLE
Exposed :key (in addition to :message)

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -122,7 +122,7 @@ class MessageBag implements Countable, MessageProviderInterface {
 	 * @param  string  $format
 	 * @return array
 	 */
-	protected function transform($messages, $format, $messages_key = null)
+	protected function transform($messages, $format, $messagesKey = null)
 	{
 		$messages = (array) $messages;
 
@@ -132,7 +132,7 @@ class MessageBag implements Countable, MessageProviderInterface {
 		// the messages to be easily formatted to each developer's desires.
 		foreach ($messages as $key => &$message)
 		{
-			$message = str_replace(array(':message',':key'), array($message,$messages_key), $format);
+			$message = str_replace(array(':message', ':key'), array($message, $messagesKey), $format);
 		}
 
 		return $messages;

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -89,7 +89,7 @@ class MessageBag implements Countable, MessageProviderInterface {
 		// methods is to return back an array of messages in the first place.
 		if (array_key_exists($key, $this->messages))
 		{
-			return $this->transform($this->messages[$key], $format);
+			return $this->transform($this->messages[$key], $format, $key);
 		}
 
 		return array();
@@ -107,9 +107,9 @@ class MessageBag implements Countable, MessageProviderInterface {
 
 		$all = array();
 
-		foreach ($this->messages as $messages)
+		foreach ($this->messages as $key => $messages)
 		{
-			$all = array_merge($all, $this->transform($messages, $format));
+			$all = array_merge($all, $this->transform($messages, $format, $key));
 		}
 
 		return $all;
@@ -122,16 +122,17 @@ class MessageBag implements Countable, MessageProviderInterface {
 	 * @param  string  $format
 	 * @return array
 	 */
-	protected function transform($messages, $format)
+	protected function transform($messages, $format, $messages_key = null)
 	{
 		$messages = (array) $messages;
 
 		// We will simply spin through the given messages and transform each one
-		// replacing the :message place holder with the real message allowing
+		// replacing the :message place holder with the real message 
+		// and  replacing the :key place holder with the message array key 
 		// the messages to be easily formatted to each developer's desires.
 		foreach ($messages as $key => &$message)
 		{
-			$message = str_replace(':message', $message, $format);
+			$message = str_replace(array(':message',':key'), array($message,$messages_key), $format);
 		}
 
 		return $messages;


### PR DESCRIPTION
I have found use case where I could do with the key of the error array exposed (proposing :key).

If I echo out my errors, on some occasions I output the errors in a single block then treat them using JS (usually moving them to an element on the page by the ID stored in a data attribute).

If I want to print <li data-key=":key">:message</li>, I cannot currently access the :key part (where :key is the ID of the associated field).

Being able to do this (as adjusted) allows a user to identify exactly what field an individual message was associated with e.g. when using ->all(), and is a simple exposure of data already held in the object.

Example:

Format: 

```
<li data-key=":key">:message</li>

<ul class="errors">
    <li data-key="item_firstname">You didn't enter your first name</li>
</ul>
```
