### PR TITLE
fixed incorrect total count when using specific column in paginate()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -169,7 +169,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	public function paginate($perPage = null, $columns = array('*'))
+	public function paginate($perPage = null, $columns = array('*'), $countColumn = '*')
 	{
 		$perPage = $perPage ?: $this->model->getPerPage();
 
@@ -181,7 +181,7 @@ class Builder {
 		}
 		else
 		{
-			return $this->ungroupedPaginate($paginator, $perPage, $columns);
+			return $this->ungroupedPaginate($paginator, $perPage, $columns, $countColumn);
 		}
 	}
 
@@ -208,9 +208,9 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	protected function ungroupedPaginate($paginator, $perPage, $columns)
+	protected function ungroupedPaginate($paginator, $perPage, $columns, $countColumn)
 	{
-		$total = $this->query->getPaginationCount();
+		$total = $this->query->getPaginationCount($countColumn);
 
 		// Once we have the paginator we need to set the limit and offset values for
 		// the query so we can get the properly paginated items. Once we have an

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1107,7 +1107,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	public function paginate($perPage = 15, $columns = array('*'))
+	public function paginate($perPage = 15, $columns = array('*'), $countColumn = '*')
 	{
 		$paginator = $this->connection->getPaginator();
 
@@ -1117,7 +1117,7 @@ class Builder {
 		}
 		else
 		{
-			return $this->ungroupedPaginate($paginator, $perPage, $columns);
+			return $this->ungroupedPaginate($paginator, $perPage, $columns, $countColumn);
 		}
 	}
 
@@ -1164,9 +1164,9 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	protected function ungroupedPaginate($paginator, $perPage, $columns)
+	protected function ungroupedPaginate($paginator, $perPage, $columns, $countColumn)
 	{
-		$total = $this->getPaginationCount();
+		$total = $this->getPaginationCount($countColumn);
 
 		// Once we have the total number of records to be paginated, we can grab the
 		// current page and the result array. Then we are ready to create a brand
@@ -1183,7 +1183,7 @@ class Builder {
 	 *
 	 * @return int
 	 */
-	public function getPaginationCount()
+	public function getPaginationCount($column = '*')
 	{
 		list($orders, $this->orders) = array($this->orders, null);
 
@@ -1192,7 +1192,7 @@ class Builder {
 		// Because some database engines may throw errors if we leave the ordering
 		// statements on the query, we will "back them up" and remove them from
 		// the query. Once we have the count we will put them back onto this.
-		$total = $this->count();
+		$total = $this->count($column);
 
 		$this->orders = $orders;
 


### PR DESCRIPTION
Doing this would give me a total of 21 but should give me a total of 3:

```
$customers = $survey->customers()->paginate(5, ['customers.id']);
dd($customers);
```

I found the problem to be that paginates second param was never passed to getPaginationCount in Query/Builder
