### PR TITLE
Detach before attach to prevent uniqueness constraint conflicts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -398,8 +398,6 @@ class BelongsToMany extends Relation {
 
 		$records = $this->formatSyncList($ids);
 
-		$this->attachNew($records, $current);
-
 		$detach = array_diff($current, array_keys($records));
 
 		// Next, we will take the differences of the currents and given IDs and detach
@@ -409,6 +407,8 @@ class BelongsToMany extends Relation {
 		{
 			$this->detach($detach);
 		}
+
+		$this->attachNew($records, $current);
 	}
 
 	/**


### PR DESCRIPTION
Example:
You have a uniqueness constraint on id and position on the pivot table. You have a list of items and each items has a position in the list hence the position field on the pivot.

You would like to remove one item from the bottom of the list and then add another one in it's place. You do this in a form, and get back a json object that has the new desired list of items. You would now like to sync this json object up with the db so you use sync(). Now sync() will try to attach a new item with a position of 3, but that position already exists and an exception is thrown.

By first detaching the old item in position 3 and then attaching the new one this conflict is removed.

Signed-off-by: Andreas Heiberg git@andreas-heiberg.com
