### PR TITLE
Fix for compiler tags reversed using same characters breaking. Fixes #1808

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -172,6 +172,13 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	protected function compileEchos($value)
 	{
+		$difference = strlen($this->contentTags[0]) - strlen($this->escapedTags[0]);
+
+		if ($difference > 0)
+		{
+			return $this->compileEscapedEchos($this->compileRegularEchos($value));
+		}
+
 		return $this->compileRegularEchos($this->compileEscapedEchos($value));
 	}
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -72,6 +72,20 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 			$name
 		}}'));
 	}
+	
+	
+	public function testReversedEchosAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$compiler->setEscapedContentTags('{{', '}}');
+		$compiler->setContentTags('{{{', '}}}');
+		$this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{$name}}'));
+		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{{$name}}}'));
+		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{{ $name }}}'));
+		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{{ 
+			$name
+		}}}'));
+	}
 
 
 	public function testExtendsAreCompiled()


### PR DESCRIPTION
As explained in the issue. Don't know if you would rather not use the `$difference` variable since it is redundant however more readable. Or even comment to explain to people why the check is needed. But Jason tested that and he said it works, I'll write tests in a minute (doing lazy github editing).
