### PR TITLE
phpunit.xml change

### DIFF
--- a/src/Illuminate/Workbench/stubs/phpunit.xml
+++ b/src/Illuminate/Workbench/stubs/phpunit.xml
@@ -12,7 +12,7 @@
 >
     <testsuites>
         <testsuite name="Package Test Suite">
-            <directory>./tests/</directory>
+            <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
If I happened to be doing something wrong please let me know but the phpunit.xml as it was previous wouldn't actually run any tests for me on either Windows 7 or Ubuntu 12.04. It would read the config fine but phpunit wouldn't run the tests. As soon as I added the .php suffix all is well.
