### PR TITLE
[Proposal] Add implicit extensions to validator (fixes #192)

### DIFF
--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -27,6 +27,13 @@ class Factory {
 	protected $extensions = array();
 
 	/**
+	 * All of the custom implicit validator extensions.
+	 *
+	 * @var array
+	 */
+	protected $implicitExtensions = array();
+
+	/**
 	 * The Validator resolver instance.
 	 *
 	 * @var Closure
@@ -63,6 +70,8 @@ class Factory {
 
 		$validator->addExtensions($this->extensions);
 
+		$validator->addImplicitExtensions($this->implicitExtensions);
+
 		return $validator;
 	}
 
@@ -96,6 +105,18 @@ class Factory {
 	public function extend($rule, Closure $extension)
 	{
 		$this->extensions[$rule] = $extension;
+	}
+
+	/**
+	 * Register a custom implicit validator extension.
+	 *
+	 * @param  string  $rule
+	 * @param  Closure $extension
+	 * @return void
+	 */
+	public function extendImplicit($rule, Closure $extension)
+	{
+		$this->implicitExtensions[$rule] = $extension;
 	}
 
 	/**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1319,6 +1319,22 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
+	 * Register an array of custom implicit validator extensions.
+	 *
+	 * @param  array  $extensions
+	 * @return void
+	 */
+	public function addImplicitExtensions(array $extensions)
+	{
+		$this->addExtensions($extensions);
+
+		foreach ($extensions as $rule => $extension)
+		{
+			$this->implicitRules[] = camel_case($rule);
+		}
+	}
+
+	/**
 	 * Register a custom validator extension.
 	 *
 	 * @param  string   $rule
@@ -1328,6 +1344,20 @@ class Validator implements MessageProviderInterface {
 	public function addExtension($rule, Closure $extension)
 	{
 		$this->extensions[$rule] = $extension;
+	}
+
+	/**
+	 * Register a custom implicit validator extension.
+	 *
+	 * @param  string   $rule
+	 * @param  Closure  $extension
+	 * @return void
+	 */
+	public function addImplicitExtension($rule, Closure $extension)
+	{
+		$this->addExtension($rule, $extension);
+
+		$this->implicitRules[] = camel_case($rule);
 	}
 
 	/**

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -22,9 +22,10 @@ class ValidationFactoryTest extends PHPUnit_Framework_TestCase {
 
 		$presence = m::mock('Illuminate\Validation\PresenceVerifierInterface');
 		$factory->extend('foo', function() {});
+		$factory->extendImplicit('implicit', function() {});
 		$factory->setPresenceVerifier($presence);
 		$validator = $factory->make(array(), array());
-		$this->assertEquals(array('foo' => function() {}), $validator->getExtensions());
+		$this->assertEquals(array('foo' => function() {}, 'implicit' => function() {}), $validator->getExtensions());
 		$this->assertEquals($presence, $validator->getPresenceVerifier());
 	}
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -623,6 +623,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testCustomImplicitValidators()
+	{
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array(), array('implicit_rule' => 'foo'));
+		$v->addImplicitExtension('implicit_rule', function() { return true; });
+		$this->assertTrue($v->passes());
+	}
+
+
 	protected function getTranslator()
 	{
 		return m::mock('Symfony\Component\Translation\TranslatorInterface');


### PR DESCRIPTION
This adds implicit extensions to the validator which will run even if the attribute to be checked doesn't exist in the data.

Tests included.
