### PR TITLE
Updated Database composer.json to require illuminate/cache.

### DIFF
--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -13,10 +13,10 @@
         "illuminate/container": "4.0.x",
         "illuminate/events": "4.0.x",
         "illuminate/support": "4.0.x",
-        "illuminate/cache": "4.0.x",
         "nesbot/carbon": "1.*"
     },
     "require-dev": {
+        "illuminate/cache": "4.0.x",
         "illuminate/console": "4.0.x",
         "illuminate/filesystem": "4.0.x",
         "illuminate/pagination": "4.0.x",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -13,6 +13,7 @@
         "illuminate/container": "4.0.x",
         "illuminate/events": "4.0.x",
         "illuminate/support": "4.0.x",
+        "illuminate/cache": "4.0.x",
         "nesbot/carbon": "1.*"
     },
     "require-dev": {


### PR DESCRIPTION
The new `remember()` function means that `illuminate\cache` is now a requirement.
