### PR TITLE
Add type param to Eloquent\Builder has method.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -530,7 +530,7 @@ class Builder {
 	 * @param  int     $count
 	 * @return \Illuminate\Database\Eloquent\Builder
 	 */
-	public function has($relation, $operator = '>=', $count = 1)
+	public function has($relation, $operator = '>=', $count = 1, $type = 'and')
 	{
 		$instance = $this->model->$relation();
 
@@ -538,7 +538,7 @@ class Builder {
 
 		$this->query->mergeBindings($query->getQuery());
 
-		return $this->where(new Expression('('.$query->toSql().')'), $operator, $count);
+		return $this->where(new Expression('('.$query->toSql().')'), $operator, $count, $type);
 	}
 
 	/**


### PR DESCRIPTION
Was imposible to use something like this:

 public function scopeActives($query) {
        return $query->has('groups')->has('deals', '>=', 1, 'or');
    }
