### PR TITLE
Fix issue with Redirect::secure

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -55,7 +55,7 @@ class Redirector {
 	 */
 	public function to($path, $status = 302, $headers = array(), $secure = false)
 	{
-		$path = $this->generator->to($path, $secure);
+		$path = $this->generator->to($path, array(), $secure);
 
 		return $this->createRedirect($path, $status, $headers);
 	}

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -55,15 +55,20 @@ class UrlGenerator {
 		if ($this->isValidUrl($path)) return $path;
 
 		$scheme = $this->getScheme($secure);
-
-		// Once we have the scheme we will compile the "tail" by collapsing the values
-		// into a single string delimited by slashes. This just makes it convenient
-		// for passing the array of parameters to this URL as a list of segments.
-		$tail = trim(implode('/', (array) $parameters), '/');
-
+		
 		$root = $this->getRootUrl($scheme);
-
-		return $root.rtrim('/'.$path.'/'.$tail, '/');
+		
+		if($parameters != 1)
+		{
+			// Once we have the scheme we will compile the "tail" by collapsing the values
+			// into a single string delimited by slashes. This just makes it convenient
+			// for passing the array of parameters to this URL as a list of segments.
+			$tail = trim(implode('/', (array) $parameters), '/');
+		
+			return $root.rtrim('/'.$path.'/'.$tail, '/');
+		}
+		else
+			return $root.rtrim('/'.$path, '/');
 	}
 
 	/**


### PR DESCRIPTION
Redirect::secure currently appends "/1" to the end of the path because when the secure method passes an empty array to method to, to sees it as "1". Also, Redirect::to is calling the Urlgenerator to incorrectly.
