### PR TITLE
Add option that allows you to disable detaching of current records

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -453,9 +453,10 @@ class BelongsToMany extends Relation {
 	 * Sync the intermediate tables with a list of IDs.
 	 *
 	 * @param  array  $ids
+	 * @param  bool   $detach
 	 * @return void
 	 */
-	public function sync(array $ids)
+	public function sync(array $ids, $detach = true)
 	{
 		// First we need to attach any of the associated models that are not currently
 		// in this joining table. We'll spin through the given IDs, checking to see
@@ -464,14 +465,17 @@ class BelongsToMany extends Relation {
 
 		$records = $this->formatSyncList($ids);
 
-		$detach = array_diff($current, array_keys($records));
-
-		// Next, we will take the differences of the currents and given IDs and detach
-		// all of the entities that exist in the "current" array but are not in the
-		// the array of the IDs given to the method which will complete the sync.
-		if (count($detach) > 0)
+		if($detach)
 		{
-			$this->detach($detach);
+			$detach = array_diff($current, array_keys($records));
+
+			// Next, we will take the differences of the currents and given IDs and detach
+			// all of the entities that exist in the "current" array but are not in the
+			// the array of the IDs given to the method which will complete the sync.
+			if (count($detach) > 0)
+			{
+				$this->detach($detach);
+			}
 		}
 
 		// Now we are finally ready to attach the new records. Note that we'll disable
@@ -709,7 +713,7 @@ class BelongsToMany extends Relation {
 	 * @return void
 	 */
 	public function touchIfTouching()
-	{ 
+	{
 	 	if ($this->touchingParent()) $this->getParent()->touch();
 
 	 	if ($this->getParent()->touches($this->relationName)) $this->touch();


### PR DESCRIPTION
The BelongsToMany relation supports sync, attach and detach.
But there is no option to attach only new records. If you use attach() it will create duplicate entries in the relationships table.

This pull request will allow you to sync but keep existing relations.

Table

``` sql
id   project_id   user_id
1    2               10
2    2               20
3    2               30
```

Code

``` php
// Normal sync 
$project->users()->sync([10]);
```

Result

``` sql
id   project_id   user_id
1    2               10
```

Code

``` php
// Sync but with detaching disabled
$project->users()->sync([30, 40], false);
```

Result

``` sql
id   project_id   user_id
1    2               10
2    2               20
3    2               30
4    2               40
```
