### PR TITLE
Namespaced Controller Routing Bug

### DIFF
--- a/src/Illuminate/Routing/Controllers/Inspector.php
+++ b/src/Illuminate/Routing/Controllers/Inspector.php
@@ -33,7 +33,7 @@ class Inspector {
 		// is a publicly routable method. If so, we will add it to this listings.
 		foreach ($reflection->getMethods() as $method)
 		{
-			if ($this->isRoutable($method, $controller))
+			if ($this->isRoutable($method, $reflection->name))
 			{
 				$data = $this->getMethodData($method, $prefix);
 

--- a/tests/Routing/RoutingControllerInspectorTest.php
+++ b/tests/Routing/RoutingControllerInspectorTest.php
@@ -5,6 +5,18 @@ class RoutingControllerInspectorTest extends PHPUnit_Framework_TestCase {
 	public function testMethodsAreCorrectlyDetermined()
 	{
 		$inspector = new Illuminate\Routing\Controllers\Inspector;
+		$data = $inspector->getRoutable('RoutingControllerInspectorStub', 'prefix');
+
+		$this->assertEquals(3, count($data));
+		$this->assertEquals(array('verb' => 'get', 'plain' => 'prefix', 'uri' => 'prefix'), $data['getIndex'][0]);
+		$this->assertEquals(array('verb' => 'get', 'plain' => 'prefix/index', 'uri' => 'prefix/index/{v1?}/{v2?}/{v3?}/{v4?}/{v5?}'), $data['getIndex'][1]);
+		$this->assertEquals(array('verb' => 'get', 'plain' => 'prefix/foo-bar', 'uri' => 'prefix/foo-bar/{v1?}/{v2?}/{v3?}/{v4?}/{v5?}'), $data['getFooBar'][0]);
+		$this->assertEquals(array('verb' => 'post', 'plain' => 'prefix/baz', 'uri' => 'prefix/baz/{v1?}/{v2?}/{v3?}/{v4?}/{v5?}'), $data['postBaz'][0]);
+	}
+
+	public function testMethodsAreCorrectWhenControllerIsNamespaced()
+	{
+		$inspector = new Illuminate\Routing\Controllers\Inspector;
 		$data = $inspector->getRoutable('\\RoutingControllerInspectorStub', 'prefix');
 
 		$this->assertEquals(3, count($data));

--- a/tests/Routing/RoutingControllerInspectorTest.php
+++ b/tests/Routing/RoutingControllerInspectorTest.php
@@ -5,7 +5,7 @@ class RoutingControllerInspectorTest extends PHPUnit_Framework_TestCase {
 	public function testMethodsAreCorrectlyDetermined()
 	{
 		$inspector = new Illuminate\Routing\Controllers\Inspector;
-		$data = $inspector->getRoutable('RoutingControllerInspectorStub', 'prefix');
+		$data = $inspector->getRoutable('\\RoutingControllerInspectorStub', 'prefix');
 
 		$this->assertEquals(3, count($data));
 		$this->assertEquals(array('verb' => 'get', 'plain' => 'prefix', 'uri' => 'prefix'), $data['getIndex'][0]);


### PR DESCRIPTION
If you use a RESTful controller call (`Route::controller()`) in your routes, things break if your controller call starts with a leading `\`.  If you do this, all traffic to this route will fall through to the controller's `missingMethod`.

The failure happens in the `isRoutable()` method of the Inspector; the ReflectionClass automatically strips the leading backslash, while the passed controller name includes the leading backslash. This causes the two class names to be seen as not equal (though they are the same) which causes the inspector to see all methods (i.e., `getIndex()`) as inherited.

So what I did here: 
1. I caused the unit test to fail by adding a leading backslash to the class name in the `getRoutable()` call. 
2. I fixed it by taking the controller's class name _from the reflector_, so it is handled the same as the method's class name.

This means both names will have leading backslashes auto-stripped, so the comparison operation doesn't need to account for the possibility of leading slashes.
