### PR TITLE
Trim both spaces and non-breaking spaces in Str::words

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -132,7 +132,7 @@ class Str {
 	 */
 	public static function words($value, $words = 100, $end = '...')
 	{
-		if (trim($value, '  ') == '') return '';
+		if (trim($value, chr(0xC2).chr(0xA0).' ') == '') return '';
 
 		preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -132,7 +132,7 @@ class Str {
 	 */
 	public static function words($value, $words = 100, $end = '...')
 	{
-		if (trim($value) == '') return '';
+		if (trim($value, '  ') == '') return '';
 
 		preg_match('/^\s*+(?:\S++\s*+){1,'.$words.'}/u', $value, $matches);
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -24,4 +24,9 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
 			$this->assertEquals('foo', Str::SupportStrTest());
 		}
 
+		public function testNonBreakingSpacesAreTrimmed()
+		{
+			$this->assertEquals('', Str::words('  ', 2));
+		}
+
 }


### PR DESCRIPTION
Otherwise for some strings, no matches are found and since Str::words assume there will be matches, an Exception is thrown.
