### PR TITLE
Minor Typo

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -57,7 +57,7 @@ class ConnectionFactory {
 				return new SqlServerConnector;
 		}
 
-		throw new \InvalidArgumentException("Unsupported driver [{$config['driver']}");
+		throw new \InvalidArgumentException("Unsupported driver [{$config['driver']}]");
 	}
 
 	/**


### PR DESCRIPTION
Minor typo: missing square bracket on error message.
