### PR TITLE
Form session fix

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -65,7 +65,7 @@ class FormBuilder {
 	public function __construct(UrlGenerator $url, Session $session)
 	{
 		$this->url = $url;
-		$this->csrfToken = $session-getToken();
+		$this->csrfToken = $session->getToken();
 
 		$this->setSessionStore( $session );
 	}

--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -64,10 +64,12 @@ class FormBuilder {
 	 */
 	public function __construct(UrlGenerator $url, Session $session)
 	{
-		$this->url = $url;
+		//set session store + csrfToken
+		$this->setSessionStore( $session );
 		$this->csrfToken = $session->getToken();
 
-		$this->setSessionStore( $session );
+		//setup url
+		$this->url = $url;
 	}
 
 	/**

--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -62,10 +62,12 @@ class FormBuilder {
 	 * @param  string  $csrfToken
 	 * @return void
 	 */
-	public function __construct(UrlGenerator $url, $csrfToken)
+	public function __construct(UrlGenerator $url, Session $session)
 	{
 		$this->url = $url;
-		$this->csrfToken = $csrfToken;
+		$this->csrfToken = $session-getToken();
+
+		$this->setSessionStore( $session );
 	}
 
 	/**

--- a/src/Illuminate/Html/HtmlServiceProvider.php
+++ b/src/Illuminate/Html/HtmlServiceProvider.php
@@ -20,7 +20,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	{
 		$this->app['form'] = $this->app->share(function($app)
 		{
-			return new FormBuilder($app['url'], $app['session']->getToken());
+			return new FormBuilder($app['url'], $app['session']);
 		});
 	}
 


### PR DESCRIPTION
Fix it so when you post a form that has errors and us `return Redirect::to('/')->withErrors( $validation )->withInput()`, the field will show the data entered by the user, which has an error and not default to the modal data or the default value.

Form Helper has the function `setSessionStore` but it's never used.

Also it has a check in place to check for `hasOldInput` from the session.
