### PR TITLE
Array length validation (min/max) + some cleanup

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -386,9 +386,9 @@ class Validator implements MessageProviderInterface {
 	{
 		$count = 0;
 
-		foreach ($attributes as $key)
+		foreach ($attributes as $attribute)
 		{
-			if (isset($this->data[$key]) or isset($this->files[$key]))
+			if ( ! is_null($this->getValue($attribute)))
 			{
 				$count++;
 			}
@@ -421,7 +421,7 @@ class Validator implements MessageProviderInterface {
 	{
 		$other = $parameters[0];
 
-		return isset($this->data[$other]) and $value == $this->data[$other];
+		return ! is_null($otherValue = $this->getValue($other)) and $value == $otherValue;
 	}
 
 	/**
@@ -436,7 +436,7 @@ class Validator implements MessageProviderInterface {
 	{
 		$other = $parameters[0];
 
-		return isset($this->data[$other]) and $value != $this->data[$other];
+		return ! is_null($otherValue = $this->getValue($other)) and $value != $otherValue;
 	}
 
 	/**
@@ -465,6 +465,18 @@ class Validator implements MessageProviderInterface {
 	protected function validateNumeric($attribute, $value)
 	{
 		return is_numeric($value);
+	}
+
+	/**
+	 * Validate that an attribute is an array.
+	 *
+	 * @param  string  $attribute
+	 * @param  mixed   $value
+	 * @return bool
+	 */
+	protected function validateArray($attribute, $value)
+	{
+		return is_array($value);
 	}
 
 	/**
@@ -578,7 +590,11 @@ class Validator implements MessageProviderInterface {
 		// entire length of the string will be considered the attribute size.
 		if (is_numeric($value) and $hasNumeric)
 		{
-			return $this->data[$attribute];
+			return $value;
+		}
+		elseif (is_array($value))
+		{
+			return count($value);
 		}
 		elseif ($value instanceof File)
 		{

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -88,6 +88,13 @@ class Validator implements MessageProviderInterface {
 	protected $numericRules = array('Numeric', 'Integer');
 
 	/**
+	 * The array related validation rules.
+	 *
+	 * @var array
+	 */
+	protected $arrayRules = array('Array');
+
+	/**
 	 * The implicit validation rules.
 	 *
 	 * @var array
@@ -1072,6 +1079,10 @@ class Validator implements MessageProviderInterface {
 		if ($this->hasRule($attribute, $this->numericRules))
 		{
 			return 'numeric';
+		}
+		elseif ($this->hasRule($attribute, $this->arrayRules))
+		{
+			return 'array';
 		}
 		elseif (array_key_exists($attribute, $this->files))
 		{

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -400,6 +400,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => '5'), array('foo' => 'Numeric|Min:3'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Min:2'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Min:5'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Min:2'));
+		$this->assertFalse($v->passes());
+
 		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));
 		$file->expects($this->any())->method('getSize')->will($this->returnValue(3072));
 		$v = new Validator($trans, array(), array('photo' => 'Min:2'));
@@ -428,6 +437,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v = new Validator($trans, array('foo' => '22'), array('foo' => 'Numeric|Max:33'));
 		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Max:5'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Max:5'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Max:2'));
+		$this->assertFalse($v->passes());
 
 		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));
 		$file->expects($this->any())->method('getSize')->will($this->returnValue(3072));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -403,10 +403,10 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Min:2'));
 		$this->assertTrue($v->passes());
 
-		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Min:5'));
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Min:2'));
 		$this->assertTrue($v->passes());
 
-		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Min:2'));
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Min:5'));
 		$this->assertFalse($v->passes());
 
 		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));


### PR DESCRIPTION
Make array length validatable in a similar fashion to Numeric/String attributes with rules like min, max, between etc.

Also, new method: `validateArray()`
