### PR TITLE
[BugFix] forget method in Cache\Section

### DIFF
--- a/src/Illuminate/Cache/Section.php
+++ b/src/Illuminate/Cache/Section.php
@@ -75,7 +75,7 @@ class Section {
 	 */
 	public function decrement($key, $value = 1)
 	{
-		$this->store->decrement($this->sectionItemKey($key), $value);	
+		$this->store->decrement($this->sectionItemKey($key), $value);
 	}
 
 	/**
@@ -98,7 +98,7 @@ class Section {
 	 */
 	public function forget($key)
 	{
-		$this->store->forget($this->sectionItemKey($key), $value);	
+		$this->store->forget($this->sectionItemKey($key));
 	}
 
 	/**


### PR DESCRIPTION
Fixed ~~2~~ 1 small oversight:
1. forget($key) passing a $value parameter to the StoreInterface
2. ~~flush() calling the store's increment method~~
