### PR TITLE
Update and rename Html.php to HTML.php

### DIFF
--- a/src/Illuminate/Support/Facades/HTML.php
+++ b/src/Illuminate/Support/Facades/HTML.php
@@ -1,6 +1,6 @@
 <?php namespace Illuminate\Support\Facades;
 
-class Html extends Facade {
+class HTML extends Facade {
 
 	/**
 	 * Get the registered name of the component.


### PR DESCRIPTION
Since the Facade was renamed in `app/config/app.php` on the `laravel/laravel` repo, we should rename the actual file so it is consistent with that of `DB.php`, `URL.php` and the class name respectively.
