### PR TITLE
May we have support for array bracket syntax in helpers/array_get

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -259,7 +259,14 @@ if ( ! function_exists('array_get'))
 	{
 		if (is_null($key)) return $array;
 		
-		if (isset($array[$key])) return $array[$key];
+		if ((count($array) > 0) && preg_match_all("/(.*?)\[(.*?)\]/", $key, $matches))
+		{
+			$subarray = $array[$matches[1][0]]; // Matches initial key part outside brackets
+			foreach ($matches[2] as $subkey)
+				$subarray = @$subarray[$subkey];
+				
+			return $subarray ? $subarray : value($default);
+		}
 
 		foreach (explode('.', $key) as $segment)
 		{

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -107,6 +107,17 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('age' => 25), $request->only('age'));
 		$this->assertEquals(array('name' => 'Taylor', 'age' => 25), $request->only('name', 'age'));
 	}
+	
+       public function testInputWithArrayMethod()
+        {
+                $request = Request::create('/', 'GET', array('user' => array('details' => array('name' => 'Taylor'))));
+                $this->assertEquals('Taylor', $request->input('user.details.name'));
+                $this->assertEquals('Taylor', $request->input('user[details][name]'));
+
+                $this->assertEquals('NY', $request->input('user.details.city', 'NY'));
+                $this->assertEquals('NY', $request->input('user[details][city]', 'NY'));
+        }
+
 
 
 	public function testExceptMethod()

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -20,9 +20,11 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 
 	public function testArrayGet()
 	{
-		$array = array('names' => array('developer' => 'taylor'));
-		$this->assertEquals('taylor', array_get($array, 'names.developer'));
+		$array = array('names' => array('developer' => array('name' => 'taylor')));
+		$this->assertEquals('taylor', array_get($array, 'names.developer.name'));
+		$this->assertEquals('taylor', array_get($array, 'names[developer][name]'));
 		$this->assertEquals('dayle', array_get($array, 'names.otherDeveloper', 'dayle'));
+		$this->assertEquals('dayle', array_get($array, 'names[otherDeveloper][name]', 'dayle'));
 		$this->assertEquals('dayle', array_get($array, 'names.otherDeveloper', function() { return 'dayle'; }));
 	}
 


### PR DESCRIPTION
Hi Guys

I get the feeling someone is going to throw me with a big old 21" CRT screen for this one, but please hear me out. 

I refer to a use-case: Former (https://github.com/Anahkiasen/former) has great support for figuring out complex relations and populating your entire form simply with 

```
Former::populate($user);
```

It is a life saver for a complex admin interface I'm building. If $user consists of a "hasmany order" and order "hasmany notes" I can then write

```
Former::text('order[notes][content]');
```

Former is great for figuring out this relationship and populating that form field with exactly the right "content" for that order note.

There is however a problem - when there is a validation error Former cannot get the input::old() values due to the way helpers.php/array_get works. There is a long standing issue regarding this. https://github.com/Anahkiasen/former/issues/122

I set out to fix this, and realized that when Former fetches the old input, it should convert the $key to dot notation. But this didn't seem very "laravelish" and I thought I could quickly try to add bracket syntax support to array_get. To my surprise the Laravel tests ran perfectly fine.

I know that previous issues on this mentioned that you have to use dot notation, but that makes parsing the POST data on forms with lots of relationships very difficult to parse and "hackish". PHP is one of the few languages with array input support and IMHO a great feature.

I therefore ask that the core developers of Laravel please consider my pull request. This immediately solves https://github.com/Anahkiasen/former/issues/122 without changing that code at all. It should make life easier for any package developer that would like to bind models to forms much easier. 

I have added test coverage to make sure I cover all bases. Please don't throw bulky 80's technology at me.
