### PR TITLE
Returning unlink function

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -97,7 +97,7 @@ class Filesystem {
 	 */
 	public function delete($path)
 	{
-		@unlink($path);
+		return unlink($path);
 	}
 
 	/**


### PR DESCRIPTION
Returning php's built in unlink() function instead of surpassing it with `@`, so you can react to an unlink error.
