### PR TITLE
Extend Str::slug for better result consistency

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -181,6 +181,10 @@ class Str {
 		// Remove all characters that are not the separator, letters, numbers, or whitespace.
 		$title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', mb_strtolower($title));
 
+		// Convert all dashes/undescores into separator
+		$flip = ($separator == '-' ? '_' : '-');
+		$title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
+
 		// Replace all separator characters and whitespace by a single separator
 		$title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -182,7 +182,8 @@ class Str {
 		$title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', mb_strtolower($title));
 
 		// Convert all dashes/undescores into separator
-		$flip = ($separator == '-' ? '_' : '-');
+		$flip = $separator == '-' ? '_' : '-';
+
 		$title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
 
 		// Replace all separator characters and whitespace by a single separator


### PR DESCRIPTION
Make Str::slug method return more consistent result when input string contains `separator`-like characters.

Original code:

``` php
\\ returns 'this-is-myblogpost'
Str::slug('This is my_blog_post!')
```

After PQ:

``` php
\\ returns 'this-is-my-blog-post'
Str::slug('This is my_blog_post!')
```

Alternative code without extra `preg_replace`, but with less readability:

``` php
$title = static::ascii($title);

$flip = ($separator == '-' ? '_' : '-');

// Remove all characters that are not the separator, letters, numbers, or whitespace.
$title = preg_replace('![^'.preg_quote($separator).preg_quote($flip).'\pL\pN\s]+!u', '', mb_strtolower($title));

// Replace all separator characters and whitespace by a single separator
$title = preg_replace('!['.preg_quote($separator).preg_quote($flip).'\s]+!u', $separator, $title);

return trim($title, $separator);

```
