### PR TITLE
Fix Str::is to not handle haystack as a regex.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -88,12 +88,14 @@ class Str {
 	{
 		if ($pattern == $value) return true;
 
+		$pattern = preg_quote($pattern, '#');
+
 		// Asterisks are translated into zero-or-more regular expression wildcards
 		// to make it convenient to check if the strings starts with the given
 		// pattern such as "library/*", making any string check convenient.
 		if ($pattern !== '/')
 		{
-			$pattern = str_replace('*', '(.*)', $pattern).'\z';
+			$pattern = str_replace('\*', '.*', $pattern).'\z';
 		}
 		else
 		{

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -120,8 +120,13 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(str_is('a', 'a'));
 		$this->assertTrue(str_is('/', '/'));
 		$this->assertTrue(str_is('*dev*', 'localhost.dev'));
+		$this->assertTrue(str_is('foo?bar', 'foo?bar'));
 		$this->assertFalse(str_is('*something', 'foobar'));
 		$this->assertFalse(str_is('foo', 'bar'));
+		$this->assertFalse(str_is('foo.*', 'foobar'));
+		$this->assertFalse(str_is('foo.ar', 'foobar'));
+		$this->assertFalse(str_is('foo?bar', 'foobar'));
+		$this->assertFalse(str_is('foo?bar', 'fobar'));
 	}
 
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -39,6 +39,22 @@ class SupportStrTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testIs()
+	{
+		$this->assertTrue(Str::is('*.dev', 'localhost.dev'));
+		$this->assertTrue(Str::is('a', 'a'));
+		$this->assertTrue(Str::is('/', '/'));
+		$this->assertTrue(Str::is('*dev*', 'localhost.dev'));
+		$this->assertTrue(Str::is('foo?bar', 'foo?bar'));
+		$this->assertFalse(Str::is('*something', 'foobar'));
+		$this->assertFalse(Str::is('foo', 'bar'));
+		$this->assertFalse(Str::is('foo.*', 'foobar'));
+		$this->assertFalse(Str::is('foo.ar', 'foobar'));
+		$this->assertFalse(Str::is('foo?bar', 'foobar'));
+		$this->assertFalse(Str::is('foo?bar', 'fobar'));
+	}
+
+
 	public function testStartsWith()
 	{
 		$this->assertTrue(Str::startsWith('jason', 'jas'));


### PR DESCRIPTION
See: https://github.com/laravel/laravel/issues/1998

By the way, slight optimization by removing useless regex grouping.

Feel free to suggest any improvements :-)
