### PR TITLE
Queue name should be quoted

### DIFF
--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -83,7 +83,7 @@ class Listener {
 	 */
 	public function makeProcess($connection, $queue, $delay, $memory, $timeout)
 	{
-		$string = 'php artisan queue:work %s --queue=%s --delay=%s --memory=%s --sleep';
+		$string = 'php artisan queue:work %s --queue="%s" --delay=%s --memory=%s --sleep';
 
 		// If the environment is set, we will append it to the command string so the
 		// workers will run under the specified environment. Otherwise, they will

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -41,7 +41,7 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf('Symfony\Component\Process\Process', $process);
 		$this->assertEquals(__DIR__, $process->getWorkingDirectory());
 		$this->assertEquals(3, $process->getTimeout());
-		$this->assertEquals('php artisan queue:work connection --queue=queue --delay=1 --memory=2 --sleep', $process->getCommandLine());
+		$this->assertEquals('php artisan queue:work connection --queue="queue" --delay=1 --memory=2 --sleep', $process->getCommandLine());
 	}
 
 }


### PR DESCRIPTION
Since queue names with spaces are accepted and handled correctly in the rest of the framework, I think that here the name queue should be quoted.
