### PR TITLE
Fix insert not using $primaryKey on Postgres

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -495,7 +495,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 		{
 			if ($this->incrementing)
 			{
-				$this->$keyName = $query->insertGetId($this->attributes);
+				$this->$keyName = $query->insertGetId($this->attributes, $keyName);
 			}
 			else
 			{


### PR DESCRIPTION
Just pass the name of the key as a second parameter to insertGetId(). The function already knows how  to use it, the key was just not passed to it so it was defaulting to "id".

For example:
    INSERT INTO questions ... RETURNING id

Becomes:
    INSERT INTO questions ... RETURNING question_id
