### PR TITLE
[Proposal] Make dependency injection work with default values

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -318,13 +318,20 @@ class Container implements ArrayAccess {
 			$dependency = $parameter->getClass();
 
 			// If the class is null, it means the dependency is a string or some other
-			// primitive type which we can not resolve since it is not a class and
-			// we'll just bomb out with an error since we have no-where to go.
+			// primitive type, which we can not resolve since it is not a class, if there
+			// is a default value we will use it otherwise we'll just bomb out with an 
+			// error since we have no-where to go.
 			if (is_null($dependency))
 			{
-				$message = "Unresolvable dependency resolving [$parameter].";
+				if ( ! $parameter->isDefaultValueAvailable())
+				{
+					$message = "Unresolvable dependency resolving [$parameter].";
 
-				throw new BindingResolutionException($message);
+					throw new BindingResolutionException($message);
+				}
+
+				$dependencies[] = $parameter->getDefaultValue();
+				continue;
 			}
 
 			$dependencies[] = $this->make($dependency->name);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -71,12 +71,12 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	public function testNestedDependencyResolutionWithDefaultValue()
 	{
 		$container = new Container;
-		$container->bind('IContainerContractSub', 'ContainerImplementationStub');
+		$container->bind('IContainerContractStub', 'ContainerImplementationStub');
 		$class = $container->make('ContainerNestedDependentWithDefaultValueStub');
 		$this->assertTrue($class->inner instanceof ContainerDependentStub);
 		$this->assertTrue($class->inner->impl instanceof ContainerImplementationStub);
 		$this->assertNull($class->innerArray);
-		$this->assertEqual($class->innerString, 'string');
+		$this->assertEquals($class->innerString, 'string');
 	}
 
 	public function testContainerIsPassedToResolvers()

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -226,6 +226,6 @@ class ContainerNestedDependentWithDefaultValueStub {
 	{
 		$this->inner = $inner;
 		$this->innerArray = $innerArray;
-		$this->innerString = 'string';
+		$this->innerString = $innerString;
 	}
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -68,6 +68,16 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($class->inner->impl instanceof ContainerImplementationStub);
 	}
 
+	public function testNestedDependencyResolutionWithDefaultValue()
+	{
+		$container = new Container;
+		$container->bind('IContainerContractSub', 'ContainerImplementationStub');
+		$class = $container->make('ContainerNestedDependentWithDefaultValueStub');
+		$this->assertTrue($class->inner instanceof ContainerDependentStub);
+		$this->assertTrue($class->inner->impl instanceof ContainerImplementationStub);
+		$this->assertNull($class->innerArray);
+		$this->assertEqual($class->innerString, 'string');
+	}
 
 	public function testContainerIsPassedToResolvers()
 	{
@@ -205,5 +215,17 @@ class ContainerNestedDependentStub {
 	public function __construct(ContainerDependentStub $inner)
 	{
 		$this->inner = $inner;
+	}
+}
+
+class ContainerNestedDependentWithDefaultValueStub {
+	public $inner;
+	public $innerArray;
+	public $innerString;
+	public function __construct(ContainerDependentStub $inner, array $innerArray = null, $innerString = 'string')
+	{
+		$this->inner = $inner;
+		$this->innerArray = $innerArray;
+		$this->innerString = 'string';
 	}
 }


### PR DESCRIPTION
I thought this would work by default, was using a component via dependency injection that has `$configuration = null` in the constructor and it threw the binding resolution exception. So I had a look and it was easy to make default values work, is there any reason to not do this?
