### PR TITLE
Adding support for nested form inputs.

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -211,9 +211,9 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function getValue($attribute)
 	{
-		if (array_key_exists($attribute, $this->data))
+		if ($value = array_get($this->data, $attribute))
 		{
-			return $this->data[$attribute];
+			return $value;
 		}
 		elseif (array_key_exists($attribute, $this->files))
 		{
@@ -343,7 +343,7 @@ class Validator implements MessageProviderInterface {
 
 		foreach ($attributes as $key)
 		{
-			if (isset($this->data[$key]) or isset($this->files[$key]))
+			if (array_get($this->data, $key) or isset($this->files[$key]))
 			{
 				$count++;
 			}
@@ -375,8 +375,9 @@ class Validator implements MessageProviderInterface {
 	protected function validateSame($attribute, $value, $parameters)
 	{
 		$other = $parameters[0];
+		$other_value = array_get($this->data, $other);
 
-		return isset($this->data[$other]) and $value == $this->data[$other];
+		return $value == $other_value;
 	}
 
 	/**
@@ -390,8 +391,9 @@ class Validator implements MessageProviderInterface {
 	protected function validateDifferent($attribute, $value, $parameters)
 	{
 		$other = $parameters[0];
+		$other_value = array_get($this->data, $other);
 
-		return isset($this->data[$other]) and $value != $this->data[$other];
+		return $value != $other_value;
 	}
 
 	/**
@@ -531,7 +533,7 @@ class Validator implements MessageProviderInterface {
 	 	// entire length of the string will be considered the attribute size.
 		if (is_numeric($value) and $hasNumeric)
 		{
-			return $this->data[$attribute];
+			return array_get($this->data, $attribute);
 		}
 		elseif ($value instanceof File)
 		{


### PR DESCRIPTION
`nested[form][inputs]` don't seem to be taken into account when validating. This adds support using the `array_get()` function to properly account for nested inputs.
