### PR TITLE
Eloquent Collection dictionary refresh

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -5,6 +5,13 @@ use Illuminate\Support\Collection as BaseCollection;
 class Collection extends BaseCollection {
 
 	/**
+	 * A cache-hash of items array.
+	 *
+	 * @var string
+	 */
+	protected $hash;
+
+	/**
 	 * A dictionary of available primary keys.
 	 *
 	 * @var array
@@ -20,7 +27,7 @@ class Collection extends BaseCollection {
 	 */
 	public function find($key, $default = null)
 	{
-		if (count($this->dictionary) == 0)
+		if (md5(json_encode($this->items)) != $this->hash)
 		{
 			$this->buildDictionary();
 		}
@@ -57,7 +64,7 @@ class Collection extends BaseCollection {
 		// If the dictionary is empty, we will re-build it upon adding the item so
 		// we can quickly search it from the "contains" method. This dictionary
 		// will give us faster look-up times while searching for given items.
-		if (count($this->dictionary) == 0)
+		if (md5(json_encode($this->items)) != $this->hash)
 		{
 			$this->buildDictionary();
 		}
@@ -81,7 +88,7 @@ class Collection extends BaseCollection {
 	 */
 	public function contains($key)
 	{
-		if (count($this->dictionary) == 0)
+		if (md5(json_encode($this->items)) != $this->hash)
 		{
 			$this->buildDictionary();
 		}
@@ -96,6 +103,8 @@ class Collection extends BaseCollection {
 	 */
 	protected function buildDictionary()
 	{
+		$this->hash = md5(json_encode($this->items));
+
 		$this->dictionary = array();
 
 		// By building the dictionary of items by key, we are able to more quickly
@@ -117,7 +126,7 @@ class Collection extends BaseCollection {
 	 */
 	public function modelKeys()
 	{
-		if (count($this->dictionary) === 0) $this->buildDictionary();
+		if (md5(json_encode($this->items)) != $this->hash) $this->buildDictionary();
 
 		return array_keys($this->dictionary);
 	}

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -34,6 +34,25 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testCollectionMutationAndDictionaryUpdate()
+	{
+		$mockModel = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel->shouldReceive('getKey')->andReturn(1);
+		$c = new Collection(array($mockModel));
+		$mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel2->shouldReceive('getKey')->andReturn(2);
+		$c->add($mockModel2);
+
+		$this->assertTrue($c->contains(1));
+		$this->assertTrue($c->contains(2));
+		$this->assertFalse($c->contains(3));
+		// Remove by index key, not primary key
+		$c->forget(1);
+		$this->assertTrue($c->contains(1));
+		$this->assertFalse($c->contains(2));
+	}
+
+
 	public function testFindMethodFindsModelById()
 	{
 		$mockModel = m::mock('Illuminate\Database\Eloquent\Model');


### PR DESCRIPTION
This is not a PR, more of an issue.

Eloquent Collection has dictionary of models that is generated any time you try to use one of the method that deals with models by it's primary key. Problem is, once that dictionary is generated it'll stay the same no matter what you do with collection. You can remove half of the models, but still will be able to access removed models via `find(id)`.

In the code you can see that i'm comparing hash strings of cached items array and current items array. It's not the fastest solution (20ms on 1000 iterations loop - about ten times slower then current dictionary length check), so that got to be considered.

Maybe add second hash variable that is being generated every time items array is being mutated and just compare to hashes.
