### PR TITLE
Add method of getting route parameter without evaluating all params

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -200,6 +200,34 @@ class Route extends BaseRoute {
 	}
 
 	/**
+	 * Get a parameter by name from the route.
+	 * This method does not evaluate all of the parameters beforehand, allowing
+	 * parameter access in another parameter's binder.
+	 *
+	 * @param  string  $name
+	 * @param  mixed   $default
+	 * @return string
+	 */
+	public function getSingleParameter($name, $default = null)
+	{
+		// If the parameter has already been parsed, return that
+		if (isset($this->parsedParameters) &&
+			array_key_exists($name, $this->parsedParameters)) {
+			return $this->parsedParameters[$name];
+		}
+
+		// Check that the parameter exists or has a binder
+		if (array_key_exists($name, $this->parameters) ||
+			$this->router->hasBinder($name)) {
+			return $this->resolveParameter($name) ?: $default;
+		} else {
+			return $default;
+		}
+
+		return $this->resolveParameter($name) ?: $default;
+	}
+
+	/**
 	 * Get the parameters to the callback.
 	 *
 	 * @return array


### PR DESCRIPTION
PR for #1787

I wanted to be able to load a model instance in the binder of another method - for example, the binder below will pass (Author, Post) to the actions of a number of routes. The problem (as in the issue) is that `$route->getParameter()` evaluates all the route variables, including this binder (so you end up with an infinite loop). `getSingleParameter` resolves just this variable.

```
Route::bind('post', function ($value, $route) {
    $author = $route->getSingleParameter('author');
    if ($author) {
        return Post::where('id', '=', $value)->where('author_id', '=', $author->id)->first();
    } else {
        // Chuck a 404 here
    }
});
```

I'm not 100% sure this is the wisest design choice but it saves me some code across controllers - let me know if this is silly :)
