### PR TITLE
[Bug] `MessageBag::any` is incorrect for one message

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -225,7 +225,7 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 	 */
 	public function any()
 	{
-		return $this->count() > 1;
+		return $this->count() > 0;
 	}
 
 	/**


### PR DESCRIPTION
The recently added `any` method would return false when only one message was set.
