### PR TITLE
Add union method to Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -113,6 +113,13 @@ class Builder {
 	 */
 	public $offset;
 
+/**
+	 * The number of records to skip.
+	 *
+	 * @var array
+	 */
+	public $union;
+
 	/**
 	 * All of the available clause operators.
 	 *
@@ -167,6 +174,22 @@ class Builder {
 
 		return $this;
 	}
+
+
+	/**
+	 * Generate a union query
+	 *
+	 * @param \Illuminate\Database\Query\Builder
+	 * @param  boolean 	$all determines whether union or union all
+	 * @return \Illuminate\Database\Query\Builder
+	 */
+
+	public function union($select, $all = TRUE)
+	{
+		$this->union[] = array('select' => $select, 'all' => $all);
+		return $this;
+	}
+
 
 	/**
 	 * Force the query to only return distinct results.

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -28,6 +28,7 @@ class Grammar extends BaseGrammar {
 		'orders',
 		'limit',
 		'offset',
+		'union',
 	);
 
 	/**
@@ -211,6 +212,28 @@ class Grammar extends BaseGrammar {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Compile the "union" portion of the query.
+	 *
+	 * @param  \Illuminate\Database\Query\Builder  $query
+	 * @return string
+	 */
+	protected function compileUnion(Builder $query)
+	{
+		$sql = '';
+		foreach ($query->union as $union) {
+			$union_query = $union['select'];
+			$select = $this->compileSelect($union_query);
+			$query->setBindings(array_merge($query->getBindings(), $union_query->getBindings()));
+			$sql .= ' UNION ';
+			if ($union['all']) {
+				$sql .= 'ALL ';
+			}
+			$sql .= $select;
+		}
+		return $sql;
 	}
 
 	/**


### PR DESCRIPTION
This adds a union() method to query builder to allow for unions.

Usage:

``` php
$users = DB::table('users')->where('user', 'like', '%foo%');
$users2 = DB::table('users_2012')->where('name', 'like', '%bar%')->union($users);
$users3 = DB::table('users_2013')->where('name', 'like', '%baz%')->union($users2)->get();
```

By default it does UNION ALL, but if you pass FALSE as the second parameter to union() it just does UNION
