### PR TITLE
Fix for issue #1281

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -120,6 +120,11 @@ class CookieJar {
 
 		$value = $this->encrypter->encrypt($value);
 
+		if ( ! headers_sent())
+		{
+			setcookie($name, $value, $time, $path, $domain, $secure, $httpOnly);
+		}
+
 		return new Cookie($name, $value, $time, $path, $domain, $secure, $httpOnly);
 	}
 


### PR DESCRIPTION
I was looking for a way to set a cookie right away with Laravel (like PHP's `setcookie()`) and I came across issue #1281.  I decided the easiest way to take care of this was to implement PHP's `setcookie()` rather than worrying about saving the cookie into some sort of CookieBag.

This commit extends `CookieJar::make()` by setting the cookie manually if headers have not already been set.  Whether or not headers have been set, the `Cookie` will still be returned so it can be attached to the Response.
