### PR TITLE
Making Cache::flush() on a Filesystem store not remove dotfiles. Fixes #526

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -107,7 +107,10 @@ class FileStore extends Store {
 	 */
 	protected function flushItems()
 	{
-		$this->files->cleanDirectory($this->directory);
+		foreach ($this->files->files($this->directory) as $file)
+		{
+			$this->files->delete($file);
+		}
 	}
 
 	/**

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -71,7 +71,9 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 	public function testFlushCleansDirectory()
 	{
 		$files = $this->mockFilesystem();
-		$files->expects($this->once())->method('cleanDirectory')->with($this->equalTo(__DIR__));
+		$files->expects($this->once())->method('files')->with($this->equalTo(__DIR__))->will($this->returnValue(array('foo', 'bar')));
+		$files->expects($this->exactly(2))->method('delete');
+
 		$store = new FileStore($files, __DIR__);
 		$store->flush();
 	}


### PR DESCRIPTION
Hi,

When calling Cache::flush() on a default installation of L4 using the Filesystem cache driver, the .gitignore supplied is removed. Kinda annoying, right?

I just switched the method so that we loop through all files and delete them (basically what the `Filesystem::cleanDirectory()` did, but we use `glob()` for this method and this doesn't return dotfiles.

The other alternative was to add options for `cleanDirectory()` but that may cause unexpected behaviour. Happy to switch to make `cleanDirectory()` and `delete()` work as expected with dotfiles if the general consensus leans that way.

Signed-off-by: Ben Corlett bencorlett@me.com
