### PR TITLE
Patchwork should be a required dependency.

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -8,10 +8,10 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "patchwork/utf8": "1.1.*"
     },
     "require-dev": {
-        "patchwork/utf8": "1.1.*",
         "mockery/mockery": "0.7.2",
         "phpunit/phpunit": "3.7.*"
     },


### PR DESCRIPTION
Since [Illuminat\Suppport\Str::ascii()](https://github.com/laravel/framework/blob/master/src/Illuminate/Support/Str.php#L18) depends on Patchwork, Patchwork should be listed under required dependencies.
