### PR TITLE
Fixed missing select statement in queries (#1223)

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -39,6 +39,14 @@ class Grammar extends BaseGrammar {
 	 */
 	public function compileSelect(Builder $query)
 	{
+		// If no columns have been specified for the select statement, we will
+		// set them to standard default of retrieving all of the columns on the
+		// table using the "wildcard" column character.
+		if (is_null($query->columns))
+		{
+			$query->columns = array('*');
+		}
+
 		return trim($this->concatenate($this->compileComponents($query)));
 	}
 


### PR DESCRIPTION
If you don't specify select columns in where subqueries/union statements select part of query is missing. See bug and my comment https://github.com/laravel/framework/issues/1223#issuecomment-17559727 for explanation.

Solution: If no columns have been specified for the select statement, we will set them to standard default of retrieving all of the columns on the table using the "wildcard" column character.
