### PR TITLE
Allow $model->visible to declare custom accessors

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1763,8 +1763,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	protected function getAccessibleAttributes()
 	{
-		// First merge the real attributes with any custom accessors
-		$attributes = array_merge( array_fill_keys($this->getMutatedAttributes(), null), $this->attributes );
+		$attributes = array_merge(array_fill_keys($this->getMutatedAttributes(), null), $this->attributes);
 
 		if (count($this->visible) > 0)
 		{

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1763,12 +1763,15 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	protected function getAccessibleAttributes()
 	{
+		// First merge the real attributes with any custom accessors
+		$attributes = array_merge( array_fill_keys($this->getMutatedAttributes(), null), $this->attributes );
+
 		if (count($this->visible) > 0)
 		{
-			return array_intersect_key($this->attributes, array_flip($this->visible));
+			return array_intersect_key($attributes, array_flip($this->visible));
 		}
 
-		return array_diff_key($this->attributes, array_flip($this->hidden));
+		return array_diff_key($attributes, array_flip($this->hidden));
 	}
 
 	/**


### PR DESCRIPTION
Scenario: An eloquent model has a custom accessor that we want included when converting the model to an array.

``` php
class User extends Eloquent {

    // first and last name are stored in the DB, full name isn't

    protected $visible = array('first_name','last_name','full_name');

    public function getFullNameAttribute() {
        return $this->first_name . ' ' . $this->last_name;
    }

}

...

$user = User::find($id);
dd($user->toJson());

```

This will return:

```
{"first_name":"Colin","last_name":"Viebrock"}
```

The `full_name` isn't included because that attribute doesn't already exist in the model.  i.e. `toArray()` and `toJson()` only operate on existing attributes, or custom accessors that modify existing attributes, but not custom accessors that create new values.

This patch fixes it, and returns:

```
{"first_name":"Colin","last_name":"Viebrock","full_name":"Colin Viebrock"}
```
