### PR TITLE
Fix radio button value getting altered by Redirect::withInput

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -203,7 +203,7 @@ class FormBuilder {
 		// in the model instance if one is set. Otherwise we will just use empty.
 		$id = $this->getIdAttribute($name, $options);
 
-		if ($type != 'file')
+		if ($type != 'file' && $type != 'radio')
 		{
 			$value = $this->getValueAttribute($name, $value);
 		}


### PR DESCRIPTION
Value should not be altered for radio buttons, otherwise all buttons with one name are given the value of the selected button when using Redirect withInput etc.
