### PR TITLE
Fixes #806 (and duplicate #1215).

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -388,7 +388,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function createMatcher($function)
 	{
-		return '/(?<!\w)(\s*)@'.$function.'(\s*\(.*\))/';
+		return '/(?<!\w)(\s*)@'.$function.'(\s*\(.*?\))/';
 	}
 
 	/**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -388,7 +388,14 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function createMatcher($function)
 	{
-		return '/(?<!\w)(\s*)@'.$function.'(\s*\(.*?\))/';
+		$pattern = '/(?<!\w)(\s*)@'.$function.'(\s*\(.*\))/';
+
+		if ($function == 'lang')
+		{
+			$pattern = '/(?<!\w)(\s*)@'.$function.'(\s*\(.*?\))/';
+		}
+
+		return $pattern;
 	}
 
 	/**


### PR DESCRIPTION
Fix a greedy regexp to allow multiple @lang() instances per line
