### PR TITLE
Fix obfuscate #2

### DIFF
--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -371,7 +371,15 @@ class HtmlBuilder {
 			// To properly obfuscate the value, we will randomly convert each letter to
 			// its entity or hexadecimal representation, keeping a bot from sniffing
 			// the randomly obfuscated letters out of the string on the responses.
-			switch (rand(1, 3))
+			$rand = rand(1, 3);
+			
+			// Protect breaking UTF-8 letter.
+			if(ord($letter) > 128)
+			{
+				$rand = 3;
+			}
+			
+			switch ($rand)
 			{
 				case 1:
 					$safe .= '&#'.ord($letter).';'; break;


### PR DESCRIPTION
Obfuscate to only characters < 128. For protect this method will break UTF-8 string.
