### PR TITLE
Fix nested group prefixes.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -510,8 +510,16 @@ class Router {
 		if (count($this->groupStack) > 0)
 		{
 			$last = count($this->groupStack) - 1;
+			$newStack = array_merge_recursive($this->groupStack[$last], $attributes);
 
-			$this->groupStack[] = array_merge_recursive($this->groupStack[$last], $attributes);
+			if (isset($attributes['prefix']))
+			{
+				$oldPrefix = array_get($this->groupStack[$last], 'prefix', '');
+				$newPrefix = array_get($attributes, 'prefix', '');
+				$newStack['prefix'] = trim($oldPrefix.'/'.$newPrefix, '/');	
+			}
+			
+			$this->groupStack[] = $newStack;
 		}
 		else
 		{

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -512,11 +512,10 @@ class Router {
 			$last = count($this->groupStack) - 1;
 			$newStack = array_merge_recursive($this->groupStack[$last], $attributes);
 
-			if (isset($attributes['prefix']))
+			// Prefixes need to be concatenated, not merged into one array
+			if (isset($newStack['prefix']))
 			{
-				$oldPrefix = array_get($this->groupStack[$last], 'prefix', '');
-				$newPrefix = array_get($attributes, 'prefix', '');
-				$newStack['prefix'] = trim($oldPrefix.'/'.$newPrefix, '/');	
+				$newStack['prefix'] = trim(implode('/', (array) $newStack['prefix']), '/');	
 			}
 			
 			$this->groupStack[] = $newStack;


### PR DESCRIPTION
If you nested two groups that both had prefixes, I got a PHP error because the use of `array_merge_recursive` was causing the prefix to be turned into an array instead of concatenated. Fixed that here.

There's probably a simpler way - suggestions anybody?
