### PR TITLE
[Proposal] Allow raw response of type array to display

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -53,6 +53,13 @@ class Response extends \Symfony\Component\HttpFoundation\Response {
 		{
 			$content = $content->render();
 		}
+		
+		// If this content is an array then we will render as human-readable and 
+		// apply pre-formatting. 
+		elseif (is_array($content))
+		{
+			$content = '<pre>'.print_r($content, true).'</pre>';
+		}
 
 		return parent::setContent($content);
 	}


### PR DESCRIPTION
Taking a look through the documentation here:
http://four.laravel.com/docs/eloquent#converting-to-arrays-or-json

With examples like:

```
return User::find(1)->toArray();
```

I hit the error

```
UnexpectedValueException: The Response content must be a string or object implementing __toString(), "array" given.
```

And that made me think that if you can return json why not be able to return an array and see the contents. So I modified the code in response to allow me to simply return an array and then it is displayed on the screen.

```
Array
(
    [id] => 1
    [name] => John Smith
)
```

Just playing around really but thought I might share this idea. It probably will break the entire system somehow no doubt.
