### PR TITLE
UrlGenerator support of alternate web server ports

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -271,7 +271,7 @@ class UrlGenerator {
 	 */
 	protected function getRootUrl($scheme)
 	{
-		$root = $this->request->root();
+		$root = $this->request->getBaseUrl();
 
 		$start = starts_with($root, 'http://') ? 'http://' : 'https://';
 


### PR DESCRIPTION
As is anything using getRootUrl in UrlGenerator does not support running on a server with an alternate port. It drops the port from the url. After changing getRootUrl from getting its url from $this->request->root() to $this->request->getBaseUrl() this issue no longer occurs. For example, a Redirect::to('/login') from http://localhost:8080/ currently generates http://localhost/login. With this patch it generates http://localhost:8080/login as expected.
