### PR TITLE
wrapTable() and wrapColumn()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -212,7 +212,7 @@ abstract class Relation {
 	{
 		$query->select(new Expression('count(*)'));
 
-		$key = $this->wrap($this->parent->getQualifiedKeyName());
+		$key = $this->wrapColumn($this->parent->getQualifiedKeyName());
 
 		return $query->where($this->getForeignKey(), '=', new Expression($key));
 	}
@@ -298,9 +298,9 @@ abstract class Relation {
 	 * @param  string  $value
 	 * @return string
 	 */
-	public function wrap($value)
+	public function wrapColumn($value)
 	{
-		return $this->parent->getQuery()->getGrammar()->wrap($value);
+		return $this->parent->getQuery()->getGrammar()->wrapColumn($value);
 	}
 
 	/**

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -30,16 +30,34 @@ abstract class Grammar {
 	{
 		if ($this->isExpression($table)) return $this->getValue($table);
 
-		return $this->wrap($this->tablePrefix.$table);
+		return $this->wrap($this->tablePrefix.$table, true);
+	}
+
+	/**
+	 * Wrap a column in keyword identifiers.
+	 *
+	 * @param  string  $column
+	 * @return string
+	 */
+	public function wrapColumn($column)
+	{
+		if ($this->isExpression($column)) return $this->getValue($column);
+
+		return $this->wrap($column);
 	}
 
 	/**
 	 * Wrap a value in keyword identifiers.
 	 *
+	 * If the optional second parameter is true, all aliases (AS clauses) will
+	 * be prefixed with the table prefix. This is needed for handling table
+	 * aliases and column aliases differently.
+	 *
 	 * @param  string  $value
+	 * @param  bool    $prefixAlias
 	 * @return string
 	 */
-	public function wrap($value)
+	public function wrap($value, $prefixAlias = false)
 	{
 		if ($this->isExpression($value)) return $this->getValue($value);
 
@@ -49,6 +67,10 @@ abstract class Grammar {
 		if (strpos(strtolower($value), ' as ') !== false)
 		{
 			$segments = explode(' ', $value);
+
+			// If we're handling table names, the table prefix has to be
+			// prepended to aliases, too.
+			if ($prefixAlias) $segments[2] = $this->tablePrefix.$segments[2];
 
 			return $this->wrap($segments[0]).' as '.$this->wrap($segments[2]);
 		}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1212,7 +1212,7 @@ class Builder {
 	 */
 	public function increment($column, $amount = 1)
 	{
-		$wrapped = $this->grammar->wrap($column);
+		$wrapped = $this->grammar->wrapColumn($column);
 
 		return $this->update(array($column => $this->raw("$wrapped + $amount")));
 	}
@@ -1226,7 +1226,7 @@ class Builder {
 	 */
 	public function decrement($column, $amount = 1)
 	{
-		$wrapped = $this->grammar->wrap($column);
+		$wrapped = $this->grammar->wrapColumn($column);
 
 		return $this->update(array($column => $this->raw("$wrapped - $amount")));
 	}

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -172,9 +172,9 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function compileJoinConstraint(array $clause)
 	{
-		$first = $this->wrap($clause['first']);
+		$first = $this->wrapColumn($clause['first']);
 
-		$second = $this->wrap($clause['second']);
+		$second = $this->wrapColumn($clause['second']);
 
 		return "{$clause['boolean']} $first {$clause['operator']} $second";
 	}
@@ -239,7 +239,7 @@ class Grammar extends BaseGrammar {
 	{
 		$select = $this->compileSelect($where['query']);
 
-		return $this->wrap($where['column']).' '.$where['operator']." ($select)";
+		return $this->wrapColumn($where['column']).' '.$where['operator']." ($select)";
 	}
 
 	/**
@@ -253,7 +253,7 @@ class Grammar extends BaseGrammar {
 	{
 		$value = $this->parameter($where['value']);
 
-		return $this->wrap($where['column']).' '.$where['operator'].' '.$value;
+		return $this->wrapColumn($where['column']).' '.$where['operator'].' '.$value;
 	}
 
 	/**
@@ -265,7 +265,7 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function whereBetween(Builder $query, $where)
 	{
-		return $this->wrap($where['column']).' between ? and ?';
+		return $this->wrapColumn($where['column']).' between ? and ?';
 	}
 
 	/**
@@ -303,7 +303,7 @@ class Grammar extends BaseGrammar {
 	{
 		$values = $this->parameterize($where['values']);
 
-		return $this->wrap($where['column']).' in ('.$values.')';
+		return $this->wrapColumn($where['column']).' in ('.$values.')';
 	}
 
 	/**
@@ -317,7 +317,7 @@ class Grammar extends BaseGrammar {
 	{
 		$values = $this->parameterize($where['values']);
 
-		return $this->wrap($where['column']).' not in ('.$values.')';
+		return $this->wrapColumn($where['column']).' not in ('.$values.')';
 	}
 
 	/**
@@ -331,7 +331,7 @@ class Grammar extends BaseGrammar {
 	{
 		$select = $this->compileSelect($where['query']);
 
-		return $this->wrap($where['column']).' in ('.$select.')';
+		return $this->wrapColumn($where['column']).' in ('.$select.')';
 	}
 
 	/**
@@ -345,7 +345,7 @@ class Grammar extends BaseGrammar {
 	{
 		$select = $this->compileSelect($where['query']);
 
-		return $this->wrap($where['column']).' not in ('.$select.')';
+		return $this->wrapColumn($where['column']).' not in ('.$select.')';
 	}
 
 	/**
@@ -357,7 +357,7 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function whereNull(Builder $query, $where)
 	{
-		return $this->wrap($where['column']).' is null';
+		return $this->wrapColumn($where['column']).' is null';
 	}
 
 	/**
@@ -369,7 +369,7 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function whereNotNull(Builder $query, $where)
 	{
-		return $this->wrap($where['column']).' is not null';
+		return $this->wrapColumn($where['column']).' is not null';
 	}
 
 	/**
@@ -439,7 +439,7 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function compileBasicHaving($having)
 	{
-		$column = $this->wrap($having['column']);
+		$column = $this->wrapColumn($having['column']);
 
 		$parameter = $this->parameter($having['value']);
 
@@ -459,7 +459,7 @@ class Grammar extends BaseGrammar {
 
 		return 'order by '.implode(', ', array_map(function($order) use ($me)
 		{
-			return $me->wrap($order['column']).' '.$order['direction'];
+			return $me->wrapColumn($order['column']).' '.$order['direction'];
 		}
 		, $orders));
 	}
@@ -572,7 +572,7 @@ class Grammar extends BaseGrammar {
 
 		foreach ($values as $key => $value)
 		{
-			$columns[] = $this->wrap($key).' = '.$this->parameter($value);
+			$columns[] = $this->wrapColumn($key).' = '.$this->parameter($value);
 		}
 
 		$columns = implode(', ', $columns);

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -42,7 +42,7 @@ class PostgresGrammar extends Grammar {
 		// list of the columns that can be added into this update query clauses.
 		foreach ($values as $key => $value)
 		{
-			$columns[] = $this->wrap($key).' = '.$this->parameter($value);
+			$columns[] = $this->wrapColumn($key).' = '.$this->parameter($value);
 		}
 
 		return implode(', ', $columns);
@@ -134,7 +134,7 @@ class PostgresGrammar extends Grammar {
 	{
 		if (is_null($sequence)) $sequence = 'id';
 
-		return $this->compileInsert($query, $values).' returning '.$this->wrap($sequence);
+		return $this->compileInsert($query, $values).' returning '.$this->wrapColumn($sequence);
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -17,7 +17,7 @@ class SQLiteGrammar extends Grammar {
 
 		return 'order by '.implode(', ', array_map(function($order) use ($me)
 		{
-			return $me->wrap($order['column']).' collate nocase '.$order['direction'];
+			return $me->wrapColumn($order['column']).' collate nocase '.$order['direction'];
 		}
 		, $orders));
 	}
@@ -58,7 +58,7 @@ class SQLiteGrammar extends Grammar {
 		// then join them all together with select unions to complete the queries.
 		foreach (array_keys($values[0]) as $column)
 		{
-			$columns[] = '? as '.$this->wrap($column);
+			$columns[] = '? as '.$this->wrapColumn($column);
 		}
 
 		$columns = array_fill(0, count($values), implode(', ', $columns));

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -118,7 +118,7 @@ abstract class Grammar extends BaseGrammar {
 			// Each of the column types have their own compiler functions which are tasked
 			// with turning the column definition into its SQL format for this platform
 			// used by the connection. The column's modifiers are compiled and added.
-			$sql = $this->wrap($column).' '.$this->getType($column);
+			$sql = $this->wrapColumn($column).' '.$this->getType($column);
 
 			$columns[] = $this->addModifiers($sql, $blueprint, $column);
 		}

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -219,16 +219,13 @@ abstract class Grammar extends BaseGrammar {
 	}
 
 	/**
-	 * Wrap a value in keyword identifiers.
-	 *
-	 * @param  string  $value
-	 * @return string
+	 * {@inheritdoc}
 	 */
-	public function wrap($value)
+	public function wrap($value, $prefixAlias = false)
 	{
 		if ($value instanceof Fluent) $value = $value->name;
 
-		return parent::wrap($value);
+		return parent::wrap($value, $prefixAlias);
 	}
 
 	/**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -477,7 +477,7 @@ class MySqlGrammar extends Grammar {
 	{
 		if ( ! is_null($column->after))
 		{
-			return ' after '.$this->wrap($column->after);
+			return ' after '.$this->wrapColumn($column->after);
 		}
 	}
 

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -103,7 +103,7 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('where')->once()->with('table.foreign_key', '=', m::type('Illuminate\Database\Query\Expression'));
 		$relation->getParent()->shouldReceive('getQuery')->andReturn($parentQuery = m::mock('StdClass'));
 		$parentQuery->shouldReceive('getGrammar')->once()->andReturn($grammar = m::mock('StdClass'));
-		$grammar->shouldReceive('wrap')->once()->with('foo');
+		$grammar->shouldReceive('wrapColumn')->once()->with('foo');
 
 		$relation->getRelationCountQuery($query);
 	}

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -53,6 +53,24 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAliasWithPrefix()
+	{
+		$builder = $this->getBuilder();
+		$builder->getGrammar()->setTablePrefix('prefix_');
+		$builder->select('*')->from('users as people');
+		$this->assertEquals('select * from "prefix_users" as "prefix_people"', $builder->toSql());
+	}
+
+
+	public function testJoinAliasesWithPrefix()
+	{
+		$builder = $this->getBuilder();
+		$builder->getGrammar()->setTablePrefix('prefix_');
+		$builder->select('*')->from('services')->join('translations AS t', 't.item_id', '=', 'services.id');
+		$this->assertEquals('select * from "prefix_services" inner join "prefix_translations" as "prefix_t" on "prefix_t"."item_id" = "prefix_services"."id"', $builder->toSql());
+	}
+
+
 	public function testBasicTableWrapping()
 	{
 		$builder = $this->getBuilder();


### PR DESCRIPTION
There is a very small difference between wrapping tables and wrapping columns, when it comes to handling aliases and table prefixes. When I have a column with an alias (AS clause), I don't need to change anything. But when a table is aliased, it has to be prefixed.

That caused problems like #711 and #861.
I would appreciate if you could test this for your use-cases (even though I added unit tests based on your reports), @bencorlett and @alfredbaudisch.

This change forces us to know whether we're wrapping a table or a column in every situation, but that is the case.

We could probably turn `wrap()` into a protected method now. Else, there's no real difference between `wrapColumn()` and `wrapTable()` now. I just thought that's more explicit, thus better.
