### PR TITLE
Allow date strings, unix timestamps, DateTime and Carbon objects in Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1951,8 +1951,22 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * @param  DateTime  $value
 	 * @return string
 	 */
-	protected function fromDateTime(DateTime $value)
+	protected function fromDateTime($value)
 	{
+		// If a timestamp has come through, we will create a
+		// DateTime object from the timestamp
+		if (is_numeric($value))
+		{
+			$value = new DateTime("@{$value}");
+		}
+
+		// Otherwise, we'll create a DateTime object which
+		// can be converted to the correct format
+		elseif (is_string($value))
+		{
+			$value = new DateTime($value);
+		}
+
 		return $value->format($this->getDateFormat());
 	}
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1953,21 +1953,23 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	protected function fromDateTime($value)
 	{
-		// If a timestamp has come through, we will create a
-		// DateTime object from the timestamp
+		$format = $this->getDateFormat();
+
+		// If a timestamp has come through we will create
+		// a carbon instance from the timestamp.
 		if (is_numeric($value))
 		{
-			$value = new DateTime("@{$value}");
+			$value = Carbon::createFromTimestampUTC($value);
 		}
 
-		// Otherwise, we'll create a DateTime object which
-		// can be converted to the correct format
-		elseif (is_string($value))
+		// Otherwise, we'll create a Carbon object based
+		// on the format for our model.
+		elseif ( ! $value instanceof DateTime)
 		{
-			$value = new DateTime($value);
+			$value = Carbon::createFromFormat($format, $value);
 		}
 
-		return $value->format($this->getDateFormat());
+		return $value->format($format);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -228,6 +228,16 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testTimestampsWillNotCreateFromInvalidStringFormats()
+	{
+		$model = new EloquentDateModelStub;
+		$model->created_at = 'invalid-format';
+	}
+
+
 	public function testDateTimeAttributesReturnNullIfSetToNull()
 	{
 		$timestamps = array(

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -150,7 +150,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertFalse($model->save());
 	}
-	
+
 
 	public function testUpdateIsCancelledIfUpdatingEventReturnsFalse()
 	{
@@ -213,6 +213,18 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$instance = $model->newInstance($timestamps);
 		$this->assertInstanceOf('Carbon\Carbon', $instance->updated_at);
 		$this->assertInstanceOf('Carbon\Carbon', $instance->created_at);
+	}
+
+
+	public function testTimestampsAreCreatedFromStringsAndIntegers()
+	{
+		$model = new EloquentDateModelStub;
+		$model->created_at = '2013-05-22 00:00:00';
+		$this->assertInstanceOf('Carbon\Carbon', $model->created_at);
+
+		$model = new EloquentDateModelStub;
+		$model->created_at = time();
+		$this->assertInstanceOf('Carbon\Carbon', $model->created_at);
 	}
 
 
@@ -448,7 +460,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->list_items = array(1, 2, 3);
 		$array = $model->toArray();
 
-		$this->assertEquals(array(1, 2, 3), $array['list_items']);	
+		$this->assertEquals(array(1, 2, 3), $array['list_items']);
 	}
 
 


### PR DESCRIPTION
As per our Skype discussion, here's the pull request to allow strings and unix timestamps to be passed to Eloquent date fields without it bitching out.

Signed-off-by: Ben Corlett bencorlett@me.com
