### PR TITLE
FormBuilder Submit Button Default

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -383,7 +383,7 @@ class FormBuilder {
 		{
 			return $this->optionGroup($display, $value, $selected);
 		}
-	
+
 		return $this->option($display, $value, $selected);
 	}
 
@@ -497,7 +497,7 @@ class FormBuilder {
 	 * @param  array   $options
 	 * @return string
 	 */
-	public function submit($value = null, $options = array())
+	public function submit($value = 'Submit', $options = array())
 	{
 		return $this->input('submit', null, $value, $options);
 	}


### PR DESCRIPTION
Right now, an exception will be thrown when calling `Form::submit()` if a value for the button is not provided.

``` html
ErrorException: Warning: htmlentities() expects parameter 1 to be string, array given in /Users/Jeffrey/Desktop/laravel/vendor/laravel/framework/src/Illuminate/Support/helpers.php line 350
```

It makes sense to me to set a sensible default of 'Submit' here.
