### PR TITLE
creating Container if none was provided during construction

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -40,6 +40,7 @@ class Dispatcher {
 	 */
 	public function __construct(Container $container = null)
 	{
+		if ($container === null) $container = new Container;
 		$this->container = $container;
 	}
 


### PR DESCRIPTION
Without this being auto-created `createClassListener` would fail unless the user passed in a Container--a dependency the app was previously not reporting:
https://github.com/laravel/framework/blob/master/src/Illuminate/Events/Dispatcher.php#

Sorry about the line ending character getting chopped....Github "issue" I guess.
