### PR TITLE
[Proposal] Fetch session manager from application container.

### DIFF
--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -21,12 +21,17 @@ class SessionServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
+		$this->app['session.manager'] = $this->app->share(function($app)
+		{
+			return new SessionManager($app);
+		});
+
 		$this->app['session'] = $this->app->share(function($app)
 		{
 			// First, we will create the session manager which is responsible for the
 			// creation of the various session drivers when they are needed by the
 			// application instance, and will resolve them on a lazy load basis.
-			$manager = new SessionManager($app);
+			$manager = $app['session.manager'];
 
 			$driver = $manager->driver();
 


### PR DESCRIPTION
Registering the `SessionManager` with the application container would allow developers to easily change the drivers or provide their own `SessionManager` implementation altogether.

My use case for this proposal is an App on Facebook. It needs some sort of persistent state but cannot rely on cookies being set/send back because of some major browsers' default policy on third-party cookies.

I would like to rely on the framework's various cache store implementations (e.g. `apc`, `memcached`) but need to provide a modified `CacheDrivenStore` driver which isn't possible as it is a **hard-coded dependency** in the current `SessionManager`.

With the proposed changes I'd be able to do something along the lines of:

```
// class CustomServiceProvider
function register()
{
    $manager = $this->app['session.manager'];
    $manager->extend('apc', function($app)
    {
        // Return a custom cache driven session driver
        return new CustomCacheDrivenStore($this->app['cache']->driver($driver));
    });
}
```
