### PR TITLE
Pluralizer Case Sensitivity

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -193,6 +193,8 @@ class Pluralizer {
 		{
 			if (preg_match($pattern = '/'.$pattern.'$/i', $value))
 			{
+				$irregular = static::matchCase($irregular, $value);
+				
 				return preg_replace($pattern, $irregular, $value);
 			}
 		}
@@ -204,9 +206,33 @@ class Pluralizer {
 		{
 			if (preg_match($pattern, $value))
 			{
-				return preg_replace($pattern, $inflected, $value);
+				$inflected = preg_replace($pattern, $inflected, $value);
+
+				return static::matchCase($inflected, $value);
 			}
 		}
+	}
+	
+	/**
+	 * Attempt to match the case on two strings.
+	 *
+	 * @param  string  $value
+	 * @param  string  $comparison
+	 * @return string
+	 */
+	protected static function matchCase($value, $comparison)
+	{
+		$functions = array('mb_strtolower', 'mb_strtoupper', 'ucfirst', 'ucwords');
+
+		foreach ($functions as $function) 
+		{
+			if (call_user_func($function, $comparison) === $comparison)
+			{
+				return call_user_func($function, $value);
+			}
+		}
+
+		return $value;
 	}
 
 }

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -224,7 +224,7 @@ class Pluralizer {
 	{
 		$functions = array('mb_strtolower', 'mb_strtoupper', 'ucfirst', 'ucwords');
 
-		foreach ($functions as $function) 
+		foreach ($functions as $function)
 		{
 			if (call_user_func($function, $comparison) === $comparison)
 			{

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -12,4 +12,20 @@ class SupportPluralizerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('deer', str_singular('deer'));
 	}
 
+	public function testCaseSensitiveUsage()
+	{
+		$this->assertEquals('Children', str_plural('Child'));
+		$this->assertEquals('CHILDREN', str_plural('CHILD'));
+		$this->assertEquals('Tests', str_plural('Test'));
+		$this->assertEquals('TESTS', str_plural('TEST'));
+		$this->assertEquals('Deer', str_plural('Deer'));
+		$this->assertEquals('DEER', str_plural('DEER'));
+		$this->assertEquals('Child', str_singular('Children'));
+		$this->assertEquals('CHILD', str_singular('CHILDREN'));
+		$this->assertEquals('Test', str_singular('Tests'));
+		$this->assertEquals('TEST', str_singular('TESTS'));
+		$this->assertEquals('Deer', str_singular('Deer'));
+		$this->assertEquals('DEER', str_singular('DEER'));
+	}
+
 }


### PR DESCRIPTION
I understand that this has been discussed before but this issue keeps bugging me so I thought I would have a crack at solving it in the cleanest way I could find in the hopes of a change of heart. I have modified the pluralizer to maintain case sensitivity on irregular words and also fixes the case matching on uppercase regular words. For example...

``` php
// Without my modification on a regular word
Str::plural('dog'); // echos 'dogs' - correct!
Str::plural('Dog'); // echos 'Dogs' - correct!
Str::plural('DOG'); // echos 'DOGs' - NOT correct
// And for an irregular word
Str::plural('child'); // echos 'children' - correct!
Str::plural('Child'); // echos 'children' - NOT correct
Str::plural('CHILD'); // echos 'children' - NOT correct
```

And if you accept this pull request.

``` php
// With my modification on a regular word
Str::plural('dog'); // echos 'dogs' - correct!
Str::plural('Dog'); // echos 'Dogs' - correct!
Str::plural('DOG'); // echos 'DOGS' - correct!
// And for an irregular word
Str::plural('child'); // echos 'children' - correct!
Str::plural('Child'); // echos 'Children' - correct!
Str::plural('CHILD'); // echos 'CHILDREN' - correct!
```

Check out the implementation and if you sitll think this is too clunky then I will let it go but I think this is not a bad fix for the current inconsistency with the function.

Also discussed here #855
