### PR TITLE
[Routing] Symfony changed the setHostname method...again.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -494,7 +494,7 @@ class Router {
 
 		if (isset($action['domain']))
 		{
-			$route->setHostname($action['domain']);
+			$route->setHost($action['domain']);
 		}
 
 		// Finally we will go through and set all of the default variables to null


### PR DESCRIPTION
Symfony changed the Hostname routing stuff....again.  The method name is now `setHost` per this commit. https://github.com/symfony/Routing/commit/7196489720091b5bb70ef1866b7ff9719a98f761

This PR fixes the issue.
