### PR TITLE
Made page parameter changeable in Pagination class

### DIFF
--- a/src/Illuminate/Pagination/Environment.php
+++ b/src/Illuminate/Pagination/Environment.php
@@ -40,6 +40,13 @@ class Environment {
 	 * @var int
 	 */
 	protected $currentPage;
+	
+	/**
+	 * The name of the page parameter
+	 *
+	 * @var string
+	 */
+	protected $pageParam = 'page';
 
 	/**
 	 * The locale to be used by the translator.
@@ -116,7 +123,7 @@ class Environment {
 	 */
 	public function getCurrentPage()
 	{
-		return $this->currentPage ?: $this->request->query->get('page', 1);
+		return $this->currentPage ?: $this->request->query->get($this->pageParam, 1);
 	}
 	
 	/**
@@ -244,5 +251,26 @@ class Environment {
 	{
 		return $this->trans;
 	}
-
+	
+	/**
+	 * Get the current name of the page parameter for the environment.
+	 *
+	 * @return string
+	 */
+	public function getPageParam()
+	{
+		return $this->pageParam;
+	}
+	
+	/*
+	 * Set the name of the page parameter for the environment.
+	 *
+	 * @param string $name
+	 * @return void
+	 */
+	public function setPageParam($name)
+	{
+		$this->pageParam = $name;
+	}
+	
 }

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -48,6 +48,13 @@ class Paginator implements ArrayAccess, Countable, IteratorAggregate {
 	 * @return int
 	 */
 	protected $lastPage;
+	
+	/**
+	 * The name of the page parameter
+	 *
+	 * @var string
+	 */
+	protected $pageParam;
 
 	/**
 	 * All of the additional query string values.
@@ -83,6 +90,8 @@ class Paginator implements ArrayAccess, Countable, IteratorAggregate {
 		$this->lastPage = ceil($this->total / $this->perPage);
 
 		$this->currentPage = $this->calculateCurrentPage($this->lastPage);
+		
+		$this->pageParam = $this->env->getPageParam();
 
 		return $this;
 	}
@@ -137,7 +146,7 @@ class Paginator implements ArrayAccess, Countable, IteratorAggregate {
 	 */
 	public function getUrl($page)
 	{
-		$url = $this->env->getCurrentUrl().'?page='.$page;
+		$url = $this->env->getCurrentUrl().'?'.$this->pageParam.'='.$page;
 
 		// If we have any extra query string key / value pairs that need to be added
 		// onto the URL, we will put them in query string form and then attach it
@@ -214,6 +223,16 @@ class Paginator implements ArrayAccess, Countable, IteratorAggregate {
 	public function getTotal()
 	{
 		return $this->total;
+	}
+	
+	/**
+	 * Get the name of the page parameter for this instance.
+	 *
+	 * @return string
+	 */
+	public function getPageParam()
+	{
+		return $this->pageParam;
 	}
 
 	/**


### PR DESCRIPTION
The pagination page get parameter can now be changed in the environment,
which will set it for all subsequently created instances of the
paginator.

This is probably not the best way of doing it, but it is the best way that I could think of without making major changes to the structure of the Pagination package.

Allows you set it like so:

``` php
Paginator::setPageParam('foo');
$p = DB::table('sometable')->paginate(); // pagination instance has page parameter set as 'foo'
```
