### PR TITLE
Removed reference to fallback locale in TranslationServiceProvider

### DIFF
--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -29,9 +29,7 @@ class TranslationServiceProvider extends ServiceProvider {
 			// configuration so we can easily get both of these values from there.
 			$locale = $app['config']['app.locale'];
 
-			$fallback = $app['config']['app.fallback_locale'];
-
-			$trans = new Translator($loader, $locale, $fallback);
+			$trans = new Translator($loader, $locale);
 
 			return $trans;
 		});


### PR DESCRIPTION
It seems as if the fallback locale feature was removed, so might as well remove this code too. 
