### PR TITLE
Cast Paginator::currentPage to an integer

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -144,7 +144,7 @@ class Paginator implements ArrayAccess, Countable, IteratorAggregate {
 			return $lastPage > 0 ? $lastPage : 1;
 		}
 
-		return $this->isValidPageNumber($page) ? $page : 1;
+		return $this->isValidPageNumber($page) ? (int) $page : 1;
 	}
 
 	/**


### PR DESCRIPTION
Not a huge deal, but it ensures getCurrentPage() returns an int instead of a numeric string.

Sorry if this is the wrong branch, couldn't work out if I should be commiting on `master` or `4.0`.
