### PR TITLE
Password fields shouldn't flash back their value

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -203,7 +203,7 @@ class FormBuilder {
 		// in the model instance if one is set. Otherwise we will just use empty.
 		$id = $this->getIdAttribute($name, $options);
 
-		if ($type != 'file')
+		if ($type != 'file' and $type != 'password')
 		{
 			$value = $this->getValueAttribute($name, $value);
 		}


### PR DESCRIPTION
When returning to a form with `->withInput()` the password fields were being filled in again. This shouldn't happen as it could lead to possible security breaches and unwanted results.

You can't pass along values to password fields anyway so they also should definitely not be filled in with old data.
