### PR TITLE
Pass the blade compiler instance as second parameter to extensions.

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -104,7 +104,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	{
 		foreach ($this->extensions as $compiler)
 		{
-			$value = call_user_func($compiler, $value);
+			$value = call_user_func($compiler, $value, $this);
 		}
 
 		return $value;


### PR DESCRIPTION
When providing custom extensions for the Blade compiler it'd be useful to have access to the compiler instance so that we could use methods like `createMatcher`, `createOpenMatcher`, and `createPlainMatcher`.

PR just provides the compiler instance as second parameter.

``` php
Blade::extend(function($value, $compiler)
{

});
```
