### PR TITLE
fixed sqlite field nullability 

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -112,7 +112,7 @@ class SQLiteGrammar extends Grammar {
 
 		$columns = $this->prefixArray('add column', $this->getColumns($blueprint));
 
-		foreach ($columns as $column) 
+		foreach ($columns as $column)
 		{
 			$statements[] = 'alter table '.$table.' '.$column;
 		}
@@ -390,7 +390,7 @@ class SQLiteGrammar extends Grammar {
 	 */
 	protected function modifyNullable(Blueprint $blueprint, Fluent $column)
 	{
-		return $column->nullable ? ' null' : ' not null';
+		return ' null';
 	}
 
 	/**


### PR DESCRIPTION
... so that it's usage will line up with the rest of the drivers.

The issue can be seen on this Laravel 3 pull request here:
https://github.com/laravel/laravel/pull/393

The problem is that if you don't explicitly declare nullable() in your migrations when using SQLITE, it'll fatally error if you do not assign a field. 

So, if you have 10 fields in your users table and try to do.. 

```
User::create(['email' => 'bob@bob.com']);
```

It'll fail because of the other 9 fields.
