### PR TITLE
[BUG] Load in Eloquent Collections doesn't work with constraints

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -23,14 +23,16 @@ class Collection extends BaseCollection {
 	/**
 	 * Load a set of relationships onto the collection.
 	 *
-	 * @param  dynamic  string
+	 * @param  array|string  $relations
 	 * @return void
 	 */
-	public function load()
+	public function load($relations)
 	{
 		if (count($this->items) > 0)
 		{
-			$query = $this->first()->newQuery()->with(func_get_args());
+			if (is_string($relations)) $relations = func_get_args();
+
+			$query = $this->first()->newQuery()->with($relations);
 
 			$this->items = $query->eagerLoadRelations($this->items);
 		}


### PR DESCRIPTION
There was a problem with eloquent collections.

The `load` method didn't check if the parameter was a string or not like in the other `load` methods (`Model` and `Builder`)
