### PR TITLE
Pass non-named routes through Form::open()

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -530,7 +530,10 @@ class FormBuilder {
 		// We will also check for a "route" or "action" parameter on the array so that
 		// developers can easily specify a route or controller action when creating
 		// a form providing a convenient interface for creating the form actions.
-		if (isset($options['url'])) return $options['url'];
+		if (isset($options['url']))
+		{
+			return $this->getUrlAction($options['url']);
+		}
 
 		if (isset($options['route']))
 		{
@@ -546,6 +549,22 @@ class FormBuilder {
 		}
 
 		return $this->url->current();
+	}
+
+	/**
+	 * Get the action for a "url" option.
+	 *
+	 * @param  array|string  $options
+	 * @return string
+	 */
+	protected function getUrlAction($options)
+	{
+		if (is_array($options))
+		{
+			return $this->url->to($options[0], array_slice($options, 1));
+		}
+
+		return $this->url->to($options);
 	}
 
 	/**


### PR DESCRIPTION
It seemed a bit odd that the option to pass along non-named routes wasn't provided. Currently you can only pass along real urls through the `url` parameter for `Form::open()`.

``` php
Form::open(array('url' => 'http://example/foo/bar'));
```

But if you want to pass along a non-named route that wouldn't work.

``` php
Form::open(array('url' => 'route/foo'));
```

You'd have to do the following:

``` php
Form::open(array('url' => URL::to('route/foo')));
```

With this PR you can now pass non-named routes alongside urls to Form::open with the 'url' parameter. The UrlGenerator will validate if it's a valid url and will otherwise try to generate an url if it's a route.
