### PR TITLE
Fix missing method implementation on Controller class

### DIFF
--- a/src/Illuminate/Routing/Controllers/Controller.php
+++ b/src/Illuminate/Routing/Controllers/Controller.php
@@ -282,12 +282,12 @@ class Controller {
 	/**
 	 * Handle calls to missing methods on the controller.
 	 *
-	 * @param  array   $parameters
+	 * @param  array  $parameters
 	 * @return mixed
 	 */
 	public function missingMethod($parameters)
 	{
-		throw new NotFoundHttpException;
+		throw new NotFoundHttpException("Controller method not found.");
 	}
 
 	/**
@@ -299,7 +299,7 @@ class Controller {
 	 */
 	public function __call($method, $parameters)
 	{
-		throw new NotFoundHttpException;
+		return $this->missingMethod($parameters);
 	}
 
 }


### PR DESCRIPTION
Missing method handler implementation for the Controller class seems to have disappeared. Re-added it along with unit tests to make sure it doesn't gets removed again.

I also included the message for the exception which Shawn wanted to add in #1653. I didn't implode the parameters like he first suggested because you can't know what type of parameters are sent along (not always strings).
