### PR TITLE
Adding support for "insert ignore into"

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1325,6 +1325,58 @@ class Builder {
 	}
 
 	/**
+	 * Insert a new record into the database, ignore duplicate entries
+	 *
+	 * @param  array  $values
+	 * @return bool
+	 */
+	public function insertIgnore(array $values)
+	{
+		// Since every insert gets treated like a batch insert, we will make sure the
+		// bindings are structured in a way that is convenient for building these
+		// inserts statements by verifying the elements are actually an array.
+		if ( ! is_array(reset($values)))
+		{
+			$values = array($values);
+		}
+
+		$bindings = array();
+
+		// We'll treat every insert like a batch insert so we can easily insert each
+		// of the records into the database consistently. This will make it much
+		// easier on the grammars to just handle one type of record insertion.
+		foreach ($values as $record)
+		{
+			$bindings = array_merge($bindings, array_values($record));
+		}
+
+		$sql = $this->grammar->compileInsertIgnore($this, $values);
+
+		// Once we have compiled the insert statement's SQL we can execute it on the
+		// connection and return a result as a boolean success indicator as that
+		// is the same type of result returned by the raw connection instance.
+		$bindings = $this->cleanBindings($bindings);
+
+		return $this->connection->insert($sql, $bindings);
+	}
+
+	/**
+	 * Insert a new record and get the value of the primary key.
+	 *
+	 * @param  array   $values
+	 * @param  string  $sequence
+	 * @return int
+	 */
+	public function insertIgnoreGetId(array $values, $sequence = null)
+	{
+		$sql = $this->grammar->compileInsertIgnoreGetId($this, $values, $sequence);
+
+		$values = $this->cleanBindings($values);
+
+		return $this->processor->processInsertGetId($this, $sql, $values, $sequence);
+	}
+
+	/**
 	 * Update a record in the database.
 	 *
 	 * @param  array  $values

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -557,6 +557,52 @@ class Grammar extends BaseGrammar {
 	}
 
 	/**
+	 * Compile an insertignore  statement into SQL.
+	 *
+	 * @param  \Illuminate\Database\Query\Builder  $query
+	 * @param  array  $values
+	 * @return string
+	 */
+	public function compileInsertIgnore(Builder $query, array $values)
+	{
+		// Essentially we will force every insert to be treated as a batch insert which
+		// simply makes creating the SQL easier for us since we can utilize the same
+		// basic routine regardless of an amount of records given to us to insert.
+		$table = $this->wrapTable($query->from);
+
+		if ( ! is_array(reset($values)))
+		{
+			$values = array($values);
+		}
+
+		$columns = $this->columnize(array_keys(reset($values)));
+
+		// We need to build a list of parameter place-holders of values that are bound
+		// to the query. Each insert should have the exact same amount of parameter
+		// bindings so we can just go off the first list of values in this array.
+		$parameters = $this->parameterize(reset($values));
+
+		$value = array_fill(0, count($values), "($parameters)");
+
+		$parameters = implode(', ', $value);
+
+		return "insert ignore into $table ($columns) values $parameters";
+	}
+
+	/**
+	 * Compile an insert and get ID statement into SQL.
+	 *
+	 * @param  \Illuminate\Database\Query\Builder  $query
+	 * @param  array   $values
+	 * @param  string  $sequence
+	 * @return string
+	 */
+	public function compileInsertIgnoreGetId(Builder $query, $values, $sequence)
+	{
+		return $this->compileInsertIgnore($query, $values);
+	}
+
+	/**
 	 * Compile an update statement into SQL.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query


### PR DESCRIPTION
These changes add support for insert ignore simply by copying and modifying the insert functions. This allows for the use of "insert ignore into" which is the same as an insert but suppresses errors for duplicate entries of unique keys.
