### PR TITLE
default environment as second parameter of detectEnvironment method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -119,7 +119,7 @@ class Application extends Container implements HttpKernelInterface {
 	 * @param  array|string  $environments
 	 * @return string
 	 */
-	public function detectEnvironment($environments)
+	public function detectEnvironment($environments, $default = 'production')
 	{
 		$base = $this['request']->getHost();
 
@@ -133,7 +133,9 @@ class Application extends Container implements HttpKernelInterface {
 			return $this->detectConsoleEnvironment($base, $environments, $arguments);
 		}
 
-		return $this->detectWebEnvironment($base, $environments);
+		$environment = $this->detectWebEnvironment($base, $environments);
+
+        return $this['env'] = $environment ? $environment : $default;
 	}
 
 	/**
@@ -166,8 +168,6 @@ class Application extends Container implements HttpKernelInterface {
 				}
 			}
 		}
-
-		return $this['env'] = 'production';
 	}
 
 	/**


### PR DESCRIPTION
Hi,

I have noticed that Laravel no longer detects environment based on url and also stopped using LARAVEL_ENV. Now, environment detection is based only on host name. In that situation, can we have a second parameter in detectEnvironment method, which defines default environment?

public function detectEnvironment($environments, $default = 'production')
{
    (...)
    return $default;
}

In my opinion, and many people will agree, many won't, it is risky to treat the default configuration files as production, because especially with tools like migrations, one runs the risk of corrupting this environment. I would prefer to have local as my default. This solution gives people choice.

Thanks,
Marcin
