### PR TITLE
[Whoops] Enable support for anchor elements in comment links

### DIFF
--- a/src/Illuminate/Exception/resources/pretty-page.css
+++ b/src/Illuminate/Exception/resources/pretty-page.css
@@ -9,6 +9,7 @@ body {
 }
   a {
     text-decoration: none;
+    color: #FE8A59;
   }
 
 .container{

--- a/src/Illuminate/Exception/resources/pretty-template.php
+++ b/src/Illuminate/Exception/resources/pretty-template.php
@@ -97,7 +97,7 @@
                       <?php extract($comment) ?>
                       <div class="frame-comment" id="comment-<?php echo $i . '-' . $commentNo ?>">
                         <span class="frame-comment-context"><?php echo $e($context) ?></span>
-                        <?php echo $e($comment) ?>
+                        <?php echo $e($comment, true) ?>
                       </div>
                     <?php endforeach ?>
                   </div>


### PR DESCRIPTION
Whoops supports URIs in frame comments, which it converts to clickable anchor elements*. This PR enables that feature in the custom Laravel template for the Whoops error page.

The change to the CSS makes links a lighter shade of orange, so they stand well against the dark color of the comments section.

\* `$e` (escape) will capture uris and convert them to anchor elements when the second argument is `true`.
