### PR TITLE
Fix error "HTML 'Class 'Html' not found" in Ubuntu

### DIFF
--- a/src/Illuminate/Support/Facades/Html.php
+++ b/src/Illuminate/Support/Facades/Html.php
@@ -1,0 +1,12 @@
+<?php namespace Illuminate\Support\Facades;
+
+class HTML extends Facade {
+
+	/**
+	 * Get the registered name of the component.
+	 *
+	 * @return string
+	 */
+	protected static function getFacadeAccessor() { return 'html'; }
+
+}


### PR DESCRIPTION
Renamed the file src/Illuminate/Support/Facades/HTML.php to src/Illuminate/Support/Facades/Html.php. This was the the fix I made when I deployed an app to an Ubuntu 12.04 LTS with PHP 5.4.14.
