### PR TITLE
Return JSON when response is array

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -36,14 +36,14 @@ class Response extends \Symfony\Component\HttpFoundation\Response {
 	{
 		$this->original = $content;
 
-		// If the content is "JSONable" we will set the appropriate header and convert
-		// the content to JSON. This is useful when returning something like models
-		// from routes that will be automatically transformed to their JSON form.
-		if ($content instanceof JsonableInterface)
+		// If the content is "JSONable" or an array, we will set the appropriate header
+		// and convert the content to JSON. This is useful when returning something like 
+		// models from routes that will be automatically transformed to their JSON form.
+		if ($content instanceof JsonableInterface || is_array($content))
 		{
 			$this->headers->set('Content-Type', 'application/json');
 
-			$content = $content->toJson();
+			$content = is_array($content) ? json_encode($content) : $content->toJson();
 		}
 
 		// If this content implements the "RenderableInterface", then we will call the

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -39,7 +39,7 @@ class Response extends \Symfony\Component\HttpFoundation\Response {
 		// If the content is "JSONable" or an array, we will set the appropriate header
 		// and convert the content to JSON. This is useful when returning something like 
 		// models from routes that will be automatically transformed to their JSON form.
-		if ($content instanceof JsonableInterface || is_array($content))
+		if ($content instanceof JsonableInterface or is_array($content))
 		{
 			$this->headers->set('Content-Type', 'application/json');
 


### PR DESCRIPTION
As described in #781, it makes sense to return JSON when an array is returned as response.
