### PR TITLE
Fix compatebility error between EloquentModelSaveStubTest::save() and Mo...

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -623,7 +623,7 @@ class EloquentDateModelStub extends EloquentModelStub {
 class EloquentModelSaveStub extends Illuminate\Database\Eloquent\Model {
 	protected $table = 'save_stub';
 	protected $guarded = array();
-	public function save() { $_SERVER['__eloquent.saved'] = true; }
+	public function save(array $options = array()) { $_SERVER['__eloquent.saved'] = true; }
 	public function setIncrementing($value)
 	{
 		$this->incrementing = $value;


### PR DESCRIPTION
...del::save()

PHPUnit was throwing this error:

Strict Standards: Declaration of EloquentModelSaveStub::save() should be compatible with Illuminate\Database\Eloquent\Model::save(array $options = Array) in /Users/Andreas/Sites/laravel/laravel-framework/tests/Database/DatabaseEloquentModelTest.php on line 631

This fixes it.

Signed-off-by: Andreas Heiberg git@andreas-heiberg.com
