### PR TITLE
Fix form populating with array names

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -596,7 +596,7 @@ class FormBuilder {
 		switch ($type)
 		{
 			case 'checkbox':
-				return $this->getCheckboxCheckedState($name, $checked);
+				return $this->getCheckboxCheckedState($name, $value, $checked);
 
 			case 'radio':
 				return $this->getRadioCheckedState($name, $value, $checked);
@@ -614,13 +614,17 @@ class FormBuilder {
 	 * @param  bool  $checked
 	 * @return bool
 	 */
-	protected function getCheckboxCheckedState($name, $checked)
+	protected function getCheckboxCheckedState($name, $value, $checked)
 	{
 		if ( ! $this->oldInputIsEmpty() and is_null($this->old($name))) return false;
 
 		if ($this->missingOldAndModel($name)) return $checked;
 
-		return (bool) $this->getValueAttribute($name);
+		$valueAttribute = $this->getValueAttribute($name);
+
+		if (is_array($valueAttribute)) return in_array($value, $valueAttribute);
+
+		return (bool) $valueAttribute;
 	}
 
 	/**
@@ -870,14 +874,14 @@ class FormBuilder {
 	{
 		if (is_null($name)) return $value;
 
-		if (isset($this->session) and $this->session->hasOldInput($name))
+		if ( ! is_null($this->old($name)))
 		{
-			return $this->session->getOldInput($name);
+			return $this->old($name);
 		}
 
 		if ( ! is_null($value)) return $value;
 
-		if (isset($this->model) and isset($this->model[$name]))
+		if (isset($this->model))
 		{
 			return $this->getModelValueAttribute($name);
 		}
@@ -893,11 +897,11 @@ class FormBuilder {
 	{
 		if (is_object($this->model))
 		{
-			return object_get($this->model, $name);
+			return object_get($this->model, $this->transformKey($name));
 		}
 		elseif (is_array($this->model))
 		{
-			return array_get($this->model, $name);
+			return array_get($this->model, $this->transformKey($name));
 		}
 	}
 
@@ -911,7 +915,7 @@ class FormBuilder {
 	{
 		if (isset($this->session))
 		{
-			return $this->session->getOldInput($name);
+			return $this->session->getOldInput($this->transformKey($name));
 		}
 	}
 
@@ -923,6 +927,17 @@ class FormBuilder {
 	public function oldInputIsEmpty()
 	{
 		return (isset($this->session) and count($this->session->getOldInput()) == 0);
+	}
+
+	/**
+	 * Transform key from array to dot syntax.
+	 *
+	 * @param  string  $key
+	 * @return string
+	 */
+	protected function transformKey($key)
+	{
+		return str_replace(array('.', '[]', '[', ']'), array('_', '', '.', ''), $key);
 	}
 
 	/**


### PR DESCRIPTION
PHP uses `[]` syntax to interpret the input as an array an not as a single value. Currently if such a name is used with input names, it is used as is without converting it to real key. As a result form is not repopulated with old input.

This PR fixes:
- Issues https://github.com/laravel/framework/issues/2033, https://github.com/laravel/framework/issues/2010 
- repopulating form input with array syntax, converting it's name to dot syntax. Also fixed dots in names (PHP will automatically replace any dots in incoming variable names with underscores, see http://www.php.net/manual/en/language.variables.external.php). This ensures that old value is always found if it exists.
  name[] => name
  name[key] => name.key
  name[key][] => name.key
  name.key => name_key
- converting to dot syntax has another advantage, it cans be used to populate form with attribute of model relation. I'have found out that `__isset` method on Eloquent for dynamic checking if an attribute exists is broken with relations. It returns false for relations which weren't accessed before.

``` php
    $post = Post::find(1);

    isset($post->author); // false
    $post->author;
    isset($post->author); // true
```

If Eloquent `__isset` were fixed it would be possible to do: 

```
    {{ Form::model($model) }}

    {{ Form::text('author[name]') }} // Automatically populate input with 'name' attribute from 'author' relation on model

```
- checking checkboxes with array name. So now checkboxes like the following ones are properly checked

```
{{ Form::checkbox('checkbox[]', 1) }}
{{ Form::checkbox('checkbox[]', 2) }} 
```

Best regards, Ruby.
