### PR TITLE
withInput() doesn't restore old input

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -63,7 +63,7 @@ class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectRespons
 	 */
 	public function withInput(array $input = null)
 	{
-		$input = $input ?: $this->request->input();
+		$input = $input ? $input : $this->request->input();
 
 		$this->session->flashInput($input);
 


### PR DESCRIPTION
$input  is not flashed to the session; $input = $input ? $input : $this->request->input(); instead of  $input = $input ? : $this->request->input();
