### PR TITLE
Allow setting of secure session cookies from the session config

### DIFF
--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -153,7 +153,7 @@ class SessionServiceProvider extends ServiceProvider {
 
 		$expire = $this->getExpireTime($config);
 
-		setcookie($config['cookie'], session_id(), $expire, $config['path'], $config['domain'], false, true);
+		setcookie($config['cookie'], session_id(), $expire, $config['path'], $config['domain'], isset($config['secure']) ? $config['secure'] : false, true);
 	}
 
 	/**


### PR DESCRIPTION
This will allow users to set an optional 'secure' flag in the session config to ensure a secure session cookie is set.
