### PR TITLE
[BUG] When logged in using Redirect::intended(), the 'url.intended' session data is persisted to subsequent logins. For some reason, logging out does not make session 'forget' the data.

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -95,6 +95,8 @@ class Redirector {
 	public function intended($default, $status = 302, $headers = array(), $secure = null)
 	{
 		$path = $this->session->get('url.intended', $default);
+		
+		$this->session->forget('url.intended');
 
 		return $this->to($path, $status, $headers, $secure);
 	}


### PR DESCRIPTION
Added line to forget intended URL once it has been retrieved on successful login to prevent subsequent logins from routing to a 'used' intended URL. For some reason, simply logging out does not erase the data from the session.
