### PR TITLE
Restricting the Workbench->starter from looking beyond the packages vendor/autoload.php file

### DIFF
--- a/src/Illuminate/Workbench/Starter.php
+++ b/src/Illuminate/Workbench/Starter.php
@@ -18,7 +18,9 @@ class Starter {
 		// the appropriate classes and file used by the given workbench package.
 		$files = $files ?: new \Illuminate\Filesystem\Filesystem;
 
-		$autoloads = $finder->in($path)->files()->name('autoload.php');
+		// The depth of the 3 assumes as autoload files are in <vendor>/<package>/vendor
+		// relative to the workbench directory.
+		$autoloads = $finder->in($path)->files()->name('autoload.php')->depth(3);
 
 		foreach ($autoloads as $file)
 		{


### PR DESCRIPTION
I was having a problem working on a package that shares a dependency on the predis/predis package with laravel/framework.  The problem is predis has a file within it called "autoload.php" that has `require` (not `require_once`) on a php class file that defines `Predis/Autoloader`.  And `Symfony\Component\Finder\Finder` works recursively by default, so it was finding it.  Which was causing this error:

> Fatal error: Cannot redeclare class Predis\Autoloader in .../workbench/bkwld/library/vendor/predis/predis/lib/Predis/Autoloader.php on line 21

I think the intent of Starter::start() is to JUST load the composer generated autoload.php, so this commit enforces this.  It also has the benefit of REALLY speeding up page loading times (as reported in #553) when you have large (or multiple) packages in the workbench.
