### PR TITLE
Get displayable name for :other on "same" and "different" validations

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1319,7 +1319,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function replaceSame($message, $attribute, $rule, $parameters)
 	{
-		return str_replace(':other', $parameters[0], $message);
+		return str_replace(':other', $this->getAttribute($parameters[0]), $message);
 	}
 
 	/**
@@ -1333,7 +1333,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function replaceDifferent($message, $attribute, $rule, $parameters)
 	{
-		return str_replace(':other', $parameters[0], $message);
+		return str_replace(':other', $this->getAttribute($parameters[0]), $message);
 	}
 
 	/**


### PR DESCRIPTION
Before this change, `same` and `different` validations against fields with underscores in their name would result in error messages like:

```
The current password and new_password must match.

The current password and new_password must be different.
```
