### PR TITLE
Changed snake_case() to better handle abbreviations.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -379,11 +379,12 @@ function secure_path($path, array $parameters = array())
  */
 function snake_case($value, $delimiter = '_')
 {
-	return trim(preg_replace_callback('/[A-Z]/', function($match) use ($delimiter)
-	{
-		return $delimiter.strtolower($match[0]);
+	$value = preg_replace('/([A-Z\d]+)([A-Z][a-z])/', '\1'.$delimiter.'\2', $value);
+	$value = preg_replace('/([a-z\d])([A-Z])/', '\1'.$delimiter.'\2', $value);
+	$value = str_replace(array(' ', '_'), $delimiter, $value);
+	$value = strtolower($value);
 
-	}, $value), $delimiter);
+	return $value;
 }
 
 /**

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -107,6 +107,8 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	public function testSnakeCase()
 	{
 		$this->assertEquals('foo_bar', snake_case('fooBar'));
+		$this->assertEquals('foo_bar', snake_case('FOOBar'));
+		$this->assertEquals('foo@bar@baz', snake_case('FOOBarBaz', '@'));
 	}
 
 


### PR DESCRIPTION
Updated snake_case() function to better handle cases like `FOOBar`, where it would turn it into `f_o_o_bar` instead of `foo_bar`. Also updated the test case.
