### PR TITLE
Cascading Views From Pacakges

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -80,7 +80,7 @@ abstract class ServiceProvider {
 		// Finally we will register the view namespace so that we can access each of
 		// the views available in this package. We use a standard convention when
 		// registering the paths to every package's views and other components.
-		$appview = App('path').'/views/packages/'. $package.'/'.$namespace;
+		$appview = $this->app['path'].'/views/packages/'. $package.'/'.$namespace;
 
 		if ($this->app['files']->isDirectory($appview))
 		{

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -80,6 +80,13 @@ abstract class ServiceProvider {
 		// Finally we will register the view namespace so that we can access each of
 		// the views available in this package. We use a standard convention when
 		// registering the paths to every package's views and other components.
+		$appview = App('path').'/views/packages/'. $package.'/'.$namespace;
+
+		if ($this->app['files']->isDirectory($appview))
+		{
+			$this->app['view']->addNamespace($namespace, $appview);
+		}
+
 		$view = $path.'/views';
 
 		if ($this->app['files']->isDirectory($view))


### PR DESCRIPTION
I don't know if there is something I am missing in the view implementation, but it seems like there is no way to override views provided by a third party package in your app.  What I mean is a situation where a package provides a set of views, and you wish to over-ride a subset of them.  The way I feel like it should work is leave your view call:

```
View::make('package::view.name');
```

But if you have the file, `app/views/packages/vendor/package/view/name.php` it should load that over the one defined in the package.  Does that make sense?

Is there something already doing this?  If not, is the attached PR satisfactory for this?  Thoughts?
