### PR TITLE
move routes.php to a file_exists check

### DIFF
--- a/src/Illuminate/Foundation/start.php
+++ b/src/Illuminate/Foundation/start.php
@@ -248,4 +248,6 @@ if (file_exists($path)) require $path;
 |
 */
 
-require $app['path'].'/routes.php';
+$path = $app['path'].'/routes.php';
+
+if (file_exists($path)) require $path;


### PR DESCRIPTION
I have a custom implementation for routes in my application that does not require a routes.php file. It would be nice to have this file behind a file_exists check so the application could avoid the extra file system operation.

I know it's not much, but it makes sense.
