### PR TITLE
Fix to object conversion on after sortBy

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -228,7 +228,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 		// to the sorted version. Then we'll just return the collection instance.
 		foreach (array_keys($results) as $key)
 		{
-			$results[$key] = $this->items[$key];
+			$sortedResults[] = $this->items[$key];
 		}
 
 		$this->items = $results;


### PR DESCRIPTION
After sortBy is called on a collection it is no longer an array but an object when the collection is outputted with toJson(). This makes sure it is still sorted, but it remains an array.

Before sortBy:

``` javascript
[
   {
      "id":2,
      "username":"user2"
   },
   {
      "id":3,
      "username":"user3"
   }
]
```

After sortBy, toJson outputs:

``` javascript
{
   "1":{
      "id":2,
      "username":"user2"
   },
   "0":{
      "id":3,
      "username":"user3"
   }
}
```

With this change:

``` javascript
[
   {
      "id":3,
      "username":"user3"
   },
   {
      "id":2,
      "username":"user2"
   }
]
```
