### PR TITLE
Move Cache implementation dependencies to 'require-dev', solves #1650.

### DIFF
--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -9,14 +9,14 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/database": "4.1.x",
-        "illuminate/encryption": "4.1.x",
-        "illuminate/filesystem": "4.1.x",
-        "illuminate/redis": "4.1.x",
         "illuminate/support": "4.1.x"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.7.*",
+        "illuminate/database": "4.1.x",
+        "illuminate/encryption": "4.1.x",
+        "illuminate/filesystem": "4.1.x",
+        "illuminate/redis": "4.1.x"
     },
     "autoload": {
         "psr-0": {"Illuminate\\Cache": ""}


### PR DESCRIPTION
The 'value' helper function is used, so 'illuminate/support' is kept as a dependency.
