### PR TITLE
Make Input::json() more logical

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -386,7 +386,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	 *
 	 * @param  string  $key
 	 * @param  mixed   $default
-	 * @return string
+	 * @return mixed
 	 */
 	public function json($key = null, $default = null)
 	{

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -392,9 +392,10 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 			return $default;
 		}
 		
+		static $json;
+
 		if ( ! isset($json))
 		{
-			static $json;
 			$json = json_decode($this->getContent(), true);
 		}
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -379,15 +379,21 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	/**
 	 * Get the JSON payload for the request.
 	 *
-	 * @return object
+	 * @param  string  $key
+	 * @param  mixed   $default
+	 * @return string
 	 */
-	public function json()
+	public function json($key = null, $default = null)
 	{
-		$arguments = func_get_args();
+		$mime = $this->retrieveItem('server', 'CONTENT_TYPE', null);
 
-		array_unshift($arguments, $this->getContent());
+		if (strpos($mime, '/json') === false) {
+			return $default;
+		}
+		
+		$json = json_decode($this->getContent(), true);
 
-		return call_user_func_array('json_decode', $arguments);
+		return array_get($json, $key, $default);
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -392,12 +392,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 			return $default;
 		}
 		
-		static $json;
-
-		if ( ! isset($json))
-		{
-			$json = json_decode($this->getContent(), true);
-		}
+		$json = json_decode($this->getContent(), true);
 
 		return array_get($json, $key, $default);
 	}

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -387,11 +387,16 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	{
 		$mime = $this->retrieveItem('server', 'CONTENT_TYPE', null);
 
-		if (strpos($mime, '/json') === false) {
+		if (strpos($mime, '/json') === false)
+		{
 			return $default;
 		}
 		
-		$json = json_decode($this->getContent(), true);
+		if ( ! isset($json))
+		{
+			static $json;
+			$json = json_decode($this->getContent(), true);
+		}
 
 		return array_get($json, $key, $default);
 	}

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -203,7 +203,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	public function testJSONMethod()
 	{
 		$payload = array('name' => 'taylor');
-		$request = Request::create('/', 'GET', array(), array(), array(), array(), json_encode($payload));
+		$request = Request::create('/', 'GET', array(), array(), array(), array('CONTENT_TYPE' => 'application/json'), json_encode($payload));
 		
 		$name = $request->json('name');
 		$this->assertEquals('taylor', $name);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -204,10 +204,8 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	{
 		$payload = array('name' => 'taylor');
 		$request = Request::create('/', 'GET', array(), array(), array(), array('CONTENT_TYPE' => 'application/json'), json_encode($payload));
-		
 		$name = $request->json('name');
 		$this->assertEquals('taylor', $name);
-
 		$data = $request->json();
 		$this->assertEquals($payload, $data);
 	}

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -202,9 +202,14 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 
 	public function testJSONMethod()
 	{
-		$request = Request::create('/', 'GET', array(), array(), array(), array(), json_encode(array('taylor' => 'name')));
-		$json = $request->json();
-		$this->assertEquals('name', $json->taylor);
+		$payload = array('name' => 'taylor');
+		$request = Request::create('/', 'GET', array(), array(), array(), array(), json_encode($payload));
+		
+		$name = $request->json('name');
+		$this->assertEquals('taylor', $name);
+
+		$data = $request->json();
+		$this->assertEquals($payload, $data);
 	}
 
 


### PR DESCRIPTION
Now you can send JSON payloads as an actual body in a PUT or POST request, instead of only decoding a specific POST param, or whatever it was doing before.

Also, if a non-JSON mime-type is sent it will refuse to try and parse the data, instead only returning the default value. This to me seems like a much more logical usage of Input::json() than the initial implementation.
