### PR TITLE
$this->getArtisan() caused infinite loop when calling a command from within a route or controller

### DIFF
--- a/src/Illuminate/Foundation/Artisan.php
+++ b/src/Illuminate/Foundation/Artisan.php
@@ -79,7 +79,7 @@ class Artisan {
 	 */
 	public function __call($method, $parameters)
 	{
-		return call_user_func_array(array($this->getArtisan(), $method), $parameters);
+		return call_user_func_array(array($this->app['artisan'], $method), $parameters);
 	}
 
 }


### PR DESCRIPTION
When adding a command using:
Artisan::add(new NameCommand);
In the app/start/artisan.php file
And calling it from within a route, example:
Route::get('/', function() {
  Artisan::call("name");
});
Caused an infinite loop when trying to resolve the Artisan.

Another solution is to add commands using:
$app['artisan']->add(new NameCommand);
in the app/start/artisan.php file
....

The call to $this->getArtisan() ocurred in an infinite loop when calling a
command from within a controller or route.
