### PR TITLE
Update the query builder to get the last page of results if the requested page is beyond the last page.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -215,8 +215,9 @@ class Builder {
 		// Once we have the paginator we need to set the limit and offset values for
 		// the query so we can get the properly paginated items. Once we have an
 		// array of items we can create the paginator instances for the items.
-		$last_page = ceil($total/$perPage);
-		$page = min($paginator->getCurrentPage(),$last_page);
+		$last_page = ceil($total / $perPage);
+
+		$page = min($paginator->getCurrentPage(), $last_page);
 
 		$this->query->forPage($page, $perPage);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -215,7 +215,8 @@ class Builder {
 		// Once we have the paginator we need to set the limit and offset values for
 		// the query so we can get the properly paginated items. Once we have an
 		// array of items we can create the paginator instances for the items.
-		$page = $paginator->getCurrentPage();
+		$last_page = ceil($total/$perPage);
+		$page = min($paginator->getCurrentPage(),$last_page);
 
 		$this->query->forPage($page, $perPage);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -215,9 +215,9 @@ class Builder {
 		// Once we have the paginator we need to set the limit and offset values for
 		// the query so we can get the properly paginated items. Once we have an
 		// array of items we can create the paginator instances for the items.
-		$last_page = ceil($total / $perPage);
+		$lastPage = ceil($total / $perPage);
 
-		$page = min($paginator->getCurrentPage(), $last_page);
+		$page = min($paginator->getCurrentPage(), $lastPage);
 
 		$this->query->forPage($page, $perPage);
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1193,8 +1193,9 @@ class Builder {
 		// Once we have the total number of records to be paginated, we can grab the
 		// current page and the result array. Then we are ready to create a brand
 		// new Paginator instances for the results which will create the links.
-		$last_page = ceil($total/$perPage);
-		$page = min($paginator->getCurrentPage(),$last_page);
+		$last_page = ceil($total / $perPage);
+
+		$page = min($paginator->getCurrentPage(), $last_page);
 
 		$results = $this->forPage($page, $perPage)->get($columns);
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1193,9 +1193,9 @@ class Builder {
 		// Once we have the total number of records to be paginated, we can grab the
 		// current page and the result array. Then we are ready to create a brand
 		// new Paginator instances for the results which will create the links.
-		$last_page = ceil($total / $perPage);
+		$lastPage = ceil($total / $perPage);
 
-		$page = min($paginator->getCurrentPage(), $last_page);
+		$page = min($paginator->getCurrentPage(), $lastPage);
 
 		$results = $this->forPage($page, $perPage)->get($columns);
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1193,7 +1193,8 @@ class Builder {
 		// Once we have the total number of records to be paginated, we can grab the
 		// current page and the result array. Then we are ready to create a brand
 		// new Paginator instances for the results which will create the links.
-		$page = $paginator->getCurrentPage();
+		$last_page = ceil($total/$perPage);
+		$page = min($paginator->getCurrentPage(),$last_page);
 
 		$results = $this->forPage($page, $perPage)->get($columns);
 


### PR DESCRIPTION
Update the query builder to get the last page of results if the requested page is beyond the last page.

The paginator has code to make sure that a page isn't requested beyond what is available, this ensures that methods such as links() do not go crazy and show links for pages that don't exist. This is sensible but the query builder doesn't do anything similar. If the user requests page 4 when there are only 3 pages, the links will show that we are displaying page 3 (it's bolded) but there will be no results present. This patch ensures that the last page of results are shown if a page beyond what exists is requested.
