### PR TITLE
[Proposal] Accept array of string wrapped integers as input for ->sync()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -474,7 +474,7 @@ class BelongsToMany extends Relation {
 
 		foreach ($records as $id => $attributes)
 		{
-			if (is_int($attributes))
+			if (is_int($attributes) or (string)(int)$attributes === $attributes)
 			{
 				list($id, $attributes) = array($attributes, array());
 			}

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -234,6 +234,24 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testSyncMethodHandlesArrayWithStringFormattedIntegers()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach'), $this->getRelationArguments());
+		$query = m::mock('stdClass');
+		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
+		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+		$query->shouldReceive('lists')->once()->with('role_id')->andReturn(array(1, 2, 3));
+		$relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(array()), $this->equalTo(false));
+		$relation->expects($this->once())->method('detach')->with($this->equalTo(array(1)));
+		$relation->getRelated()->shouldReceive('touches')->andReturn(false);
+		$relation->getParent()->shouldReceive('touches')->andReturn(false);
+
+		$relation->sync(array('2', '3', '4'));
+	}
+
+
 	public function testSyncMethodSyncsIntermediateTableWithGivenArrayAndAttributes()
 	{
 		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach', 'touchIfTouching'), $this->getRelationArguments());


### PR DESCRIPTION
When you're using the an array from a form (with a bunch of "input[]" style inputs) the cells of the resulting array is formatted as strings. Instead of having to make make it into an array of integers to use with ->sync() it would be convenient if laravel took care of that for you.
