### PR TITLE
Fixes where('column', null) generating incorrect sql in query builder.

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -263,8 +263,6 @@ class Builder {
 			return $this->whereSub($column, $operator, $value, $boolean);
 		}
 
-        // If the value is null we switch to calling whereNull to deal with the proper
-        // operators otherwise where column = null is produced which is not valid SQL
         if (is_null($value))
         {
             return $this->whereNull($column, $boolean);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -263,6 +263,13 @@ class Builder {
 			return $this->whereSub($column, $operator, $value, $boolean);
 		}
 
+        // If the value is null we switch to calling whereNull to deal with the proper
+        // operators otherwise where column = null is produced which is not valid SQL
+        if (is_null($value))
+        {
+            return $this->whereNull($column, $boolean);
+        }
+
 		// Now that we are working with just a simple query we can put the elements
 		// in our array and add the query binding to our array of bindings that
 		// will be bound to each SQL statements when it is finally executed.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -263,10 +263,10 @@ class Builder {
 			return $this->whereSub($column, $operator, $value, $boolean);
 		}
 
-        if (is_null($value))
-        {
-            return $this->whereNull($column, $boolean);
-        }
+		if (is_null($value))
+		{
+			return $this->whereNull($column, $boolean);
+		}
 
 		// Now that we are working with just a simple query we can put the elements
 		// in our array and add the query binding to our array of bindings that

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -583,6 +583,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testProvidingNullOrFalseAsSecondParameterBuildsCorrectly()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->where('foo', null);
+		$this->assertEquals('select * from "users" where "foo" is null', $builder->toSql());
+	}
+
+
 	protected function getBuilder()
 	{
 		$grammar = new Illuminate\Database\Query\Grammars\Grammar;


### PR DESCRIPTION
Let's say you want to filter your users, based on a column that is either a string value, or `null` and you only want users where their `status` column is `1`

Currently you would need to do 

```
$users = User::where('status', 1); 

if(is_null($status))
{
    $users = $users->whereNull('column')->get();
} 
else 
{
    $users = $users->where('column', $value)->get();
}
```

This pull would allow you to do 

```
$users = User::where('status', 1)->where('column', $value)->get();
```

And have it generate the correct SQL (`WHERE column IS null`),

presently if `$value` was `null` it would generate `WHERE column = null` which is not valid sql.
