### PR TITLE
Adding a true mime validator, old one renamed to validateExtension

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -828,7 +828,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateImage($attribute, $value)
 	{
-		return $this->validateMimes($attribute, $value, array('jpeg', 'png', 'gif', 'bmp'));
+		return $this->validateMimes($attribute, $value, array('image/jpeg', 'image/gif', 'image/png', 'image/bmp', 'image/x-bmp'));
 	}
 
 	/**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -832,6 +832,27 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
+	 * Validate the extension of an uploaded file against a set of extensions.
+	 *
+	 * @param  string  $attribute
+	 * @param  array   $value
+	 * @param  array   $parameters
+	 * @return bool
+	 */
+	protected function validateExtension($attribute, $value, $parameters)
+	{
+		if ( ! $value instanceof File or $value->getPath() == '')
+		{
+			return true;
+		}
+
+		// The Symfony File class should do a decent job of guessing the extension
+		// based on the true MIME type so we'll just loop through the array of
+		// extensions and compare it to the guessed extension of the files.
+		return in_array($value->guessExtension(), $parameters);
+	}
+
+	/**
 	 * Validate the MIME type of a file upload attribute is in a set of MIME types.
 	 *
 	 * @param  string  $attribute
@@ -846,10 +867,7 @@ class Validator implements MessageProviderInterface {
 			return true;
 		}
 
-		// The Symfony File class should do a decent job of guessing the extension
-		// based on the true MIME type so we'll just loop through the array of
-		// extensions and compare it to the guessed extension of the files.
-		return in_array($value->guessExtension(), $parameters);
+		return in_array($value->getMimeType(), $parameters);
 	}
 
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -611,34 +611,54 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	public function testValidateImage()
 	{
 		$trans = $this->getRealTranslator();
-		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('guessExtension'), array(__FILE__, false));
-		$file->expects($this->any())->method('guessExtension')->will($this->returnValue('php'));
+		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getMimeType'), array(__FILE__, false));
+		$file->expects($this->any())->method('getMimeType')->will($this->returnValue('application/x-php'));
 		$v = new Validator($trans, array(), array('x' => 'Image'));
 		$v->setFiles(array('x' => $file));
 		$this->assertFalse($v->passes());
 
 		$v = new Validator($trans, array(), array('x' => 'Image'));
+		$file2 = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getMimeType'), array(__FILE__, false));
+		$file2->expects($this->any())->method('getMimeType')->will($this->returnValue('image/jpeg'));
+		$v->setFiles(array('x' => $file2));
+		$this->assertTrue($v->passes());
+
+		$file3 = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getMimeType'), array(__FILE__, false));
+		$file3->expects($this->any())->method('getMimeType')->will($this->returnValue('image/gif'));
+		$v->setFiles(array('x' => $file3));
+		$this->assertTrue($v->passes());
+
+		$file4 = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getMimeType'), array(__FILE__, false));
+		$file4->expects($this->any())->method('getMimeType')->will($this->returnValue('image/bmp'));
+		$v->setFiles(array('x' => $file4));
+		$this->assertTrue($v->passes());
+
+		$file5 = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getMimeType'), array(__FILE__, false));
+		$file5->expects($this->any())->method('getMimeType')->will($this->returnValue('image/png'));
+		$v->setFiles(array('x' => $file5));
+		$this->assertTrue($v->passes());
+	}
+    
+	public function testValidateExtension()
+	{
+		$trans = $this->getRealTranslator();
+		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('guessExtension'), array(__FILE__, false));
+		$file->expects($this->any())->method('guessExtension')->will($this->returnValue('php'));
+		$v = new Validator($trans, array(), array('x' => 'Extension:php'));
+		$v->setFiles(array('x' => $file));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array(), array('x' => 'Extension:xlsx'));
 		$file2 = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('guessExtension'), array(__FILE__, false));
-		$file2->expects($this->any())->method('guessExtension')->will($this->returnValue('jpeg'));
+		$file2->expects($this->any())->method('guessExtension')->will($this->returnValue('xlsx'));
 		$v->setFiles(array('x' => $file2));
 		$this->assertTrue($v->passes());
 
 		$file3 = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('guessExtension'), array(__FILE__, false));
 		$file3->expects($this->any())->method('guessExtension')->will($this->returnValue('gif'));
 		$v->setFiles(array('x' => $file3));
-		$this->assertTrue($v->passes());
-
-		$file4 = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('guessExtension'), array(__FILE__, false));
-		$file4->expects($this->any())->method('guessExtension')->will($this->returnValue('bmp'));
-		$v->setFiles(array('x' => $file4));
-		$this->assertTrue($v->passes());
-
-		$file5 = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('guessExtension'), array(__FILE__, false));
-		$file5->expects($this->any())->method('guessExtension')->will($this->returnValue('png'));
-		$v->setFiles(array('x' => $file5));
-		$this->assertTrue($v->passes());
+		$this->assertFalse($v->passes());
 	}
-
 
 	public function testValidateAlpha()
 	{


### PR DESCRIPTION
This change will introduce a true mime validator and rename the old one to validateExtension. If you check the code of the old validateMimes is just checking the extension and not the mime of the file.
