### PR TITLE
[Enhancement] Use default button type (="button") in FormBuilder

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -526,6 +526,11 @@ class FormBuilder {
 	 */
 	public function button($value = null, $options = array())
 	{
+		if ( ! array_key_exists('type', $options) )
+		{
+			$options['type'] = 'button';
+		}
+		
 		return '<button'.Html::attributes($options).'>'.e($value).'</button>';
 	}
 


### PR DESCRIPTION
> A button element with no type attribute specified represents the same thing as a button element with its type attribute set to "submit".
> http://dev.w3.org/html5/markup/button.html

Makes Form::button() behave like a regular button by setting its type (unless it's been set in the options).
