### PR TITLE
Add phpunit to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
         "aws/aws-sdk-php": "2.2.*",
         "iron-io/iron_mq": "1.4.4",
         "pda/pheanstalk": "2.0.*",
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
     	"files": [

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -18,7 +18,8 @@
     },
     "require-dev": {
         "illuminate/console": "4.0.x",
-        "illuminate/routing": "4.0.x"
+        "illuminate/routing": "4.0.x",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {"Illuminate\\Auth": ""}

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -14,6 +14,9 @@
         "illuminate/redis": "4.0.x",
         "illuminate/support": "4.0.x"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
     "autoload": {
         "psr-0": {"Illuminate\\Cache": ""}
     },

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -11,6 +11,9 @@
         "illuminate/filesystem": "4.0.x",
         "illuminate/support": "4.0.x"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
     "autoload": {
         "psr-0": {"Illuminate\\Config": ""}
     },

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -10,6 +10,9 @@
     "require": {
         "symfony/console": "2.2.*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
     "autoload": {
         "psr-0": {
             "Illuminate\\Console": ""

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -9,6 +9,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
     "autoload": {
         "psr-0": {
             "Illuminate\\Container": ""

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -14,7 +14,8 @@
         "symfony/http-foundation": "2.2.*"
     },
     "require-dev": {
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -19,7 +19,8 @@
         "illuminate/filesystem": "4.0.x",
         "illuminate/pagination": "4.0.x",
         "illuminate/support": "4.0.x",
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -11,6 +11,9 @@
         "php": ">=5.3.0",
         "illuminate/support": "4.0.x"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
     "autoload": {
         "psr-0": {
             "Illuminate\\Encryption": ""

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -13,7 +13,8 @@
         "illuminate/support": "4.0.x"
     },
     "require-dev": {
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Exception/composer.json
+++ b/src/Illuminate/Exception/composer.json
@@ -13,7 +13,8 @@
         "symfony/http-kernel": "2.2.*"
     },
     "require-dev": {
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -11,6 +11,9 @@
         "php": ">=5.3.0",
         "illuminate/support": "4.0.x"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
     "autoload": {
         "psr-0": {
             "Illuminate\\Filesystem": ""

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -13,6 +13,9 @@
         "illuminate/support": "4.0.x",
         "ircmaxell/password-compat": "1.0.*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
     "autoload": {
         "psr-0": {
             "Illuminate\\Hashing": ""

--- a/src/Illuminate/Html/composer.json
+++ b/src/Illuminate/Html/composer.json
@@ -13,7 +13,8 @@
         "illuminate/support": "4.0.x"
     },
     "require-dev": {
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -13,7 +13,8 @@
         "symfony/http-foundation": "2.2.*"
     },
     "require-dev": {
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -13,6 +13,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*",
         "illuminate/events": "4.0.x"
     },
     "autoload": {

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -15,7 +15,8 @@
         "swiftmailer/swiftmailer": "4.3.*"
     },
     "require-dev": {
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -16,7 +16,8 @@
         "symfony/translation": "2.2.*"
     },
     "require-dev": {
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -15,7 +15,8 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "2.1.*",
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -12,7 +12,8 @@
         "illuminate/support": "4.0.x"
     },
     "require-dev": {
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -20,7 +20,8 @@
     "require-dev": {
         "illuminate/console": "4.0.x",
         "illuminate/filesystem": "4.0.x",
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -19,7 +19,8 @@
     },
     "require-dev": {
         "illuminate/console": "4.0.x",
-        "mockery/mockery": ">=0.7.2"
+        "mockery/mockery": ">=0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -12,7 +12,8 @@
     },
     "require-dev": {
         "patchwork/utf8": "1.0.*",
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -13,7 +13,8 @@
         "symfony/translation": "2.2.*"
     },
     "require-dev": {
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -15,7 +15,8 @@
     },
     "require-dev": {
         "illuminate/database": "4.0.x",
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -14,7 +14,8 @@
         "illuminate/support": "4.0.x"
     },
     "require-dev": {
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Workbench/composer.json
+++ b/src/Illuminate/Workbench/composer.json
@@ -14,7 +14,8 @@
     },
     "require-dev": {
         "illuminate/console": "4.0.x",
-        "mockery/mockery": "0.7.2"
+        "mockery/mockery": "0.7.2",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Seems silly not to, so there it is. Now `composer install --dev` will actually install what you need to help develop. :smile: 
