### PR TITLE
[Patch] remember() for relations in Eloquent\Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -455,7 +455,7 @@ class Builder {
 
 		// Attach cache information to relation query.
 		// Key is skipped because will generate cache conflicts, when passed.
-		list($key, $minutes) = $this->getQuery()->getCacheInfo();
+		$minutes = $this->getQuery()->getCacheMinutes();
 
 		if( ! is_null($minutes)) $relation->getQuery()->remember($minutes);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -453,6 +453,12 @@ class Builder {
 
 		$models = $relation->initRelation($models, $name);
 
+		// Attach cache information to relation query.
+		// Key is skipped because will generate cache conflicts, when passed.
+		list($key, $minutes) = $this->getQuery()->getCacheInfo();
+
+		if( ! is_null($minutes)) $relation->getQuery()->remember($minutes);
+
 		// Once we have the results, we just match those back up to their parent models
 		// using the relationship instance. Then we just return the finished arrays
 		// of models which have been eagerly hydrated and are readied for return.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1004,6 +1004,16 @@ class Builder {
 	}
 
 	/**
+	 * Return cache life time in minutes
+	 *
+	 * @return int
+	 */
+	public function getCacheMinutes()
+	{
+		return $this->cacheMinutes;
+	}
+
+	/**
 	 * Generate the unique cache key for the query.
 	 *
 	 * @return string

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -185,7 +185,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMock('Illuminate\Database\Eloquent\Builder', array('getRelation'), $this->getMocks());
 		$builder->setEagerLoads(array('orders' => function($query) { $_SERVER['__eloquent.constrain'] = $query; }));
-    $builder->getQuery()->shouldReceive('getCacheInfo')->andReturn(null, null);
+    $builder->getQuery()->shouldReceive('getCacheMinutes')->andReturn(null);
 		$relation = m::mock('stdClass');
 		$relation->shouldReceive('getAndResetWheres')->once()->andReturn(array(array('wheres'), array('bindings')));
 		$relation->shouldReceive('addEagerConstraints')->once()->with(array('models'));
@@ -204,7 +204,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 
   public function testGetRelationsWithCaching()
   {
-    $builder_query = m::mock('Illuminate\Database\Query\Builder', array('getCacheInfo'));
+    $builder_query = m::mock('Illuminate\Database\Query\Builder', array('getCacheMinutes'));
 		$builder = $this->getMock('Illuminate\Database\Eloquent\Builder', array('getRelation'), array($builder_query));
     $relation_query = m::mock('StdClass');
     $relation_query->shouldReceive('remember')->once()->with(5);
@@ -219,7 +219,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
     $relation->shouldReceive('getQuery')->once()->andReturn($relation_query);
 
 		$builder->expects($this->once())->method('getRelation')->with($this->equalTo('orders'))->will($this->returnValue($relation));
-    $builder->getQuery()->shouldReceive('getCacheInfo')->once()->andReturn(array(null, 5));
+    $builder->getQuery()->shouldReceive('getCacheMinutes')->once()->andReturn(5);
     $builder->setEagerLoads(array('orders' => function($query) {}));
 
     $builder->eagerLoadRelations(array('orders'));

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -210,7 +210,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
     $relation_query->shouldReceive('remember')->once()->with(5);
 
 		$relation = m::mock('StdClass');
-		$relation->shouldReceive('getAndResetWheres')->once()->andReturn(array());
+		$relation->shouldReceive('getAndResetWheres')->once()->andReturn(array(array('wheres'), array('bindings')));
 		$relation->shouldReceive('addEagerConstraints')->once();
 		$relation->shouldReceive('mergeWheres')->once();
 		$relation->shouldReceive('initRelation')->once();

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -185,6 +185,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMock('Illuminate\Database\Eloquent\Builder', array('getRelation'), $this->getMocks());
 		$builder->setEagerLoads(array('orders' => function($query) { $_SERVER['__eloquent.constrain'] = $query; }));
+    $builder->getQuery()->shouldReceive('getCacheInfo')->andReturn(null, null);
 		$relation = m::mock('stdClass');
 		$relation->shouldReceive('getAndResetWheres')->once()->andReturn(array(array('wheres'), array('bindings')));
 		$relation->shouldReceive('addEagerConstraints')->once()->with(array('models'));
@@ -199,6 +200,30 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($relation, $_SERVER['__eloquent.constrain']);
 		unset($_SERVER['__eloquent.constrain']);
 	}
+
+
+  public function testGetRelationsWithCaching()
+  {
+    $builder_query = m::mock('Illuminate\Database\Query\Builder', array('getCacheInfo'));
+		$builder = $this->getMock('Illuminate\Database\Eloquent\Builder', array('getRelation'), array($builder_query));
+    $relation_query = m::mock('StdClass');
+    $relation_query->shouldReceive('remember')->once()->with(5);
+
+		$relation = m::mock('StdClass');
+		$relation->shouldReceive('getAndResetWheres')->once()->andReturn(array());
+		$relation->shouldReceive('addEagerConstraints')->once();
+		$relation->shouldReceive('mergeWheres')->once();
+		$relation->shouldReceive('initRelation')->once();
+		$relation->shouldReceive('get')->once();
+		$relation->shouldReceive('match')->once();
+    $relation->shouldReceive('getQuery')->once()->andReturn($relation_query);
+
+		$builder->expects($this->once())->method('getRelation')->with($this->equalTo('orders'))->will($this->returnValue($relation));
+    $builder->getQuery()->shouldReceive('getCacheInfo')->once()->andReturn(array(null, 5));
+    $builder->setEagerLoads(array('orders' => function($query) {}));
+
+    $builder->eagerLoadRelations(array('orders'));
+  }
 
 
 	public function testGetRelationProperlySetsNestedRelationships()


### PR DESCRIPTION
I found out that `remember()` works only with model query builder. Related models are not cached.

This patch provides the functionality for caching related models queries.

@taylorotwell could You take a minute and review it?
I'm not sure what to do with parent model cache key. 

For now related models won't get cache key from parent (because it will conflict with cache data).
