### PR TITLE
[Fix/Tweak] Bootstrap Paginator to remove the anchors on the disabled/current page(s)

### DIFF
--- a/src/Illuminate/Pagination/BootstrapPresenter.php
+++ b/src/Illuminate/Pagination/BootstrapPresenter.php
@@ -76,7 +76,7 @@ class BootstrapPresenter {
 			// for the link. These views use the "Twitter Bootstrap" styles by default.
 			if ($this->currentPage == $page)
 			{
-				$pages[] = '<li class="active"><a href="#">'.$page.'</a></li>';
+				$pages[] = '<li class="active"><span>'.$page.'</span></li>';
 			}
 			else
 			{
@@ -176,7 +176,7 @@ class BootstrapPresenter {
 		// when that is the case. Otherwise, we will give it an active "status".
 		if ($this->currentPage <= 1)
 		{
-			return '<li class="disabled"><a href="#">'.$text.'</a></li>';
+			return '<li class="disabled"><span>'.$text.'</span></li>';
 		}
 		else
 		{
@@ -199,7 +199,7 @@ class BootstrapPresenter {
 		// that is available, so we will make it the "next" link style disabled.
 		if ($this->currentPage >= $this->lastPage)
 		{
-			return '<li class="disabled"><a href="#">'.$text.'</a></li>';
+			return '<li class="disabled"><span>'.$text.'</span></li>';
 		}
 		else
 		{
@@ -216,7 +216,7 @@ class BootstrapPresenter {
 	 */
 	public function getDots()
 	{
-		return '<li class="disabled"><a href="#">...</a></li>';
+		return '<li class="disabled"><span>...</span></li>';
 	}
 
 	/**

--- a/tests/Pagination/PaginationBootstrapPresenterTest.php
+++ b/tests/Pagination/PaginationBootstrapPresenterTest.php
@@ -124,7 +124,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter = $this->getPresenter();
 		$output = $presenter->getFinish();
 
-		$this->assertEquals('<li class="disabled"><span>...</span></li><li class="active"><span>1</a></li><li><a href="http://foo.com?page=2">2</a></li>', $output);
+		$this->assertEquals('<li class="disabled"><span>...</span></li><li class="active"><span>1</span></li><li><a href="http://foo.com?page=2">2</a></li>', $output);
 	}
 
 

--- a/tests/Pagination/PaginationBootstrapPresenterTest.php
+++ b/tests/Pagination/PaginationBootstrapPresenterTest.php
@@ -115,7 +115,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter = $this->getPresenter();
 		$output = $presenter->getStart();
 
-		$this->assertEquals('<li class="active"><span>1</a></li><li><a href="http://foo.com?page=2">2</a></li><li class="disabled"><span>...</span></li>', $output);
+		$this->assertEquals('<li class="active"><span>1</span></li><li><a href="http://foo.com?page=2">2</a></li><li class="disabled"><span>...</span></li>', $output);
 	}
 
 

--- a/tests/Pagination/PaginationBootstrapPresenterTest.php
+++ b/tests/Pagination/PaginationBootstrapPresenterTest.php
@@ -34,7 +34,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter->setCurrentPage(1);
 		$content = $presenter->getPageRange(1, 2);
 
-		$this->assertEquals('<li class="active"><a href="#">1</a></li><li><a href="http://foo.com?page=2">2</a></li>', $content);
+		$this->assertEquals('<li class="active"><span>1</span></li><li><a href="http://foo.com?page=2">2</a></li>', $content);
 	}
 
 
@@ -83,8 +83,8 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 	public function testPreviousLinkCanBeRendered()
 	{
 		$output = $this->getPresenter()->getPrevious();
-		
-		$this->assertEquals('<li class="disabled"><a href="#">&laquo;</a></li>', $output);
+
+		$this->assertEquals('<li class="disabled"><span>&laquo;</span></li>', $output);
 
 		$presenter = $this->getPresenter();
 		$presenter->setCurrentPage(2);
@@ -100,7 +100,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter->setCurrentPage(2);
 		$output = $presenter->getNext();
 
-		$this->assertEquals('<li class="disabled"><a href="#">&raquo;</a></li>', $output);
+		$this->assertEquals('<li class="disabled"><span>&raquo;</span></li>', $output);
 
 		$presenter = $this->getPresenter();
 		$presenter->setCurrentPage(1);
@@ -115,7 +115,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter = $this->getPresenter();
 		$output = $presenter->getStart();
 
-		$this->assertEquals('<li class="active"><a href="#">1</a></li><li><a href="http://foo.com?page=2">2</a></li><li class="disabled"><a href="#">...</a></li>', $output);
+		$this->assertEquals('<li class="active"><span>1</a></li><li><a href="http://foo.com?page=2">2</a></li><li class="disabled"><span>...</span></li>', $output);
 	}
 
 
@@ -124,7 +124,7 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 		$presenter = $this->getPresenter();
 		$output = $presenter->getFinish();
 
-		$this->assertEquals('<li class="disabled"><a href="#">...</a></li><li class="active"><a href="#">1</a></li><li><a href="http://foo.com?page=2">2</a></li>', $output);
+		$this->assertEquals('<li class="disabled"><span>...</span></li><li class="active"><span>1</a></li><li><a href="http://foo.com?page=2">2</a></li>', $output);
 	}
 
 


### PR DESCRIPTION
This PR removes the `<a href="#">` from the pagination `links` from the current active page and from the disabled ones, since there is no point on having them, we should just use `<span>` instead.
