### PR TITLE
[Bugfix]Fix SQLite add Columns schema

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -100,11 +100,11 @@ class SQLiteGrammar extends Grammar {
 	}
 
 	/**
-	 * Compile a create table command.
+	 * Compile alter table commands for adding columns
 	 *
 	 * @param  Illuminate\Database\Schema\Blueprint  $blueprint
 	 * @param  Illuminate\Support\Fluent  $command
-	 * @return string
+	 * @return array
 	 */
 	public function compileAdd(Blueprint $blueprint, Fluent $command)
 	{
@@ -112,7 +112,12 @@ class SQLiteGrammar extends Grammar {
 
 		$columns = $this->prefixArray('add column', $this->getColumns($blueprint));
 
-		return 'alter table '.$table.' '.implode(', ', $columns);
+		foreach ($columns as $column) 
+		{
+			$statements[] = 'alter table '.$table.' '.$column;
+		}
+
+		return $statements;
 	}
 
 	/**

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -27,8 +27,12 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$blueprint->string('email');
 		$statements = $blueprint->toSql($this->getGrammar());
 
-		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement, add column "email" varchar not null', $statements[0]);
+		$this->assertEquals(2, count($statements));
+		$expected = array(
+			'alter table "users" add column "id" integer not null primary key autoincrement',
+			'alter table "users" add column "email" varchar not null',
+		);
+		$this->assertEquals($expected, $statements);
 	}
 
 
@@ -305,8 +309,12 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$blueprint->timestamps();
 		$statements = $blueprint->toSql($this->getGrammar());
 
-		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "created_at" datetime not null, add column "updated_at" datetime not null', $statements[0]);
+		$this->assertEquals(2, count($statements));
+		$expected = array(
+			'alter table "users" add column "created_at" datetime not null',
+			'alter table "users" add column "updated_at" datetime not null'
+		);
+		$this->assertEquals($expected, $statements);
 	}
 
 


### PR DESCRIPTION
SQLite add Columns schema only allows one column to be added at a time. Schema grammar (and associated tests) has been altered to return the proper SQLite statements for adding columns. Although there are no test cases that run SQLite as part of the Framework package, I have tested these locally with SQLite, and the corrections work. See: http://www.sqlite.org/lang_altertable.html
