### PR TITLE
improve troubleshooting for the controller class

### DIFF
--- a/src/Illuminate/Routing/Controllers/Controller.php
+++ b/src/Illuminate/Routing/Controllers/Controller.php
@@ -287,7 +287,7 @@ class Controller {
 	 */
 	public function missingMethod($parameters)
 	{
-		throw new NotFoundHttpException;
+		throw new NotFoundHttpException("controller action not found: " . implode(', ', $parameters));
 	}
 
 	/**
@@ -299,7 +299,7 @@ class Controller {
 	 */
 	public function __call($method, $parameters)
 	{
-		throw new NotFoundHttpException;
+		throw new NotFoundHttpException('controller method not found: ' . $method);
 	}
 
 }


### PR DESCRIPTION
When users go to http://mysite.com/users/bob (where bob doesn't exist) they'll see a message.

"controller action not found: bob"

When users, from within a controller try to call a method from within the controller class they'll get...

"controller method not found: whatever"
