### PR TITLE
Including a better exception for query issues

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -495,11 +495,7 @@ class Connection implements ConnectionInterface {
 	 */
 	protected function handleQueryException(\Exception $e, $query, $bindings)
 	{
-		$bindings = var_export($bindings, true);
-
-		$message = $e->getMessage()." (SQL: {$query}) (Bindings: {$bindings})";
-
-		throw new \Exception($message);
+		throw new QueryException($query, $bindings, $e->getMessage(), $e->getCode(), $e);
 	}
 
 	/**

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -11,7 +11,9 @@ class QueryException extends \PDOException {
         $this->sql       = $sql;
         $this->bindings  = $bindings;
         $this->errorInfo = $previous->errorInfo;
-        parent::__construct($message, $code, $previous);
+        $this->message   = $message;
+        $this->code      = $code;
+        $this->previous  = $previous;
     }
 
     public function getSql()

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -1,0 +1,31 @@
+<?php namespace Illuminate\Database;
+
+class QueryException extends \PDOException {
+
+    protected $bindings = array();
+
+    protected $sql = '';
+
+    public function __construct($sql, array $bindings, $message = '', $code = 0, \Exception $previous = null)
+    {
+        $this->sql = $sql;
+        $this->bindings = $bindings;
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getSql()
+    {
+        return $this->sql;
+    }
+
+    public function getBindings()
+    {
+        return $this->bindings;
+    }
+
+    public function getSqlBindings()
+    {
+        $bindings = strtr(var_export($this->bindings, true), array("\n" => ''));
+        return "(SQL: $this->sql) (Bindings: $bindings)";
+    }
+}

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -6,10 +6,11 @@ class QueryException extends \PDOException {
 
     protected $sql = '';
 
-    public function __construct($sql, array $bindings, $message = '', $code = 0, \Exception $previous = null)
+    public function __construct($sql, array $bindings, $message = '', $code = 0, \PDOException $previous = null)
     {
-        $this->sql = $sql;
-        $this->bindings = $bindings;
+        $this->sql       = $sql;
+        $this->bindings  = $bindings;
+        $this->errorInfo = $previous->errorInfo;
         parent::__construct($message, $code, $previous);
     }
 


### PR DESCRIPTION
Included QueryException class, that holds SQL and Bindings. Throwing it instead of a bland Exception helps a lot developers to actually catch different problems instead of having to use a catch-all clause that informs very little about the problem.
