### PR TITLE
Error on DatabaseManager Line 118: undefined index cache

### DIFF
--- a/src/Illuminate/Database/Capsule.php
+++ b/src/Illuminate/Database/Capsule.php
@@ -3,6 +3,7 @@
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Database\Connectors\ConnectionFactory;
+use Illuminate\Cache\CacheManager;
 
 class Capsule {
 
@@ -85,8 +86,9 @@ class Capsule {
 	protected function getEmptyConfig($dispatcher)
 	{
 		$dispatcher = $dispatcher ?: new Dispatcher(new Container);
+		$cache = new CacheManager;
 
-		return array('events' => $dispatcher, 'config' => array());
+		return array('events' => $dispatcher, 'config' => array(), 'cache'=>$cache);
 	}
 
 	/**


### PR DESCRIPTION
Update Capsule.php to avoid error.
Type: ErrorException
Code: 8
Message: Undefined index: cache
File: /var/www/myapp/vendor/illuminate/database/Illuminate/Database/DatabaseManager.php
Line: 118

Line 118 : $connection->setCacheManager($this->app['cache']);
