### PR TITLE
Migration Options

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/BaseCommand.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
 
 class BaseCommand extends Command {
 
@@ -44,6 +45,26 @@ class BaseCommand extends Command {
 		}
 
 		return $this->laravel['path'].'/database/migrations';
+	}
+
+	/**
+	 * Get the console command options.
+	 *
+	 * @return array
+	 */
+	protected function getOptions()
+	{
+		return array(
+			array('bench', null, InputOption::VALUE_OPTIONAL, 'The name of the workbench to migrate.', null),
+
+			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+
+			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to migration files.', null),
+
+			array('package', null, InputOption::VALUE_OPTIONAL, 'The package to migrate.', null),
+
+			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
+		);
 	}
 
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -92,24 +92,4 @@ class MigrateCommand extends BaseCommand {
 		}
 	}
 
-	/**
-	 * Get the console command options.
-	 *
-	 * @return array
-	 */
-	protected function getOptions()
-	{
-		return array(
-			array('bench', null, InputOption::VALUE_OPTIONAL, 'The name of the workbench to migrate.', null),
-
-			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
-
-			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to migration files.', null),
-
-			array('package', null, InputOption::VALUE_OPTIONAL, 'The package to migrate.', null),
-
-			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
-		);
-	}
-
 }

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -26,14 +26,30 @@ class RefreshCommand extends Command {
 	 */
 	public function fire()
 	{
+		$bench = $this->input->getOption('bench');
 		$database = $this->input->getOption('database');
+		$path = $this->input->getOption('path');
+		$package = $this->input->getOption('package');
+		$pretend = $this->input->getOption('pretend');
 
-		$this->call('migrate:reset', array('--database' => $database));
+		$this->call('migrate:reset', array(
+			'--bench' => $bench,
+			'--database' => $database,
+			'--path' => $path,
+			'--package' => $package,
+			'--pretend' => $pretend,
+		));
 
 		// The refresh command is essentially just a brief aggregate of a few other of
 		// the migration commands and just provides a convenient wrapper to execute
 		// them in succession. We'll also see if we need to res-eed the database.
-		$this->call('migrate', array('--database' => $database));
+		$this->call('migrate', array(
+			'--bench' => $bench,
+			'--database' => $database,
+			'--path' => $path,
+			'--package' => $package,
+			'--pretend' => $pretend,
+		));
 
 		if ($this->input->getOption('seed'))
 		{
@@ -49,7 +65,15 @@ class RefreshCommand extends Command {
 	protected function getOptions()
 	{
 		return array(
+			array('bench', null, InputOption::VALUE_OPTIONAL, 'The name of the workbench to migrate.', null),
+
 			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+
+			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to migration files.', null),
+
+			array('package', null, InputOption::VALUE_OPTIONAL, 'The package to migrate.', null),
+
+			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
 
 			array('seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'),
 		);

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -70,24 +70,4 @@ class ResetCommand extends BaseCommand {
 		}
 	}
 
-	/**
-	 * Get the console command options.
-	 *
-	 * @return array
-	 */
-	protected function getOptions()
-	{
-		return array(
-			array('bench', null, InputOption::VALUE_OPTIONAL, 'The name of the workbench to migrate.', null),
-
-			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
-
-			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to migration files.', null),
-
-			array('package', null, InputOption::VALUE_OPTIONAL, 'The package to migrate.', null),
-
-			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
-		);
-	}
-
 }

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -4,7 +4,7 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
-class ResetCommand extends Command {
+class ResetCommand extends BaseCommand {
 
 	/**
 	 * The console command name.
@@ -33,11 +33,12 @@ class ResetCommand extends Command {
 	 * @param  Illuminate\Database\Migrations\Migrator  $migrator
 	 * @return void
 	 */
-	public function __construct(Migrator $migrator)
+	public function __construct(Migrator $migrator, $packagePath)
 	{
 		parent::__construct();
 
 		$this->migrator = $migrator;
+		$this->packagePath = $packagePath;
 	}
 
 	/**
@@ -49,11 +50,13 @@ class ResetCommand extends Command {
 	{
 		$this->migrator->setConnection($this->input->getOption('database'));
 
+		$path = $this->getMigrationPath();
+
 		$pretend = $this->input->getOption('pretend');
 
 		while (true)
 		{
-			$count = $this->migrator->rollback($pretend);
+			$count = $this->migrator->rollback($path, $pretend);
 
 			// Once the migrator has run we will grab the note output and send it out to
 			// the console screen, since the migrator itself functions without having
@@ -75,7 +78,13 @@ class ResetCommand extends Command {
 	protected function getOptions()
 	{
 		return array(
+			array('bench', null, InputOption::VALUE_OPTIONAL, 'The name of the workbench to migrate.', null),
+
 			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+
+			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to migration files.', null),
+
+			array('package', null, InputOption::VALUE_OPTIONAL, 'The package to migrate.', null),
 
 			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
 		);

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -4,7 +4,7 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
-class RollbackCommand extends Command {
+class RollbackCommand extends BaseCommand {
 
 	/**
 	 * The console command name.
@@ -28,16 +28,22 @@ class RollbackCommand extends Command {
 	protected $migrator;
 
 	/**
+	 * The path to the packages directory (vendor).
+	 */
+	protected $packagePath;
+
+	/**
 	 * Create a new migration rollback command instance.
 	 *
 	 * @param  Illuminate\Database\Migrations\Migrator  $migrator
 	 * @return void
 	 */
-	public function __construct(Migrator $migrator)
+	public function __construct(Migrator $migrator, $packagePath)
 	{
 		parent::__construct();
 
 		$this->migrator = $migrator;
+		$this->packagePath = $packagePath;
 	}
 
 	/**
@@ -51,7 +57,9 @@ class RollbackCommand extends Command {
 
 		$pretend = $this->input->getOption('pretend');
 
-		$this->migrator->rollback($pretend);
+		$path = $this->getMigrationPath();
+
+		$this->migrator->rollback($path, $pretend);
 
 		// Once the migrator has run we will grab the note output and send it out to
 		// the console screen, since the migrator itself functions without having
@@ -70,7 +78,13 @@ class RollbackCommand extends Command {
 	protected function getOptions()
 	{
 		return array(
+			array('bench', null, InputOption::VALUE_OPTIONAL, 'The name of the workbench to migrate.', null),
+
 			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+
+			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to migration files.', null),
+
+			array('package', null, InputOption::VALUE_OPTIONAL, 'The package to migrate.', null),
 
 			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
 		);

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -70,24 +70,4 @@ class RollbackCommand extends BaseCommand {
 		}
 	}
 
-	/**
-	 * Get the console command options.
-	 *
-	 * @return array
-	 */
-	protected function getOptions()
-	{
-		return array(
-			array('bench', null, InputOption::VALUE_OPTIONAL, 'The name of the workbench to migrate.', null),
-
-			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
-
-			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to migration files.', null),
-
-			array('package', null, InputOption::VALUE_OPTIONAL, 'The package to migrate.', null),
-
-			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
-		);
-	}
-
 }

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -138,7 +138,9 @@ class MigrationServiceProvider extends ServiceProvider {
 	{
 		$this->app['command.migrate.reset'] = $this->app->share(function($app)
 		{
-			return new ResetCommand($app['migrator']);
+			$packagePath = $app['path.base'].'/vendor';
+
+			return new ResetCommand($app['migrator'], $packagePath);
 		});
 	}
 

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -123,7 +123,9 @@ class MigrationServiceProvider extends ServiceProvider {
 	{
 		$this->app['command.migrate.rollback'] = $this->app->share(function($app)
 		{
-			return new RollbackCommand($app['migrator']);
+			$packagePath = $app['path.base'].'/vendor';
+
+			return new RollbackCommand($app['migrator'], $packagePath);
 		});
 	}
 

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -58,7 +58,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 	{
 		$query = $this->table()->where('batch', $this->getLastBatchNumber() + $offset);
 
-		return $query->orderBy('migration', 'desc')->get();
+		return $query->orderBy('migration', 'desc')->lists('migration');
 	}
 
 	/**
@@ -81,9 +81,9 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 	 * @param  StdClass  $migration
 	 * @return void
 	 */
-	public function delete($migration)
+	public function delete($file)
 	{
-		$query = $this->table()->where('migration', $migration->migration)->delete();
+		$query = $this->table()->where('migration', $file)->delete();
 	}
 
 	/**

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -54,9 +54,9 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 	 *
 	 * @return array
 	 */
-	public function getLast()
+	public function getLast($offset = 0)
 	{
-		$query = $this->table()->where('batch', $this->getLastBatchNumber());
+		$query = $this->table()->where('batch', $this->getLastBatchNumber() + $offset);
 
 		return $query->orderBy('migration', 'desc')->get();
 	}

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -160,15 +160,15 @@ class Migrator {
 		// a migration that exists in our current migration path.
 		// Conflicts would be near impossible as the migration files
 		// are timestamped.
-		$migrations = $this->repository->getLast();
+		$migrations = array();
 		$offset = 0;
-		while (empty($migrations) and $offset++)
+		while (empty($migrations))
 		{
 			$migrations = array();
 
 			if ($this->repository->getLastBatchNumber() - $offset == 0)
 			{
-				$this->note('Nothing to rollback.');
+				$this->note('<info>Nothing to rollback.</info>');
 
 				return;
 			}
@@ -176,6 +176,8 @@ class Migrator {
 			// Intersect last batch of migration files with the files that exists
 			// within our current migration space.
 			$migrations = array_intersect($this->repository->getLast(-$offset), $files);
+
+			$offset++;
 		}
 
 		// We need to reverse these migrations so that they are "downed" in reverse

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -42,6 +42,24 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testGetLastMigrationsWithOffsetGetsFromCorrectOffset()
+	{
+		$repo = $this->getMock('Illuminate\Database\Migrations\DatabaseMigrationRepository', array('getLastBatchNumber'), array(
+			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'), 'migrations'
+		));
+		$repo->expects($this->once())->method('getLastBatchNumber')->will($this->returnValue(5));
+		$query = m::mock('stdClass');
+		$connectionMock = m::mock('Illuminate\Database\Connection');
+		$repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
+		$repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+		$query->shouldReceive('where')->once()->with('batch', 1)->andReturn($query);
+		$query->shouldReceive('orderBy')->once()->with('migration', 'desc')->andReturn($query);
+		$query->shouldReceive('get')->once()->andReturn('foo');
+
+		$this->assertEquals('foo', $repo->getLast(-4));
+	}
+
+
 	public function testLogMethodInsertsRecordIntoMigrationTable()
 	{
 		$repo = $this->getRepository();

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -36,7 +36,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 		$repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('batch', 1)->andReturn($query);
 		$query->shouldReceive('orderBy')->once()->with('migration', 'desc')->andReturn($query);
-		$query->shouldReceive('get')->once()->andReturn('foo');
+		$query->shouldReceive('lists')->once()->andReturn('foo');
 
 		$this->assertEquals('foo', $repo->getLast());
 	}
@@ -54,7 +54,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 		$repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('batch', 1)->andReturn($query);
 		$query->shouldReceive('orderBy')->once()->with('migration', 'desc')->andReturn($query);
-		$query->shouldReceive('get')->once()->andReturn('foo');
+		$query->shouldReceive('lists')->once()->andReturn('foo');
 
 		$this->assertEquals('foo', $repo->getLast(-4));
 	}
@@ -82,9 +82,8 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 		$repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('migration', 'foo')->andReturn($query);
 		$query->shouldReceive('delete')->once();
-		$migration = (object) array('migration' => 'foo');
 
-		$repo->delete($migration);
+		$repo->delete('foo');
 	}
 
 

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -13,9 +13,11 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testResetCommandCallsMigratorWithProperArguments()
 	{
-		$command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+		$command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');;
+		$app = array('path' => __DIR__);
+		$command->setLaravel($app);
 		$migrator->shouldReceive('setConnection')->once()->with(null);
-		$migrator->shouldReceive('rollback')->twice()->with(false)->andReturn(true, false);
+		$migrator->shouldReceive('rollback')->twice()->with(__DIR__.'/database/migrations', false)->andReturn(true, false);
 		$migrator->shouldReceive('getNotes')->andReturn(array());
 
 		$this->runCommand($command);
@@ -24,9 +26,11 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testResetCommandCanBePretended()
 	{
-		$command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+		$command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');;
+		$app = array('path' => __DIR__);
+		$command->setLaravel($app);
 		$migrator->shouldReceive('setConnection')->once()->with('foo');
-		$migrator->shouldReceive('rollback')->twice()->with(true)->andReturn(true, false);
+		$migrator->shouldReceive('rollback')->twice()->with(__DIR__.'/database/migrations', true)->andReturn(true, false);
 		$migrator->shouldReceive('getNotes')->andReturn(array());
 
 		$this->runCommand($command, array('--pretend' => true, '--database' => 'foo'));

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -13,9 +13,11 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testRollbackCommandCallsMigratorWithProperArguments()
 	{
-		$command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+		$command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+		$app = array('path' => __DIR__);
+		$command->setLaravel($app);
 		$migrator->shouldReceive('setConnection')->once()->with(null);
-		$migrator->shouldReceive('rollback')->once()->with(false);
+		$migrator->shouldReceive('rollback')->once()->with(__DIR__.'/database/migrations', false);
 		$migrator->shouldReceive('getNotes')->andReturn(array());
 
 		$this->runCommand($command);
@@ -24,9 +26,11 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testRollbackCommandCanBePretended()
 	{
-		$command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+		$command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+		$app = array('path' => __DIR__);
+		$command->setLaravel($app);
 		$migrator->shouldReceive('setConnection')->once()->with('foo');
-		$migrator->shouldReceive('rollback')->once()->with(true);
+		$migrator->shouldReceive('rollback')->once()->with(__DIR__.'/database/migrations', true);
 		$migrator->shouldReceive('getNotes')->andReturn(array());
 
 		$this->runCommand($command, array('--pretend' => true, '--database' => 'foo'));

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -109,9 +109,14 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
 		));
+		$migrator->getFilesystem()->shouldReceive('glob')->once()->with(__DIR__.'/*_*.php')->andReturn(array(
+			__DIR__.'/bar.php',
+			__DIR__.'/foo.php',
+			__DIR__.'/baz.php',
+		));
 		$migrator->getRepository()->shouldReceive('getLast')->once()->andReturn(array(
-			$fooMigration = new MigratorTestMigrationStub('foo'),
-			$barMigration = new MigratorTestMigrationStub('bar'),
+			'foo',
+			'bar',
 		));
 
 		$barMock = m::mock('stdClass');
@@ -123,10 +128,10 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 		$migrator->expects($this->at(0))->method('resolve')->with($this->equalTo('foo'))->will($this->returnValue($barMock));
 		$migrator->expects($this->at(1))->method('resolve')->with($this->equalTo('bar'))->will($this->returnValue($fooMock));
 
-		$migrator->getRepository()->shouldReceive('delete')->once()->with($barMigration);
-		$migrator->getRepository()->shouldReceive('delete')->once()->with($fooMigration);
+		$migrator->getRepository()->shouldReceive('delete')->once()->with('foo');
+		$migrator->getRepository()->shouldReceive('delete')->once()->with('bar');
 
-		$migrator->rollback();
+		$migrator->rollback(__DIR__);
 	}
 
 
@@ -137,9 +142,14 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
 		));
+		$migrator->getFilesystem()->shouldReceive('glob')->once()->with(__DIR__.'/*_*.php')->andReturn(array(
+			__DIR__.'/bar.php',
+			__DIR__.'/foo.php',
+			__DIR__.'/baz.php',
+		));
 		$migrator->getRepository()->shouldReceive('getLast')->once()->andReturn(array(
-			$fooMigration = new MigratorTestMigrationStub('foo'),
-			$barMigration = new MigratorTestMigrationStub('bar'),
+			'foo',
+			'bar',
 		));
 
 		$barMock = m::mock('stdClass');
@@ -166,7 +176,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 		});
 		$resolver->shouldReceive('connection')->with(null)->andReturn($connection);
 
-		$migrator->rollback(true);
+		$migrator->rollback(__DIR__, true);
 	}
 
 
@@ -177,9 +187,10 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
 		));
+		$migrator->getFilesystem()->shouldReceive('glob')->once()->with(__DIR__.'/*_*.php')->andReturn(array());
 		$migrator->getRepository()->shouldReceive('getLast')->once()->andReturn(array());
 
-		$migrator->rollback();
+		$migrator->rollback(__DIR__);
 	}
 
 }

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -114,10 +114,17 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 			__DIR__.'/foo.php',
 			__DIR__.'/baz.php',
 		));
-		$migrator->getRepository()->shouldReceive('getLast')->once()->andReturn(array(
-			'foo',
-			'bar',
-		));
+		$migrator->getRepository()->shouldReceive('getLast')->twice()->andReturn(
+			array(
+				'oof',
+				'rab',
+			),
+			array(
+				'foo',
+				'bar',
+			)
+		);
+		$migrator->getRepository()->shouldReceive('getLastBatchNumber')->twice()->andReturn(2);
 
 		$barMock = m::mock('stdClass');
 		$barMock->shouldReceive('down')->once();
@@ -151,6 +158,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 			'foo',
 			'bar',
 		));
+		$migrator->getRepository()->shouldReceive('getLastBatchNumber')->once()->andReturn(2);
 
 		$barMock = m::mock('stdClass');
 		$barMock->shouldReceive('getConnection')->once()->andReturn(null);
@@ -188,7 +196,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 			m::mock('Illuminate\Filesystem\Filesystem'),
 		));
 		$migrator->getFilesystem()->shouldReceive('glob')->once()->with(__DIR__.'/*_*.php')->andReturn(array());
-		$migrator->getRepository()->shouldReceive('getLast')->once()->andReturn(array());
+		$migrator->getRepository()->shouldReceive('getLastBatchNumber')->once()->andReturn(0);
 
 		$migrator->rollback(__DIR__);
 	}


### PR DESCRIPTION
The `migrate:rollback`, `migrate:reset` and `migrate:refresh` commands now accept the options that you might expect them to provide:
- `--bench`
- `--path`
- `--package`

This makes migrations a lot more viable in packages.

Rollback works by looping all ran migration batches until it finds a batch that intersects with one or more migrations inside the active migration path. (app/database/migrations, vendor/x/y/src/migrations, etc)

If it finds an intersecting batch, it will down all migrations within the batch.
If it doesn't, it will spit `Nothing to rollback.` at you.
