### PR TITLE
ServeCommand - make host:port output "clickable"

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -34,7 +34,7 @@ class ServeCommand extends Command {
 
 		$public = $this->laravel['path.public'];
 
-		$this->info("Laravel development server started on {$host}:{$port}...");
+		$this->info("Laravel development server started on http://{$host}:{$port}...");
 
 		passthru("php -S {$host}:{$port} -t \"{$public}\" server.php");
 	}


### PR DESCRIPTION
This is a really trivial change, but `http://localhost:8000` is ctrl+clickable in my Ubuntu terminal (and maybe others?) while `localhost:8000` is not.

This will probably save me tenths of seconds a couple of times per day. :smile: 
