### PR TITLE
Make arrays and its contents validatable

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -193,13 +193,35 @@ class Validator implements MessageProviderInterface {
 		// that the attribute is required, rules are not run for missing values.
 		$value = $this->getValue($attribute);
 
-		$validatable = $this->isValidatable($rule, $attribute, $value);
-
-		$method = "validate{$rule}";
-
-		if ($validatable and ! $this->$method($attribute, $value, $parameters, $this))
+		if (is_array($value))
 		{
-			$this->addError($attribute, $rule, $parameters);
+			// In case if array is empty, we add one NULL element in order to
+			// continue with validation. Otherwise validator will just skip
+			// that attribute without checking even for required.
+			$value = (empty($value) ? array(null) : $value);
+
+			foreach ($value as $element)
+			{
+				$validatable = $this->isValidatable($rule, $attribute, $element);
+
+				$method = "validate{$rule}";
+
+				if ($validatable and ! $this->$method($attribute, $element, $parameters, $this))
+				{
+					$this->addError($attribute, $rule, $parameters);
+				}
+			}
+		}
+		else
+		{
+			$validatable = $this->isValidatable($rule, $attribute, $value);
+
+			$method = "validate{$rule}";
+
+			if ($validatable and ! $this->$method($attribute, $value, $parameters, $this))
+			{
+				$this->addError($attribute, $rule, $parameters);
+			}
 		}
 	}
 
@@ -211,13 +233,14 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function getValue($attribute)
 	{
-		if (array_key_exists($attribute, $this->data))
+		// Use array_get to search in array with dot notation
+		if ( ! is_null($value = array_get($this->data, $attribute)) )
 		{
-			return $this->data[$attribute];
+			return $value;
 		}
-		elseif (array_key_exists($attribute, $this->files))
+		elseif ( ! is_null($value = array_get($this->files, $attribute)) )
 		{
-			return $this->files[$attribute];
+			return $value;
 		}
 	}
 
@@ -275,7 +298,7 @@ class Validator implements MessageProviderInterface {
 		{
 			return false;
 		}
-		elseif (is_string($value) and trim($value) === '')
+		elseif ((is_string($value) and trim($value) === '') or (is_array($value) and empty($value)) )
 		{
 			return false;
 		}
@@ -347,6 +370,10 @@ class Validator implements MessageProviderInterface {
 			{
 				$count++;
 			}
+			elseif ( ! is_null(array_get($this->data, $key)) or ! is_null(array_get($this->files, $key)) )
+			{
+				$count++;
+			}
 		}
 
 		return $count;
@@ -376,7 +403,14 @@ class Validator implements MessageProviderInterface {
 	{
 		$other = $parameters[0];
 
-		return isset($this->data[$other]) and $value == $this->data[$other];
+		if ( is_array($arrayValue = array_get($this->data, $attribute)) )
+		{
+			return ! is_null($otherValue = array_get($this->data, $other)) and $arrayValue == $otherValue;
+		}
+		else
+		{
+			return isset($this->data[$other]) and $value == $this->data[$other];
+		}
 	}
 
 	/**
@@ -391,7 +425,14 @@ class Validator implements MessageProviderInterface {
 	{
 		$other = $parameters[0];
 
-		return isset($this->data[$other]) and $value != $this->data[$other];
+		if ( is_array($arrayValue = array_get($this->data, $attribute)) )
+		{
+			return ! is_null($otherValue = array_get($this->data, $other)) and $arrayValue != $otherValue;
+		}
+		else
+		{
+			return isset($this->data[$other]) and $value != $this->data[$other];
+		}
 	}
 
 	/**
@@ -649,6 +690,13 @@ class Validator implements MessageProviderInterface {
 		// verified as existing. If this parameter is not specified we will guess
 		// that the columns being "verified" shares the given attribute's name.
 		$column = isset($parameters[1]) ? $parameters[1] : $attribute;
+
+		// Search for the array by attribute in data/files, to use in whereIn.
+		// Assuming, we won't be dealing with FILES array, this could be changed to array_get
+		if ( is_array($arrayValue = $this->getValue($attribute)) )
+		{
+			$value = $arrayValue;
+		}
 
 		$expected = (is_array($value)) ? count($value) : 1;
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -572,7 +572,7 @@ class Validator implements MessageProviderInterface {
 	 	// entire length of the string will be considered the attribute size.
 		if (is_numeric($value) and $hasNumeric)
 		{
-			return $this->getValue($attribute);
+			return $value;
 		}
 		elseif ($value instanceof File)
 		{
@@ -692,8 +692,7 @@ class Validator implements MessageProviderInterface {
 		$column = isset($parameters[1]) ? $parameters[1] : $attribute;
 
 		// Search for the array by attribute in data/files, to use in whereIn.
-		// Assuming, we won't be dealing with FILES array, this could be changed to array_get
-		if ( is_array($arrayValue = $this->getValue($attribute)) )
+		if ( is_array($arrayValue = array_get($this->data, $attribute)) )
 		{
 			$value = $arrayValue;
 		}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -572,7 +572,7 @@ class Validator implements MessageProviderInterface {
 	 	// entire length of the string will be considered the attribute size.
 		if (is_numeric($value) and $hasNumeric)
 		{
-			return $this->data[$attribute];
+			return $this->getValue($attribute);
 		}
 		elseif ($value instanceof File)
 		{

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -247,6 +247,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => '1.23'), array('foo' => 'Numeric'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('1.23','3.14')), array('foo' => 'Numeric'));
+		$this->assertTrue($v->passes());
+
 		$v = new Validator($trans, array('foo' => '-1'), array('foo' => 'Numeric'));
 		$this->assertTrue($v->passes());
 
@@ -267,6 +270,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => '1.23'), array('foo' => 'Integer'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('1.23', '0.12')), array('foo' => 'Integer'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('foo' => '-1'), array('foo' => 'Integer'));
 		$this->assertTrue($v->passes());
 
@@ -284,6 +290,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => '12345'), array('foo' => 'Digits:5'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('12345','56789')), array('foo' => 'Digits:5'));
+		$this->assertTrue($v->passes());
+
 		$v = new Validator($trans, array('foo' => '123'), array('foo' => 'Digits:200'));
 		$this->assertFalse($v->passes());
 
@@ -291,7 +300,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => '12345'), array('foo' => 'digits_between:1,6'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('12345','22345')), array('foo' => 'digits_between:1,6'));
+		$this->assertTrue($v->passes());
+
 		$v = new Validator($trans, array('foo' => '123'), array('foo' => 'digits_between:4,5'));
+		$this->assertFalse($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('123','789')), array('foo' => 'digits_between:4,5'));
 		$this->assertFalse($v->passes());
 	}
 
@@ -305,10 +320,19 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => 'anc'), array('foo' => 'Size:3'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('anc','spq')), array('foo' => 'Size:3'));
+		$this->assertTrue($v->passes());
+
 		$v = new Validator($trans, array('foo' => '123'), array('foo' => 'Numeric|Size:3'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('123','456')), array('foo' => 'Numeric|Size:3'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('foo' => '3'), array('foo' => 'Numeric|Size:3'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('3','3')), array('foo' => 'Numeric|Size:3'));
 		$this->assertTrue($v->passes());
 
 		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));
@@ -331,7 +355,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => 'asdad'), array('foo' => 'Between:3,4'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('asdad','qwert')), array('foo' => 'Between:3,4'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('foo' => 'anc'), array('foo' => 'Between:3,5'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('anc','spq')), array('foo' => 'Between:3,5'));
 		$this->assertTrue($v->passes());
 
 		$v = new Validator($trans, array('foo' => 'ancf'), array('foo' => 'Between:3,5'));
@@ -340,10 +370,16 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => 'ancfs'), array('foo' => 'Between:3,5'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('ancfs','zxcvb')), array('foo' => 'Between:3,5'));
+		$this->assertTrue($v->passes());
+
 		$v = new Validator($trans, array('foo' => '123'), array('foo' => 'Numeric|Between:50,100'));
 		$this->assertFalse($v->passes());
 
 		$v = new Validator($trans, array('foo' => '3'), array('foo' => 'Numeric|Between:1,5'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('3','4')), array('foo' => 'Numeric|Between:1,5'));
 		$this->assertTrue($v->passes());
 
 		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));
@@ -366,7 +402,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => '3'), array('foo' => 'Min:3'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('3','2')), array('foo' => 'Min:3'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('foo' => 'anc'), array('foo' => 'Min:3'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('anc','qwe')), array('foo' => 'Min:3'));
 		$this->assertTrue($v->passes());
 
 		$v = new Validator($trans, array('foo' => '2'), array('foo' => 'Numeric|Min:3'));
@@ -525,7 +567,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('ip' => 'aslsdlks'), array('ip' => 'Ip'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('ip' => array('127.0.0.1','localhost')), array('ip' => 'Ip'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('ip' => '127.0.0.1'), array('ip' => 'Ip'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('ip' => array('127.0.0.1','192.168.0.1')), array('ip' => 'Ip'));
 		$this->assertTrue($v->passes());
 	}
 
@@ -536,7 +584,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('x' => 'aslsdlks'), array('x' => 'Email'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('x' => array('aslsdlks','foo@gmail.com')), array('x' => 'Email'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('x' => 'foo@gmail.com'), array('x' => 'Email'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('x' => array('foo@gmail.com','bar@gmail.com')), array('x' => 'Email'));
 		$this->assertTrue($v->passes());
 	}
 
@@ -648,6 +702,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('x' => '2000-01-01'), array('x' => 'date'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('x' => array('2000-01-01','2013-01-01')), array('x' => 'date'));
+		$this->assertTrue($v->passes());
+
 		$v = new Validator($trans, array('x' => 'Not a date'), array('x' => 'date'));
 		$this->assertTrue($v->fails());
 
@@ -655,6 +712,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 
 		$v = new Validator($trans, array('x' => '01/01/2001'), array('x' => 'date_format:Y-m-d'));
+		$this->assertTrue($v->fails());
+
+		$v = new Validator($trans, array('x' => array('01/01/2001','02/02/2002')), array('x' => 'date_format:Y-m-d'));
 		$this->assertTrue($v->fails());
 	}
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -19,6 +19,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$trans->shouldReceive('trans')->never();
 		$v = new Validator($trans, array('foo' => 'taylor'), array('name' => 'Confirmed'));
 		$this->assertTrue($v->passes());
+
+		$trans = $this->getTranslator();
+		$trans->shouldReceive('trans')->never();
+		$v = new Validator($trans, array('foo' => array('taylor')), array('name' => 'Confirmed'));
+		$this->assertTrue($v->passes());
 	}
 
 
@@ -105,10 +110,19 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('first' => 'Taylor'), array('last' => 'required_with:first'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('first' => array('Taylor')), array('last' => 'required_with:first'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('first' => 'Taylor', 'last' => ''), array('last' => 'required_with:first'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('first' => array('Taylor'), 'last' => ''), array('last' => 'required_with:first'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('first' => ''), array('last' => 'required_with:first'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('first' => array()), array('last' => 'required_with:first'));
 		$this->assertTrue($v->passes());
 
 		$v = new Validator($trans, array(), array('last' => 'required_with:first'));
@@ -116,6 +130,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v = new Validator($trans, array('first' => 'Taylor', 'last' => 'Otwell'), array('last' => 'required_with:first'));
 		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('first' => array('Taylor'), 'last' => 'Otwell'), array('last' => 'required_with:first'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('first' => array('name' => array('Taylor')), 'last' => 'Otwell'), array('last' => 'required_with:first.name'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('first' => array('name' => array('Taylor')), 'last' => ''), array('last' => 'required_with:first.name'));
+		$this->assertFalse($v->passes());
 
 		$file = new File('', false);
 		$v = new Validator($trans, array('file' => $file, 'foo' => ''), array('foo' => 'required_with:file'));
@@ -138,6 +161,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('password' => 'foo'), array('password' => 'Confirmed'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('password' => array('foo')), array('password' => 'Confirmed'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('password' => 'foo', 'password_confirmation' => 'bar'), array('password' => 'Confirmed'));
 		$this->assertFalse($v->passes());
 
@@ -152,10 +178,16 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => 'bar', 'baz' => 'boom'), array('foo' => 'Same:baz'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('bar'), 'baz' => array('boom')), array('foo' => 'Same:baz'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('foo' => 'bar'), array('foo' => 'Same:baz'));
 		$this->assertFalse($v->passes());
 
 		$v = new Validator($trans, array('foo' => 'bar', 'baz' => 'bar'), array('foo' => 'Same:baz'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('bar'), 'baz' => array('bar')), array('foo' => 'Same:baz'));
 		$this->assertTrue($v->passes());
 	}
 
@@ -171,6 +203,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v = new Validator($trans, array('foo' => 'bar', 'baz' => 'bar'), array('foo' => 'Different:baz'));
 		$this->assertFalse($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('bar'), 'baz' => array('bar')), array('foo' => 'Different:baz'));
+		$this->assertFalse($v->passes());
 	}
 
 
@@ -180,6 +215,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => 'no'), array('foo' => 'Accepted'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('bar' => 'no')), array('foo.bar' => 'Accepted'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('foo' => null), array('foo' => 'Accepted'));
 		$this->assertFalse($v->passes());
 
@@ -187,6 +225,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($v->passes());
 
 		$v = new Validator($trans, array('foo' => 'yes'), array('foo' => 'Accepted'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('bar' => 'yes')), array('foo.bar' => 'Accepted'));
 		$this->assertTrue($v->passes());
 
 		$v = new Validator($trans, array('foo' => '1'), array('foo' => 'Accepted'));
@@ -200,6 +241,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => 'asdad'), array('foo' => 'Numeric'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('asdad', 'nyan')), array('foo' => 'Numeric'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('foo' => '1.23'), array('foo' => 'Numeric'));
 		$this->assertTrue($v->passes());
 
@@ -207,6 +251,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 
 		$v = new Validator($trans, array('foo' => '1'), array('foo' => 'Numeric'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('1', '2', '3')), array('foo' => 'Numeric'));
 		$this->assertTrue($v->passes());
 	}
 
@@ -224,6 +271,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 
 		$v = new Validator($trans, array('foo' => '1'), array('foo' => 'Integer'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('1', '2')), array('foo' => 'Integer'));
 		$this->assertTrue($v->passes());
 	}
 
@@ -325,6 +375,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => '5'), array('foo' => 'Numeric|Min:3'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('5')), array('foo' => 'Numeric|Min:3'));
+		$this->assertTrue($v->passes());
+
 		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));
 		$file->expects($this->any())->method('getSize')->will($this->returnValue(3072));
 		$v = new Validator($trans, array(), array('photo' => 'Min:2'));
@@ -398,7 +451,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('name' => 'foo'), array('name' => 'In:bar,baz'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('name' => array('foo','nyan')), array('name' => 'In:bar,baz'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('name' => 'foo'), array('name' => 'In:foo,baz'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('name' => array('foo')), array('name' => 'In:foo,baz'));
 		$this->assertTrue($v->passes());
 	}
 


### PR DESCRIPTION
Currently, there's no way to validate contents of input arrays. This pull request tries to fix that.

Example:

``` html
<input name="tags[]" value="foo"/>
<input name="tags[]" value="bar" />
<input name="tags[]" value="baz" />
```

will send to PHP following array:

``` php
array('tags' => array('foo', 'bar', 'baz'));
```

Right now there's no way to check whole array for a certain rules, like alpha/numeric etc. However, with this patch you can validate `tags` array like so:

``` php
$val = Validator::make(array('tags' => array('foo', 'bar', 'baz')), array('tags' => 'required|alpha'));
```

Validator will determine that `tags` key refers to the array and will proceed to validate each element according to set rules `required|alpha`;

This patch also allows to use dot notation to validate inner arrays of other arrays:

``` html
<input name="tags[new][]" value="foo"/>
<input name="tags[new][]" value="bar" />
<input name="tags[new][]" value="baz" />
```

``` php
$input = array('tags' => array(
    'new' => array('foo', 'bar', 'baz'),
    'old' => array()
));

$val = Validator::make($input, array('tags.new' => 'required|alpha'));
```

In this case Validator will validate `new` array that is inside of the `tags` array.

P.S.: Some of the test were omitted because of a similarities with other tests.
