### PR TITLE
fix for the loggedIn state in Auth

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -233,6 +233,7 @@ class Guard {
 		}
 
 		$this->user = $user;
+		$this->loggedOut = false;
 	}
 
 	/**


### PR DESCRIPTION
1. when I call logout it goes here: https://github.com/laravel/framework/blob/master/src/Illuminate/Auth/Guard.php#L268 and it sets         $this->loggedOut = true;
2. Notice that in attempt(), it doesn't set loggedOut back to false. https://github.com/laravel/framework/blob/master/src/Illuminate/Auth/Guard.php#L186
3. when I call Auth::user() in Guard.php, it checks whether it's loggedOut if it is, it will return nothing. https://github.com/laravel/framework/blob/master/src/Illuminate/Auth/Guard.php#L101

The fix is just one line, set the loggedIn flag to true.
