### PR TITLE
$start variable was unnecessary

### DIFF
--- a/src/Illuminate/Pagination/BootstrapPresenter.php
+++ b/src/Illuminate/Pagination/BootstrapPresenter.php
@@ -136,9 +136,7 @@ class BootstrapPresenter {
 	 */
 	public function getAdjacentRange()
 	{
-		$start = $this->currentPage - 3;
-
-		return $this->getPageRange($start, $this->currentPage + 3);
+		return $this->getPageRange($this->currentPage - 3, $this->currentPage + 3);
 	}
 
 	/**


### PR DESCRIPTION
Hi,

`$start` was a temporary variable holding `$this->currentPage + 3` value.

The second parameter was `$this->currentPage + 3` so it seemed a little weird.

With this change, those two parameters in function looks more logical, and I got rid of the unnecessary temporary variable.
