### PR TITLE
Pass in the Error Code from the Database

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -499,7 +499,7 @@ class Connection implements ConnectionInterface {
 
 		$message = $e->getMessage()." (SQL: {$query}) (Bindings: {$bindings})";
 
-		throw new \Exception($message, $e->getCode());
+		throw new \Exception($message, 0, $e);
 	}
 
 	/**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -499,7 +499,7 @@ class Connection implements ConnectionInterface {
 
 		$message = $e->getMessage()." (SQL: {$query}) (Bindings: {$bindings})";
 
-		throw new \Exception($message);
+		throw new \Exception($message, $e->getCode());
 	}
 
 	/**


### PR DESCRIPTION
It's a good idea to pass in the error code as well since we're using the generic `Exception` class. This way, in our code, we can distinguish what kind of error we're dealing with, rather than having to guess from the error message or even try to parse the error code from it.
