### PR TITLE
Allowing method inheritance with controller inspectors. Fixes #312.

### DIFF
--- a/src/Illuminate/Routing/Controllers/Inspector.php
+++ b/src/Illuminate/Routing/Controllers/Inspector.php
@@ -11,7 +11,7 @@ class Inspector {
 	 * @var array
 	 */
 	protected $verbs = array(
-		'any', 'get', 'post', 'put', 
+		'any', 'get', 'post', 'put',
 		'delete', 'head', 'options'
 	);
 
@@ -69,8 +69,6 @@ class Inspector {
 	 */
 	public function isRoutable(ReflectionMethod $method, $controller)
 	{
-		if ($method->class != $controller) return false;
-
 		return $method->isPublic() and starts_with($method->name, $this->verbs);
 	}
 

--- a/tests/Routing/RoutingControllerInspectorTest.php
+++ b/tests/Routing/RoutingControllerInspectorTest.php
@@ -7,11 +7,12 @@ class RoutingControllerInspectorTest extends PHPUnit_Framework_TestCase {
 		$inspector = new Illuminate\Routing\Controllers\Inspector;
 		$data = $inspector->getRoutable('RoutingControllerInspectorStub', 'prefix');
 
-		$this->assertEquals(3, count($data));
+		$this->assertEquals(4, count($data));
 		$this->assertEquals(array('verb' => 'get', 'plain' => 'prefix', 'uri' => 'prefix'), $data['getIndex'][0]);
 		$this->assertEquals(array('verb' => 'get', 'plain' => 'prefix/index', 'uri' => 'prefix/index/{v1?}/{v2?}/{v3?}/{v4?}/{v5?}'), $data['getIndex'][1]);
 		$this->assertEquals(array('verb' => 'get', 'plain' => 'prefix/foo-bar', 'uri' => 'prefix/foo-bar/{v1?}/{v2?}/{v3?}/{v4?}/{v5?}'), $data['getFooBar'][0]);
 		$this->assertEquals(array('verb' => 'post', 'plain' => 'prefix/baz', 'uri' => 'prefix/baz/{v1?}/{v2?}/{v3?}/{v4?}/{v5?}'), $data['postBaz'][0]);
+		$this->assertEquals(array('verb' => 'get', 'plain' => 'prefix/breeze', 'uri' => 'prefix/breeze/{v1?}/{v2?}/{v3?}/{v4?}/{v5?}'), $data['getBreeze'][0]);
 	}
 
 }


### PR DESCRIPTION
As @wlionGit said, "The methods are already guaranteed to be public and start with an allowable verb".

It doesn't make sense to restrict to no-inheritence of methods inspected. I can see where you may use it if methods were not prefixed with the HTTP verbs, but nobody is going to make a public method prefixed with a HTTP verb on a controller and dynamically create implicit routes to it, are they?!

Signed-off-by: Ben Corlett bencorlett@me.com
