### PR TITLE
Sane default connection/queue if none specified in queue:listen

### DIFF
--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -72,6 +72,11 @@ class ListenCommand extends Command {
 	 */
 	protected function getQueue($connection)
 	{
+		if ($connection === NULL)
+		{
+			$connection = $this->laravel['config']->get("queue.default");
+		}
+		
 		$queue = $this->laravel['config']->get("queue.connections.{$connection}.queue", 'default');
 
 		return $this->input->getOption('queue') ?: $queue;

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -72,7 +72,7 @@ class ListenCommand extends Command {
 	 */
 	protected function getQueue($connection)
 	{
-		if ($connection === NULL)
+		if (is_null($connection))
 		{
 			$connection = $this->laravel['config']->get("queue.default");
 		}


### PR DESCRIPTION
If you execute the command `php artisan queue:listen` then queue the system uses will end up as `default` even if the real default queue for your selected queue driver is different. This should fix that.
