### PR TITLE
Memcached get() checks against Memcached::RES_SUCCESS

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -39,7 +39,8 @@ class MemcachedStore implements StoreInterface {
 	{
 		$value = $this->memcached->get($this->prefix.$key);
 
-		if ($value !== false)
+		// Memcached::RES_SUCCESS === 0
+		if ($this->memcached->getResultCode() === 0)
 		{
 			return $value;
 		}


### PR DESCRIPTION
Howdy!

I added some code to harden the Memcached implementation of L4's cache. This checks the returned value of `MemcachedStore::get()` in a more preferable way. Here's my thinking:
## Problem:

The current code in `Illuminate\Cache\MemachedStore` for retrieving a cache value is:

``` php
public function get($key)
{
    $value = $this->memcached->get($this->prefix.$key);

    if ($value !== false)
    {
        return $value;
    }
}
```

This checks if the returned value is FALSE, and returns NULL if so. **If a key gets _purposely_ assigned the value FALSE, however, this will return NULL, which can create bugs/unexpected behavior**.
## Solution:

As per slide 6 of this [presentation](http://ilia.ws/files/tnphp_memcached.pdf) by Ilia Alshanetsky (co-author of memcached extension), for `MemcachedStore::get()`, I changed the code to test against `Memcached::getResultCode()` rather than testing to see if the result is FALSE.

``` php
public function get($key)
{
    $value = $this->memcached->get($this->prefix.$key);

    // Memcached::RES_SUCCESS === 0
    if ($this->memcached->getResultCode() === 0)
    {
        return $value;
    }
}
```

More info in [PHP docs](http://www.php.net/manual/en/memcached.getresultcode.php).

`Memcached::get()` would then check if the value was returned successfully via `Memcached::getResultCode()`, rather than assuming value of FALSE is a cache miss.
## Room for Improvement (feedback appreciated):

Unit tests still pass! However, it's not perfect. I avoided using the Memcached class constant `Memcached::RES_SUCCESS`, as it's not very testable:
1. Using this constant would fail on users computers who do not have Memcached installed. 
2. Unless I'm mistaken, Mockery doesn't support mocking a constant.

Before I put the effort into creating a Stub to be able to use the constant (preferable to hard-coding the value 0 there, IMO) **or** figuring out the heavier lift of handling more/all of Memcached result codes*, I wanted to see your opinion on this direction.

*For instance, result codes can be used to test successful writes via `Memcached::RES_NOTSTORED`, etc
