### PR TITLE
Added option to create an autoincrement not unsigned in SchemaBuilder

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -316,9 +316,13 @@ class Blueprint {
 	 * @param  string  $column
 	 * @return Illuminate\Support\Fluent
 	 */
-	public function increments($column)
+	public function increments($column, $unsigned = true)
 	{
-		return $this->unsignedInteger($column, true);
+		if ($unsigned) {
+          return $this->unsignedInteger($column, true);
+        } else {
+            return $this->integer($column, true, false);
+        }
 	}
 
 	/**


### PR DESCRIPTION
We are not able to create a primary key, with autoincrement and **not** unsigned.

With theses changes, we can do this now:

``` php
Schema::create('products', function($table)
{
    $table->increments('id') // unsigned
    $table->increments('id', false); // not unsigned
});
```
