### PR TITLE
Adding support for ArrayableInterface and JsonableInterface in Message Bag

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Contracts\ArrayableInterface;
 use Illuminate\Support\Contracts\JsonableInterface;
 use Illuminate\Support\Contracts\MessageProviderInterface;
 
-class MessageBag implements ArrayableInterface, JsonableInterface, Countable, MessageProviderInterface {
+class MessageBag implements ArrayableInterface, Countable, JsonableInterface, MessageProviderInterface {
 
 	/**
 	 * All of the registered messages.

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -1,9 +1,11 @@
 <?php namespace Illuminate\Support;
 
 use Countable;
+use Illuminate\Support\Contracts\ArrayableInterface;
+use Illuminate\Support\Contracts\JsonableInterface;
 use Illuminate\Support\Contracts\MessageProviderInterface;
 
-class MessageBag implements Countable, MessageProviderInterface {
+class MessageBag implements ArrayableInterface, JsonableInterface, Countable, MessageProviderInterface {
 
 	/**
 	 * All of the registered messages.
@@ -16,7 +18,7 @@ class MessageBag implements Countable, MessageProviderInterface {
 	 * Default format for message output.
 	 *
 	 * @var string
-	 */	
+	 */
 	protected $format = '<span class="help-inline">:message</span>';
 
 	/**
@@ -196,6 +198,37 @@ class MessageBag implements Countable, MessageProviderInterface {
 	public function count()
 	{
 		return count($this->messages);
+	}
+
+	/**
+	 * Get the instance as an array.
+	 *
+	 * @return array
+	 */
+	public function toArray()
+	{
+		return $this->getMessages();
+	}
+
+	/**
+	 * Convert the object to its JSON representation.
+	 *
+	 * @param  int  $options
+	 * @return string
+	 */
+	public function toJson($options = 0)
+	{
+		return json_encode($this->toArray(), $options);
+	}
+
+	/**
+	 * Convert the message bag to its string representation.
+	 *
+	 * @return string
+	 */
+	public function __toString()
+	{
+		return $this->toJson();
 	}
 
 }

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\MessageBag;
+use Mockery as m;
 
 class SupportMessageBagTest extends PHPUnit_Framework_TestCase {
 
@@ -81,5 +82,36 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('bar'), $container->get('foo', ':message'));
 		$this->assertEquals(array('bar', 'baz'), $container->all(':message'));
 	}
+
+
+	public function testMessageBagReturnsCorrectArray()
+	{
+		$container = new MessageBag;
+		$container->setFormat(':message');
+		$container->add('foo', 'bar');
+		$container->add('boom', 'baz');
+
+		$this->assertEquals(array('foo' => array('bar'), 'boom' => array('baz')), $container->toArray());
+	}
+
+
+	public function testMessageBagReturnsExpectedJson()
+	{
+		$container = new MessageBag;
+		$container->setFormat(':message');
+		$container->add('foo', 'bar');
+		$container->add('boom', 'baz');
+
+		$this->assertEquals('{"foo":["bar"],"boom":["baz"]}', $container->toJson());
+	}
+
+
+	public function testCastingAsStringReturnsBagAsJson()
+	{
+		$container = m::mock('Illuminate\Support\MessageBag[toJson]');
+		$container->shouldReceive('toJson')->once()->andReturn('foo');
+		$this->assertEquals('foo', (string) $container);
+	}
+
 
 }


### PR DESCRIPTION
Hi Taylor,

I've added support (and tests obviously) for the MessageBag to implement both `ArrayableInterface` and `JsonableInterface` which includes `__toString()`.

This is useful, for example it can allow you to return a `MessageBag` instance and have it returned as an array. I've been using it for validation within APIs and it proves to be quite useful. It obviously does not take away any functionality and I can see a number of use-cases for it.

Thanks,

 - Ben

Signed-off-by: Ben Corlett bencorlett@me.com
