### PR TITLE
Remove array dependencies from url helpers

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -66,7 +66,7 @@ class UrlGenerator {
 	 * Generate a absolute URL to the given path.
 	 *
 	 * @param  string  $path
-	 * @param  array   $parameters
+	 * @param  mixed   $parameters
 	 * @param  bool    $secure
 	 * @return string
 	 */
@@ -154,7 +154,7 @@ class UrlGenerator {
 	 * Get the URL to a named route.
 	 *
 	 * @param  string  $name
-	 * @param  array   $parameters
+	 * @param  mixed   $parameters
 	 * @param  bool    $absolute
 	 * @return string
 	 */
@@ -211,7 +211,7 @@ class UrlGenerator {
 	 * Get the URL to a controller action.
 	 *
 	 * @param  string  $action
-	 * @param  array   $parameters
+	 * @param  mixed   $parameters
 	 * @param  bool    $absolute
 	 * @return string
 	 */

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -431,10 +431,10 @@ if ( ! function_exists('secure_url'))
 	 * Generate a HTTPS url for the application.
 	 *
 	 * @param  string  $path
-	 * @param  array   $parameters
+	 * @param  mixed   $parameters
 	 * @return string
 	 */
-	function secure_url($path, array $parameters = array())
+	function secure_url($path, $parameters = array())
 	{
 		return url($path, $parameters, true);
 	}
@@ -619,11 +619,11 @@ if ( ! function_exists('url'))
 	 * Generate a url for the application.
 	 *
 	 * @param  string  $path
-	 * @param  array   $parameters
+	 * @param  mixed   $parameters
 	 * @param  bool    $secure
 	 * @return string
 	 */
-	function url($path = null, array $parameters = array(), $secure = null)
+	function url($path = null, $parameters = array(), $secure = null)
 	{
 		$app = app();
 


### PR DESCRIPTION
The array dependency isn't necessary anymore since the `to()` function in `UrlGenerator` uses typecasting to convert the $parameters variable into an array. This allows a user to use a single variable instead of a an array. 

``` php
// For example:
url('foo/bar', $id);
secure_url('foo/bar', $id);
// Instead of:
url('foo/bar', array($id));
secure_url('foo/bar', array($id));
```

Also updated documentation to indicate a mixed type of parameters.
