### PR TITLE
Allow App::down() callback to be configurable based on app requirement. Fixes #1701.

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -515,12 +515,10 @@ class Application extends Container implements HttpKernelInterface, ResponsePrep
 		{
 			$response = $this['events']->until('illuminate.app.down');
 
-			return $this->prepareResponse($response, $request);
+			if ( ! is_null($response)) return $this->prepareResponse($response, $request);
 		}
-		else
-		{
-			return $this['router']->dispatch($this->prepareRequest($request));
-		}
+		
+		return $this['router']->dispatch($this->prepareRequest($request));
 	}
 
 	/**


### PR DESCRIPTION
With this changes, developer can actually add a whitelist structure:

``` php

App::down(function()
{
    if (in_array($_SERVER['REMOTE_ADDR'], ['51.24.49.100', '34.245.99.39'])) return false;

    return Response::make("Be right back!", 503);
});
```

With this changes, we can customize the app down based on our application requirement/need for example:
- restriction through hostname instead of ip.
- restriction based on IP wildcard instead of fixed ip.
- restriction based on logged-in user/roles.

Signed-off-by: crynobone crynobone@gmail.com
