### PR TITLE
Assign Cookie payload name with value from config

### DIFF
--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -75,8 +75,8 @@ class SessionServiceProvider extends ServiceProvider {
 	{
 		$app->booting(function($app)
 		{
-			$app['session']->start($app['cookie'], $app['config']['session.cookie']);
 			$app['session']->setPayloadName($app['config']['session.payload']);
+			$app['session']->start($app['cookie'], $app['config']['session.cookie']);
 		});
 	}
 

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -76,6 +76,7 @@ class SessionServiceProvider extends ServiceProvider {
 		$app->booting(function($app)
 		{
 			$app['session']->start($app['cookie'], $app['config']['session.cookie']);
+			$app['session']->setPayloadName($app['config']['session.payload']);
 		});
 	}
 


### PR DESCRIPTION
Not really a PR, more of a proposal with an example.

In session config file there's an option to set cookie name `session.cookie` which allows developer to change default session cookie name to whatever name he wants.

Then, there's a driver CookieStore which uses it's own cookie name - 'illuminate_payload'. I believe it's pretty reasonable to expect an option in config file which allows to change CookieStore's name too.

Of course, right now there's a `setPayloadName()` method available, but i really think addition of `payload` option in config file brings consistency.

Anyway, besides the change in this PR, there must be additional change to `app/confing/session.php` file:

``` php
....
'payload' => 'illuminate_payload',
```
