### PR TITLE
[Bug] Http\Request::has($key) does not return TRUE for empty values

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -148,7 +148,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 			return true;
 		}
 
-		return trim((string) $this->input($key)) !== '';
+		return null !== $this->input($key);
 	}
 
 	/**


### PR DESCRIPTION
This line is problematic.

I wanna be able to append `?debug` to any URL, in my dev environment to enable debugging tools and features (like form novalidate).

But `Input::has` returns false for empty values, which is not correct.
