### PR TITLE
Bugfix: Missing argument 2 for Builder::whereIn()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -330,7 +330,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		if (is_array($id))
 		{
-			return $instance->newQuery()->whereIn($instance->primaryKey, $id)->get($columns);
+			return $instance->newQuery()->whereIn($instance->getKeyName(), $id)->get($columns);
 		}
 
 		return $instance->newQuery()->find($id, $columns);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -330,7 +330,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		if (is_array($id))
 		{
-			return $instance->newQuery()->whereIn($id)->get($columns);
+			return $instance->newQuery()->whereIn($instance->primaryKey, $id)->get($columns);
 		}
 
 		return $instance->newQuery()->find($id, $columns);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -588,7 +588,7 @@ class EloquentModelFindManyStub extends Illuminate\Database\Eloquent\Model {
 	public function newQuery()
 	{
 		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
-		$mock->shouldReceive('whereIn')->once()->with(array(1, 2))->andReturn($mock);
+		$mock->shouldReceive('whereIn')->once()->with('id', array(1, 2))->andReturn($mock);
 		$mock->shouldReceive('get')->once()->with(array('*'))->andReturn('foo');
 		return $mock;
 	}


### PR DESCRIPTION
When doing a search with an array of id's (`Model::find(array(1,2,3))`) the following error occured.

```
Missing argument 2 for Illuminate\Database\Query\Builder::whereIn() 
```

I hope it's ok :smile: 
