### PR TITLE
Added isRoute() method to the Request class.

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Http;
 
 use Illuminate\Session\Store as SessionStore;
+use Illuminate\Support\Facades\Route as Route;
 
 class Request extends \Symfony\Component\HttpFoundation\Request {
 
@@ -96,6 +97,17 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 		}
 		
 		return false;
+	}
+
+	/**
+	 * Determine if the current request URI is a named route.
+	 *
+	 * @param  string  $name
+	 * @return bool
+	 */
+	public function isRoute($name)
+	{
+		return Route::currentRouteNamed($name);
 	}
 
 	/**


### PR DESCRIPTION
This method is useful for a couple of reasons:

1) When using named routes it's much simpler and cleaner than using Request::is(_pattern_)
2) If the underlying named route changes this code will still work, as opposed to Request::is() (which will require a rewrite of the pattern)

This method is particularly useful inside of views. For instance, it can be used it the following way:

<a class="{{ Request::isRoute('home') ? 'active' : '' }}" href= ...

Regards,
Chris

Signed-off-by: crhayes chris@moderncognition.com
