### PR TITLE
Allow ServiceProvider::commands to receive an array of commands

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -160,12 +160,12 @@ abstract class ServiceProvider {
 	/**
 	 * Register the package's custom Artisan commands.
 	 *
-	 * @param  dynamic  string
+	 * @param  array  $commands
 	 * @return void
 	 */
-	public function commands()
+	public function commands($commands)
 	{
-		$commands = func_get_args();
+		$commands = is_array($commands) ? $commands : func_get_args();
 
 		// To register the commands with Artisan, we will grab each of the arguments
 		// passed into the method and listen for Artisan "start" event which will


### PR DESCRIPTION
I'm creating a package that allows users to register certain classes as commands in the namespace of the package, this would make my life a lot easier.
