### PR TITLE
Properly allow array of route requirements. 

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -313,7 +313,7 @@ class Route extends BaseRoute {
 	 * @param  string  $expression
 	 * @return \Illuminate\Routing\Route
 	 */
-	public function where($name, $expression)
+	public function where($name, $expression = null)
 	{
 		if (is_array($name)) return $this->setArrayOfWheres($name);
 

--- a/tests/Routing/RoutingTest.php
+++ b/tests/Routing/RoutingTest.php
@@ -373,6 +373,15 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testWhereAcceptsArrayOfRequirements()
+	{
+		$router = new Router;
+		$router->get('/foo/{name}/{age}', function($name, $age) { return $name.$age; })->where(['age' => '[0-9]+']);
+		$request = Request::create('/foo/jason/22', 'GET');
+		$this->assertEquals('jason22', $router->dispatch($request)->getContent());
+	}
+
+
 	/**
 	 * @expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
 	 */

--- a/tests/Routing/RoutingTest.php
+++ b/tests/Routing/RoutingTest.php
@@ -376,7 +376,7 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 	public function testWhereAcceptsArrayOfRequirements()
 	{
 		$router = new Router;
-		$router->get('/foo/{name}/{age}', function($name, $age) { return $name.$age; })->where(['age' => '[0-9]+']);
+		$router->get('/foo/{name}/{age}', function($name, $age) { return $name.$age; })->where(array('age' => '[0-9]+'));
 		$request = Request::create('/foo/jason/22', 'GET');
 		$this->assertEquals('jason22', $router->dispatch($request)->getContent());
 	}


### PR DESCRIPTION
The ability to add an array of route requirements was there but you couldn't actually do it without passing in a second parameter. This fixes that.

Test added as well.
