### PR TITLE
Add support for --bench to artisan controller:make

### DIFF
--- a/src/Illuminate/Routing/Console/MakeControllerCommand.php
+++ b/src/Illuminate/Routing/Console/MakeControllerCommand.php
@@ -96,6 +96,15 @@ class MakeControllerCommand extends Command {
 			return $this->laravel['path.base'].'/'.$this->input->getOption('path');
 		}
 
+		$bench = $this->input->getOption('bench');
+
+		if ( ! is_null($bench))
+		{
+			$path = "/workbench/{$bench}/src/controllers";
+
+			return $this->laravel['path.base'].$path;
+		}
+
 		return $this->path;
 	}
 
@@ -150,6 +159,8 @@ class MakeControllerCommand extends Command {
 			array('only', null, InputOption::VALUE_OPTIONAL, 'The methods that should be included'),
 
 			array('except', null, InputOption::VALUE_OPTIONAL, 'The methods that should be excluded'),
+
+			array('bench', null, InputOption::VALUE_OPTIONAL, 'The workbench the controller belongs to'),
 
 			array('path', null, InputOption::VALUE_OPTIONAL, 'Where to place the controller'),
 		);

--- a/src/Illuminate/Routing/Generators/ControllerGenerator.php
+++ b/src/Illuminate/Routing/Generators/ControllerGenerator.php
@@ -64,6 +64,11 @@ class ControllerGenerator {
 	 */
 	protected function writeFile($stub, $controller, $path)
 	{
+		if (str_contains($path, 'workbench'))
+		{
+			$this->makeDirectory($controller, $path, true);
+		}
+
 		if (str_contains($controller, '\\'))
 		{
 			$this->makeDirectory($controller, $path);
@@ -82,10 +87,19 @@ class ControllerGenerator {
 	 *
 	 * @param  string  $controller
 	 * @param  string  $path
+	 * @param  boolean $prep_bench
 	 * @return void
 	 */
-	protected function makeDirectory($controller, $path)
+	protected function makeDirectory($controller, $path, $prep_bench = false)
 	{
+		// If the controller is being created in a workbench, first of all
+		// we need to make sure the bench's src/controllers dir exists
+		if ($prep_bench && ! $this->files->isDirectory($path))
+		{
+			$this->files->makeDirectory($path, 0777, true);
+			return;
+		}
+
 		$directory = $this->getDirectory($controller);
 
 		if ( ! $this->files->isDirectory($full = $path.'/'.$directory))


### PR DESCRIPTION
Proposal #1658 got closed due to PR #1982 being created as a duplicate of my fork, but it doesn't include directory creation. As a result, if the full path to controllers doesn't already exist, the command will fail.

This PR resolves that issue by checking for and creating the controllers directory if it doesn't already exist. Since #1982 appears to have been copied from my fork originally, this PR supersedes it in terms of functionality/stability.
