### PR TITLE
Add static destroy method to Eloquent\Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -336,6 +336,30 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
+	* Delete a model by its primary key.
+	*
+	* @param mixed $id
+	* @return void
+	*/
+	public static function destroy($id)
+	{
+		$instance = new static;
+
+		$instance->fireModelEvent('deleting', false);
+
+		if (is_array($id))
+		{
+			$instance->newQuery()->whereIn($instance->getKeyName(), $id)->delete();
+		}
+		else
+		{
+			$instance->newQuery()->where($instance->getKeyName(), $id)->delete();
+		}
+
+		$instance->fireModelEvent('deleted', false);
+	}
+
+	/**
 	 * Find a model by its primary key.
 	 *
 	 * @param  mixed  $id

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -61,6 +61,30 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDestroyDeletesModel()
+	{
+		$builderMock = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builderMock->shouldReceive('where')->once()->with('id', 1)->andReturn($builderMock);
+		$builderMock->shouldReceive('delete')->once();
+
+		EloquentModelDestroyStub::$builderMock = $builderMock;
+
+		EloquentModelDestroyStub::destroy(1);
+	}
+
+
+	public function testDestroyDeletesMultipleModels()
+	{
+		$builderMock = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builderMock->shouldReceive('whereIn')->once()->with('id', array(1,2))->andReturn($builderMock);
+		$builderMock->shouldReceive('delete')->once();
+
+		EloquentModelDestroyStub::$builderMock = $builderMock;
+
+		EloquentModelDestroyStub::destroy(array(1,2));
+	}
+
+
 	public function testFindMethodCallsQueryBuilderCorrectly()
 	{
 		$result = EloquentModelFindStub::find(1);
@@ -618,6 +642,16 @@ class EloquentModelSaveStub extends Illuminate\Database\Eloquent\Model {
 	public function setIncrementing($value)
 	{
 		$this->incrementing = $value;
+	}
+}
+
+class EloquentModelDestroyStub extends Illuminate\Database\Eloquent\Model {
+	public $primaryKey = 'id';
+	public static $builderMock;
+
+	public function newQuery()
+	{
+		return self::$builderMock;
 	}
 }
 


### PR DESCRIPTION
This method allows for deleting a record or multiple records.
It allows for deletion without unnecessary retrieval (eg. `User::find(1)->delete();`), and is more terse than manual query building (eg. `User::where('id', 1)->delete();`).
Also fires appropriate deleting/deleted events, and can accept an array of ids for deletion.
