### PR TITLE
Translation tokenizer: Use :token: instead of :token

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -111,7 +111,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	{
 		foreach ($replace as $key => $value)
 		{
-			$line = str_replace(':'.$key, $value, $line);
+			$line = str_replace(':'.$key.':', $value, $line);
 		}
 
 		return $line;

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -26,7 +26,7 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 	public function testGetMethodProperlyLoadsAndRetrievesItem()
 	{
 		$t = $this->getMock('Illuminate\Translation\Translator', null, array($this->getLoader(), 'en'));
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(array('foo' => 'foo', 'baz' => 'breeze :foo'));
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(array('foo' => 'foo', 'baz' => 'breeze :foo:'));
 		$this->assertEquals('breeze bar', $t->get('foo::bar.baz', array('foo' => 'bar'), 'en'));
 		$this->assertEquals('foo', $t->get('foo::bar.foo'));
 	}
@@ -35,7 +35,7 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 	public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
 	{
 		$t = $this->getMock('Illuminate\Translation\Translator', null, array($this->getLoader(), 'en'));
-		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(array('bar' => 'breeze :foo'));
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(array('bar' => 'breeze :foo:'));
 		$this->assertEquals('breeze bar', $t->get('foo.bar', array('foo' => 'bar')));
 	}
 


### PR DESCRIPTION
If a `prefix` and a `prefixEnd` tokens are defined (in this order), the Translation package will first replace `:prefix` with it's value and then proceed to `prefixEnd`.

This behaviour breaks this translation `dummy :prefixEnd`.

This commit proposes to use `:token:` instead of `:token` to solve this problem.
## 

Arthur
