### PR TITLE
Allow any implementation of ArrayableInterface be passed to views. Fixes #362

### DIFF
--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -98,10 +98,10 @@ class Environment {
 	 * Get a evaluated view contents for the given view.
 	 *
 	 * @param  string  $view
-	 * @param  array   $data
+	 * @param  mixed   $data
 	 * @return Illuminate\View\View
 	 */
-	public function make($view, array $data = array())
+	public function make($view, $data = array())
 	{
 		$path = $this->finder->find($view);
 
@@ -230,7 +230,7 @@ class Environment {
 		elseif (is_string($callback))
 		{
 			return $this->addClassComposer($view, $callback);
-		}		
+		}
 	}
 
 	/**

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -3,6 +3,7 @@
 use ArrayAccess;
 use Illuminate\View\Engines\EngineInterface;
 use Illuminate\Support\Contracts\RenderableInterface as Renderable;
+use Illuminate\Support\Contracts\ArrayableInterface as Arrayable;
 
 class View implements ArrayAccess, Renderable {
 
@@ -51,11 +52,23 @@ class View implements ArrayAccess, Renderable {
 	 * @param  array   $data
 	 * @return void
 	 */
-	public function __construct(Environment $environment, EngineInterface $engine, $view, $path, array $data = array())
+	public function __construct(Environment $environment, EngineInterface $engine, $view, $path, $data = array())
 	{
+		if (is_array($data))
+		{
+			$this->data = $data;
+		}
+		elseif ($data instanceof Arrayable)
+		{
+			$this->data = $data->toArray();
+		}
+		else
+		{
+			throw new \InvalidArgumentException('Invalid data type '.gettype($data).' for view.');
+		}
+
 		$this->view = $view;
 		$this->path = $path;
-		$this->data = $data;
 		$this->engine = $engine;
 		$this->environment = $environment;
 	}
@@ -135,7 +148,7 @@ class View implements ArrayAccess, Renderable {
 		{
 			$this->data[$key] = $value;
 		}
-		
+
 		return $this;
 	}
 

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\View\View;
+use Illuminate\Support\Contracts\ArrayableInterface;
 
 class ViewTest extends PHPUnit_Framework_TestCase {
 
@@ -60,6 +61,21 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testViewAcceptsArrayableImplementations()
+	{
+		$view = new View(
+			m::mock('Illuminate\View\Environment'),
+			m::mock('Illuminate\View\Engines\EngineInterface'),
+			'view',
+			'path',
+			new ArrayablePayloadStub
+		);
+
+		$this->assertEquals('bar', $view->foo);
+		$this->assertEquals(array('qux', 'corge'), $view->baz);
+	}
+
+
 	protected function getView()
 	{
 		return new View(
@@ -69,6 +85,15 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 			'path',
 			array('foo' => 'bar')
 		);
+	}
+
+}
+
+class ArrayablePayloadStub implements ArrayableInterface {
+
+	public function toArray()
+	{
+		return array('foo' => 'bar', 'baz' => array('qux', 'corge'));
 	}
 
 }


### PR DESCRIPTION
As described in #362, any Arrayable implementation should be allowed to be passed to a view. Done and tested.

Signed-off-by: Ben Corlett bencorlett@me.com
