### PR TITLE
Access Paginator Environment via public Paginator method

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -165,6 +165,16 @@ class Paginator implements ArrayAccess, Countable, IteratorAggregate {
 	}
 
 	/**
+	 * The pagination environment.
+	 *
+	 * @var \Illuminate\Pagination\Environment
+	 */
+	public function getEnvironment()
+	{
+		return $this->env;
+	}
+
+	/**
 	 * Add a query string value to the paginator.
 	 *
 	 * @param  string  $key

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -98,6 +98,13 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testEnvironmentAccess()
+	{
+		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('foo', 'bar', 'baz'), 3, 2);
+		$this->assertInstanceOf('Illuminate\Pagination\Environment', $p->getEnvironment());
+	}
+
+
 	public function testPaginatorIsCountable()
 	{
 		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('foo', 'bar', 'baz'), 3, 2);


### PR DESCRIPTION
Access Paginator Environment object via `Paginator::getEnvironment()` method. Useful when one wants to set variables such as currentPage, baseUrl, pageName etc. via Paginator itself.
