### PR TITLE
Add implode method to Collection class and Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1063,6 +1063,22 @@ class Builder {
 	}
 
 	/**
+	 * Concatenate values of a given column as a string.
+	 *
+	 * @param  string  $column
+	 * @param  string  $glue
+	 * @return string
+	 */
+	public function implode($column, $glue = null)
+	{
+		$values = $this->lists($column);
+
+		if (is_null($glue)) return implode($values);
+
+		return implode($glue, $values);
+	}
+
+	/**
 	 * Get the columns that should be used in a list array.
 	 *
 	 * @param  string  $column

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -363,6 +363,22 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Concatenate values of a given key as a string.
+	 *
+	 * @param  string  $value
+	 * @param  string  $glue
+	 * @return string
+	 */
+	public function implode($value, $glue = null)
+	{
+		$values = $this->lists($value);
+
+		if (is_null($glue)) return implode($values);
+
+		return implode($glue, $values);
+	}
+
+	/**
 	 * Determine if the collection is empty or not.
 	 *
 	 * @return bool

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -413,6 +413,30 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testImplode()
+	{
+		// Test without glue.
+		$builder = $this->getBuilder();
+		$builder->getConnection()->shouldReceive('select')->once()->andReturn(array(array('foo' => 'bar'), array('foo' => 'baz')));
+		$builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, array(array('foo' => 'bar'), array('foo' => 'baz')))->andReturnUsing(function($query, $results)
+		{
+			return $results;
+		});
+		$results = $builder->from('users')->where('id', '=', 1)->implode('foo');
+		$this->assertEquals('barbaz', $results);
+
+		// Test with glue.
+		$builder = $this->getBuilder();
+		$builder->getConnection()->shouldReceive('select')->once()->andReturn(array(array('foo' => 'bar'), array('foo' => 'baz')));
+		$builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, array(array('foo' => 'bar'), array('foo' => 'baz')))->andReturnUsing(function($query, $results)
+		{
+			return $results;
+		});
+		$results = $builder->from('users')->where('id', '=', 1)->implode('foo', ',');
+		$this->assertEquals('bar,baz', $results);
+	}
+
+
 	public function testPaginateCorrectlyCreatesPaginatorInstance()
 	{
 		$connection = m::mock('Illuminate\Database\ConnectionInterface');

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -195,4 +195,12 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('foo', 'bar'), $data->lists('email'));
 	}
 
+
+	public function testImplode()
+	{
+		$data = new Collection(array(array('name' => 'taylor', 'email' => 'foo'), array('name' => 'dayle', 'email' => 'bar')));
+		$this->assertEquals('foobar', $data->implode('email'));
+		$this->assertEquals('foo,bar', $data->implode('email', ','));
+	}
+
 }


### PR DESCRIPTION
By re-using the `lists` function on various classes we can add some other useful functionality. I've added an `implode` function to the Collection class and the Query Builder class. This makes it easy to concatentate values.

Instead of having to do this:

```
$values = $collection->lists('title');

echo implode(',', $values); // taylor,dayle
```

You just can do this:

```
echo $collection->implode('title', ','); // taylor,dayle
```

Or just paste them together by omitting the delimiter:

```
echo $collection->implode('title'); // taylordayle
```
## Use Cases
### Tags

Use it to lists tag titles quickly:

```
echo $tags->implode('title', ',');
```
### List values

Create a quick html list of values.

```
echo '<ul><li>' . $collection->implode('title', '</li><li>') . '</li></ul>';
```
