### PR TITLE
Safely flush empty cache section, and avoid returning stale data from sections

### DIFF
--- a/src/Illuminate/Cache/Section.php
+++ b/src/Illuminate/Cache/Section.php
@@ -189,7 +189,7 @@ class Section {
 	}
 
 	/**
-	 * Reset the section, returning a new section key
+	 * Reset the section, returning a new section identifier
 	 *
 	 * @return string
 	 */

--- a/src/Illuminate/Cache/Section.php
+++ b/src/Illuminate/Cache/Section.php
@@ -123,7 +123,7 @@ class Section {
 	 */
 	public function flush()
 	{
-		$this->store->increment($this->sectionKey());
+		$this->reset();
 	}
 
 	/**
@@ -189,6 +189,17 @@ class Section {
 	}
 
 	/**
+	 * Reset the section, returning a new section key
+	 *
+	 * @return string
+	 */
+	protected function reset()
+	{
+		$this->store->forever($this->sectionKey(), $id = uniqid());
+		return $id;
+	}
+
+	/**
 	 * Get the unique section identifier.
 	 *
 	 * @return string
@@ -199,7 +210,7 @@ class Section {
 
 		if (is_null($id))
 		{
-			$this->store->forever($this->sectionKey(), $id = rand(1, 10000));
+			$id = $this->reset();
 		}
 
 		return $id;


### PR DESCRIPTION
This patch should solve two issues.

First, it allows flush to be called on a section even if the section does not exist. (see issue #1885)

Second, it will solve a potential bug that would allow stale data to be served from a section. This second bug would come about as follows: Memcached does not guarantee to keep all records. Say a section has been used, and flushed, frequently, before the Memcached record corresponding to the SectionId is lost for some reason. If the ID had originally started at, say, 1000, and it had been flushed thousands of times, then it is likely that any new sectionId (a random number 1-10000) would collide with one of the old sectionIds. The caches stored in that old section would then be returned, with the stale data. Changing the sectionId from a random integer to a uniqid will prevent the return of stale data in this way.

There were no test cases for Cache Sections, and I don't have any caching systems installed on my local system to test my changes, so this is not fully tested, but the change is quite simple.
