### PR TITLE
Added ability to pass Closure to union statement in query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -824,7 +824,7 @@ class Builder {
 	/**
 	 * Add a union statement to the query.
 	 *
-	 * @param  \Illuminate\Database\Query\Builder  $query
+	 * @param  \Illuminate\Database\Query\Builder|\Closure  $query
 	 * @param  bool $all
 	 * @return \Illuminate\Database\Query\Builder
 	 */
@@ -832,10 +832,7 @@ class Builder {
 	{
 		if ($query instanceof Closure)
 		{
-			$callback = $query;
-			$query = $this->newQuery();
-
-			call_user_func($callback, $query);
+			call_user_func($query, $query = $this->newQuery());
 		}
 		
 		$this->unions[] = compact('query', 'all');
@@ -846,7 +843,7 @@ class Builder {
 	/**
 	 * Add a union all statement to the query.
 	 *
-	 * @param  \Illuminate\Database\Query\Builder  $query
+	 * @param  \Illuminate\Database\Query\Builder|\Closure  $query
 	 * @return \Illuminate\Database\Query\Builder
 	 */
 	public function unionAll($query)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -828,8 +828,16 @@ class Builder {
 	 * @param  bool $all
 	 * @return \Illuminate\Database\Query\Builder
 	 */
-	public function union(Builder $query, $all = false)
+	public function union($query, $all = false)
 	{
+		if ($query instanceof Closure)
+		{
+			$callback = $query;
+			$query = $this->newQuery();
+
+			call_user_func($callback, $query);
+		}
+		
 		$this->unions[] = compact('query', 'all');
 
 		return $this->mergeBindings($query);
@@ -841,7 +849,7 @@ class Builder {
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @return \Illuminate\Database\Query\Builder
 	 */
-	public function unionAll(Builder $query)
+	public function unionAll($query)
 	{
 		return $this->union($query, true);
 	}


### PR DESCRIPTION
Example:

``` php
$users = DB::table('users')->select('*')->where('id', '=', 1)->union(function($q)
{
    $q->select('*')->from('users')->where('id', '=', 2);
})
->get();
```
