### PR TITLE
Ensuring that deferred services are set on the application before eager services are registered

### DIFF
--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -48,7 +48,7 @@ class ProviderRepository {
 		// provides. This is used to know which services are "deferred" loaders.
 		if ($this->shouldRecompile($manifest, $providers))
 		{
-			$manifest = $this->compileManifest($app, $providers);	
+			$manifest = $this->compileManifest($app, $providers);
 		}
 
 		// If the application is running in the console, we will not lazy load any of
@@ -59,6 +59,8 @@ class ProviderRepository {
 			$manifest['eager'] = $manifest['providers'];
 		}
 
+		$app->setDeferredServices($manifest['deferred']);
+
 		// We will go ahead and register all of the eagerly loaded providers with the
 		// application so their services can be registered with the application as
 		// a provided service. Then we will set the deferred service list on it.
@@ -66,8 +68,6 @@ class ProviderRepository {
 		{
 			$app->register($this->createProvider($app, $provider));
 		}
-
-		$app->setDeferredServices($manifest['deferred']);
 	}
 
 	/**

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -2,7 +2,7 @@
 
 use Mockery as m;
 
-class ProviderRepositoryTest extends PHPUnit_Framework_TestCase {
+class FoundationProviderRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -116,7 +116,7 @@ class FoundationProviderRepositoryTest extends PHPUnit_Framework_TestCase {
 		$app->shouldReceive('runningInConsole')->andReturn(false);
 
 		$app->shouldReceive('setDeferredServices')->ordered()->once()->with(array('deferred'));
-		$app->shouldReceive('register')->once()->ordered()->with($provider);
+		$app->shouldReceive('register')->ordered()->once()->with($provider);
 
 		$repo->load($app, array());
 	}


### PR DESCRIPTION
After a discussion with @jasonlewis regarding service providers, we have determined that if deferred services were known to the application before the eagar loaded services were registered, they'd have access to kick-start deferred services.

This would allow you to register `$this->package()` (which relies on deferred services like `lang`) in the `register()` command, which makes a whole lot more sense than hooking onto the application's `boo()` event.

This pull request fixes issue #265 as we can now successfully register packages in the `register()` method.
