### PR TITLE
Add missing comma to the changes.json JSON array

### DIFF
--- a/src/Illuminate/Foundation/changes.json
+++ b/src/Illuminate/Foundation/changes.json
@@ -2,7 +2,7 @@
 	"4.1.x": [
 		{"message": "Added implode method to query builder and Colletion class.", "backport": "4.0.x"},
 		{"message": "Fixed bug that caused Model->push method to fail.", "backport": "4.0.x"},
-		{"message": "Make session cookie HttpOnly by default.", "backport": "4.0.x"}
+		{"message": "Make session cookie HttpOnly by default.", "backport": "4.0.x"},
 		{"message": "Added mail.pretend configuration option.", "backport": "4.0.x"}
 	]
 }


### PR DESCRIPTION
Fixes the following error:

```
$ php artisan changes
{"error":{"type":"ErrorException","message":"Argument 1 passed to Illuminate\\Foundation\\Console\\ChangesCommand::getChangeVersion() must be of the type array, null given, called in \/Users\/andrew\/Sites\/app.local.leve.rs\/vendor\/laravel\/framework\/src\/Illuminate\/Foundation\/Console\/ChangesCommand.php on line 30 and defined","file":"\/Users\/andrew\/Sites\/app.local.leve.rs\/vendor\/laravel\/framework\/src\/Illuminate\/Foundation\/Console\/ChangesCommand.php","line":77}}
```

Also thought about writing a quick unit test for it to make sure it can be decoded properly. But there aren't any unit tests for any of the commands to tack onto.
