### PR TITLE
Adding true randomness to str_random 

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -489,6 +489,25 @@ function str_plural($value, $count = 2)
  */
 function str_random($length = 16)
 {
+	// We'll check if the user has OpenSSL installed with PHP. If they do
+	// we'll use a better method of getting a random string. Otherwise, we'll
+	// fallback to a reasonably reliable method.
+	if (function_exists('openssl_random_pseudo_bytes'))
+	{
+		// We generate twice as many bytes here because we want to ensure we have
+		// enough after we base64 encode it to get the length we need because we
+		// take out the "/", "+", and "=" characters.
+		$bytes = openssl_random_pseudo_bytes($length * 2, $strong);
+
+		// We want to stop execution if the key fails because, well, that is bad.
+		if ($bytes === false)
+		{
+			throw new \RuntimeException('Error generating random string.');
+		}
+
+		return substr(str_replace(array('/', '+', '='), '', base64_encode($bytes)), 0, $length);
+	}
+
 	$pool = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
 	return substr(str_shuffle(str_repeat($pool, 5)), 0, $length); 


### PR DESCRIPTION
If the OpenSSL extension is installed, we'll now use openssl_random_pseudo_bytes to generate a more random string than just shuffling.

Potentially fixes #293, depending on your take on it.
