### PR TITLE
Small fix for providing an zero (integer) to the validateAccept function

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -474,7 +474,7 @@ class Validator implements MessageProviderInterface {
 	{
 		$acceptable = array('yes', 'on', 1);
 
-		return $this->validateRequired($attribute, $value) and in_array($value, $acceptable);
+		return $this->validateRequired($attribute, $value) and in_array($value, $acceptable) and $value;
 	}
 
 	/**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -474,7 +474,7 @@ class Validator implements MessageProviderInterface {
 	{
 		$acceptable = array('yes', 'on', 1);
 
-		return $this->validateRequired($attribute, $value) and in_array($value, $acceptable) and $value;
+		return $value and $this->validateRequired($attribute, $value) and in_array($value, $acceptable);
 	}
 
 	/**


### PR DESCRIPTION
If 0 (integer), is passed to the validateAccept function, the function always returns 1. This small fix will prevent that the 'in_array' function returns zero if there is an zero (integer) provided as $value.
