### PR TITLE
Add array items validation and wildcard support. 

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -206,36 +206,6 @@ if ( ! function_exists('array_forget'))
 if ( ! function_exists('array_get'))
 {
 	/**
-	 * Get an item from an array using "dot" notation.
-	 *
-	 * @param  array   $array
-	 * @param  string  $key
-	 * @param  mixed   $default
-	 * @return mixed
-	 */
-	function array_get($array, $key, $default = null)
-	{
-		if (is_null($key)) return $array;
-
-		if (isset($array[$key])) return $array[$key];
-
-		foreach (explode('.', $key) as $segment)
-		{
-			if ( ! is_array($array) or ! array_key_exists($segment, $array))
-			{
-				return value($default);
-			}
-
-			$array = $array[$segment];
-		}
-
-		return $array;
-	}
-}
-
-if ( ! function_exists('array_select'))
-{
-	/**
 	 * Get an item from an array using "dot" notation and "wildcards".
 	 *
 	 * @param  array   $array
@@ -243,7 +213,7 @@ if ( ! function_exists('array_select'))
 	 * @param  mixed   $default
 	 * @return mixed
 	 */
-	function array_select($array, $key, $default = null)
+	function array_get($array, $key, $default = null)
 	{
 		if (is_null($key)) return $array;
 
@@ -273,7 +243,7 @@ if ( ! function_exists('array_select'))
 						else
 						{
 							// Pass current array item deeper.
-							$innerItem = array_select($item, $innerKey, $default);
+							$innerItem = array_get($item, $innerKey, $default);
 							if (is_array($innerItem) and count(array_keys($keys, '*')) > 1)
 							{
 								// Multiple wildcards, add each item of inner array to the resulting new array.

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -386,9 +386,9 @@ class Validator implements MessageProviderInterface {
 	{
 		$count = 0;
 
-		foreach ($attributes as $key)
+		foreach ($attributes as $attribute)
 		{
-			if (isset($this->data[$key]) or isset($this->files[$key]))
+			if ( ! is_null($this->getValue($attribute)))
 			{
 				$count++;
 			}
@@ -421,7 +421,7 @@ class Validator implements MessageProviderInterface {
 	{
 		$other = $parameters[0];
 
-		return isset($this->data[$other]) and $value == $this->data[$other];
+		return ! is_null($otherValue = $this->getValue($other)) and $value == $otherValue;
 	}
 
 	/**
@@ -436,7 +436,7 @@ class Validator implements MessageProviderInterface {
 	{
 		$other = $parameters[0];
 
-		return isset($this->data[$other]) and $value != $this->data[$other];
+		return ! is_null($otherValue = $this->getValue($other)) and $value != $otherValue;
 	}
 
 	/**
@@ -465,6 +465,18 @@ class Validator implements MessageProviderInterface {
 	protected function validateNumeric($attribute, $value)
 	{
 		return is_numeric($value);
+	}
+
+	/**
+	 * Validate that an attribute is an array.
+	 *
+	 * @param  string  $attribute
+	 * @param  mixed   $value
+	 * @return bool
+	 */
+	protected function validateArray($attribute, $value)
+	{
+		return is_array($value);
 	}
 
 	/**
@@ -578,7 +590,11 @@ class Validator implements MessageProviderInterface {
 		// entire length of the string will be considered the attribute size.
 		if (is_numeric($value) and $hasNumeric)
 		{
-			return $this->data[$attribute];
+			return $value;
+		}
+		elseif (is_array($value))
+		{
+			return count($value);
 		}
 		elseif ($value instanceof File)
 		{

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -88,6 +88,13 @@ class Validator implements MessageProviderInterface {
 	protected $numericRules = array('Numeric', 'Integer');
 
 	/**
+	 * The array related validation rules.
+	 *
+	 * @var array
+	 */
+	protected $arrayRules = array('Array');
+
+	/**
 	 * The implicit validation rules.
 	 *
 	 * @var array
@@ -1072,6 +1079,10 @@ class Validator implements MessageProviderInterface {
 		if ($this->hasRule($attribute, $this->numericRules))
 		{
 			return 'numeric';
+		}
+		elseif ($this->hasRule($attribute, $this->arrayRules))
+		{
+			return 'array';
 		}
 		elseif (array_key_exists($attribute, $this->files))
 		{

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -271,11 +271,11 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function getValue($attribute)
 	{
-		if ( ! is_null($value = array_select($this->data, $attribute)))
+		if ( ! is_null($value = array_get($this->data, $attribute)))
 		{
 			return $value;
 		}
-		elseif ( ! is_null($value = array_select($this->files, $attribute)))
+		elseif ( ! is_null($value = array_get($this->files, $attribute)))
 		{
 			return $value;
 		}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -18,6 +18,27 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testArraySelect()
+	{
+		$array = array('users' => array(
+			0 => array(
+				'name' => 'Taylor',
+				'password' => 'abcdef',
+				'friends'  => array('Shawn', 'Dayle')
+			),
+			1 => array(
+				'name' => 'Dayle',
+				'password' => 123456,
+				'friends'  => array('Rommie', 'Jessee')
+			)
+		));
+		$this->assertEquals(array('Taylor', 'Dayle'), array_select($array, 'users.*.name'));
+		$this->assertEquals(array('abcdef', 123456), array_select($array, 'users.*.password'));
+		$this->assertEquals(array(array('Shawn', 'Dayle'), array('Rommie', 'Jessee')), array_select($array, 'users.*.friends'));
+		$this->assertEquals(array('Shawn', 'Dayle', 'Rommie', 'Jessee'), array_select($array, 'users.*.friends.*'));
+	}
+
+
 	public function testArraySet()
 	{
 		$array = array();

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -18,7 +18,7 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testArraySelect()
+	public function testArrayGetWithWildcard()
 	{
 		$array = array('users' => array(
 			0 => array(
@@ -32,10 +32,10 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 				'friends'  => array('Rommie', 'Jessee')
 			)
 		));
-		$this->assertEquals(array('Taylor', 'Dayle'), array_select($array, 'users.*.name'));
-		$this->assertEquals(array('abcdef', 123456), array_select($array, 'users.*.password'));
-		$this->assertEquals(array(array('Shawn', 'Dayle'), array('Rommie', 'Jessee')), array_select($array, 'users.*.friends'));
-		$this->assertEquals(array('Shawn', 'Dayle', 'Rommie', 'Jessee'), array_select($array, 'users.*.friends.*'));
+		$this->assertEquals(array('Taylor', 'Dayle'), array_get($array, 'users.*.name'));
+		$this->assertEquals(array('abcdef', 123456), array_get($array, 'users.*.password'));
+		$this->assertEquals(array(array('Shawn', 'Dayle'), array('Rommie', 'Jessee')), array_get($array, 'users.*.friends'));
+		$this->assertEquals(array('Shawn', 'Dayle', 'Rommie', 'Jessee'), array_get($array, 'users.*.friends.*'));
 	}
 
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -95,7 +95,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('name' => ''), array('name' => 'Required'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('name' => array()), array('name' => 'Required'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('name' => 'foo'), array('name' => 'Required'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('name' => array('foo')), array('name' => 'Required'));
 		$this->assertTrue($v->passes());
 
 		$file = new File('', false);
@@ -227,10 +233,16 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => 'bar', 'baz' => 'boom'), array('foo' => 'Same:baz'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('bar'), 'baz' => array('boom')), array('foo' => 'Same:baz'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('foo' => 'bar'), array('foo' => 'Same:baz'));
 		$this->assertFalse($v->passes());
 
 		$v = new Validator($trans, array('foo' => 'bar', 'baz' => 'bar'), array('foo' => 'Same:baz'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('bar'), 'baz' => array('bar')), array('foo' => 'Same:baz'));
 		$this->assertTrue($v->passes());
 	}
 
@@ -241,10 +253,16 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => 'bar', 'baz' => 'boom'), array('foo' => 'Different:baz'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('bar'), 'baz' => array('boom')), array('foo' => 'Different:baz'));
+		$this->assertTrue($v->passes());
+
 		$v = new Validator($trans, array('foo' => 'bar'), array('foo' => 'Different:baz'));
 		$this->assertFalse($v->passes());
 
 		$v = new Validator($trans, array('foo' => 'bar', 'baz' => 'bar'), array('foo' => 'Different:baz'));
+		$this->assertFalse($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('bar'), 'baz' => array('bar')), array('foo' => 'Different:baz'));
 		$this->assertFalse($v->passes());
 	}
 
@@ -283,6 +301,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v = new Validator($trans, array('foo' => '1'), array('foo' => 'Numeric'));
 		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('1', '2', '3')), array('foo.*' => 'Numeric'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('1', '2', 'hello')), array('foo.*' => 'Numeric'));
+		$this->assertFalse($v->passes());
 	}
 
 
@@ -300,6 +324,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v = new Validator($trans, array('foo' => '1'), array('foo' => 'Integer'));
 		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('1', '2', '3')), array('foo.*' => 'Integer'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('1', '2', 'hello')), array('foo.*' => 'Integer'));
+		$this->assertFalse($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('1', '2', '3')), array('foo' => 'Integer'));
+		$this->assertFalse($v->passes());
 	}
 
 
@@ -307,6 +340,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	{
 		$trans = $this->getRealTranslator();
 		$v = new Validator($trans, array('foo' => '12345'), array('foo' => 'Digits:5'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('12345', '67890')), array('foo.*' => 'Digits:5'));
 		$this->assertTrue($v->passes());
 
 		$v = new Validator($trans, array('foo' => '123'), array('foo' => 'Digits:200'));
@@ -317,6 +353,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 
 		$v = new Validator($trans, array('foo' => '123'), array('foo' => 'digits_between:4,5'));
+		$this->assertFalse($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('123', '543')), array('foo.*' => 'digits_between:1,6'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('123', '445')), array('foo.*' => 'digits_between:4,5'));
 		$this->assertFalse($v->passes());
 	}
 
@@ -330,10 +372,31 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => 'anc'), array('foo' => 'Size:3'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('abc', 'qwe')), array('foo' => 'Size:3'));
+		$this->assertFalse($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('abc', 'qwe')), array('foo.*' => 'Size:3'));
+		$this->assertTrue($v->passes());
+
 		$v = new Validator($trans, array('foo' => '123'), array('foo' => 'Numeric|Size:3'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('abc', 'qwe')), array('foo' => 'Numeric|Size:3'));
+		$this->assertFalse($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('abc', 'qwe', 'dvo')), array('foo' => 'Array|Size:3'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('abc', 'qwe')), array('foo' => 'Array|Size:3'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('foo' => '3'), array('foo' => 'Numeric|Size:3'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('3', '3')), array('foo' => 'Numeric|Size:3'));
+		$this->assertFalse($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('3', '3')), array('foo.*' => 'Numeric|Size:3'));
 		$this->assertTrue($v->passes());
 
 		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));
@@ -365,11 +428,20 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => 'ancfs'), array('foo' => 'Between:3,5'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('foo' => array(1,2,3)), array('foo' => 'Between:3,5'));
+		$this->assertTrue($v->passes());
+
 		$v = new Validator($trans, array('foo' => '123'), array('foo' => 'Numeric|Between:50,100'));
 		$this->assertFalse($v->passes());
 
 		$v = new Validator($trans, array('foo' => '3'), array('foo' => 'Numeric|Between:1,5'));
 		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('3', '4')), array('foo.*' => 'Numeric|Between:1,5'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('3', '8')), array('foo.*' => 'Numeric|Between:1,5'));
+		$this->assertFalse($v->passes());
 
 		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));
 		$file->expects($this->any())->method('getSize')->will($this->returnValue(3072));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -400,6 +400,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => '5'), array('foo' => 'Numeric|Min:3'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Min:2'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Min:5'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Min:2'));
+		$this->assertFalse($v->passes());
+
 		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));
 		$file->expects($this->any())->method('getSize')->will($this->returnValue(3072));
 		$v = new Validator($trans, array(), array('photo' => 'Min:2'));
@@ -428,6 +437,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v = new Validator($trans, array('foo' => '22'), array('foo' => 'Numeric|Max:33'));
 		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Max:5'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Max:5'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Max:2'));
+		$this->assertFalse($v->passes());
 
 		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));
 		$file->expects($this->any())->method('getSize')->will($this->returnValue(3072));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -403,10 +403,10 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Min:2'));
 		$this->assertTrue($v->passes());
 
-		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Min:5'));
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Min:2'));
 		$this->assertTrue($v->passes());
 
-		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Min:2'));
+		$v = new Validator($trans, array('foo' => array('a', 'b', 'c')), array('foo' => 'Array|Min:5'));
 		$this->assertFalse($v->passes());
 
 		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));


### PR DESCRIPTION
Ok, i know that you've asked me to stop making PRs on validation, but after a lot of thought i came to the conclusion that it's impossible to make Validator intelligent enough so that it'll know when and how to validate an array and its contents.

Simple example. Validate following array against these rules:
- Make sure that it's an array
- It has at least 3 items
- Each item is a string and has at least 3 character in it
- Check each item with exists

I think it's just not possible unless you have at least two attributes and some serious magic in Validator going on. This PR tries to make it easy to use and to understand for a developer without serious docs crunching or voodoo magic.

``` php

$input = array('input' => array('foo', 'bar', 'baz'));
$rules = array(
    'input'   => 'Array|Min:3|Exists:users,name', // Run Exists against whole array - only one query
    'input.*' => 'String|Min:3'
);

$v = Validator::make($input, $rules);

```

First rule makes sure our `input` attribute is an array with at least three items. **Check**.
Second rules uses `array_select` and wildcrads to check each item of the array if it's a string and if it has at least 3 characters. **Check**.

I think it's pretty simple and intuitive.

Based upon my two other PRs: #1134 and #833.
