### PR TITLE
Fix Request::only

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -199,9 +199,9 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 
 		$keys = is_array($keys) ? $keys : func_get_args();
 
-		foreach ($keys as $key) $results[$key] = $this->input($key);
+		$input = $this->input();
 
-		return $results;
+		return array_only($input, $keys);
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -199,7 +199,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 
 		$keys = is_array($keys) ? $keys : func_get_args();
 
-		foreach ($keys as $key) $results[$key] = $this->get($key);
+		foreach ($keys as $key) $results[$key] = $this->input($key);
 
 		return $results;
 	}


### PR DESCRIPTION
Currently this function can't retrieve from json input. The function will only select from the the http headers.
