### PR TITLE
Adding events to logging. Fixes #494.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@
 - Added `DB::getName` to get the configured name of the connection.
 - Made Eloquent casing agnostic. Will use whatever casing the properties use. Added `snakeRelations` property to model (default `true`) to control casing on relationships when using `toArray`.
 - Added `restart identity` to Postgres `truncate` SQL.
+- Added `Log::listen` callback and `illuminate.log` event which can be hooked into for custom logging handling.
 
 ## Beta 3
 

--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -18,7 +18,7 @@ class LogServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$logger = new Writer(new \Monolog\Logger('log'));
+		$logger = new Writer(new \Monolog\Logger('log'), $this->app['events']);
 
 		$this->app->instance('log', $logger);
 

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -147,7 +147,7 @@ class Writer {
 	 * @param  Closure  $callback
 	 * @return void
 	 */
-	public function logging(Closure $callback)
+	public function listen(Closure $callback)
 	{
 		$this->handlers[] = $callback;
 	}

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -159,7 +159,7 @@ class Writer {
 	 */
 	public function getEventDispatcher()
 	{
-		return $this->dispathcer;
+		return $this->dispatcher;
 	}
 
 	/**

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -12,7 +12,8 @@
         "monolog/monolog": "1.3.*"
     },
     "require-dev": {
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "illuminate/events": "4.0.x"
     },
     "autoload": {
         "psr-0": {

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -36,12 +36,12 @@ class LogWriterTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testObservingLogging()
+	public function testListening()
 	{
 		$writer = new Writer($monolog = m::mock('Monolog\Logger'));
 		$monolog->shouldReceive('addError')->once()->with('foo');
 
-		$writer->logging(function($level, $parameters)
+		$writer->listen(function($level, $parameters)
 		{
 			$_SERVER['__log.level']      = $level;
 			$_SERVER['__log.parameters'] = $parameters;

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -36,45 +36,49 @@ class LogWriterTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testListening()
-	{
-		$writer = new Writer($monolog = m::mock('Monolog\Logger'));
-		$monolog->shouldReceive('addError')->once()->with('foo');
-
-		$writer->listen(function($level, $parameters)
-		{
-			$_SERVER['__log.level']      = $level;
-			$_SERVER['__log.parameters'] = $parameters;
-		});
-
-		$writer->error('foo');
-		$this->assertTrue(isset($_SERVER['__log.level']));
-		$this->assertEquals('error', $_SERVER['__log.level']);
-		unset($_SERVER['__log.level']);
-		$this->assertTrue(isset($_SERVER['__log.parameters']));
-		$this->assertEquals(array('foo'), $_SERVER['__log.parameters']);
-		unset($_SERVER['__log.parameters']);
-	}
-
-
 	public function testWriterFiresEventsDispatcher()
 	{
 		$writer = new Writer($monolog = m::mock('Monolog\Logger'), $events = new Illuminate\Events\Dispatcher);
 		$monolog->shouldReceive('addError')->once()->with('foo');
 
-		$events->listen('illuminate.log', function($level, $parameters)
+		$events->listen('illuminate.log', function($level, $message, array $context = array())
 		{
 			$_SERVER['__log.level']      = $level;
-			$_SERVER['__log.parameters'] = $parameters;
+			$_SERVER['__log.message'] = $message;
+			$_SERVER['__log.context']    = $context;
 		});
 
 		$writer->error('foo');
 		$this->assertTrue(isset($_SERVER['__log.level']));
 		$this->assertEquals('error', $_SERVER['__log.level']);
 		unset($_SERVER['__log.level']);
-		$this->assertTrue(isset($_SERVER['__log.parameters']));
-		$this->assertEquals(array('foo'), $_SERVER['__log.parameters']);
-		unset($_SERVER['__log.parameters']);
+		$this->assertTrue(isset($_SERVER['__log.message']));
+		$this->assertEquals('foo', $_SERVER['__log.message']);
+		unset($_SERVER['__log.message']);
+		$this->assertTrue(isset($_SERVER['__log.context']));
+		$this->assertEquals(array(), $_SERVER['__log.context']);
+		unset($_SERVER['__log.context']);
+	}
+
+
+	/**
+	 * @expectedException RuntimeException
+	 */
+	public function testListenShortcutFailsWithNoDispatcher()
+	{
+		$writer = new Writer($monolog = m::mock('Monolog\Logger'));
+		$writer->listen(function() {});
+	}
+
+
+	public function testListenShortcut()
+	{
+		$writer = new Writer($monolog = m::mock('Monolog\Logger'), $events = m::mock('Illuminate\Events\Dispatcher'));
+
+		$callback = function() { return 'success'; };
+		$events->shouldReceive('listen')->with('illuminate.log', $callback)->once();
+
+		$writer->listen($callback);
 	}
 
 }


### PR DESCRIPTION
Anytime when you log now, an event, `illuminate.log` will be fired.

Additionally, there is a method, `listen`, on the logging class which you can tap into to observe logging.

``` php
Log::listen(function($level, $parameters)
{
    //
});
```

Putting in a separate PR for that on `laravel/laravel`. Will update this PR with details.

Signed-off-by: Ben Corlett bencorlett@me.com
