### PR TITLE
Find autoload files for packages that aren't in a vendor/package directory structure.

### DIFF
--- a/src/Illuminate/Workbench/Starter.php
+++ b/src/Illuminate/Workbench/Starter.php
@@ -18,7 +18,7 @@ class Starter {
 		// the appropriate classes and file used by the given workbench package.
 		$files = $files ?: new \Illuminate\Filesystem\Filesystem;
 
-		$autoloads = $finder->in($path)->files()->name('autoload.php')->depth(3);
+		$autoloads = $finder->in($path)->files()->name('autoload.php')->depth('<= 3');
 
 		foreach ($autoloads as $file)
 		{


### PR DESCRIPTION
A somewhat recent merge (#985) made it impossible to use the workbench to develop packages that don't have a `vendor/package` directory structure.

This just keeps package development as flexible as possible.
