### PR TITLE
Allow the iron.io cloud host to be set via the queue config file.

### DIFF
--- a/src/Illuminate/Queue/Connectors/IronConnector.php
+++ b/src/Illuminate/Queue/Connectors/IronConnector.php
@@ -45,7 +45,7 @@ class IronConnector implements ConnectorInterface {
 		$ironConfig = array('token' => $config['token'], 'project_id' => $config['project']);
 
         if (isset($config ['host']))
-            $ironConfig['host'] = $config ['host'];
+            $ironConfig['host'] = $config['host'];
 
 		return new IronQueue(new IronMQ($ironConfig), $this->crypt, $this->request, $config['queue']);
 	}

--- a/src/Illuminate/Queue/Connectors/IronConnector.php
+++ b/src/Illuminate/Queue/Connectors/IronConnector.php
@@ -44,6 +44,9 @@ class IronConnector implements ConnectorInterface {
 	{
 		$ironConfig = array('token' => $config['token'], 'project_id' => $config['project']);
 
+        if (isset($config ['host']))
+            $ironConfig['host'] = $config ['host'];
+
 		return new IronQueue(new IronMQ($ironConfig), $this->crypt, $this->request, $config['queue']);
 	}
 

--- a/src/Illuminate/Queue/Connectors/IronConnector.php
+++ b/src/Illuminate/Queue/Connectors/IronConnector.php
@@ -44,8 +44,8 @@ class IronConnector implements ConnectorInterface {
 	{
 		$ironConfig = array('token' => $config['token'], 'project_id' => $config['project']);
 
-        if (isset($config ['host']))
-            $ironConfig['host'] = $config['host'];
+        	if (isset($config['host']))
+            		$ironConfig['host'] = $config['host'];
 
 		return new IronQueue(new IronMQ($ironConfig), $this->crypt, $this->request, $config['queue']);
 	}


### PR DESCRIPTION
This will default to 'mq-aws-us-east-1.iron.io' if not set.  See http://dev.iron.io/mq/reference/clouds/ for more info.
