### PR TITLE
Fix the default encryption algo with wrong key size

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -40,7 +40,7 @@ class Encrypter {
 	 */
 	public function __construct($key)
 	{
-		$this->key = $key;
+		$this->key = md5($key);
 	}
 
 	/**

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -37,6 +37,14 @@ class EncrypterTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+    public function testLargeKeyWithDefaultEncryption()
+    {
+        $encrypter = new Encrypter(str_repeat('a', 133));
+        $cipher = $encrypter->encrypt('something');
+        $this->assertEquals('something', $encrypter->decrypt($cipher));
+    }
+
+
 	protected function getEncrypter()
 	{
 		return new Encrypter(str_repeat('a', 32));


### PR DESCRIPTION
In `app/config/app.php`,

The doc says the `key` should be `random`, `long string`, but it failed to mention what key size should be. 

The default algo `rijndael-256`'s max key size is `256`, so I suggest to do a `md5` on the `key` inside of `Encrypter`'s constructor. However, leave out the `setKey`, because I believe the callers should know about the algo and key size before setting a different key/algo.

Or should we just update the docs to indicate the default key size should be <= `256 bits`
