### PR TITLE
[Bug] CreatePasswordRemindersTable migration fixed

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/reminders.php
+++ b/src/Illuminate/Auth/Console/stubs/reminders.php
@@ -11,7 +11,7 @@ class CreatePasswordRemindersTable extends Migration {
 	 */
 	public function up()
 	{
-		Schema::table('password_reminders', function($t)
+		Schema::create('password_reminders', function($t)
 		{
 			$t->string('email');
 			$t->string('token');


### PR DESCRIPTION
After use `auth:reminders` Artisan command, a migration is generated called `CreatePasswordRemindersTable`. But in `up` method, `Schema::table` was used instead of `Schema::create`
