### PR TITLE
Fixed an issue with Redis data retrieval

### DIFF
--- a/src/Illuminate/Redis/Database.php
+++ b/src/Illuminate/Redis/Database.php
@@ -164,7 +164,7 @@ class Database {
 		// If the response size is listed as a negative one it means that there is
 		// no data for the given keys, and we should return "null" according to
 		// the Redis protocol documentation for every client Redis libraries.
-		if ($response == '$-1')
+		if (trim($response) == '$-1')
 		{
 			return null;
 		}


### PR DESCRIPTION
There was a bug when calling methods like $redis->get() that caused the webserver to hang. In short, the check to see if a "null" response from redis was being returned was incorrect, due to redis also adding space/newline characters. This resolves that issue.
