### PR TITLE
Add last_key helpers method

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -548,6 +548,22 @@ if ( ! function_exists('last'))
 	}
 }
 
+if ( ! function_exists('last_key'))
+{
+	/**
+	 * Get the last key from an array.
+	 *
+	 * @param  array  $array
+	 * @return mixed
+	 */
+	function last_key($array)
+	{
+		end($array);
+
+		return key($array);
+	}
+}
+
 if ( ! function_exists('link_to_asset'))
 {
 	/**

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -123,6 +123,13 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testLastKey()
+	{
+		$array = array('foo' => 'taylor', 'bar' => 'dayle', 'baz' => 'shawn');
+		$this->assertEquals('baz', last_key($array));
+	}
+
+
 	public function testStrIs()
 	{
 		$this->assertTrue(str_is('*.dev', 'localhost.dev'));


### PR DESCRIPTION
Use case: indicating that by default the last item on a select field needs to be selected. This would work for both numeric and string types of keys.

``` php
echo Form::select('names', $names, last_key($names));
```
