### PR TITLE
Make sure the order of fields is correct on batch inserts. Fixes laravel/laravel#2220

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1310,6 +1310,18 @@ class Builder {
 		{
 			$values = array($values);
 		}
+		else
+		{
+			// Since we do a batch insert, the order of the fields is based on the
+			// order of the first record. Make sure the fields are in the same order
+			// for every record we want to insert. Otherwise, values could happen
+			// to be inserted into the wrong fields.
+			foreach($values as $index => $record)
+			{
+				ksort($record);
+				$values[$index] = $record;
+			}
+		}
 
 		$bindings = array();
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -553,6 +553,15 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testSQLiteMultipleInsertsWithDifferentKeyOrder()
+	{
+		$builder = $this->getSQLiteBuilder();
+		$builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email", "name") select ? as "email", ? as "name" union select ? as "email", ? as "name"', array('foo', 'taylor', 'bar', 'dayle'))->andReturn(true);
+		$result = $builder->from('users')->insert(array(array('email' => 'foo', 'name' => 'taylor'), array('name' => 'dayle', 'email' => 'bar')));
+		$this->assertTrue($result);
+	}
+
+
 	public function testInsertGetIdMethod()
 	{
 		$builder = $this->getBuilder();


### PR DESCRIPTION
If you try to insert multiple records using Illuminate\Database\Query\Builder->insert()
things can get mixed up if any of your records keys are in the wrong order.

E.g. assuming an attempt to insert like

``` php
$users = array(
    array(
        'email' => 'foo',
        'name' => 'taylor',
    ),
    array(
        'name' => 'dayle'
        'email' => 'bar',
    ),
);
DB::table('users')->insert($users);
```

this will generate a SQL query like

``` sql
insert into "users" ("email", "name") select ? as "email", ? as "name" union select ? as "email", ? as "name"
```

with bindings like

``` php
array(
    'foo',
    'taylor',
    'dayle',
    'bar',
)
```

This will lead to the following situation in the database:

```
+-------+--------+
| email | name   |
+-------+--------+
| foo   | taylor |
| dayle | bar    |
+-------+--------+
```

This change will fix this problem by sorting the records to be inserted before the
SQL query is generated.
