### PR TITLE
Should return $this->parameters that compiled

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -211,7 +211,7 @@ class Route extends BaseRoute {
 		// a binder that uses a database repository and shouldn't be run again.
 		if (isset($this->parsedParameters))
 		{
-			return $this->parsedParameters;
+			return $this->parameters;
 		}
 
 		$variables = $this->compile()->getVariables();
@@ -219,14 +219,14 @@ class Route extends BaseRoute {
 		// To get the parameter array, we need to spin the names of the variables on
 		// the compiled route and match them to the parameters that we got when a
 		// route is matched by the router, as routes instances don't have them.
-		$parameters = array();
-
 		foreach ($variables as $variable)
 		{
-			$parameters[$variable] = $this->resolveParameter($variable);
+			$this->parameters[$variable] = $this->resolveParameter($variable);
 		}
 
-		return $this->parsedParameters = $parameters;
+		$this->parsedParameters = true;
+
+		return $this->parameters;
 	}
 
 	/**


### PR DESCRIPTION
After Route::bind('something') when I want to edit route parameter. I can't edit parameter with $route->getParameters() and $route->setParameters().

I use this filter to do it before method in controller will call it.

``` php
Route::filter('action.profile.force', function($route, $request, $path)
{
    $profile = $route->getParameter('path');

    if ($profile->path != $path)
    {
        $route_parameters = $route->getParameters();

            $profile = Profile::wherePath($path)->first();
            $route_parameters['path'] = new ProfileRepository($profile);

            $route->setParameters($route_parameters);
    }
});
```
