### PR TITLE
Update Builder.php

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -284,7 +284,7 @@ class Builder {
 		// that method for convenience so the developer doesn't have to check.
 		if (is_null($value))
 		{
-			return $this->whereNull($column, $boolean);
+			return $this->whereNull($column, $boolean, $operator !== '=');
 		}
 
 		// Now that we are working with just a simple query we can put the elements


### PR DESCRIPTION
$query->where('column', '!=', null) gets interpreted the same as $query->where('column', '=', null)
