### PR TITLE
Container: use default value for unbuildable optional dependencies if available

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -340,15 +340,29 @@ class Container implements ArrayAccess {
 			$dependency = $parameter->getClass();
 
 			// If the class is null, it means the dependency is a string or some other
-			// primitive type which we can not resolve since it is not a class and
-			// we'll just bomb out with an error since we have no-where to go.
+			// primitive type which we can not resolve since it is not a class, so
+			// check if there is a default value as a last resort.
 			if (is_null($dependency))
 			{
 				$dependencies[] = $this->resolveNonClass($parameter);
 			}
 			else
 			{
-				$dependencies[] = $this->make($dependency->name);
+				try
+				{
+					$dependencies[] = $this->make($dependency->name);
+				}
+				catch (BindingResolutionException $exception)
+				{
+					if ($parameter->isOptional())
+					{
+						$dependencies[] = $parameter->getDefaultValue();
+					}
+					else
+					{
+						throw $exception;
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
When Container is building an object it recursively tries to build any dependencies (constructor parameters) first. However, it does not handle unbuildable dependencies consistently.

For scalar types (which are all unbuildable) Container checks if the parameter has a default value and uses that if so.

For non-scalar types this check is not performed, so binding can fail even in cases where it would be possible to fall back to a default value. This patch enables this feature.

Example use case:

``` php
abstract class Composite
{
    public function __construct(Composite $parent = null) {}
}

class Whatever extends Composite {}

$container->make('Whatever'); // fails, but it really shouldn't
```
