### PR TITLE
Allow laravel/framework to replace illuminate/html

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "illuminate/foundation": "self.version",
         "illuminate/hashing": "self.version",
         "illuminate/http": "self.version",
+        "illuminate/html": "self.version",
         "illuminate/log": "self.version",
         "illuminate/mail": "self.version",
         "illuminate/pagination": "self.version",


### PR DESCRIPTION
I notice that `laravel/framework` doesn't replace require `illuminate/html`.

```
$ composer install 

  - Installing laravel/framework (dev-master 3ad1bc3)
    Cloning 3ad1bc33f5cc752602a3e793b27219c616441985

  - Installing illuminate/html (dev-master a120936)
    Cloning a12093614800cf427462d092d69702e47c9e6244    
```

Signed-off-by: crynobone crynobone@gmail.com
