### PR TITLE
Array validation with non iterative rules

### DIFF
--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -34,6 +34,13 @@ class Factory {
 	protected $implicitExtensions = array();
 
 	/**
+	 * List of new non iterable rules.
+	 *
+	 * @var array
+	 */
+	protected $nonIterative = array();
+
+	/**
 	 * The Validator resolver instance.
 	 *
 	 * @var Closure
@@ -77,6 +84,11 @@ class Factory {
 		// and accepted rule in that they are run even if the attributes is not in a
 		// array of data that is given to a validator instances via instantiation.
 		$implicit = $this->implicitExtensions;
+
+		if ( ! empty($this->nonIterative))
+		{
+			$validator->addNonIterative($this->nonIterative);
+		}
 
 		$validator->addImplicitExtensions($implicit);
 
@@ -125,6 +137,49 @@ class Factory {
 	public function extendImplicit($rule, Closure $extension)
 	{
 		$this->implicitExtensions[$rule] = $extension;
+	}
+
+	/**
+	 * Register non iterative rules.
+	 *
+	 * @param  string/array  $rules
+	 * @return void
+	 */
+	public function setNonIterative($rules)
+	{
+		$this->nonIterative = (array) $rules;
+	}
+
+	/**
+	 * Register additional non iterative rules.
+	 *
+	 * @param  string/array  $rules
+	 * @return void
+	 */
+	public function addNonIterative($rules)
+	{
+		$this->nonIterative = array_merge($this->nonIterative, (array) $rules);
+	}
+
+	/**
+	 * Remove non iterative rule.
+	 *
+	 * @param  string/array  $rules
+	 * @return void
+	 */
+	public function removeNonIterative($rules)
+	{
+		$this->nonIterative = array_diff($this->nonIterative, (array) $rules);
+	}
+
+	/**
+	 * Get non iterative rules.
+	 *
+	 * @return array
+	 */
+	public function getNonIterative()
+	{
+		return $this->nonIterative;
 	}
 
 	/**


### PR DESCRIPTION
Ok, one more PR related to Validator and its ability to validate arrays.
### How it works.

We have several additional methods in Factory and Validator:

Factory:
- setNonIterative()
- addNonIterative()
- removeNonIterative()
- getNonIterative()

Validator:
- setNonIterative() - not recommended in use (overrides default nonIterative rules)
- addNonIterative()
- removeNonIterative()
- getNonIterative()

These methods allow user to set/remove/view so called `nonIterative` rules. If currently validated rule is set in `nonIterative` array, then current value will be validated as a whole array (as it is), otherwise it'll be validated item by item if that value is an array but not present in `nonIterative`.

With default settings, Validator will work the same way as described in #255 PR. 
Except of several cases:
- `exists` rule will use "WHERE IN", so if value is an array there won't be tons of queries
- `same` & `different` will compare whole array with `other` attribute

Default `nonIterative`: `array('Exists', 'Same', 'Different')`.
### Add/Remove rules

Global:

``` php
// sets new global non iterative array
Validator::setNonIterative('custom_rule');

// adds new rule to global non iterative array
Validator::addNonIterative('extra_rule');

// result: array('custom_rule', 'extra_rule');
```

Local:

``` php
// $val - new validator class
$val->addNonIterative('custom_rule');
// or multiple
$val->addNonIterative(array('custom_rule', 'extra_rule'));
```

You can explicitly remove any rule from Factory and Validator:

``` php
Validator::removeNonIterative('custom_rule');

// $val - new validator class
$val->removeNonIterative('custom_rule');
// or multiple
$val->removeNonIterative(array('custom_rule', 'extra_rule'));
```

In order to check which rules are set you can call `getNonIterative` (both on Factory and Validator class).
### Custom rules

If user creates custom validation rule via extends or just extends Validator class, then this rule will be validated on `per item` basis. You'll have to explicitly add your custom rule to the nonIterative array via `addNonIterative` on Factory or Validator class.
