### PR TITLE
Fixed MySqlBuilder where table prefix was missing

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -14,6 +14,8 @@ class MySqlBuilder extends Builder {
 
 		$database = $this->connection->getDatabaseName();
 
+		$table = $this->connection->getTablePrefix().$table;
+
 		return count($this->connection->select($sql, array($database, $table))) > 0;
 	}
 


### PR DESCRIPTION
The prefix was set in the hasTable() method in Builder but not in the extending class MySqlBuilder
