### PR TITLE
BugFix : Default cookie value

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -66,7 +66,7 @@ class CookieJar {
 	{
 		$value = $this->request->cookies->get($key);
 
-		if ( ! is_null($key))
+		if ( ! is_null($value))
 		{
 			return $this->decrypt($value);
 		}

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -40,7 +40,8 @@ class CookieTest extends PHPUnit_Framework_TestCase {
 		$value = $cookie->getEncrypter()->encrypt('bar');
 		$cookie->getRequest()->cookies->set('foo', $value);
 		$this->assertEquals('bar', $cookie->get('foo'));
-
+        $this->assertEquals('zee', $cookie->get('someOtherFoo', 'zee'));
+        
 		$cookie = $this->getCreator();
 		$value = $cookie->getEncrypter()->encrypt('bar');
 		$value .= '111';


### PR DESCRIPTION
FIxed a typo where the default value for a cookie with a certain key would never be returned (because we were checking the key and not the value). 
