### PR TITLE
Using array_set() in Session::flash() for consistency.

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -296,7 +296,7 @@ abstract class Store implements TokenProvider, ArrayAccess {
 	 */
 	public function flash($key, $value)
 	{
-		$this->session['data'][':new:'][$key] = $value;
+		array_set($this->session['data'][':new:'], $key, $value);
 	}
 
 	/**

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -238,6 +238,9 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 		$store->forget('foo.bat');
 		$this->assertEquals(array('bar' => 'baz'), $store->get('foo'));
 		$this->assertFalse($store->has('foo.bat'));
+		$store->flash('flash.foo', 'bar');
+		$this->assertEquals(array('foo' => 'bar'), $store->get('flash'));
+		$store->forget('flash');
 	}
 
 


### PR DESCRIPTION
I refer to my earlier pull request, #251. I missed using `array_set` on one of the methods, `Session::flash`, as pointed out in #403.

Resolved. Vòila.

Signed-off-by: Ben Corlett bencorlett@me.com
