### PR TITLE
Fixed an incorrect comment within the RedisStore class.

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -19,7 +19,7 @@ class RedisStore implements StoreInterface {
 	protected $prefix;
 
 	/**
-	 * Create a new APC store.
+	 * Create a new Redis store.
 	 *
 	 * @param  \Illuminate\Redis\Database  $redis
 	 * @param  string                     $prefix


### PR DESCRIPTION
Fixed an incorrect comment within the RedisStore class. 'Created a new APC store.' should have been 'Create a new Redis store.
