### PR TITLE
Custom datetime fields on models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -126,6 +126,13 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	protected $with = array();
 
 	/**
+	 * Fields that should be retrieved as Carbon objects.
+	 *
+	 * @var array
+	 */
+	protected $dateTimeFields = array();
+
+	/**
 	 * Indicates if the model exists.
 	 *
 	 * @var bool
@@ -2047,7 +2054,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function getDates()
 	{
-		return array(static::CREATED_AT, static::UPDATED_AT, static::DELETED_AT);
+		return array_merge($this->dateTimeFields, array(static::CREATED_AT, static::UPDATED_AT, static::DELETED_AT));
 	}
 
 	/**


### PR DESCRIPTION
This will allow you to easily set which fields should be converted to/from Carbon objects when setting/getting their values, just like created_at, updated_at and deleted_at - without having to write custom accessor/mutator methods for each of them. Example:

``` php
// example model class
class Article extends Eloquent
{
    protected $dateTimeFields = array('pub_time');
}

// somewhere else...
$article = Article::first();
echo $article->pub_time->format('j. F H:i');
```
