### PR TITLE
Allow options to be passed along with IronMQ messages/tasks - this time with tests :)

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -41,7 +41,7 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 	 * @param  string  $queue
 	 * @return void
 	 */
-	public function push($job, $data = '', $queue = null)
+	public function push($job, $data = '', $queue = null, $options = array())
 	{
 		$payload = $this->createPayload($job, $data);
 

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -61,11 +61,11 @@ class IronQueue extends Queue implements QueueInterface {
 	 * @param  string  $queue
 	 * @return void
 	 */
-	public function push($job, $data = '', $queue = null)
+	public function push($job, $data = '', $queue = null, $options = array())
 	{
 		$payload = $this->createPayload($job, $data);
 
-		$this->iron->postMessage($this->getQueue($queue), $payload);
+		$this->iron->postMessage($this->getQueue($queue), $payload, $options);
 	}
 
 	/**

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -59,6 +59,7 @@ class IronQueue extends Queue implements QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed   $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return void
 	 */
 	public function push($job, $data = '', $queue = null, $options = array())

--- a/src/Illuminate/Queue/QueueInterface.php
+++ b/src/Illuminate/Queue/QueueInterface.php
@@ -8,9 +8,10 @@ interface QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed   $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return void
 	 */
-	public function push($job, $data = '', $queue = null);
+	public function push($job, $data = '', $queue = null, $options = array());
 
 	/**
 	 * Push a new job onto the queue after a delay.

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -40,7 +40,7 @@ class SqsQueue extends Queue implements QueueInterface {
 	 * @param  string  $queue
 	 * @return void
 	 */
-	public function push($job, $data = '', $queue = null)
+	public function push($job, $data = '', $queue = null, $options = array())
 	{
 		$payload = $this->createPayload($job, $data);
 

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -10,7 +10,7 @@ class SyncQueue extends Queue implements QueueInterface {
 	 * @param  string  $queue
 	 * @return void
 	 */
-	public function push($job, $data = '', $queue = null)
+	public function push($job, $data = '', $queue = null, $options = array())
 	{
 		$this->resolveJob($job, $data)->fire();
 	}

--- a/tests/Queue/QueueIronQueueTest.php
+++ b/tests/Queue/QueueIronQueueTest.php
@@ -14,7 +14,7 @@ class QueueIronQueueTest extends PHPUnit_Framework_TestCase {
 	{
 		$queue = new Illuminate\Queue\IronQueue($iron = m::mock('IronMQ'), $crypt = m::mock('Illuminate\Encryption\Encrypter'), m::mock('Illuminate\Http\Request'), 'default');
 		$crypt->shouldReceive('encrypt')->once()->with(json_encode(array('job' => 'foo', 'data' => array(1, 2, 3))))->andReturn('encrypted');
-		$iron->shouldReceive('postMessage')->once()->with('default', 'encrypted');
+		$iron->shouldReceive('postMessage')->once()->with('default', 'encrypted', array());
 		$queue->push('foo', array(1, 2, 3));
 	}
 
@@ -25,7 +25,7 @@ class QueueIronQueueTest extends PHPUnit_Framework_TestCase {
 		$name = 'Foo';
 		$closure = new Illuminate\Support\SerializableClosure($innerClosure = function() use ($name) { return $name; });
 		$crypt->shouldReceive('encrypt')->once()->with(json_encode(array('job' => 'IlluminateQueueClosure', 'data' => array('closure' => serialize($closure)))))->andReturn('encrypted');
-		$iron->shouldReceive('postMessage')->once()->with('default', 'encrypted');
+		$iron->shouldReceive('postMessage')->once()->with('default', 'encrypted', array());
 		$queue->push($innerClosure);
 	}
 
@@ -42,7 +42,7 @@ class QueueIronQueueTest extends PHPUnit_Framework_TestCase {
 	public function testPopProperlyPopsJobOffOfIron()
 	{
 		$queue = new Illuminate\Queue\IronQueue($iron = m::mock('IronMQ'), $crypt = m::mock('Illuminate\Encryption\Encrypter'), m::mock('Illuminate\Http\Request'), 'default');
-		$queue->setContainer(m::mock('Illuminate\Container\Container'));		
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
 		$iron->shouldReceive('getMessage')->once()->with('default')->andReturn($job = m::mock('IronMQ_Message'));
 		$job->body = 'foo';
 		$crypt->shouldReceive('decrypt')->once()->with('foo')->andReturn('foo');


### PR DESCRIPTION
EDIT: This was lacking proper unit tests - sorry about that! I have now added them.

IronMQ, as well as its PHP library which Laravel uses, allows options to be set for individual messages, such as delay, timeout and expiration (see http://dev.iron.io/mq/reference/environment/).

While trying to preserve the interface of QueueInterface, specifically the order of the parameters, I added support for this. I simply added an extra optional parameter to QueueInterface::push(), and in IronQueue::push() added this parameter to $this->iron->postMessage().
