### PR TITLE
Fixed bug when URLs starting with protocol were not matched as valid URLs

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -288,6 +288,8 @@ class UrlGenerator {
 	{
 		if (starts_with($path, array('#', '//', 'mailto:', 'tel:'))) return true;
 
+		if (preg_match('/^[a-z]+:\/\//i', $path)) return true;
+
 		return filter_var($path, FILTER_VALIDATE_URL) !== false;
 	}
 


### PR DESCRIPTION
Opened a bug topic on [forum](http://forums.laravel.io/viewtopic.php?pid=47241#p47241) and fixed it recently.

The idea was to add regexp-based matching on URLs to check if they start with protocol. E. g. `http://moo.foo/` was decided as non-valid URL.
