### PR TITLE
Use PK for lists method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -115,7 +115,7 @@ class Builder {
 	 */
 	public function lists($column, $key = null)
 	{
-		$results = $this->query->lists($column, $key);
+		$results = $this->query->lists($column, $key ?: $this->model->getKeyName());
 
 		// If the model has a mutator for the requested column, we will spin through
 		// the results and mutate the values so that the mutated version of these

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -238,6 +238,21 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testListsMethodIsKeyedByPrimaryKey()
+	{
+		$builder = $this->getBuilder();
+		$builder->getQuery()->shouldReceive('lists')->once()->with('foo', 'bar')->andReturn(array('2' => 'bar', '5' => 'baz'));
+		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model->shouldReceive('getKeyName')->once()->andReturn('bar');
+		$model->shouldReceive('getTable')->once()->andReturn('table');
+		$model->shouldReceive('hasGetMutator')->once()->with('foo')->andReturn(false);
+		$builder->getQuery()->shouldReceive('from')->once()->with('table');
+		$builder->setModel($model);
+		$results = $builder->lists('foo');
+		$this->assertEquals(array('2' => 'bar', '5' => 'baz'), $results);
+	}
+
+
 	public function testQueryPassThru()
 	{
 		$builder = $this->getBuilder();


### PR DESCRIPTION
Fix for #995.

This will only use the primary key when the `lists` method is called from an Eloquent query, the base Query builder does not know about the key and may only guess, which would mess things up.
