### PR TITLE
Fixed Pluralizer capitalization of compound words terminated by an irregular

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -185,11 +185,14 @@ class Pluralizer {
 		// "teeth", both of which cannot get inflected using our typical rules.
 		foreach ($irregular as $irregular => $pattern)
 		{
-			if (preg_match($pattern = '/'.$pattern.'$/i', $value))
+			if (preg_match($fullPattern = '/'.$pattern.'$/i', $value))
 			{
-				$irregular = static::matchCase($irregular, $value);
+				// We only need to math the case of the irregular part of the value
+				$valuePart = substr($value, -strlen($pattern));
 				
-				return preg_replace($pattern, $irregular, $value);
+				$irregular = static::matchCase($irregular, $valuePart);
+				
+				return preg_replace($fullPattern, $irregular, $value);
 			}
 		}
 

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -7,9 +7,11 @@ class SupportPluralizerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('children', str_plural('child'));
 		$this->assertEquals('tests', str_plural('test'));
 		$this->assertEquals('deer', str_plural('deer'));
+		$this->assertEquals('freshmen', str_plural('freshman'));
 		$this->assertEquals('child', str_singular('children'));
 		$this->assertEquals('test', str_singular('tests'));
 		$this->assertEquals('deer', str_singular('deer'));
+		$this->assertEquals('freshman', str_singular('freshmen'));
 	}
 
 	public function testCaseSensitiveUsage()
@@ -21,12 +23,18 @@ class SupportPluralizerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('tests', str_plural('test'));
 		$this->assertEquals('Deer', str_plural('Deer'));
 		$this->assertEquals('DEER', str_plural('DEER'));
+		$this->assertEquals('Freshmen', str_plural('Freshman'));
+		$this->assertEquals('FRESHMEN', str_plural('FRESHMAN'));
+		$this->assertEquals('FreshMen', str_plural('FreshMan'));
 		$this->assertEquals('Child', str_singular('Children'));
 		$this->assertEquals('CHILD', str_singular('CHILDREN'));
 		$this->assertEquals('Test', str_singular('Tests'));
 		$this->assertEquals('TEST', str_singular('TESTS'));
 		$this->assertEquals('Deer', str_singular('Deer'));
 		$this->assertEquals('DEER', str_singular('DEER'));
+		$this->assertEquals('Freshman', str_singular('Freshmen'));
+		$this->assertEquals('FRESHMAN', str_singular('FRESHMEN'));
+		$this->assertEquals('FreshMan', str_singular('FreshMen'));
 	}
 
 }


### PR DESCRIPTION
`Pluralizer` doesn't properly handle compound words (with a capital first letter) that end in an irregular. For example:

```
str_plural('Freshman') === 'FreshMen'
```

This works with any word that ends with any of the `Pluralizer::$irregular` words and is a problem in both directions (singular to plural or plural to singular). The cause of this problem is that `Pluralizer::inflect` tries to match the case of the original `$value` by passing it to `Pluralizer::matchCase`. However, since the value in this instance has a capital letter, `matchCase` assumes that `ucfirst` is the correct function to capitalize the irregular substitution. However, the actual part of the word being changed should match `mb_strtolower` (`'man'`).

To fix this bug, I modified `inflect` to only pass to `matchCase` the part of the original `$value` that (with the exception of case) matches the irregular. I also added some unit tests for this case.
