### PR TITLE
Small Cache prefix fix for MemcachedStore

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -25,9 +25,9 @@ class MemcachedStore implements StoreInterface {
 	 * @param  string     $prefix
 	 * @return void
 	 */
-	public function __construct(Memcached $memcached, $prefix = '')
+	public function __construct(Memcached $memcached, $prefix = null)
 	{
-		$this->prefix = $prefix.':';
+		$this->prefix = is_null($prefix) ? null : $prefix.':';
 		$this->memcached = $memcached;
 	}
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -25,10 +25,10 @@ class RedisStore implements StoreInterface {
 	 * @param  string                     $prefix
 	 * @return void
 	 */
-	public function __construct(Redis $redis, $prefix = '')
+	public function __construct(Redis $redis, $prefix = null)
 	{
 		$this->redis = $redis;
-		$this->prefix = $prefix.':';
+		$this->prefix = is_null($prefix) ? null : $prefix.':';
 	}
 
 	/**


### PR DESCRIPTION
If no prefix is set, we should not have ":" at the beginning of the key name.
