### PR TITLE
Fixes an issue with using Blade syntax for localization on the same line

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -329,10 +329,10 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	{
 		$pattern = '/(?<!\w)(\s*)@(lang|choice)(\s*\([^\)]*)\)/';
 
-		return preg_replace_callback($pattern, function($matches) {	
-		
+		return preg_replace_callback($pattern, function($matches) 
+		{			
 			$type = strtolower($matches[2]);
-			if( $type == 'lang' )
+			if($type == 'lang')
 			{
 				$type = 'get';
 			}

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -327,13 +327,18 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	protected function compileLanguage($value)
 	{
-		$pattern = $this->createMatcher('lang');
+		$pattern = '/(?<!\w)(\s*)@(lang|choice)(\s*\([^\)]*)\)/';
 
-		$value = preg_replace($pattern, '$1<?php echo \Illuminate\Support\Facades\Lang::get$2; ?>', $value);
-
-		$pattern = $this->createMatcher('choice');
-
-		return preg_replace($pattern, '$1<?php echo \Illuminate\Support\Facades\Lang::choice$2; ?>', $value);
+		return preg_replace_callback($pattern, function($matches) {	
+		
+			$type = strtolower($matches[2]);
+			if( $type == 'lang' )
+			{
+				$type = 'get';
+			}
+			
+			return $matches[1].'<?php echo \Illuminate\Support\Facades\Lang::'.$type.$matches[3].'); ?>';		
+		}, $value);		
 	}
 
 	/**


### PR DESCRIPTION
Updated the regex to end the  `\Illuminate\Support\Facades\Lang::get` and  `\Illuminate\Support\Facades\Lang::choice` methods after the first ending parantheses.
