### PR TITLE
Added the possibility to get the validations rules that failed

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -93,6 +93,13 @@ class Validator implements MessageProviderInterface {
 	 * @var array
 	 */
 	protected $implicitRules = array('Required', 'RequiredWith', 'RequiredWithout', 'RequiredIf', 'Accepted');
+	
+	/**
+	 * The failed validation rules.
+	 *
+	 * @var array
+	 */
+	protected $failedRules = array();
 
 	/**
 	 * Create a new Validator instance.
@@ -208,8 +215,32 @@ class Validator implements MessageProviderInterface {
 
 		if ($validatable and ! $this->$method($attribute, $value, $parameters, $this))
 		{
+			$this->addFailedRules($attribute, $rule, $parameters);
 			$this->addError($attribute, $rule, $parameters);
 		}
+	}
+
+	/**
+	 * Add an failed rules to the collection.
+	 *
+	 * @param  string  $attribute
+	 * @param  string  $rule
+	 * @param  array   $parameters
+	 * @return void
+	 */
+	protected function addFailedRules($attribute, $rule, $parameters)
+	{
+		$this->failedRules[$attribute][$rule] = $parameters;
+	}
+
+	/**
+	 * Get the failed validation rules
+	 *
+	 * @return array
+	 */
+	public function getFailedRules()
+	{
+		return $this->failedRules;
 	}
 
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -13,6 +13,25 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testHasFailedValidationRules()
+	{
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('foo' => 'bar', 'baz' => 'boom'), array('foo' => 'Same:baz'));
+		$this->assertFalse($v->passes());
+		$this->assertEquals(array('foo' => array('Same' => array('baz'))), $v->getFailedRules());
+	}
+
+
+	public function testHasNotFailedValidationRules()
+	{
+		$trans = $this->getTranslator();
+		$trans->shouldReceive('trans')->never();
+		$v = new Validator($trans, array('foo' => 'taylor'), array('name' => 'Confirmed'));
+		$this->assertTrue($v->passes());
+		$this->assertEmpty($v->getFailedRules());
+	}
+
+
 	public function testInValidatableRulesReturnsValid()
 	{
 		$trans = $this->getTranslator();


### PR DESCRIPTION
In some cases, it would be interesting to return a list of validation rules that failed instead of receiving only the messages list or the MessageBag.

A simple use case would be to generate an error list, which will then be distributed by an API and allow the client to manage the error messages by itself.
