### PR TITLE
Add \Illuminate\Eloquent\Collection::modelValues() to get an array of model attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -72,12 +72,30 @@ class Collection extends BaseCollection {
 	
 	/**
 	 * Get an array of property values
+     * 
+     * @param String|Array a model attribute, or list
 	 * 
+     * @example $usernames = $users->modelValues('usernames');
+     * @example $fullnames = $users->modelValues('firstname', 'surname');
+     * @example $fullnames = $users->modelValues(array('firstname', 'surname'));
+     * 
 	 * @return array
 	 */
 	public function modelValues($key)
 	{
-		return array_map(function($m) use ($key) { return $m->$key; }, $this->items);
+        $args = func_get_args();
+        if ( count($args) > 1 ) {
+            $key = $args;
+        }
+		return array_map(function($m) use ($key) {
+            if ( is_array($key) ) {
+                return array_map(function($k) use($m) {
+                    return $m->$k;
+                }, $key);
+            } else {
+                return $m->$key;
+            }
+        }, $this->items);
 	}
 
 }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -69,5 +69,15 @@ class Collection extends BaseCollection {
 	{
 		return array_map(function($m) { return $m->getKey(); }, $this->items);
 	}
+	
+	/**
+	 * Get an array of property values
+	 * 
+	 * @return array
+	 */
+	public function modelValues($key)
+	{
+		return array_map(function($m) use ($key) { return $m->$key; }, $this->items);
+	}
 
 }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -90,5 +90,37 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(array('1','2','3'), $c->modelValues('thing'));
     }
+    
+    public function testCollectionDictionaryReturnsArraysOfModelValuesWithMultipleArguments()
+    {
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one->shouldReceive('getAttribute')->andReturn('1');
+
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two->shouldReceive('getAttribute')->andReturn('2');
+
+        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three->shouldReceive('getAttribute')->andReturn('3');
+
+        $c = new Collection(array($one, $two, $three));
+
+        $this->assertEquals(array(array('1','1'),array('2','2'),array('3','3')), $c->modelValues('thing', 'otherthing'));
+    }
+    
+    public function testCollectionDictionaryReturnsArraysOfModelValuesWithSingleArrayArgument()
+    {
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one->shouldReceive('getAttribute')->andReturn('1');
+
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two->shouldReceive('getAttribute')->andReturn('2');
+
+        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three->shouldReceive('getAttribute')->andReturn('3');
+
+        $c = new Collection(array($one, $two, $three));
+
+        $this->assertEquals(array(array('1','1'),array('2','2'),array('3','3')), $c->modelValues(array('thing', 'otherthing')));
+    }
 
 }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -74,5 +74,21 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(array(1,2,3), $c->modelKeys());
 	}
+    
+    public function testCollectionDictionaryReturnsModelValues()
+    {
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $one->shouldReceive('getAttribute')->andReturn('1');
+
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $two->shouldReceive('getAttribute')->andReturn('2');
+
+        $three = m::mock('Illuminate\Database\Eloquent\Model');
+        $three->shouldReceive('getAttribute')->andReturn('3');
+
+        $c = new Collection(array($one, $two, $three));
+
+        $this->assertEquals(array('1','2','3'), $c->modelValues('thing'));
+    }
 
 }


### PR DESCRIPTION
It would be nice to be able to pluck attributes from collections in the way you can pluck primary keys with Collection::modelKeys

I wasn't sure about the overly complex set of method signatures I implemented, so it might be worth deciding on one approach or another (if you're even interested in including this, of course!)

I guess my preference would be that you give a string to get an array of strings, and you give an array to get an array of arrays.  That would mean dropping the method signature that lets you pass multiple parameters (currently it behaves the same as passing a single array).
