### PR TITLE
Change dependency from Command to Fluent

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -54,7 +54,7 @@ abstract class Grammar extends BaseGrammar {
 	 * @param  \Doctrine\DBAL\Schema\Column  $column
 	 * @return \Doctrine\DBAL\Schema\TableDiff
 	 */
-	protected function setRenamedColumns(TableDiff $tableDiff, Command $command, Column $column)
+	protected function setRenamedColumns(TableDiff $tableDiff, Fluent $command, Column $column)
 	{
 		$newColumn = new Column($command->to, $column->getType(), $column->toArray());
 


### PR DESCRIPTION
Artisan was giving errors on running migrations for renaming DB columns. An incorrect Command dependency was the reason behind the bug. Changed it to the correct Fluent dependency.
