### PR TITLE
Fix for using lists() and key formatted like 'table.field'

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -900,7 +900,8 @@ class Builder {
 		// otherwise we can just give these values back without a specific key.
 		$results = new Collection($this->get($columns));
 
-		$values = $results->fetch($column)->all();
+		$fetchColumn = explode('.', $column);
+		$values = $results->fetch(end($fetchColumn))->all();
 
 		// If a key was specified and we have results, we will go ahead and combine
 		// the values with the keys of all of the records so that the values can


### PR DESCRIPTION
Sorry this thing isn't pretty.

This fixes an error where you wouldn't be able to use the lists function if your query had joins.

Heres the code I was running that caused me errors.

Question::join('question_survey', 'questions.id', '=', 'question_survey.question_id')
                        ->where('question_survey.survey_id', $surveyId)
                        ->join('tags', 'questions.tag_id', '=', 'tags.id')
                        ->where('tags.category_id', $categoryId)
                        ->lists('questions.id');

Signed-off-by: Andreas Heiberg git@andreas-heiberg.com
