### PR TITLE
Added Request method to return remote IP address.

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -481,4 +481,14 @@ class Request extends \Symfony\Component\HttpFoundation\Request {
 		return isset($this->sessionStore);
 	}
 
+	/**
+	 * Return the remote IP address.
+	 *
+	 * @return string
+	 */
+	public function remoteIP()
+	{
+		return $_SERVER['REMOTE_ADDR'];
+	}
+
 }


### PR DESCRIPTION
Felt like this should exist. `$_SERVER['REMOTE_ADDR']` is not hard to type, but we needed a hipster way of dong it.  That, and I hate underscores, and that has TWO of them.
