### PR TITLE
[SECURITY] Eloquent: use Model::setAttribute method instead of $this->$key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -162,7 +162,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 			// assignment to the model, and all others will just be ignored.
 			if ($this->isFillable($key))
 			{
-				$this->$key = $value;
+				$this->setAttribute($key, $value);
 			}
 		}
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -581,7 +581,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 		{
 			$keyName = $this->getKeyName();
 
-			$this->$keyName = $query->insertGetId($attributes, $keyName);
+			$this->setAttribute($keyName, $query->insertGetId($attributes, $keyName));
 		}
 
 		// If the table is not incrementing we'll simply insert this attirbutes as they


### PR DESCRIPTION
If you validate your models' attributes in per model method like `User::setUsernameAttribute()`, the validation won't even be done when the `Model::fill()` is called. This could lead to wrongly formatted data being inserted in your DB just fine if you haven't implemented domain checks on your database server.
