### PR TITLE
[Whoops] Share whoops.handler instances, allowing easier handler customization

### DIFF
--- a/src/Illuminate/Exception/ExceptionServiceProvider.php
+++ b/src/Illuminate/Exception/ExceptionServiceProvider.php
@@ -105,7 +105,7 @@ class ExceptionServiceProvider extends ServiceProvider {
 	{
 		if ($this->shouldReturnJson())
 		{
-			$this->app['whoops.handler'] = function() { return new JsonResponseHandler; };
+			$this->app['whoops.handler'] = $this->app->share(function() { return new JsonResponseHandler; });
 		}
 		else
 		{
@@ -134,7 +134,7 @@ class ExceptionServiceProvider extends ServiceProvider {
 	{
 		$me = $this;
 		
-		$this->app['whoops.handler'] = function() use ($me)
+		$this->app['whoops.handler'] = $this->app->share(function() use ($me)
 		{
 			with($handler = new PrettyPageHandler)->setEditor('sublime');
 
@@ -147,7 +147,7 @@ class ExceptionServiceProvider extends ServiceProvider {
 			}
 
 			return $handler;
-		};
+		});
 	}
 
 	/**


### PR DESCRIPTION
Currently Whoops handlers are not shared through the IoC container, so in order to customize pre-set Whoops handlers, such as the handler responsible for displaying the error page, one must get the `Whoops\Run` instance, retrieve all the handlers, and find the handler we want.

This PR shares the `whoops.handler` service by default, making it easier to perform tasks on the default Whoops handler:

``` php
($app["whoops.handler"] instanceof Whoops\Handler\PrettyPageHandler)
  and $app["whoops.handler"]->setPageTitle("We get signal :(");
```
