### PR TITLE
make pretend a mail config param (fixes #1558)

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -45,6 +45,12 @@ class MailServiceProvider extends ServiceProvider {
 				$mailer->alwaysFrom($from['address'], $from['name']);
 			}
 
+			// set the pretend flag			
+			$pretend = $app['config']['mail.pretend'];
+			if ( $pretend !== null ) {
+				$mailer->pretend($pretend);
+			}
+
 			return $mailer;
 		});
 	}


### PR DESCRIPTION
Add the ability to specify 'pretend' mode in config parameters. This fixes the queued mail case, as there it wasn't picking up programmatic changes to the pretend flag.
