### PR TITLE
[Proposal] Fix for HtmlBuilder and FormBuilder for correct xHTML

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -573,7 +573,7 @@ class FormBuilder {
 	 */
 	protected function getMethod($method)
 	{
-		return $method != 'GET' ? 'POST' : $method;
+		return $method != 'get' ? 'post' : $method;
 	}
 
 	/**

--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -97,7 +97,7 @@ class FormBuilder {
 		// We need to extract the proper method from the attributes. If the method is
 		// something other than GET or POST we'll use POST since we will spoof the
 		// actual method since forms don't support the reserved methods in HTML.
-		$attributes['method'] = $this->getMethod($method);
+		$attributes['method'] = $this->getMethod(strtolower($method));
 
 		$attributes['action'] = $this->getAction($options);
 
@@ -215,7 +215,7 @@ class FormBuilder {
 
 		$options = array_merge($options, $merge);
 
-		return '<input'.$this->html->attributes($options).'>';
+		return '<input'.$this->html->attributes($options).$this->html->closingSlash().'>';
 	}
 
 	/**

--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -19,14 +19,23 @@ class HtmlBuilder {
 	protected $macros;
 
 	/**
+	 * The config for HTML
+	 *
+	 * @var array
+	 */
+	protected $config;
+
+	/**
 	 * Create a new HTML builder instance.
 	 *
 	 * @param  \Illuminate\Routing\UrlGenerator  $url
+	 * @param  array
 	 * @return void
 	 */
-	public function __construct(UrlGenerator $url = null)
+	public function __construct(UrlGenerator $url = null, $config = null)
 	{
 		$this->url = $url;
+		$this->config = $config;
 	}
 
 	/**
@@ -64,6 +73,54 @@ class HtmlBuilder {
 	}
 
 	/**
+	 * Generate a HTML !DOCTYPE
+	 *
+	 * @param  string  $type
+	 * @return string
+	 */
+	public function doctype($type = false)
+	{
+		if ($type === false && isset($this->config['doctype']))
+		{
+			$type = $this->config['doctype'];
+		}
+
+		if (isset($this->config['doctypes'][$type]))
+		{
+			return $this->config['doctypes'][$type];
+		}
+		elseif ($type == 'html5')
+		{
+			return '<!DOCTYPE html>';
+		}
+		else
+		{
+			throw new \InvalidArgumentException('Unknown doctype or it has not been listed in the config!');
+		}
+	}
+
+	/**
+	 * Return slash or empty string depending on html markup
+	 * defined in the config
+	 *
+	 * @return string
+	 */
+	public function closingSlash()
+	{
+		return ((isset($this->config['markup']) && $this->config['markup'] == 'xhtml') ? '/' : "");
+	}
+
+	/**
+	 * Set the markup
+	 *
+	 * Mainly for testing
+	 */
+	public function setMarkup($markup)
+	{
+		$this->config['markup'] = $markup;
+	}
+
+	/**
 	 * Generate a link to a JavaScript file.
 	 *
 	 * @param  string  $url
@@ -92,7 +149,7 @@ class HtmlBuilder {
 
 		$attributes['href'] = $this->url->asset($url);
 
-		return '<link'.$this->attributes($attributes).'>'.PHP_EOL;
+		return '<link'.$this->attributes($attributes).$this->closingSlash().'>'.PHP_EOL;
 	}
 
 	/**
@@ -107,7 +164,7 @@ class HtmlBuilder {
 	{
 		$attributes['alt'] = $alt;
 
-		return '<img src="'.$this->url->asset($url).'"'.$this->attributes($attributes).'>';
+		return '<img src="'.$this->url->asset($url).'"'.$this->attributes($attributes).$this->closingSlash().'>';
 	}
 
 	/**

--- a/src/Illuminate/Html/HtmlServiceProvider.php
+++ b/src/Illuminate/Html/HtmlServiceProvider.php
@@ -32,7 +32,7 @@ class HtmlServiceProvider extends ServiceProvider {
 	{
 		$this->app['html'] = $this->app->share(function($app)
 		{
-			return new HtmlBuilder($app['url']);
+			return new HtmlBuilder($app['url'], $app['config']['html']);
 		});
 	}
 

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -36,10 +36,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form4 = $this->formBuilder->open(array('method' => 'GET', 'accept-charset' => 'UTF-16', 'files' => true));
 
 
-		$this->assertEquals('<form method="GET" action="http://localhost/foo" accept-charset="UTF-8">', $form1);
-		$this->assertEquals('<form method="POST" action="http://localhost/foo" accept-charset="UTF-8" class="form" id="id-form">', $form2);
-		$this->assertEquals('<form method="GET" action="http://localhost/foo" accept-charset="UTF-16">', $form3);
-		$this->assertEquals('<form method="GET" action="http://localhost/foo" accept-charset="UTF-16" enctype="multipart/form-data">', $form4);
+		$this->assertEquals('<form method="get" action="http://localhost/foo" accept-charset="UTF-8">', $form1);
+		$this->assertEquals('<form method="post" action="http://localhost/foo" accept-charset="UTF-8" class="form" id="id-form">', $form2);
+		$this->assertEquals('<form method="get" action="http://localhost/foo" accept-charset="UTF-16">', $form3);
+		$this->assertEquals('<form method="get" action="http://localhost/foo" accept-charset="UTF-16" enctype="multipart/form-data">', $form4);
 	}
 
 
@@ -69,6 +69,30 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<input name="foo" type="text" value="foobar">', $form2);
 		$this->assertEquals('<input class="span2" name="foobar" type="date">', $form3);
 	}
+
+
+    public function testFormInputWithXhtml()
+    {
+        $this->htmlBuilder->setMarkup('xhtml');
+
+        $form1 = $this->formBuilder->input('text', 'foo');
+        $form2 = $this->formBuilder->input('text', 'foo', 'foobar');
+        $form3 = $this->formBuilder->input('date', 'foobar', null, array('class' => 'span2'));
+
+        $this->assertEquals('<input name="foo" type="text"/>', $form1);
+        $this->assertEquals('<input name="foo" type="text" value="foobar"/>', $form2);
+        $this->assertEquals('<input class="span2" name="foobar" type="date"/>', $form3);
+    }
+
+
+    public function testFormInputWithUnknownMarkup()
+    {
+        $this->htmlBuilder->setMarkup('laravel');
+
+        $form1 = $this->formBuilder->input('text', 'foo');
+
+        $this->assertEquals('<input name="foo" type="text">', $form1);
+    }
 
 
 	public function testFormText()

--- a/tests/Html/HtmlBuilderTest.php
+++ b/tests/Html/HtmlBuilderTest.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use Symfony\Component\Routing\RouteCollection;
 
 
-class FormBuilderTest extends PHPUnit_Framework_TestCase {
+class HtmlBuilderTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Setup the test environment.

--- a/tests/Html/HtmlBuilderTest.php
+++ b/tests/Html/HtmlBuilderTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Html\HtmlBuilder;
+use Illuminate\Routing\UrlGenerator;
+use Illuminate\Http\Request;
+use Symfony\Component\Routing\RouteCollection;
+
+
+class FormBuilderTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * Setup the test environment.
+	 */
+	public function setUp()
+	{
+		$this->urlGenerator = new UrlGenerator(new RouteCollection, Request::create('/foo', 'GET'));
+		$this->htmlBuilder = new HtmlBuilder($this->urlGenerator, $this->getHtmlConfig());
+	}
+
+	/**
+	 * Destroy the test environment.
+	 */
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testDoctype()
+	{
+		$doc1 = $this->htmlBuilder->doctype('html5');
+		$doc2 = $this->htmlBuilder->doctype('html-transitional');
+		$doc3 = $this->htmlBuilder->doctype('xhtml-mp12');
+
+		$this->assertEquals('<!DOCTYPE html>', $doc1);
+		$this->assertEquals('<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">', $doc2);
+		$this->assertEquals('<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.2//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">', $doc3);
+	}
+
+
+	public function testStyle()
+	{
+		$stl1 = $this->htmlBuilder->style('http://laravel.com/style.css');
+		$stl2 = $this->htmlBuilder->style('http://laravel.com/style.css', array('media' => 'handheld'));
+
+		$this->htmlBuilder->setMarkup('xhtml');
+
+		$stl3 = $this->htmlBuilder->style('http://laravel.com/style.css', array('media' => 'handheld'));
+
+		$this->assertEquals('<link media="all" type="text/css" rel="stylesheet" href="http://laravel.com/style.css">'.PHP_EOL, $stl1);
+		$this->assertEquals('<link media="handheld" type="text/css" rel="stylesheet" href="http://laravel.com/style.css">'.PHP_EOL, $stl2);
+		$this->assertEquals('<link media="handheld" type="text/css" rel="stylesheet" href="http://laravel.com/style.css"/>'.PHP_EOL, $stl3);
+	}
+
+
+	public function testImage()
+	{
+		$img1 = $this->htmlBuilder->image('http://laravel.com/laravel.ico');
+		$img2 = $this->htmlBuilder->image('http://laravel.com/laravel.ico', 'Icon');
+
+		$this->htmlBuilder->setMarkup('xhtml');
+
+		$img3 = $this->htmlBuilder->image('http://laravel.com/laravel.ico', 'Icon', array('id' => 'img'));
+
+		$this->assertEquals('<img src="http://laravel.com/laravel.ico">', $img1);
+		$this->assertEquals('<img src="http://laravel.com/laravel.ico" alt="Icon">', $img2);
+		$this->assertEquals('<img src="http://laravel.com/laravel.ico" id="img" alt="Icon"/>', $img3);
+	}
+
+
+	public function getHtmlConfig()
+	{
+		return array(
+
+			/*
+			|--------------------------------------------------------------------------
+			| Markup
+			|--------------------------------------------------------------------------
+			|
+			| Here you may specify the markup for HTML Builder and Form builder for
+			| correct tags rendering.
+			|
+			| Supported: 'html', 'xhtml'
+			|
+			*/
+
+			'markup' => 'html',
+
+
+			/*
+			|--------------------------------------------------------------------------
+			| Document Type Declaration
+			|--------------------------------------------------------------------------
+			|
+			| Here you can specify the default document type, which will be used
+			| with HTML::doctype
+			|
+			*/
+
+			'doctype' => 'html5',
+
+
+			/*
+			|--------------------------------------------------------------------------
+			| List Of Doctypes
+			|--------------------------------------------------------------------------
+			|
+			| Taken from:
+			|  - http://www.w3schools.com/tags/tag_doctype.asp
+			|  - http://en.wikipedia.org/wiki/Document_type_declaration
+			|
+			*/
+
+			'doctypes' => array(
+
+				'html5'              => '<!DOCTYPE html>',
+
+				'html-strict'        => '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">',
+				'html-transitional'  => '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">',
+				'html-frameset'      => '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd">',
+
+				'xhtml'              => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">',
+				'xhtml-strict'       => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">',
+				'xhtml-transitional' => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',
+				'xhtml-frameset'     => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">',
+
+				'xhtml-basic'        => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN" "http://www.w3.org/TR/xhtml-basic/xhtml-basic11.dtd">',
+				'xhtml-mp10'         => '<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.0//EN" "http://www.wapforum.org/DTD/xhtml-mobile10.dtd">',
+				'xhtml-mp11'         => '<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.1//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile11.dtd">',
+				'xhtml-mp12'         => '<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.2//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">'
+
+			)
+
+		);
+	}
+
+}


### PR DESCRIPTION
I need this for my project where I am using xHTML MP 1.2. Since I am quite new to Laravel, I am not sure whether it is a good idea to implement that stuff like I  did.

In addition, I created a doctype function for just shorter syntax.

In my view, the config `app/config/html.php` should look like this:

``` php
return array(

    /*
    |--------------------------------------------------------------------------
    | Markup
    |--------------------------------------------------------------------------
    |
    | Here you may specify the markup for HTML Builder and Form builder for
    | correct tags rendering.
    |
    | Supported: 'html', 'xhtml'
    |
    */

    'markup' => 'html',


    /*
    |--------------------------------------------------------------------------
    | Document Type Declaration
    |--------------------------------------------------------------------------
    |
    | Here you can specify the default document type, which will be used
    | with HTML::doctype
    |
    */

    'doctype' => 'html5',


    /*
    |--------------------------------------------------------------------------
    | List Of Doctypes
    |--------------------------------------------------------------------------
    |
    | Taken from:
    |  - http://www.w3schools.com/tags/tag_doctype.asp
    |  - http://en.wikipedia.org/wiki/Document_type_declaration
    |
    */

    'doctypes' => array(

        'html5'              => '<!DOCTYPE html>',

        'html-strict'        => '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">',
        'html-transitional'  => '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">',
        'html-frameset'      => '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd">',

        'xhtml'              => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">',
        'xhtml-strict'       => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">',
        'xhtml-transitional' => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',
        'xhtml-frameset'     => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">',

        'xhtml-basic'        => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN" "http://www.w3.org/TR/xhtml-basic/xhtml-basic11.dtd">',
        'xhtml-mp10'         => '<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.0//EN" "http://www.wapforum.org/DTD/xhtml-mobile10.dtd">',
        'xhtml-mp11'         => '<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.1//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile11.dtd">',
        'xhtml-mp12'         => '<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.2//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">'

    )

);
```

Tests included.
