### PR TITLE
Update src/Illuminate/Session/Store.php

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -159,7 +159,10 @@ abstract class Store implements TokenProvider, ArrayAccess {
 	{
 		if ( ! is_array($session)) return true;
 
-		return (time() - $session['last_activity']) > ($this->lifetime * 60);
+		return ( $this->lifetime === 0 
+		         ? false 
+		         : (time() - $session['last_activity']) > ($this->lifetime * 60) 
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixing the issue #107 

If session's lifetime parameter equals to 0 session should expire 
after browser closes. But it doesn't, it expires immediately. If 
lifetime is something like 30 mins, session class works as expected.

This patch fixes the problem and improves our math knowledge.
