### PR TITLE
Bulk setting for redirectors with() method

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -30,6 +30,16 @@ class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectRespons
 	 */
 	public function with($key, $value)
 	{
+		if (is_array($key))
+		{
+			foreach ($key AS $k => $value)
+			{
+				$this->with($k, $value);
+			}
+			
+			return $this;
+		}
+		
 		$this->session->flash($key, $value);
 
 		return $this;


### PR DESCRIPTION
Just add support for arrays sent to `RedirectResponse::with`... I find this..

``` php
return Redirect::to('somewhere')->with(['one' => 'message here', 'two' => 'message']);
```

much cleaner. 

Also this makes it easier if you are creating what to send with the redirect before actually calling it.
