### PR TITLE
Fix pagination when using distinct() in Query or Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -175,7 +175,7 @@ class Builder {
 
 		$paginator = $this->query->getConnection()->getPaginator();
 
-		if (isset($this->query->groups))
+		if (isset($this->query->groups) || isset($this->query->distinct))
 		{
 			return $this->groupedPaginate($paginator, $perPage, $columns);
 		}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1109,7 +1109,7 @@ class Builder {
 	{
 		$paginator = $this->connection->getPaginator();
 
-		if (isset($this->groups))
+		if (isset($this->groups) || isset($this->distinct))
 		{
 			return $this->groupedPaginate($paginator, $perPage, $columns);
 		}


### PR DESCRIPTION
Pagination works correcty when using groupBy(), but not when distinct() is used. I think this patch fixes this issue, but please have a good look at it as I don't know the ins and outs of L4.

I realize it's still not a very efficient solution, but this fixes behaviour when using distinct(). Better a slow result that a wrong result. A solution using SQL_CALC_FOUND_ROWS or similar is preferred.
