### PR TITLE
Update helpers.php

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -499,7 +499,7 @@ if ( ! function_exists('e'))
 	 */
 	function e($value)
 	{
-		return htmlentities($value, ENT_QUOTES, 'UTF-8', false);
+		return htmlentities($value, ENT_QUOTES, 'UTF-8');
 	}
 }
 


### PR DESCRIPTION
changes e helper method to more predictable behavior. What was the reason for disabling double encode?
