### PR TITLE
SqlServerConnection::transaction() should use PDO transactions with sqlsrv driver (see issue #1882)

### DIFF
--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -12,6 +12,12 @@ class SqlServerConnection extends Connection {
 	 */
 	public function transaction(Closure $callback)
 	{
+		// Microsoft SQL Server driver for pdo (pdo_sqlsrv, driver name sqlsrv)
+		// correctly supports PDO transactions, and will throw an error if you
+		// don't use them. As a result, if using this driver we'd rather use the 
+		// generic PDO transaction implementation.
+		if ($this->getDriverName() == 'sqlsrv') return parent::transaction($callback);
+
 		$this->pdo->exec('BEGIN TRAN');
 
 		// We'll simply execute the given callback within a try / catch block


### PR DESCRIPTION
The connection seems to do transactions properly if the generic PDO transaction implementation is called instead of the raw "begin tran / commit tran / rollback tran" commands get called on the sqlsrv driver.
