### PR TITLE
Add is_true and is_false helper methods

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -517,6 +517,34 @@ if ( ! function_exists('head'))
 	}
 }
 
+if ( ! function_exists('is_false'))
+{
+	/**
+	 * Determine if a variable is false.
+	 *
+	 * @param  mixed  $value
+	 * @return bool
+	 */
+	function is_false($value)
+	{
+		return $value === false;
+	}
+}
+
+if ( ! function_exists('is_true'))
+{
+	/**
+	 * Determine if a variable is true.
+	 *
+	 * @param  mixed  $value
+	 * @return bool
+	 */
+	function is_true($value)
+	{
+		return $value === true;
+	}
+}
+
 if ( ! function_exists('link_to'))
 {
 	/**

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -123,6 +123,18 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testIsTrue()
+	{
+		$this->assertEquals(true, is_true(true));
+	}
+
+
+	public function testIsFalse()
+	{
+		$this->assertEquals(true, is_false(false));
+	}
+
+
 	public function testStrIs()
 	{
 		$this->assertTrue(str_is('*.dev', 'localhost.dev'));


### PR DESCRIPTION
Natively PHP supports a lot of variable handling functions. One of those which is used a lot is the `is_null` function. It takes away the pain of having to write `$variable === null` all the time. The function f.e. is heavily used in the Laravel Framework core (Trivia: 164 times at this point :wink:).

To be honest, I don't understand why there isn't an equivalent for `true` and `false`. It would provide the same purpose as the `is_null` function. 

With this PR I'm proposing to add these two functions.
