### PR TITLE
[BUG] Validator not processing custom message specific attribute first.

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -962,7 +962,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function getInlineMessage($attribute, $lowerRule)
 	{
-		$keys = array($lowerRule, "{$attribute}.{$lowerRule}");
+		$keys = array("{$attribute}.{$lowerRule}", $lowerRule);
 
 		// First we will check for a custom message for an attribute specific rule
 		// message for the fields, then we will check for a general custom line


### PR DESCRIPTION
Example code to reproduce

``` php
$messages = array(
    'password.required' => 'You forgot the password... noob!',
    'required' => 'You forgot :attribute!'
    );
Validator::make($input, $rules, $messages);
```

If password is empty it will use "You forgot password!'.

The comment in getInlineMessage states

``` php
// First we will check for a custom message for an attribute specific rule
// message for the fields, then we will check for a general custom line
// that is not attribute specific. If we find either we'll return it.
```
