### PR TITLE
Fixing Blade not trimming the result

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -43,7 +43,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function compile($path)
 	{
-		$contents = $this->compileString($this->files->get($path));
+		$contents = trim($this->compileString($this->files->get($path)));
 
 		if ( ! is_null($this->cachePath))
 		{


### PR DESCRIPTION
When a view extends a layout that yields a content, normaly you give some spaces between the @extends('masterview') and the @section('example'), those spaces are being printed in the source code of the html.
The solution was trimming the content received from the compileString method.

Hope it helps.

Best wishes,
João Lopes
