### PR TITLE
Setter / Getter for Custom Messages in Validator

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1537,6 +1537,27 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
+	 * Set the custom messages for the validator
+	 *
+	 * @param array $messages
+	 * @return void
+	 */
+	public function setCustomMessages($messages)
+	{
+		$this->customMessages = $messages;
+	}
+
+	/**
+	 * Get the custom messages for the validator
+	 *
+	 * @return array
+	 */
+	public function getCustomMessages()
+	{
+		return $this->customMessages;
+	}
+
+	/**
 	 * Get the message container for the validator.
 	 *
 	 * @return \Illuminate\Support\MessageBag


### PR DESCRIPTION
Expose custom message in the Validator class. This will allow for more flexibility in setting them. At the current state you can only set custom messages with the factory.

``` php
$validator = Validator::make($input, $rules);
$validator->setCustomMessages(array('password.required' => 'You forgot the password... noob!', 'required' => 'You forgot :attribute!'));
```
