### PR TITLE
UrlGenerator to accept extra parameters

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -222,7 +222,7 @@ class UrlGenerator {
 			$difference = count($keys) - count($params);
 
 			$params += array_fill(count($params), $difference, null);
-		}else{
+		} else {
 			
 			$extra_parameters = array_slice($params,count($keys));
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -224,7 +224,7 @@ class UrlGenerator {
 			$params += array_fill(count($params), $difference, null);
 		} else {
 			
-			$extra_parameters = array_slice($params,count($keys));
+			$extra_parameters = array_slice($params, count($keys));
 
 			$keys += array_keys($extra_parameters);
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -230,7 +230,7 @@ class UrlGenerator {
 
 			$params += array_values($extra_parameters);
 
-                }
+		}
 
 		return array_combine($keys, $params);
 	}

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -222,7 +222,15 @@ class UrlGenerator {
 			$difference = count($keys) - count($params);
 
 			$params += array_fill(count($params), $difference, null);
-		}
+		}else{
+			
+			$extra_parameters = array_slice($params,count($keys));
+
+			$keys += array_keys($extra_parameters);
+
+			$params += array_values($extra_parameters);
+
+                }
 
 		return array_combine($keys, $params);
 	}

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -223,13 +223,11 @@ class UrlGenerator {
 
 			$params += array_fill(count($params), $difference, null);
 		} else {
-			
 			$extra_parameters = array_slice($params, count($keys));
 
 			$keys += array_keys($extra_parameters);
 
 			$params += array_values($extra_parameters);
-
 		}
 
 		return array_combine($keys, $params);


### PR DESCRIPTION
Symfony2's UrlGenerator accepts extra parameters and extra params are added as query string to the URL. So should we.
### Example:

routes.php:

``` php
Route::get('testroute/{id}', array('as'=>'testroute',function($id)
{
    return 'This is :'.$id . 
        'And this is QS : '. $_SERVER['QUERY_STRING'];
}));
```

the only parameter is {id}. but if we post 2 parameters to url builder like this:

``` php
return URL::route('testroute',array('id'=>999,'diren'=>'geziparki'));
```

generated URL will be:
`/testroute/999?diren=geziparki`

This is so useful with strict route definitions like in `Route::resource` controllers.
