### PR TITLE
Fix Str::slug() separator flip.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -267,13 +267,13 @@ class Str {
 	{
 		$title = static::ascii($title);
 
-		// Remove all characters that are not the separator, letters, numbers, or whitespace.
-		$title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', mb_strtolower($title));
-
 		// Convert all dashes/undescores into separator
 		$flip = $separator == '-' ? '_' : '-';
 
 		$title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
+
+		// Remove all characters that are not the separator, letters, numbers, or whitespace.
+		$title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', mb_strtolower($title));
 
 		// Replace all separator characters and whitespace by a single separator
 		$title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -77,4 +77,12 @@ class SupportStrTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('Class', 'foo'), Str::parseCallback('Class', 'foo'));
 	}
 
+	public function testSlug()
+	{
+		$this->assertEquals('hello-world', Str::slug('hello world'));
+		$this->assertEquals('hello-world', Str::slug('hello-world'));
+		$this->assertEquals('hello-world', Str::slug('hello_world'));
+		$this->assertEquals('hello_world', Str::slug('hello_world', '_'));
+	}
+
 }


### PR DESCRIPTION
Previously flip thingy just didn't work because it was set after preg_replace already cleaned up a string. Moved flip above couple of lines and added tests.
