### PR TITLE
Change Artisan#getArtisan() to public

### DIFF
--- a/src/Illuminate/Foundation/Artisan.php
+++ b/src/Illuminate/Foundation/Artisan.php
@@ -61,7 +61,7 @@ class Artisan {
 	 *
 	 * @return \Illuminate\Console\Application
 	 */
-	protected function getArtisan()
+	public function getArtisan()
 	{
 		if ( ! is_null($this->artisan)) return $this->artisan;
 


### PR DESCRIPTION
To be able to hook in to artisan (Pullrequest for Laravel will come too) it should be public.

We can use $artisan = \Artisan::getArtisan(); in artisan then.
