### PR TITLE
[Bug] Eloquent::toArray does not include null relations (empty hasOne or belongsTo relations)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1866,7 +1866,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			// If the relation value has been set, we will set it on this attributes
 			// list for returning. If it was not arrayable or null, we'll not set
 			// the value on the array because it is some type of invalid value.
-			if (isset($relation))
+			if (isset($relation) || is_null($value))
 			{
 				$attributes[$key] = $relation;
 			}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -414,6 +414,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 			new EloquentModelStub(array('bar' => 'baz')), new EloquentModelStub(array('bam' => 'boom'))
 		)));
 		$model->setRelation('partner', new EloquentModelStub(array('name' => 'abby')));
+		$model->setRelation('group', null);
+		$model->setRelation('empty_collection', new Illuminate\Database\Eloquent\Collection(array()));
 		$array = $model->toArray();
 
 		$this->assertTrue(is_array($array));
@@ -421,6 +423,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('baz', $array['names'][0]['bar']);
 		$this->assertEquals('boom', $array['names'][1]['bam']);
 		$this->assertEquals('abby', $array['partner']['name']);
+		$this->assertEquals(null, $array['group']);
+		$this->assertEquals(array(), $array['empty_collection']);
 		$this->assertFalse(isset($array['password']));
 	}
 


### PR DESCRIPTION
My understanding is that an empty `hasOne` or `belongsTo` relationship should be represented as _null_ within the returned array.
