### PR TITLE
Query logger shouldn't deal with time formatting

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -544,7 +544,7 @@ class Connection implements ConnectionInterface {
 	 */
 	protected function getElapsedTime($start)
 	{
-		return number_format((microtime(true) - $start) * 1000, 2);
+		return round((microtime(true) - $start) * 1000,2);
 	}
 
 	/**


### PR DESCRIPTION
The query time in logger should not use number_format. With times >1000ms a comma is added to the number, e.g. 1,203.34. IMO the logger shouldn't care about the format, it should store the value in a workable way. Otherwise packages that use the information have a hard time to e.g. calculate the sum of times.

Example: https://github.com/loic-sharma/profiler/issues/30

I propose to either ditch the number_format, or, as shown, to round with 2 decimals, which is probably the perfect compromise.
