### PR TITLE
Add new 'required_without' validation rule

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -90,7 +90,7 @@ class Validator implements MessageProviderInterface {
 	 *
 	 * @var array
 	 */
-	protected $implicitRules = array('Required', 'RequiredWith', 'Accepted');
+	protected $implicitRules = array('Required', 'RequiredWith', 'RequiredWithout', 'Accepted');
 
 	/**
 	 * Create a new Validator instance.
@@ -336,6 +336,24 @@ class Validator implements MessageProviderInterface {
 		}
 
 		return $this->validateRequired($attribute, $value);
+	}
+
+	/**
+	 * Validate that an attribute exists when another attribute does not exists
+	 *
+	 * @param  string  $attribute
+	 * @param  mixed   $value
+	 * @param  mixed   $parameters
+	 * @return bool
+	 */
+	protected function validateRequiredWithout($attribute, $value, $parameters)
+	{
+		if ($this->anyFailingRequired($parameters))
+		{
+			return $this->validateRequired($attribute, $value);
+		}
+
+		return true;
 	}
 
 	/**
@@ -1194,6 +1212,20 @@ class Validator implements MessageProviderInterface {
 	 * @return string
 	 */
 	protected function replaceRequiredWith($message, $attribute, $rule, $parameters)
+	{
+		return str_replace(':values', implode(' / ', $parameters), $message);
+	}
+
+	/**
+	 * Replace all place-holders for the required_without rule.
+	 *
+	 * @param  string  $message
+	 * @param  string  $attribute
+	 * @param  string  $rule
+	 * @param  array   $parameters
+	 * @return string
+	 */
+	protected function replaceRequiredWithout($message, $attribute, $rule, $parameters)
 	{
 		return str_replace(':values', implode(' / ', $parameters), $message);
 	}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -140,6 +140,60 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($v->passes());
 	}
 
+	public function testValidateRequiredWithout()
+	{
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('first' => 'Taylor'), array('last' => 'required_without:first'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('first' => 'Taylor', 'last' => ''), array('last' => 'required_without:first'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('first' => ''), array('last' => 'required_without:first'));
+		$this->assertFalse($v->passes());
+
+		$v = new Validator($trans, array(), array('last' => 'required_without:first'));
+		$this->assertFalse($v->passes());
+
+		$v = new Validator($trans, array('first' => 'Taylor', 'last' => 'Otwell'), array('last' => 'required_without:first'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('last' => 'Otwell'), array('last' => 'required_without:first'));
+		$this->assertTrue($v->passes());
+
+		$file = new File('', false);
+		$v = new Validator($trans, array('file' => $file), array('foo' => 'required_without:file'));
+		$this->assertFalse($v->passes());
+
+		$foo = new File('', false);
+		$v = new Validator($trans, array('foo' => $foo), array('foo' => 'required_without:file'));
+		$this->assertFalse($v->passes());
+
+		$foo = new File(__FILE__, false);
+		$v = new Validator($trans, array('foo' => $foo), array('foo' => 'required_without:file'));
+		$this->assertTrue($v->passes());
+
+		$file = new File(__FILE__, false);
+		$foo  = new File(__FILE__, false);
+		$v = new Validator($trans, array('file' => $file, 'foo' => $foo), array('foo' => 'required_without:file'));
+		$this->assertTrue($v->passes());
+
+		$file = new File(__FILE__, false);
+		$foo  = new File('', false);
+		$v = new Validator($trans, array('file' => $file, 'foo' => $foo), array('foo' => 'required_without:file'));
+		$this->assertTrue($v->passes());
+
+		$file = new File('', false);
+		$foo  = new File(__FILE__, false);
+		$v = new Validator($trans, array('file' => $file, 'foo' => $foo), array('foo' => 'required_without:file'));
+		$this->assertTrue($v->passes());
+
+		$file = new File('', false);
+		$foo  = new File('', false);
+		$v = new Validator($trans, array('file' => $file, 'foo' => $foo), array('foo' => 'required_without:file'));
+		$this->assertFalse($v->passes());
+	}
+
 	public function testValidateConfirmed()
 	{
 		$trans = $this->getRealTranslator();
@@ -279,7 +333,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$file->expects($this->any())->method('getSize')->will($this->returnValue(4072));
 		$v = new Validator($trans, array(), array('photo' => 'Size:3'));
 		$v->setFiles(array('photo' => $file));
-		$this->assertFalse($v->passes());		
+		$this->assertFalse($v->passes());
 	}
 
 
@@ -314,7 +368,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$file->expects($this->any())->method('getSize')->will($this->returnValue(4072));
 		$v = new Validator($trans, array(), array('photo' => 'Between:1,2'));
 		$v->setFiles(array('photo' => $file));
-		$this->assertFalse($v->passes());		
+		$this->assertFalse($v->passes());
 	}
 
 
@@ -343,7 +397,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$file->expects($this->any())->method('getSize')->will($this->returnValue(4072));
 		$v = new Validator($trans, array(), array('photo' => 'Min:10'));
 		$v->setFiles(array('photo' => $file));
-		$this->assertFalse($v->passes());		
+		$this->assertFalse($v->passes());
 	}
 
 
@@ -372,7 +426,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$file->expects($this->any())->method('getSize')->will($this->returnValue(4072));
 		$v = new Validator($trans, array(), array('photo' => 'Max:2'));
 		$v->setFiles(array('photo' => $file));
-		$this->assertFalse($v->passes());		
+		$this->assertFalse($v->passes());
 	}
 
 


### PR DESCRIPTION
Add new 'required_without' validation rule that verifies that the field under validation must be present only if the other specified fields are _not_ present.

This is the opposite of the 'required_with' validation rule. It makes sense to have a rule like this since we already have the 'same' and 'different' validation rules which are each other's counterparts. I also need a rule like this for a personal project that I am working on. :-)
