### PR TITLE
Add timestamps column to migration stub.

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/create.php
+++ b/src/Illuminate/Database/Migrations/stubs/create.php
@@ -15,6 +15,7 @@ class {{class}} extends Migration {
 		Schema::create('{{table}}', function(Blueprint $table)
 		{
 			$table->increments('id');
+			$table->timestamps();
 		});
 	}
 


### PR DESCRIPTION
This is consistent with the default setting for Eloquent models, having timestamps enabled.

Fixes #865.
