### PR TITLE
[Bugfix] Fix flushing of a Redis cache section

### DIFF
--- a/src/Illuminate/Cache/RedisSection.php
+++ b/src/Illuminate/Cache/RedisSection.php
@@ -27,7 +27,7 @@ class RedisSection extends Section {
 
 		$this->getRedis()->del($this->foreverKey());
 
-		$this->store->increment($this->sectionKey());
+		parent::flush();
 	}
 
 	/**


### PR DESCRIPTION
When I fixed the bug on section flushing in issue #1918, I missed the fact that the redis section still did the old-style flushing. This should fix that, although I have not tested this code because I do not have access to Redis. As I read the code, without this fix, flush will try to increment a string that is not an integer, and will throw an error.
