### PR TITLE
Adding ability to guess namespaced model table names. (#389).

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -503,7 +503,7 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 			$name = get_called_class();
 
 			static::$dispatcher->listen("eloquent.{$event}: {$name}", $callback);
-		}	
+		}
 	}
 
 	/**
@@ -708,7 +708,9 @@ abstract class Model implements ArrayableInterface, JsonableInterface {
 	 */
 	public function getTable()
 	{
-		return $this->table ?: snake_case(str_plural(get_class($this)));
+		if (isset($this->table)) return $this->table;
+
+		return str_replace('\\', '', snake_case(str_plural(get_class($this))));
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -451,6 +451,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	{
 		$model = new EloquentModelWithoutTableStub;
 		$this->assertEquals('eloquent_model_without_table_stubs', $model->getTable());
+
+		require_once __DIR__.'/stubs/EloquentModelNamespacedStub.php';
+		$namespacedModel = new Foo\Bar\EloquentModelNamespacedStub;
+		$this->assertEquals('foo_bar_eloquent_model_namespaced_stubs', $namespacedModel->getTable());
 	}
 
 

--- a/tests/Database/stubs/EloquentModelNamespacedStub.php
+++ b/tests/Database/stubs/EloquentModelNamespacedStub.php
@@ -1,0 +1,7 @@
+<?php namespace Foo\Bar;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelNamespacedStub extends Model {
+
+}


### PR DESCRIPTION
Previously, Eloquent would guess the table name for a model `Foo\Bar\Bat` as `foo\_bar\_bats`. Now, it's fixed.

Signed-off-by: Ben Corlett bencorlett@me.com
