### PR TITLE
Made a few changes to schema for MySQL grammar

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -306,7 +306,8 @@ class MySqlGrammar extends Grammar {
 	 */
 	protected function typeInteger(Fluent $column)
 	{
-		return 'int';
+		$length = isset($column->length) ? $column->length : 11;
+		return "int({$column->length})";
 	}
 
 	/**
@@ -428,6 +429,8 @@ class MySqlGrammar extends Grammar {
 	protected function typeTimestamp(Fluent $column)
 	{
 		if ( ! $column->nullable) return 'timestamp default 0';
+
+		if( $column->auto ) return 'timestamp default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP';
 
 		return 'timestamp';
 	}


### PR DESCRIPTION
... with foreign keys where the data length did not match. Here it is always explicitly set.

Also added a fluen attribute to timestamp type. The attribute '$column->auto()' makes the column auto updatable.
Laravel takes care of this value when updating the db, but sometimes db updates are manual and the timestamp value does not change or needs to be manually done.
It is just safer to make it auto for most use cases.
