### PR TITLE
[Bugfix] Re-enable array_get to fetch "flat" array keys containing dots.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -169,6 +169,8 @@ if ( ! function_exists('array_get'))
 	function array_get($array, $key, $default = null)
 	{
 		if (is_null($key)) return $array;
+		
+		if (isset($array[$key])) return $array[$key];
 
 		foreach (explode('.', $key) as $segment)
 		{


### PR DESCRIPTION
Fixes an issue introduced with #530, when using array_get to fetch flat array keys containing dots. These are used by e.g. Symony's Translation Component:

``` php
// e.g. lang/en/messages.php
return array(
    'symfony2.is.great' => 'Symfony2 is great',
    'symfony2.is.amazing' => 'Symfony2 is amazing',
    'symfony2.has.bundles' => 'Symfony2 has bundles',
    'user.login' => 'Login',
);
```

Example taken from [Symfony Translation Docs](http://symfony.com/doc/2.1/book/translation.html).

This PR simply makes array_get check if the array key exists (and return its value if true), before attempting to iterate through the array using the keys "dot"-notation.
