### PR TITLE
Add an option to access the raw cookie in CookieJar

### DIFF
--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -46,6 +46,9 @@ class CookieTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($c->isSecure());
 		$this->assertEquals('/domain', $c->getDomain());
 		$this->assertEquals('/path', $c->getPath());
+
+		$c2 = $cookie->makePlain('color2', 'red');
+		$this->assertEquals('red', $c2->getValue());
 	}
 
 
@@ -54,7 +57,9 @@ class CookieTest extends PHPUnit_Framework_TestCase {
 		$cookie = $this->getCreator();
 		$value = $cookie->getEncrypter()->encrypt('bar');
 		$cookie->getRequest()->cookies->set('foo', $value);
+		$cookie->getRequest()->cookies->set('color', 'red');
 		$this->assertEquals('bar', $cookie->get('foo'));
+		$this->assertEquals('red', $cookie->getPlain('color'));
         $this->assertEquals('zee', $cookie->get('someOtherFoo', 'zee'));
         
 		$cookie = $this->getCreator();


### PR DESCRIPTION
CookieJar encrypts its cookies, which is great but being able to set/access the cookie from the client javascript is sometimes necessary.
Using `$_COOKIE` is an immediate work-around this problem of course, but it doesn't look very nice…

Thanks!
Arthur

cc @julien-c @Anahkiasen
