### PR TITLE
Fix order of query bindings

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -107,7 +107,7 @@ abstract class Relation {
 	{
 		$first = array_shift($this->getBaseQuery()->wheres);
 
-		$bindings = $this->getBaseQuery()->getBindings();
+		$bindings = $this->getBaseQuery()->getWhereBindings();
 
 		// When resetting the relation where clause, we want to shift the first element
 		// off of the bindings, leaving only the constraints that the developers put
@@ -117,7 +117,7 @@ abstract class Relation {
 			$bindings = array_slice($bindings, 1);
 		}
 
-		$this->getBaseQuery()->setBindings(array_values($bindings));
+		$this->getBaseQuery()->setWhereBindings(array_values($bindings));
 	}
 
 	/**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -217,6 +217,21 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testWheresWithHavings()
+	{
+		$builder = $this->getBuilder();
+		$builder->from('users')->where('registered', 1)->groupBy('city')->having('population', '>', 3);
+		$this->assertEquals('select * from "users" where "registered" = ? group by "city" having "population" > ?', $builder->toSql());
+		$this->assertEquals(array(0 => 1, 1 => 3), $builder->getBindings());
+
+		// This makes sure that the order of calling where() and having() does not matter.
+		$builder = $this->getBuilder();
+		$builder->from('users')->groupBy('city')->having('population', '>', 3)->where('registered', 1);
+		$this->assertEquals('select * from "users" where "registered" = ? group by "city" having "population" > ?', $builder->toSql());
+		$this->assertEquals(array(0 => 1, 1 => 3), $builder->getBindings());
+	}
+
+
 	public function testLimitsAndOffsets()
 	{
 		$builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -220,13 +220,13 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testWheresWithHavings()
 	{
 		$builder = $this->getBuilder();
-		$builder->from('users')->where('registered', 1)->groupBy('city')->having('population', '>', 3);
+		$builder->select('*')->from('users')->where('registered', 1)->groupBy('city')->having('population', '>', 3);
 		$this->assertEquals('select * from "users" where "registered" = ? group by "city" having "population" > ?', $builder->toSql());
 		$this->assertEquals(array(0 => 1, 1 => 3), $builder->getBindings());
 
 		// This makes sure that the order of calling where() and having() does not matter.
 		$builder = $this->getBuilder();
-		$builder->from('users')->groupBy('city')->having('population', '>', 3)->where('registered', 1);
+		$builder->select('*')->from('users')->groupBy('city')->having('population', '>', 3)->where('registered', 1);
 		$this->assertEquals('select * from "users" where "registered" = ? group by "city" having "population" > ?', $builder->toSql());
 		$this->assertEquals(array(0 => 1, 1 => 3), $builder->getBindings());
 	}


### PR DESCRIPTION
This is related to https://github.com/laravel/laravel/issues/1677.

What this allows us to do is dynamically add a WHERE condition to a query object that already has a GROUP BY / HAVING clause configured.
I need this ability in FluxBB's extension system.
