### PR TITLE
Fix issue with dropIndex/dropUnique generating invalid index names

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -223,7 +223,7 @@ class Blueprint {
 	 */
 	public function dropPrimary($index = null)
 	{
-		return $this->dropIndexCommand('dropPrimary', $index);
+		return $this->dropIndexCommand('dropPrimary', 'primary', $index);
 	}
 
 	/**
@@ -234,7 +234,7 @@ class Blueprint {
 	 */
 	public function dropUnique($index)
 	{
-		return $this->dropIndexCommand('dropUnique', $index);
+		return $this->dropIndexCommand('dropUnique', 'unique', $index);
 	}
 
 	/**
@@ -245,7 +245,7 @@ class Blueprint {
 	 */
 	public function dropIndex($index)
 	{
-		return $this->dropIndexCommand('dropIndex', $index);
+		return $this->dropIndexCommand('dropIndex', 'index', $index);
 	}
 
 	/**
@@ -256,7 +256,7 @@ class Blueprint {
 	 */
 	public function dropForeign($index)
 	{
-		return $this->dropIndexCommand('dropForeign', $index);
+		return $this->dropIndexCommand('dropForeign', 'foreign', $index);
 	}
 
 	/**
@@ -591,7 +591,7 @@ class Blueprint {
 	 * @param  string|array  $index
 	 * @return \Illuminate\Support\Fluent
 	 */
-	protected function dropIndexCommand($type, $index)
+	protected function dropIndexCommand($command, $type, $index)
 	{
 		$columns = array();
 
@@ -602,10 +602,10 @@ class Blueprint {
 		{
 			$columns = $index;
 
-			$index = null;
+			$index = $this->createIndexName($type, $columns);
 		}
 
-		return $this->indexCommand($type, $columns, $index);
+		return $this->indexCommand($command, $columns, $index);
 	}
 
 	/**

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -37,4 +37,18 @@ class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('users_foo_index', $commands[0]->index);
 	}
 
+
+	public function testDropIndexDefaultNames() 
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->dropUnique(array('foo', 'bar'));
+		$commands = $blueprint->getCommands();
+		$this->assertEquals('users_foo_bar_unique', $commands[0]->index);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->dropIndex(array('foo'));
+		$commands = $blueprint->getCommands();
+		$this->assertEquals('users_foo_index', $commands[0]->index);
+	}
+
 }


### PR DESCRIPTION
Drop index commands were generating names such as `users_foo_bar_dropunique` since type was being used to generate names.

Updated dropIndexCommand to accept both command and type parameters.
