### PR TITLE
Make URL::to() enough flexible to be simpler and more readable by accepting object as path

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -83,6 +83,13 @@ class UrlGenerator {
 	 */
 	public function to($path, $parameters = array(), $secure = null)
 	{
+		// If the given path is an object, we build a string path based on resource
+		// controllers conventions
+		if (is_object($path))
+		{
+			$path = strtolower(get_class($path)).'/'.$path->id;
+		}
+
 		if ($this->isValidUrl($path)) return $path;
 
 		$scheme = $this->getScheme($secure);

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -30,6 +30,10 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://foobar.com/dayle/rees', $gen->to(null, array('dayle', 'rees')));
 		$this->assertEquals('http://foobar.com/something/dayle/rees', $gen->to('/something', array('dayle', 'rees')));
 		$this->assertEquals('http://foobar.com/something/dayle/rees', $gen->to('something', array('dayle', 'rees')));
+
+		$object = new stdClass;
+		$object->id = 3;
+		$this->assertEquals('http://foobar.com/stdclass/3', $gen->to($object));
 	}
 
 


### PR DESCRIPTION
When we use resource controllers, we call a lot of time the same URLs like `http://www.example.com/user/3`. In fact we want to go to a model page not a route, we want to see the HTML representation of a user object, so it seems to me natural to get an URL directly from an object. If the [conventions](http://laravel.com/docs/controllers#resource-controllers) are respected it's an easy implementation.

My goal is to switch form this quite ugly syntax :

``` php
URL::to('user/'.$user->id);
URL::to('user/'.$user->id.'/edit');

URL::to('user', array($user->id));
URL::to('user', array($user->id, 'edit'));
```

To this simpler and more readable one :

``` php
URL::to($user);
URL::to($user, array('edit'));
```

Of course, the previous behavior is maintained because it is useful in many cases.

Any comment about the idea or the implementation is welcome :)
