### PR TITLE
[Proposal] Add Str Count function to determine word state

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -49,6 +49,18 @@ class Str {
 	}
 
 	/**
+	 * Determines parsing to plural or singular depending on the amount passed.
+	 *
+	 * @param  int     $amount
+	 * @param  string  $word
+	 * @return string
+	 */
+	public static function count($amount, $word)
+	{
+		return $amount === 1 ? static::singular($word) : static::plural($word);
+	}
+
+	/**
 	 * Determine if a given string ends with a given needle.
 	 *
 	 * @param string $haystack

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -758,6 +758,21 @@ if ( ! function_exists('str_contains'))
 	}
 }
 
+if ( ! function_exists('str_count'))
+{
+	/**
+	 * Determine if a given string contains a given sub-string.
+	 *
+	 * @param  int     $amount
+	 * @param  string  $word
+	 * @return string
+	 */
+	function str_count($amount, $word)
+	{
+		return Illuminate\Support\Str::count($amount, $word);
+	}
+}
+
 if ( ! function_exists('str_finish'))
 {
 	/**

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -166,6 +166,18 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testStrCount()
+	{
+		$amount = 1;
+		$word = str_count($amount, 'posts');
+		$this->assertEquals('post', $word);
+
+		$amount = 5;
+		$word = str_count($amount, 'posts');
+		$this->assertEquals('posts', $word);
+	}
+
+
 	public function testSnakeCase()
 	{
 		$this->assertEquals('foo_bar', snake_case('fooBar'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -71,6 +71,19 @@ class SupportStrTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testStrCount()
+	{
+		$amount = 1;
+		$word = Str::count($amount, 'posts');
+		$this->assertEquals('post', $word);
+
+		$amount = 5;
+		$word = Str::count($amount, 'posts');
+		$this->assertEquals('posts', $word);
+	}
+
+
+
 	public function testParseCallback()
 	{
 		$this->assertEquals(array('Class', 'method'), Str::parseCallback('Class@method', 'foo'));


### PR DESCRIPTION
I thought of this function after running into the problem where I needed to display the phrasing of "x posts" but not knowing what x is. Of course you want "posts" to be singular when x = 1. So I added `Str::count($amount, $word)` to solve this.

``` php
$amount = count($posts);
echo "$amount ".Str::count($amount, 'posts'); // Outputs "1 post" or "x posts".
```

If `$amount` is 1 then the singular version will be used and if `$amount` is anything else, the plural version of the word will be used.

Perhaps the `count` function isn't really descriptive but I couldn't think of anything else.
