### PR TITLE
Ensure that Request reads JSON from php server

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -430,7 +430,7 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 	 */
 	public function isJson()
 	{
-		return str_contains($this->server->get('CONTENT_TYPE'), '/json');
+		return str_contains($this->header('CONTENT_TYPE'), '/json');
 	}
 
 	/**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -213,6 +213,21 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($payload, $data);
 	}
 
+	public function testJSONEmulatingPHPBuiltInServer()
+	{
+		$payload = array('name' => 'taylor');
+		$content = json_encode($payload);
+		// The built in PHP 5.4 webserver incorrectly provides HTTP_CONTENT_TYPE and HTTP_CONTENT_LENGTH,
+		// rather than CONTENT_TYPE and CONTENT_LENGTH
+		$request = Request::create('/', 'GET', array(), array(), array(), array('HTTP_CONTENT_TYPE' => 'application/json', 'HTTP_CONTENT_LENGTH' => strlen($content)), $content);
+		$this->assertTrue($request->isJson());
+		$data = $request->json()->all();
+		$this->assertEquals($payload, $data);
+
+		$data = $request->all();
+		$this->assertEquals($payload, $data);
+	}
+
 
 
 	public function testAllInputReturnsInputAndFiles()


### PR DESCRIPTION
There is a problem in the PHP 5.4 built in web server.  It incorrectly sends CONTENT_TYPE and CONTENT_LENGTH headers as HTTP_CONTENT_TYPE and HTTP_CONTENT_LENGTH headers.
This fix elegantly manages this problem, allowing Laravel to continue to load up JSON with  Input::all() even if we are running off this dev PHP server.
