### PR TITLE
Allows multiple arguments on insert()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1039,6 +1039,10 @@ class Builder {
 	 */
 	public function insert(array $values)
 	{
+		
+		// Retrieval of multiple arguments.
+		$values = func_get_args();
+
 		// Since every insert gets treated like a batch insert, we will make sure the
 		// bindings are structured in a way that is convenient for building these
 		// inserts statements by verifying the elements are actually an array.


### PR DESCRIPTION
Fixed insert() function in Database\Query\Builder.php to allow for multiple arguments, as I believe was intended.
