### PR TITLE
Change typeBoolean from tinyint to bit

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -343,7 +343,7 @@ class SqlServerGrammar extends Grammar {
 	 */
 	protected function typeBoolean(Fluent $column)
 	{
-		return 'tinyint';
+		return 'bit';
 	}
 
 	/**

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -323,7 +323,7 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add "foo" tinyint not null', $statements[0]);
+		$this->assertEquals('alter table "users" add "foo" bit not null', $statements[0]);
 	}
 
 


### PR DESCRIPTION
Changing datatype for boolean from tinyint to bit for SQLServer. Bit stores 0/1 and has storage improvements if more than 1 boolean exists in a table. (http://msdn.microsoft.com/en-us/library/ms177603.aspx)
