### PR TITLE
[bugfix] Consistency & Resolvable Dependencies Fix

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -499,7 +499,7 @@ class Connection implements ConnectionInterface {
 
 		$message = $e->getMessage()." (SQL: {$query}) (Bindings: {$bindings})";
 
-		throw new \Exception($message, 0);	
+		throw new \Exception($message, 0);
 	}
 
 	/**
@@ -741,16 +741,21 @@ class Connection implements ConnectionInterface {
 	 */
 	public function getCacheManager()
 	{
+		if ($this->cache instanceof Closure)
+		{
+			$this->cache = call_user_func($this->cache);
+		}
+
 		return $this->cache;
 	}
 
 	/**
 	 * Set the cache manager instance on the connection.
 	 *
-	 * @param  \Illuminate\Cache\CacheManager  $cache
+	 * @param  \Illuminate\Cache\CacheManager|Closure  $cache
 	 * @return void
 	 */
-	public function setCacheManager(CacheManager $cache)
+	public function setCacheManager($cache)
 	{
 		$this->cache = $cache;
 	}

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -726,7 +726,7 @@ class Connection implements ConnectionInterface {
 	/**
 	 * Set the pagination environment instance.
 	 *
-	 * @param  \Illuminate\Pagination\Environment|Closure  $paginator
+	 * @param  \Illuminate\Pagination\Environment|\Closure  $paginator
 	 * @return void
 	 */
 	public function setPaginator($paginator)
@@ -752,7 +752,7 @@ class Connection implements ConnectionInterface {
 	/**
 	 * Set the cache manager instance on the connection.
 	 *
-	 * @param  \Illuminate\Cache\CacheManager|Closure  $cache
+	 * @param  \Illuminate\Cache\CacheManager|\Closure  $cache
 	 * @return void
 	 */
 	public function setCacheManager($cache)

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -203,6 +203,18 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testResolvingCacheThroughClosure()
+	{
+		$connection = $this->getMockConnection();
+		$cache  = m::mock('Illuminate\Cache\CacheManager');
+		$connection->setCacheManager(function() use ($cache)
+		{
+			return $cache;
+		});
+		$this->assertEquals($cache, $connection->getCacheManager());
+	}
+
+
 	protected function getMockConnection($methods = array(), $pdo = null)
 	{
 		$pdo = $pdo ?: new DatabaseConnectionTestMockPDO;

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -203,6 +203,18 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testResolvingPaginatorThroughClosure()
+	{
+		$connection = $this->getMockConnection();
+		$paginator  = m::mock('Illuminate\Pagination\Environment');
+		$connection->setPaginator(function() use ($paginator)
+		{
+			return $paginator;
+		});
+		$this->assertEquals($paginator, $connection->getPaginator());
+	}
+
+
 	public function testResolvingCacheThroughClosure()
 	{
 		$connection = $this->getMockConnection();


### PR DESCRIPTION
Hi,

Since the cache was added, every package which uses `illuminate/database` also must require `illuminate/cache` to be able to either:
1. Run unit tests using mockery to resolve dependencies
2. Use (any) IoC container to resolve dependencies.

You get all sorts of [fun errors like this](http://d.pr/i/q7u7). I have hit two birds with the one stone, I have allowed you to resolve the cache manager through a closure or by passing an instance through. That's the first bird. The second bird, this method is now consistent with the Paginator dependency (the only other time where something that's not required by `illuminate/database` may be resolved.
