### PR TITLE
Fixed Request::has() from throwing error if data checking is an array

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -148,7 +148,14 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 			return true;
 		}
 
-		return trim((string) $this->input($key)) !== '';
+		if (!is_array($this->input($key)))
+		{
+			return trim((string) $this->input($key)) !== '';
+		}
+		else
+		{
+			return true;
+		}
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -148,14 +148,12 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 			return true;
 		}
 
-		if (!is_array($this->input($key)))
-		{
-			return trim((string) $this->input($key)) !== '';
-		}
-		else
+		if (is_array($this->input($key)))
 		{
 			return true;
 		}
+
+		return trim((string) $this->input($key)) !== '';
 	}
 
 	/**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -83,6 +83,10 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$request = Request::create('/', 'GET', array('name' => 'Taylor', 'email' => 'foo'));
 		$this->assertTrue($request->has('name'));
 		$this->assertTrue($request->has('name', 'email'));
+
+		//test arrays within query string
+		$request = Request::create('/', 'GET', array('foo' => array('bar', 'baz')));
+		$this->assertTrue($request->has('foo'));
 	}
 
 


### PR DESCRIPTION
Fixing bug where Request::has() would throw error because of trying to use trim if the data type was an array
