### PR TITLE
Cloned eloquent query builders do not clone the base query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -38,6 +38,11 @@ class Builder {
 		'count', 'min', 'max', 'avg', 'sum', 'exists',
 	);
 
+	public function __clone()
+	{
+		$this->query = clone $this->query;
+	}
+
 	/**
 	 * Create a new Eloquent query builder instance.
 	 *


### PR DESCRIPTION
Test Code:

``` php
class TestModel extends Eloquent
{
}

$query = TestModel::select('test_model.*')->where('cheese', '=', 1);

var_dump($query->getQuery()->toSql());

try {
$countQuery = clone $query;
$countQuery->count();
} catch (Exception $e) {}

var_dump($query->getQuery()->toSql());
```

Expected result:

> string(59) "select "test_model".\* from "test_models" where "cheese" = ?"
> string(59) "select "test_model".\* from "test_models" where "cheese" = ?"

Actual result:

> string(59) "select "test_model".\* from "test_models" where "cheese" = ?"
> string(66) "select count(*) as aggregate from "test_models" where "cheese" = ?"
