### PR TITLE
Switch merge order in View\Environment::make()

### DIFF
--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -114,7 +114,7 @@ class Environment {
 	{
 		$path = $this->finder->find($view);
 
-		$data = array_merge($this->parseData($data), $mergeData);
+		$data = array_merge($mergeData, $this->parseData($data));
 
 		return new View($this, $this->getEngineFromPath($path), $view, $path, $data);
 	}


### PR DESCRIPTION
As mentioned in my last comment on #1095, the recent change to accept a third parameter is merged in the wrong order - variables defined in the parent view override those passed as a parameter. This ensures variables passed to `@include()` override the variables from the calling view.

I couldn't work out how to write a unit test for this, but here is a simple example:

``` html+php
<?php $page = 1 ?>
@include('test', ['page' => 2])
```

Previously this would have `$page = 1` in the `test` view, now it has `$page = 2`.
