### PR TITLE
Added saving and saved model events

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -558,7 +558,29 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			$this->fireModelEvent('deleted', false);
 		}
 	}
-
+	
+	/**
+	 * Register a saving model event with the dispatcher.
+	 *
+	 * @param  Closure  $callback
+	 * @return void
+	 */
+	public static function saving(Closure $callback)
+	{
+		static::registerModelEvent('saving', $callback);
+	}
+	
+	/**
+	 * Register a saved model event with the dispatcher.
+	 *
+	 * @param  Closure  $callback
+	 * @return void
+	 */
+	public static function saved(Closure $callback)
+	{
+		static::registerModelEvent('saved', $callback);
+	}
+	
 	/**
 	 * Register an updating model event with the dispatcher.
 	 *
@@ -659,6 +681,12 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			$this->updateTimestamps();
 		}
 
+		// If the saving event returns false, we will cancel the save operation
+		if ($this->fireModelEvent('saving') === false)
+		{
+			return false;
+		}
+
 		// If the model already exists in the database we can just update our record
 		// that is already in this database using the current IDs in this "where"
 		// clause to only update this model. Otherwise, we'll just insert them.
@@ -678,6 +706,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		}
 
 		$this->syncOriginal();
+
+		$this->fireModelEvent('saved', false);
 
 		return $saved;
 	}
@@ -753,6 +783,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	/**
 	 * Fire the given event for the model.
 	 *
+	 * @param  string $event
+	 * @param  bool   $halt
 	 * @return mixed
 	 */
 	protected function fireModelEvent($event, $halt = true)


### PR DESCRIPTION
There are already events for updating, updated, creating, created (and deleting, deleted). If you want an event to run for every save irrespective of whether its a create or update, you would have to listen to both the updating and creating (or updated and created) events at the moment.
