### PR TITLE
Remove unneeded use() statement.

### DIFF
--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -79,9 +79,7 @@ class SessionServiceProvider extends ServiceProvider {
 	 */
 	protected function registerSessionEvents()
 	{
-		$app = $this->app;
-
-		$config = $app['config']['session'];
+		$config = $this->app['config']['session'];
 
 		// The session needs to be started and closed, so we will register a before
 		// and after events to do all stuff for us. This will manage the loading
@@ -101,8 +99,6 @@ class SessionServiceProvider extends ServiceProvider {
 	 */
 	protected function registerBootingEvent()
 	{
-		$app = $this->app;
-
 		$this->app->booting(function($app)
 		{
 			$app['session']->start();

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -103,7 +103,7 @@ class SessionServiceProvider extends ServiceProvider {
 	{
 		$app = $this->app;
 
-		$this->app->booting(function($app) use ($app)
+		$this->app->booting(function($app)
 		{
 			$app['session']->start();
 		});


### PR DESCRIPTION
That closure already gets passed the application instance as first parameter.
