### PR TITLE
MessageBag instance was not being returned (Updated)

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1674,6 +1674,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	public function messages()
 	{
+		if ( ! $this->messages) $this->passes();
+		
 		return $this->messages;
 	}
 
@@ -1684,6 +1686,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	public function errors()
 	{
+		if ( ! $this->messages) $this->passes();
+		
 		return $this->messages;
 	}
 


### PR DESCRIPTION
Calling getMessageBag(), errors(), or messages() was not returning an instance if passes() or fails() was not first called. This way these function will always return a MessageBag instance regardless.

Adhered to L4 syntax standards. Removed the line from getMessageBag() as it wasn't need because it calls messages() anyways.

Thank you so much!
