### PR TITLE
skip not set when 0 or less

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -830,7 +830,7 @@ class Builder {
 	 */
 	public function skip($value)
 	{
-		$this->offset = $value;
+		if ($value > 0)  $this->offset = $value;
 
 		return $this;
 	}


### PR DESCRIPTION
According to MYSQL docs if you specify an offset, a limit must be in place as well. Although this is not a perfect solution, it should help cases where skip and take are being used for paging, and we happen to be on the first page where set() will be given 0 as an offset.
