### PR TITLE
Implementing support for compound primary keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1474,7 +1474,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		}
 		else
 		{
-			$keyValues = [];
+			$keyValues = array();
 			foreach ($key as $pk)
 			{
 				$keyValues[] = $this->getAttribute($pk);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -99,7 +99,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	{
 		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
-		$query->shouldReceive('where')->once()->with('id', '=', 1);
+		$query->shouldReceive('where')->once()->with('id', 1);
 		$query->shouldReceive('update')->once()->with(array('id' => 1, 'name' => 'taylor'));
 		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
 		$model->expects($this->once())->method('updateTimestamps');
@@ -123,7 +123,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	{
 		$model = $this->getMock('EloquentModelStub', array('newQuery'));
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
-		$query->shouldReceive('where')->once()->with('id', '=', 1);
+		$query->shouldReceive('where')->once()->with('id', 1);
 		$query->shouldReceive('update')->once()->with(array('id' => 1, 'created_at' => 'foo', 'updated_at' => 'bar'));
 		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
@@ -172,7 +172,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps', 'fireModelEvent'));
 		$model->timestamps = false;
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
-		$query->shouldReceive('where')->once()->with('id', '=', 1);
+		$query->shouldReceive('where')->once()->with('id', 1);
 		$query->shouldReceive('update')->once()->with(array('id' => 1, 'name' => 'taylor'));
 		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
 		$model->expects($this->never())->method('updateTimestamps');


### PR DESCRIPTION
Most methods have been adapted to account for an array of key names as the  property. The exception is the insertGetId method, that currently depends on a PDO/database feature, and I'm unsure how best change this part.

It lacks tests about compound keys as well.

This PR fixes the abandoned issue https://github.com/laravel/laravel/issues/1888.
