### PR TITLE
Can't pass array into flashOnly and flashExcept of the Request class

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -304,9 +304,11 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	 * @param  dynamic  string
 	 * @return void
 	 */
-	public function flashOnly()
+	public function flashOnly($keys)
 	{
-		return $this->flash('only', func_get_args());
+		$keys = is_array($keys) ? $keys : func_get_args();
+		
+		return $this->flash('only', $keys);
 	}
 
 	/**
@@ -315,9 +317,11 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	 * @param  dynamic  string
 	 * @return void
 	 */
-	public function flashExcept()
+	public function flashExcept($keys)
 	{
-		return $this->flash('except', func_get_args());
+		$keys = is_array($keys) ? $keys : func_get_args();
+		
+		return $this->flash('except', $keys);
 	}
 
 	/**


### PR DESCRIPTION
If you pass an array into `flashOnly` or `flashExcept` like in other methods by the time it gets to `only` or `except` we have `[0 => ['email', 'name']]` etc. 
