### PR TITLE
Suggestion for alternative way of naming routes.   

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -411,4 +411,16 @@ class Route extends BaseRoute {
 		return $this;
 	}
 
+    /**
+     * Change the name for this route.
+     *
+     * @param string $name New Name
+     * @return Illuminate\Routing\Route
+     */
+    public function named($name)
+    {
+        $this->router->rename($this, $name);
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1283,7 +1283,8 @@ class Router {
         }
 
         // Do a linear scan through the routes array
-        foreach($this->routes->getIterator() as $n => $r) {
+        $iter->rewind();
+        foreach($iter as $n => $r) {
             if ($r === $route) {
                 $this->routes->remove($n);
                 $this->routes->add($name, $r);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1272,6 +1272,17 @@ class Router {
      */
     public function rename($route, $name)
     {
+        $iter = $this->routes->getIterator();
+
+        // Try the most recently added route first
+        $iter->seek($iter->count() - 1);
+        if ($iter->current() === $route) {
+            $this->routes->remove($iter->key());
+            $this->routes->add($name, $route);
+            return;
+        }
+
+        // Do a linear scan through the routes array
         foreach($this->routes->getIterator() as $n => $r) {
             if ($r === $route) {
                 $this->routes->remove($n);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1263,4 +1263,21 @@ class Router {
 		$this->container = $container;
 	}
 
+    /**
+     * Change the name of a route
+     *
+     * @param $route
+     * @param $name
+     * @return void
+     */
+    public function rename($route, $name)
+    {
+        foreach($this->routes->getIterator() as $n => $r) {
+            if ($r === $route) {
+                $this->routes->remove($n);
+                $this->routes->add($name, $r);
+                return;
+            }
+        }
+    }
 }

--- a/tests/Routing/RoutingTest.php
+++ b/tests/Routing/RoutingTest.php
@@ -398,6 +398,16 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($router->currentRouteNamed('bar.route'));
 	}
 
+    public function testCurrentRouteNameCanBeChecked2()
+    {
+        $router = new Router(new Illuminate\Container\Container);
+        $route = $router->get('foo', function() {})->named('foo.route');
+        $route2 = $router->get('bar', function() {})->named('bar.route');
+        $router->setCurrentRoute($route);
+
+        $this->assertTrue($router->currentRouteNamed('foo.route'));
+        $this->assertFalse($router->currentRouteNamed('bar.route'));
+    }
 
 	public function testCurrentRouteActionCanBeChecked()
 	{

--- a/tests/Routing/RoutingTest.php
+++ b/tests/Routing/RoutingTest.php
@@ -473,6 +473,21 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('sub', $router->dispatch($request)->getContent());
 	}
 
+    public function testWeirdRouteNaming()
+    {
+        $router = new Router(new Illuminate\Container\Container);
+        $route = $router->get('foo', function() {});
+        $route2 = $router->get('bar', function() {})->named('bar.route');
+
+        // Try changing a route's name after another route has been created
+        $route->named('foo.route');
+
+        $router->setCurrentRoute($route);
+
+        $this->assertTrue($router->currentRouteNamed('foo.route'));
+        $this->assertFalse($router->currentRouteNamed('bar.route'));
+    }
+
 }
 
 class RoutingModelBindingStub {


### PR DESCRIPTION
Add a "named" method to Routes, so you can say:

  Route::get('/foo', 'xxx@yyy')
      ->named('my_route');

I think that's a bit more natural that wrapping the controller in an array with an 'as' => 'my_route' entry
