### PR TITLE
avoid ErrorException Undefined index: cache 

### DIFF
--- a/src/Illuminate/Database/Capsule.php
+++ b/src/Illuminate/Database/Capsule.php
@@ -85,8 +85,10 @@ class Capsule {
 	protected function getEmptyConfig($dispatcher)
 	{
 		$dispatcher = $dispatcher ?: new Dispatcher(new Container);
+		
+		$cache = new CacheManager;
 
-		return array('events' => $dispatcher, 'config' => array());
+		return array('events' => $dispatcher, 'config' => array(), 'cache'=>$cache);
 	}
 
 	/**


### PR DESCRIPTION
update Capsule.php to avoid error 
Type: ErrorException
Code: 8
Message: Undefined index: cache
File: /var/www/myapp/vendor/illuminate/database/Illuminate/Database/DatabaseManager.php
Line: 118

Line 118 : $connection->setCacheManager($this->app['cache']);
Tanks.
