### PR TITLE
Support table prefixed fields in Builder->lists()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -907,6 +907,8 @@ class Builder {
 		// be accessed by the key of the rows instead of simply being numeric.
 		if ( ! is_null($key) and count($results) > 0)
 		{
+			$keyparts = explode('.', $key);
+			$key = array_pop($keyparts);
 			$keys = $results->fetch($key)->all();
 
 			return array_combine($keys, $values);


### PR DESCRIPTION
In the event that you want to use the `lists()` method, but one of the fields that you send it needs to be prefixed by the table name because that field exists in two or more of the tables being joined for the query.

In my case, I wanted to do this:

```
$all_users = User::join('company_user', 'users.id', '=', 'company_user.user_id')
    ->where('company_id', Session::get('company_id'))
    ->lists('email', 'users.id');
```

This would get me an array of id => email, for all users that are associated with the company.

Without this fix, the `array_fetch()` method is called with the table name, not the field (i.e., users, not id)
