### PR TITLE
Add symfony/event-dispatcher to composer.json

### DIFF
--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -10,7 +10,8 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/container": "4.0.x",
-        "illuminate/support": "4.0.x"
+        "illuminate/support": "4.0.x",
+        "symfony/event-dispatcher": "2.2.*"
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",


### PR DESCRIPTION
If this library is used outside of Laravel it lacks the Symfony EventDispatcher dependency.  Adding it back in.
