### PR TITLE
When Exception occurs, return also the exception code not only a message...

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -499,7 +499,7 @@ class Connection implements ConnectionInterface {
 
 		$message = $e->getMessage()." (SQL: {$query}) (Bindings: {$bindings})";
 
-		throw new \Exception($message, 0);
+		throw new \Exception($message, $e->getCode() );
 	}
 
 	/**


### PR DESCRIPTION
....

If we don't return any exception code, or return always 0,  programmer have to parse a exception message. It's not a developer friendly approach.
