### PR TITLE
Fix for empty keys in app.php are not replaced by artisan key:generate

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -44,7 +44,7 @@ class KeyGenerateCommand extends Command {
 
 		$key = $this->getRandomKey();
 
-		$contents = str_replace($this->laravel['config']['app.key'], $key, $contents);
+    $contents = preg_replace("/['\"]key['\"].*=>.*,/", "'key' => '$key',", $contents);
 
 		$this->files->put($path, $contents);
 

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -44,7 +44,7 @@ class KeyGenerateCommand extends Command {
 
 		$key = $this->getRandomKey();
 
-    $contents = preg_replace("/['\"]key['\"].*=>.*,/", "'key' => '$key',", $contents);
+    $contents = preg_replace("/['\"]key['\"]\s*=>[^,]*,/", "'key' => '$key',", $contents);
 
 		$this->files->put($path, $contents);
 


### PR DESCRIPTION
In Laravel 3, it was required that the app.key property be an empty string for replacement to happen with artisan key:generate

eg. 'key' => '',

When running artisan key:generate with an empty key in Laravel 4 this does not happen.  In addition an inaccurate message stating that the application key was set successfully is output by this command.
