### PR TITLE
Added Postgres ilike operator

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -119,7 +119,7 @@ class Builder {
 	 */
 	protected $operators = array(
 		'=', '<', '>', '<=', '>=', '<>', '!=',
-		'like', 'not like', 'between',
+		'like', 'not like', 'between', 'ilike',
 	);
 
 	/**


### PR DESCRIPTION
In Postgres, we have an `ilike` operator.

This pull request add this operator in the `Illuminate\Database\Query\Builder` array of operators.
