### PR TITLE
Allow for checking whether there is any old input

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -60,7 +60,7 @@ class Store extends SymfonySession {
 	 * @param  string  $key
 	 * @return bool
 	 */
-	public function hasOldInput($key)
+	public function hasOldInput($key = null)
 	{
 		return ! is_null($this->getOldInput($key));
 	}


### PR DESCRIPTION
The `$key` parameter was not optional until now.
