### PR TITLE
Find with join causes "ambiguous name id"

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -58,7 +58,7 @@ class Builder {
 	 */
 	public function find($id, $columns = array('*'))
 	{
-		$this->query->where($this->model->getKeyName(), '=', $id);
+		$this->query->where($this->model->getTable() . '.' .$this->model->getKeyName(), '=', $id);
 
 		return $this->first($columns);
 	}


### PR DESCRIPTION
This:

```
Car::join('another_table', 'another_column', '=', 'xx')->find(1);
```

causes "Ambiguous column name 'id'".
