### PR TITLE
Add JSONResponse support for Arrayable data

### DIFF
--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -27,8 +27,6 @@ class Response {
 	 */
 	public static function json($data = array(), $status = 200, array $headers = array())
 	{
-		// If the data is "Arrayable" we will convert it to its array form before 
-		// sending it as JSON.
 		if ($data instanceof ArrayableInterface)
 		{
 			$data = $data->toArray();

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -1,5 +1,7 @@
 <?php namespace Illuminate\Support\Facades;
 
+use Illuminate\Support\Contracts\ArrayableInterface;
+
 class Response {
 
 	/**

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -25,6 +25,13 @@ class Response {
 	 */
 	public static function json($data = array(), $status = 200, array $headers = array())
 	{
+		// If the data is "Arrayable" we will convert it to its array form before 
+		// sending it as JSON.
+		if ($data instanceof ArrayableInterface)
+		{
+			$data = $data->toArray();
+		}
+
 		return new \Symfony\Component\HttpFoundation\JsonResponse($data, $status, $headers);
 	}
 

--- a/tests/Support/SupportFacadeResponseTest.php
+++ b/tests/Support/SupportFacadeResponseTest.php
@@ -11,7 +11,7 @@ class SupportFacadeResponseTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testArrayifyDataBeforeSendingAsJson()
+	public function testArrayableSendAsJson()
 	{
 		$data = m::mock('Illuminate\Support\Contracts\ArrayableInterface');
 		$data->shouldReceive('toArray')->andReturn(array('foo' => 'bar'));

--- a/tests/Support/SupportFacadeResponseTest.php
+++ b/tests/Support/SupportFacadeResponseTest.php
@@ -11,7 +11,7 @@ class SupportFacadeResponseTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testArrayfyDataBeforeSendingAsJson()
+	public function testArrayifyDataBeforeSendingAsJson()
 	{
 		$data = m::mock('Illuminate\Support\Contracts\ArrayableInterface');
 		$data->shouldReceive('toArray')->andReturn(array('foo' => 'bar'));

--- a/tests/Support/SupportFacadeResponseTest.php
+++ b/tests/Support/SupportFacadeResponseTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Support\Facades\Response;
+
+class SupportFacadeResponseTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testArrayfyDataBeforeSendingAsJson()
+	{
+		$data = m::mock('Illuminate\Support\Contracts\ArrayableInterface');
+		$data->shouldReceive('toArray')->andReturn(array('foo' => 'bar'));
+
+		$response = Response::json($data);
+		$this->assertEquals('{"foo":"bar"}', $response->getContent());
+	}
+
+}


### PR DESCRIPTION
That way seems more coherent with the default behaviour for controllers, for example when directly returning an Eloquent model from a controller. 

If `$user` is an Eloquent model or any object that implements `ArrayableInterface` you can just write:

``` php
return Response::json($user, 201, $headers);
```

Which is useful when you need to specify headers, etc.
