### PR TITLE
Fix Travis CI build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ php:
 
 before_script:
   - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --prefer-dist --dev
+  - php composer.phar install --prefer-source --no-interaction --dev
 
 script: phpunit


### PR DESCRIPTION
Composer uses the GitHub API to download packages, but the API is
rate-limited so repeated builds from the same IP hit the limit. This
adds --prefer-source to download from source, which is slower but more
reliable. It also adds --no-interaction to avoid hanging in case a
similar issue should arise in the future.

Reference:
https://github.com/composer/composer/issues/1314
