### PR TITLE
[BugFix] eager loading should also use snake_case

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1236,7 +1236,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function setRelation($relation, $value)
 	{
-		$this->relations[$relation] = $value;
+		$this->relations[snake_case($relation)] = $value;
 	}
 
 	/**


### PR DESCRIPTION
Modified the Model::setRelation method so that when relationships are eager loaded, they are set in snake_case only
