### PR TITLE
Provide better assertion feedback for missing view

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -149,6 +149,11 @@ class TestCase extends \PHPUnit_Framework_TestCase {
 
 		if (is_null($value))
 		{
+			if ( ! method_exists($response, 'getData'))
+			{
+				$this->fail('A view has not yet been loaded.');
+			}
+			
 			$this->assertArrayHasKey($key, $response->getData());
 		}
 		else


### PR DESCRIPTION
If you assert that a view has a variable, but a View instance hasn't yet been returned, then a nasty fatal error will be displayed.

``` bash
.PHP Fatal error:  Call to a member function getData() on a non-object
```

This doesn't really help when following a TDD process. This commit simply checks whether the getData method exists. If it doesn't, then it provides more actionable feedback.

``` bash
1) ExampleTest::testAssignsOrdersToView
A view has not yet been loaded.
```
