### PR TITLE
Encodes numeric strings as numbers.

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -43,7 +43,7 @@ class Response extends \Symfony\Component\HttpFoundation\Response {
 		{
 			$this->headers->set('Content-Type', 'application/json');
 
-			$content = $content->toJson();
+			$content = $content->toJson(JSON_NUMERIC_CHECK);
 		}
 
 		// If this content implements the "RenderableInterface", then we will call the


### PR DESCRIPTION
When Json string is given, numeric values are set as string.
I think it  will be better to have the value set as numbers, which enables compatibility with javascript frameworks like Angularjs using Json objects.
