### PR TITLE
[Bug?] Fix FileLoader for published, environment-specific package configurations.

### DIFF
--- a/src/Illuminate/Config/FileLoader.php
+++ b/src/Illuminate/Config/FileLoader.php
@@ -153,9 +153,9 @@ class FileLoader implements LoaderInterface {
 		// Once we have merged the regular package configuration we need to look for
 		// an environment specific configuration file. If one exists, we will get
 		// the contents and merge them on top of this array of options we have.
-		$path = $this->defaultPath."/{$environment}/".$file;
+		$file = "packages/{$package}/{$environment}/{$group}.php";
 
-		if ($this->files->exists($path))
+		if ($this->files->exists($path = $this->defaultPath.'/'.$file))
 		{
 			$items = array_merge($items, $this->getRequire($path));
 		}

--- a/tests/Config/ConfigFileLoaderTest.php
+++ b/tests/Config/ConfigFileLoaderTest.php
@@ -80,8 +80,8 @@ class ConfigFileLoaderTest extends PHPUnit_Framework_TestCase {
 		$loader = $this->getLoader();
 		$loader->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/packages/dayle/rees/group.php')->andReturn(true);
 		$loader->getFilesystem()->shouldReceive('getRequire')->once()->with(__DIR__.'/packages/dayle/rees/group.php')->andReturn(array('bar' => 'baz'));
-		$loader->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/local/packages/dayle/rees/group.php')->andReturn(true);
-		$loader->getFilesystem()->shouldReceive('getRequire')->once()->with(__DIR__.'/local/packages/dayle/rees/group.php')->andReturn(array('foo' => 'boom'));
+		$loader->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/packages/dayle/rees/local/group.php')->andReturn(true);
+		$loader->getFilesystem()->shouldReceive('getRequire')->once()->with(__DIR__.'/packages/dayle/rees/local/group.php')->andReturn(array('foo' => 'boom'));
 		$items = $loader->cascadePackage('local', 'dayle/rees', 'group', array('foo' => 'bar'));
 
 		$this->assertEquals(array('foo' => 'boom', 'bar' => 'baz'), $items);


### PR DESCRIPTION
According to the [Package Configuration Docs](http://four.laravel.com/docs/packages#package-configuration), environment-specific configurations are meant to be placed in `app/config/packages/<vendor>/<package>/<environment>`. This is also works well with `artisan config:publish`.

However `Config\FileLoader::cascadePackage`, responsible for loading published, environment-specific configurations, attempts to load them from  `app/config/<environment>/packages/<vendor>/<package>` – thereby omitting environment-specific files published by `ConfigPublisher`.

I'd like to suggest modifying `Config\FileLoader::cascadePackage` to assume the configurations in `app/config/packages/<vendor>/<package>/<environment>`.
