### PR TITLE
Add PHP 5.5 to travis config file for workbench packages

### DIFF
--- a/src/Illuminate/Workbench/stubs/.travis.yml
+++ b/src/Illuminate/Workbench/stubs/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php: 
   - 5.3
   - 5.4
+  - 5.5
 
 before_script:
   - curl -s http://getcomposer.org/installer | php


### PR DESCRIPTION
Since PHP 5.5 and Laravel itself has added testing for it by default in its core, it's only natural that workbench packages should follow.
