### PR TITLE
Added support for nesting parenthesis on Blade expressions

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -159,7 +159,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	protected function compileOpenings($value)
 	{
-		$pattern = '/(?<!\w)(\s*)@(if|elseif|foreach|for|while)(\s*\(.*\))/';
+		$pattern = '/(?(R)\((?:[^\(\)]|(?R))*\)|(?<!\w)(\s*)@(if|elseif|foreach|for|while)(\s*(?R)+))/';
 
 		return preg_replace($pattern, '$1<?php $2$3: ?>', $value);
 	}


### PR DESCRIPTION
Currently, a limitation of the Blade engine prevents you from using expressions containing parenthesis as arguments to @if, @elseif, @foreach, @for and @while, **if there is more than one directive on a single line**.

For instance, currently you cannot do this:

``` php
@if ($k==count($admin['navPath'])-1) <a href="#">Some link</a> @endif
```

This patch enables recursive RegEx parsing of Blade argument expressions, therefore allowing the use of nested parenthesis **and multiple directives per text line**.

It's a very small change on a single line of a single file, on the regular expression responsible for compiling directives that have a single argument enclosed in parenthesis. Instead of the parser to just blindly search for the first closing parenthesis, it now takes into account nested parenthesis, using recursive regex matching.

This patch will allow developers to use more complex expressions if they whish (having the choice is good) and, more importantly, **it makes the parser more robust**, preventing some nasty bugs when compiling templates, which may generate invalid PHP code on the cached template, leaving the developer clueless as to the reason causing the problem.

For instance, see Issue #296, which would be solved if Blade allowed parsing nested parenthesis. It took me a while to understand what was causing the PHP syntax errors on the compiled templates (this could happen to other developers too!). That prompted me to investigate the root cause of the problem, which lead to this fix.
