### PR TITLE
Make Str:ascii use character translit map

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -3,6 +3,82 @@
 class Str {
 
 	/**
+	 * Map of characters and what they're to be replaced with
+	 *
+	 * @var array
+	 */
+	protected static $ascii = array(
+		'de' => array( /* German */
+			'Ä' => 'Ae', 'Ö' => 'Oe', 'Ü' => 'Ue', 'ä' => 'ae', 'ö' => 'oe', 'ü' => 'ue', 'ß' => 'ss',
+			'ẞ' => 'SS'
+		),
+		'latin' => array(
+			'À' => 'A', 'Á' => 'A', 'Â' => 'A', 'Ã' => 'A', 'Ä' => 'A', 'Å' => 'A', 'Æ' => 'AE', 'Ç' =>
+			'C', 'È' => 'E', 'É' => 'E', 'Ê' => 'E', 'Ë' => 'E', 'Ì' => 'I', 'Í' => 'I', 'Î' => 'I',
+			'Ï' => 'I', 'Ð' => 'D', 'Ñ' => 'N', 'Ò' => 'O', 'Ó' => 'O', 'Ô' => 'O', 'Õ' => 'O', 'Ö' =>
+			'O', 'Ő' => 'O', 'Ø' => 'O', 'Ù' => 'U', 'Ú' => 'U', 'Û' => 'U', 'Ü' => 'U', 'Ű' => 'U',
+			'Ý' => 'Y', 'Þ' => 'TH', 'ß' => 'ss', 'à' => 'a', 'á' => 'a', 'â' => 'a', 'ã' => 'a', 'ä' =>
+			'a', 'å' => 'a', 'æ' => 'ae', 'ç' => 'c', 'è' => 'e', 'é' => 'e', 'ê' => 'e', 'ë' => 'e',
+			'ì' => 'i', 'í' => 'i', 'î' => 'i', 'ï' => 'i', 'ð' => 'd', 'ñ' => 'n', 'ò' => 'o', 'ó' =>
+			'o', 'ô' => 'o', 'õ' => 'o', 'ö' => 'o', 'ő' => 'o', 'ø' => 'o', 'ù' => 'u', 'ú' => 'u',
+			'û' => 'u', 'ü' => 'u', 'ű' => 'u', 'ý' => 'y', 'þ' => 'th', 'ÿ' => 'y'
+		),
+		'latinSymbols' => array(
+			'©' => '(c)'
+		),
+		'el' => array( /* Greek */
+			'α' => 'a', 'β' => 'b', 'γ' => 'g', 'δ' => 'd', 'ε' => 'e', 'ζ' => 'z', 'η' => 'h', 'θ' => '8',
+			'ι' => 'i', 'κ' => 'k', 'λ' => 'l', 'μ' => 'm', 'ν' => 'n', 'ξ' => '3', 'ο' => 'o', 'π' => 'p',
+			'ρ' => 'r', 'σ' => 's', 'τ' => 't', 'υ' => 'y', 'φ' => 'f', 'χ' => 'x', 'ψ' => 'ps', 'ω' => 'w',
+			'ά' => 'a', 'έ' => 'e', 'ί' => 'i', 'ό' => 'o', 'ύ' => 'y', 'ή' => 'h', 'ώ' => 'w', 'ς' => 's',
+			'ϊ' => 'i', 'ΰ' => 'y', 'ϋ' => 'y', 'ΐ' => 'i',
+			'Α' => 'A', 'Β' => 'B', 'Γ' => 'G', 'Δ' => 'D', 'Ε' => 'E', 'Ζ' => 'Z', 'Η' => 'H', 'Θ' => '8',
+			'Ι' => 'I', 'Κ' => 'K', 'Λ' => 'L', 'Μ' => 'M', 'Ν' => 'N', 'Ξ' => '3', 'Ο' => 'O', 'Π' => 'P',
+			'Ρ' => 'R', 'Σ' => 'S', 'Τ' => 'T', 'Υ' => 'Y', 'Φ' => 'F', 'Χ' => 'X', 'Ψ' => 'PS', 'Ω' => 'W',
+			'Ά' => 'A', 'Έ' => 'E', 'Ί' => 'I', 'Ό' => 'O', 'Ύ' => 'Y', 'Ή' => 'H', 'Ώ' => 'W', 'Ϊ' => 'I',
+			'Ϋ' => 'Y'
+		),
+		'tr' => array( /* Turkish */
+			'ş' => 's', 'Ş' => 'S', 'ı' => 'i', 'İ' => 'I', 'ç' => 'c', 'Ç' => 'C', 'ü' => 'u', 'Ü' => 'U',
+			'ö' => 'o', 'Ö' => 'O', 'ğ' => 'g', 'Ğ' => 'G'
+		),
+		'ru' => array( /* Russian */
+			'а' => 'a', 'б' => 'b', 'в' => 'v', 'г' => 'g', 'д' => 'd', 'е' => 'e', 'ё' => 'yo', 'ж' => 'zh',
+			'з' => 'z', 'и' => 'i', 'й' => 'j', 'к' => 'k', 'л' => 'l', 'м' => 'm', 'н' => 'n', 'о' => 'o',
+			'п' => 'p', 'р' => 'r', 'с' => 's', 'т' => 't', 'у' => 'u', 'ф' => 'f', 'х' => 'h', 'ц' => 'c',
+			'ч' => 'ch', 'ш' => 'sh', 'щ' => 'sh', 'ъ' => '', 'ы' => 'y', 'ь' => '', 'э' => 'e', 'ю' => 'yu',
+			'я' => 'ya',
+			'А' => 'A', 'Б' => 'B', 'В' => 'V', 'Г' => 'G', 'Д' => 'D', 'Е' => 'E', 'Ё' => 'Yo', 'Ж' => 'Zh',
+			'З' => 'Z', 'И' => 'I', 'Й' => 'J', 'К' => 'K', 'Л' => 'L', 'М' => 'M', 'Н' => 'N', 'О' => 'O',
+			'П' => 'P', 'Р' => 'R', 'С' => 'S', 'Т' => 'T', 'У' => 'U', 'Ф' => 'F', 'Х' => 'H', 'Ц' => 'C',
+			'Ч' => 'Ch', 'Ш' => 'Sh', 'Щ' => 'Sh', 'Ъ' => '', 'Ы' => 'Y', 'Ь' => '', 'Э' => 'E', 'Ю' => 'Yu',
+			'Я' => 'Ya'
+		),
+		'uk' => array( /* Ukrainian */
+			'Є' => 'Ye', 'І' => 'I', 'Ї' => 'Yi', 'Ґ' => 'G', 'є' => 'ye', 'і' => 'i', 'ї' => 'yi', 'ґ' => 'g'
+		),
+		'cs' => array( /* Czech */
+			'č' => 'c', 'ď' => 'd', 'ě' => 'e', 'ň' => 'n', 'ř' => 'r', 'š' => 's', 'ť' => 't', 'ů' => 'u',
+			'ž' => 'z', 'Č' => 'C', 'Ď' => 'D', 'Ě' => 'E', 'Ň' => 'N', 'Ř' => 'R', 'Š' => 'S', 'Ť' => 'T',
+			'Ů' => 'U', 'Ž' => 'Z'
+		),
+		'pl' => array( /* Polish */
+			'ą' => 'a', 'ć' => 'c', 'ę' => 'e', 'ł' => 'l', 'ń' => 'n', 'ó' => 'o', 'ś' => 's', 'ź' => 'z',
+			'ż' => 'z', 'Ą' => 'A', 'Ć' => 'C', 'Ę' => 'e', 'Ł' => 'L', 'Ń' => 'N', 'Ó' => 'O', 'Ś' => 'S',
+			'Ź' => 'Z', 'Ż' => 'Z'
+		),
+		'lv' => array( /* Latvian */
+			'ā' => 'a', 'č' => 'c', 'ē' => 'e', 'ģ' => 'g', 'ī' => 'i', 'ķ' => 'k', 'ļ' => 'l', 'ņ' => 'n',
+			'š' => 's', 'ū' => 'u', 'ž' => 'z', 'Ā' => 'A', 'Č' => 'C', 'Ē' => 'E', 'Ģ' => 'G', 'Ī' => 'i',
+			'Ķ' => 'k', 'Ļ' => 'L', 'Ņ' => 'N', 'Š' => 'S', 'Ū' => 'u', 'Ž' => 'Z'
+		),
+		'lt' => array( /* Lithuanian */
+			'ą' => 'a', 'č' => 'c', 'ę' => 'e', 'ė' => 'e', 'į' => 'i', 'š' => 's', 'ų' => 'u', 'ū' => 'u', 'ž' => 'z',
+			'Ą' => 'A', 'Č' => 'C', 'Ę' => 'E', 'Ė' => 'E', 'Į' => 'I', 'Š' => 'S', 'Ų' => 'U', 'Ū' => 'U', 'Ž' => 'Z'
+		)
+	);
+
+	/**
 	 * The registered string macros.
 	 *
 	 * @var array
@@ -15,9 +91,42 @@ class Str {
 	 * @param  string  $value
 	 * @return string
 	 */
-	public static function ascii($value)
+	public static function ascii($value, $language = '')
 	{
-		return \Patchwork\Utf8::toAscii($value);
+		$ascii = static::$ascii;
+
+		// Remove from temp ascii map language specific characters.
+		// They will be appended later
+		unset($ascii[$language]);
+
+		// Prepare regex character map
+		$map = array();
+		foreach ($ascii as $key => $chars)
+		{
+			if (is_array($chars))
+			{
+				foreach ($chars as $foreign => $char)
+				{
+					$map["/$foreign/"] = $char;
+				}
+			}
+			else
+			{
+				$map["/$key/"] = $chars;
+			}
+		}
+		// Append language specific map
+		if (isset(static::$ascii[$language]))
+		{
+			foreach (static::$ascii[$language] as $foreign => $char)
+			{
+				$map["/$foreign/"] = $char;
+			}
+		}
+
+    $value = preg_replace(array_keys($map), array_values($map), $value);
+
+    return preg_replace('/[^\x09\x0A\x0D\x20-\x7E]/', '', $value);
 	}
 
 	/**
@@ -225,9 +334,9 @@ class Str {
 	 * @param  string  $separator
 	 * @return string
 	 */
-	public static function slug($title, $separator = '-')
+	public static function slug($title, $separator = '-', $language = '')
 	{
-		$title = static::ascii($title);
+		$title = static::ascii($title, $language);
 
 		// Remove all characters that are not the separator, letters, numbers, or whitespace.
 		$title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', mb_strtolower($title));

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -79,7 +79,7 @@ class Str {
 	);
 
 	/**
-	 * Map cache.
+	 * Transliteration map cache.
 	 *
 	 * @var array
 	 */
@@ -93,10 +93,10 @@ class Str {
 	protected static $macros = array();
 
 	/**
-	 * Get ascii map from cache cache.
+	 * Get ascii map from cache.
 	 *
-	 * @param  string  $value
-	 * @return string
+	 * @param  string  $language
+	 * @return array
 	 */
 	private static function map($language = '')
 	{

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -11,7 +11,6 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "patchwork/utf8": "1.1.*",
         "mockery/mockery": "0.7.2",
         "phpunit/phpunit": "3.7.*"
     },

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -18,10 +18,34 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
 		}
 
 
+		public function testAscii()
+		{
+			$this->assertEquals('hello world', Str::ascii('hello world'));
+			$this->assertEquals('hello world', Str::ascii('ηέllο ώορlδ'));
+			$this->assertEquals('geistergrosse', Str::ascii('geistergröße'));
+			$this->assertEquals('privet mir', Str::ascii('привет мир'));
+		}
+
+
+		public function testSlug()
+		{
+			$this->assertEquals('hello-world', Str::slug('hello world'));
+			$this->assertEquals('hello-world', Str::slug('ηέllο ώορlδ'));
+			$this->assertEquals('geistergrosse', Str::slug('geistergröße'));
+			$this->assertEquals('privet-mir', Str::slug('привет мир'));
+		}
+
+
 		public function testStringMacros()
 		{
 			Illuminate\Support\Str::macro(__CLASS__, function() { return 'foo'; });
 			$this->assertEquals('foo', Str::SupportStrTest());
 		}
 
+
+		public function testLanguagePriority()
+		{
+			$this->assertEquals('geistergroesse', Str::ascii('geistergröße', 'de'));
+			$this->assertEquals('geistergroesse', Str::slug('geistergröße', '-', 'de'));
+		}
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -48,4 +48,12 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
 			$this->assertEquals('geistergroesse', Str::ascii('geistergröße', 'de'));
 			$this->assertEquals('geistergroesse', Str::slug('geistergröße', '-', 'de'));
 		}
+
+
+		public function testAsciiExtending()
+		{
+			Str::addAscii(array('ö' => ':token:'));
+			$this->assertEquals('geistergr:token:sse', Str::ascii('geistergröße'));
+			$this->assertEquals('geistergroesse', Str::ascii('geistergröße', 'de'));
+		}
 }


### PR DESCRIPTION
Ok, alternative String class rewrite.

Works the same way as Str class except for transliteration it uses more reliable character map array.

Also one small feature is a language priority (third argument in slug/second argument in ascii).

Should be used in order to specify which language has priority during transliteration.

For example:
- Str::ascii('ö') => 'o'
- Str::ascii('ö','de') => 'oe'
