### PR TITLE
Bug/return and suppress unlink

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -97,7 +97,7 @@ class Filesystem {
 	 */
 	public function delete($path)
 	{
-		return unlink($path);
+		return @unlink($path);
 	}
 
 	/**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -97,7 +97,7 @@ class Filesystem {
 	 */
 	public function delete($path)
 	{
-		@unlink($path);
+		return unlink($path);
 	}
 
 	/**


### PR DESCRIPTION
Fix for #1016 after help from https://github.com/JoostK

Returning and suppressing `unlink()`, so you can do react to an error without outputting it.
