### PR TITLE
Added the ability to pass in default parameters when auto resolving an instance of a class from the container.

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -193,6 +193,16 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('taylor', $instance->default);
 	}
 
+	public function testDefaultParametersCanBePassedWhenResolving()
+	{
+		$container = new Container;
+		$parameter1 = new ContainerConcreteStub;
+		$parameter2 = 'dayle';
+		$instance = $container->make('ContainerDefaultValueStub', array($parameter1, $parameter2));
+		
+		$this->assertTrue($parameter1 === $instance->stub);
+		$this->assertEquals('dayle', $instance->default);
+	}
 
 	public function testResolvingCallbacksAreCalled()
 	{


### PR DESCRIPTION
When auto-resolving an instance of a class from the container, sometimes you might already have instances of dependencies that class may need that aren't currently in the container.  This pull request gives the ability to pass these directly into the container when auto-resolving an instance.  It it equivalent to the functionality added by @kdocki for Laravel 3.

Signed-off-by: Travis Bennett tandrewbennett@hotmail.com
