### PR TITLE
updated README.md with working code order & objects

### DIFF
--- a/src/Illuminate/Database/README.md
+++ b/src/Illuminate/Database/README.md
@@ -22,17 +22,19 @@ $capsule->addConnection([
 	'prefix'    => '',
 ]);
 
-// Setup the Eloquent ORM... (optional)
-$capsule->bootEloquent();
-
 // Set the event dispatcher used by Eloquent models... (optional)
-$capsule->setEventDispatcher(...);
+use Illuminate\Events\Dispatcher;
+use Illuminate\Container\Container;
+$capsule->setEventDispatcher(new Dispatcher(new Container));
 
 // Set the cache manager instance used by connections... (optional)
 $capsule->setCacheManager(...);
 
 // Make this Capsule instance available globally via static methods... (optional)
 $capsule->setAsGlobal();
+
+// Setup the Eloquent ORM... (optional; unless you've used setEventDispatcher())
+$capsule->bootEloquent();
 ```
 
 Once the Capsule instance has been registered. You may use it like so:


### PR DESCRIPTION
Added `Dispatcher` and `Container` creation/passing to `setEventDispatcher` so the code can be used (`setCacheManager` example could benefit from the same treatment).

Also moved `bootEloquent` below the `setEventDispatcher` (and other) calls. If it's called in it's old location above `setEventDispatcher`, than `setEventDispatcher` fails.
