### PR TITLE
Fixed typo

### DIFF
--- a/src/Illuminate/Routing/Generators/stubs/controller.php
+++ b/src/Illuminate/Routing/Generators/stubs/controller.php
@@ -1,6 +1,6 @@
 <?php{{namespace}}
 
-class {{class}} extends \BaseController {
+class {{class}} extends BaseController {
 
 {{methods}}
 

--- a/tests/Routing/fixtures/controller.php
+++ b/tests/Routing/fixtures/controller.php
@@ -1,6 +1,6 @@
 <?php
 
-class FooController extends \BaseController {
+class FooController extends BaseController {
 
 	/**
 	 * Display a listing of the resource.

--- a/tests/Routing/fixtures/except_controller.php
+++ b/tests/Routing/fixtures/except_controller.php
@@ -1,6 +1,6 @@
 <?php
 
-class FooController extends \BaseController {
+class FooController extends BaseController {
 
 	/**
 	 * Show the form for creating a new resource.

--- a/tests/Routing/fixtures/only_controller.php
+++ b/tests/Routing/fixtures/only_controller.php
@@ -1,6 +1,6 @@
 <?php
 
-class FooController extends \BaseController {
+class FooController extends BaseController {
 
 	/**
 	 * Display a listing of the resource.


### PR DESCRIPTION
I discovered when you perfom  `artisan controller:make Controller` the Controller have a typo on his declaration.
