### PR TITLE
Input Patch

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -197,9 +197,9 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	{
 		$keys = is_array($keys) ? $keys : func_get_args();
 
-		$input = $this->input();
+		$input = array_only($this->input(), $keys);
 
-		return array_only($input, $keys);
+		return array_merge(array_fill_keys($keys, null), $input);
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -170,7 +170,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	 */
 	public function all()
 	{
-		return array_merge($this->input(), $this->files->all());
+		return $this->input() + $this->files->all();
 	}
 
 	/**
@@ -182,7 +182,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	 */
 	public function input($key = null, $default = null)
 	{
-		$input = array_merge($this->getInputSource()->all(), $this->query->all());
+		$input = $this->getInputSource()->all() + $this->query->all();
 
 		return array_get($input, $key, $default);
 	}
@@ -199,7 +199,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 
 		$input = array_only($this->input(), $keys);
 
-		return array_merge(array_fill_keys($keys, null), $input);
+		return $input + array_fill_keys($keys, null);
 	}
 
 	/**


### PR DESCRIPTION
Fixed Laravel from re-indexing the input array. Only happens if input names are numbers. This was caused by merging the arrays with array_merge when the array union should of been used.

PHP Reference: http://php.net/array_merge (Example 3)
Minimum Code: http://paste.laravel.com/stF

---

Fixed a bug introduced with commit 41ec1e0. Input::only would only return the keys that existed. Before it would return with the default value of null.

``` php
$input = Input::get('email', 'password');

//If password wasn't submitted then this will throw undefined variable
$password = Hash::make($input['password']);
```
