### PR TITLE
Automatically generate command name for new Artisan-generated commands

### DIFF
--- a/src/Illuminate/Foundation/Console/CommandMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CommandMakeCommand.php
@@ -49,10 +49,18 @@ class CommandMakeCommand extends Command {
 		// typically using the PSR-0 standards we can safely assume the classes name
 		// will correspond to what the actual file should be stored as on storage.
 		$file = $path.'/'.$this->input->getArgument('name').'.php';
+		
+		// Make sure we don't replace an already existing command
+		if ($this->files->exists($file))
+		{
+			$this->error('Command already exists!');
+		}
+		else
+		{
+			$this->files->put($file, $this->formatStub($stub));
 
-		$this->files->put($file, $this->formatStub($stub));
-
-		$this->info('Command created successfully.');
+			$this->info('Command created successfully.');
+		}
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/CommandMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CommandMakeCommand.php
@@ -63,7 +63,9 @@ class CommandMakeCommand extends Command {
 	 */
 	protected function formatStub($stub)
 	{
-		$stub = str_replace('{{class}}', $this->input->getArgument('name'), $stub);
+		$name = $this->input->getArgument('name');
+
+		$stub = str_replace('{{class}}', $name, $stub);
 
 		if ( ! is_null($namespace = $this->input->getOption('namespace')))
 		{
@@ -73,6 +75,21 @@ class CommandMakeCommand extends Command {
 		{
 			$stub = str_replace('{{namespace}}', '', $stub);
 		}
+
+		// Split the command name to words based on camelisation ( CamelCase => ['Camel', 'Case'] )
+		$parts = preg_split('/(?=[A-Z])/', $name, -1, PREG_SPLIT_NO_EMPTY);
+
+		// Make all parts lowercase
+		$parts = array_map('strtolower', $parts);
+
+		// Remove the 'command' part if present
+		$parts = array_filter($parts, function($part)
+		{
+			return $part != 'command' ? true : false;
+		});
+
+		// Put the command name into the stub
+		$stub = str_replace('{{command}}', implode(':', $parts), $stub);
 
 		return $stub;
 	}

--- a/src/Illuminate/Foundation/Console/stubs/command.stub
+++ b/src/Illuminate/Foundation/Console/stubs/command.stub
@@ -11,7 +11,7 @@ class {{class}} extends Command {
 	 *
 	 * @var string
 	 */
-	protected $name = 'command:name';
+	protected $name = '{{command}}';
 
 	/**
 	 * The console command description.


### PR DESCRIPTION
Instead of having to manually replace "command:name" with something
meaningful, we can auto-generate the command name from what the user
specified on command line while generating the command.
