### PR TITLE
Making the view finder / environment not greedy. Fixes #506.

### DIFF
--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -488,6 +488,8 @@ class Environment {
 			$this->engines->register($engine, $resolver);
 		}
 
+		if (isset($this->extensions[$engine])) unset($this->extensions[$engine]);
+
 		$this->extensions = array_merge(array($extension => $engine), $this->extensions);
 	}
 

--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -488,7 +488,7 @@ class Environment {
 			$this->engines->register($engine, $resolver);
 		}
 
-		$this->extensions[$extension] = $engine;
+		$this->extensions = array_merge(array($extension => $engine), $this->extensions);
 	}
 
 	/**
@@ -529,6 +529,16 @@ class Environment {
 	public function getContainer()
 	{
 		return $this->container;
+	}
+
+	/**
+	 * Get the extension to engine bindings.
+	 *
+	 * @return array
+	 */
+	public function getExtensions()
+	{
+		return $this->extensions;
 	}
 
 	/**

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -176,7 +176,7 @@ class FileViewFinder implements ViewFinderInterface {
 	 */
 	public function addExtension($extension)
 	{
-		$this->extensions[] = $extension;
+		array_unshift($this->extensions, $extension);
 	}
 
 	/**

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -176,6 +176,14 @@ class FileViewFinder implements ViewFinderInterface {
 	 */
 	public function addExtension($extension)
 	{
+		// We will remove the existing extension from our extensions
+		// if it exists. This will ensure the newly registered extension
+		// is prepended as expected.
+		if (($index = array_search($extension, $this->extensions)) !== false)
+		{
+			unset($this->extensions[$index]);
+		}
+
 		array_unshift($this->extensions, $extension);
 	}
 

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -30,7 +30,7 @@ class FileViewFinder implements ViewFinderInterface {
 	 *
 	 * @var array
 	 */
-	protected $extensions = array('php', 'blade.php');
+	protected $extensions = array('blade.php', 'php');
 
 	/**
 	 * Create a new file view loader instance.

--- a/tests/View/ViewEnvironmentTest.php
+++ b/tests/View/ViewEnvironmentTest.php
@@ -96,6 +96,21 @@ class ViewEnvironmentTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testPrependedExtensionOverridesExistingExtensions()
+	{
+		$environment = $this->getEnvironment();
+		$environment->getFinder()->shouldReceive('addExtension')->once()->with('foo');
+		$environment->getFinder()->shouldReceive('addExtension')->once()->with('baz');
+
+		$environment->addExtension('foo', 'bar');
+		$environment->addExtension('baz', 'bar');
+
+		$extensions = $environment->getExtensions();
+		$this->assertEquals('bar', reset($extensions));
+		$this->assertEquals('baz', key($extensions));
+	}
+
+
 	public function testComposersAreProperlyRegistered()
 	{
 		$env = $this->getEnvironment();

--- a/tests/View/ViewEnvironmentTest.php
+++ b/tests/View/ViewEnvironmentTest.php
@@ -83,6 +83,19 @@ class ViewEnvironmentTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAddingExtensionPrependsNotAppends()
+	{
+		$environment = $this->getEnvironment();
+		$environment->getFinder()->shouldReceive('addExtension')->once()->with('foo');
+
+		$environment->addExtension('foo', 'bar');
+
+		$extensions = $environment->getExtensions();
+		$this->assertEquals('bar', reset($extensions));
+		$this->assertEquals('foo', key($extensions));
+	}
+
+
 	public function testComposersAreProperlyRegistered()
 	{
 		$env = $this->getEnvironment();

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -13,19 +13,19 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 	public function testBasicViewFinding()
 	{
 		$finder = $this->getFinder();
-		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(true);
+		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(true);
 
-		$this->assertEquals(__DIR__.'/foo.php', $finder->find('foo'));
+		$this->assertEquals(__DIR__.'/foo.blade.php', $finder->find('foo'));
 	}
 
 
 	public function testCascadingFileLoading()
 	{
 		$finder = $this->getFinder();
-		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
-		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(true);
+		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
+		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(true);
 
-		$this->assertEquals(__DIR__.'/foo.blade.php', $finder->find('foo'));
+		$this->assertEquals(__DIR__.'/foo.php', $finder->find('foo'));
 	}
 
 
@@ -33,11 +33,11 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 	{
 		$finder = $this->getFinder();
 		$finder->addLocation(__DIR__.'/nested');
-		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
 		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
-		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/nested/foo.php')->andReturn(true);
+		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
+		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/nested/foo.blade.php')->andReturn(true);
 
-		$this->assertEquals(__DIR__.'/nested/foo.php', $finder->find('foo'));
+		$this->assertEquals(__DIR__.'/nested/foo.blade.php', $finder->find('foo'));
 	}
 
 
@@ -45,9 +45,9 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 	{
 		$finder = $this->getFinder();
 		$finder->addNamespace('foo', __DIR__.'/foo');
-		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.php')->andReturn(true);
+		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.blade.php')->andReturn(true);
 
-		$this->assertEquals(__DIR__.'/foo/bar/baz.php', $finder->find('foo::bar.baz'));
+		$this->assertEquals(__DIR__.'/foo/bar/baz.blade.php', $finder->find('foo::bar.baz'));
 	}
 
 
@@ -55,10 +55,10 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 	{
 		$finder = $this->getFinder();
 		$finder->addNamespace('foo', __DIR__.'/foo');
-		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.php')->andReturn(false);
-		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.blade.php')->andReturn(true);
+		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.blade.php')->andReturn(false);
+		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.php')->andReturn(true);
 
-		$this->assertEquals(__DIR__.'/foo/bar/baz.blade.php', $finder->find('foo::bar.baz'));
+		$this->assertEquals(__DIR__.'/foo/bar/baz.php', $finder->find('foo::bar.baz'));
 	}
 
 
@@ -66,11 +66,11 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 	{
 		$finder = $this->getFinder();
 		$finder->addNamespace('foo', array(__DIR__.'/foo', __DIR__.'/bar'));
-		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.php')->andReturn(false);
 		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.blade.php')->andReturn(false);
-		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/bar/bar/baz.php')->andReturn(true);
+		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo/bar/baz.php')->andReturn(false);
+		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/bar/bar/baz.blade.php')->andReturn(true);
 
-		$this->assertEquals(__DIR__.'/bar/bar/baz.php', $finder->find('foo::bar.baz'));
+		$this->assertEquals(__DIR__.'/bar/bar/baz.blade.php', $finder->find('foo::bar.baz'));
 	}
 
 
@@ -80,8 +80,8 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 	public function testExceptionThrownWhenViewNotFound()
 	{
 		$finder = $this->getFinder();
-		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
 		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.blade.php')->andReturn(false);
+		$finder->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/foo.php')->andReturn(false);
 
 		$finder->find('foo');
 	}

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -116,6 +116,16 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAddingExtensionsReplacesOldOnes()
+	{
+		$finder = $this->getFinder();
+		$finder->addExtension('baz');
+		$finder->addExtension('baz');
+
+		$this->assertCount(3, $finder->getExtensions());
+	}
+
+
 	protected function getFinder()
 	{
 		return new Illuminate\View\FileViewFinder(m::mock('Illuminate\Filesystem\Filesystem'), array(__DIR__));

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -107,6 +107,15 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAddingExtensionPrependsNotAppends()
+	{
+		$finder = $this->getFinder();
+		$finder->addExtension('baz');
+		$extensions = $finder->getExtensions();
+		$this->assertEquals('baz', reset($extensions));
+	}
+
+
 	protected function getFinder()
 	{
 		return new Illuminate\View\FileViewFinder(m::mock('Illuminate\Filesystem\Filesystem'), array(__DIR__));


### PR DESCRIPTION
As mentioned in #506, if you register your own custom view compiler, e.g. for `mustache.php` files, they will never be loaded, as the `php` "compiler" matches first. I have made the view environment prepend new extensions rather than append them, so any custom registered compilers are used first.

I know there can be better ways (e.g. through the `IoC` container, but purely for example), this could also easily let you override the blade compiler (as an example) by registering a new engine for `blade.php`.

Just a simple little fix. Enjoy.

Signed-off-by: Ben Corlett bencorlett@me.com
