### PR TITLE
[Bug] Hard-coded view file extensions take precedence over self-added, more accurately matching extensions.

### DIFF
--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -175,9 +175,14 @@ class Environment {
 	{
 		$extensions = array_keys($this->extensions);
 
-		return array_first($extensions, function($key, $value) use ($path)
+		return array_reduce($extensions, function($match, $candidate) use ($path)
 		{
-			return ends_with($path, $value);
+			if (strlen($match) < strlen($candidate))
+			{
+				$match = ends_with($path, '.'.$candidate) ? $candidate : $match;
+			}
+
+			return $match;
 		});
 	}
 
@@ -230,7 +235,7 @@ class Environment {
 		elseif (is_string($callback))
 		{
 			return $this->addClassComposer($view, $callback);
-		}		
+		}
 	}
 
 	/**

--- a/tests/View/ViewEnvironmentTest.php
+++ b/tests/View/ViewEnvironmentTest.php
@@ -23,6 +23,28 @@ class ViewEnvironmentTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($engine === $view->getEngine());
 	}
 
+	public function testEnvironmentReturnsLongestMatchingExtensionForGivenPath()
+	{
+		$extensions = array(
+			'blade.php' => 'blade',
+			'php'       => 'php',
+			'twig.php'  => 'twig',
+		);
+
+		$env = $this->getEnvironment();
+		$env->getFinder()->shouldReceive('find')->once()->with('view')->andReturn('path.twig.php');
+		$env->getEngineResolver()->shouldReceive('resolve')->once()->with('twig')->andReturn($engine = m::mock('Illuminate\View\Engines\EngineInterface'));
+		$env->getFinder()->shouldReceive('addExtension')->times(count($extensions))->with('/(php|blade|twig)$/');
+
+		foreach ($extensions as $ext => $eng)
+		{
+			$env->addExtension($ext, $eng);
+		}
+
+		$view = $env->make('view', array('data'));
+
+		$this->assertTrue($engine === $view->getEngine());
+	}
 
 	public function testRenderEachCreatesViewForEachItemInArray()
 	{
@@ -151,7 +173,7 @@ class ViewEnvironmentTest extends PHPUnit_Framework_TestCase {
 		$environment->startSection('foo');
 		echo 'there';
 		$environment->stopSection();
-		$this->assertEquals('hi there', $environment->yieldContent('foo'));	
+		$this->assertEquals('hi there', $environment->yieldContent('foo'));
 	}
 
 


### PR DESCRIPTION
The `Environment::getExtension($path)` method has a strong bias towards the two hard-coded extensions. In fact, the way the above method resolves the "correct" extension makes it impossible for me to associate view file extensions ending in `php` with a third party engine like Twig, Smarty etc.

Quick example:

```
// Suppose we have a view file named `hello.twig.php` under our main
// views directory that's ment to be consumed by the Twig templating
// engine. Further suppose we properly added the engine by means
// of a EngineServiceProvider and set it up correctly.

$env->addExtension('twig.php', 'twig');

// Current status of Environment::$extensions
dump($env): {
    protected $extensions =>
    array(3) {
        'blade.php' => string(5) "blade"
        'php' => string(3) "php"
        'tiwg.php' => string(4) "twig"
    }
}

// The call to Environment::getEngineFromPath('home.twig.php') wrongly
// returns the `php` engine instead
$env->make('home', $data);
```

With the fix itself I've included a test in `ViewEnvironmentTest.php` that proofs the issue.
