### PR TITLE
Allow shouldReceive to be called multiple times on the same Facade.

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -39,9 +39,9 @@ abstract class Facade {
 	{
 		$name = static::getFacadeAccessor();
 
-		//If there is already a mock set as the instance for this facade, use that.
+		// If there is already a mock set as the instance for this facade, use that.
 		if (isset(static::$resolvedInstance[$name]) 
-			&& static::$resolvedInstance[$name] instanceof \Mockery\MockInterface)
+			and static::$resolvedInstance[$name] instanceof \Mockery\MockInterface)
 		{
 			$mock = static::$resolvedInstance[$name];
 		}
@@ -49,7 +49,7 @@ abstract class Facade {
 		{
 			static::$resolvedInstance[$name] = $mock = \Mockery::mock(get_class(static::getFacadeRoot()));
 
-			static::$app->instance($name, $mock);  			
+			static::$app->instance($name, $mock);
 		}
 
 		return call_user_func_array(array($mock, 'shouldReceive'), func_get_args());

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -39,9 +39,7 @@ abstract class Facade {
 	{
 		$name = static::getFacadeAccessor();
 
-		// If there is already a mock set as the instance for this facade, use that.
-		if (isset(static::$resolvedInstance[$name]) 
-			and static::$resolvedInstance[$name] instanceof \Mockery\MockInterface)
+		if (static::isMock())
 		{
 			$mock = static::$resolvedInstance[$name];
 		}
@@ -53,6 +51,19 @@ abstract class Facade {
 		}
 
 		return call_user_func_array(array($mock, 'shouldReceive'), func_get_args());
+	}
+
+	/**
+	 * Determines whether a mock is set as the instance of the facade
+	 *
+	 * @return bool
+	 */
+	protected static function isMock()
+	{
+		$name = static::getFacadeAccessor();
+
+		return (isset(static::$resolvedInstance[$name])
+			and static::$resolvedInstance[$name] instanceof \Mockery\MockInterface);
 	}
 
 	/**

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -39,9 +39,18 @@ abstract class Facade {
 	{
 		$name = static::getFacadeAccessor();
 
-		static::$resolvedInstance[$name] = $mock = \Mockery::mock(get_class(static::getFacadeRoot()));
+		//If there is already a mock set as the instance for this facade, use that.
+		if (isset(static::$resolvedInstance[$name]) 
+			&& static::$resolvedInstance[$name] instanceof \Mockery\MockInterface)
+		{
+			$mock = static::$resolvedInstance[$name];
+		}
+		else
+		{
+			static::$resolvedInstance[$name] = $mock = \Mockery::mock(get_class(static::getFacadeRoot()));
 
-		static::$app->instance($name, $mock);
+			static::$app->instance($name, $mock);  			
+		}
 
 		return call_user_func_array(array($mock, 'shouldReceive'), func_get_args());
 	}

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -36,7 +36,7 @@ class SupportFacadeTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('baz', $app['foo']->foo('bar'));
 	}
 
-	public function testShouldReceiveCanByCalledTwice()
+	public function testShouldReceiveCanBeCalledTwice()
 	{
 		$app = new ApplicationStub;
 		$app->setAttributes(array('foo' => new StdClass));

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -36,6 +36,18 @@ class SupportFacadeTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('baz', $app['foo']->foo('bar'));
 	}
 
+	public function testShouldReceiveCanByCalledTwice()
+	{
+		$app = new ApplicationStub;
+		$app->setAttributes(array('foo' => new StdClass));
+		FacadeStub::setFacadeApplication($app);
+
+		$this->assertInstanceOf('Mockery\MockInterface', $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
+		$this->assertInstanceOf('Mockery\MockInterface', $mock = FacadeStub::shouldReceive('foo2')->once()->with('bar2')->andReturn('baz2')->getMock());
+		$this->assertEquals('baz', $app['foo']->foo('bar'));
+		$this->assertEquals('baz2', $app['foo']->foo2('bar2'));
+	}
+
 }
 
 class FacadeStub extends Illuminate\Support\Facades\Facade {


### PR DESCRIPTION
This patch will allow shouldReceive to be called on a Facade multiple times. It should make testing of facades with fluid interfaces easier.
