### PR TITLE
added php_uname('n') for CLI environment detection

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -262,6 +262,7 @@ class Application extends Container implements HttpKernelInterface {
 			}
 		}
 
+		if (empty($base)) $base = php_uname('n');
 		return $this->detectWebEnvironment($base, $environments);
 	}
 


### PR DESCRIPTION
We are using artisan for **a lot** of things with our new project here at Liquid Compass. One thing I've noticed is that we always have to pass in an `--env=` argument on the artisan calls. This isn't needed because we properly set our machine's `hostname` on build to reflect the same DNS name serving the application on the web.

The above will only change `$base` if it's empty, then try and pass the `hostname` value into the web detection to try and use the `$environments` just like a web request.
