### PR TITLE
Config Repository fails on a true value due to weak comparison

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -64,7 +64,7 @@ class Repository extends NamespacedItemResolver implements ArrayAccess {
 	{
 		$default = microtime(true);
 
-		return $this->get($key, $default) != $default;
+		return $this->get($key, $default) !== $default;
 	}
 
 	/**

--- a/tests/Config/ConfigRepositoryTest.php
+++ b/tests/Config/ConfigRepositoryTest.php
@@ -9,23 +9,22 @@ class ConfigRepositoryTest extends PHPUnit_Framework_TestCase {
 		m::close();
 	}
 
+	public function testHasGroupIndicatesIfConfigGroupExists()
+	{
+		$config = $this->getRepository();
+		$config->getLoader()->shouldReceive('exists')->once()->with('group', 'namespace')->andReturn(false);
+		$this->assertFalse($config->hasGroup('namespace::group'));
+	}
 
-    public function testHasGroupIndicatesIfConfigGroupExists()
-    {
-        $config = $this->getRepository();
-        $config->getLoader()->shouldReceive('exists')->once()->with('group', 'namespace')->andReturn(false);
-        $this->assertFalse($config->hasGroup('namespace::group'));
-    }
+	public function testHasOnTrueReturnsTrue()
+	{
+		$config = $this->getRepository();
+		$options = $this->getDummyOptions();
+		$config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
 
-    public function testHasOnTrueReturnsTrue()
-    {
-        $config = $this->getRepository();
-        $options = $this->getDummyOptions();
-        $config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
-
-        $this->assertTrue($config->has('app.bing'));
-        $this->assertEquals(true,$config->get('app.bing'));
-    }
+		$this->assertTrue($config->has('app.bing'));
+		$this->assertEquals(true,$config->get('app.bing'));
+	}
 
 	public function testGetReturnsBasicItems()
 	{

--- a/tests/Config/ConfigRepositoryTest.php
+++ b/tests/Config/ConfigRepositoryTest.php
@@ -9,12 +9,14 @@ class ConfigRepositoryTest extends PHPUnit_Framework_TestCase {
 		m::close();
 	}
 
+
 	public function testHasGroupIndicatesIfConfigGroupExists()
 	{
 		$config = $this->getRepository();
 		$config->getLoader()->shouldReceive('exists')->once()->with('group', 'namespace')->andReturn(false);
 		$this->assertFalse($config->hasGroup('namespace::group'));
 	}
+
 
 	public function testHasOnTrueReturnsTrue()
 	{
@@ -25,6 +27,7 @@ class ConfigRepositoryTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($config->has('app.bing'));
 		$this->assertEquals(true,$config->get('app.bing'));
 	}
+
 
 	public function testGetReturnsBasicItems()
 	{

--- a/tests/Config/ConfigRepositoryTest.php
+++ b/tests/Config/ConfigRepositoryTest.php
@@ -10,13 +10,22 @@ class ConfigRepositoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testHasGroupIndicatesIfConfigGroupExists()
-	{
-		$config = $this->getRepository();
-		$config->getLoader()->shouldReceive('exists')->once()->with('group', 'namespace')->andReturn(false);
-		$this->assertFalse($config->hasGroup('namespace::group'));
-	}
+    public function testHasGroupIndicatesIfConfigGroupExists()
+    {
+        $config = $this->getRepository();
+        $config->getLoader()->shouldReceive('exists')->once()->with('group', 'namespace')->andReturn(false);
+        $this->assertFalse($config->hasGroup('namespace::group'));
+    }
 
+    public function testHasOnTrueReturnsTrue()
+    {
+        $config = $this->getRepository();
+        $options = $this->getDummyOptions();
+        $config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
+
+        $this->assertTrue($config->has('app.bing'));
+        $this->assertEquals(true,$config->get('app.bing'));
+    }
 
 	public function testGetReturnsBasicItems()
 	{
@@ -128,7 +137,7 @@ class ConfigRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	protected function getDummyOptions()
 	{
-		return array('foo' => 'bar', 'baz' => array('boom' => 'breeze'));
+		return array('foo' => 'bar', 'baz' => array('boom' => 'breeze'), 'bing' => true);
 	}
 
 }


### PR DESCRIPTION
When you have a true value in your config like `'bing' => true,` then Laravel fails to detect the value with `Config::has()` due to the weak comparison it does on the has method.

I have updated the method to a strong comparison and added two new tests for this behaviour.
