### PR TITLE
Add array_sort helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -153,6 +153,38 @@ if ( ! function_exists('array_fetch'))
 	}
 }
 
+if ( ! function_exists('array_sort'))
+{
+	/**
+	 * Sort a multidimensional array by a column value.
+	 *
+	 * @param  array   $array
+	 * @param  string  $column
+	 * @param  string  $order
+	 * @return array
+	 */
+	function array_sort($array, $column, $order = 'asc')
+	{
+		$keys = array();
+		
+		foreach ($array as $key => $value)
+		{
+			$keys[$key] = $value[$column];
+		}
+		
+		switch ($order) 
+		{
+		    case 'asc':
+		        array_multisort($keys, SORT_ASC, $array);
+		        break;
+		    case 'desc':
+		        array_multisort($keys, SORT_DESC, $array);
+		}
+
+		return $array;
+	}
+}
+
 if ( ! function_exists('array_first'))
 {
 	/**

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -107,6 +107,45 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(array('#foo', '#bar'), array('#baz')), array_fetch($data, 'comments.tags'));
 	}
 
+	public function testArraySort()
+	{
+		$data = array(
+			array(
+				'name' => 'baz'
+			),
+			array(
+				'name' => 'foo'
+			),
+			array(
+				'name' => 'bar'
+			)						
+		);	
+		
+		$this->assertEquals(array(
+			array(
+				'name' => 'bar'
+			),
+			array(
+				'name' => 'baz'
+			),
+			array(
+				'name' => 'foo'
+			)			
+		), array_sort($data, 'name'));
+
+		$this->assertEquals(array(
+			array(
+				'name' => 'foo'
+			),
+			array(
+				'name' => 'baz'
+			),
+			array(
+				'name' => 'bar'
+			)			
+		), array_sort($data, 'name', 'desc'));
+	}
+
 
 	public function testArrayFlatten()
 	{


### PR DESCRIPTION
The array_sort helper ("array_sort" may be too vague...) sorts a multidimensional array by a column value.

For example:

```
$data = array(
    array('name' => 'baz'),
    array('name' => 'foo'),
    array('name' => 'bar')                      
);
return array_sort($data, 'name'); 
```

Would return the nested arrays in ascending order by the value of the 'name' column.

```
Array
(
    [0] => Array
        (
            [name] => bar
        )
    [1] => Array
        (
            [name] => baz
        )
    [2] => Array
        (
            [name] => foo
        )
)
```

The optional $order parameter could be converted to an array later on to allow for more sorting options like numeric vs string sorting. For now, it just accepts a string of 'asc' or 'desc'...
