### PR TITLE
Namespace Support for Relation in Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -469,7 +469,8 @@ class Builder {
 	 */
 	public function getRelation($relation)
 	{
-		$query = $this->getModel()->$relation();
+		$method = ltrim(strrchr($relation, '\\'), '\\') ?: $relation;
+		$query = $this->getModel()->$method();
 
 		// If there are nested relationships set on the query, we will put those onto
 		// the query instances so that they can be handled after this relationship


### PR DESCRIPTION
When a relational model is namespaced, Eloquent will try to call the relation method along with the namespace of that class, which will throw an undefined method error. This should fix the issue by telling it to call the method based on the class name, but without the namespace.
