### PR TITLE
Added doctrine/dbal as a require in the illuminate/database composer.json

### DIFF
--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
+        "doctrine/dbal": "2.4.x",
         "illuminate/container": "4.1.x",
         "illuminate/events": "4.1.x",
         "illuminate/support": "4.1.x",


### PR DESCRIPTION
doctrine/dbal is in the laravel/framework composer.json but we also need it as a require in illuminate/database for devs that use the standalone package with other platforms like PyroCMS. 
