### PR TITLE
Add a DB::execute($query) to execute unprepared queries

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -300,6 +300,24 @@ class Connection implements ConnectionInterface {
 	}
 
 	/**
+	 * Execute an unprepared SQL statement and return the boolean result.
+	 *
+	 * @param  string  $query
+	 * @return bool
+	 */
+	public function execute($query)
+	{
+		return $this->run($query, array(), function($me, $query, $bindings)
+		{
+			// Since this is an unprepared statement, $bindings was kept in closure list
+			// of parameters just for compatibility with run()'s callback call.
+			if ($me->pretending()) return true;
+
+			return $me->getPdo()->exec($query);
+		});
+	}
+
+	/**
 	 * Run an SQL statement and get the number of rows affected.
 	 *
 	 * @param  string  $query

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -203,6 +203,15 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testExecuteMethod()
+	{
+		$connection = $this->getMockConnection(array('execute'));
+		$connection->expects($this->once())->method('execute')->with($this->equalTo('foo'))->will($this->returnValue(true));
+		$results = $connection->execute('foo');
+		$this->assertTrue($results);
+	}
+
+
 	protected function getMockConnection($methods = array(), $pdo = null)
 	{
 		$pdo = $pdo ?: new DatabaseConnectionTestMockPDO;


### PR DESCRIPTION
In some DMBS DDL statements (like CREATE TRIGGER in MySQL) needs to be run unprepared, as shown in issue https://github.com/laravel/framework/issues/53.
