### PR TITLE
Minor Typo

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -94,7 +94,7 @@ class Connection implements ConnectionInterface {
 	/**
 	 * The database connection configuration options.
 	 *
-	 * @var string
+	 * @var array
 	 */
 	protected $config = array();
 


### PR DESCRIPTION
Minor typo: doc block var type string should be array
