### PR TITLE
Added JSON_NUMERIC_CHECK as default on toJson

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1062,7 +1062,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * @param  int  $options
 	 * @return string
 	 */
-	public function toJson($options = 0)
+	public function toJson($options = JSON_NUMERIC_CHECK)
 	{
 		return json_encode($this->toArray(), $options);
 	}


### PR DESCRIPTION
This was previously the default but appears to have gone missing in a previous commit.

The problem with not having this as the default is it's impossible to pass JSON options to an Eloquent object if its being returned with out an explicit `toJson` call. Maybe as an alternative there should be a `defaultJsonOptions` attribute on the `Eloquent\Model` class which can be overridden in the models where this is needed?
