### PR TITLE
Error when aggregate query return no results

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1096,9 +1096,16 @@ class Builder {
 		// the aggregate value getting in the way when the grammar builds it.
 		$this->aggregate = null;
 
-		$result = (array) $results[0];
-
-		return $result['aggregate'];
+	        if (isset($results[0]))
+	        {
+	            $result = (array) $results[0];
+	            
+	            return $result['aggregate'];                
+	        }
+	        else 
+	        {
+	            return null;
+	        }
 	}
 
 	/**


### PR DESCRIPTION
When using a query with groupBy that return no results I was getting the following error:

ErrorException: Notice: Undefined offset: 0 in .../vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php line 1101

Example:
    Users::groupBy(‘name’)->having(‘aggregate’, ’>‘, 2)->count();

To resolve this issue we change the Illuminate\Database\Query/Builder->aggregate() function to test if exists results for the query. If no results exist the function returns null avoiding throw an error.
