### PR TITLE
Update Builder.php

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1094,6 +1094,8 @@ class Builder {
 		// that more select queries can be executed against the database without
 		// the aggregate value getting in the way when the grammar builds it.
 		$this->aggregate = null;
+		
+		if (!isset($results[0])) return '0';
 
 		$result = (array) $results[0];
 


### PR DESCRIPTION
In MySQL, when you run a count(_) against a query with a "group by" and the result is "0", MySQL returns an empty record set rather than "0". In the existing code, it's assumed there will always be a result to count(_), causing $results[0] to be an undefined index, resulting in a fatal exception.
