### PR TITLE
Add ignore method to query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -724,6 +724,20 @@ class Builder {
 	}
 
 	/**
+	 * Ignores an operation on a list of values for a given column.
+	 *
+	 * @param  mixed   $values
+	 * @param  string  $column
+	 * @return \Illuminate\Database\Query\Builder
+	 */
+	public function ignore($values, $column = 'id')
+	{
+		$values = $values instanceof Closure ? $values : (array) $values;
+
+		return $this->whereNotIn($column, $values);
+	}
+
+	/**
 	 * Add a "group by" clause to the query.
 	 *
 	 * @param  dynamic  $columns

--- a/src/Illuminate/Foundation/changes.json
+++ b/src/Illuminate/Foundation/changes.json
@@ -1,11 +1,12 @@
 {
 	"4.0.x": [
-		{"message": "Added implode method to query builder and Colletion class.", "backport": null},
+		{"message": "Added implode method to query builder and Collection class.", "backport": null},
 		{"message": "Fixed bug that caused Model->push method to fail.", "backport": null},
 		{"message": "Make session cookie HttpOnly by default.", "backport": null},
 		{"message": "Added mail.pretend configuration option.", "backport": null},
 		{"message": "Query elapsed time is now reported as float instead of string.", "backport": null},
 		{"message": "Added Model::query method for generating an empty query builder.", "backport": null},
-		{"message": "The @yield Blade directive now accepts a default value as the second argument.", "backport": null}
+		{"message": "The @yield Blade directive now accepts a default value as the second argument.", "backport": null},
+		{"message": "Added ignore method to query builder", "backport": null}
 	]
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -154,6 +154,25 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testBasicIgnore()
+	{
+		$builder = $this->getBuilder();
+			$builder->select('*')->from('users')->ignore(array(1, 2, 3));
+		$this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
+		$this->assertEquals(array(0 => 1, 1 => 2, 2 => 3), $builder->getBindings());
+
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->ignore(array('taylor', 'dayle'), 'name');
+		$this->assertEquals('select * from "users" where "name" not in (?, ?)', $builder->toSql());
+		$this->assertEquals(array(0 => 'taylor', 1 => 'dayle'), $builder->getBindings());
+
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->ignore('taylor', 'name');
+		$this->assertEquals('select * from "users" where "name" not in (?)', $builder->toSql());
+		$this->assertEquals(array(0 => 'taylor'), $builder->getBindings());
+	}
+
+
 	public function testUnions()
 	{
 		$builder = $this->getBuilder();


### PR DESCRIPTION
I added an `ignore` function to the query builder. This function allows you to pass in an array of values (or a closure) to ignore records when performing a query. Basically this is just a layer on top of the `whereNotIn` function but a bit more readable and usable because you'll mostly want to use this for ignoring record id's (default column).

I also added a type casting to array for none closure values so single values can be used.
### Use Cases

Select records from a table but ignore some record IDs.

``` php
$users = DB::table('users')->ignore(array(1, 5, 7))->get();
```

Use it to perform an update but ignore the update for some record IDs. In this case, reset all posts to the default category except for posts in the category 'important'.

``` php
Post::ignore('important', 'category')->update(array('category' => 'default'));
```

Delete all pages except for the default page.

``` php
Page::ignore('default', 'type')->delete();
```
