### PR TITLE
Return SQS response from SqsClient

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -44,7 +44,7 @@ class SqsQueue extends Queue implements QueueInterface {
 	{
 		$payload = $this->createPayload($job, $data);
 
-		$this->sqs->sendMessage(array('QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload));
+		return $this->sqs->sendMessage(array('QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload));
 	}
 
 	/**
@@ -60,7 +60,7 @@ class SqsQueue extends Queue implements QueueInterface {
 	{
 		$payload = $this->createPayload($job, $data);
 
-		$this->sqs->sendMessage(array(
+		return $this->sqs->sendMessage(array(
 
 			'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload, 'DelaySeconds' => $delay,
 


### PR DESCRIPTION
There are situations where you want to know SQS response information after sending a message to SQS.
I'm not familiar with beanstalkd so didn't make the same change to the beanstalkd equivalent.
