### PR TITLE
Update Whoops version to 1.0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "classpreloader/classpreloader": "1.0.*",
         "doctrine/dbal": "2.4.x",
         "ircmaxell/password-compat": "1.0.*",
-        "filp/whoops": "1.0.4",
+        "filp/whoops": "1.0.6",
         "monolog/monolog": "1.5.*",
         "nesbot/carbon": "1.*",
         "patchwork/utf8": "1.1.*",

--- a/src/Illuminate/Exception/composer.json
+++ b/src/Illuminate/Exception/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "filp/whoops": "1.0.1",
+        "filp/whoops": "1.0.6",
         "illuminate/support": "4.0.x",
         "symfony/http-foundation": "2.3.x",
         "symfony/http-kernel": "2.3.*"


### PR DESCRIPTION
This PR updates the Whoops version used in Laravel to 1.0.6. The changes are mostly bug-fixes and small feature implementations, with no known BC-breaks.

Some interesting additions to the API are an overhauled `FrameCollection` (easier to, for example, filter frames from a stack trace), serializable `FrameCollection` and `Frame` objects, lazy data tables, and support for clickable URIs in frame comments within `PrettyPageHandler`.

More tests were also added for both new and old features.

Full compare view from `1.0.1` to `1.0.6`:
https://github.com/filp/whoops/compare/1.0.1...1.0.6

Cheers!
