### PR TITLE
Allowing dot-notation arrays to be used in session data.

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -177,7 +177,7 @@ abstract class Store implements TokenProvider, ArrayAccess {
 
 	/**
 	 * Get the full array of session data, including flash data.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function all()
@@ -210,28 +210,26 @@ abstract class Store implements TokenProvider, ArrayAccess {
 		// First we will check for the value in the general session data and if it
 		// is not present in that array we'll check the session flash datas to
 		// get the data from there. If netiher is there we give the default.
-		if (isset($data[$key]))
+		return array_get($data, $key, function() use ($data, $key, $default)
 		{
-			return $data[$key];
-		}
+			// Session flash data is only persisted for the next request into the app
+			// which makes it convenient for temporary status messages or various
+			// other strings. We'll check all of this flash data for the items.
+			if (isset($data[':new:'][$key]))
+			{
+				return $data[':new:'][$key];
+			}
 
-		// Session flash data is only persisted for the next request into the app
-		// which makes it convenient for temporary status messages or various
-		// other strings. We'll check all of this flash data for the items.
-		elseif (isset($data[':new:'][$key]))
-		{
-			return $data[':new:'][$key];
-		}
+			// The "old" flash data are the data flashed during the previous request
+			// while the "new" data is the data flashed during the course of this
+			// current request. Usually developers will be retrieving the olds.
+			elseif (isset($data[':old:'][$key]))
+			{
+				return $data[':old:'][$key];
+			}
 
-		// The "old" flash data are the data flashed during the previous request
-		// while the "new" data is the data flashed during the course of this
-		// current request. Usually developers will be retrieving the olds.
-		elseif (isset($data[':old:'][$key]))
-		{
-			return $data[':old:'][$key];
-		}
-
-		return $default instanceof Closure ? $default() : $default;
+			return $default instanceof Closure ? $default() : $default;
+		});
 	}
 
 	/**
@@ -252,14 +250,8 @@ abstract class Store implements TokenProvider, ArrayAccess {
 		{
 			return $input;
 		}
-		elseif (array_key_exists($key, $input))
-		{
-			return $input[$key];
-		}
-		else
-		{
-			return $default instanceof Closure ? $default() : $default;
-		}
+
+		return array_get($input, $key, $default);
 	}
 
 	/**
@@ -281,7 +273,7 @@ abstract class Store implements TokenProvider, ArrayAccess {
 	 */
 	public function put($key, $value)
 	{
-		$this->session['data'][$key] = $value;
+		array_set($this->session['data'], $key, $value);
 	}
 
 	/**
@@ -343,7 +335,7 @@ abstract class Store implements TokenProvider, ArrayAccess {
 	 */
 	public function forget($key)
 	{
-		unset($this->session['data'][$key]);
+		array_forget($this->session['data'], $key);
 	}
 
 	/**

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -215,17 +215,17 @@ abstract class Store implements TokenProvider, ArrayAccess {
 			// Session flash data is only persisted for the next request into the app
 			// which makes it convenient for temporary status messages or various
 			// other strings. We'll check all of this flash data for the items.
-			if (isset($data[':new:'][$key]))
+			if ($value = array_get($data, ":new:.$key"))
 			{
-				return $data[':new:'][$key];
+				return $value;
 			}
 
 			// The "old" flash data are the data flashed during the previous request
 			// while the "new" data is the data flashed during the course of this
 			// current request. Usually developers will be retrieving the olds.
-			elseif (isset($data[':old:'][$key]))
+			if ($value = array_get($data, ":old:.$key"))
 			{
-				return $data[':old:'][$key];
+				return $value;
 			}
 
 			return $default instanceof Closure ? $default() : $default;

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -181,7 +181,7 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 		$store->setExists(false);
 		$response = new Response;
 		$cookie = $this->getCookieJarMock();
-		$store->finish($response, $cookie, 0);	
+		$store->finish($response, $cookie, 0);
 	}
 
 
@@ -233,6 +233,26 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('foo' => 'bar'), $store->getOldInput());
 		$this->assertEquals('bar', $store->getOldInput('adslkasd', 'bar'));
 		$this->assertEquals('bar', $store->getOldInput('adlkasdf', function() { return 'bar'; }));
+	}
+
+
+	public function testComplexArrayPayloadManipulation()
+	{
+		$store = $this->storeMock('isInvalid');
+		$cookies = m::mock('Illuminate\Cookie\CookieJar');
+		$cookies->shouldReceive('get')->once()->with('illuminate_session')->andReturn('foo');
+		$store->start($cookies);
+
+		$store->put('foo.bar', 'baz');
+		$this->assertEquals('baz', $store->get('foo.bar'));
+		$this->assertEquals(array('bar' => 'baz'), $store->get('foo'));
+		$store->put('foo.bat', 'qux');
+		$this->assertCount(2, $store->get('foo'));
+		$this->assertEquals(array('bar' => 'baz', 'bat' => 'qux'), $store->get('foo'));
+		$this->assertTrue($store->has('foo.bat'));
+		$store->forget('foo.bat');
+		$this->assertEquals(array('bar' => 'baz'), $store->get('foo'));
+		$this->assertFalse($store->has('foo.bat'));
 	}
 
 


### PR DESCRIPTION
Hi,

Let's say you have the following form:

``` php
<form>
    <input type="text" name="user[first_name]" value="{{ Input::old('user.first_name') }}">
</form>
```

This will not work under the current session implementation as the keys are limited to 1 deep, i.e. 'user' or 'user_first_name', but not 'user.first_name'. I have implemented `array_set`, `array_get` and `array_forget` (`illuminate/support` is already a dependency of `illuminate/session` so no issues there) to allow multi-dimensional arrays to be set.

There are several use-cases where you may wish to set / access multi-dimensional session data, HTML forms are but one of them.

 - Ben
