### PR TITLE
Update whoops to version 1.07, port template tweaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "classpreloader/classpreloader": "1.0.*",
         "doctrine/dbal": "2.4.x",
         "ircmaxell/password-compat": "1.0.*",
-        "filp/whoops": "1.0.6",
+        "filp/whoops": "1.0.7",
         "monolog/monolog": "1.5.*",
         "nesbot/carbon": "1.*",
         "patchwork/utf8": "1.1.*",

--- a/src/Illuminate/Exception/composer.json
+++ b/src/Illuminate/Exception/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "filp/whoops": "1.0.6",
+        "filp/whoops": "1.0.7",
         "illuminate/support": "4.1.x",
         "symfony/http-foundation": "2.3.x",
         "symfony/http-kernel": "2.3.*"

--- a/src/Illuminate/Exception/resources/pretty-page.css
+++ b/src/Illuminate/Exception/resources/pretty-page.css
@@ -18,6 +18,8 @@ body {
     position: fixed;
     margin: 0;
     padding: 0;
+    left: 0;
+    top: 0;
 }
 
 .branding {
@@ -94,8 +96,13 @@ header {
       background: #F0E5DF;
     }
 
-    .frame-class, .frame-function {
+    .frame-class, .frame-function, .frame-index {
       font-weight: bold;
+    }
+
+    .frame-index {
+      font-size: 11px;
+      color: #BDBDBD;
     }
 
     .frame-class {
@@ -286,6 +293,10 @@ pre.prettyprint, code.prettyprint {
 
   pre.prettyprint a, code.prettyprint a {
     text-decoration:none;
+  }
+
+  .linenums li {
+    color: #A5A5A5;
   }
 
   .linenums li.current{

--- a/src/Illuminate/Exception/resources/pretty-template.php
+++ b/src/Illuminate/Exception/resources/pretty-template.php
@@ -26,7 +26,8 @@
                    for that particular frame */ ?>
           <?php foreach($v->frames as $i => $frame): ?>
             <div class="frame <?php echo ($i == 0 ? 'active' : '') ?>" id="frame-line-<?php echo $i ?>">
-                <div class="frame-method-info">
+		<div class="frame-method-info">
+		  <span class="frame-index"><?php echo (count($v->frames) - $i - 1) ?>.</span>
                   <span class="frame-class"><?php echo $e($frame->getClass() ?: '') ?></span>
                   <span class="frame-function"><?php echo $e($frame->getFunction() ?: '') ?></span>
                 </div>
@@ -81,7 +82,8 @@
                     if($line !== null):
 
                     // the $line is 1-indexed, we nab -1 where needed to account for this
-                    $range = $frame->getFileLines($line - 8, 10);
+		    $range = $frame->getFileLines($line - 8, 10);
+		    $range = array_map(function($line){ return empty($line) ? ' ' : $line;}, $range);
                     $start = key($range) + 1;
                     $code  = join("\n", $range);
                   ?>


### PR DESCRIPTION
Compare view `1.0.6...1.0.7`: https://github.com/filp/whoops/compare/1.0.6...1.0.7

This PR updates whoops to version `1.0.7`, and introduces the needed template tweaks, including a missing tweak that was not ported in the `1.0.6` update (#1763).

Cheers!
