### PR TITLE
Add dropTimestamps() function on Schema creator

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -252,6 +252,16 @@ class Blueprint {
 	}
 
 	/**
+	 * Indicate that the timestamp columns should be dropped.
+	 *
+	 * @return void
+	 */
+	public function dropTimestamps()
+	{
+		$this->dropColumns('created_at', 'updated_at');
+	}
+
+	/**
 	 * Rename the table to a given name.
 	 *
 	 * @param  string  $to

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -155,6 +155,17 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDropTimestamps()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->dropTimestamps();
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
+	}
+
+
 	public function testRenameTable()
 	{
 		$blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -127,6 +127,17 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDropTimestamps()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->dropTimestamps();
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
+	}
+
+
 	public function testRenameTable()
 	{
 		$blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -116,6 +116,17 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDropTimestamps()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->dropTimestamps();
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table "users" drop "created_at", drop "updated_at"', $statements[0]);
+	}
+
+
 	public function testRenameTable()
 	{
 		$blueprint = new Blueprint('users');


### PR DESCRIPTION
It seemed a bit odd to provide the functionality to create the timestamp columns by a single function and not having an option to remove them with a single function. I actually came across a certain use case for this where I wanted to remove the columns again in a migration.

``` php
Schema::table('users', function($table)
{
    $table->dropTimestamps();
});
```
