### PR TITLE
Eloquent date mutators should not use the current time for date fields

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2051,7 +2051,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		}
 
 		// If the value is in simply year-month-day format, we will create a
-		// Carbon object from that fomrat. Again, this provides for simple date
+		// Carbon object from that format. Again, this provides for simple date
 		// fields in the database, while still supporting Carbonized conversion.
 		elseif (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value))
 		{

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2043,16 +2043,16 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	protected function asDateTime($value)
 	{
 		// If this value is an integer, we will assume it is a UNIX timestamp's value
-		// and format a Carbon object from this timestamp. This allows flexibility
+		// and create a Carbon object from this timestamp. This allows flexibility
 		// when defining your date fields as they might be UNIX timestamps here.
 		if (is_numeric($value))
 		{
 			return Carbon::createFromTimestamp($value);
 		}
 
-		// If the value is in simply year, month, day format, we will instantiate the
-		// Carbon instances from that fomrat. Again, this provides for simple date
-		// fields on the database, while still supporting Carbonized conversion.
+		// If the value is in simply year-month-day format, we will create a
+		// Carbon object from that fomrat. Again, this provides for simple date
+		// fields in the database, while still supporting Carbonized conversion.
 		elseif (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value))
 		{
 			return Carbon::createFromFormat('Y-m-d', $value)->setTime(0, 0, 0);
@@ -2060,7 +2060,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		// Finally, we will just assume this date is in the format used by default on
 		// the database connection and use that format to create the Carbon object
-		// that is returned back out to the developers after we convert it here.
+		// that is returned back out to the developer after we convert it here.
 		elseif ( ! $value instanceof DateTime)
 		{
 			$format = $this->getDateFormat();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2053,9 +2053,9 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// If the value is in simply year, month, day format, we will instantiate the
 		// Carbon instances from that fomrat. Again, this provides for simple date
 		// fields on the database, while still supporting Carbonized conversion.
-		elseif (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $value))
+		elseif (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value))
 		{
-			return Carbon::createFromFormat('Y-m-d', $value);
+			return Carbon::createFromFormat('Y-m-d', $value)->setTime(0, 0, 0);
 		}
 
 		// Finally, we will just assume this date is in the format used by default on


### PR DESCRIPTION
Currently, when using date mutators (`getDates()`) on date fields, the date instance returned will be set to the current time. I think the correct behavior is for it to be set to 0:0:0.

Also, there's no need for the group capturing in that regex, since it's not being used.
