### PR TITLE
Fixed FormBuilder selectMonth. mktime() fails on the 31st of a month.

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -455,7 +455,7 @@ class FormBuilder {
 
 		foreach (range(1, 12) as $month)
 		{
-			$months[$month] = strftime('%B', mktime(0, 0, 0, $month));
+			$months[$month] = strftime('%B', mktime(0, 0, 0, $month, 1));
 		}
 
 		return $this->select($name, $months, $selected, $options);

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -211,7 +211,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$month2 = $this->formBuilder->selectMonth('month', '1');
 		$month3 = $this->formBuilder->selectMonth('month', null, array('id' => 'foo'));
 
-		$this->assertContains('<select name="month"><option value="1">January</option>', $month1);
+		$this->assertContains('<select name="month"><option value="1">January</option><option value="2">February</option>', $month1);
 		$this->assertContains('<select name="month"><option value="1" selected="selected">January</option>', $month2);
 		$this->assertContains('<select id="foo" name="month"><option value="1">January</option>', $month3);
 	}


### PR DESCRIPTION
Fixed FormBuilder selectMonth. mktime() fails on the 31st of a month when the day is null.
See http://www.php.net/manual/en/function.mktime.php#99707
