### PR TITLE
[Proposal] Implement an 'after' modifier to the mysql schema

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -17,7 +17,7 @@ class MySqlGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $modifiers = array('Unsigned', 'Nullable', 'Default', 'Increment');
+	protected $modifiers = array('Unsigned', 'Nullable', 'Default', 'Increment', 'After');
 
 	/**
 	 * Compile the query to determine if a table exists.
@@ -410,5 +410,20 @@ class MySqlGrammar extends Grammar {
 			return ' auto_increment primary key';
 		}
 	}
+	
+	/**
+	 * Get the SQL for an after column modifier.
+	 *
+	 * @param  Illuminate\Database\Schema\Blueprint  $blueprint
+	 * @param  Illuminate\Support\Fluent  $column
+	 * @return string|null
+	 */
+	protected function modifyAfter(Blueprint $blueprint, Fluent $column)
+	{
+		if ( ! is_null($column->after))
+		{
+			return ' after '.$this->wrap($column->after);
+		}
+	}	
 
 }


### PR DESCRIPTION
```
Schema::table('users', function($table)
{
    $table->integer('age')->after('name');
});
```

It would be great to be able to specify that you want a column to be added to a table in a specific position. This functionality is sparsely supported across all the database types. I'm pretty sure postgres does not allow you to do this at all.

Should this functionality be added to the core or because it cannot be applied to all database types it should therefore be left out?

I've added the code as an example but if you guys want to go ahead I can create some tests and look into adding similar functionality to some of the other database types (the ones that can handle this functionality of course).
