### PR TITLE
Moving Facade::$app to Application::$Current

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -25,24 +25,24 @@ class Application extends Container implements HttpKernelInterface {
 	/**
 	 * Singleton instance
 	 */
-	private static $Current = null;
-  
+	private static $Current;
+
 	/**
-	 * Facade function: Get instance of Application
-         * Set instance of Application, returns old instance
-	 *
-	 * @param Application  $newCurrent = null
-	 * @return Application
+	 * Facade function, get singleton of Application
 	 */
-	public static function Current($newCurrent = null) {
+	public static function getCurrent() {    
+		return static::$Current;
+	}
+
+	public static function setCurrent($newCurrent) {
 		$current = static::$Current;
-    
+		
 		if ($newCurrent !== null) {
 			// Force this to be only in testing environment?
 			static::$Current = $newCurrent;
 		}
-
-		return $current;  // return only current or the old current
+		
+		return $current;
 	}
 
 	/**
@@ -88,7 +88,7 @@ class Application extends Container implements HttpKernelInterface {
 	public function __construct()
 	{
 		// Auto push master Application
-		if (static::$Current == null) static::$Current = $this;
+		if (static::getCurrent() == null) static::setCurrent($this);
 
 		$this['request'] = Request::createFromGlobals();
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -23,6 +23,29 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class Application extends Container implements HttpKernelInterface {
 
 	/**
+	 * Singleton instance
+	 */
+	private static $Current = null;
+  
+	/**
+	 * Facade function: Get instance of Application
+         * Set instance of Application, returns old instance
+	 *
+	 * @param Application  $newCurrent = null
+	 * @return Application
+	 */
+	public static function Current($newCurrent = null) {
+		$current = static::$Current;
+    
+		if ($newCurrent !== null) {
+			// Force this to be only in testing environment?
+			static::$Current = $newCurrent;
+		}
+
+		return $current;  // return only current or the old current
+	}
+
+	/**
 	 * Indicates if the application has "booted".
 	 *
 	 * @var bool

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -25,7 +25,7 @@ class Application extends Container implements HttpKernelInterface {
 	/**
 	 * Singleton instance
 	 */
-	private static $Current;
+	protected static $Current = null;
 
 	/**
 	 * Facade function, get singleton of Application

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -87,6 +87,9 @@ class Application extends Container implements HttpKernelInterface {
 	 */
 	public function __construct()
 	{
+		// Auto push master Application
+		if (static::$Current == null) static::$Current = $this;
+
 		$this['request'] = Request::createFromGlobals();
 
 		// The exception handler class takes care of determining which of the bound

--- a/src/Illuminate/Foundation/start.php
+++ b/src/Illuminate/Foundation/start.php
@@ -67,21 +67,6 @@ error_reporting(-1);
 
 /*
 |--------------------------------------------------------------------------
-| Load The Illuminate Facades
-|--------------------------------------------------------------------------
-|
-| The facades provide a terser static interface over the various parts
-| of the application, allowing their methods to be accessed through
-| a mixtures of magic methods and facade derivatives. It's slick.
-|
-*/
-
-Facade::clearResolvedInstances();
-
-Facade::setFacadeApplication($app);
-
-/*
-|--------------------------------------------------------------------------
 | Register The Configuration Loader
 |--------------------------------------------------------------------------
 |

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -5,10 +5,10 @@ class App extends Facade {
 	/**
 	 * Get the Application.
 	 *
-	 * @return Illuminate\Foundation\Application
+	 * @return \Illuminate\Foundation\Application
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current();
+		return \Illuminate\Foundation\Application::Current();
 	}
 
 }

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -7,8 +7,8 @@ class App extends Facade {
 	 *
 	 * @return \Illuminate\Foundation\Application
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current();
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent();
 	}
 
 }

--- a/src/Illuminate/Support/Facades/App.php
+++ b/src/Illuminate/Support/Facades/App.php
@@ -3,10 +3,12 @@
 class App extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the Application.
 	 *
-	 * @return string
+	 * @return Illuminate\Foundation\Application
 	 */
-	protected static function getFacadeAccessor() { return static::$app; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current();
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Artisan.php
+++ b/src/Illuminate/Support/Facades/Artisan.php
@@ -3,10 +3,12 @@
 class Artisan extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'artisan'.
 	 *
-	 * @return string
+	 * @return Illuminate\Console\Application
 	 */
-	protected static function getFacadeAccessor() { return 'artisan'; }
-
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['artisan'];
+	}
+	
 }

--- a/src/Illuminate/Support/Facades/Artisan.php
+++ b/src/Illuminate/Support/Facades/Artisan.php
@@ -5,10 +5,10 @@ class Artisan extends Facade {
 	/**
 	 * Get the registered component 'artisan'.
 	 *
-	 * @return Illuminate\Console\Application
+	 * @return \Illuminate\Console\Application
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['artisan'];
+		return \Illuminate\Foundation\Application::Current()['artisan'];
 	}
 	
 }

--- a/src/Illuminate/Support/Facades/Artisan.php
+++ b/src/Illuminate/Support/Facades/Artisan.php
@@ -7,8 +7,8 @@ class Artisan extends Facade {
 	 *
 	 * @return \Illuminate\Console\Application
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['artisan'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['artisan'];
 	}
 	
 }

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -5,10 +5,10 @@ class Auth extends Facade {
 	/**
 	 * Get the registered component 'auth'.
 	 *
-	 * @return Illuminate\Auth\
+	 * @return \Illuminate\Auth\AuthManager
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['auth'];
+		return \Illuminate\Foundation\Application::Current()['auth'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -7,8 +7,8 @@ class Auth extends Facade {
 	 *
 	 * @return \Illuminate\Auth\AuthManager
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['auth'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['auth'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -3,10 +3,12 @@
 class Auth extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'auth'.
 	 *
-	 * @return string
+	 * @return Illuminate\Auth\
 	 */
-	protected static function getFacadeAccessor() { return 'auth'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['auth'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -5,10 +5,10 @@ class Blade extends Facade {
 	/**
 	 * Resolve a BladeCompiler from the registered component 'view'.
 	 *
-	 * @return Illuminate\View\Compilers\BladeCompiler
+	 * @return \Illuminate\View\Compilers\BladeCompiler
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['view']->getEngineResolver()->resolve('blade')->getCompiler();
+		return \Illuminate\Foundation\Application::Current()['view']->getEngineResolver()->resolve('blade')->getCompiler();
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -3,13 +3,12 @@
 class Blade extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Resolve a BladeCompiler from the registered component 'view'.
 	 *
-	 * @return string
+	 * @return Illuminate\View\Compilers\BladeCompiler
 	 */
-	protected static function getFacadeAccessor()
-	{
-		return static::$app['view']->getEngineResolver()->resolve('blade')->getCompiler();
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['view']->getEngineResolver()->resolve('blade')->getCompiler();
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -7,8 +7,8 @@ class Blade extends Facade {
 	 *
 	 * @return \Illuminate\View\Compilers\BladeCompiler
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['view']->getEngineResolver()->resolve('blade')->getCompiler();
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['view']->getEngineResolver()->resolve('blade')->getCompiler();
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -7,8 +7,8 @@ class Cache extends Facade {
 	 *
 	 * @return \Illuminate\Cache\CacheManager
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['cache'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['cache'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -5,10 +5,10 @@ class Cache extends Facade {
 	/**
 	 * Get the registered component 'cache'.
 	 *
-	 * @return Illuminate\Cache\CacheManager
+	 * @return \Illuminate\Cache\CacheManager
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['cache'];
+		return \Illuminate\Foundation\Application::Current()['cache'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -3,10 +3,12 @@
 class Cache extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'cache'.
 	 *
-	 * @return string
+	 * @return Illuminate\Cache\CacheManager
 	 */
-	protected static function getFacadeAccessor() { return 'cache'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['cache'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Config.php
+++ b/src/Illuminate/Support/Facades/Config.php
@@ -3,10 +3,12 @@
 class Config extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'config'.
 	 *
-	 * @return string
+	 * @return Illuminate\Config\
 	 */
-	protected static function getFacadeAccessor() { return 'config'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['config'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Config.php
+++ b/src/Illuminate/Support/Facades/Config.php
@@ -5,10 +5,10 @@ class Config extends Facade {
 	/**
 	 * Get the registered component 'config'.
 	 *
-	 * @return Illuminate\Config\
+	 * @return \Illuminate\Config\
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['config'];
+		return \Illuminate\Foundation\Application::Current()['config'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Config.php
+++ b/src/Illuminate/Support/Facades/Config.php
@@ -7,8 +7,8 @@ class Config extends Facade {
 	 *
 	 * @return \Illuminate\Config\
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['config'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['config'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -3,10 +3,12 @@
 class Cookie extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'cookie'.
 	 *
-	 * @return string
+	 * @return Illuminate\Cookie\CookieJar
 	 */
-	protected static function getFacadeAccessor() { return 'cookie'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['cookie'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -7,8 +7,8 @@ class Cookie extends Facade {
 	 *
 	 * @return \Illuminate\Cookie\CookieJar
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['cookie'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['cookie'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -5,10 +5,10 @@ class Cookie extends Facade {
 	/**
 	 * Get the registered component 'cookie'.
 	 *
-	 * @return Illuminate\Cookie\CookieJar
+	 * @return \Illuminate\Cookie\CookieJar
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['cookie'];
+		return \Illuminate\Foundation\Application::Current()['cookie'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Crypt.php
+++ b/src/Illuminate/Support/Facades/Crypt.php
@@ -5,10 +5,10 @@ class Crypt extends Facade {
 	/**
 	 * Get the registered component 'encrypter'.
 	 *
-	 * @return Illuminate\Encryption\
+	 * @return \Illuminate\Encryption\
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['encrypter'];
+		return \Illuminate\Foundation\Application::Current()['encrypter'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Crypt.php
+++ b/src/Illuminate/Support/Facades/Crypt.php
@@ -7,8 +7,8 @@ class Crypt extends Facade {
 	 *
 	 * @return \Illuminate\Encryption\
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['encrypter'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['encrypter'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Crypt.php
+++ b/src/Illuminate/Support/Facades/Crypt.php
@@ -3,10 +3,12 @@
 class Crypt extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'encrypter'.
 	 *
-	 * @return string
+	 * @return Illuminate\Encryption\
 	 */
-	protected static function getFacadeAccessor() { return 'encrypter'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['encrypter'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -5,10 +5,10 @@ class DB extends Facade {
 	/**
 	 * Get the registered component 'db'.
 	 *
-	 * @return Illuminate\db\
+	 * @return \Illuminate\db\
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['db'];
+		return \Illuminate\Foundation\Application::Current()['db'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -7,8 +7,8 @@ class DB extends Facade {
 	 *
 	 * @return \Illuminate\db\
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['db'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['db'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -3,10 +3,12 @@
 class DB extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'db'.
 	 *
-	 * @return string
+	 * @return Illuminate\db\
 	 */
-	protected static function getFacadeAccessor() { return 'db'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['db'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -3,10 +3,12 @@
 class Event extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'events'.
 	 *
-	 * @return string
+	 * @return Illuminate\Events\Dispatcher
 	 */
-	protected static function getFacadeAccessor() { return 'events'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['events'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -7,8 +7,8 @@ class Event extends Facade {
 	 *
 	 * @return \Illuminate\Events\Dispatcher
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['events'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['events'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -5,10 +5,10 @@ class Event extends Facade {
 	/**
 	 * Get the registered component 'events'.
 	 *
-	 * @return Illuminate\Events\Dispatcher
+	 * @return \Illuminate\Events\Dispatcher
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['events'];
+		return \Illuminate\Foundation\Application::Current()['events'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -1,92 +1,16 @@
 <?php namespace Illuminate\Support\Facades;
 
 abstract class Facade {
-
+	
 	/**
-	 * The application instance being facaded.
-	 *
-	 * @var Illuminate\Foundation\Application
+	 * Facade function for a Singleton, or registered component
 	 */
-	protected static $app;
-
-	/**
-	 * The resolved object instances.
-	 *
-	 * @var array
-	 */
-	protected static $resolvedInstance;
-
-	/**
-	 * Get the root object behind the facade.
-	 *
-	 * @return mixed
-	 */
-	public static function getFacadeRoot()
-	{
-		return static::resolveFacadeInstance(static::getFacadeAccessor());
+	public static function Current() {
+		throw new \RuntimeException("Facade does not implement Current method.");
 	}
-
+	
 	/**
-	 * Get the registered name of the component.
-	 *
-	 * @return string
-	 */
-	protected static function getFacadeAccessor()
-	{
-		throw new \RuntimeException("Facade does not implement getFacadeAccessor method.");
-	}
-
-	/**
-	 * Resolve the facade root instance from the container.
-	 *
-	 * @param  string  $name
-	 * @return mixed
-	 */
-	protected static function resolveFacadeInstance($name)
-	{
-		if (is_object($name)) return $name;
-
-		if (isset(static::$resolvedInstance[$name]))
-		{
-			return static::$resolvedInstance[$name];
-		}
-
-		return static::$resolvedInstance[$name] = static::$app[$name];
-	}
-
-	/**
-	 * Clear all of the resolved instances.
-	 *
-	 * @return void
-	 */
-	public static function clearResolvedInstances()
-	{
-		static::$resolvedInstance = array();
-	}
-
-	/**
-	 * Get the application instance behind the facade.
-	 *
-	 * @return Illuminate\Foundation\Application
-	 */
-	public static function getFacadeApplication()
-	{
-		return static::$app;
-	}
-
-	/**
-	 * Set the application instance.
-	 *
-	 * @param  Illuminate\Foundation\Application  $app
-	 * @return void
-	 */
-	public static function setFacadeApplication($app)
-	{
-		static::$app = $app;
-	}
-
-	/**
-	 * Handle dynamic, static calls to the object.
+	 * Handle dynamic, static calls to the Current() object.
 	 *
 	 * @param  string  $method
 	 * @param  array   $args
@@ -94,28 +18,7 @@ abstract class Facade {
 	 */
 	public static function __callStatic($method, $args)
 	{
-		$instance = static::resolveFacadeInstance(static::getFacadeAccessor());
-
-		switch (count($args))
-		{
-			case 0:
-				return $instance->$method();
-
-			case 1:
-				return $instance->$method($args[0]);
-
-			case 2:
-				return $instance->$method($args[0], $args[1]);
-
-			case 3:
-				return $instance->$method($args[0], $args[1], $args[2]);
-
-			case 4:
-				return $instance->$method($args[0], $args[1], $args[2], $args[3]);
-
-			default:
-				return call_user_func_array(array($instance, $method), $args);
-		}
+		return call_user_func_array(array(static::Current(), $method), $args);
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -5,7 +5,7 @@ abstract class Facade {
 	/**
 	 * Facade function for a Singleton, or registered component
 	 */
-	public static function Current() {
+	public static function getCurrent() {
 		throw new \RuntimeException("Facade does not implement Current method.");
 	}
 	
@@ -18,7 +18,7 @@ abstract class Facade {
 	 */
 	public static function __callStatic($method, $args)
 	{
-		return call_user_func_array(array(static::Current(), $method), $args);
+		return call_user_func_array(array(static::getCurrent(), $method), $args);
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -6,7 +6,7 @@ abstract class Facade {
 	 * Facade function for a Singleton, or registered component
 	 */
 	public static function getCurrent() {
-		throw new \RuntimeException("Facade does not implement Current method.");
+		throw new \RuntimeException("Facade does not implement static getCurrent method.");
 	}
 	
 	/**

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -5,10 +5,10 @@ class File extends Facade {
 	/**
 	 * Get the registered component 'files'.
 	 *
-	 * @return Illuminate\Filesystem\Filesystem
+	 * @return \Illuminate\Filesystem\Filesystem
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['files'];
+		return \Illuminate\Foundation\Application::Current()['files'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -7,8 +7,8 @@ class File extends Facade {
 	 *
 	 * @return \Illuminate\Filesystem\Filesystem
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['files'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['files'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -3,10 +3,12 @@
 class File extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'files'.
 	 *
-	 * @return string
+	 * @return Illuminate\Filesystem\Filesystem
 	 */
-	protected static function getFacadeAccessor() { return 'files'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['files'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Hash.php
+++ b/src/Illuminate/Support/Facades/Hash.php
@@ -5,10 +5,10 @@ class Hash extends Facade {
 	/**
 	 * Get the registered component 'hash'.
 	 *
-	 * @return Illuminate\Hashing\HasherInterface
+	 * @return \Illuminate\Hashing\HasherInterface
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['hash'];
+		return \Illuminate\Foundation\Application::Current()['hash'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Hash.php
+++ b/src/Illuminate/Support/Facades/Hash.php
@@ -7,8 +7,8 @@ class Hash extends Facade {
 	 *
 	 * @return \Illuminate\Hashing\HasherInterface
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['hash'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['hash'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Hash.php
+++ b/src/Illuminate/Support/Facades/Hash.php
@@ -3,10 +3,12 @@
 class Hash extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'hash'.
 	 *
-	 * @return string
+	 * @return Illuminate\Hashing\HasherInterface
 	 */
-	protected static function getFacadeAccessor() { return 'hash'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['hash'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Input.php
+++ b/src/Illuminate/Support/Facades/Input.php
@@ -22,7 +22,7 @@ class Input extends Facade {
 	 * @return Illuminate\Http\Request
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['request'];
+		return \Illuminate\Foundation\Application::Current()['request'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Input.php
+++ b/src/Illuminate/Support/Facades/Input.php
@@ -13,7 +13,7 @@ class Input extends Facade {
 	 */
 	public static function get($key = null, $default = null)
 	{
-		return static::Current()->input($key, $default);
+		return static::getCurrent()->input($key, $default);
 	}
 
 	/**
@@ -21,8 +21,8 @@ class Input extends Facade {
 	 *
 	 * @return Illuminate\Http\Request
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['request'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['request'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Input.php
+++ b/src/Illuminate/Support/Facades/Input.php
@@ -13,14 +13,16 @@ class Input extends Facade {
 	 */
 	public static function get($key = null, $default = null)
 	{
-		return static::$app['request']->input($key, $default);
+		return static::Current()->input($key, $default);
 	}
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'request'.
 	 *
-	 * @return string
+	 * @return Illuminate\Http\Request
 	 */
-	protected static function getFacadeAccessor() { return 'request'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['request'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Lang.php
+++ b/src/Illuminate/Support/Facades/Lang.php
@@ -3,12 +3,12 @@
 class Lang extends Facade {
 
 	/**
-	 * Get the registered component 'hash'.
+	 * Get the registered component 'translator'.
 	 *
-	 * @return Illuminate\Hashing\HasherInterface
+	 * @return \Illuminate\Translation\Translator
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['translator'];
+		return \Illuminate\Foundation\Application::Current()['translator'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Lang.php
+++ b/src/Illuminate/Support/Facades/Lang.php
@@ -7,8 +7,8 @@ class Lang extends Facade {
 	 *
 	 * @return \Illuminate\Translation\Translator
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['translator'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['translator'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Lang.php
+++ b/src/Illuminate/Support/Facades/Lang.php
@@ -3,10 +3,12 @@
 class Lang extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'hash'.
 	 *
-	 * @return string
+	 * @return Illuminate\Hashing\HasherInterface
 	 */
-	protected static function getFacadeAccessor() { return 'translator'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['translator'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -7,8 +7,8 @@ class Log extends Facade {
 	 *
 	 * @return \Illuminate\Log\Writer
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['log'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['log'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -3,10 +3,12 @@
 class Log extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'log'.
 	 *
-	 * @return string
+	 * @return Illuminate\Log\Writer
 	 */
-	protected static function getFacadeAccessor() { return 'log'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['log'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Log.php
+++ b/src/Illuminate/Support/Facades/Log.php
@@ -5,10 +5,10 @@ class Log extends Facade {
 	/**
 	 * Get the registered component 'log'.
 	 *
-	 * @return Illuminate\Log\Writer
+	 * @return \Illuminate\Log\Writer
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['log'];
+		return \Illuminate\Foundation\Application::Current()['log'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -3,10 +3,12 @@
 class Mail extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'mailer'.
 	 *
-	 * @return string
+	 * @return Illuminate\Mail\Mailer
 	 */
-	protected static function getFacadeAccessor() { return 'mailer'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['mailer'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -5,10 +5,10 @@ class Mail extends Facade {
 	/**
 	 * Get the registered component 'mailer'.
 	 *
-	 * @return Illuminate\Mail\Mailer
+	 * @return \Illuminate\Mail\Mailer
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['mailer'];
+		return \Illuminate\Foundation\Application::Current()['mailer'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -7,8 +7,8 @@ class Mail extends Facade {
 	 *
 	 * @return \Illuminate\Mail\Mailer
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['mailer'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['mailer'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Paginator.php
+++ b/src/Illuminate/Support/Facades/Paginator.php
@@ -7,8 +7,8 @@ class Paginator extends Facade {
 	 *
 	 * @return \Illuminate\Pagination\Environment
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['paginator'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['paginator'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Paginator.php
+++ b/src/Illuminate/Support/Facades/Paginator.php
@@ -5,10 +5,10 @@ class Paginator extends Facade {
 	/**
 	 * Get the registered component 'paginator'.
 	 *
-	 * @return Illuminate\Pagination\Environment
+	 * @return \Illuminate\Pagination\Environment
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['paginator'];
+		return \Illuminate\Foundation\Application::Current()['paginator'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Paginator.php
+++ b/src/Illuminate/Support/Facades/Paginator.php
@@ -3,10 +3,12 @@
 class Paginator extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'paginator'.
 	 *
-	 * @return string
+	 * @return Illuminate\Pagination\Environment
 	 */
-	protected static function getFacadeAccessor() { return 'paginator'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['paginator'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Password.php
+++ b/src/Illuminate/Support/Facades/Password.php
@@ -3,10 +3,12 @@
 class Password extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'auth.reminder'.
 	 *
-	 * @return string
+	 * @return Illuminate\Auth\PasswordBroker
 	 */
-	protected static function getFacadeAccessor() { return 'auth.reminder'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['auth.reminder'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Password.php
+++ b/src/Illuminate/Support/Facades/Password.php
@@ -5,10 +5,10 @@ class Password extends Facade {
 	/**
 	 * Get the registered component 'auth.reminder'.
 	 *
-	 * @return Illuminate\Auth\PasswordBroker
+	 * @return \Illuminate\Auth\PasswordBroker
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['auth.reminder'];
+		return \Illuminate\Foundation\Application::Current()['auth.reminder'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Password.php
+++ b/src/Illuminate/Support/Facades/Password.php
@@ -7,8 +7,8 @@ class Password extends Facade {
 	 *
 	 * @return \Illuminate\Auth\PasswordBroker
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['auth.reminder'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['auth.reminder'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -7,8 +7,8 @@ class Queue extends Facade {
 	 *
 	 * @return \Illuminate\Queue\QueueManager
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['queue'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['queue'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -5,10 +5,10 @@ class Queue extends Facade {
 	/**
 	 * Get the registered component 'queue'.
 	 *
-	 * @return Illuminate\Queue\QueueManager
+	 * @return \Illuminate\Queue\QueueManager
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['queue'];
+		return \Illuminate\Foundation\Application::Current()['queue'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -3,10 +3,12 @@
 class Queue extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'queue'.
 	 *
-	 * @return string
+	 * @return Illuminate\Queue\QueueManager
 	 */
-	protected static function getFacadeAccessor() { return 'queue'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['queue'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Redirect.php
+++ b/src/Illuminate/Support/Facades/Redirect.php
@@ -3,10 +3,12 @@
 class Redirect extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'redirect'.
 	 *
-	 * @return string
+	 * @return Illuminate\Routing\Redirector
 	 */
-	protected static function getFacadeAccessor() { return 'redirect'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['redirect'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Redirect.php
+++ b/src/Illuminate/Support/Facades/Redirect.php
@@ -5,10 +5,10 @@ class Redirect extends Facade {
 	/**
 	 * Get the registered component 'redirect'.
 	 *
-	 * @return Illuminate\Routing\Redirector
+	 * @return \Illuminate\Routing\Redirector
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['redirect'];
+		return \Illuminate\Foundation\Application::Current()['redirect'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Redirect.php
+++ b/src/Illuminate/Support/Facades/Redirect.php
@@ -7,8 +7,8 @@ class Redirect extends Facade {
 	 *
 	 * @return \Illuminate\Routing\Redirector
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['redirect'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['redirect'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Redis.php
+++ b/src/Illuminate/Support/Facades/Redis.php
@@ -7,8 +7,8 @@ class Redis extends Facade {
 	 *
 	 * @return \Illuminate\Redis\RedisManager
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['redis'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['redis'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Redis.php
+++ b/src/Illuminate/Support/Facades/Redis.php
@@ -5,10 +5,10 @@ class Redis extends Facade {
 	/**
 	 * Get the registered component 'redis'.
 	 *
-	 * @return Illuminate\Redis\RedisManager
+	 * @return \Illuminate\Redis\RedisManager
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['redis'];
+		return \Illuminate\Foundation\Application::Current()['redis'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Redis.php
+++ b/src/Illuminate/Support/Facades/Redis.php
@@ -3,10 +3,12 @@
 class Redis extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'redis'.
 	 *
-	 * @return string
+	 * @return Illuminate\Redis\RedisManager
 	 */
-	protected static function getFacadeAccessor() { return 'redis'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['redis'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -5,10 +5,10 @@ class Request extends Facade {
 	/**
 	 * Get the registered component 'request'.
 	 *
-	 * @return Illuminate\Http\Request
+	 * @return \Illuminate\Http\Request
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['request'];
+		return \Illuminate\Foundation\Application::Current()['request'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -7,8 +7,8 @@ class Request extends Facade {
 	 *
 	 * @return \Illuminate\Http\Request
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['request'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['request'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Request.php
+++ b/src/Illuminate/Support/Facades/Request.php
@@ -3,10 +3,12 @@
 class Request extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'request'.
 	 *
-	 * @return string
+	 * @return Illuminate\Http\Request
 	 */
-	protected static function getFacadeAccessor() { return 'request'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['request'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -55,8 +55,8 @@ class Route extends Facade {
 	 *
 	 * @return Illuminate\Routing\Router
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['router'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['router'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -1,5 +1,7 @@
 <?php namespace Illuminate\Support\Facades;
 
+use Illuminate\Foundation\Application;
+
 class Route extends Facade {
 
 	/**
@@ -11,7 +13,7 @@ class Route extends Facade {
 	 */
 	public static function filter($name, $callback)
 	{
-		return static::$app['router']->addFilter($name, $callback);
+		return static::addFilter($name, $callback);
 	}
 
 	/**
@@ -23,7 +25,7 @@ class Route extends Facade {
 	 */
 	public static function when($pattern, $name)
 	{
-		return static::$app['router']->matchFilter($pattern, $name);
+		return static::matchFilter($pattern, $name);
 	}
 
 	/**
@@ -34,7 +36,7 @@ class Route extends Facade {
 	 */
 	public static function is($name)
 	{
-		return static::$app['router']->currentRouteNamed($name);
+		return static::currentRouteNamed($name);
 	}
 
 	/**
@@ -45,14 +47,16 @@ class Route extends Facade {
 	 */
 	public static function uses($action)
 	{
-		return static::$app['router']->currentRouteUses($action);
+		return static::currentRouteUses($action);
 	}
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'router'.
 	 *
-	 * @return string
+	 * @return Illuminate\Routing\Router
 	 */
-	protected static function getFacadeAccessor() { return 'router'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['router'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -56,7 +56,7 @@ class Route extends Facade {
 	 * @return Illuminate\Routing\Router
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['router'];
+		return \Illuminate\Foundation\Application::Current()['router'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -1,5 +1,7 @@
 <?php namespace Illuminate\Support\Facades;
 
+use Illuminate\Foundation\Application;
+
 class Schema extends Facade {
 
 	/**
@@ -10,17 +12,16 @@ class Schema extends Facade {
 	 */
 	public static function connection($name)
 	{
-		return static::$app['db']->connection($name)->getSchemaBuilder();
+		return Application::Current()['db']->connection($name)->getSchemaBuilder();
 	}
 
 	/**
-	 * Get the registered name of the component.
+	 * Get a SchemaBuilder from the Connection of the registered component 'db'
 	 *
-	 * @return string
+	 * @return Illuminate\Database\Schema\Builder
 	 */
-	protected static function getFacadeAccessor()
-	{
-		return static::$app['db']->connection()->getSchemaBuilder();
+	public static function Current() {
+		return Application::Current()['db']->connection()->getSchemaBuilder();;
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -12,7 +12,7 @@ class Schema extends Facade {
 	 */
 	public static function connection($name)
 	{
-		return Application::Current()['db']->connection($name)->getSchemaBuilder();
+		return Application::getCurrent()['db']->connection($name)->getSchemaBuilder();
 	}
 
 	/**
@@ -20,8 +20,8 @@ class Schema extends Facade {
 	 *
 	 * @return Illuminate\Database\Schema\Builder
 	 */
-	public static function Current() {
-		return Application::Current()['db']->connection()->getSchemaBuilder();;
+	public static function getCurrent() {
+		return Application::getCurrent()['db']->connection()->getSchemaBuilder();;
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Session.php
+++ b/src/Illuminate/Support/Facades/Session.php
@@ -7,8 +7,8 @@ class Session extends Facade {
 	 *
 	 * @return Illuminate\Session\SessionManager
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['session'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['session'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Session.php
+++ b/src/Illuminate/Support/Facades/Session.php
@@ -3,10 +3,12 @@
 class Session extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'session'.
 	 *
-	 * @return string
+	 * @return Illuminate\Session\SessionManager
 	 */
-	protected static function getFacadeAccessor() { return 'session'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['session'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Session.php
+++ b/src/Illuminate/Support/Facades/Session.php
@@ -8,7 +8,7 @@ class Session extends Facade {
 	 * @return Illuminate\Session\SessionManager
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['session'];
+		return \Illuminate\Foundation\Application::Current()['session'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -7,8 +7,8 @@ class URL extends Facade {
 	 *
 	 * @return Illuminate\Routing\UrlGenerator
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['url'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['url'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -8,7 +8,7 @@ class URL extends Facade {
 	 * @return Illuminate\Routing\UrlGenerator
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['url'];
+		return \Illuminate\Foundation\Application::Current()['url'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -3,10 +3,12 @@
 class URL extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'url'.
 	 *
-	 * @return string
+	 * @return Illuminate\Routing\UrlGenerator
 	 */
-	protected static function getFacadeAccessor() { return 'url'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['url'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -8,7 +8,7 @@ class Validator extends Facade {
 	 * @return Illuminate\Validation\Factory
 	 */
 	public static function Current() {
-		return Illuminate\Foundation\Application::Current()['validator'];
+		return \Illuminate\Foundation\Application::Current()['validator'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -7,8 +7,8 @@ class Validator extends Facade {
 	 *
 	 * @return Illuminate\Validation\Factory
 	 */
-	public static function Current() {
-		return \Illuminate\Foundation\Application::Current()['validator'];
+	public static function getCurrent() {
+		return \Illuminate\Foundation\Application::getCurrent()['validator'];
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Validator.php
+++ b/src/Illuminate/Support/Facades/Validator.php
@@ -3,10 +3,12 @@
 class Validator extends Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'validator'.
 	 *
-	 * @return string
+	 * @return Illuminate\Validation\Factory
 	 */
-	protected static function getFacadeAccessor() { return 'validator'; }
+	public static function Current() {
+		return Illuminate\Foundation\Application::Current()['validator'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/View.php
+++ b/src/Illuminate/Support/Facades/View.php
@@ -1,12 +1,16 @@
 <?php namespace Illuminate\Support\Facades;
 
-class View extends Facade {
+use Illuminate\Foundation\Application;
+
+class View extends Facade 
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component 'view'.
 	 *
-	 * @return string
+	 * @return Illuminate\View\Environment
 	 */
-	protected static function getFacadeAccessor() { return 'view'; }
+	public static function Current() {
+		return Application::Current()['view'];
+	}
 
 }

--- a/src/Illuminate/Support/Facades/View.php
+++ b/src/Illuminate/Support/Facades/View.php
@@ -9,8 +9,8 @@ class View extends Facade
 	 *
 	 * @return Illuminate\View\Environment
 	 */
-	public static function Current() {
-		return Application::Current()['view'];
+	public static function getCurrent() {
+		return Application::getCurrent()['view'];
 	}
 
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -32,7 +32,7 @@ function app($make = null)
 		return app()->make($make);
 	}
 
-	return Illuminate\Support\Facades\Facade::getFacadeApplication();
+	return \Illuminate\Foundation\Application::getCurrent();
 }
 
 /**

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -13,11 +13,11 @@ class SupportFacadeTest extends PHPUnit_Framework_TestCase {
 class FacadeStub extends Illuminate\Support\Facades\Facade {
 
 	/**
-	 * Get the registered name of the component.
+	 * Get the registered component.
 	 *
 	 * @return string
 	 */
-	public static function getCurrent()
+	public static function getCurrent()  // facaded Singleton
 	{
 		return ApplicationStub::getCurrent();
 	}
@@ -26,7 +26,7 @@ class FacadeStub extends Illuminate\Support\Facades\Facade {
 
 class ApplicationStub {
 
-	protected $Current;
+	protected static $Current;  // real Singleton
 
 	public static function getCurrent()
 	{
@@ -34,7 +34,7 @@ class ApplicationStub {
 	}
 
 	public function __construct() {
-		$Current = $this;
+		static::$Current = $this;
 	}
 
 	public function bar()

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -17,7 +17,7 @@ class FacadeStub extends Illuminate\Support\Facades\Facade {
 	 *
 	 * @return string
 	 */
-	protected static function getCurrent()
+	public static function getCurrent()
 	{
 		return new ApplicationStub;
 	}

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -17,9 +17,9 @@ class FacadeStub extends Illuminate\Support\Facades\Facade {
 	 *
 	 * @return string
 	 */
-	protected static function getFacadeAccessor()
+	protected static function getCurrent()
 	{
-		return 'foo';
+		return new ApplicationStub;
 	}
 
 }

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -4,7 +4,7 @@ class SupportFacadeTest extends PHPUnit_Framework_TestCase {
 
 	public function testFacadeCallsUnderlyingApplication()
 	{
-		FacadeStub::setFacadeApplication(array('foo' => new ApplicationStub));
+		new ApplicationStub;
 		$this->assertEquals('baz', FacadeStub::bar());
 	}
 
@@ -19,12 +19,23 @@ class FacadeStub extends Illuminate\Support\Facades\Facade {
 	 */
 	public static function getCurrent()
 	{
-		return new ApplicationStub;
+		return ApplicationStub::getCurrent();
 	}
 
 }
 
 class ApplicationStub {
+
+	protected $Current;
+
+	public static function getCurrent()
+	{
+		return static::$Current;
+	}
+
+	public function __construct() {
+		$Current = $this;
+	}
 
 	public function bar()
 	{


### PR DESCRIPTION
I really like the Facades construct, because it simplifies a call to a singleton, static instance of a Class.

I moved the Facade::$app to

``` php

class Application extends Container implements HttpKernelInterface {

    /**
     * Singleton instance
     */
    protected static $Current = null;

    /**
     * Facade function, get singleton of Application
     */
    public static function getCurrent() {    
        return static::$Current;
    }

    public static function setCurrent($newCurrent) {
        $current = static::$Current;

        if ($newCurrent !== null) {
            // Force this to be only in testing environment?
            static::$Current = $newCurrent;
        }

        return $current;
    }

    // ...  

    /**
     * Create a new Illuminate application instance.
     *
     * @return void
     */
    public function __construct()
    {
        // Auto push master Application
        if (static::getCurrent() == null) static::setCurrent($this);

        // ...
```

The getCurrent() function is also the heart of the new Facade class. Using the explicit getCurrent function, Facades and real Singletons are streamlined in usage:
App::getCurrent() returns Application::getCurrent(), and that returns the protected Application::$Current variable. 
Because App extends Facade, Facade will __callStatic any method on the App::getCurrent (= Application::getCurrent) instance.

``` php
namespace Illuminate\Support\Facades;

abstract class Facade {

    /**
     * Facade function for a Singleton, or registered component
     */
    public static function getCurrent() {
        throw new \RuntimeException("Facade does not implement static getCurrent method.");
    }

    /**
     * Handle dynamic, static calls to the Current() object.
     *
     * @param  string  $method
     * @param  array   $args
     * @return mixed
     */
    public static function __callStatic($method, $args)
    {
        return call_user_func_array(array(static::getCurrent(), $method), $args);
    }
}
```

Now for example, in the \Illuminate\Support\Facades\Router class you see, that the functions become direct aliases:

``` php
class Route extends Facade {

    // ...

    /**
     * Determine if the current route uses a given controller action.
     *
     * @param  string  $action
     * @return bool
     */
    public static function uses($action)
    {
        return static::currentRouteUses($action);
    // instead of
    //  return static::$app->currentRouteUses($action);
    }

    /**
     * Get the registered component 'router'.
     *
     * @return \Illuminate\Routing\Router
     */
    public static function getCurrent() {
        return \Illuminate\Foundation\Application::getCurrent()['router'];
    }
}
```

This change touches one line in helpers.php, instead of

``` php
    return \Illuminate\Support\Facades\Facade::getFacadeApplication();
```

it is now

``` php
    return \Illuminate\Foundation\Application::getCurrent(); 
```

And in start.php the following lines are removed:

``` php
Facade::clearResolvedInstances();
Facade::setFacadeApplication($app);
```

The Support\Facade classes are now absolutely independent from the rest of the framework.

``` php
        // same methods tied down:
    Application::getCurrent()['router']->currentRouteUses()
    // is
    App::getCurrent()['router']->currentRouteUses()
    // is
    Route::getCurrent()->currentRouteUses()
    // is
    Route::currentRouteUses()
    // is
    Route::uses()
```
