### PR TITLE
Fixes an issue in the exists and toSql function

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -33,7 +33,8 @@ class Builder {
 	 */
 	protected $passthru = array(
 		'lists', 'insert', 'insertGetId', 'update', 'delete', 'increment',
-		'decrement', 'pluck', 'count', 'min', 'max', 'avg', 'sum',
+		'decrement', 'pluck', 'count', 'min', 'max', 'avg', 'sum', 'exists',
+		'toSql',
 	);
 
 	/**


### PR DESCRIPTION
Update to correct a bug when using the exists function within a Model object. 
Example: when using User::where('id', '>', '0')->exists() it was returning a Builder object. With this change we can know get the boolean value as expected.
The same issue was happening with the toSql function.
