### PR TITLE
[Request] auth:reminders command: set the name of the password reminders table according to the config.

### DIFF
--- a/src/Illuminate/Auth/Console/MakeRemindersCommand.php
+++ b/src/Illuminate/Auth/Console/MakeRemindersCommand.php
@@ -50,7 +50,13 @@ class MakeRemindersCommand extends Command {
 	{
 		$fullPath = $this->createBaseMigration();
 
-		$this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/reminders.stub'));
+		$contents = str_replace(
+			'password_reminders',
+			$this->laravel['config']['auth']['reminder']['table'],
+			$this->files->get(__DIR__.'/stubs/reminders.stub');
+		);
+
+		$this->files->put($fullPath, $contents);
 
 		$this->info('Migration created successfully!');
 


### PR DESCRIPTION
Artisan’s `auth:reminders` command always sets a default table name of `'password_reminders'` when it creates its migration, even if a different name has been defined in `config/auth.php`.

This pull request makes the command use the existing configuration, so the developer doesn’t have to edit the generated migration manually to correct the table name.
