### PR TITLE
Fix Cache::get()/Cache::section()->get() for empty-like values that are not null

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -46,7 +46,9 @@ class Repository implements ArrayAccess {
 	 */
 	public function get($key, $default = null)
 	{
-		return $this->store->get($key) ?: value($default);
+		$value = $this->store->get($key);
+		
+		return  ! is_null($value) ? $value : value($default);
 	}
 
 	/**

--- a/src/Illuminate/Cache/Section.php
+++ b/src/Illuminate/Cache/Section.php
@@ -38,7 +38,9 @@ class Section {
 	 */
 	public function get($key, $default = null)
 	{
-		return $this->store->get($this->sectionItemKey($key)) ?: value($default);
+		$value = $this->store->get($this->sectionItemKey($key));
+		
+		return ! is_null($value) ? $value : value($default);
 	}
 
 	/**


### PR DESCRIPTION
When non-null but empty-like\* values are placed in the cache, `Cache::get()` or `Cache::section()->get` won't return them since the ternary operator used will evaluate them as empty and therefore return null.
- **Empty-like:** http://www.php.net/manual/en/function.empty.php
