### PR TITLE
[fix] using pipe separation to filter routes does not work on nested filtered routes

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -438,7 +438,16 @@ class Route extends BaseRoute {
 	 */
 	public function setAfterFilters($value)
 	{
-		$filters = is_string($value) ? explode('|', $value) : (array) $value;
+		$filters = array();
+		$filterStrings = (array) $value;
+
+		foreach ($filterStrings as $filterString)
+		{
+			foreach (explode('|', $filterString) as $filter)
+			{
+				$filters[] = $filter;
+			}
+		}
 
 		$this->setOption('_after', array_merge($this->getAfterFilters(), $filters));
 	}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -406,7 +406,16 @@ class Route extends BaseRoute {
 	 */
 	public function setBeforeFilters($value)
 	{
-		$filters = is_string($value) ? explode('|', $value) : (array) $value;
+		$filters = array();
+		$filterStrings = (array) $value;
+
+		foreach ($filterStrings as $filterString)
+		{
+			foreach (explode('|', $filterString) as $filter)
+			{
+				$filters[] = $filter;
+			}
+		}
 
 		$this->setOption('_before', array_merge($this->getBeforeFilters(), $filters));
 	}

--- a/tests/Routing/RoutingTest.php
+++ b/tests/Routing/RoutingTest.php
@@ -259,6 +259,19 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('filtered!', $router->dispatch($request)->getContent());
 	}
 
+	public function testBeforeFiltersCanBeNestedInGroups()
+	{
+		$router = new Router;
+		$router->group(array('before' => 'foo|bar'), function() use ($router)
+		{
+			$router->get('foo', function() {});
+			$router->get('bar', array('before' => 'nestedFoo|nestedBaz', function() {}));
+		});
+		$routes = array_values($router->getRoutes()->getIterator()->getArrayCopy());
+
+		$this->assertEquals(array('foo', 'bar'), $routes[0]->getOption('_before'));
+		$this->assertEquals(array('foo', 'bar', 'nestedFoo', 'nestedBaz'), $routes[1]->getOption('_before'));
+	}
 
 	public function testBeforeFiltersArePassedRouteAndRequest()
 	{


### PR DESCRIPTION
To resolve #1697, as outlined in the issue comments.

The `setBeforeFilters` method of `Illuminate\Routing\Route` only exploded pipe-separated filter strings if the value passed in was a string. If it was an array of strings, it would leave the array as is, without exploding them.

If multiple levels of a nested route group have filters on them, they are sent as to this function as an array of strings, that should be pipe separable.
