### PR TITLE
isEmpty method in Paginator

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -215,6 +215,16 @@ class Paginator implements ArrayAccess, Countable, IteratorAggregate {
 	}
 
 	/**
+	 * Determine if the list of items is empty or not.
+	 *
+	 * @return bool
+	 */
+	public function isEmpty()
+	{
+		return empty($this->items);
+	}
+
+	/**
 	 * Get the number of items for the current page.
 	 *
 	 * @return int


### PR DESCRIPTION
Added an isEmpty method to the paginator, as noted in this issue report:
https://github.com/laravel/framework/issues/178

(This is my first pull request ever, so bear with me that everything is okay.
edit: Ok ok, I found out that i should have used hub to make the pull request so it was attached to above issue. Sorry for that.)
