### PR TITLE
Added in functionality to connect to DB2 over ODBC

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -6,6 +6,7 @@ use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SqlServerConnection;
+use Illuminate\Database\DB2Connection;
 
 class ConnectionFactory {
 
@@ -81,6 +82,9 @@ class ConnectionFactory {
 
 			case 'sqlsrv':
 				return new SqlServerConnector;
+
+			case 'db2':
+				return new DB2Connector;
 		}
 
 		throw new \InvalidArgumentException("Unsupported driver [{$config['driver']}]");
@@ -116,6 +120,9 @@ class ConnectionFactory {
 
 			case 'sqlsrv':
 				return new SqlServerConnection($connection, $database, $prefix, $config);
+
+			case 'db2':
+				return new DB2Connection($connection, $database, $prefix, $config);
 		}
 
 		throw new \InvalidArgumentException("Unsupported driver [$driver]");

--- a/src/Illuminate/Database/Connectors/DB2Connector.php
+++ b/src/Illuminate/Database/Connectors/DB2Connector.php
@@ -1,0 +1,55 @@
+<?php namespace Illuminate\Database\Connectors;
+
+class DB2Connector extends Connector implements ConnectorInterface {
+
+	/**
+	 * Establish a database connection.
+	 *
+	 * @param  array  $options
+	 * @return PDO
+	 */
+	public function connect(array $config)
+	{
+		$dsn = $this->getDsn($config);
+
+		// We need to grab the PDO options that should be used while making the brand
+		// new connection instance. The PDO options control various aspects of the
+		// connection's behavior, and some might be specified by the developers.
+		$options = $this->getOptions($config);
+
+		return $this->createConnection($this->getDsn($config), $config, $options);
+	}
+
+	/**
+	 * Create a DSN string from a configuration.
+	 *
+	 * TODO: Figure out ODBC for Mac
+	 *
+	 * @param  array   $config
+	 * @return string
+	 */
+	protected function getDsn(array $config)
+	{
+		// First we will create the basic DSN setup as well as the port if it is in
+		// in the configuration options. This will give us the basic DSN we will
+		// need to establish the PDO connections and return them back for use.
+		// NOTE: This PDO connection MAY be able to get used as a fallback for 
+		// SQLServer
+		extract($config);
+
+		// NOTE: This will 100% require pdo_odbc functionality and ODBC drivers on 
+		// your machine - Windoze; you're fine - OSX ;-(
+		$dsn = "odbc:Driver={iSeries Access ODBC Driver};System=$host;Naming=1;Database=$database"; // Not sure what naming does
+
+		if (isset($library) && $library !== '') {
+			$dsn .= ";Dbq=$library";
+		}
+
+		if (isset($port) && is_integer($port)) {
+			$dsn .= ";Port=$port";
+		}
+
+		return $dsn;
+	}
+
+}

--- a/src/Illuminate/Database/DB2Connection.php
+++ b/src/Illuminate/Database/DB2Connection.php
@@ -1,0 +1,37 @@
+<?php namespace Illuminate\Database;
+
+class DB2Connection extends Connection {
+
+	/**
+	 * Get the default query grammar instance.
+	 *
+	 * @return \Illuminate\Database\Query\Grammars\Grammars\Grammar
+	 */
+	protected function getDefaultQueryGrammar()
+	{
+		return $this->withTablePrefix(new Query\Grammars\DB2Grammar);
+	}
+
+	/**
+	 * Get the default schema grammar instance.
+	 *
+	 * @return \Illuminate\Database\Schema\Grammars\Grammar
+	 */
+	protected function getDefaultSchemaGrammar()
+	{
+		return $this->withTablePrefix(new Schema\Grammars\DB2Grammar);
+	}
+
+	/**
+	 * Get the Doctrine DBAL Driver.
+	 *
+	 * TODO: Build an ODBC Doctrine driver
+	 * 
+	 * @return \Doctrine\DBAL\Driver
+	 */
+	/*protected function getDoctrineDriver()
+	{
+		return new \Doctrine\DBAL\Driver\PDOMySql\Driver;
+	}*/
+
+}

--- a/src/Illuminate/Database/Query/Grammars/DB2Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/DB2Grammar.php
@@ -1,0 +1,5 @@
+<?php namespace Illuminate\Database\Query\Grammars;
+
+class DB2Grammar extends Grammar {
+
+}


### PR DESCRIPTION
Added db2 connectivity functionality to the framework.  Modifications to database.php configuration file should be as follows (added to connections array): -

``` php
'db2' => array(
    'driver'    => 'db2',
    'host'      => 'localhost',
    'database'  => 'database',
    'username'  => 'root',
    'password'  => '',
    'prefix'    => '',
    'library'   => '' // optional
),
```

Note:  This is designed to connect to a remote DB2 installation.  If you're deploying on AS400/IBMi, your PHP installation with be compiled with ibm_db2 drivers - that connectivity is coming shortly.

pdo_odbc must be enabled in your PHP installation.  For Windows users, this will work just fine.  OSX users... well, we have to EAD.  I'm still working on getting this working with PHP recompiling.  Currently using MAMP and PHP 5.4.4 (thinking unixODBC with Macports might be the best option, although I was hoping to make it easier for n00bs than
