### PR TITLE
[Proposal] Add File::sanitize to sanitize filenames

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -137,7 +137,7 @@ class Filesystem {
 	}
 
 	/**
-	 * Returns a sanitized filename
+	 * Returns a sanitized filename.
 	 *
 	 * @param  string  $filename
 	 * @return string

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -1,6 +1,8 @@
 <?php namespace Illuminate\Filesystem;
 
+ini_set('memory_limit', '1200M');
 use FilesystemIterator;
+use Illuminate\Support\Str;
 
 class FileNotFoundException extends \Exception {}
 
@@ -126,13 +128,30 @@ class Filesystem {
 
 	/**
 	 * Extract the file extension from a file path.
-	 * 
+	 *
 	 * @param  string  $path
 	 * @return string
 	 */
 	public function extension($path)
 	{
 		return pathinfo($path, PATHINFO_EXTENSION);
+	}
+
+	/**
+	 * Returns a sanitized filename
+	 *
+	 * @param string $filename A filename
+	 *
+	 * @return string
+	 */
+	public function sanitize($filename)
+	{
+		$extension = '.'.substr(strrchr($filename, '.'), 1);
+
+		$sanitized = str_replace($extension, null, $filename);
+		$sanitized = Str::slug($sanitized).$extension;
+
+		return $sanitized;
 	}
 
 	/**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -7,337 +7,337 @@ class FileNotFoundException extends \Exception {}
 
 class Filesystem {
 
-  /**
-   * Determine if a file exists.
-   *
-   * @param  string  $path
-   * @return bool
-   */
-  public function exists($path)
-  {
-    return file_exists($path);
-  }
+	/**
+	 * Determine if a file exists.
+	 *
+	 * @param  string  $path
+	 * @return bool
+	 */
+	public function exists($path)
+	{
+		return file_exists($path);
+	}
 
-  /**
-   * Get the contents of a file.
-   *
-   * @param  string  $path
-   * @return string
-   */
-  public function get($path)
-  {
-    if ($this->exists($path)) return file_get_contents($path);
+	/**
+	 * Get the contents of a file.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public function get($path)
+	{
+		if ($this->exists($path)) return file_get_contents($path);
 
-    throw new FileNotFoundException("File does not exist at path {$path}");
-  }
+		throw new FileNotFoundException("File does not exist at path {$path}");
+	}
 
-  /**
-   * Get the contents of a remote file.
-   *
-   * @param  string  $path
-   * @return string
-   */
-  public function getRemote($path)
-  {
-    return file_get_contents($path);
-  }
+	/**
+	 * Get the contents of a remote file.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public function getRemote($path)
+	{
+		return file_get_contents($path);
+	}
 
-  /**
-   * Get the returned value of a file.
-   *
-   * @param  string  $path
-   * @return mixed
-   */
-  public function getRequire($path)
-  {
-    if ($this->exists($path)) return require $path;
+	/**
+	 * Get the returned value of a file.
+	 *
+	 * @param  string  $path
+	 * @return mixed
+	 */
+	public function getRequire($path)
+	{
+		if ($this->exists($path)) return require $path;
 
-    throw new FileNotFoundException("File does not exist at path {$path}");
-  }
+		throw new FileNotFoundException("File does not exist at path {$path}");
+	}
 
-  /**
-   * Require the given file once.
-   *
-   * @param  string  $file
-   * @return void
-   */
-  public function requireOnce($file)
-  {
-    require_once $file;
-  }
+	/**
+	 * Require the given file once.
+	 *
+	 * @param  string  $file
+	 * @return void
+	 */
+	public function requireOnce($file)
+	{
+		require_once $file;
+	}
 
-  /**
-   * Write the contents of a file.
-   *
-   * @param  string  $path
-   * @param  string  $contents
-   * @return int
-   */
-  public function put($path, $contents)
-  {
-    return file_put_contents($path, $contents, LOCK_EX);
-  }
+	/**
+	 * Write the contents of a file.
+	 *
+	 * @param  string  $path
+	 * @param  string  $contents
+	 * @return int
+	 */
+	public function put($path, $contents)
+	{
+		return file_put_contents($path, $contents, LOCK_EX);
+	}
 
-  /**
-   * Append to a file.
-   *
-   * @param  string  $path
-   * @param  string  $data
-   * @return int
-   */
-  public function append($path, $data)
-  {
-    return file_put_contents($path, $data, LOCK_EX | FILE_APPEND);
-  }
+	/**
+	 * Append to a file.
+	 *
+	 * @param  string  $path
+	 * @param  string  $data
+	 * @return int
+	 */
+	public function append($path, $data)
+	{
+		return file_put_contents($path, $data, LOCK_EX | FILE_APPEND);
+	}
 
-  /**
-   * Delete the file at a given path.
-   *
-   * @param  string  $path
-   * @return bool
-   */
-  public function delete($path)
-  {
-    @unlink($path);
-  }
+	/**
+	 * Delete the file at a given path.
+	 *
+	 * @param  string  $path
+	 * @return bool
+	 */
+	public function delete($path)
+	{
+		@unlink($path);
+	}
 
-  /**
-   * Move a file to a new location.
-   *
-   * @param  string  $path
-   * @param  string  $target
-   * @return void
-   */
-  public function move($path, $target)
-  {
-    return rename($path, $target);
-  }
+	/**
+	 * Move a file to a new location.
+	 *
+	 * @param  string  $path
+	 * @param  string  $target
+	 * @return void
+	 */
+	public function move($path, $target)
+	{
+		return rename($path, $target);
+	}
 
-  /**
-   * Copy a file to a new location.
-   *
-   * @param  string  $path
-   * @param  string  $target
-   * @return void
-   */
-  public function copy($path, $target)
-  {
-    return copy($path, $target);
-  }
+	/**
+	 * Copy a file to a new location.
+	 *
+	 * @param  string  $path
+	 * @param  string  $target
+	 * @return void
+	 */
+	public function copy($path, $target)
+	{
+		return copy($path, $target);
+	}
 
-  /**
-   * Extract the file extension from a file path.
-   *
-   * @param  string  $path
-   * @return string
-   */
-  public function extension($path)
-  {
-    return pathinfo($path, PATHINFO_EXTENSION);
-  }
+	/**
+	 * Extract the file extension from a file path.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public function extension($path)
+	{
+		return pathinfo($path, PATHINFO_EXTENSION);
+	}
 
-  /**
-   * Returns a sanitized filename
-   *
-   * @param  string  $filename
-   * @return string
-   */
-  public function sanitize($filename)
-  {
-    $extension = $this->extension($filename);
+	/**
+	 * Returns a sanitized filename
+	 *
+	 * @param  string  $filename
+	 * @return string
+	 */
+	public function sanitize($filename)
+	{
+		$extension = $this->extension($filename);
 
-    $sanitized = str_replace($extension, '', $filename);
-    $sanitized = Str::slug($sanitized).$extension;
+		$sanitized = str_replace($extension, '', $filename);
+		$sanitized = Str::slug($sanitized).$extension;
 
-    return $sanitized;
-  }
+		return $sanitized;
+	}
 
-  /**
-   * Get the file type of a given file.
-   *
-   * @param  string  $path
-   * @return string
-   */
-  public function type($path)
-  {
-    return filetype($path);
-  }
+	/**
+	 * Get the file type of a given file.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public function type($path)
+	{
+		return filetype($path);
+	}
 
-  /**
-   * Get the file size of a given file.
-   *
-   * @param  string  $path
-   * @return int
-   */
-  public function size($path)
-  {
-    return filesize($path);
-  }
+	/**
+	 * Get the file size of a given file.
+	 *
+	 * @param  string  $path
+	 * @return int
+	 */
+	public function size($path)
+	{
+		return filesize($path);
+	}
 
-  /**
-   * Get the file's last modification time.
-   *
-   * @param  string  $path
-   * @return int
-   */
-  public function lastModified($path)
-  {
-    return filemtime($path);
-  }
+	/**
+	 * Get the file's last modification time.
+	 *
+	 * @param  string  $path
+	 * @return int
+	 */
+	public function lastModified($path)
+	{
+		return filemtime($path);
+	}
 
-  /**
-   * Determine if the given path is a directory.
-   *
-   * @param  string  $directory
-   * @return bool
-   */
-  public function isDirectory($directory)
-  {
-    return is_dir($directory);
-  }
+	/**
+	 * Determine if the given path is a directory.
+	 *
+	 * @param  string  $directory
+	 * @return bool
+	 */
+	public function isDirectory($directory)
+	{
+		return is_dir($directory);
+	}
 
-  /**
-   * Find path names matching a given pattern.
-   *
-   * @param  string  $pattern
-   * @param  int     $flags
-   * @return array
-   */
-  public function glob($pattern, $flags = 0)
-  {
-    return glob($pattern, $flags);
-  }
+	/**
+	 * Find path names matching a given pattern.
+	 *
+	 * @param  string  $pattern
+	 * @param  int     $flags
+	 * @return array
+	 */
+	public function glob($pattern, $flags = 0)
+	{
+		return glob($pattern, $flags);
+	}
 
-  /**
-   * Get an array of all files in a directory.
-   *
-   * @param  string  $directory
-   * @return array
-   */
-  public function files($directory)
-  {
-    $glob = glob($directory.'/*');
+	/**
+	 * Get an array of all files in a directory.
+	 *
+	 * @param  string  $directory
+	 * @return array
+	 */
+	public function files($directory)
+	{
+		$glob = glob($directory.'/*');
 
-    if ($glob === false) return array();
+		if ($glob === false) return array();
 
-    // To get the appropriate files, we'll simply glob the directory and filter
-    // out any "files" that are not truly files so we do not end up with any
-    // directories in our list, but only true files within the directory.
-    return array_filter($glob, function($file)
-    {
-      return filetype($file) == 'file';
-    });
-  }
+		// To get the appropriate files, we'll simply glob the directory and filter
+		// out any "files" that are not truly files so we do not end up with any
+		// directories in our list, but only true files within the directory.
+		return array_filter($glob, function($file)
+		{
+			return filetype($file) == 'file';
+		});
+	}
 
-  /**
-   * Create a directory.
-   *
-   * @param  string  $path
-   * @param  int     $mode
-   * @param  bool    $recursive
-   * @return bool
-   */
-  public function makeDirectory($path, $mode = 0777, $recursive = false)
-  {
-    return mkdir($path, $mode, $recursive);
-  }
+	/**
+	 * Create a directory.
+	 *
+	 * @param  string  $path
+	 * @param  int     $mode
+	 * @param  bool    $recursive
+	 * @return bool
+	 */
+	public function makeDirectory($path, $mode = 0777, $recursive = false)
+	{
+		return mkdir($path, $mode, $recursive);
+	}
 
-  /**
-   * Copy a directory from one location to another.
-   *
-   * @param  string  $directory
-   * @param  string  $destination
-   * @param  int     $options
-   * @return void
-   */
-  public function copyDirectory($directory, $destination, $options = null)
-  {
-    if ( ! $this->isDirectory($directory)) return false;
+	/**
+	 * Copy a directory from one location to another.
+	 *
+	 * @param  string  $directory
+	 * @param  string  $destination
+	 * @param  int     $options
+	 * @return void
+	 */
+	public function copyDirectory($directory, $destination, $options = null)
+	{
+		if ( ! $this->isDirectory($directory)) return false;
 
-    $options = $options ?: FilesystemIterator::SKIP_DOTS;
+		$options = $options ?: FilesystemIterator::SKIP_DOTS;
 
-    // If the destination directory does not actually exist, we will go ahead and
-    // create it recursively, which just gets the destination prepared to copy
-    // the files over. Once we make the directory we'll proceed the copying.
-    if ( ! $this->isDirectory($destination))
-    {
-      $this->makeDirectory($destination, 0777, true);
-    }
+		// If the destination directory does not actually exist, we will go ahead and
+		// create it recursively, which just gets the destination prepared to copy
+		// the files over. Once we make the directory we'll proceed the copying.
+		if ( ! $this->isDirectory($destination))
+		{
+			$this->makeDirectory($destination, 0777, true);
+		}
 
-    $items = new FilesystemIterator($directory, $options);
+		$items = new FilesystemIterator($directory, $options);
 
-    foreach ($items as $item)
-    {
-      // As we spin through items, we will check to see if the current file is actually
-      // a directory or a file. When it is actually a directory we will need to call
-      // back into this function recursively to keep copying these nested folders.
-      $target = $destination.'/'.$item->getBasename();
+		foreach ($items as $item)
+		{
+			// As we spin through items, we will check to see if the current file is actually
+			// a directory or a file. When it is actually a directory we will need to call
+			// back into this function recursively to keep copying these nested folders.
+			$target = $destination.'/'.$item->getBasename();
 
-      if ($item->isDir())
-      {
-        $path = $item->getRealPath();
+			if ($item->isDir())
+			{
+				$path = $item->getRealPath();
 
-        if ( ! $this->copyDirectory($path, $target, $options)) return false;
-      }
+				if ( ! $this->copyDirectory($path, $target, $options)) return false;
+			}
 
-      // If the current items is just a regular file, we will just copy this to the new
-      // location and keep looping. If for some reason the copy fails we'll bail out
-      // and return false, so the developer is aware that the copy process failed.
-      else
-      {
-        if ( ! $this->copy($item->getRealPath(), $target)) return false;
-      }
-    }
+			// If the current items is just a regular file, we will just copy this to the new
+			// location and keep looping. If for some reason the copy fails we'll bail out
+			// and return false, so the developer is aware that the copy process failed.
+			else
+			{
+				if ( ! $this->copy($item->getRealPath(), $target)) return false;
+			}
+		}
 
-    return true;
-  }
+		return true;
+	}
 
-  /**
-   * Recursively delete a directory.
-   *
-   * The directory itself may be optionally preserved.
-   *
-   * @param  string  $directory
-   * @param  bool    $preserve
-   * @return void
-   */
-  public function deleteDirectory($directory, $preserve = false)
-  {
-    if ( ! $this->isDirectory($directory)) return;
+	/**
+	 * Recursively delete a directory.
+	 *
+	 * The directory itself may be optionally preserved.
+	 *
+	 * @param  string  $directory
+	 * @param  bool    $preserve
+	 * @return void
+	 */
+	public function deleteDirectory($directory, $preserve = false)
+	{
+		if ( ! $this->isDirectory($directory)) return;
 
-    $items = new FilesystemIterator($directory);
+		$items = new FilesystemIterator($directory);
 
-    foreach ($items as $item)
-    {
-      // If the item is a directory, we can just recurse into the function and
-      // delete that sub-director, otherwise we'll just delete the file and
-      // keep iterating through each file until the directory is cleaned.
-      if ($item->isDir())
-      {
-        $this->deleteDirectory($item->getRealPath());
-      }
+		foreach ($items as $item)
+		{
+			// If the item is a directory, we can just recurse into the function and
+			// delete that sub-director, otherwise we'll just delete the file and
+			// keep iterating through each file until the directory is cleaned.
+			if ($item->isDir())
+			{
+				$this->deleteDirectory($item->getRealPath());
+			}
 
-      // If the item is just a file, we can go ahead and delete it since we're
-      // just looping through and waxing all of the files in this directory
-      // and calling directories recursively, so we delete the real path.
-      else
-      {
-        $this->delete($item->getRealPath());
-      }
-    }
+			// If the item is just a file, we can go ahead and delete it since we're
+			// just looping through and waxing all of the files in this directory
+			// and calling directories recursively, so we delete the real path.
+			else
+			{
+				$this->delete($item->getRealPath());
+			}
+		}
 
-    if ( ! $preserve) @rmdir($directory);
-  }
+		if ( ! $preserve) @rmdir($directory);
+	}
 
-  /**
-   * Empty the specified directory of all files and folders.
-   *
-   * @param  string  $directory
-   * @return void
-   */
-  public function cleanDirectory($directory)
-  {
-    return $this->deleteDirectory($directory, true);
-  }
+	/**
+	 * Empty the specified directory of all files and folders.
+	 *
+	 * @param  string  $directory
+	 * @return void
+	 */
+	public function cleanDirectory($directory)
+	{
+		return $this->deleteDirectory($directory, true);
+	}
 
 }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -146,7 +146,7 @@ class Filesystem {
 	{
 		$extension = '.'.$this->extension($filename);
 
-		$sanitized = strstr($filename, $extension, true);
+		$sanitized = substr($filename, 0, -strlen($extension));
 		$sanitized = Str::slug($sanitized).$extension;
 
 		return $sanitized;

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -1,6 +1,5 @@
 <?php namespace Illuminate\Filesystem;
 
-ini_set('memory_limit', '1200M');
 use FilesystemIterator;
 use Illuminate\Support\Str;
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -7,338 +7,337 @@ class FileNotFoundException extends \Exception {}
 
 class Filesystem {
 
-	/**
-	 * Determine if a file exists.
-	 *
-	 * @param  string  $path
-	 * @return bool
-	 */
-	public function exists($path)
-	{
-		return file_exists($path);
-	}
+  /**
+   * Determine if a file exists.
+   *
+   * @param  string  $path
+   * @return bool
+   */
+  public function exists($path)
+  {
+    return file_exists($path);
+  }
 
-	/**
-	 * Get the contents of a file.
-	 *
-	 * @param  string  $path
-	 * @return string
-	 */
-	public function get($path)
-	{
-		if ($this->exists($path)) return file_get_contents($path);
+  /**
+   * Get the contents of a file.
+   *
+   * @param  string  $path
+   * @return string
+   */
+  public function get($path)
+  {
+    if ($this->exists($path)) return file_get_contents($path);
 
-		throw new FileNotFoundException("File does not exist at path {$path}");
-	}
+    throw new FileNotFoundException("File does not exist at path {$path}");
+  }
 
-	/**
-	 * Get the contents of a remote file.
-	 *
-	 * @param  string  $path
-	 * @return string
-	 */
-	public function getRemote($path)
-	{
-		return file_get_contents($path);
-	}
+  /**
+   * Get the contents of a remote file.
+   *
+   * @param  string  $path
+   * @return string
+   */
+  public function getRemote($path)
+  {
+    return file_get_contents($path);
+  }
 
-	/**
-	 * Get the returned value of a file.
-	 *
-	 * @param  string  $path
-	 * @return mixed
-	 */
-	public function getRequire($path)
-	{
-		if ($this->exists($path)) return require $path;
+  /**
+   * Get the returned value of a file.
+   *
+   * @param  string  $path
+   * @return mixed
+   */
+  public function getRequire($path)
+  {
+    if ($this->exists($path)) return require $path;
 
-		throw new FileNotFoundException("File does not exist at path {$path}");
-	}
+    throw new FileNotFoundException("File does not exist at path {$path}");
+  }
 
-	/**
-	 * Require the given file once.
-	 *
-	 * @param  string  $file
-	 * @return void
-	 */
-	public function requireOnce($file)
-	{
-		require_once $file;
-	}
+  /**
+   * Require the given file once.
+   *
+   * @param  string  $file
+   * @return void
+   */
+  public function requireOnce($file)
+  {
+    require_once $file;
+  }
 
-	/**
-	 * Write the contents of a file.
-	 *
-	 * @param  string  $path
-	 * @param  string  $contents
-	 * @return int
-	 */
-	public function put($path, $contents)
-	{
-		return file_put_contents($path, $contents, LOCK_EX);
-	}
+  /**
+   * Write the contents of a file.
+   *
+   * @param  string  $path
+   * @param  string  $contents
+   * @return int
+   */
+  public function put($path, $contents)
+  {
+    return file_put_contents($path, $contents, LOCK_EX);
+  }
 
-	/**
-	 * Append to a file.
-	 *
-	 * @param  string  $path
-	 * @param  string  $data
-	 * @return int
-	 */
-	public function append($path, $data)
-	{
-		return file_put_contents($path, $data, LOCK_EX | FILE_APPEND);
-	}
+  /**
+   * Append to a file.
+   *
+   * @param  string  $path
+   * @param  string  $data
+   * @return int
+   */
+  public function append($path, $data)
+  {
+    return file_put_contents($path, $data, LOCK_EX | FILE_APPEND);
+  }
 
-	/**
-	 * Delete the file at a given path.
-	 *
-	 * @param  string  $path
-	 * @return bool
-	 */
-	public function delete($path)
-	{
-		@unlink($path);
-	}
+  /**
+   * Delete the file at a given path.
+   *
+   * @param  string  $path
+   * @return bool
+   */
+  public function delete($path)
+  {
+    @unlink($path);
+  }
 
-	/**
-	 * Move a file to a new location.
-	 *
-	 * @param  string  $path
-	 * @param  string  $target
-	 * @return void
-	 */
-	public function move($path, $target)
-	{
-		return rename($path, $target);
-	}
+  /**
+   * Move a file to a new location.
+   *
+   * @param  string  $path
+   * @param  string  $target
+   * @return void
+   */
+  public function move($path, $target)
+  {
+    return rename($path, $target);
+  }
 
-	/**
-	 * Copy a file to a new location.
-	 *
-	 * @param  string  $path
-	 * @param  string  $target
-	 * @return void
-	 */
-	public function copy($path, $target)
-	{
-		return copy($path, $target);
-	}
+  /**
+   * Copy a file to a new location.
+   *
+   * @param  string  $path
+   * @param  string  $target
+   * @return void
+   */
+  public function copy($path, $target)
+  {
+    return copy($path, $target);
+  }
 
-	/**
-	 * Extract the file extension from a file path.
-	 *
-	 * @param  string  $path
-	 * @return string
-	 */
-	public function extension($path)
-	{
-		return pathinfo($path, PATHINFO_EXTENSION);
-	}
+  /**
+   * Extract the file extension from a file path.
+   *
+   * @param  string  $path
+   * @return string
+   */
+  public function extension($path)
+  {
+    return pathinfo($path, PATHINFO_EXTENSION);
+  }
 
-	/**
-	 * Returns a sanitized filename
-	 *
-	 * @param string $filename A filename
-	 *
-	 * @return string
-	 */
-	public function sanitize($filename)
-	{
-		$extension = '.'.substr(strrchr($filename, '.'), 1);
+  /**
+   * Returns a sanitized filename
+   *
+   * @param  string  $filename
+   * @return string
+   */
+  public function sanitize($filename)
+  {
+    $extension = $this->extension($filename);
 
-		$sanitized = str_replace($extension, null, $filename);
-		$sanitized = Str::slug($sanitized).$extension;
+    $sanitized = str_replace($extension, '', $filename);
+    $sanitized = Str::slug($sanitized).$extension;
 
-		return $sanitized;
-	}
+    return $sanitized;
+  }
 
-	/**
-	 * Get the file type of a given file.
-	 *
-	 * @param  string  $path
-	 * @return string
-	 */
-	public function type($path)
-	{
-		return filetype($path);
-	}
+  /**
+   * Get the file type of a given file.
+   *
+   * @param  string  $path
+   * @return string
+   */
+  public function type($path)
+  {
+    return filetype($path);
+  }
 
-	/**
-	 * Get the file size of a given file.
-	 *
-	 * @param  string  $path
-	 * @return int
-	 */
-	public function size($path)
-	{
-		return filesize($path);
-	}
+  /**
+   * Get the file size of a given file.
+   *
+   * @param  string  $path
+   * @return int
+   */
+  public function size($path)
+  {
+    return filesize($path);
+  }
 
-	/**
-	 * Get the file's last modification time.
-	 *
-	 * @param  string  $path
-	 * @return int
-	 */
-	public function lastModified($path)
-	{
-		return filemtime($path);
-	}
+  /**
+   * Get the file's last modification time.
+   *
+   * @param  string  $path
+   * @return int
+   */
+  public function lastModified($path)
+  {
+    return filemtime($path);
+  }
 
-	/**
-	 * Determine if the given path is a directory.
-	 *
-	 * @param  string  $directory
-	 * @return bool
-	 */
-	public function isDirectory($directory)
-	{
-		return is_dir($directory);
-	}
+  /**
+   * Determine if the given path is a directory.
+   *
+   * @param  string  $directory
+   * @return bool
+   */
+  public function isDirectory($directory)
+  {
+    return is_dir($directory);
+  }
 
-	/**
-	 * Find path names matching a given pattern.
-	 *
-	 * @param  string  $pattern
-	 * @param  int     $flags
-	 * @return array
-	 */
-	public function glob($pattern, $flags = 0)
-	{
-		return glob($pattern, $flags);
-	}
+  /**
+   * Find path names matching a given pattern.
+   *
+   * @param  string  $pattern
+   * @param  int     $flags
+   * @return array
+   */
+  public function glob($pattern, $flags = 0)
+  {
+    return glob($pattern, $flags);
+  }
 
-	/**
-	 * Get an array of all files in a directory.
-	 *
-	 * @param  string  $directory
-	 * @return array
-	 */
-	public function files($directory)
-	{
-		$glob = glob($directory.'/*');
+  /**
+   * Get an array of all files in a directory.
+   *
+   * @param  string  $directory
+   * @return array
+   */
+  public function files($directory)
+  {
+    $glob = glob($directory.'/*');
 
-		if ($glob === false) return array();
+    if ($glob === false) return array();
 
-		// To get the appropriate files, we'll simply glob the directory and filter
-		// out any "files" that are not truly files so we do not end up with any
-		// directories in our list, but only true files within the directory.
-		return array_filter($glob, function($file)
-		{
-			return filetype($file) == 'file';
-		});
-	}
+    // To get the appropriate files, we'll simply glob the directory and filter
+    // out any "files" that are not truly files so we do not end up with any
+    // directories in our list, but only true files within the directory.
+    return array_filter($glob, function($file)
+    {
+      return filetype($file) == 'file';
+    });
+  }
 
-	/**
-	 * Create a directory.
-	 *
-	 * @param  string  $path
-	 * @param  int     $mode
-	 * @param  bool    $recursive
-	 * @return bool
-	 */
-	public function makeDirectory($path, $mode = 0777, $recursive = false)
-	{
-		return mkdir($path, $mode, $recursive);
-	}
+  /**
+   * Create a directory.
+   *
+   * @param  string  $path
+   * @param  int     $mode
+   * @param  bool    $recursive
+   * @return bool
+   */
+  public function makeDirectory($path, $mode = 0777, $recursive = false)
+  {
+    return mkdir($path, $mode, $recursive);
+  }
 
-	/**
-	 * Copy a directory from one location to another.
-	 *
-	 * @param  string  $directory
-	 * @param  string  $destination
-	 * @param  int     $options
-	 * @return void
-	 */
-	public function copyDirectory($directory, $destination, $options = null)
-	{
-		if ( ! $this->isDirectory($directory)) return false;
+  /**
+   * Copy a directory from one location to another.
+   *
+   * @param  string  $directory
+   * @param  string  $destination
+   * @param  int     $options
+   * @return void
+   */
+  public function copyDirectory($directory, $destination, $options = null)
+  {
+    if ( ! $this->isDirectory($directory)) return false;
 
-		$options = $options ?: FilesystemIterator::SKIP_DOTS;
+    $options = $options ?: FilesystemIterator::SKIP_DOTS;
 
-		// If the destination directory does not actually exist, we will go ahead and
-		// create it recursively, which just gets the destination prepared to copy
-		// the files over. Once we make the directory we'll proceed the copying.
-		if ( ! $this->isDirectory($destination))
-		{
-			$this->makeDirectory($destination, 0777, true);
-		}
+    // If the destination directory does not actually exist, we will go ahead and
+    // create it recursively, which just gets the destination prepared to copy
+    // the files over. Once we make the directory we'll proceed the copying.
+    if ( ! $this->isDirectory($destination))
+    {
+      $this->makeDirectory($destination, 0777, true);
+    }
 
-		$items = new FilesystemIterator($directory, $options);
+    $items = new FilesystemIterator($directory, $options);
 
-		foreach ($items as $item)
-		{
-			// As we spin through items, we will check to see if the current file is actually
-			// a directory or a file. When it is actually a directory we will need to call
-			// back into this function recursively to keep copying these nested folders.
-			$target = $destination.'/'.$item->getBasename();
+    foreach ($items as $item)
+    {
+      // As we spin through items, we will check to see if the current file is actually
+      // a directory or a file. When it is actually a directory we will need to call
+      // back into this function recursively to keep copying these nested folders.
+      $target = $destination.'/'.$item->getBasename();
 
-			if ($item->isDir())
-			{
-				$path = $item->getRealPath();
+      if ($item->isDir())
+      {
+        $path = $item->getRealPath();
 
-				if ( ! $this->copyDirectory($path, $target, $options)) return false;
-			}
+        if ( ! $this->copyDirectory($path, $target, $options)) return false;
+      }
 
-			// If the current items is just a regular file, we will just copy this to the new
-			// location and keep looping. If for some reason the copy fails we'll bail out
-			// and return false, so the developer is aware that the copy process failed.
-			else
-			{
-				if ( ! $this->copy($item->getRealPath(), $target)) return false;
-			}
-		}
+      // If the current items is just a regular file, we will just copy this to the new
+      // location and keep looping. If for some reason the copy fails we'll bail out
+      // and return false, so the developer is aware that the copy process failed.
+      else
+      {
+        if ( ! $this->copy($item->getRealPath(), $target)) return false;
+      }
+    }
 
-		return true;
-	}
+    return true;
+  }
 
-	/**
-	 * Recursively delete a directory.
-	 *
-	 * The directory itself may be optionally preserved.
-	 *
-	 * @param  string  $directory
-	 * @param  bool    $preserve
-	 * @return void
-	 */
-	public function deleteDirectory($directory, $preserve = false)
-	{
-		if ( ! $this->isDirectory($directory)) return;
+  /**
+   * Recursively delete a directory.
+   *
+   * The directory itself may be optionally preserved.
+   *
+   * @param  string  $directory
+   * @param  bool    $preserve
+   * @return void
+   */
+  public function deleteDirectory($directory, $preserve = false)
+  {
+    if ( ! $this->isDirectory($directory)) return;
 
-		$items = new FilesystemIterator($directory);
+    $items = new FilesystemIterator($directory);
 
-		foreach ($items as $item)
-		{
-			// If the item is a directory, we can just recurse into the function and
-			// delete that sub-director, otherwise we'll just delete the file and
-			// keep iterating through each file until the directory is cleaned.
-			if ($item->isDir())
-			{
-				$this->deleteDirectory($item->getRealPath());
-			}
+    foreach ($items as $item)
+    {
+      // If the item is a directory, we can just recurse into the function and
+      // delete that sub-director, otherwise we'll just delete the file and
+      // keep iterating through each file until the directory is cleaned.
+      if ($item->isDir())
+      {
+        $this->deleteDirectory($item->getRealPath());
+      }
 
-			// If the item is just a file, we can go ahead and delete it since we're
-			// just looping through and waxing all of the files in this directory
-			// and calling directories recursively, so we delete the real path.
-			else
-			{
-				$this->delete($item->getRealPath());
-			}
-		}
+      // If the item is just a file, we can go ahead and delete it since we're
+      // just looping through and waxing all of the files in this directory
+      // and calling directories recursively, so we delete the real path.
+      else
+      {
+        $this->delete($item->getRealPath());
+      }
+    }
 
-		if ( ! $preserve) @rmdir($directory);
-	}
+    if ( ! $preserve) @rmdir($directory);
+  }
 
-	/**
-	 * Empty the specified directory of all files and folders.
-	 *
-	 * @param  string  $directory
-	 * @return void
-	 */
-	public function cleanDirectory($directory)
-	{
-		return $this->deleteDirectory($directory, true);
-	}
+  /**
+   * Empty the specified directory of all files and folders.
+   *
+   * @param  string  $directory
+   * @return void
+   */
+  public function cleanDirectory($directory)
+  {
+    return $this->deleteDirectory($directory, true);
+  }
 
 }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -144,10 +144,10 @@ class Filesystem {
 	 */
 	public function sanitize($filename)
 	{
-		$extension = $this->extension($filename);
+		$extension = '.'.$this->extension($filename);
 
-		$sanitized = str_replace($extension, '', $filename);
-		$sanitized = Str::slug($sanitized).'.'.$extension;
+		$sanitized = strstr($filename, $extension, true);
+		$sanitized = Str::slug($sanitized).$extension;
 
 		return $sanitized;
 	}

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -147,7 +147,7 @@ class Filesystem {
 		$extension = $this->extension($filename);
 
 		$sanitized = str_replace($extension, '', $filename);
-		$sanitized = Str::slug($sanitized).$extension;
+		$sanitized = Str::slug($sanitized).'.'.$extension;
 
 		return $sanitized;
 	}

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -113,6 +113,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 		$files = new Filesystem;
 
 		$this->assertEquals('this-is-unsnitized.jpg', $files->sanitize('Th.îs—I._s-«Uns@ñïTî//\zèd.jpg'));
+		$this->assertEquals('eoaujpegpngjpg.jpg', $files->sanitize('èôàùjpegpngjpg.jpg'));
 	}
 
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -114,6 +114,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals('this-is-unsnitized.jpg', $files->sanitize('Th.îs—I._s-«Uns@ñïTî//\zèd.jpg'));
 		$this->assertEquals('eoaujpegpngjpg.jpg', $files->sanitize('èôàùjpegpngjpg.jpg'));
+		$this->assertEquals('myjpgfile.jpg', $files->sanitize('my.jpgfile.jpg'));
 	}
 
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -107,4 +107,12 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 		rmdir(__DIR__.'/tmp2');
 	}
 
+
+	public function testSanitizeFilenames()
+	{
+		$files = new Filesystem;
+
+		$this->assertEquals('this-is-unsnitized.jpg', $files->sanitize('Th.îs—I._s-«Uns@ñïTî//\zèd.jpg'));
+	}
+
 }


### PR DESCRIPTION
While `Str::slug` is great, it fails to be used as a way to sanitize user uploaded files's names as it strips the dot from the extension. This is a little helper to allow easy sanitation of file names.
