### PR TITLE
[Proposal] Add back Eloquent->touch method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -507,6 +507,15 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 	}
 
 	/**
+	 * Updates the current model's timestamps
+	 */
+	public function touch()
+	{
+		$this->updateTimestamps();
+		$this->save();
+	}
+
+	/**
 	 * Set the keys for a save update query.
 	 *
 	 * @param  Illuminate\Database\Eloquent\Builder


### PR DESCRIPTION
This adds back the old `Eloquent->touch()` method from Laravel 3 that would update a model's timestamps and save it.
