### PR TITLE
Removed array_column alias function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -90,21 +90,6 @@ if ( ! function_exists('array_build'))
 	}
 }
 
-if ( ! function_exists('array_column'))
-{
-	/**
-	 * Pluck an array of values from an array.
-	 *
-	 * @param  array   $array
-	 * @param  string  $key
-	 * @return array
-	 */
-	function array_column($array, $key)
-	{
-		return array_pluck($array, $key);
-	}
-}
-
 if ( ! function_exists('array_divide'))
 {
 	/**


### PR DESCRIPTION
The array_column function is only an alias to array_pluck. The alias is not used by Laravel and does not match PHP's spec for array_column. This can cause confusion and also makes it difficult to include the polyfill array_column which is available.

The polyfill function for < PHP 5.5 (from the developer of the native function, matching the spec) is available via Composer at https://github.com/ramsey/array_column.

This is PR #1995 resubmitted on the correct branch (sorry!) and relates to issue #1827.
