### PR TITLE
Use absolute class names for Lang facade.

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -329,11 +329,11 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	{
 		$pattern = $this->createMatcher('lang');
 
-		$value = preg_replace($pattern, '$1<?php echo Lang::get$2; ?>', $value);
+		$value = preg_replace($pattern, '$1<?php echo \Illuminate\Support\Facades\Lang::get$2; ?>', $value);
 
 		$pattern = $this->createMatcher('choice');
 
-		return preg_replace($pattern, '$1<?php echo Lang::choice$2; ?>', $value);
+		return preg_replace($pattern, '$1<?php echo \Illuminate\Support\Facades\Lang::choice$2; ?>', $value);
 	}
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -203,8 +203,8 @@ breeze
 	public function testLanguageAndChoicesAreCompiled()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
-		$this->assertEquals('<?php echo Lang::get(\'foo\'); ?>', $compiler->compileString("@lang('foo')"));
-		$this->assertEquals('<?php echo Lang::choice(\'foo\', 1); ?>', $compiler->compileString("@choice('foo', 1)"));
+		$this->assertEquals('<?php echo \Illuminate\Support\Facades\Lang::get(\'foo\'); ?>', $compiler->compileString("@lang('foo')"));
+		$this->assertEquals('<?php echo \Illuminate\Support\Facades\Lang::choice(\'foo\', 1); ?>', $compiler->compileString("@choice('foo', 1)"));
 	}
 
 


### PR DESCRIPTION
As discussed [in this ticket](https://github.com/laravel/framework/pull/695#issuecomment-15733012). Allows for replacing the `Lang` alias without causing problems.
