### PR TITLE
Add values method to the Collection.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -116,6 +116,18 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Reset items index.
+	 *
+	 * @return Illuminate\Support\Collection
+	 */
+	public function values()
+	{
+		$this->items = array_values($this->items);
+
+		return $this;
+	}
+
+	/**
 	 * Fetch a nested element of the collection.
 	 *
 	 * @param  string  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -104,6 +104,26 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testFilter()
+	{
+		$c = new Collection(array(array('id' => 1, 'name' => 'Hello'), array('id' => 2, 'name' => 'World')));
+		$this->assertEquals(array(1 => array('id' => 2, 'name' => 'World')), $c->filter(function($item)
+		{
+			return $item['id'] == 2;
+		})->all());
+	}
+
+
+	public function testValues()
+	{
+		$c = new Collection(array(array('id' => 1, 'name' => 'Hello'), array('id' => 2, 'name' => 'World')));
+		$this->assertEquals(array(array('id' => 2, 'name' => 'World')), $c->filter(function($item)
+		{
+			return $item['id'] == 2;
+		})->values()->all());
+	}
+
+
 	public function testFlatten()
 	{
 		$c = new Collection(array(array('#foo', '#bar'), array('#baz')));


### PR DESCRIPTION
Tiny helpful method to reset items index in Collection after said items were `filter`ed.

Explanation. Often, Collections might be used as an object which renders to json on echo/response. Right now it works great returning something like that:

``` javascript
[{"id":"1","user_id":"1","name":"Foo"},{"id":"2","user_id":"2","name":"Bar"}]
```

Proper js array.

But, if we use `filter` method on said collection:

``` php
return $coll->filter(function($item) {
    return $item->user_id == 2;
});
```

We'll get not an array of objects, but an object of objects:

``` javascript
{"1":{"id":"2","user_id":"2","name":"Bar"}}
```

So, with this PR now user can reset items index while retaining collection:

``` php
return $coll->filter(function($item) {
    return $item->user_id == 2;
})->values();
```

Results in proper js array:

``` javascript
[{"id":"2","user_id":"2","name":"Bar"}]
```
