### PR TITLE
Changed environment config loading from array_merge() to array_replace_recursive()

### DIFF
--- a/src/Illuminate/Config/FileLoader.php
+++ b/src/Illuminate/Config/FileLoader.php
@@ -84,7 +84,7 @@ class FileLoader implements LoaderInterface {
 
 		if ($this->files->exists($file))
 		{
-			$items = array_merge($items, $this->files->getRequire($file));
+			$items = array_replace_recursive($items, $this->files->getRequire($file));
 		}
 
 		return $items;
@@ -207,7 +207,7 @@ class FileLoader implements LoaderInterface {
 	{
 		$this->hints[$namespace] = $hint;
 	}
-	
+
 	/**
 	 * Returns all registered namespaces with the config
 	 * loader.


### PR DESCRIPTION
Small change when loading environment specific configurations. Now the code below will merge the username/password into database connections array instead of replacing it entirely.

``` php
<?php
// my app/config/local/database.php
return array(
    'connections' => array(
        'mysql' => array(
            'username' => 'myname',
            'password' => 'mypass',
        ),
    ),
);
```
