### PR TITLE
Remove intended location from session before redirect

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -96,6 +96,8 @@ class Redirector {
 	{
 		$path = $this->session->get('url.intended', $default);
 
+		$this->session->forget('url.intended');
+
 		return $this->to($path, $status, $headers, $secure);
 	}
 


### PR DESCRIPTION
I think we should remove intended url from session (before redirect happens), so it won't be used next time user login to the app (when he isn't redirected to the login form with `Redirect::guest`).
