### PR TITLE
Created migrations will now show the name of the migration in the output

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MakeCommand.php
@@ -69,9 +69,11 @@ class MakeCommand extends BaseCommand {
 		// Now we're ready to get the path where these migrations should be placed
 		// on disk. This may be specified via the package option on the command
 		// and we will verify that option to determine the appropriate paths.
-		$this->writeMigration($name, $table, $create);
+		$path = $this->writeMigration($name, $table, $create);
+		
+		$file = pathinfo($path, PATHINFO_FILENAME);
 
-		$this->info('Migration created successfully!');
+		$this->line("<info>Created Migration:</info> $file");
 	}
 
 	/**
@@ -80,13 +82,13 @@ class MakeCommand extends BaseCommand {
 	 * @param  string  $name
 	 * @param  string  $table
 	 * @param  bool    $create
-	 * @return void
+	 * @return string
 	 */
 	protected function writeMigration($name, $table, $create)
 	{
 		$path = $this->getMigrationPath();
 
-		$this->creator->create($name, $path, $table, $create);
+		return $this->creator->create($name, $path, $table, $create);
 	}
 
 	/**


### PR DESCRIPTION
Trivial, but this makes it look consistent with migration:make.
