### PR TITLE
[Bug] Inconsistency in config:publish

### DIFF
--- a/src/Illuminate/Foundation/ConfigPublisher.php
+++ b/src/Illuminate/Foundation/ConfigPublisher.php
@@ -47,7 +47,7 @@ class ConfigPublisher {
 	 */
 	public function publish($package, $source)
 	{
-		$destination = $this->publishPath."/packages/{$package}";		
+		$destination = $this->publishPath."/packages/{$package}";
 
 		$this->makeDestination($destination);
 

--- a/src/Illuminate/Foundation/ConfigPublisher.php
+++ b/src/Illuminate/Foundation/ConfigPublisher.php
@@ -85,7 +85,7 @@ class ConfigPublisher {
 	 */
 	protected function getSource($package, $name, $packagePath)
 	{
-		$source = $packagePath."/{$package}/src/config";
+		$source = $packagePath."/{$package}/config";
 
 		if ( ! $this->files->isDirectory($source))
 		{


### PR DESCRIPTION
The default place for the packages `config` folder is, according to the Workbench and the Service provider `vendor/package/config` :

``` php
$path = $path ?: $this->guessPackagePath();

$config = $path.'/config';
```

However Artisan when publishing config looks for `vendor/package/src/config`. This fixes that.
