### PR TITLE
Default paginator indicators shouldn't have an 'active' class

### DIFF
--- a/src/Illuminate/Pagination/BootstrapPresenter.php
+++ b/src/Illuminate/Pagination/BootstrapPresenter.php
@@ -44,7 +44,7 @@ class BootstrapPresenter {
 	public function render()
 	{
 		// The hard-coded thirteen represents the minimum number of pages we need to
-		// ba able to create a sliding page window. If we have less than that, we
+		// be able to create a sliding page window. If we have less than that, we
 		// will just render a simple range of page links insteadof the sliding.
 		if ($this->lastPage < 13)
 		{

--- a/src/Illuminate/Pagination/BootstrapPresenter.php
+++ b/src/Illuminate/Pagination/BootstrapPresenter.php
@@ -70,12 +70,12 @@ class BootstrapPresenter {
 
 		for ($page = $start; $page <= $end; $page++)
 		{
-			// If the current page is equal to the page we're iterating on, we will create a
-			// disabled link for that page. Otherwise, we can create a typical active one
-			// for the link. These views use the "Twitter Bootstrap" styles by default.
+			// If the current page is equal to the page we're iterating on, we will give it
+			// an active link for that page. Otherwise, we'll create a typical link. These 
+			// views use the "Twitter Bootstrap" styles by default.
 			if ($this->currentPage == $page)
 			{
-				$pages[] = '<li class="disabled"><a href="#">'.$page.'</a></li>';
+				$pages[] = '<li class="active"><a href="#">'.$page.'</a></li>';
 			}
 			else
 			{
@@ -172,7 +172,7 @@ class BootstrapPresenter {
 	{
 		// If the current page is less than or equal to one, it means we can't go any
 		// further back in the pages, so we will render a disabled previous button
-		// when that is the case. Otherwise, we will give it an active "status".
+		// when that is the case.
 		if ($this->currentPage <= 1)
 		{
 			return '<li class="disabled"><a href="#">'.$text.'</a></li>';
@@ -181,7 +181,7 @@ class BootstrapPresenter {
 		{
 			$url = $this->paginator->getUrl($this->currentPage - 1);
 
-			return '<li class="active"><a href="'.$url.'">'.$text.'</a></li>';
+			return '<li><a href="'.$url.'">'.$text.'</a></li>';
 		}
 	}
 
@@ -204,7 +204,7 @@ class BootstrapPresenter {
 		{
 			$url = $this->paginator->getUrl($this->currentPage + 1);
 
-			return '<li class="active"><a href="'.$url.'">'.$text.'</a></li>';
+			return '<li><a href="'.$url.'">'.$text.'</a></li>';
 		}
 	}
 
@@ -228,7 +228,7 @@ class BootstrapPresenter {
 	{
 		$url = $this->paginator->getUrl($page);
 
-		return '<li class="active"><a href="'.$url.'">'.$page.'</a></li>';
+		return '<li><a href="'.$url.'">'.$page.'</a></li>';
 	}
 
 	/**

--- a/tests/Pagination/PaginationBootstrapPresenterTest.php
+++ b/tests/Pagination/PaginationBootstrapPresenterTest.php
@@ -34,7 +34,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter->setCurrentPage(1);
 		$content = $presenter->getPageRange(1, 2);
 
-		$this->assertEquals('<li class="disabled"><a href="#">1</a></li><li><a href="http://foo.com?page=2">2</a></li>', $content);
+		$this->assertEquals('<li class="active"><a href="#">1</a></li><li><a href="http://foo.com?page=2">2</a></li>', $content);
 	}
 
 
@@ -115,7 +115,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter = $this->getPresenter();
 		$output = $presenter->getStart();
 
-		$this->assertEquals('<li class="active"><a href="#">1</a></li><li><a href="http://foo.com?page=2">2</a></li><li><a href="#">...</a></li>', $output);
+		$this->assertEquals('<li class="active"><a href="#">1</a></li><li><a href="http://foo.com?page=2">2</a></li><li class="disabled"><a href="#">...</a></li>', $output);
 	}
 
 

--- a/tests/Pagination/PaginationBootstrapPresenterTest.php
+++ b/tests/Pagination/PaginationBootstrapPresenterTest.php
@@ -34,7 +34,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter->setCurrentPage(1);
 		$content = $presenter->getPageRange(1, 2);
 
-		$this->assertEquals('<li class="disabled"><a href="#">1</a></li><li class="active"><a href="http://foo.com?page=2">2</a></li>', $content);
+		$this->assertEquals('<li class="disabled"><a href="#">1</a></li><li><a href="http://foo.com?page=2">2</a></li>', $content);
 	}
 
 
@@ -90,7 +90,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter->setCurrentPage(2);
 		$output = $presenter->getPrevious();
 
-		$this->assertEquals('<li class="active"><a href="http://foo.com?page=1">&laquo;</a></li>', $output);
+		$this->assertEquals('<li><a href="http://foo.com?page=1">&laquo;</a></li>', $output);
 	}
 
 
@@ -106,7 +106,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter->setCurrentPage(1);
 		$output = $presenter->getNext();
 
-		$this->assertEquals('<li class="active"><a href="http://foo.com?page=2">&raquo;</a></li>', $output);
+		$this->assertEquals('<li><a href="http://foo.com?page=2">&raquo;</a></li>', $output);
 	}
 
 
@@ -115,7 +115,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter = $this->getPresenter();
 		$output = $presenter->getStart();
 
-		$this->assertEquals('<li class="disabled"><a href="#">1</a></li><li class="active"><a href="http://foo.com?page=2">2</a></li><li class="disabled"><a href="#">...</a></li>', $output);
+		$this->assertEquals('<li class="active"><a href="#">1</a></li><li><a href="http://foo.com?page=2">2</a></li><li><a href="#">...</a></li>', $output);
 	}
 
 
@@ -124,7 +124,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter = $this->getPresenter();
 		$output = $presenter->getFinish();
 
-		$this->assertEquals('<li class="disabled"><a href="#">...</a></li><li class="disabled"><a href="#">1</a></li><li class="active"><a href="http://foo.com?page=2">2</a></li>', $output);
+		$this->assertEquals('<li class="disabled"><a href="#">...</a></li><li class="active"><a href="#">1</a></li><li><a href="http://foo.com?page=2">2</a></li>', $output);
 	}
 
 


### PR DESCRIPTION
As said in the commit and title, default paginator indicators shouldn't have an 'active' class. The 'active' class was meant to indicate the current active page, not a clickable link to a page.

Also because of this, the 'active' class should never be used on 'previous' or 'next' links. 'Previous' or 'next' links are only meant to move towards the previous or next page in the sequence. They shouldn't indicate an 'active' page stage because they aren't page indicators.

See the [Twitter Bootstrap](http://twitter.github.com/bootstrap/components.html#pagination) docs under `Pagination > Options > Disabled and active states` for more info.

Fixes #100.
