### PR TITLE
Allow incrementing offsets in a collection.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -251,7 +251,14 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 */
 	public function offsetSet($key, $value)
 	{
-		$this->items[$key] = $value;
+		if(is_null($key))
+		{
+			$this->items[] = $value;
+		}
+		else
+		{
+			$this->items[$key] = $value;
+		}
 	}
 
 	/**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -86,6 +86,8 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(isset($c['name']));
 		unset($c['name']);
 		$this->assertFalse(isset($c['name']));
+		$c[] = 'jason';
+		$this->assertEquals('jason', $c[0]);
 	}
 
 


### PR DESCRIPTION
I actually needed this for a project and was surprised that I had to use associative arrays with a collection. At the moment if you add an item to a collection without a key.

``` php
$collection[] = 'Hello World';
```

The dump of the collection looks like this.

```
object Illuminate\Support\Collection (1) {
    protected items -> array(1) [
        '' => string (3) "Hello World"
    ]
}
```

This PR will allow it to behave like a normal array. Tests included.
