### PR TITLE
Casting "insertGetId" as an integer where appropriate. Fixes #377.

### DIFF
--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -29,7 +29,17 @@ class Processor {
 	{
 		$query->getConnection()->insert($sql, $values);
 
-		return $query->getConnection()->getPdo()->lastInsertId($sequence);
+		// If the table has an incrementing primary key, we will
+		// receive the ID back as the next incremental value of
+		// the primary key. However, sometimes we won't have
+		// incrementing primary keys, in which case casting as
+		// an ID would return 0.
+		if (is_numeric($id = $query->getConnection()->getPdo()->lastInsertId($sequence)))
+		{
+			return (int) $id;
+		}
+
+		return $id;
 	}
 
 }

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -13,7 +13,7 @@ class DatabaseProcessorTest extends PHPUnit_Framework_TestCase {
 	public function testInsertGetIdProcessing()
 	{
 		$pdo = $this->getMock('ProcessorTestPDOStub');
-		$pdo->expects($this->once())->method('lastInsertId')->with($this->equalTo('id'))->will($this->returnValue(1));
+		$pdo->expects($this->once())->method('lastInsertId')->with($this->equalTo('id'))->will($this->returnValue('1'));
 		$connection = m::mock('Illuminate\Database\Connection');
 		$connection->shouldReceive('insert')->once()->with('sql', array('foo'));
 		$connection->shouldReceive('getPdo')->once()->andReturn($pdo);
@@ -21,7 +21,7 @@ class DatabaseProcessorTest extends PHPUnit_Framework_TestCase {
 		$builder->shouldReceive('getConnection')->andReturn($connection);
 		$processor = new Illuminate\Database\Query\Processors\Processor;
 		$result = $processor->processInsertGetId($builder, 'sql', array('foo'), 'id');
-		$this->assertEquals(1, $result);
+		$this->assertSame(1, $result);
 	}
 
 }


### PR DESCRIPTION
As #377 says, it would be nice to get integers back for new IDs from `insertGetId`.
#### Disclaimer

PDO (currently, at least) will return `null` for when you call `lastInsertId` on tables without an incrementing primary key. This has been taken into account with the latest fix and only casts numeric results as integers.

Signed-off-by: Ben Corlett bencorlett@me.com
