### PR TITLE
IronConnector.php Error Argument 1 passed to Illuminate\Queue\Connectors...

### DIFF
--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -205,7 +205,7 @@ class QueueServiceProvider extends ServiceProvider {
 
 		$manager->addConnector('iron', function() use ($app)
 		{
-			return new IronConnector($app['request']);
+			return new IronConnector($app['encrypter'], $app['request']);
 		});
 	}
 


### PR DESCRIPTION
When using Iron.io as a queue and run php artisan queue:subscribe we get this error. 8

Problem seems to be in line 208 of

framework / src / Illuminate / Queue / QueueServiceProvider.php

(ie https://github.com/laravel/framework/blob/master/src/Illuminate/Queue/QueueServiceProvider.php#L208 )

Which is:

return new IronConnector($app['request']);

But should be:

return new IronConnector($app['encrypter'], $app['request']);
