### PR TITLE
Add date and date format validation rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -817,6 +817,33 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
+	 * Validate that an attribute is a valid date.
+	 *
+	 * @param  string  $attribute
+	 * @param  mixed   $value
+	 * @return bool
+	 */
+	protected function validateDate($attribute, $value)
+	{
+		return strtotime($value) !== false;
+	}
+
+	/**
+	 * Validate that an attribute matches a date format.
+	 *
+	 * @param  string  $attribute
+	 * @param  mixed   $value
+	 * @param  array   $parameters
+	 * @return bool
+	 */
+	protected function validateDateFormat($attribute, $value, $parameters)
+	{
+		$parsed = date_parse_from_format($parameters[0], $value);
+
+		return $parsed['error_count'] === 0;
+	}
+
+	/**
 	 * Validate the date is before a given date.
 	 *
 	 * @param  string  $attribute
@@ -1175,6 +1202,20 @@ class Validator implements MessageProviderInterface {
 	protected function replaceDifferent($message, $attribute, $rule, $parameters)
 	{
 		return str_replace(':other', $parameters[0], $message);
+	}
+
+	/**
+	 * Replace all place-holders for the date_format rule.
+	 *
+	 * @param  string  $message
+	 * @param  string  $attribute
+	 * @param  string  $rule
+	 * @param  array   $parameters
+	 * @return string
+	 */
+	protected function replaceDateFormat($message, $attribute, $rule, $parameters)
+	{
+		return str_replace(':format', $parameters[0], $message);
 	}
 
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -582,6 +582,22 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($v->passes());	
 	}
 
+	public function testValidateDateAndFormat()
+	{
+		date_default_timezone_set('UTC');
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('x' => '2000-01-01'), array('x' => 'date'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('x' => 'Not a date'), array('x' => 'date'));
+		$this->assertTrue($v->fails());
+
+		$v = new Validator($trans, array('x' => '2000-01-01'), array('x' => 'date_format:Y-m-d'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('x' => '01/01/2001'), array('x' => 'date_format:Y-m-d'));
+		$this->assertTrue($v->fails());
+	}
 
 	public function testBeforeAndAfter()
 	{


### PR DESCRIPTION
Adds `date` and `date_format:format` validation rules.  The date format string is tested against the string formatting options of http://php.net/manual/en/datetime.createfromformat.php

The following can be used as validation messages:

``` php
    "date"            => "The :attribute is not a valid date.",
    "date_format"     => "The :attribute does not match the format :format.",
```

Tests also included.

I'm happy to update the docs if this is merged.
