### PR TITLE
Set depth on Symfony finder

### DIFF
--- a/src/Illuminate/Workbench/Starter.php
+++ b/src/Illuminate/Workbench/Starter.php
@@ -18,7 +18,7 @@ class Starter {
 		// We will use the finder to locate all "autoload.php" files in the workbench
 		// directory, then we will include them each so that they are able to load
 		// the appropriate classes and file used by the given workbench package.
-		$autoloads = $finder->in($path)->files()->name('autoload.php');
+		$autoloads = $finder->in($path)->depth('< 5')->files()->name('autoload.php');
 
 		foreach ($autoloads as $file)
 		{


### PR DESCRIPTION
Fix Symfony Finder recursion issue. The system can't load packages without this variable set (or upstream fixing the recursion issue). 

(Sorry, this is my first github submit ever so pardon if I didn't do it right...)
