### PR TITLE
Fix missing environment variables when using artisan serve

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -38,7 +38,7 @@ class ServeCommand extends Command {
 
 		$this->info("Laravel development server started on http://{$host}:{$port}");
 
-		passthru("php -S {$host}:{$port} -t \"{$public}\" server.php");
+		passthru("php -d variables_order=EGPCS -S {$host}:{$port} -t \"{$public}\" server.php");
 	}
 
 	/**


### PR DESCRIPTION
I often use environment variables to configure applications and noticed that the $_ENV array was completely empty when using artisan serve.  The array is set correctly by any other use of artisan, or when accessing the application via apache.  After some digging this seems to be an issue with PHP's built-in server, where for some reason E is missing from the 'variables_order'.  The solution is to set variables_order manually, adding E back in.

See this Stack Overflow answer for further explanation.
http://stackoverflow.com/a/16275594/149427

The problem exists with both PHP 5.4 and 5.5, and the solution has also been tested with both versions.
