### PR TITLE
[Feature] Added elegant redirecting from Router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -637,6 +637,69 @@ class Router {
 	}
 
 	/**
+	 * Redirect requests to an outdated path to a new path.
+	 * @param  string  $oldUri
+	 * @param  string  $newUri
+	 * @param  integer $statusCode
+	 * @param  array   $headers
+	 * @param  mixed   $secure
+	 * @return \Illuminate\Routing\Route
+	 */
+	public function redirect($oldUri, $newUri, $statusCode = 301, $headers = array(), $secure = null)
+	{
+		$redirector = $this->container->make('redirect');
+
+		return $this->get($oldUri, function() use($redirector, $newUri, $statusCode, $headers, $secure) {
+			return $redirector->to($newUri, $statusCode, $headers, $secure);
+		});
+	}
+
+	/**
+	 * Redirect requests to an outdated secure path to a new secure path.
+	 * @param  string  $oldUri
+	 * @param  string  $newUri
+	 * @param  integer $statusCode
+	 * @param  array   $headers
+	 * @return \Illuminate\Routing\Route
+	 */
+	public function redirectSecure($oldUri, $newUri, $statusCode = 301, $headers = array())
+	{
+		return $this->redirect($oldUri, $newUri, $statusCode, $headers, true);
+	}
+
+	/**
+	 * Redirect requests to an outdated path to a named route.
+	 * @param  string  $oldUri
+	 * @param  string  $route
+	 * @param  integer $statusCode
+	 * @return \Illuminate\Routing\Route
+	 */
+	public function redirectRoute($oldUri, $route, $parameters = array(), $statusCode = 301, $headers = array())
+	{
+		$redirector = $this->container->make('redirect');
+
+		return $this->get($oldUri, function() use($redirector, $route, $parameters, $statusCode, $headers) {
+			return $redirector->route($route, $parameters, $statusCode, $headers);
+		});
+	}
+
+	/**
+	 * Redirect requests to an outdated path to a controller action.
+	 * @param  string  $oldUri
+	 * @param  string  $action
+	 * @param  integer $statusCode
+	 * @return \Illuminate\Routing\Route
+	 */
+	public function redirectAction($oldUri, $action, $parameters = array(), $statusCode = 301, $headers = array())
+	{
+		$redirector = $this->container->make('redirect');
+
+		return $this->get($oldUri, function() use($redirector, $action, $parameters, $statusCode, $headers) {
+			return $redirector->action($action, $parameters, $statusCode, $headers);
+		});
+	}
+
+	/**
 	 * Create a route group with shared attributes.
 	 *
 	 * @param  array    $attributes

--- a/tests/Routing/RoutingTest.php
+++ b/tests/Routing/RoutingTest.php
@@ -208,6 +208,99 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testUriRedirection()
+	{
+		$redirector = m::mock('Illuminate\Routing\Redirector');
+		$redirector->shouldReceive('to')->with('/foo', 301, array(), null)->once()->andReturn('baz');
+		$container = m::mock('Illuminate\Container\Container');
+		$container->shouldReceive('make')->with('redirect')->once()->andReturn($redirector);
+		$router = new Router($container);
+		$router->redirect('/old-foo', '/foo');
+		$request = Request::create('/old-foo', 'GET');
+		$this->assertEquals('baz', $router->dispatch($request)->getContent());
+
+		$redirector = m::mock('Illuminate\Routing\Redirector');
+		$redirector->shouldReceive('to')->with('/foo', 302, array(), null)->once()->andReturn('baz');
+		$container = m::mock('Illuminate\Container\Container');
+		$container->shouldReceive('make')->with('redirect')->once()->andReturn($redirector);
+		$router = new Router($container);
+		$router->redirect('/old-foo', '/foo', 302);
+		$request = Request::create('/old-foo', 'GET');
+		$this->assertEquals('baz', $router->dispatch($request)->getContent());
+
+		$redirector = m::mock('Illuminate\Routing\Redirector');
+		$redirector->shouldReceive('to')->with('/foo', 301, array(), true)->once()->andReturn('baz');
+		$container = m::mock('Illuminate\Container\Container');
+		$container->shouldReceive('make')->with('redirect')->once()->andReturn($redirector);
+		$router = new Router($container);
+		$router->redirectSecure('/old-foo', '/foo');
+		$request = Request::create('/old-foo', 'GET');
+		$this->assertEquals('baz', $router->dispatch($request)->getContent());
+	}
+
+
+	public function testNamedRouteRedirection()
+	{
+		$redirector = m::mock('Illuminate\Routing\Redirector');
+		$redirector->shouldReceive('route')->with('foo', array(), 301, array())->once()->andReturn('baz');
+		$container = m::mock('Illuminate\Container\Container');
+		$container->shouldReceive('make')->with('redirect')->once()->andReturn($redirector);
+		$router = new Router($container);
+		$router->redirectRoute('/old-foo', 'foo');
+		$request = Request::create('/old-foo', 'GET');
+		$this->assertEquals('baz', $router->dispatch($request)->getContent());
+
+		$redirector = m::mock('Illuminate\Routing\Redirector');
+		$redirector->shouldReceive('route')->with('foo', 'bar', 301, array())->once()->andReturn('baz');
+		$container = m::mock('Illuminate\Container\Container');
+		$container->shouldReceive('make')->with('redirect')->once()->andReturn($redirector);
+		$router = new Router($container);
+		$router->redirectRoute('/old-foo', 'foo', 'bar');
+		$request = Request::create('/old-foo', 'GET');
+		$this->assertEquals('baz', $router->dispatch($request)->getContent());
+
+		$redirector = m::mock('Illuminate\Routing\Redirector');
+		$redirector->shouldReceive('route')->with('foo', array(), 302, array())->once()->andReturn('baz');
+		$container = m::mock('Illuminate\Container\Container');
+		$container->shouldReceive('make')->with('redirect')->once()->andReturn($redirector);
+		$router = new Router($container);
+		$router->redirectRoute('/old-foo', 'foo', array(), 302);
+		$request = Request::create('/old-foo', 'GET');
+		$this->assertEquals('baz', $router->dispatch($request)->getContent());
+	}
+
+
+	public function testActionRedirection()
+	{
+		$redirector = m::mock('Illuminate\Routing\Redirector');
+		$redirector->shouldReceive('action')->with('FooController@bar', array(), 301, array())->once()->andReturn('baz');
+		$container = m::mock('Illuminate\Container\Container');
+		$container->shouldReceive('make')->with('redirect')->once()->andReturn($redirector);
+		$router = new Router($container);
+		$router->redirectAction('/old-foo', 'FooController@bar');
+		$request = Request::create('/old-foo', 'GET');
+		$this->assertEquals('baz', $router->dispatch($request)->getContent());
+
+		$redirector = m::mock('Illuminate\Routing\Redirector');
+		$redirector->shouldReceive('action')->with('FooController@bar', 'bar', 301, array())->once()->andReturn('baz');
+		$container = m::mock('Illuminate\Container\Container');
+		$container->shouldReceive('make')->with('redirect')->once()->andReturn($redirector);
+		$router = new Router($container);
+		$router->redirectAction('/old-foo', 'FooController@bar', 'bar');
+		$request = Request::create('/old-foo', 'GET');
+		$this->assertEquals('baz', $router->dispatch($request)->getContent());
+
+		$redirector = m::mock('Illuminate\Routing\Redirector');
+		$redirector->shouldReceive('action')->with('FooController@bar', array(), 302, array())->once()->andReturn('baz');
+		$container = m::mock('Illuminate\Container\Container');
+		$container->shouldReceive('make')->with('redirect')->once()->andReturn($redirector);
+		$router = new Router($container);
+		$router->redirectAction('/old-foo', 'FooController@bar', array(), 302);
+		$request = Request::create('/old-foo', 'GET');
+		$this->assertEquals('baz', $router->dispatch($request)->getContent());
+	}
+
+
 	public function testGlobalBeforeFiltersHaltRequestCycle()
 	{
 		$router = new Router;


### PR DESCRIPTION
Relating to Issue #1862:

This feature pull request simplifies the redirection of old URLs with the `Router` class, by adding several shorthand convenience methods (creating shortcuts to `Redirector::to()`, `Redirector::secure()`, `Redirector::route()`, and `Redirector::action()`). It was mentioned in the issue that although using the appropriate sever configuration would be faster (since it would intervene before Laravel would be loaded), it loses the benefit of easily changing route URIs in Laravel by referring to them by name or action. This PR allows the code below to ease the URL changing process should a redirected URL ever need to be modified:

```
Route::redirect('/old-page/?p=123', '/');
Route::redirectRoute('/pages/contact/form/contact_us.html', 'contact-us-form');
Route::redirectAction('/view_post?id=welcome', 'PostsController@show', 'welcome');
```

Unit tests also committed to cover major features of this PR.
