### PR TITLE
Simplify array creation.

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -302,7 +302,7 @@ class Guard {
 	{
 		if ($this->events)
 		{
-			$payload = array_values(compact('credentials', 'remember', 'login'));
+			$payload = array($credentials, $remember, $login);
 
 			$this->events->fire('auth.attempt', $payload);
 		}


### PR DESCRIPTION
You can even use `func_get_args()` if you're lazy.
