### PR TITLE
Update default pagination::slide view to work with bootstrap3

### DIFF
--- a/src/Illuminate/Pagination/views/slider.php
+++ b/src/Illuminate/Pagination/views/slider.php
@@ -4,7 +4,7 @@
 
 <?php if ($paginator->getLastPage() > 1): ?>
 	<div class="pagination">
-		<ul>
+		<ul class="pagination">
 			<?php echo $presenter->render(); ?>
 		</ul>
 	</div>


### PR DESCRIPTION
By just adding the class="pagination" to the ul tag, the view will work with bootstrap3 as well

``` php
<div class="pagination">
        <ul class="pagination">
            <?php echo $presenter->render(); ?>
        </ul>
    </div>
```
