### PR TITLE
Fix for session being written multiple times.

### DIFF
--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -118,7 +118,7 @@ class SessionServiceProvider extends ServiceProvider {
 	{
 		$app = $this->app;
 
-		$this->app->close(function() use ($app)
+		$this->app->finish(function() use ($app)
 		{
 			$app['session']->save();
 		});


### PR DESCRIPTION
Allowing multiple routing calls ("HMVC" if you will) and sessions to play nicely by only writing the session after the application is finished, not after each time the router works.

I have an API package which allows you do to internal calls to your own API. Everything is fine, except that every time a route is executed, the session is written, which causes anything after the first write to be discarded, meaning session data is not saved.

Switching when data is written so it only happens once in the request cycle.

Signed-off-by: Ben Corlett bencorlett@me.com
