### PR TITLE
Fixed Blade Spaces Between Sections

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -43,7 +43,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function compile($path)
 	{
-		$contents = trim($this->compileString($this->files->get($path)));
+		$contents = $this->compileString($this->files->get($path));
 
 		if ( ! is_null($this->cachePath))
 		{

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -76,7 +76,7 @@ class View implements ArrayAccess, Renderable {
 
 		$env->callComposer($this);
 
-		$contents = $this->getContents();
+		$contents = trim($this->getContents());
 
 		// Once we've finished rendering the view, we'll decrement the render count
 		// then if we are at the bottom of the stack we'll flush out sections as


### PR DESCRIPTION
My first commit about this error was not solving every problem.
Initialy the content was showing spaces if there were spaces between @extends and @section
So i trimmed the content on the BladeCompiler.
Turns out that when you print spaces between @sections, they are still being printed on the HTML top.
Hopefully this is a final solution, since i'm trimming the content on the View.
Also removed the trim on the BladeCompiler since it's being trimmed on the final render.
