### PR TITLE
Implement Whoops feature to open referenced files in editor/IDE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.3.7",
         "classpreloader/classpreloader": "1.0.*",
         "ircmaxell/password-compat": "1.0.*",
-        "filp/whoops": "1.0.0",
+        "filp/whoops": "1.0.1",
         "monolog/monolog": "1.4.*",
         "patchwork/utf8": "1.0.*",
         "predis/predis": "0.8.*",

--- a/src/Illuminate/Exception/composer.json
+++ b/src/Illuminate/Exception/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "filp/whoops": "1.0.0",
+        "filp/whoops": "1.0.1",
         "illuminate/support": "4.0.x",
         "symfony/http-foundation": "2.3.x",
         "symfony/http-kernel": "2.3.*"

--- a/src/Illuminate/Exception/resources/pretty-page.css
+++ b/src/Illuminate/Exception/resources/pretty-page.css
@@ -109,6 +109,17 @@ header {
       color:#999;
       word-wrap:break-word;
     }
+      .editor-link {
+        color: inherit;
+      }
+        .editor-link:hover strong {
+          color: #F0E5DF;
+        }
+
+        .editor-link-callout {
+          padding: 2px 4px;
+          background: #872D00;
+        }
 
     .frame-line {
       font-weight: bold;

--- a/src/Illuminate/Exception/resources/pretty-template.php
+++ b/src/Illuminate/Exception/resources/pretty-template.php
@@ -67,7 +67,14 @@
               <?php $line = $frame->getLine(); ?>
                 <div class="frame-code <?php echo ($i == 0 ) ? 'active' : '' ?>" id="frame-code-<?php echo $i ?>">
                   <div class="frame-file">
-                    <strong><?php echo $e($frame->getFile() ?: '<#unknown>') ?></strong>
+                    <?php $filePath = $frame->getFile(); ?>
+                    <?php if($filePath && $editorHref = $v->handler->getEditorHref($filePath, (int) $line)): ?>
+                      <a href="<?php echo $editorHref ?>" class="editor-link">
+                        <span class="editor-link-callout">open:</span> <strong><?php echo $e($filePath ?: '<#unknown>') ?></strong>
+                      </a>
+                    <?php else: ?>
+                      <strong><?php echo $e($filePath ?: '<#unknown>') ?></strong>
+                    <?php endif ?>
                   </div>
                   <?php
                     // Do nothing if there's no line to work off


### PR DESCRIPTION
This PR updates the `filps/whoops` dependency to `1.0.1`, which includes among other small fixes a feature to enable opening files referenced in the error page in the user's editor/IDE of choice. Required changes to templates & CSS were also ported.

![Whoops!](http://i.imgur.com/7YHsYZo.png)

Currently, **the feature will not be visible, as no editor is set by default**. I've decided against making the choice to structure that myself. My idea was to add another option to `app/config/app.php` named `editor` or some such, but there's probably room to allow machine-specific editor choices, loading from environment variables, etc.

Setting an editor is simple:
1. Check the available editors in `PrettyPageHandler`
2. Use `PrettyPageHandler::setEditor( string $identifier )` to set an editor by identifier
3. Alternatively, pass a callable to `setEditor` that accepts a file path and a line number, and returns a string usable as an `href` property
4. Alternatively, add your own editor options with `PrettyPageHandler::addEditor(string $identifier, callable)`

Finally, @daylerees might want to have a look at my changes to the template and CSS, and tweak them to fit his choices - my solution is far from perfect :sweat_smile:

Additional info is available [in the whoops repo](https://github.com/filp/whoops#opening-referenced-files-with-your-favorite-editor-or-ide).

Cheers!
