### PR TITLE
Updated composer.json to require Carbon library

### DIFF
--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -12,7 +12,8 @@
         "php": ">=5.3.0",
         "illuminate/container": "4.0.x",
         "illuminate/events": "4.0.x",
-        "illuminate/support": "4.0.x"
+        "illuminate/support": "4.0.x",
+        "nesbot/Carbon": "1.2.*"
     },
     "require-dev": {
         "illuminate/console": "4.0.x",


### PR DESCRIPTION
Would it be ok to add Carbon as a requirement for illuminate database? I use illuminate database outside of the laravel framework and it is required for DataTime functionality.
