### PR TITLE
Don't process the value if there isn't one.

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -43,6 +43,9 @@ abstract class Grammar {
 	{
 		if ($this->isExpression($value)) return $this->getValue($value);
 
+		// Don't attempt to wrap an empty value;
+		if (empty($value)) return;
+		
 		// If the value being wrapped has a column alias we will need to separate out
 		// the pieces so we can wrap each of the segments of the expression on it
 		// own, and then joins them both back together with the "as" connector.


### PR DESCRIPTION
Hi.

I'm very new to Illuminate and couldn't find out how to join with an AND `column` = 'literal'.

Tiny bit of research led to the use of an Expression.

That seemed to work but built in an extra `` for some reason.

The `` was the result of wrapping the $second value in the join. When there isn't one.

The fix may be better moved up the call tree - I don't know for sure.

The half working code was ...

```
$pitch->leftJoin(
  'pitches_event_dates',
  new \Illuminate\Database\Query\Expression(
    "pitches_event_dates.pitch_id = pitches.id AND pitches_event_dates.event_name = 'funded_emails_sent_date'"
  )
);
```

And as the leftJoin() only has the table to join and the Expression, no $operator or $second. But $second was being wrapped and ended up with `` in the SQL.

The real issue is that exploding an empty string or null always results in an array.

```
php -r 'var_dump(explode(".", null));'
```

results in ...

```
array(1) {
  [0]=>
  string(0) ""
}
```

Hope this all makes sense.
