### PR TITLE
Pluralizer improvements (multi languages)

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -8,26 +8,43 @@ class Pluralizer {
 	 * @var array
 	 */
 	protected static $plural = array(
-		'/(quiz)$/i' => "$1zes",
-		'/^(ox)$/i' => "$1en",
-		'/([m|l])ouse$/i' => "$1ice",
-		'/(matr|vert|ind)ix|ex$/i' => "$1ices",
-		'/(x|ch|ss|sh)$/i' => "$1es",
-		'/([^aeiouy]|qu)y$/i' => "$1ies",
-		'/(hive)$/i' => "$1s",
-		'/(?:([^f])fe|([lr])f)$/i' => "$1$2ves",
-		'/(shea|lea|loa|thie)f$/i' => "$1ves",
-		'/sis$/i' => "ses",
-		'/([ti])um$/i' => "$1a",
-		'/(tomat|potat|ech|her|vet)o$/i' => "$1oes",
-		'/(bu)s$/i' => "$1ses",
-		'/(alias)$/i' => "$1es",
-		'/(octop)us$/i' => "$1i",
-		'/(ax|test)is$/i' => "$1es",
-		'/(us)$/i' => "$1es",
-		'/s$/i' => "s",
-		'/$/' => "s",
+		'en' => array(
+			'/(quiz)$/i' => "$1zes",
+			'/^(ox)$/i' => "$1en",
+			'/([m|l])ouse$/i' => "$1ice",
+			'/(matr|vert|ind)ix|ex$/i' => "$1ices",
+			'/(x|ch|ss|sh)$/i' => "$1es",
+			'/([^aeiouy]|qu)y$/i' => "$1ies",
+			'/(hive)$/i' => "$1s",
+			'/(?:([^f])fe|([lr])f)$/i' => "$1$2ves",
+			'/(shea|lea|loa|thie)f$/i' => "$1ves",
+			'/sis$/i' => "ses",
+			'/([ti])um$/i' => "$1a",
+			'/(tomat|potat|ech|her|vet)o$/i' => "$1oes",
+			'/(bu)s$/i' => "$1ses",
+			'/(alias)$/i' => "$1es",
+			'/(octop)us$/i' => "$1i",
+			'/(ax|test)is$/i' => "$1es",
+			'/(us)$/i' => "$1es",
+			'/s$/i' => "s",
+			'/$/' => "s",
+		),
+		'fr' => array(
+			'/al$/i' => "$1aux",
+			'/(b|cor|ém|ferm|soupir|trav|vant|vitr)ail$/i' => "$1aux",
+			'/(bl|pn|ém)eu$/i' => "$1eus",
+			'/(land|sarr)au$/i' => "$1aus",
+			'/eu$/i' => "$1eux",
+			'/au$/i' => "$1aux",
+			'/(bij|caill|ch|gen|hib|jouj|p)ou$/i' => "$1oux",
+			'/ou$/i' => "ous",
+			'/([s|x|z])$/i' => "$1",
+			'/$/' => "s",
+		),
 	);
+
+
+
 
 	/**
 	 * Singular word form rules.
@@ -35,36 +52,43 @@ class Pluralizer {
 	 * @var array
 	 */
 	protected static $singular = array(
-		'/(quiz)zes$/i' => "$1",
-		'/(matr)ices$/i' => "$1ix",
-		'/(vert|ind)ices$/i' => "$1ex",
-		'/^(ox)en$/i' => "$1",
-		'/(alias)es$/i' => "$1",
-		'/(octop|vir)i$/i' => "$1us",
-		'/(cris|ax|test)es$/i' => "$1is",
-		'/(shoe)s$/i' => "$1",
-		'/(o)es$/i' => "$1",
-		'/(bus)es$/i' => "$1",
-		'/([m|l])ice$/i' => "$1ouse",
-		'/(x|ch|ss|sh)es$/i' => "$1",
-		'/(m)ovies$/i' => "$1ovie",
-		'/(s)eries$/i' => "$1eries",
-		'/([^aeiouy]|qu)ies$/i' => "$1y",
-		'/([lr])ves$/i' => "$1f",
-		'/(tive)s$/i' => "$1",
-		'/(hive)s$/i' => "$1",
-		'/(li|wi|kni)ves$/i' => "$1fe",
-		'/(shea|loa|lea|thie)ves$/i' => "$1f",
-		'/(^analy)ses$/i' => "$1sis",
-		'/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => "$1$2sis",
-		'/([ti])a$/i' => "$1um",
-		'/(n)ews$/i' => "$1ews",
-		'/(h|bl)ouses$/i' => "$1ouse",
-		'/(corpse)s$/i' => "$1",
-		'/(us)es$/i' => "$1",
-		'/(us|ss)$/i' => "$1",
-		'/s$/i' => "",
+		'en' => array(
+			'/(quiz)zes$/i' => "$1",
+			'/(matr)ices$/i' => "$1ix",
+			'/(vert|ind)ices$/i' => "$1ex",
+			'/^(ox)en$/i' => "$1",
+			'/(alias)es$/i' => "$1",
+			'/(octop|vir)i$/i' => "$1us",
+			'/(cris|ax|test)es$/i' => "$1is",
+			'/(shoe)s$/i' => "$1",
+			'/(o)es$/i' => "$1",
+			'/(bus)es$/i' => "$1",
+			'/([m|l])ice$/i' => "$1ouse",
+			'/(x|ch|ss|sh)es$/i' => "$1",
+			'/(m)ovies$/i' => "$1ovie",
+			'/(s)eries$/i' => "$1eries",
+			'/([^aeiouy]|qu)ies$/i' => "$1y",
+			'/([lr])ves$/i' => "$1f",
+			'/(tive)s$/i' => "$1",
+			'/(hive)s$/i' => "$1",
+			'/(li|wi|kni)ves$/i' => "$1fe",
+			'/(shea|loa|lea|thie)ves$/i' => "$1f",
+			'/(^analy)ses$/i' => "$1sis",
+			'/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => "$1$2sis",
+			'/([ti])a$/i' => "$1um",
+			'/(n)ews$/i' => "$1ews",
+			'/(h|bl)ouses$/i' => "$1ouse",
+			'/(corpse)s$/i' => "$1",
+			'/(us)es$/i' => "$1",
+			'/(us|ss)$/i' => "$1",
+			'/s$/i' => "",
+		),
+		'fr' => array(
+			'/z$/i' => "$1z",
+			'/[s|x|z]$/i' => "$1"
+		),
 	);
+
 
 	/**
 	 * Irregular word forms.
@@ -72,15 +96,29 @@ class Pluralizer {
 	 * @var array
 	 */
 	protected static $irregular = array(
-		'child' => 'children',
-		'foot' => 'feet',
-		'goose' => 'geese',
-		'man' => 'men',
-		'move' => 'moves',
-		'person' => 'people',
-		'sex' => 'sexes',
-		'tooth' => 'teeth',
+		'en' => array(
+			'child' => 'children',
+			'foot' => 'feet',
+			'goose' => 'geese',
+			'man' => 'men',
+			'move' => 'moves',
+			'person' => 'people',
+			'sex' => 'sexes',
+			'tooth' => 'teeth',
+		),
+		'fr' => array(
+			'oeil' => 'yeux',
+			'ciel' => 'cieux',
+			'travail' => 'travaux',
+			'madame' => 'mesdames',
+			'monsieur' => 'messieurs',
+			'il' => 'ils',
+			'un' => 'des',
+			'le' => 'les',
+			'la' => 'les',
+		),
 	);
+
 
 	/**
 	 * Uncountable word forms.
@@ -88,22 +126,36 @@ class Pluralizer {
 	 * @var array
 	 */
 	protected static $uncountable = array(
-		'audio',
-		'equipment',
-		'deer',
-		'fish',
-		'gold',
-		'information',
-		'money',
-		'rice',
-		'police',
-		'series',
-		'sheep',
-		'species',
-		'moose',
-		'chassis',
-		'traffic',
+		'en' => array(
+			'audio',
+			'equipment',
+			'deer',
+			'fish',
+			'gold',
+			'information',
+			'money',
+			'rice',
+			'police',
+			'series',
+			'sheep',
+			'species',
+			'moose',
+			'chassis',
+			'traffic',
+			'bison',
+			'buffalo',
+			'deer', 
+			'pike',
+			'salmon',
+			'trout',
+			'swine',
+			'plankton',
+		),
+		'fr' => array(
+			'corps',
+		),
 	);
+
 
 	/**
 	 * The cached copies of the plural inflections.
@@ -125,16 +177,25 @@ class Pluralizer {
 	 * @param  string  $value
 	 * @return string
 	 */
-	public static function singular($value)
+	public static function singular($value, $language = 'en')
 	{
-		if (isset(static::$singularCache[$value]))
+		if(!isset(static::$singular[$language]))
 		{
-			return static::$singularCache[$value];
+			throw new \RuntimeException("Language not supported.");
 		}
 
-		$result = static::inflect($value, static::$singular, static::$irregular);
+		if (isset(static::$singularCache[$language][$value]))
+		{
+			return static::$singularCache[$language][$value];
+		}
 
-		return static::$singularCache[$value] = $result ?: $value;
+		$irregular = static::$irregular[$language];
+
+		$singular = static::$singular[$language];
+
+		$result = static::inflect($value, $singular, $irregular, $language);
+
+		return static::$singularCache[$language][$value] = $result ?: $value;
 	}
 
 	/**
@@ -144,28 +205,33 @@ class Pluralizer {
 	 * @param  int     $count
 	 * @return string
 	 */
-	public static function plural($value, $count = 2)
+	public static function plural($value, $count = 2, $language = 'en')
 	{
 		if ($count == 1) return $value;
+
+		if(!isset(static::$plural[$language]))
+		{
+			throw new \RuntimeException("Language not supported.");
+		}
 
 		// First we'll check the cache of inflected values. We cache each word that
 		// is inflected so we don't have to spin through the regular expressions
 		// on each subsequent method calls for this word by the app developer.
-		if (isset(static::$pluralCache[$value]))
+		if (isset(static::$pluralCache[$language][$value]))
 		{
 			return static::$pluralCache[$value];
 		}
 
-		$irregular = array_flip(static::$irregular);
+		$irregular = array_flip(static::$irregular[$language]);
 
 		// When doing the singular to plural transformation, we'll flip the irregular
 		// array since we need to swap sides on the keys and values. After we have
 		// the transformed value we will cache it in memory for faster look-ups.
-		$plural = static::$plural;
+		$plural = static::$plural[$language];
 
-		$result = static::inflect($value, $plural, $irregular);
+		$result = static::inflect($value, $plural, $irregular, $language);
 
-		return static::$pluralCache[$value] = $result;
+		return static::$pluralCache[$language][$value] = $result;
 	}
 
 	/**
@@ -176,12 +242,12 @@ class Pluralizer {
 	 * @param  array   $irregular
 	 * @return string
 	 */
-	protected static function inflect($value, $source, $irregular)
+	protected static function inflect($value, $source, $irregular, $language)
 	{
 		// If the word hasn't been cached, we'll check the list of words that are in
 		// this list of uncountable word forms. This will be a quick search since
 		// we will just hit the arrays directly for values without expressions.
-		if (in_array(strtolower($value), static::$uncountable))
+		if (in_array(strtolower($value), static::$uncountable[$language]))
 		{
 			return $value;
 		}

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -145,15 +145,15 @@ class Str {
 	}
 
 	/**
-	 * Get the plural form of an English word.
+	 * Get the plural form of a word.
 	 *
 	 * @param  string  $value
 	 * @param  int  $count
 	 * @return string
 	 */
-	public static function plural($value, $count = 2)
+	public static function plural($value, $count = 2, $language = 'en')
 	{
-		return Pluralizer::plural($value, $count);
+		return Pluralizer::plural($value, $count, $language);
 	}
 
 	/**
@@ -206,14 +206,14 @@ class Str {
 	}
 
 	/**
-	 * Get the singular form of an English word.
+	 * Get the singular form of a word.
 	 *
 	 * @param  string  $value
 	 * @return string
 	 */
-	public static function singular($value)
+	public static function singular($value, $language = 'en')
 	{
-		return Pluralizer::singular($value);
+		return Pluralizer::singular($value, $language);
 	}
 
 	/**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -656,15 +656,15 @@ if ( ! function_exists('str_is'))
 if ( ! function_exists('str_plural'))
 {
 	/**
-	 * Get the plural form of an English word.
+	 * Get the plural form of a word.
 	 *
 	 * @param  string  $value
 	 * @param  int  $count
 	 * @return string
 	 */
-	function str_plural($value, $count = 2)
+	function str_plural($value, $count = 2, $language = 'en')
 	{
-		return Illuminate\Support\Str::plural($value, $count);
+		return Illuminate\Support\Str::plural($value, $count, $language);
 	}
 }
 
@@ -687,14 +687,14 @@ if ( ! function_exists('str_random'))
 if ( ! function_exists('str_singular'))
 {
 	/**
-	 * Get the singular form of an English word.
+	 * Get the singular form of a word.
 	 *
 	 * @param  string  $value
 	 * @return string
 	 */
-	function str_singular($value)
+	function str_singular($value, $language = 'en')
 	{
-		return Illuminate\Support\Str::singular($value);
+		return Illuminate\Support\Str::singular($value, $language);
 	}
 }
 

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -2,14 +2,116 @@
 
 class SupportPluralizerTest extends PHPUnit_Framework_TestCase {
 
-	public function testBasicUsage()
+	public function testEnglish()
 	{
 		$this->assertEquals('children', str_plural('child'));
 		$this->assertEquals('tests', str_plural('test'));
 		$this->assertEquals('deer', str_plural('deer'));
+		$this->assertEquals('dishes', str_plural('dish'));
+		$this->assertEquals('judges', str_plural('judge'));
+		$this->assertEquals('laps', str_plural('lap'));
+		$this->assertEquals('clocks', str_plural('clock'));
+		$this->assertEquals('cuffs', str_plural('cuff'));
+		$this->assertEquals('deaths', str_plural('death'));
+		$this->assertEquals('heroes', str_plural('hero'));
+		$this->assertEquals('potatoes', str_plural('potato'));
+		$this->assertEquals('photos', str_plural('photo'));
+		$this->assertEquals('zeros', str_plural('zero'));
+		$this->assertEquals('ladies', str_plural('lady'));
+		$this->assertEquals('monkeys', str_plural('monkey'));
+		$this->assertEquals('baths', str_plural('bath'));
+		$this->assertEquals('calves', str_plural('calf'));
+		$this->assertEquals('leaves', str_plural('leaf'));
+		$this->assertEquals('proofs', str_plural('proof'));
+		$this->assertEquals('women', str_plural('woman'));
+		$this->assertEquals('teeth', str_plural('tooth'));
+		$this->assertEquals('salmon', str_plural('salmon'));
+		$this->assertEquals('fish', str_plural('fish'));
+		$this->assertEquals('matrices', str_plural('matrix'));
+		$this->assertEquals('crises', str_plural('crisis'));
+		$this->assertEquals('millennia', str_plural('millennium'));
+		$this->assertEquals('ninjas', str_plural('ninja'));
+ 	
+
 		$this->assertEquals('child', str_singular('children'));
 		$this->assertEquals('test', str_singular('tests'));
 		$this->assertEquals('deer', str_singular('deer'));
+		$this->assertEquals('dish', str_singular('dishes'));
+		$this->assertEquals('judge', str_singular('judges'));
+		$this->assertEquals('lap', str_singular('laps'));
+		$this->assertEquals('clock', str_singular('clocks'));
+		$this->assertEquals('cuff', str_singular('cuffs'));
+		$this->assertEquals('death', str_singular('deaths'));
+		$this->assertEquals('hero', str_singular('heroes'));
+		$this->assertEquals('potato', str_singular('potatoes'));
+		$this->assertEquals('photo', str_singular('photos'));
+		$this->assertEquals('zero', str_singular('zeros'));
+		$this->assertEquals('lady', str_singular('ladies'));
+		$this->assertEquals('monkey', str_singular('monkeys'));
+		$this->assertEquals('bath', str_singular('baths'));
+		$this->assertEquals('calf', str_singular('calves'));
+		$this->assertEquals('leaf', str_singular('leaves'));
+		$this->assertEquals('proof', str_singular('proofs'));
+		$this->assertEquals('woman', str_singular('women'));
+		$this->assertEquals('tooth', str_singular('teeth'));
+		$this->assertEquals('salmon', str_singular('salmon'));
+		$this->assertEquals('fish', str_singular('fish'));
+		$this->assertEquals('matrix', str_singular('matrices'));
+		$this->assertEquals('crisis', str_singular('crises'));
+		$this->assertEquals('millennium', str_singular('millennia'));
+		$this->assertEquals('ninja', str_singular('ninjas'));
 	}
 
+
+
+
+
+	public function testFrench()
+	{
+		$this->assertEquals('généraux', str_plural('général', 2, 'fr'));
+		$this->assertEquals('amicales', str_plural('amicale', 2, 'fr'));
+		$this->assertEquals('détails', str_plural('détail', 2, 'fr'));
+		$this->assertEquals('travaux', str_plural('travail', 2, 'fr'));
+		$this->assertEquals('filous', str_plural('filou', 2, 'fr'));
+		$this->assertEquals('genoux', str_plural('genou', 2, 'fr'));
+		$this->assertEquals('bureaux', str_plural('bureau', 2, 'fr'));
+		$this->assertEquals('oiseaux', str_plural('oiseau', 2, 'fr'));
+		$this->assertEquals('jeux', str_plural('jeu', 2, 'fr'));
+		$this->assertEquals('chevaux', str_plural('cheval', 2, 'fr'));
+		$this->assertEquals('sarraus', str_plural('sarrau', 2, 'fr'));
+		$this->assertEquals('bleus', str_plural('bleu', 2, 'fr'));
+		$this->assertEquals('cieux', str_plural('ciel', 2, 'fr'));
+		$this->assertEquals('ails', str_plural('ail', 2, 'fr'));
+		$this->assertEquals('corps', str_plural('corps', 2, 'fr'));
+		$this->assertEquals('yeux', str_plural('oeil', 2, 'fr'));
+		$this->assertEquals('mesdames', str_plural('madame', 2, 'fr'));
+		$this->assertEquals('messieurs', str_plural('monsieur', 2, 'fr'));
+		$this->assertEquals('ils', str_plural('il', 2, 'fr'));
+		$this->assertEquals('des', str_plural('un', 2, 'fr'));
+		$this->assertEquals('les', str_plural('le', 2, 'fr'));
+		$this->assertEquals('les', str_plural('la', 2, 'fr'));
+		$this->assertEquals('familles', str_plural('famille', 2, 'fr'));
+		$this->assertEquals('nez', str_plural('nez', 2, 'fr'));
+
+
+		$this->assertEquals('détail', str_singular('détails', 'fr'));
+		$this->assertEquals('travail', str_singular('travaux', 'fr'));
+		$this->assertEquals('filou', str_singular('filous', 'fr'));
+		$this->assertEquals('genou', str_singular('genoux', 'fr'));
+		$this->assertEquals('bureau', str_singular('bureaux', 'fr'));
+		$this->assertEquals('oiseau', str_singular('oiseaux', 'fr'));
+		$this->assertEquals('jeu', str_singular('jeux', 'fr'));
+		$this->assertEquals('sarrau', str_singular('sarraus', 'fr'));
+		$this->assertEquals('bleu', str_singular('bleus', 'fr'));
+		$this->assertEquals('ciel', str_singular('cieux', 'fr'));
+		$this->assertEquals('ail', str_singular('ails', 'fr'));
+		$this->assertEquals('corps', str_singular('corps', 'fr'));
+		$this->assertEquals('oeil', str_singular('yeux', 'fr'));
+		$this->assertEquals('madame', str_singular('mesdames', 'fr'));
+		$this->assertEquals('monsieur', str_singular('messieurs', 'fr'));
+		$this->assertEquals('il', str_singular('ils', 'fr'));
+		$this->assertEquals('un', str_singular('des', 'fr'));
+		$this->assertEquals('nez', str_singular('nez', 'fr'));
+		$this->assertEquals('famille', str_singular('familles', 'fr'));
+	}
 }


### PR DESCRIPTION
I added a $language attribute in the Pluralizer's singular() and plural() function, because I needed to use it with the french grammar rules.

Unfortunately, the french language is tricky, and I was not really able to make all the rules for singularizing a word. For example, plural verbs ending in AUX can end in AL or in AU when singular.
I was pondering using a list of the singular words finishing in AL (a few hundreds) or maybe throwing an exception, when the plural() function is called with a word that ends with AUX.
What do you think ?

In my case, I only use plural() so it's okay.
