### PR TITLE
Add Str::possessive($value)

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -172,6 +172,17 @@ class Str {
 	{
 		return Pluralizer::plural($value, $count);
 	}
+	
+	/**
+	 * Get the possessive form of an English word.
+	 *
+	 * @param  string  $value
+	 * @return string
+	 */
+	public static function possessive($value)
+	{
+		return $value."'".($value[strlen($value) - 1] != 's' ? 's' : '');
+	}
 
 	/**
 	 * Generate a more truly "random" alpha-numeric string.


### PR DESCRIPTION
Add a function to get the possessive form of an English word. Properly handle strings ending with the character 's'.

Useful for those of us working with people's names.

``` PHP
Str::possessive('Taylor');   // Taylor's
Str::possessive('Chris');    // Chris'
```
