### PR TITLE
Fix issue with increment/decrement in Redis cache driver

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -69,7 +69,15 @@ class RedisStore implements StoreInterface {
 	 */
 	public function increment($key, $value = 1)
 	{
-		return $this->redis->incrby($this->prefix.$key, $value);
+		$count = $this->get($key);
+
+		if ( ! is_null($count))
+		{
+			$count += $value;
+			$this->redis->set($this->prefix.$key, serialize($count));
+
+			return $count;
+		}
 	}
 
 	/**
@@ -81,7 +89,15 @@ class RedisStore implements StoreInterface {
 	 */
 	public function decrement($key, $value = 1)
 	{
-		return $this->redis->decrby($this->prefix.$key, $value);
+		$count = $this->get($key);
+
+		if ( ! is_null($count))
+		{
+			$count -= $value;
+			$this->redis->set($this->prefix.$key, serialize($count));
+
+			return $count;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Just tried out using the new `increment` and `decrement` methods with the Redis driver, and it wasn't working due to the fact that the Redis cache driver serializes and unserializes data when set and retrieved. These should now work properly.
