### PR TITLE
updated FormBuilder class to prevent passwords from being filled from flash

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -217,7 +217,7 @@ class FormBuilder {
 		// in the model instance if one is set. Otherwise we will just use empty.
 		$id = $this->getIdAttribute($name, $options);
 
-		if ($type != 'file')
+		if ($type != 'file' and $type != 'password')
 		{
 			$value = $this->getValueAttribute($name, $value);
 		}

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -70,6 +70,17 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<input class="span2" name="foobar" type="date">', $form3);
 	}
 
+	public function testPasswordsNotFilled()
+	{
+		$session = m::mock('Illuminate\Session\Store');
+		$session->shouldReceive('hasOldInput')->with('password')->andReturn(true);
+		$session->shouldReceive('getOldInput')->with('password')->andReturn('mypass');
+		$this->formBuilder->setSessionStore($session);
+
+		$form1 = $this->formBuilder->password('password');
+
+		$this->assertEquals('<input name="password" type="password" value="">', $form1);
+	}
 
 	public function testFormText()
 	{
@@ -144,7 +155,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testSelect()
 	{
 		$select = $this->formBuilder->select(
-			'size', 
+			'size',
 			array('L' => 'Large', 'S' => 'Small')
 		);
 		$this->assertEquals($select, '<select name="size"><option value="L">Large</option><option value="S">Small</option></select>');
@@ -153,7 +164,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
 		$select = $this->formBuilder->select(
 			'size',
-			 array('L' => 'Large', 'S' => 'Small'), 
+			 array('L' => 'Large', 'S' => 'Small'),
 			 'L'
 		);
 		$this->assertEquals($select, '<select name="size"><option value="L" selected="selected">Large</option><option value="S">Small</option></select>');
@@ -161,8 +172,8 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
 
 		$select = $this->formBuilder->select(
-			'size', 
-			array('L' => 'Large', 'S' => 'Small'), 
+			'size',
+			array('L' => 'Large', 'S' => 'Small'),
 			null,
 			array('class' => 'class-name', 'id' => 'select-id')
 		);


### PR DESCRIPTION
Passwords were filling from flash data when redirecting using withInput()

I believe that this is a security issue since all it takes is for anyone to use withInput() anywhere that a password is referenced. 

The password isn't being set from Form::model(). It's being done automatically. Many inexperienced developers would simply not even know where it's coming from or assume that it's their browser cache.
