### PR TITLE
Sync with attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -401,15 +401,16 @@ class BelongsToMany extends Relation {
 			return (int)$value;
 		}, $current);
 
-		foreach ($ids as $id)
+		$ids = array_assoc($ids);
+		foreach ($ids as $id => $attributes)
 		{
-			if ( ! in_array($id, $current)) $this->attach($id);
+			if ( ! in_array($id, $current)) $this->attach($id, $attributes);
 		}
 
 		// Next, we will take the differences of the currents and given IDs and detach
 		// all of the entities that exist in the "current" array but are not in the
 		// the array of the IDs given to the method which will complete the sync.
-		$detach = array_diff($current, $ids);
+		$detach = array_diff($current, array_keys($ids));
 
 		if (count($detach) > 0)
 		{

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -396,6 +396,11 @@ class BelongsToMany extends Relation {
 		// if they exist in the array of current ones, and if not we will insert.
 		$current = $this->newPivotQuery()->lists($this->otherKey);
 
+		$current = array_map(function($value)
+		{
+			return (int)$value;
+		}, $current);
+
 		foreach ($ids as $id)
 		{
 			if ( ! in_array($id, $current)) $this->attach($id);

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -264,7 +264,7 @@ if ( ! function_exists('array_assoc'))
 	 * @param  mixed   $defaultValue
 	 * @return array
 	 */
-	function array_assoc($array, $defaultValue = [])
+	function array_assoc($array, $defaultValue = array())
 	{
 		$results = array();
 
@@ -289,7 +289,7 @@ if ( ! function_exists('is_assoc'))
 	 * @param  array   $array
 	 * @return bool
 	 */
-	function is_assoc($array, $defaultValue = [])
+	function is_assoc($array)
 	{
 		// Keys of the array
 		$keys = array_keys($array);

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -255,6 +255,51 @@ if ( ! function_exists('array_set'))
 	}
 }
 
+if ( ! function_exists('array_assoc'))
+{
+	/**
+	 * Convert a sequential array to an associative arrray.
+	 *
+	 * @param  array   $array
+	 * @param  mixed   $defaultValue
+	 * @return array
+	 */
+	function array_assoc($array, $defaultValue = [])
+	{
+		$results = array();
+
+		if ( ! is_assoc($array) )
+		{
+			foreach ($array as $key => $value) {
+				$results[$value] = $defaultValue;
+			}
+
+			return $results;
+		}
+
+		return $array;
+	}
+}
+
+if ( ! function_exists('is_assoc'))
+{
+	/**
+	 * Checks if an array is associative
+	 *
+	 * @param  array   $array
+	 * @return bool
+	 */
+	function is_assoc($array, $defaultValue = [])
+	{
+		// Keys of the array
+		$keys = array_keys($array);
+
+		// If the array keys of the keys match the keys, then the array must
+		// not be associative (e.g. the keys array looked like {0:0, 1:1...}).
+		return array_keys($keys) !== $keys;
+	}
+}
+
 if ( ! function_exists('asset'))
 {
 	/**

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -83,7 +83,7 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	public function testArrayAssoc()
 	{
 		$array = array(1, 2, 3);
-		$this->assertEquals(array(1 => [], 2 => [], 3 => []), array_assoc($array));
+		$this->assertEquals(array(1 => array(), 2 => array(), 3 => array()), array_assoc($array));
 
 		$array = array(1 => 'test1', 2 => 'test2', 3 => 'test3');
 		$this->assertEquals(array(1 => 'test1', 2 => 'test2', 3 => 'test3'), array_assoc($array));

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -71,6 +71,23 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('dayle', array_first($array, function($key, $value) { return $value == 'dayle'; }));
 	}
 
+	public function testIsAssoc()
+	{
+		$array = array(1, 2, 3);
+		$this->assertEquals(false, is_assoc($array));
+
+		$array = array(1 => 'test', 2 => 'test1', 3 => 'test2');
+		$this->assertEquals(true, is_assoc($array));
+	}	
+
+	public function testArrayAssoc()
+	{
+		$array = array(1, 2, 3);
+		$this->assertEquals(array(1 => [], 2 => [], 3 => []), array_assoc($array));
+
+		$array = array(1 => 'test1', 2 => 'test2', 3 => 'test3');
+		$this->assertEquals(array(1 => 'test1', 2 => 'test2', 3 => 'test3'), array_assoc($array));
+	}
 
 	public function testStrIs()
 	{


### PR DESCRIPTION
So the idea here is that you would want to sync with attributes.

There is one problem that I know of with this implementation. As attach does not know how to handle updates of attributes the code is checking to see if the pivot already exists. This would mean that existing pivots would not get their attributes updated.

Usage without attributes:
$model->othermodel()->sync([1, 2, 3]);

Usage with attributes:
$model->othermodel()->sync([1 => ['position' => 1], 2 => ['position' => 2], 3 => ['position' => 3]]);
