### PR TITLE
Convert to MessageBag when sending an array to withErrors

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -100,7 +100,7 @@ class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectRespons
 		else
 		{
 			$errors = new MessageBag;
-			$errors->merge($provider);
+			$errors->merge((array) $provider);
 			$this->with('errors', $errors);
 		}
 

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -3,6 +3,7 @@
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Support\Contracts\MessageProviderInterface;
+use Illuminate\Support\MessageBag;
 
 class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectResponse {
 
@@ -98,7 +99,9 @@ class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectRespons
 		}
 		else
 		{
-			$this->with('errors', (array) $provider);
+			$errors = new MessageBag;
+			$errors->merge($provider);
+			$this->with('errors', $errors);
 		}
 
 		return $this;

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -71,6 +71,16 @@ class HttpResponseTest extends PHPUnit_Framework_TestCase {
         $response->withErrors($provider);
     }
 
+    public function testRedirectWithErrorsArrayConvertsToMessageBag()
+    {
+        $response = new RedirectResponse('foo.bar');
+        $response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
+        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\MessageBag'));
+        $provider = array('foo' => 'bar');
+        $response->withErrors($provider);
+    }
+
 }
 
 class JsonableStub implements JsonableInterface {


### PR DESCRIPTION
The `withErrors` method of Redirect Responses accepts either an instance of MessageProviderInterface (like Validator) or an array. This is nice since it gives you an easy way to send errors simply as an array.
The problem is that `withErrors` extracts the MessageBag object out of the MessageProviderInterface instance, but when sent an array it just passes it on unchanged.
When `withErrors` isn't in the picture the available `errors` variable in the session is an empty MessageBag.

This creates some problems since you cannot count on what type the `errors` variable is if you want to use the array approach.

That's why I modified `withErrors` to convert any array sent to it to a MessageBag before passing it on to the session.
