### PR TITLE
allow disabling the creation of the compiled.php

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -31,6 +31,13 @@ class OptimizeCommand extends Command {
 	protected $composer;
 
 	/**
+	 * The output path for the compiled class.
+	 *
+	 * @var string
+	 */
+	protected $outputPath;
+
+	/**
 	 * Create a new optimize command instance.
 	 *
 	 * @param  \Illuminate\Foundation\Composer  $composer
@@ -54,6 +61,14 @@ class OptimizeCommand extends Command {
 
 		$this->composer->dumpOptimized();
 
+		$this->outputPath = $this->laravel['path.base'].'/bootstrap/compiled.php';
+
+		if ($this->laravel['config']['compile']['run'] === false)
+		{
+			@unlink($this->outputPath);
+			return;
+		}
+
 		$this->info('Compiling common classes...');
 
 		$this->compileClasses();
@@ -68,9 +83,7 @@ class OptimizeCommand extends Command {
 	{
 		$this->registerClassPreloaderCommand();
 
-		$outputPath = $this->laravel['path.base'].'/bootstrap/compiled.php';
-
-		$this->callSilent('compile', array('--output' => $outputPath, '--config' => implode(',', $this->getClassFiles())));
+		$this->callSilent('compile', array('--output' => $this->outputPath, '--config' => implode(',', $this->getClassFiles())));
 	}
 
 	/**
@@ -84,7 +97,7 @@ class OptimizeCommand extends Command {
 
 		$core = require __DIR__.'/Optimize/config.php';
 
-		return array_merge($core, $this->laravel['config']['compile']);
+		return array_merge($core, $this->laravel['config']['compile']['classes']);
 	}
 
 	/**


### PR DESCRIPTION
I would like to propose a feature request on the `artisan optimize` command. Right now, the `compile.php` file is always generated no matter what. When I'm debugging projects of mine, I use xDebug to step through my code. It has become a little annoying to step into the compiled.php file and discovering bugs with my code. You then have to scroll around and figure out what class you're in, then hunt that file down and make the changes then rerun the `optimize` command.

I would like the ability to disable the creation of this file for local development. This change also would propose a configuration change to the config file `compile.php` in the skeleton application.

That file would now need to look like this:

```
<?php
return array(
    /*
    |--------------------------------------------------------------------------
    | Compile Classes Toggle
    |--------------------------------------------------------------------------
    |
    | If you wish to not generate a compiled.php class set this to false. This
    | is only recommended for debugging purposes.
    |
    */
    'run' => true,

    /*
    |--------------------------------------------------------------------------
    | Additional Compiled Classes
    |--------------------------------------------------------------------------
    |
    | Here you may specify additional classes to include in the compiled file
    | generated by the `artisan optimize` command. These should be classes
    | that are included on basically every request into the application.
    |
    */
    'classes' => array()
);
```

I have tested this locally and it works fantastic now. I don't know if there is anyone else out there who would like to be able to do this, but if this made it in I'd be a happy panda. 

Best regards,
Andrew
