### PR TITLE
Attributes defaults to empty array

### DIFF
--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -56,7 +56,7 @@ class HtmlBuilder {
 	 * @param  array   $attributes
 	 * @return string
 	 */
-	protected static function listing($type, $list, $attributes)
+	protected static function listing($type, $list, $attributes = array())
 	{
 		$html = '';
 


### PR DESCRIPTION
Small fix to ensure that `$attributes` always has a default value of an empty array. See existing line 110 of HtmlBuilder, where attributes is never passed to `static::listing`, which generates a warning.

``` php
if (is_int($key))
{
   return static::listing($type, $value);
}
```
