### PR TITLE
Allow merge to actually merge in another array or collection.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@
 - Added support for maintenance mode via `php artisan down` and `php artisan up`.
 - Added "soft delete" support to Eloquent via new "softDelete" property. `restore` method added to "un-delete".
 - Added `trashed` method to Eloquent model and `trashed` to Eloquent builder.
+- Renamed `merge` method to `collapse` and added new `merge` method in `Collection`.
 
 ## Beta 4
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -255,11 +255,11 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
-	 * Merge the collection itmes into a single array.
+	 * Collapse the collection items into a single array.
 	 *
 	 * @return \Illuminate\Support\Collection
 	 */
-	public function merge()
+	public function collapse()
 	{
 		$results = array();
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -272,6 +272,24 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Merge items with the collection items.
+	 *
+	 * @param  \Illuminate\Support\Contracts\ArrayableInterface|array
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function merge($items)
+	{
+		if ($items instanceof ArrayableInterface)
+		{
+			$items = $items->toArray();
+		}
+
+		$results = array_merge($this->items, $items);
+
+		return new Collection($results);
+	}
+
+	/**
 	 * Slice the underlying collection array.
 	 *
 	 * @param  int   $offset

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -133,6 +133,20 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testMergeArray()
+	{
+		$c = new Collection(array('name' => 'Hello'));
+		$this->assertEquals(array('name' => 'Hello', 'id' => 1), $c->merge(array('id' => 1))->all());
+	}
+
+
+	public function testMergeCollection()
+	{
+		$c = new Collection(array('name' => 'Hello'));
+		$this->assertEquals(array('name' => 'World', 'id' => 1), $c->merge(new Collection(array('name' => 'World', 'id' => 1)))->all());
+	}
+
+
 	public function testCollapse()
 	{
 		$data = new Collection(array(array($object1 = new StdClass), array($object2 = new StdClass)));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -133,10 +133,10 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testMerge()
+	public function testCollapse()
 	{
 		$data = new Collection(array(array($object1 = new StdClass), array($object2 = new StdClass)));
-		$this->assertEquals(array($object1, $object2), $data->merge()->all());
+		$this->assertEquals(array($object1, $object2), $data->collapse()->all());
 	}
 
 


### PR DESCRIPTION
Currently a collections `merge` method essentially collapses the array into a single array and merges the values in. This PR renames the `merge` method to `collapse` and implements another `merge` method that allows an array or an object that implements the `ArrayableInterface` contract to be merged into the collection.

Example.

``` php
$collection = new Collection(array('name' => 'Jason'));

$collection->merge(array('age' => 22));
```

Tests included.
