### PR TITLE
Unnecessary multiple calls to `DatabaseManager::getConfig`

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -84,7 +84,7 @@ class DatabaseManager implements ConnectionResolverInterface {
 			return call_user_func($this->extensions[$name], $config);
 		}
 
-		return $this->factory->make($this->getConfig($name));
+		return $this->factory->make($config);
 	}
 
 	/**


### PR DESCRIPTION
Just forgotten, I think.
