### PR TITLE
Fix fetching a flattened array of eloquent collection

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -180,7 +180,7 @@ if ( ! function_exists('array_fetch'))
 
 			foreach ($array as $value)
 			{
-				$value = (array) $value;
+				$value = ($value instanceof Illuminate\Support\Contracts\ArrayableInterface) ? $value->toArray() : (array) $value;
 
 				$results[] = $value[$segment];
 			}


### PR DESCRIPTION
Post::all()->fetch('title') throws undefined index exception
