### PR TITLE
Add fragments to Paginator links

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -71,6 +71,13 @@ class Paginator implements ArrayAccess, Countable, IteratorAggregate {
 	 */
 	protected $query = array();
 
+    /**
+     * A fragment to add at the end of all urls
+     *
+     * @var string
+     */
+    protected $fragment;
+
 	/**
 	 * Create a new Paginator instance.
 	 *
@@ -188,7 +195,31 @@ class Paginator implements ArrayAccess, Countable, IteratorAggregate {
 			$parameters = array_merge($parameters, $this->query);
 		}
 
-		return $this->env->getCurrentUrl().'?'.http_build_query($parameters, null, '&');
+		return $this->env->getCurrentUrl().'?'.http_build_query($parameters, null, '&') . $this->getFragment();
+	}
+
+    /**
+     * Set the fragment to add at the end of each URL's
+     *
+     * @param $fragment
+     */
+	public function setFragment($fragment)
+	{
+		$this->fragment = $fragment;
+	}
+
+	/**
+	 * Get the fragment with a # if it exists
+	 *
+	 * @return string
+	 */
+	public function getFragment()
+	{
+		if ($this->fragment) {
+			return '#' . $this->fragment;
+		}
+
+		return '';
 	}
 
 	/**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -206,6 +206,8 @@ class Paginator implements ArrayAccess, Countable, IteratorAggregate {
 	public function setFragment($fragment)
 	{
 		$this->fragment = $fragment;
+
+        return $this;
 	}
 
 	/**

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -108,6 +108,19 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://foo.com?page=1&foo=bar', $p->getUrl(1));
 	}
 
+    public function testGetUrlAddsFragment()
+    {
+        $p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('foo', 'bar', 'baz'), 3, 2);
+        $env->shouldReceive('getCurrentUrl')->twice()->andReturn('http://foo.com');
+        $env->shouldReceive('getPageName')->twice()->andReturn('page');
+
+        $p->setFragment("a-fragment");
+
+        $this->assertEquals('http://foo.com?page=1#a-fragment', $p->getUrl(1));
+        $p->addQuery('foo', 'bar');
+        $this->assertEquals('http://foo.com?page=1&foo=bar#a-fragment', $p->getUrl(1));
+    }
+
 
 	public function testEnvironmentAccess()
 	{


### PR DESCRIPTION
Hi,

I added the abilty to set a fragment at the end of the url's in a Paginator

As we can't add them with `->appends` and the Paginator class isn't easily extensible (you have to extend `Environment` before)

I also wrote the tests for it, they seem to pass correctly
