### PR TITLE
Fixes bug with new fillable stuff and morphOneOrMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -109,7 +109,10 @@ abstract class MorphOneOrMany extends HasOneOrMany {
 
 		$attributes = array_merge($attributes, $foreign);
 
-		$instance = $this->related->newInstance($attributes);
+		$instance = $this->related->newInstance();
+
+		$instance->fillable(array_merge($instance->getFillable(), array_keys($foreign)));
+		$instance->fill($attributes);
 
 		$instance->save();
 


### PR DESCRIPTION
The array_merge here could probably be re-factored into the model but I am just showing you this instead of attempting to explain the bug.

If you use the models `$fillable` you have to prefix it with `table.`. If you use `$guarded` instead there are no issues.
