### PR TITLE
Unescape Form::button() value

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -550,7 +550,7 @@ class FormBuilder {
 			$options['type'] = 'button';
 		}
 		
-		return '<button'.$this->html->attributes($options).'>'.e($value).'</button>';
+		return '<button'.$this->html->attributes($options).'>'.$value.'</button>';
 	}
 
 	/**


### PR DESCRIPTION
Form::button() values escaping. that is contrary to the architecture of the html5.
Maybe i want use dom element in button

Example; Twitter bootstrap
