### PR TITLE
Fix for whoopse container being placed off screen

### DIFF
--- a/src/Illuminate/Exception/resources/pretty-page.css
+++ b/src/Illuminate/Exception/resources/pretty-page.css
@@ -12,9 +12,11 @@ body {
   }
 
 .container{
-    height: 100%;
-    width: 100%;
     position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
     margin: 0;
     padding: 0;
 }


### PR DESCRIPTION
Example of the problem http://d.pr/i/fTZC

As you can see the whoopse container was placed of screen to the right for some reason. This should make that impossible.
