### PR TITLE
Enable the use of @lang and @choice for Blade Templates

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -33,6 +33,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 		'Shows',
 		'SectionStart',
 		'SectionStop',
+		'Language',
 	);
 
 	/**
@@ -342,6 +343,22 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 		$pattern = $this->createPlainMatcher('stop');
 
 		return preg_replace($pattern, '$1<?php $__env->stopSection(); ?>$2', $value);
+	}
+	
+	/**
+	 * Compile Blade language and language choice statements into valid PHP.
+	 *
+	 * @param  string  $value
+	 * @return string
+	 */
+	protected function compileLanguage($value)
+	{
+		$pattern = $this->createMatcher('lang');
+		$value = preg_replace($pattern, '$1<?php echo Lang::get$2; ?>', $value);
+		
+		$pattern = $this->createMatcher('choice');
+		return preg_replace($pattern, '$1<?php echo Lang::choice$2; ?>', $value);
+		
 	}
 
 	/**


### PR DESCRIPTION
I wanted to be able to allow the use of @lang and @choice for localization.

This meaning I'm now able to write my localized templates with the pretty Blade style and syntax.

```
@lang('messages.key') // produces <?php echo Lang::get('messages.key'); ?>
@lang('messages.key', array('variable' => 'replacement'))  // produces <?php echo Lang::get('messages.key', array('variable' => 'replacement')); ?>
@choice('messages.key', 1)  // produces <?php echo Lang::choice('messages.key', 1); ?>
@choice('messages.key', 10)  // produces <?php echo Lang::choice('messages.key'. 10); ?>
```
