### PR TITLE
Commenting out error reporting

### DIFF
--- a/src/Illuminate/Foundation/start.php
+++ b/src/Illuminate/Foundation/start.php
@@ -60,7 +60,7 @@ if (isset($unitTesting))
 
 if ($env != 'testing') ini_set('display_errors', 'Off');
 
-error_reporting(-1);
+//error_reporting(-1);
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Please can we have the error reporting call commented out.

I've just spent hours trying to figure out why it wasn't using the value from the php.ini file only to find it being hard coded as -1 in the bootstrap.

As of PHP 5.4, they've decided to make E_STRICT part of E_ALL in the error reporting, so now, overridden methods are throwing errors as they have different parameters.

This should be a decision that the developer makes as to how strict their php matches zend's vision, so by allowing laravel to use the error reporting set in the php ini, the developer can make this decision.
