### PR TITLE
[Proposal] Allow resource routing directly to the resource instead of .index

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -305,9 +305,11 @@ class Router {
 	 */
 	protected function addResourceIndex($name, $base, $controller)
 	{
-		$action = $this->getResourceAction($name, $controller, 'index');
-
-		return $this->get($this->getResourceUri($name), $action);
+		$uri = $this->getResourceUri($name);
+		
+		$this->get($uri, $this->getResourceAction($name, $controller, ''));
+		
+		return $this->get($uri, $this->getResourceAction($name, $controller, 'index'));
 	}
 
 	/**
@@ -467,7 +469,16 @@ class Router {
 	 */
 	protected function getResourceAction($resource, $controller, $method)
 	{
-		return array('as' => $resource.'.'.$method, 'uses' => $controller.'@'.$method);
+		if ($method)
+		{
+			$resource .= '.'.$method;
+		}
+		else
+		{
+			$method = 'index';
+		}
+		
+		return array('as' => $resource, 'uses' => $controller.'@'.$method);
 	}
 
 	/**

--- a/tests/Routing/RoutingTest.php
+++ b/tests/Routing/RoutingTest.php
@@ -121,7 +121,7 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 		$router = new Router;
 		$router->resource('foo.bar', 'FooController');
 
-		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo.bar'))
+		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo.bar'));
 		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo.bar.index'));
 		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo.bar.show'));
 		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo.bar.create'));

--- a/tests/Routing/RoutingTest.php
+++ b/tests/Routing/RoutingTest.php
@@ -109,6 +109,7 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 		$router = new Router;
 		$router->resource('foo', 'FooController');
 
+		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo'));
 		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo.index'));
 		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo.show'));
 		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo.create'));
@@ -120,6 +121,7 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 		$router = new Router;
 		$router->resource('foo.bar', 'FooController');
 
+		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo.bar'))
 		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo.bar.index'));
 		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo.bar.show'));
 		$this->assertInstanceOf('Illuminate\Routing\Route', $router->getRoutes()->get('foo.bar.create'));
@@ -135,6 +137,7 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 		$router = new Router;
 		$router->resource('foo.bar', 'FooController');
 
+		$this->assertEquals('/foo/{foo}/bar', $router->getRoutes()->get('foo.bar')->getPath());
 		$this->assertEquals('/foo/{foo}/bar', $router->getRoutes()->get('foo.bar.index')->getPath());
 		$this->assertEquals('/foo/{foo}/bar/{bar}', $router->getRoutes()->get('foo.bar.show')->getPath());
 		$this->assertEquals('/foo/{foo}/bar/create', $router->getRoutes()->get('foo.bar.create')->getPath());

--- a/tests/Routing/RoutingTest.php
+++ b/tests/Routing/RoutingTest.php
@@ -88,7 +88,7 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 		$router->resource('foo', 'FooController');
 		$routes = $router->getRoutes();
 
-		$this->assertEquals(8, count($routes));
+		$this->assertEquals(9, count($routes));
 
 		$router = new Router;
 		$router->resource('foo', 'FooController', array('only' => array('show', 'destroy')));
@@ -100,7 +100,7 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 		$router->resource('foo', 'FooController', array('except' => array('show', 'destroy')));
 		$routes = $router->getRoutes();
 
-		$this->assertEquals(6, count($routes));
+		$this->assertEquals(7, count($routes));
 	}
 
 


### PR DESCRIPTION
I expected `URL::route('resource')` to work but turns out I needed `URL::route('resource.index')`. This change adds the ability to do the first one as well. 

You will probably have a better way to do it if you add it though, the way I did feels messy.
