### PR TITLE
Fix the Paginator getTo() method not returning the correct values

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -122,7 +122,7 @@ class Paginator implements ArrayAccess, Countable, IteratorAggregate {
 	{
 		$this->from = ($this->currentPage - 1) * $this->perPage + 1;
 
-		$this->to = $this->currentPage * $this->perPage;
+		$this->to = min($this->total, $this->currentPage * $this->perPage);
 	}
 
 	/**


### PR DESCRIPTION
Currently if we have for example 3 items and we are paginating 2 items per page, the `getTo()` returns 4 on the second page, when it should return 3.

This PR should fix this issue!
