### PR TITLE
HTML::link Be more strict about $title parameter

### DIFF
--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -123,7 +123,10 @@ class HtmlBuilder {
 	{
 		$url = $this->url->to($url, array(), $secure);
 
-		$title = $title ?: $url;
+		if (is_null($title) || $title === FALSE) 
+		{
+			$title = $url;
+		}
 
 		return '<a href="'.$url.'"'.$this->attributes($attributes).'>'.$this->entities($title).'</a>';
 	}

--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -123,7 +123,7 @@ class HtmlBuilder {
 	{
 		$url = $this->url->to($url, array(), $secure);
 
-		if (is_null($title) || $title === FALSE) 
+		if (is_null($title) or $title === FALSE)
 		{
 			$title = $url;
 		}

--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -123,7 +123,7 @@ class HtmlBuilder {
 	{
 		$url = $this->url->to($url, array(), $secure);
 
-		if (is_null($title) or $title === FALSE)
+		if (is_null($title) or $title === false)
 		{
 			$title = $url;
 		}


### PR DESCRIPTION
The title parameter of HTML::link currently assumes that any 'falsey' value means that it should use the full url as the content of the anchor tag. This behaviour is troublesome in some cases, for example when trying to generate a link with the anchor text of "0". 

I've made this more strict by specifically checking for null values and FALSE only. 

Thoughts?
