### PR TITLE
Better FileStore implementation for large caches

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -73,8 +73,15 @@ class FileStore implements StoreInterface {
 	public function put($key, $value, $minutes)
 	{
 		$value = $this->expiration($minutes).serialize($value);
+		$path = $this->path($key);
+		$dir = dirname($path);
 
-		$this->files->put($this->path($key), $value);
+		if( ! $this->files->isDirectory($dir))
+		{
+			$this->files->makeDirectory($dir, 0777, true);
+		}
+
+		$this->files->put($path, $value);
 	}
 
 	/**
@@ -145,7 +152,10 @@ class FileStore implements StoreInterface {
 	 */
 	protected function path($key)
 	{
-		return $this->directory.'/'.md5($key);
+		$md5 = md5($key);
+		$parts = array_slice(str_split($md5, 2), 0, 2);
+
+		return $this->directory.'/'.join('/', $parts).'/'.$md5;
 	}
 
 	/**

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -14,6 +14,19 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testPutCreatesMissingDirectories()
+	{
+		$files = $this->mockFilesystem();
+		$md5 = md5('foo');
+		$full_dir = __DIR__.'/'.substr($md5, 0, 2).'/'.substr($md5, 2, 2);
+		$files->expects($this->once())->method('isDirectory')->with($this->equalTo($full_dir))->will($this->returnValue(false));
+		$files->expects($this->once())->method('makeDirectory')->with($this->equalTo($full_dir), $this->equalTo(0777), $this->equalTo(true));
+		$files->expects($this->once())->method('put')->with($this->equalTo($full_dir.'/'.$md5));
+		$store = new FileStore($files, __DIR__);
+		$store->put('foo', '0000000000', 0);
+	}
+
+
 	public function testExpiredItemsReturnNull()
 	{
 		$files = $this->mockFilesystem();
@@ -44,7 +57,9 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 		$store = $this->getMock('Illuminate\Cache\FileStore', array('expiration'), array($files, __DIR__));
 		$store->expects($this->once())->method('expiration')->with($this->equalTo(10))->will($this->returnValue(1111111111));
 		$contents = '1111111111'.serialize('Hello World');
-		$files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.md5('foo')), $this->equalTo($contents));
+		$md5 = md5('foo');
+		$cache_dir = substr($md5, 0, 2).'/'.substr($md5, 2, 2);
+		$files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$md5), $this->equalTo($contents));
 		$store->put('foo', 'Hello World', 10);
 	}
 
@@ -53,7 +68,9 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 	{
 		$files = $this->mockFilesystem();
 		$contents = '9999999999'.serialize('Hello World');
-		$files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.md5('foo')), $this->equalTo($contents));
+		$md5 = md5('foo');
+		$cache_dir = substr($md5, 0, 2).'/'.substr($md5, 2, 2);
+		$files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$md5), $this->equalTo($contents));
 		$store = new FileStore($files, __DIR__);
 		$store->forever('foo', 'Hello World', 10);
 	}
@@ -62,7 +79,9 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 	public function testRemoveDeletesFile()
 	{
 		$files = $this->mockFilesystem();
-		$files->expects($this->once())->method('delete')->with($this->equalTo(__DIR__.'/'.md5('foo')));
+		$md5 = md5('foo');
+		$cache_dir = substr($md5, 0, 2).'/'.substr($md5, 2, 2);
+		$files->expects($this->once())->method('delete')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$md5));
 		$store = new FileStore($files, __DIR__);
 		$store->forget('foo');
 	}


### PR DESCRIPTION
This PR is related to https://github.com/laravel/framework/issues/893

I've decided to store cache files in directories like `/app/storage/cache/xx/xx/md5file`. It's a little bit different version from proposed by @awellis13 but I think that this will do the trick.
