### PR TITLE
Add optional sub-path argument to *_path helper functions

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -42,9 +42,9 @@ if ( ! function_exists('app_path'))
 	 *
 	 * @return  string
 	 */
-	function app_path()
+	function app_path($path = '')
 	{
-		return app('path');
+		return app('path').($path ? '/'.$path : $path);
 	}
 }
 
@@ -417,9 +417,9 @@ if ( ! function_exists('base_path'))
 	 *
 	 * @return string
 	 */
-	function base_path()
+	function base_path($path = '')
 	{
-		return app('path.base');
+		return app('path.base').($path ? '/'.$path : $path);
 	}
 }
 
@@ -649,9 +649,9 @@ if ( ! function_exists('public_path'))
 	 *
 	 * @return string
 	 */
-	function public_path()
+	function public_path($path = '')
 	{
-		return app()->make('path.public');
+		return app()->make('path.public').($path ? '/'.$path : $path);
 	}
 }
 
@@ -737,9 +737,9 @@ if ( ! function_exists('storage_path'))
 	 *
 	 * @return  string
 	 */
-	function storage_path()
+	function storage_path($path = '')
 	{
-		return app('path.storage');
+		return app('path.storage').($path ? '/'.$path : $path);
 	}
 }
 


### PR DESCRIPTION
This change provides a slightly cleaner-looking way of using the *_path functions with subdirectories.

Mostly useful for is_file()-type calls - i.e. is_file(app_path('customdir/file.txt'))
