### PR TITLE
Only compare value if no key is provided

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -78,7 +78,7 @@ class TestCase extends \PHPUnit_Framework_TestCase {
 
 		return $this->call($method, $uri, $parameters, $files, $server, $content, $changeHistory);
 	}
-	
+
 	/**
 	 * Call a named route and return the Response.
 	 *
@@ -219,7 +219,14 @@ class TestCase extends \PHPUnit_Framework_TestCase {
 	{
 		foreach ($bindings as $key => $value)
 		{
-			$this->assertSessionHas($key, $value);
+			if(is_int($key))
+			{
+				$this->assertSessionHas($value);
+			}
+			else
+			{
+				$this->assertSessionHas($key, $value);
+			}
 		}
 	}
 


### PR DESCRIPTION
If you want to assert a redirect with only the session key it will fail.
Because we haven't given a value to compare it with.

``` php
$this->assertRedirectedTo('signup/client', array('errors'));
```

`Failed asserting that null matches expected 'errors'.`

``` php
    // $bindings = array('errors');
    public function assertSessionHasAll(array $bindings)
    {
        foreach ($bindings as $key => $value)
        {
            // $key = 0
            // $value = 'errors'
            $this->assertSessionHas($key, $value); // Fails
        }
    }
```
