### PR TITLE
Get the collection of items in a key=>value array

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -365,6 +365,23 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Get the collection of items in a key=>value array
+	 * 
+	 * @param string $key
+	 * @param string $value
+	 * @return array
+	 */
+	public function toKeyValue($key, $value)
+	{
+		$keyvalue = array();
+		foreach($this as $item)
+		{
+			$keyvalue[$item->$key] = $item->$value;
+		}
+		return $keyvalue;
+	}
+	
+	/**
 	 * Get an iterator for the items.
 	 *
 	 * @return ArrayIterator


### PR DESCRIPTION
I posted an issue about this in the laravel/laravel github repository, it got "resolved" extending the Collection class, and creating a Model class implementing the newCollection method.

While it works, I think this belongs in the core Collection class.

I pushed a simple implementation, but it would work better with a KeyValueIterator I wrote (too bad generators will only be available in php5.5)

This function would not break anything and goes great with laravel's philosophy of making repetitive tasks easier for the developer, as this need is quite common.
