### PR TITLE
Serialize data in Queue instead of json_encoding it

### DIFF
--- a/src/Illuminate/Queue/IlluminateQueueClosure.php
+++ b/src/Illuminate/Queue/IlluminateQueueClosure.php
@@ -11,9 +11,7 @@ class IlluminateQueueClosure {
 	 */
 	public function fire($job, $data)
 	{
-		$closure = unserialize($data['closure']);
-
-		$closure($job);
+		$data($job);
 	}
 
 }

--- a/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
+++ b/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
@@ -44,7 +44,7 @@ class BeanstalkdJob extends Job {
 	 */
 	public function fire()
 	{
-		$this->resolveAndFire(json_decode($this->job->getData(), true));
+		$this->resolveAndFire(unserialize($this->job->getData()));
 	}
 
 	/**

--- a/src/Illuminate/Queue/Jobs/IronJob.php
+++ b/src/Illuminate/Queue/Jobs/IronJob.php
@@ -53,7 +53,7 @@ class IronJob extends Job {
 	 */
 	public function fire()
 	{
-		$this->resolveAndFire(json_decode($this->job->body, true));
+		$this->resolveAndFire(unserialize($this->job->body));
 	}
 
 	/**

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -53,7 +53,7 @@ class SqsJob extends Job {
 	 */
 	public function fire()
 	{
-		$this->resolveAndFire(json_decode($this->job['Body'], true));
+		$this->resolveAndFire(unserialize($this->job['Body']));
 	}
 
 	/**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -34,11 +34,11 @@ abstract class Queue {
 	{
 		if ($job instanceof Closure)
 		{
-			return json_encode($this->createClosurePayload($job, $data));
+			return serialize($this->createClosurePayload($job));
 		}
 		else
 		{
-			return json_encode(array('job' => $job, 'data' => $data));
+			return serialize(array('job' => $job, 'data' => $data));
 		}
 	}
 
@@ -49,11 +49,9 @@ abstract class Queue {
 	 * @param  mixed  $data
 	 * @return string
 	 */
-	protected function createClosurePayload($job, $data)
+	protected function createClosurePayload($job)
 	{
-		$closure = serialize(new SerializableClosure($job));
-
-		return array('job' => 'IlluminateQueueClosure', 'data' => compact('closure'));
+		return array('job' => 'IlluminateQueueClosure', 'data' => new SerializableClosure($job));
 	}
 
 	/**

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -13,7 +13,7 @@ class QueueBeanstalkdJobTest extends PHPUnit_Framework_TestCase {
 	public function testFireProperlyCallsTheJobHandler()
 	{
 		$job = $this->getJob();
-		$job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(json_encode(array('job' => 'foo', 'data' => array('data'))));
+		$job->getPheanstalkJob()->shouldReceive('getData')->once()->andReturn(serialize(array('job' => 'foo', 'data' => array('data'))));
 		$job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
 		$handler->shouldReceive('fire')->once()->with($job, array('data'));
 

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -16,7 +16,7 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('useTube')->once()->with('stack')->andReturn($pheanstalk);
 		$pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
-		$pheanstalk->shouldReceive('put')->twice()->with(json_encode(array('job' => 'foo', 'data' => array('data'))));
+		$pheanstalk->shouldReceive('put')->twice()->with(serialize(array('job' => 'foo', 'data' => array('data'))));
 
 		$queue->push('foo', array('data'), 'stack');
 		$queue->push('foo', array('data'));
@@ -29,7 +29,7 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('useTube')->once()->with('stack')->andReturn($pheanstalk);
 		$pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
-		$pheanstalk->shouldReceive('put')->twice()->with(json_encode(array('job' => 'foo', 'data' => array('data'))), Pheanstalk_Pheanstalk::DEFAULT_PRIORITY, 5);
+		$pheanstalk->shouldReceive('put')->twice()->with(serialize(array('job' => 'foo', 'data' => array('data'))), Pheanstalk_Pheanstalk::DEFAULT_PRIORITY, 5);
 
 		$queue->later(5, 'foo', array('data'), 'stack');
 		$queue->later(5, 'foo', array('data'));

--- a/tests/Queue/QueueIronJobTest.php
+++ b/tests/Queue/QueueIronJobTest.php
@@ -34,7 +34,7 @@ class QueueIronJobTest extends PHPUnit_Framework_TestCase {
 		$job = new Illuminate\Queue\Jobs\IronJob(
 			m::mock('Illuminate\Container\Container'),
 			m::mock('IronMQ'),
-			(object) array('id' => 1, 'body' => json_encode(array('job' => 'foo', 'data' => array('data'))), 'timeout' => 60, 'pushed' => true),
+			(object) array('id' => 1, 'body' => serialize(array('job' => 'foo', 'data' => array('data'))), 'timeout' => 60, 'pushed' => true),
 			'default'
 		);
 		$job->getIron()->shouldReceive('deleteMessage')->never();
@@ -57,7 +57,7 @@ class QueueIronJobTest extends PHPUnit_Framework_TestCase {
 		return new Illuminate\Queue\Jobs\IronJob(
 			m::mock('Illuminate\Container\Container'),
 			m::mock('IronMQ'),
-			(object) array('id' => 1, 'body' => json_encode(array('job' => 'foo', 'data' => array('data'))), 'timeout' => 60),
+			(object) array('id' => 1, 'body' => serialize(array('job' => 'foo', 'data' => array('data'))), 'timeout' => 60),
 			'default'
 		);
 	}


### PR DESCRIPTION
The documentation does not specify/limit the kind of object that can be passed as data to `Queue::push` and the current queue workers are broken when any non-array as data (except for the `sync` worker).

This uses `serialize` instead of `json_encode` to prepare the data for the workers (and `unserialize` afterward), this allows to use simple objects as job data.
