### PR TITLE
Provide closure filters $route and $request vars

### DIFF
--- a/src/Illuminate/Routing/Controllers/Controller.php
+++ b/src/Illuminate/Routing/Controllers/Controller.php
@@ -256,7 +256,7 @@ class Controller {
 		{
 			$callback = $this->callbackFilters[$filter];
 
-			return call_user_func_array($callback, $parameters);
+			return call_user_func($callback, $route, $request, $parameters);
 		}
 
 		return $route->callFilter($filter, $request, $parameters);


### PR DESCRIPTION
When adding filters in Controller constructs, provide closure filters $route and $request variables besides $parameters array.

``` php
// in construct
$this->beforeFilter(function($route, $request, $parameters)
{
 // code
}
```

One difference, now when calling afterFilter, it'll provide $response as the third parameter:

``` php
// in construct
$this->afterFilter(function($route, $request, $response)
{
 // code
}
```
