### PR TITLE
[Bugfix] Migration workbench autoload generation.

### DIFF
--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -208,6 +208,22 @@ class MigrationServiceProvider extends ServiceProvider {
 				$app['composer']->dumpAutoloads();
 			});
 
+			// We also want to regenerate autoload files for any workbench
+			// packages.
+			$creator->afterCreate(function() use ($app)
+			{
+				$packages = $app['files']->glob($app['path.base'].'/workbench/*', GLOB_ONLYDIR);
+				$vendors = $app['files']->glob($app['path.base'].'/workbench/*/*', GLOB_ONLYDIR);
+
+				if ($packages === false) $packages = array();
+				if ($vendors === false) $vendors = array();
+
+				foreach (array_merge($packages, $vendors) as $path)
+				{
+					$app['composer']->dumpAutoloads($path);
+				}
+			});
+
 			return $creator;
 		});
 	}

--- a/src/Illuminate/Foundation/Composer.php
+++ b/src/Illuminate/Foundation/Composer.php
@@ -35,11 +35,12 @@ class Composer {
 	/**
 	 * Regenerate the Composer autoloader files.
 	 *
+	 * @param string $path
 	 * @return void
 	 */
-	public function dumpAutoloads()
+	public function dumpAutoloads($path = null)
 	{
-		$process = $this->getProcess();
+		$process = $this->getProcess($path);
 
 		$process->setCommandLine($this->findComposer().' dump-autoload --optimize');
 
@@ -55,7 +56,9 @@ class Composer {
 	{
 		if ($this->files->exists($this->workingPath.'/composer.phar'))
 		{
-			return 'php composer.phar';
+			// We explicitly specify composer path because we might not
+			// be in the workingPath.
+			return "php '{$this->workingPath}/composer.phar'";
 		}
 		else
 		{
@@ -66,11 +69,13 @@ class Composer {
 	/**
 	 * Get a new Symfony process instance.
 	 *
+	 * @param string $path
 	 * @return Symfony\Component\Process\Process
 	 */
-	protected function getProcess()
+	protected function getProcess($path = null)
 	{
-		return new Process('', $this->workingPath);
+		if (!$path) $path = $this->workingPath;
+		return new Process('', $path);
 	}
 
 }

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -16,10 +16,23 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase {
 		$files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
 		$process = m::mock('stdClass');
 		$composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
-		$process->shouldReceive('setCommandLine')->once()->with('php composer.phar dump-autoload --optimize');
+		$process->shouldReceive('setCommandLine')->once()->with('php \''.__DIR__.'/composer.phar\' dump-autoload --optimize');
 		$process->shouldReceive('run')->once();
 
 		$composer->dumpAutoloads();
+	}
+
+
+	public function testDumpAutoloadRespectsCustomPath()
+	{
+		$composer = $this->getMock('Illuminate\Foundation\Composer', array('getProcess'), array($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__));
+		$files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
+		$process = m::mock('stdClass');
+		$composer->expects($this->once())->method('getProcess')->with('custom')->will($this->returnValue($process));
+		$process->shouldReceive('setCommandLine')->once()->with('php \''.__DIR__.'/composer.phar\' dump-autoload --optimize');
+		$process->shouldReceive('run')->once();
+
+		$composer->dumpAutoloads('custom');
 	}
 
 


### PR DESCRIPTION
I was noticing while making migrations in the workbench that the autoload dumping wasn't being applied to packages in the workbench.

This fixes that and also made it possible to override the working directory of the composer instance by passing the path to the `dumpAutoloads()` and `getProcess()` methods of `Illuminate\Foundation\Composer`.

The `findComposer()` method was only modified to include the entire path to composer.phar if it exists in the working path. (Can't be overridden)
