### PR TITLE
Fix minor inconsistencies in Illuminate\Http\Request class

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -410,4 +410,14 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 		$this->sessionStore = $session;
 	}
 
+	/**
+	* Determine if the current request has a valid session store.
+	*
+	* @return bool
+	*/
+	public function hasSessionStore()
+	{
+		return isset( $this->sessionStore );
+	}
+
 }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -39,7 +39,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	public function url()
 	{
 		return rtrim(preg_replace('/\?.*/', '', $this->getUri()), '/');
-	}	
+	}
 
 	/**
 	 * Get the full URL for the request.
@@ -94,13 +94,13 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 				return true;
 			}
 		}
-		
+
 		return false;
 	}
 
 	/**
 	 * Determine if the request is the result of an AJAX call.
-	 * 
+	 *
 	 * @return bool
 	 */
 	public function ajax()
@@ -283,7 +283,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	{
 		$flash = ( ! is_null($filter)) ? $this->$filter($keys) : $this->input();
 
-		$this->sessionStore->flashInput($flash);
+		$this->getSessionStore()->flashInput($flash);
 	}
 
 	/**
@@ -315,7 +315,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	 */
 	public function flush()
 	{
-		$this->sessionStore->flashInput(array());
+		$this->getSessionStore()->flashInput(array());
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -417,7 +417,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	*/
 	public function hasSessionStore()
 	{
-		return isset( $this->sessionStore );
+		return isset($this->sessionStore);
 	}
 
 }


### PR DESCRIPTION
The `Illuminate\Http\Request` class has a method named `getSessionStore()` which is used to fetch the session store associated with the request. This method raises a `RuntimeException` if the underlying session store has not been initialized. However, `flash()` and `flush()` methods on the same class try to access the $sessionStore field directly. These methods should take advantage of `getSessionStore()` which guards against null object.

I have modified the said methods to utilize `getSessionStore()`:

``` php
public function flash($filter = null, $keys = array())
{
    $flash = ( ! is_null($filter)) ? $this->$filter($keys) : $this->input();

    $this->getSessionStore()->flashInput($flash);
}

public function flush()
{
    $this->getSessionStore()->flashInput(array());
}
```

Additionally, I have added the `hasSessionStore()` method to check if the request object has a valid session store (cf. issues [#229](https://github.com/laravel/framework/issues/229) and [#227](https://github.com/laravel/framework/issues/229) as well as [ardent#3](https://github.com/laravelbook/ardent/issues/3))

``` php
/**
 * Determine if the current request has a valid session store.
 *
 * @return bool
 */
public function hasSessionStore()
{
    return isset( $this->sessionStore );
}
```
