### PR TITLE
Creation of the setBaseURL function for Ajax requests

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -153,6 +153,17 @@ class Paginator implements ArrayAccess, Countable, IteratorAggregate {
 	}
 
 	/**
+	* Set the base URL in use by the paginator.
+	*
+	* @param  string  $baseUrl
+	* @return void
+	*/
+	public function setBaseUrl($baseUrl)
+	{
+		$this->env->setBaseUrl($baseUrl);
+	}
+
+	/**
 	 * Add a query string value to the paginator.
 	 *
 	 * @param  string  $key


### PR DESCRIPTION
When using pagination in an Ajax request is useful to be able to define the URL to be consider to build the paginate links. By default, in an  Ajax request, it will be consider the Ajax URL to build the paginate links. This is a problem because generally in an Ajax response we do not rebuild the entry HTML page. To resolve this problem, we add to the Paginator class the setBaseURL function to indicate the URL to be consider. With this change we can, for example, proceed in the following way in the context of an Ajax request:

$users = User:where(‘age’, ‘>’, ’18‘)->get();
foreach ($users as $user)
{
    echo $user->name;
}
$users->setBaseUrl(URL::route(‘users_list’));
$users->links();

We can use the function $users->getEnvironment()->setBaseUrl() but we think the previous solution much more simple an elegant.
