### PR TITLE
Fix relation field values in a Form

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -766,7 +766,7 @@ class FormBuilder {
 
 		if ( ! is_null($value)) return $value;
 
-		if (isset($this->model) and isset($this->model[$name]))
+		if (isset($this->model))
 		{
 			return $this->getModelValueAttribute($name);
 		}


### PR DESCRIPTION
Because of `isset($this->model[$name])`, it was not possible to have fields pre-filled with values of a Model's relationships (__offsetGet simply returns the attribute of the given name, which doesn't work for relations).

I've removed this check because 1) the model value is the last fallback so this won't prevent lower ranked values from being filled in and 2) `object_get()` is used for resolving the given attribute of the Model, which supports the dot syntax.

With this fix, `Form::text('modelrelation.relationattribute')` will return the proper value if no session or hardcoded values exist.
