### PR TITLE
Update Validator.php

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1555,7 +1555,7 @@ class Validator implements MessageProviderInterface {
 	{
 		$this->addExtensions($extensions);
 
-		foreach ($extensions as $rule => $extension)
+		foreach ($this->extensions as $rule => $extension)
 		{
 			$this->implicitRules[] = studly_case($rule);
 		}


### PR DESCRIPTION
When extending the validator via `Validator::extend`, custom validations aren't picked up because they aren't marked as `isValidatable`.

This happens because all extensions aren't being added to the `implicitRules` array.
