### PR TITLE
Added missing SQL operators for each grammar

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -142,6 +142,7 @@ class Builder {
 	protected $operators = array(
 		'=', '<', '>', '<=', '>=', '<>', '!=',
 		'like', 'not like', 'between', 'ilike',
+		'&', '|', '^', '<<', '>>'
 	);
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -5,6 +5,17 @@ use Illuminate\Database\Query\Builder;
 class PostgresGrammar extends Grammar {
 
 	/**
+	 * All of the available clause operators.
+	 *
+	 * @var array
+	 */
+	protected $operators = array(
+		'=', '<', '>', '<=', '>=', '<>', '!=',
+		'like', 'not like', 'between', 'ilike',
+		'&', '|', '#', '<<', '>>'
+	);
+
+	/**
 	 * Compile an update statement into SQL.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -5,6 +5,17 @@ use Illuminate\Database\Query\Builder;
 class SQLiteGrammar extends Grammar {
 
 	/**
+	 * All of the available clause operators.
+	 *
+	 * @var array
+	 */
+	protected $operators = array(
+		'=', '==', '<', '>', '<=', '>=', '<>', '!=',
+		'like', 'not like', 'between', 'ilike',
+		'&', '|', '<<', '>>'
+	);
+
+	/**
 	 * Compile the "order by" portions of the query.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -5,6 +5,17 @@ use Illuminate\Database\Query\Builder;
 class SqlServerGrammar extends Grammar {
 
 	/**
+	 * All of the available clause operators.
+	 *
+	 * @var array
+	 */
+	protected $operators = array(
+		'=', '==', '<', '>', '<=', '>=', '!<', '!>', '<>', '!=',
+		'like', 'not like', 'between', 'ilike',
+		'&', '&=', '|', '|=', '^', '^='
+	);
+
+	/**
 	 * The keyword identifier wrapper format.
 	 *
 	 * @var string


### PR DESCRIPTION
I've added bitwise operators using the following grid:

|  | MySQL | PgSQL | SQLite | MSSQL |
| --- | :-: | :-: | :-: | :-: |
| AND | & | & | & | & |
| AND-E |  |  |  | &= |
| OR | (pipe) | (pipe) | (pipe) | (pipe) |
| OR-E |  |  |  | (pipe=) |
| XOR | ^ | # |  | ^ |
| XOR-E |  |  |  | ^= |
| L-SHFT | << | << | << |  |
| R-SHFT | >> | >> | >> |  |

Additionally added:
- SQLite's `==` operator,
- MSSQL's not-greater-than (`!>`), not-less-than (`!<`) operators.

I haven't added NOT (which is universally `~`) as I'm not sure how this would be used with `where($col, $op, $val)`.
