### PR TITLE
[Bug Fix] Wrapped public path with quotes to protect spaces

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -36,7 +36,7 @@ class ServeCommand extends Command {
 
 		$this->info("Laravel development server started on {$host}:{$port}...");
 
-		passthru("php -S {$host}:{$port} -t {$public} server.php");
+		passthru("php -S {$host}:{$port} -t \"{$public}\" server.php");
 	}
 
 	/**


### PR DESCRIPTION
When using "artisan serve" on a system with spaces in the public path, e.g. C:\Program Files\Webroot\public or /Volumes/FreeAgent Drive/Web/public, PHP's built-in server will fail due to the spaces in the path name. To resolve this, you must wrap the path in double-quotes.
