### PR TITLE
Using the new str_random() helper, keep things DRY.

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -143,11 +143,7 @@ abstract class Store implements TokenProvider, ArrayAccess {
 	 */
 	protected function createSessionID()
 	{
-		$pool = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-
-		$value = substr(str_shuffle(str_repeat($pool, 5)), 0, 40);
-
-		return sha1($value.time());
+		return sha1(str_random(40).time());
 	}
 
 	/**


### PR DESCRIPTION
As the title says, we're creating random strings in `illuminate/support` now. I thought the session class could use this when generating session IDs.

Random strings have been improved in #303 and this issue could fix #293.

Looking forward to feedback.
