### PR TITLE
Added $prepend to selectMonth, selectRange and selectYear in FormBuilder.

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -392,8 +392,7 @@ class FormBuilder {
 		// Split the _prepend option out of the options array, if it exists.
 		if (isset($options['_prepend'])) 
 		{
-			$list = $options['_prepend'] + $list;
-			unset($options['_prepend']);
+			$list = array_pull($options, '_prepend') + $list;
 		}
 
 		// We will simply loop through the options and build an HTML value for each of

--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -389,6 +389,13 @@ class FormBuilder {
 
 		$options['name'] = $name;
 
+		// Split the _prepend option out of the options array, if it exists.
+		if (isset($options['_prepend'])) 
+		{
+			$list = $options['_prepend'] + $list;
+			unset($options['_prepend']);
+		}
+
 		// We will simply loop through the options and build an HTML value for each of
 		// them until we have an array of HTML declarations. Then we will join them
 		// all together into one single HTML element that can be put on the form.
@@ -417,12 +424,11 @@ class FormBuilder {
 	 * @param  string  $end
 	 * @param  string  $selected
 	 * @param  array   $options
-	 * @param  array   $prepend
 	 * @return string
 	 */
-	public function selectRange($name, $begin, $end, $selected = null, $options = array(), $prepend = array())
+	public function selectRange($name, $begin, $end, $selected = null, $options = array())
 	{
-		$range = $prepend + array_combine($range = range($begin, $end), $range);
+		$range = array_combine($range = range($begin, $end), $range);
 
 		return $this->select($name, $range, $selected, $options);
 	}
@@ -435,7 +441,6 @@ class FormBuilder {
 	 * @param  string  $end
 	 * @param  string  $selected
 	 * @param  array   $options
-	 * @param  array   $prepend
 	 * @return string
 	 */
 	public function selectYear()
@@ -449,12 +454,11 @@ class FormBuilder {
 	 * @param  string  $name
 	 * @param  string  $selected
 	 * @param  array   $options
-	 * @param  array   $prepend
 	 * @return string
 	 */
-	public function selectMonth($name, $selected = null, $options = array(), $prepend = array())
+	public function selectMonth($name, $selected = null, $options = array())
 	{
-		$months = $prepend;
+		$months = array();
 
 		foreach (range(1, 12) as $month)
 		{

--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -417,11 +417,12 @@ class FormBuilder {
 	 * @param  string  $end
 	 * @param  string  $selected
 	 * @param  array   $options
+	 * @param  array   $prepend
 	 * @return string
 	 */
-	public function selectRange($name, $begin, $end, $selected = null, $options = array())
+	public function selectRange($name, $begin, $end, $selected = null, $options = array(), $prepend = array())
 	{
-		$range = array_combine($range = range($begin, $end), $range);
+		$range = $prepend + array_combine($range = range($begin, $end), $range);
 
 		return $this->select($name, $range, $selected, $options);
 	}
@@ -434,6 +435,7 @@ class FormBuilder {
 	 * @param  string  $end
 	 * @param  string  $selected
 	 * @param  array   $options
+	 * @param  array   $prepend
 	 * @return string
 	 */
 	public function selectYear()
@@ -447,11 +449,12 @@ class FormBuilder {
 	 * @param  string  $name
 	 * @param  string  $selected
 	 * @param  array   $options
+	 * @param  array   $prepend
 	 * @return string
 	 */
-	public function selectMonth($name, $selected = null, $options = array())
+	public function selectMonth($name, $selected = null, $options = array(), $prepend = array())
 	{
-		$months = array();
+		$months = $prepend;
 
 		foreach (range(1, 12) as $month)
 		{

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -189,7 +189,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$select1 = $this->formBuilder->selectYear('year', 2000, 2020);
 		$select2 = $this->formBuilder->selectYear('year', 2000, 2020, null, array('id' => 'foo'));
 		$select3 = $this->formBuilder->selectYear('year', 2000, 2020, '2000');
-		$select4 = $this->formBuilder->selectYear('year', 2000, 2020, null, array(), array('' => 'Choose a Year'));
+		$select4 = $this->formBuilder->selectYear('year', 2000, 2020, null, array('_prepend' => array('' => 'Choose a Year')));
 
 		$this->assertContains('<select name="year"><option value="2000">2000</option><option value="2001">2001</option>', $select1);
 		$this->assertContains('<select id="foo" name="year"><option value="2000">2000</option><option value="2001">2001</option>', $select2);
@@ -212,7 +212,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$month1 = $this->formBuilder->selectMonth('month');
 		$month2 = $this->formBuilder->selectMonth('month', '1');
 		$month3 = $this->formBuilder->selectMonth('month', null, array('id' => 'foo'));
-		$month4 = $this->formBuilder->selectMonth('month', null, array(), array('' => 'Choose a Month'));
+		$month4 = $this->formBuilder->selectMonth('month', null, array('_prepend' => array('' => 'Choose a Year')));
 
 		$this->assertContains('<select name="month"><option value="1">January</option><option value="2">February</option>', $month1);
 		$this->assertContains('<select name="month"><option value="1" selected="selected">January</option>', $month2);

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -212,7 +212,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$month1 = $this->formBuilder->selectMonth('month');
 		$month2 = $this->formBuilder->selectMonth('month', '1');
 		$month3 = $this->formBuilder->selectMonth('month', null, array('id' => 'foo'));
-		$month4 = $this->formBuilder->selectMonth('month', null, array('_prepend' => array('' => 'Choose a Year')));
+		$month4 = $this->formBuilder->selectMonth('month', null, array('_prepend' => array('' => 'Choose a Month')));
 
 		$this->assertContains('<select name="month"><option value="1">January</option><option value="2">February</option>', $month1);
 		$this->assertContains('<select name="month"><option value="1" selected="selected">January</option>', $month2);

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -189,10 +189,12 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$select1 = $this->formBuilder->selectYear('year', 2000, 2020);
 		$select2 = $this->formBuilder->selectYear('year', 2000, 2020, null, array('id' => 'foo'));
 		$select3 = $this->formBuilder->selectYear('year', 2000, 2020, '2000');
+		$select4 = $this->formBuilder->selectYear('year', 2000, 2020, null, array(), array('' => 'Choose a Year'));
 
 		$this->assertContains('<select name="year"><option value="2000">2000</option><option value="2001">2001</option>', $select1);
 		$this->assertContains('<select id="foo" name="year"><option value="2000">2000</option><option value="2001">2001</option>', $select2);
 		$this->assertContains('<select name="year"><option value="2000" selected="selected">2000</option><option value="2001">2001</option>', $select3);
+		$this->assertContains('<select name="year"><option value="" selected="selected">Choose a Year</option><option value="2000">2000</option>', $select4);
 	}
 
 
@@ -210,10 +212,12 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$month1 = $this->formBuilder->selectMonth('month');
 		$month2 = $this->formBuilder->selectMonth('month', '1');
 		$month3 = $this->formBuilder->selectMonth('month', null, array('id' => 'foo'));
+		$month4 = $this->formBuilder->selectMonth('month', null, array(), array('' => 'Choose a Month'));
 
 		$this->assertContains('<select name="month"><option value="1">January</option><option value="2">February</option>', $month1);
 		$this->assertContains('<select name="month"><option value="1" selected="selected">January</option>', $month2);
 		$this->assertContains('<select id="foo" name="month"><option value="1">January</option>', $month3);
+		$this->assertContains('<select name="month"><option value="" selected="selected">Choose a Month</option><option value="1">January</option>', $month4);
 	}
 
 


### PR DESCRIPTION
I know it sucks to add another parameter and if you don't have any options to set then you have to pass an empty array. Like this:

```
Form::selectMonth('month', null, array(), array('' => 'Choose a Month'))
```

As an alternative solution, maybe the prepend array could be passed into the options array. Named something like '_prepend' to avoid collisions with any potential future HTML attributes. That would also leave room for an append option or other things like that in the future. 

```
Form::selectMonth('month', null, array('_prepend' => array('' => 'Choose a Month')))
```
