### PR TITLE
Use freshTimestamp method when updating columns in Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -735,7 +735,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		if ($this->softDelete)
 		{
-			$query->update(array(static::DELETED_AT => new DateTime));
+			$query->update(array(static::DELETED_AT => $this->freshTimestamp()));
 		}
 		else
 		{

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1,6 +1,5 @@
 <?php namespace Illuminate\Database\Eloquent\Relations;
 
-use DateTime;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
@@ -343,7 +342,7 @@ class BelongsToMany extends Relation {
 	{
 		$key = $this->getRelated()->getKeyName();
 
-		$columns = array($this->getRelatedUpdated() => new DateTime);
+		$columns = $this->getRelatedUpdated();
 
 		// If we actually have IDs for the relation, we will run the query to update all
 		// the related model's timestamps, to make sure these all reflect the changes
@@ -709,7 +708,7 @@ class BelongsToMany extends Relation {
 	 * @return void
 	 */
 	public function touchIfTouching()
-	{ 
+	{
 	 	if ($this->touchingParent()) $this->getParent()->touch();
 
 	 	if ($this->getParent()->touches($this->relationName)) $this->touch();
@@ -822,16 +821,6 @@ class BelongsToMany extends Relation {
 	public function withTimestamps()
 	{
 		return $this->withPivot($this->createdAt(), $this->updatedAt());
-	}
-
-	/**
-	 * Get the related model's updated at column name.
-	 *
-	 * @return string
-	 */
-	public function getRelatedUpdated()
-	{
-		return $this->getRelated()->getUpdatedAtColumn();
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -225,7 +225,7 @@ abstract class HasOneOrMany extends Relation {
 	{
 		if ($this->related->usesTimestamps())
 		{
-			$attributes[$this->updatedAt()] = $this->related->freshTimestamp();
+			$attributes = array_merge($attributes, $this->getRelatedUpdated());
 		}
 
 		return $this->query->update($attributes);

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -95,8 +95,9 @@ abstract class Relation {
 	public function touch()
 	{
 		$column = $this->getRelated()->getUpdatedAtColumn();
+		$time = $this->getRelated()->freshTimestamp();
 
-		$this->rawUpdate(array($column => new DateTime));
+		$this->rawUpdate(array($column => $time));
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -1,7 +1,5 @@
 <?php namespace Illuminate\Database\Eloquent\Relations;
 
-use DateTime;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
@@ -94,10 +92,7 @@ abstract class Relation {
 	 */
 	public function touch()
 	{
-		$column = $this->getRelated()->getUpdatedAtColumn();
-		$time = $this->getRelated()->freshTimestamp();
-
-		$this->rawUpdate(array($column => $time));
+		$this->rawUpdate($this->getRelatedUpdated());
 	}
 
 	/**
@@ -133,7 +128,7 @@ abstract class Relation {
 		// When a model is "soft deleting", the "deleted at" where clause will be the
 		// first where clause on the relationship query, so we will actually clear
 		// the second where clause as that is the lazy loading relations clause.
-		if ($this->query->getModel()->isSoftDeleting())
+		if ($this->related->isSoftDeleting())
 		{
 			$this->removeSecondWhereClause();
 		}
@@ -271,6 +266,19 @@ abstract class Relation {
 	public function getRelated()
 	{
 		return $this->related;
+	}
+
+	/**
+	 * Get the related model's updated at column with current timestamp.
+	 *
+	 * @return array
+	 */
+	public function getRelatedUpdated()
+	{
+		$column = $this->related->getUpdatedAtColumn();
+		$time = $this->related->freshTimestamp();
+
+		return array($column => $time);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -32,7 +32,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		// Make sure the foreign keys were set on the pivot models...
 		$this->assertEquals('user_id', $results[0]->pivot->getForeignKey());
 		$this->assertEquals('role_id', $results[0]->pivot->getOtherKey());
-		
+
 		$this->assertEquals('taylor', $results[0]->name);
 		$this->assertEquals(1, $results[0]->pivot->user_id);
 		$this->assertEquals(2, $results[0]->pivot->role_id);
@@ -132,7 +132,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
 		$relation->expects($this->once())->method('touchIfTouching');
-		
+
 		$relation->attach(2, array('foo' => 'bar'));
 	}
 
@@ -167,7 +167,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
 		$relation->getParent()->shouldReceive('freshTimestamp')->once()->andReturn('time');
 		$relation->expects($this->once())->method('touchIfTouching');
-		
+
 		$relation->attach(2, array('foo' => 'bar'));
 	}
 
@@ -267,12 +267,13 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 	{
 		$relation = $this->getRelation();
 		$relation->getRelated()->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+		$relation->getRelated()->shouldReceive('freshTimestamp')->andReturn(100);
 		$relation->getRelated()->shouldReceive('getQualifiedKeyName')->andReturn('table.id');
 		$relation->getQuery()->shouldReceive('select')->once()->with('table.id')->andReturn($relation->getQuery());
 		$relation->getQuery()->shouldReceive('lists')->once()->with('id')->andReturn(array(1, 2, 3));
 		$relation->getRelated()->shouldReceive('newQuery')->once()->andReturn($query = m::mock('StdClass'));
 		$query->shouldReceive('whereIn')->once()->with('id', array(1, 2, 3))->andReturn($query);
-		$query->shouldReceive('update')->once()->with(array('updated_at' => new DateTime));
+		$query->shouldReceive('update')->once()->with(array('updated_at' => 100));
 
 		$relation->touch();
 	}

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -27,6 +27,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 	{
 		$relation = $this->getRelation();
 		$relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
+		$relation->getRelated()->shouldReceive('getUpdatedAtColumn')->once()->andReturn('updated_at');
 		$relation->getRelated()->shouldReceive('freshTimestamp')->once()->andReturn(100);
 		$relation->getQuery()->shouldReceive('update')->once()->with(array('foo' => 'bar', 'updated_at' => 100))->andReturn('results');
 

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -40,6 +40,7 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 	{
 		$relation = $this->getRelation();
 		$relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
+		$relation->getRelated()->shouldReceive('getUpdatedAtColumn')->once()->andReturn('updated_at');
 		$relation->getRelated()->shouldReceive('freshTimestamp')->once()->andReturn(100);
 		$relation->getQuery()->shouldReceive('update')->once()->with(array('foo' => 'bar', 'updated_at' => 100))->andReturn('results');
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -38,7 +38,8 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
 		$relation = new HasOne($builder, $parent, 'foreign_key');
 		$related->shouldReceive('getTable')->andReturn('table');
 		$related->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-		$builder->shouldReceive('update')->once()->with(array('updated_at' => new DateTime));
+		$related->shouldReceive('freshTimestamp')->andReturn(100);
+		$builder->shouldReceive('update')->once()->with(array('updated_at' => 100));
 
 		$relation->touch();
 	}


### PR DESCRIPTION
In some cases instead of using `freshTimestamp()` method when updating default timestamp columns for model only `new Datetime` have been used.
