### PR TITLE
[BugFix] FileStore flush() method.

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -136,10 +136,7 @@ class FileStore implements StoreInterface {
 	 */
 	public function flush()
 	{
-		foreach ($this->files->files($this->directory) as $file)
-		{
-			$this->files->delete($file);
-		}
+		$this->files->cleanDirectory($this->directory);
 	}
 
 	/**

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -90,8 +90,7 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 	public function testFlushCleansDirectory()
 	{
 		$files = $this->mockFilesystem();
-		$files->expects($this->once())->method('files')->with($this->equalTo(__DIR__))->will($this->returnValue(array('foo', 'bar')));
-		$files->expects($this->exactly(2))->method('delete');
+		$files->expects($this->once())->method('cleanDirectory')->with($this->equalTo(__DIR__));
 
 		$store = new FileStore($files, __DIR__);
 		$store->flush();


### PR DESCRIPTION
To adapt to new FileStore structure introduced in #913.
