### PR TITLE
[Fix] Standalone remote component doesn't load its classes

### DIFF
--- a/src/Illuminate/Remote/composer.json
+++ b/src/Illuminate/Remote/composer.json
@@ -14,7 +14,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Illuminate\\Remote": "src/"
+            "Illuminate\\Remote": ""
         }
     },
     "target-dir": "Illuminate/Remote",


### PR DESCRIPTION
The PSR autoload directive was targeting a non-existant folder.
