### PR TITLE
Using PDO::CASE_NATURAL in default database connector

### DIFF
--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -10,7 +10,7 @@ class Connector {
 	 * @var array
 	 */
 	protected $options = array(
-			PDO::ATTR_CASE => PDO::CASE_LOWER,
+			PDO::ATTR_CASE => PDO::CASE_NATURAL,
 			PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
 			PDO::ATTR_ORACLE_NULLS => PDO::NULL_NATURAL,
 			PDO::ATTR_STRINGIFY_FETCHES => false,


### PR DESCRIPTION
Though PSR1 doesn't force StudlyCaps, camelCase or under_score for property names using PDO::CASE_LOWER disables users from using StudlyCaps or camelCase for column names (properties in models). 

This should also be changed on: 
src/Illuminate/Database/Connectors/PostgresConnector.php 
src/Illuminate/Database/Connectors/SqlServerConnector.php

but since I don't use Postgre or MsSQL I decided to leave it to people with more expirience.
