### PR TITLE
[Propsal] Add a way to bind global variables to the Application

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -696,8 +696,8 @@ class Application extends Container implements HttpKernelInterface {
 	/**
 	 * Fetches a global from the application.
 	 *
-	 * @param  string $key
-	 * @param  mixed  $value
+	 * @param  string  $key
+	 * @param  mixed   $value
 	 * @return void
 	 */
 	public function set($key, $value)
@@ -708,12 +708,23 @@ class Application extends Container implements HttpKernelInterface {
 	/**
 	 * Bind a global to the application.
 	 *
-	 * @param  string $key
+	 * @param  string  $key
 	 * @return mixed
 	 */
 	public function get($key)
 	{
 		return $this->$key;
+	}
+
+	/**
+	 * Checks if a given global is bound to the application.
+	 *
+	 * @param  string  $key
+	 * @return boolean
+	 */
+	public function isset($key)
+	{
+		return isset($this->$key);
 	}
 
 }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -693,4 +693,27 @@ class Application extends Container implements HttpKernelInterface {
 		$this[$key] = $value;
 	}
 
+	/**
+	 * Fetches a global from the application.
+	 *
+	 * @param  string $key
+	 * @param  mixed  $value
+	 * @return void
+	 */
+	public function set($key, $value)
+	{
+		$this->$key = $value;
+	}
+
+	/**
+	 * Bind a global to the application.
+	 *
+	 * @param  string $key
+	 * @return mixed
+	 */
+	public function get($key)
+	{
+		return $this->$key;
+	}
+
 }


### PR DESCRIPTION
Currently there is no real way to pass large chunks of data around in the Application. You can bind something to the global IoC by doing `App::bind('Something', $user)` (or `singleton` or all the other simlar methods).
But you will have problems as when comes the time to get it back as the IoC container under Application will try to resolve whatever name you gave your global : it will either throw an Exception if it hasn't been set already, or try to resolve names that match classes (ie. "User") and return a new instance.

These three small methods allow you to set and set global variables around the application that may be too large for session.
