### PR TITLE
Remove array_column dummy function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -90,21 +90,6 @@ if ( ! function_exists('array_build'))
 	}
 }
 
-if ( ! function_exists('array_column'))
-{
-	/**
-	 * Pluck an array of values from an array.
-	 *
-	 * @param  array   $array
-	 * @param  string  $key
-	 * @return array
-	 */
-	function array_column($array, $key)
-	{
-		return array_pluck($array, $key);
-	}
-}
-
 if ( ! function_exists('array_divide'))
 {
 	/**


### PR DESCRIPTION
array_column is a dummy function to array_pluck, is not used in Laravel and does not match the PHP spec for array_column. Therefore it should not exist.

For < PHP 5.5 a polyfill array_column is available via Composer at https://github.com/ramsey/array_column.

Fixes #1827
