### PR TITLE
Remove duplicate dropColumns function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@
 - Migrated entire session back-end to Symfony HttpFoundation Session. The `native` driver should now be used in place of the `cookie` driver. All other drivers are available and work the same. New sessions will not be backwards compatible after updating.
 - Renamed `Session::getToken` to `Session::token`.
 - Added a few more helper methods to the `Collection` class.
+- Removed `dropColumns` function.
 
 ## Beta 4
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -204,17 +204,6 @@ class Blueprint {
 	}
 
 	/**
-	 * Indicate that the given columns should be dropped.
-	 *
-	 * @param  dynamic
-	 * @return \Illuminate\Support\Fluent
-	 */
-	public function dropColumns()
-	{
-		return $this->dropColumn(func_get_args());
-	}
-
-	/**
 	 * Indicate that the given columns should be renamed.
 	 *
 	 * @param  string  $from
@@ -277,7 +266,7 @@ class Blueprint {
 	 */
 	public function dropTimestamps()
 	{
-		$this->dropColumns('created_at', 'updated_at');
+		$this->dropColumn('created_at', 'updated_at');
 	}
 
 	/**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -97,6 +97,13 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table `users` drop `foo`, drop `bar`', $statements[0]);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->dropColumn('foo', 'bar');
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` drop `foo`, drop `bar`', $statements[0]);
 	}
 
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -100,17 +100,6 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testDropColumns()
-	{
-		$blueprint = new Blueprint('users');
-		$blueprint->dropColumns('foo', 'bar');
-		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
-		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table `users` drop `foo`, drop `bar`', $statements[0]);
-	}
-
-
 	public function testDropPrimary()
 	{
 		$blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -69,6 +69,13 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->dropColumn('foo', 'bar');
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
 	}
 
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -72,17 +72,6 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testDropColumns()
-	{
-		$blueprint = new Blueprint('users');
-		$blueprint->dropColumns('foo', 'bar');
-		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
-		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
-	}
-
-
 	public function testDropPrimary()
 	{
 		$blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -58,6 +58,13 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table "users" drop column "foo", "bar"', $statements[0]);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->dropColumn('foo', 'bar');
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table "users" drop column "foo", "bar"', $statements[0]);
 	}
 
 

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -61,17 +61,6 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testDropColumns()
-	{
-		$blueprint = new Blueprint('users');
-		$blueprint->dropColumns('foo', 'bar');
-		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
-
-		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" drop column "foo", "bar"', $statements[0]);
-	}
-
-
 	public function testDropPrimary()
 	{
 		$blueprint = new Blueprint('users');


### PR DESCRIPTION
`dropColumn` now supports `func_get_args()` so `dropColumns` is only a duplicate which can be removed.

I also added some unit tests for the new `func_get_args()` functionality in `dropColumn`.
