### PR TITLE
Make TestCase::assertSessionHasErrors() more useful

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -260,12 +260,30 @@ class TestCase extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * Assert that the session has errors bound.
-	 *
+	 * 
+	 * @param  string|array  $bindings
+	 * @param  mixed  $format
 	 * @return void
 	 */
-	public function assertSessionHasErrors()
+	public function assertSessionHasErrors($bindings = array(), $format = null)
 	{
-		return $this->assertSessionHas('errors');
+		$this->assertSessionHas('errors');
+
+		$bindings = (array)$bindings;
+
+		$errors = $this->app['session']->get('errors');
+
+		foreach ($bindings as $key => $value)
+		{
+			if (is_int($key))
+			{
+				$this->assertTrue($errors->has($value));
+			}
+			else
+			{
+				$this->assertContains($value, $errors->get($key, $format));
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
Currently, `TestCase::assertSessionHasErrors()` checks only that the session has the `'errors'` item bound.

This change will allow that and some more specific things, like:

``` php

$this->assertSessionHasErrors('email');

$this->assertSessionHasErrors(array('email', 'password'));

$this->assertSessionHasErrors(array(
    'email' => Lang::get('validation.required', array('attribute' => 'email')),
    'password' => Lang::get('validation.required', array('attribute' => 'password')),
), ':message'); // This last bit's a little weird, but it keeps the message from being wrapped in the Bootstrap span

```

I like them. Anybody else?
