### PR TITLE
snake_case in setRawAttributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1132,7 +1132,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 	 */
 	public function setRawAttributes(array $attributes, $sync = false)
 	{
-		$this->attributes = $attributes;
+		$this->attributes = array_combine(array_map('snake_case',array_keys($attributes)),$attributes);
 
 		if ($sync) $this->syncOriginal();
 	}


### PR DESCRIPTION
Attributes' keys are snake_cased in setAttributes and in getAttributes. Why not in setRawAttributes ? 
Otherwise, in case they are camelCase in DB, attributes are not accessible.
