### PR TITLE
[Proposal]Make detach() method in BelongsToMany a bit more docile

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -471,19 +471,23 @@ class BelongsToMany extends Relation {
 	{
 		if ($ids instanceof Model) $ids = (array) $ids->getKey();
 
-		$query = $this->newPivotQuery();
-
-		// If associated IDs were passed to the method we will only delete those
-		// associations, otherwise all of the association ties will be broken.
 		// We'll return the numbers of affected rows when we do the deletes.
+		// If no associated IDs were passed to the method we will just return 0,
+		// since no associated models will be detatched.
 		$ids = (array) $ids;
 
 		if (count($ids) > 0)
 		{
-			$query->whereIn($this->otherKey, $ids);
-		}
+			$query = $this->newPivotQuery();
 
-		return $query->delete();
+			$query->whereIn($this->otherKey, $ids);
+
+			return $query->delete();
+		}
+		else
+		{
+			return 0;
+		}
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -464,30 +464,26 @@ class BelongsToMany extends Relation {
 	/**
 	 * Detach models from the relationship.
 	 *
-	 * @param  int|array  $ids
+	 * @param  array  $ids
 	 * @return int
 	 */
-	public function detach($ids = array())
+	public function detach(array $ids = array())
 	{
 		if ($ids instanceof Model) $ids = (array) $ids->getKey();
 
+		$query = $this->newPivotQuery();
+
+		// If associated IDs were passed to the method we will only delete those
+		// associations, otherwise all of the association ties will be broken.
 		// We'll return the numbers of affected rows when we do the deletes.
-		// If no associated IDs were passed to the method we will just return 0,
-		// since no associated models will be detatched.
 		$ids = (array) $ids;
 
 		if (count($ids) > 0)
 		{
-			$query = $this->newPivotQuery();
-
 			$query->whereIn($this->otherKey, $ids);
+		}
 
-			return $query->delete();
-		}
-		else
-		{
-			return 0;
-		}
+		return $query->delete();
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -184,18 +184,13 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
+	public function testDetachMethodExpectsArray()
 	{
 		$relation = $this->getRelation();
-		$query = m::mock('stdClass');
-		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
-		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
-		$query->shouldReceive('whereIn')->never();
-		$query->shouldReceive('delete')->once()->andReturn(true);
-		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
-		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+		$notAnArray = 'foobar';
+		$this->expectError(new PatternExpectation("/must be an array/i"));
 
-		$this->assertTrue($relation->detach());
+		$this->assertTrue($relation->detach($notAnArray));
 	}
 
 

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -183,14 +183,14 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($relation->detach(array(1, 2, 3)));
 	}
 
-
+	/**
+	 * @expectedException PHPUnit_Framework_Error
+	 */
 	public function testDetachMethodExpectsArray()
 	{
 		$relation = $this->getRelation();
 		$notAnArray = 'foobar';
-		$this->expectError(new PatternExpectation("/must be an array/i"));
-
-		$this->assertTrue($relation->detach($notAnArray));
+		$relation->detach($notAnArray);
 	}
 
 


### PR DESCRIPTION
Calling the `detach` method without a supplied integer or array results in all attached models being detached.
I don't think this is the intuitive result of calling detach() without an input, and I could see some unintentional deletes being done with this behavior.

The _delete all related models_ feature already exists with the `delete` method, so it's still possible to do when making the `detatch` method more docile.

_Edit: Now with code attached_
