### PR TITLE
[BUG] Adding to a collection after the dictionary has been built adds a ...

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -67,7 +67,7 @@ class Collection extends BaseCollection {
 		// be able to quickly determine it is in the array when asked for it.
 		elseif ($item instanceof Model)
 		{
-			$this->dictionary[$item->getKey()] = true;
+			$this->dictionary[$item->getKey()] = $item;
 		}
 
 		return $this;


### PR DESCRIPTION
...boolean true to the dictionary key, rather than a model instance.

Fixed to add the Model to the dictionary when using $collection->add() rather than (bool) true. Otherwise $collection->find() method will just return true rather than the Model itself.
