### PR TITLE
Add a success session variable to Password::remind

### DIFF
--- a/src/Illuminate/Auth/Reminders/PasswordBroker.php
+++ b/src/Illuminate/Auth/Reminders/PasswordBroker.php
@@ -91,7 +91,7 @@ class PasswordBroker {
 
 		$this->sendReminder($user, $token, $callback);
 
-		return $this->redirect->refresh();
+		return $this->redirect->refresh()->with('success', true);
 	}
 
 	/**

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -52,7 +52,8 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 		$mocks['reminders']->shouldReceive('create')->once()->with($user)->andReturn('token');
 		$callback = function() {};
 		$broker->expects($this->once())->method('sendReminder')->with($this->equalTo($user), $this->equalTo('token'), $this->equalTo($callback));
-		$mocks['redirect']->shouldReceive('refresh')->once();
+		$mocks['redirect']->shouldReceive('refresh')->andReturn($redirect = m::mock('Illuminate\Http\RedirectResponse'));
+		$redirect->shouldReceive('with')->once()->with('success', true)->andReturn($redirect);
 
 		$broker->remind(array('foo'), $callback);
 	}


### PR DESCRIPTION
Currently there doesn't seem to be a way to differentiate between just showing the reset form, or if that form was successfully submitted (you can check for an error but not for success). Added a 'success' session variable to allow for that. 
