### PR TITLE
Added havingRaw() and orHavingRaw()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -643,11 +643,44 @@ class Builder {
 	 */
 	public function having($column, $operator = null, $value = null)
 	{
-		$this->havings[] = compact('column', 'operator', 'value');
+		$type = 'Basic';
+
+		$this->havings[] = compact('type', 'column', 'operator', 'value');
 
 		$this->bindings[] = $value;
 
 		return $this;
+	}
+
+	/**
+	 * Add a raw where clause to the query.
+	 *
+	 * @param  string  $sql
+	 * @param  array   $bindings
+	 * @param  string  $boolean
+	 * @return Illuminate\Database\Query\Builder
+	 */
+	public function havingRaw($sql, array $bindings = array(), $boolean = 'and')
+	{
+		$type = 'raw';
+
+		$this->havings[] = compact('type', 'sql', 'boolean');
+
+		$this->bindings = array_merge($this->bindings, $bindings);
+
+		return $this;
+	}
+
+	/**
+	 * Add a raw or having clause to the query.
+	 *
+	 * @param  string  $sql
+	 * @param  array   $bindings
+	 * @return Illuminate\Database\Query\Builder
+	 */
+	public function orHavingRaw($sql, array $bindings = array())
+	{
+		return $this->havingRaw($sql, $bindings, 'or');
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -653,7 +653,7 @@ class Builder {
 	}
 
 	/**
-	 * Add a raw where clause to the query.
+	 * Add a raw having clause to the query.
 	 *
 	 * @param  string  $sql
 	 * @param  array   $bindings

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -408,6 +408,10 @@ class Grammar extends BaseGrammar {
 		{
 			extract($having);
 
+			if ($type === 'raw') {
+				return $boolean.' '.$sql;
+			}
+
 			return 'and '.$me->wrap($column).' '.$operator.' '.$me->parameter($value);
 
 		}, $havings));

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -192,8 +192,28 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testHavings()
 	{
 		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->having('email', '>', 1);
+		$this->assertEquals('select * from "users" having "email" > ?', $builder->toSql());
+		
+		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->groupBy('email')->having('email', '>', 1);
 		$this->assertEquals('select * from "users" group by "email" having "email" > ?', $builder->toSql());
+
+		$builder = $this->getBuilder();
+		$builder->select('email as foo_email')->from('users')->having('foo_email', '>', 1);
+		$this->assertEquals('select "email" as "foo_email" from "users" having "foo_email" > ?', $builder->toSql());
+	}
+
+
+	public function testRawHavings()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->havingRaw('user_foo < user_bar');
+		$this->assertEquals('select * from "users" having user_foo < user_bar', $builder->toSql());
+
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->having('baz', '=', 1)->orHavingRaw('user_foo < user_bar');
+		$this->assertEquals('select * from "users" having "baz" = ? or user_foo < user_bar', $builder->toSql());
 	}
 
 


### PR DESCRIPTION
I'm not sure if this is the perfect implementation, but it does what I need at the tests are green.

The main cause of my confusion over the implementation is that where and having seem to be built entirely differently. Really the two things should be IDENTICAL in implementation, as the only difference between how they are build is litterally it saying "having" instead of "where".

The only actual difference between the two in MySQL land is that a having works with calculated fields and aliases of stuff that doesn't exist, so having is run on the end result and not run as a criteria for finding relevant rows. That means PHP should treat the two exactly the same and only MySQL cares about the difference.

BUT, what I've done works, so if they're a little different for now under the hood I don't really care. :)
