### PR TITLE
Cache createApcDriver Not Adding Prefix

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -11,7 +11,7 @@ class CacheManager extends Manager {
 	 */
 	protected function createApcDriver()
 	{
-		return $this->repository(new ApcStore(new ApcWrapper));
+		return $this->repository(new ApcStore(new ApcWrapper), $this->app['config']['cache.prefix']);
 	}
 
 	/**


### PR DESCRIPTION
Noticed that the prefix was not being used with APC on my server.
