### PR TITLE
`artisan dump-autoload` should handle the actual dumpAutoload, and only call optimize when app.debug === false

### DIFF
--- a/src/Illuminate/Foundation/Console/AutoloadCommand.php
+++ b/src/Illuminate/Foundation/Console/AutoloadCommand.php
@@ -49,7 +49,18 @@ class AutoloadCommand extends Command {
 	 */
 	public function fire()
 	{
-		$this->call('optimize');
+		$this->info('Generating optimized class loader...');
+
+		$this->composer->dumpOptimized();
+
+		if ($this->laravel['config']['app.debug'] === false)
+		{
+			$this->call('optimize');
+		}
+		else
+		{
+			$this->call('clear-compiled');
+		}
 
 		foreach ($this->findWorkbenches() as $workbench)
 		{
@@ -87,7 +98,7 @@ class AutoloadCommand extends Command {
 
 		if ( ! is_dir($workbench)) return array();
 
-		return Finder::create()->files()->in($workbench)->name('composer.json')->depth('< 3');		
+		return Finder::create()->files()->in($workbench)->name('composer.json')->depth('< 3');
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -50,10 +50,6 @@ class OptimizeCommand extends Command {
 	 */
 	public function fire()
 	{
-		$this->info('Generating optimized class loader...');
-
-		$this->composer->dumpOptimized();
-
 		$this->info('Compiling common classes...');
 
 		$this->compileClasses();


### PR DESCRIPTION
This is a new pull request based on the discussions with other developers in issue #1303. This will make it so the `compiled.php` file is not generated when `app.debug === true`. This helps with debugging and local development as it cuts out the time hunting down the file in which an error occurred as we don't have to muck with the `compiled.php`.
