### PR TITLE
added missing "use Closure;" to SqlServerConnection.php

### DIFF
--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -1,5 +1,7 @@
 <?php namespace Illuminate\Database;
 
+use Closure;
+
 class SqlServerConnection extends Connection {
 
 	/**


### PR DESCRIPTION
### Introduction
- Issue has been discovered in http://forums.laravel.io/viewtopic.php?id=9900.
- This pull request has previously been sent to the wrong branch (master instead of 4.0) in https://github.com/laravel/framework/pull/1826.
### Problem analysis

In `Illuminate/Database/SqlServerConnection.php` the method signature of `transaction` looks like this

```
public function transaction(Closure $callback)
```

If the `Closure` class is referenced like this, it has to be declared in a `use` statement after the namespace definition in the file. However the `use` statement is missing, resulting in an error message when `transaction` method is called:

```
Argument 1 passed to Illuminate\Database\SqlServerConnection::transaction() must be an instance of Illuminate\Database\Closure, instance of Closure given
```
### Solution

This pull request adds `use Closure;` to the file `SqlServerConnection.php`.

Signed-off-by: aeberhardo aeberhard@gmx.ch
