### PR TITLE
Router - Moved groupStack merge to createRoute() fixes #116

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -405,6 +405,18 @@ class Router {
 		{
 			$action = $this->parseAction($action);
 		}
+		
+		$groupCount = count($this->groupStack);
+
+		// If there are attributes being grouped across routes we will merge those
+		// attributes into the action array so that they will get shared across
+		// the routes. The route can override the attribute by specifying it.
+		if ($groupCount > 0)
+		{
+			$index = $groupCount - 1;
+
+			$action = array_merge($this->groupStack[$index], $action);
+		}
 
 		$name = $this->getName($method, $pattern, $action);
 
@@ -464,18 +476,6 @@ class Router {
 	 */
 	protected function setAttributes(Route $route, $action, $optional)
 	{
-		$groupCount = count($this->groupStack);
-
-		// If there are attributes being grouped across routes we will merge those
-		// attributes into the action array so that they will get shared across
-		// the routes. The route can override the attribute by specifying it.
-		if ($groupCount > 0)
-		{
-			$index = $groupCount - 1;
-
-			$action = array_merge($this->groupStack[$index], $action);
-		}
-
 		// First we will set the requirement for the HTTP schemes. Some routes may
 		// only respond to requests using the HTTPS scheme, while others might
 		// respond to all, regardless of the scheme, so we'll set that here.

--- a/tests/Routing/RoutingTest.php
+++ b/tests/Routing/RoutingTest.php
@@ -421,6 +421,25 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 		$request = Request::create('http://bar.com', 'GET');
 		$this->assertEquals('sub', $router->dispatch($request)->getContent());
 	}
+	
+	public function testRoutesArentOverriddenBySubDomainWithGroups()
+	{
+		$router = new Router(new Illuminate\Container\Container);
+		$router->group(array('domain' => 'foo.com'), function() use ($router)
+		{
+			$router->get('/', function() { return 'main'; });
+		});
+		$router->group(array('domain' => 'bar.com'), function() use ($router)
+		{
+			$router->get('/', function() { return 'sub'; });
+		});
+		
+		$request = Request::create('http://foo.com', 'GET');
+		$this->assertEquals('main', $router->dispatch($request)->getContent());
+
+		$request = Request::create('http://bar.com', 'GET');
+		$this->assertEquals('sub', $router->dispatch($request)->getContent());
+	}
 
 }
 


### PR DESCRIPTION
Fixes #116 , which is still the case when groups are used.

Right now the domain is never set in the route's name if it's coming from a group.
I just moved the groupStack merge to the createRoute before the route name is set, which does not break tests.
