### PR TITLE
Zero value to return with no limit in take func

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -796,8 +796,10 @@ class Builder {
 	 */
 	public function take($value)
 	{
-		$this->limit = $value;
-
+		if ($value > 0) 
+		{
+			$this->limit = $value;
+		}
 		return $this;
 	}
 


### PR DESCRIPTION
In many situations, when using Eloquent objects, we create a function to retrieve a Collection of objects based on a specific filter. Example:

public function getUsersByName ($name, $limit = 0) 
{
return User::where('name', 'like', '%'.$name'%')->take($limit)->get();
}

In this kind of functions we want to limit the collection when some limit is specified and retrieve all objects when no limit is specified. To accomplish this we change the take function in order to consider the value 0 as to retrieve all the founded objects. Without this change we have always to implement the previous function like this:

public function getUsersByName ($name, $limit = 0) 
{
if ($limit = 0) {
return User::where('name', 'like', '%'.$name'%')->get();
}
else {
return User::where('name', 'like', '%'.$name'%')->take($limit)->get();
}
}
