### PR TITLE
View data accessors return by reference

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -228,7 +228,6 @@ class View implements ArrayAccess, Renderable {
 
 	/**
 	 * Get a piece of bound data to the view.
-	 * (Returned by reference so that `$view['arr'][] = 1` is possible)
 	 *
 	 * @param  string  $key
 	 * @return mixed
@@ -263,7 +262,6 @@ class View implements ArrayAccess, Renderable {
 
 	/**
 	 * Get a piece of data from the view.
-	 * (Returned by reference so that `$view->arr[] = 1` is possible)
 	 *
 	 * @return mixed
 	 */

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -228,11 +228,12 @@ class View implements ArrayAccess, Renderable {
 
 	/**
 	 * Get a piece of bound data to the view.
+	 * (Returned by reference so that `$view['arr'][] = 1` is possible)
 	 *
 	 * @param  string  $key
 	 * @return mixed
 	 */
-	public function offsetGet($key)
+	public function &offsetGet($key)
 	{
 		return $this->data[$key];
 	}
@@ -262,10 +263,11 @@ class View implements ArrayAccess, Renderable {
 
 	/**
 	 * Get a piece of data from the view.
+	 * (Returned by reference so that `$view->arr[] = 1` is possible)
 	 *
 	 * @return mixed
 	 */
-	public function __get($key)
+	public function &__get($key)
 	{
 		return $this->data[$key];
 	}

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -21,6 +21,17 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testArrayCanBeAppendedToViaViewDataAccessors()
+	{
+		$view = new View(m::mock('Illuminate\View\Environment'), m::mock('Illuminate\View\Engines\EngineInterface'), 'view', 'path', array());
+		$view->foo = array();
+		$view->foo[] = 'bar';
+		$view['baz'] = array();
+		$view['baz'][] = 'boom';
+		$this->assertEquals(array('foo' => array('bar'), 'baz' => array('boom')), $view->getData());
+	}
+
+
 	public function testRenderProperlyRendersView()
 	{
 		$view = $this->getView();


### PR DESCRIPTION
Currently, if you add an array as view data, you cannot append to it through the usual `$arr[] = 123;`. The following:

```
$view = View::make('some.view')->with('links', array());
$view->links[] = 'http://www.laravel.com';
print_r($view->links);
```

Raises an error introduced in PHP 5.2 (And still present in 5.4):

```
Indirect modification of overloaded property Illuminate\View\View::$links has no effect
```

This is addressed in [PHP bug #39449](https://bugs.php.net/bug.php?id=39449) and was fixed AFAIK in 5.2.6. The bug discusses that when returning by reference from `__get()` (and in Laravel's case `offsetGet()` as well), the above code will output the expected:

```
Array
(
    [0] => http://www.laravel.com
)
```

Since Laravel requires PHP >= 5.3.0 in `laravel/framework`'s `composer.json`, it should be safe to have `View::__get()` and `View::offsetGet()` return by reference and assume the above will work properly. I added an extra test to the suite to verify this.

Otherwise, the alternative is using an unnecessary `ArrayObject` in place of an array (which I find less graceful than `$view->links[]`).
