### PR TITLE
Use object_get in Collection::lists() to support pivot tables

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -344,7 +344,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 
 		foreach ($this->items as $item)
 		{
-			$itemValue = is_object($item) ? $item->{$value} : $item[$value];
+			$itemValue = is_object($item) ? object_get($item, $value) : $item[$value];
 
 			// If the key is "null", we will just append the value to the array and keep
 			// looping. Otherwise we will key the array using the value of the key we
@@ -355,7 +355,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 			}
 			else
 			{
-				$itemKey = is_object($item) ? $item->{$key} : $item[$key];
+				$itemKey = is_object($item) ? object_get($item, $key) : $item[$key];
 
 				$results[$itemKey] = $itemValue;
 			}


### PR DESCRIPTION
A small change to support doing this: `$collection->lists('pivot.column', 'id')`

Signed-off-by: Daniel Bondergaard danielboendergaard@gmail.com
