### PR TITLE
Added support to MySQL's SET type.

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -508,6 +508,18 @@ class Blueprint {
 	}
 
 	/**
+	 * Create a new set column on the table.
+	 *
+	 * @param  string  $column
+	 * @param  array   $allowed
+	 * @return \Illuminate\Support\Fluent
+	 */
+	public function set($column, array $allowed)
+	{
+		return $this->addColumn('set', $column, compact('allowed'));
+	}
+
+	/**
 	 * Create a new date column on the table.
 	 *
 	 * @param  string  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -387,6 +387,17 @@ class MySqlGrammar extends Grammar {
 	}
 
 	/**
+	 * Create the column definition for a set type.
+	 *
+	 * @param  \Illuminate\Support\Fluent  $column
+	 * @return string
+	 */
+	protected function typeSet(Fluent $column)
+	{
+		return "set('".implode("', '", $column->allowed)."')";
+	}
+
+	/**
 	 * Create the column definition for a date type.
 	 *
 	 * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -340,6 +340,17 @@ class PostgresGrammar extends Grammar {
 	}
 
 	/**
+	 * Create the column definition for an set type.
+	 *
+	 * @param  \Illuminate\Support\Fluent  $column
+	 * @return string
+	 */
+	protected function typeSet(Fluent $column)
+	{
+		return 'varchar(255)';
+	}
+
+	/**
 	 * Create the column definition for a date type.
 	 *
 	 * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -404,6 +404,17 @@ class SQLiteGrammar extends Grammar {
 	}
 
 	/**
+	 * Create the column definition for a set type.
+	 *
+	 * @param  \Illuminate\Support\Fluent  $column
+	 * @return string
+	 */
+	protected function typeSet(Fluent $column)
+	{
+		return 'varchar';
+	}
+
+	/**
 	 * Create the column definition for a date type.
 	 *
 	 * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -336,6 +336,17 @@ class SqlServerGrammar extends Grammar {
 	}
 
 	/**
+	 * Create the column definition for a enum type.
+	 *
+	 * @param  \Illuminate\Support\Fluent  $column
+	 * @return string
+	 */
+	protected function typeSet(Fluent $column)
+	{
+		return 'nvarchar(255)';
+	}
+
+	/**
 	 * Create the column definition for a date type.
 	 *
 	 * @param  \Illuminate\Support\Fluent  $column


### PR DESCRIPTION
Added support to MySQL SET type, so now it can be used in Schema Builder.

``` php
Schema::create('users', function($table)
{
    $table->increments('id');

    $table->set('column', array('value_1', 'value_2', 'value_3'))->default('value_2');

});
```

For Postgres, SQLite and SqlServer, that do not support the SET type, I replicated the way they work with the ENUM type.
