### PR TITLE
Load ProvidersRepository with IoC in Foundation/start.php

### DIFF
--- a/src/Illuminate/Foundation/start.php
+++ b/src/Illuminate/Foundation/start.php
@@ -179,9 +179,11 @@ Request::enableHttpMethodParameterOverride();
 
 $manifestPath = $config['manifest'];
 
-$services = new ProviderRepository(new Filesystem, $manifestPath);
+$app->singleton('ProviderRepository', function() use ($manifestPath) {
+    return new ProviderRepository(new Filesystem, $manifestPath);
+});
 
-$services->load($app, $config['providers']);
+$app->make('ProviderRepository')->load($app, $config['providers']);
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Currently, if a ServiceProvider in a package has other ServiceProvider dependencies, the app has to register them in their app/config/app.php:providers. By exposing the ProvidersRepository via IoC, packages can register the ServceProviders they need in the register() method.
