### PR TITLE
[Proposal] Implement save() method on the BelongsTo relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -171,6 +171,19 @@ class BelongsTo extends Relation {
 	}
 
 	/**
+	 * Attach a model instance to the parent model.
+	 *
+	 * @param  \Illuminate\Database\Eloquent\Model  $model
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function save(Model $model)
+	{
+		$this->parent->setAttribute($this->foreignKey, $model->getKey());
+
+		return $this->parent->save() ? $model : false;
+	}
+
+	/**
 	 * Update the parent model on the relationship.
 	 *
 	 * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -171,16 +171,16 @@ class BelongsTo extends Relation {
 	}
 
 	/**
-	 * Attach a model instance to the parent model.
+	 * Associate a model instance to the parent model.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Model  $model
 	 * @return \Illuminate\Database\Eloquent\Model
 	 */
-	public function save(Model $model)
+	public function associate(Model $model)
 	{
 		$this->parent->setAttribute($this->foreignKey, $model->getKey());
 
-		return $this->parent->save() ? $model : false;
+		return $this->parent;
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -74,6 +74,28 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 		return new BelongsTo($builder, $parent, 'foreign_key');
 	}
 
+	public function testSaveMethodSetsForeignKeyOnModel()
+	{
+		$mockOwner = $this->getMock('Illuminate\Database\Eloquent\Model', array('getTable'));
+		$mockOwner->expects($this->atLeastOnce())->method('getTable')->will($this->returnValue('owner_table'));
+
+		$mockBelonger = $this->getMock('Illuminate\Database\Eloquent\Model', array('save', 'getAttribute', 'setAttribute', 'getTable'));
+		$mockBelonger->expects($this->once())->method('getAttribute')->with($this->equalTo('owner_key'))->will($this->returnValue(321));
+		$mockBelonger->expects($this->once())->method('setAttribute')->with($this->equalTo('owner_key'), $this->equalTo(123));
+		$mockBelonger->expects($this->once())->method('save')->will($this->returnValue(true));
+
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder->shouldReceive('getModel')->andReturn($mockOwner);
+		$builder->shouldReceive('where')->with("owner_table.id", "=", 321);
+		
+		$relation = new BelongsTo($builder, $mockBelonger, 'owner_key');
+
+		$newOwner = m::mock('Illuminate\Database\Eloquent\Model');
+		$newOwner->shouldReceive('getKey')->andReturn(123);
+
+		$relation->save($newOwner);
+	}
+
 }
 
 class EloquentBelongsToModelStub extends Illuminate\Database\Eloquent\Model {

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -74,7 +74,7 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 		return new BelongsTo($builder, $parent, 'foreign_key');
 	}
 
-	public function testSaveMethodSetsForeignKeyOnModel()
+	public function testAssociateMethodSetsForeignKeyOnModel()
 	{
 		$mockOwner = $this->getMock('Illuminate\Database\Eloquent\Model', array('getTable'));
 		$mockOwner->expects($this->atLeastOnce())->method('getTable')->will($this->returnValue('owner_table'));
@@ -82,7 +82,6 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 		$mockBelonger = $this->getMock('Illuminate\Database\Eloquent\Model', array('save', 'getAttribute', 'setAttribute', 'getTable'));
 		$mockBelonger->expects($this->once())->method('getAttribute')->with($this->equalTo('owner_key'))->will($this->returnValue(321));
 		$mockBelonger->expects($this->once())->method('setAttribute')->with($this->equalTo('owner_key'), $this->equalTo(123));
-		$mockBelonger->expects($this->once())->method('save')->will($this->returnValue(true));
 
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
 		$builder->shouldReceive('getModel')->andReturn($mockOwner);
@@ -93,7 +92,7 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 		$newOwner = m::mock('Illuminate\Database\Eloquent\Model');
 		$newOwner->shouldReceive('getKey')->andReturn(123);
 
-		$relation->save($newOwner);
+		$relation->associate($newOwner);
 	}
 
 }


### PR DESCRIPTION
I feel it would be reasonable to have a method to persist the relationship from the side of the BelongsTo relationship. I do know that this is available through the side of `HasOneOrMany::save()` however this limits one from persisting a mixed batch of models against another mixed batch (one would be forced to juggle `instanceof` statements to sniff which type of relationship was being given). A generic API for persisting a hasMany/belongsTo relationship seems like something Eloquent should support.

Example:

``` php
    class Country {
        public function users()
        {
            return $this->hasMany('User');
        }
    }

    class User {
        public function country()
        {
            return $this->belongsTo('Country');
        }
    }

    $user = User::find(123);
    $country = Country::find(1);

    // HasMany::save(Model $model)
    $country->users()->save($user);

    // BelongsTo::save(Model $model)
    $user->country()->save($country);
```
