### PR TITLE
Config Repository fails on a true value due to weak comparison

### DIFF
--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -6,409 +6,409 @@ use Illuminate\Support\NamespacedItemResolver;
 
 class Repository extends NamespacedItemResolver implements ArrayAccess {
 
-    /**
-     * The loader implementation.
-     *
-     * @var \Illuminate\Config\LoaderInterface
-     */
-    protected $loader;
+	/**
+	 * The loader implementation.
+	 *
+	 * @var \Illuminate\Config\LoaderInterface
+	 */
+	protected $loader;
 
-    /**
-     * The current environment.
-     *
-     * @var string
-     */
-    protected $environment;
+	/**
+	 * The current environment.
+	 *
+	 * @var string
+	 */
+	protected $environment;
 
-    /**
-     * All of the configuration items.
-     *
-     * @var array
-     */
-    protected $items = array();
+	/**
+	 * All of the configuration items.
+	 *
+	 * @var array
+	 */
+	protected $items = array();
 
-    /**
-     * All of the registered packages.
-     *
-     * @var array
-     */
-    protected $packages = array();
+	/**
+	 * All of the registered packages.
+	 *
+	 * @var array
+	 */
+	protected $packages = array();
 
-    /**
-     * The after load callbacks for namespaces.
-     *
-     * @var array
-     */
-    protected $afterLoad = array();
+	/**
+	 * The after load callbacks for namespaces.
+	 *
+	 * @var array
+	 */
+	protected $afterLoad = array();
 
-    /**
-     * Create a new configuration repository.
-     *
-     * @param  \Illuminate\Config\LoaderInterface  $loader
-     * @param  string  $environment
-     * @return void
-     */
-    public function __construct(LoaderInterface $loader, $environment)
-    {
-        $this->loader = $loader;
-        $this->environment = $environment;
-    }
+	/**
+	 * Create a new configuration repository.
+	 *
+	 * @param  \Illuminate\Config\LoaderInterface  $loader
+	 * @param  string  $environment
+	 * @return void
+	 */
+	public function __construct(LoaderInterface $loader, $environment)
+	{
+		$this->loader = $loader;
+		$this->environment = $environment;
+	}
 
-    /**
-     * Determine if the given configuration value exists.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    public function has($key)
-    {
-        $default = microtime(true);
+	/**
+	 * Determine if the given configuration value exists.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		$default = microtime(true);
 
-        return $this->get($key, $default) !== $default;
-    }
+		return $this->get($key, $default) !== $default;
+	}
 
-    /**
-     * Determine if a configuration group exists.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    public function hasGroup($key)
-    {
-        list($namespace, $group, $item) = $this->parseKey($key);
+	/**
+	 * Determine if a configuration group exists.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function hasGroup($key)
+	{
+		list($namespace, $group, $item) = $this->parseKey($key);
 
-        return $this->loader->exists($group, $namespace);
-    }
+		return $this->loader->exists($group, $namespace);
+	}
 
-    /**
-     * Get the specified configuration value.
-     *
-     * @param  string  $key
-     * @param  mixed   $default
-     * @return mixed
-     */
-    public function get($key, $default = null)
-    {
-        list($namespace, $group, $item) = $this->parseKey($key);
+	/**
+	 * Get the specified configuration value.
+	 *
+	 * @param  string  $key
+	 * @param  mixed   $default
+	 * @return mixed
+	 */
+	public function get($key, $default = null)
+	{
+		list($namespace, $group, $item) = $this->parseKey($key);
 
-        // Configuration items are actually keyed by "collection", which is simply a
-        // combination of each namespace and groups, which allows a unique way to
-        // identify the arrays of configuration items for the particular files.
-        $collection = $this->getCollection($group, $namespace);
+		// Configuration items are actually keyed by "collection", which is simply a
+		// combination of each namespace and groups, which allows a unique way to
+		// identify the arrays of configuration items for the particular files.
+		$collection = $this->getCollection($group, $namespace);
 
-        $this->load($group, $namespace, $collection);
+		$this->load($group, $namespace, $collection);
 
-        return array_get($this->items[$collection], $item, $default);
-    }
+		return array_get($this->items[$collection], $item, $default);
+	}
 
-    /**
-     * Set a given configuration value.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
-     */
-    public function set($key, $value)
-    {
-        list($namespace, $group, $item) = $this->parseKey($key);
+	/**
+	 * Set a given configuration value.
+	 *
+	 * @param  string  $key
+	 * @param  mixed   $value
+	 * @return void
+	 */
+	public function set($key, $value)
+	{
+		list($namespace, $group, $item) = $this->parseKey($key);
 
-        $collection = $this->getCollection($group, $namespace);
+		$collection = $this->getCollection($group, $namespace);
 
-        // We'll need to go ahead and lazy load each configuration groups even when
-        // we're just setting a configuration item so that the set item does not
-        // get overwritten if a different item in the group is requested later.
-        $this->load($group, $namespace, $collection);
+		// We'll need to go ahead and lazy load each configuration groups even when
+		// we're just setting a configuration item so that the set item does not
+		// get overwritten if a different item in the group is requested later.
+		$this->load($group, $namespace, $collection);
 
-        if (is_null($item))
-        {
-            $this->items[$collection] = $value;
-        }
-        else
-        {
-            array_set($this->items[$collection], $item, $value);
-        }
-    }
+		if (is_null($item))
+		{
+			$this->items[$collection] = $value;
+		}
+		else
+		{
+			array_set($this->items[$collection], $item, $value);
+		}
+	}
 
-    /**
-     * Load the configuration group for the key.
-     *
-     * @param  string  $key
-     * @param  string  $namespace
-     * @param  string  $collection
-     * @return void
-     */
-    protected function load($group, $namespace, $collection)
-    {
-        $env = $this->environment;
+	/**
+	 * Load the configuration group for the key.
+	 *
+	 * @param  string  $key
+	 * @param  string  $namespace
+	 * @param  string  $collection
+	 * @return void
+	 */
+	protected function load($group, $namespace, $collection)
+	{
+		$env = $this->environment;
 
-        // If we've already loaded this collection, we will just bail out since we do
-        // not want to load it again. Once items are loaded a first time they will
-        // stay kept in memory within this class and not loaded from disk again.
-        if (isset($this->items[$collection]))
-        {
-            return;
-        }
+		// If we've already loaded this collection, we will just bail out since we do
+		// not want to load it again. Once items are loaded a first time they will
+		// stay kept in memory within this class and not loaded from disk again.
+		if (isset($this->items[$collection]))
+		{
+			return;
+		}
 
-        $items = $this->loader->load($env, $group, $namespace);
+		$items = $this->loader->load($env, $group, $namespace);
 
-        // If we've already loaded this collection, we will just bail out since we do
-        // not want to load it again. Once items are loaded a first time they will
-        // stay kept in memory within this class and not loaded from disk again.
-        if (isset($this->afterLoad[$namespace]))
-        {
-            $items = $this->callAfterLoad($namespace, $group, $items);
-        }
+		// If we've already loaded this collection, we will just bail out since we do
+		// not want to load it again. Once items are loaded a first time they will
+		// stay kept in memory within this class and not loaded from disk again.
+		if (isset($this->afterLoad[$namespace]))
+		{
+			$items = $this->callAfterLoad($namespace, $group, $items);
+		}
 
-        $this->items[$collection] = $items;
-    }
+		$this->items[$collection] = $items;
+	}
 
-    /**
-     * Call the after load callback for a namespace.
-     *
-     * @param  string  $namespace
-     * @param  string  $group
-     * @param  array   $items
-     * @return array
-     */
-    protected function callAfterLoad($namespace, $group, $items)
-    {
-        $callback = $this->afterLoad[$namespace];
+	/**
+	 * Call the after load callback for a namespace.
+	 *
+	 * @param  string  $namespace
+	 * @param  string  $group
+	 * @param  array   $items
+	 * @return array
+	 */
+	protected function callAfterLoad($namespace, $group, $items)
+	{
+		$callback = $this->afterLoad[$namespace];
 
-        return call_user_func($callback, $this, $group, $items);
-    }
+		return call_user_func($callback, $this, $group, $items);
+	}
 
-    /**
-     * Parse an array of namespaced segments.
-     *
-     * @param  string  $key
-     * @return array
-     */
-    protected function parseNamespacedSegments($key)
-    {
-        list($namespace, $item) = explode('::', $key);
+	/**
+	 * Parse an array of namespaced segments.
+	 *
+	 * @param  string  $key
+	 * @return array
+	 */
+	protected function parseNamespacedSegments($key)
+	{
+		list($namespace, $item) = explode('::', $key);
 
-        // If the namespace is registered as a package, we will just assume the group
-        // is equal to the namespace since all packages cascade in this way having
-        // a single file per package, otherwise we'll just parse them as normal.
-        if (in_array($namespace, $this->packages))
-        {
-            return $this->parsePackageSegments($key, $namespace, $item);
-        }
+		// If the namespace is registered as a package, we will just assume the group
+		// is equal to the namespace since all packages cascade in this way having
+		// a single file per package, otherwise we'll just parse them as normal.
+		if (in_array($namespace, $this->packages))
+		{
+			return $this->parsePackageSegments($key, $namespace, $item);
+		}
 
-        return parent::parseNamespacedSegments($key);
-    }
+		return parent::parseNamespacedSegments($key);
+	}
 
-    /**
-     * Parse the segments of a package namespace.
-     *
-     * @param  string  $namespace
-     * @param  string  $item
-     * @return array
-     */
-    protected function parsePackageSegments($key, $namespace, $item)
-    {
-        $itemSegments = explode('.', $item);
+	/**
+	 * Parse the segments of a package namespace.
+	 *
+	 * @param  string  $namespace
+	 * @param  string  $item
+	 * @return array
+	 */
+	protected function parsePackageSegments($key, $namespace, $item)
+	{
+		$itemSegments = explode('.', $item);
 
-        // If the configuration file doesn't exist for the given package group we can
-        // assume that we should implicitly use the config file matching the name
-        // of the namespace. Generally packages should use one type or another.
-        if ( ! $this->loader->exists($itemSegments[0], $namespace))
-        {
-            return array($namespace, 'config', $item);
-        }
+		// If the configuration file doesn't exist for the given package group we can
+		// assume that we should implicitly use the config file matching the name
+		// of the namespace. Generally packages should use one type or another.
+		if ( ! $this->loader->exists($itemSegments[0], $namespace))
+		{
+			return array($namespace, 'config', $item);
+		}
 
-        return parent::parseNamespacedSegments($key);
-    }
+		return parent::parseNamespacedSegments($key);
+	}
 
-    /**
-     * Register a package for cascading configuration.
-     *
-     * @param  string  $package
-     * @param  string  $hint
-     * @param  string  $namespace
-     * @return void
-     */
-    public function package($package, $hint, $namespace = null)
-    {
-        $namespace = $this->getPackageNamespace($package, $namespace);
+	/**
+	 * Register a package for cascading configuration.
+	 *
+	 * @param  string  $package
+	 * @param  string  $hint
+	 * @param  string  $namespace
+	 * @return void
+	 */
+	public function package($package, $hint, $namespace = null)
+	{
+		$namespace = $this->getPackageNamespace($package, $namespace);
 
-        $this->packages[] = $namespace;
+		$this->packages[] = $namespace;
 
-        // First we will simply register the namespace with the repository so that it
-        // can be loaded. Once we have done that we'll register an after namespace
-        // callback so that we can cascade an application package configuration.
-        $this->addNamespace($namespace, $hint);
+		// First we will simply register the namespace with the repository so that it
+		// can be loaded. Once we have done that we'll register an after namespace
+		// callback so that we can cascade an application package configuration.
+		$this->addNamespace($namespace, $hint);
 
-        $this->afterLoading($namespace, function($me, $group, $items) use ($package)
-        {
-            $env = $me->getEnvironment();
+		$this->afterLoading($namespace, function($me, $group, $items) use ($package)
+		{
+			$env = $me->getEnvironment();
 
-            $loader = $me->getLoader();
+			$loader = $me->getLoader();
 
-            return $loader->cascadePackage($env, $package, $group, $items);
-        });
-    }
+			return $loader->cascadePackage($env, $package, $group, $items);
+		});
+	}
 
-    /**
-     * Get the configuration namespace for a package.
-     *
-     * @param  string  $package
-     * @param  string  $namespace
-     * @return string
-     */
-    protected function getPackageNamespace($package, $namespace)
-    {
-        if (is_null($namespace))
-        {
-            list($vendor, $namespace) = explode('/', $package);
-        }
+	/**
+	 * Get the configuration namespace for a package.
+	 *
+	 * @param  string  $package
+	 * @param  string  $namespace
+	 * @return string
+	 */
+	protected function getPackageNamespace($package, $namespace)
+	{
+		if (is_null($namespace))
+		{
+			list($vendor, $namespace) = explode('/', $package);
+		}
 
-        return $namespace;
-    }
+		return $namespace;
+	}
 
-    /**
-     * Register an after load callback for a given namespace.
-     *
-     * @param  string   $namespace
-     * @param  Closure  $callback
-     * @return void
-     */
-    public function afterLoading($namespace, Closure $callback)
-    {
-        $this->afterLoad[$namespace] = $callback;
-    }
+	/**
+	 * Register an after load callback for a given namespace.
+	 *
+	 * @param  string   $namespace
+	 * @param  Closure  $callback
+	 * @return void
+	 */
+	public function afterLoading($namespace, Closure $callback)
+	{
+		$this->afterLoad[$namespace] = $callback;
+	}
 
-    /**
-     * Get the collection identifier.
-     *
-     * @param  string  $group
-     * @param  string  $namespace
-     * @return string
-     */
-    protected function getCollection($group, $namespace = null)
-    {
-        $namespace = $namespace ?: '*';
+	/**
+	 * Get the collection identifier.
+	 *
+	 * @param  string  $group
+	 * @param  string  $namespace
+	 * @return string
+	 */
+	protected function getCollection($group, $namespace = null)
+	{
+		$namespace = $namespace ?: '*';
 
-        return $namespace.'::'.$group;
-    }
+		return $namespace.'::'.$group;
+	}
 
-    /**
-     * Add a new namespace to the loader.
-     *
-     * @param  string  $namespace
-     * @param  string  $hint
-     * @return void
-     */
-    public function addNamespace($namespace, $hint)
-    {
-        return $this->loader->addNamespace($namespace, $hint);
-    }
+	/**
+	 * Add a new namespace to the loader.
+	 *
+	 * @param  string  $namespace
+	 * @param  string  $hint
+	 * @return void
+	 */
+	public function addNamespace($namespace, $hint)
+	{
+		return $this->loader->addNamespace($namespace, $hint);
+	}
 
-    /**
-     * Returns all registered namespaces with the config
-     * loader.
-     *
-     * @return array
-     */
-    public function getNamespaces()
-    {
-        return $this->loader->getNamespaces();
-    }
+	/**
+	 * Returns all registered namespaces with the config
+	 * loader.
+	 *
+	 * @return array
+	 */
+	public function getNamespaces()
+	{
+		return $this->loader->getNamespaces();
+	}
 
-    /**
-     * Get the loader implementation.
-     *
-     * @return \Illuminate\Config\LoaderInterface
-     */
-    public function getLoader()
-    {
-        return $this->loader;
-    }
+	/**
+	 * Get the loader implementation.
+	 *
+	 * @return \Illuminate\Config\LoaderInterface
+	 */
+	public function getLoader()
+	{
+		return $this->loader;
+	}
 
-    /**
-     * Set the loader implementation.
-     *
-     * @param \Illuminate\Config\LoaderInterface  $loader
-     * @return void
-     */
-    public function setLoader(LoaderInterface $loader)
-    {
-        $this->loader = $loader;
-    }
+	/**
+	 * Set the loader implementation.
+	 *
+	 * @param \Illuminate\Config\LoaderInterface  $loader
+	 * @return void
+	 */
+	public function setLoader(LoaderInterface $loader)
+	{
+		$this->loader = $loader;
+	}
 
-    /**
-     * Get the current configuration environment.
-     *
-     * @return string
-     */
-    public function getEnvironment()
-    {
-        return $this->environment;
-    }
+	/**
+	 * Get the current configuration environment.
+	 *
+	 * @return string
+	 */
+	public function getEnvironment()
+	{
+		return $this->environment;
+	}
 
-    /**
-     * Get the after load callback array.
-     *
-     * @return array
-     */
-    public function getAfterLoadCallbacks()
-    {
-        return $this->afterLoad;
-    }
+	/**
+	 * Get the after load callback array.
+	 *
+	 * @return array
+	 */
+	public function getAfterLoadCallbacks()
+	{
+		return $this->afterLoad;
+	}
 
-    /**
-     * Get all of the configuration items.
-     *
-     * @return array
-     */
-    public function getItems()
-    {
-        return $this->items;
-    }
+	/**
+	 * Get all of the configuration items.
+	 *
+	 * @return array
+	 */
+	public function getItems()
+	{
+		return $this->items;
+	}
 
-    /**
-     * Determine if the given configuration option exists.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    public function offsetExists($key)
-    {
-        return $this->has($key);
-    }
+	/**
+	 * Determine if the given configuration option exists.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function offsetExists($key)
+	{
+		return $this->has($key);
+	}
 
-    /**
-     * Get a configuration option.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    public function offsetGet($key)
-    {
-        return $this->get($key);
-    }
+	/**
+	 * Get a configuration option.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function offsetGet($key)
+	{
+		return $this->get($key);
+	}
 
-    /**
-     * Set a configuration option.
-     *
-     * @param  string  $key
-     * @param  string  $value
-     * @return void
-     */
-    public function offsetSet($key, $value)
-    {
-        $this->set($key, $value);
-    }
+	/**
+	 * Set a configuration option.
+	 *
+	 * @param  string  $key
+	 * @param  string  $value
+	 * @return void
+	 */
+	public function offsetSet($key, $value)
+	{
+		$this->set($key, $value);
+	}
 
-    /**
-     * Unset a configuration option.
-     *
-     * @param  string  $key
-     * @return void
-     */
-    public function offsetUnset($key)
-    {
-        $this->set($key, null);
-    }
+	/**
+	 * Unset a configuration option.
+	 *
+	 * @param  string  $key
+	 * @return void
+	 */
+	public function offsetUnset($key)
+	{
+		$this->set($key, null);
+	}
 
 }

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -6,409 +6,409 @@ use Illuminate\Support\NamespacedItemResolver;
 
 class Repository extends NamespacedItemResolver implements ArrayAccess {
 
-	/**
-	 * The loader implementation.
-	 *
-	 * @var \Illuminate\Config\LoaderInterface
-	 */
-	protected $loader;
+    /**
+     * The loader implementation.
+     *
+     * @var \Illuminate\Config\LoaderInterface
+     */
+    protected $loader;
 
-	/**
-	 * The current environment.
-	 *
-	 * @var string
-	 */
-	protected $environment;
+    /**
+     * The current environment.
+     *
+     * @var string
+     */
+    protected $environment;
 
-	/**
-	 * All of the configuration items.
-	 *
-	 * @var array
-	 */
-	protected $items = array();
+    /**
+     * All of the configuration items.
+     *
+     * @var array
+     */
+    protected $items = array();
 
-	/**
-	 * All of the registered packages.
-	 *
-	 * @var array
-	 */
-	protected $packages = array();
+    /**
+     * All of the registered packages.
+     *
+     * @var array
+     */
+    protected $packages = array();
 
-	/**
-	 * The after load callbacks for namespaces.
-	 *
-	 * @var array
-	 */
-	protected $afterLoad = array();
+    /**
+     * The after load callbacks for namespaces.
+     *
+     * @var array
+     */
+    protected $afterLoad = array();
 
-	/**
-	 * Create a new configuration repository.
-	 *
-	 * @param  \Illuminate\Config\LoaderInterface  $loader
-	 * @param  string  $environment
-	 * @return void
-	 */
-	public function __construct(LoaderInterface $loader, $environment)
-	{
-		$this->loader = $loader;
-		$this->environment = $environment;
-	}
+    /**
+     * Create a new configuration repository.
+     *
+     * @param  \Illuminate\Config\LoaderInterface  $loader
+     * @param  string  $environment
+     * @return void
+     */
+    public function __construct(LoaderInterface $loader, $environment)
+    {
+        $this->loader = $loader;
+        $this->environment = $environment;
+    }
 
-	/**
-	 * Determine if the given configuration value exists.
-	 *
-	 * @param  string  $key
-	 * @return bool
-	 */
-	public function has($key)
-	{
-		$default = microtime(true);
+    /**
+     * Determine if the given configuration value exists.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        $default = microtime(true);
 
-		return $this->get($key, $default) != $default;
-	}
+        return $this->get($key, $default) !== $default;
+    }
 
-	/**
-	 * Determine if a configuration group exists.
-	 *
-	 * @param  string  $key
-	 * @return bool
-	 */
-	public function hasGroup($key)
-	{
-		list($namespace, $group, $item) = $this->parseKey($key);
+    /**
+     * Determine if a configuration group exists.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasGroup($key)
+    {
+        list($namespace, $group, $item) = $this->parseKey($key);
 
-		return $this->loader->exists($group, $namespace);
-	}
+        return $this->loader->exists($group, $namespace);
+    }
 
-	/**
-	 * Get the specified configuration value.
-	 *
-	 * @param  string  $key
-	 * @param  mixed   $default
-	 * @return mixed
-	 */
-	public function get($key, $default = null)
-	{
-		list($namespace, $group, $item) = $this->parseKey($key);
+    /**
+     * Get the specified configuration value.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        list($namespace, $group, $item) = $this->parseKey($key);
 
-		// Configuration items are actually keyed by "collection", which is simply a
-		// combination of each namespace and groups, which allows a unique way to
-		// identify the arrays of configuration items for the particular files.
-		$collection = $this->getCollection($group, $namespace);
+        // Configuration items are actually keyed by "collection", which is simply a
+        // combination of each namespace and groups, which allows a unique way to
+        // identify the arrays of configuration items for the particular files.
+        $collection = $this->getCollection($group, $namespace);
 
-		$this->load($group, $namespace, $collection);
+        $this->load($group, $namespace, $collection);
 
-		return array_get($this->items[$collection], $item, $default);
-	}
+        return array_get($this->items[$collection], $item, $default);
+    }
 
-	/**
-	 * Set a given configuration value.
-	 *
-	 * @param  string  $key
-	 * @param  mixed   $value
-	 * @return void
-	 */
-	public function set($key, $value)
-	{
-		list($namespace, $group, $item) = $this->parseKey($key);
+    /**
+     * Set a given configuration value.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return void
+     */
+    public function set($key, $value)
+    {
+        list($namespace, $group, $item) = $this->parseKey($key);
 
-		$collection = $this->getCollection($group, $namespace);
+        $collection = $this->getCollection($group, $namespace);
 
-		// We'll need to go ahead and lazy load each configuration groups even when
-		// we're just setting a configuration item so that the set item does not
-		// get overwritten if a different item in the group is requested later.
-		$this->load($group, $namespace, $collection);
+        // We'll need to go ahead and lazy load each configuration groups even when
+        // we're just setting a configuration item so that the set item does not
+        // get overwritten if a different item in the group is requested later.
+        $this->load($group, $namespace, $collection);
 
-		if (is_null($item))
-		{
-			$this->items[$collection] = $value;
-		}
-		else
-		{
-			array_set($this->items[$collection], $item, $value);
-		}
-	}
+        if (is_null($item))
+        {
+            $this->items[$collection] = $value;
+        }
+        else
+        {
+            array_set($this->items[$collection], $item, $value);
+        }
+    }
 
-	/**
-	 * Load the configuration group for the key.
-	 *
-	 * @param  string  $key
-	 * @param  string  $namespace
-	 * @param  string  $collection
-	 * @return void
-	 */
-	protected function load($group, $namespace, $collection)
-	{
-		$env = $this->environment;
+    /**
+     * Load the configuration group for the key.
+     *
+     * @param  string  $key
+     * @param  string  $namespace
+     * @param  string  $collection
+     * @return void
+     */
+    protected function load($group, $namespace, $collection)
+    {
+        $env = $this->environment;
 
-		// If we've already loaded this collection, we will just bail out since we do
-		// not want to load it again. Once items are loaded a first time they will
-		// stay kept in memory within this class and not loaded from disk again.
-		if (isset($this->items[$collection]))
-		{
-			return;
-		}
+        // If we've already loaded this collection, we will just bail out since we do
+        // not want to load it again. Once items are loaded a first time they will
+        // stay kept in memory within this class and not loaded from disk again.
+        if (isset($this->items[$collection]))
+        {
+            return;
+        }
 
-		$items = $this->loader->load($env, $group, $namespace);
+        $items = $this->loader->load($env, $group, $namespace);
 
-		// If we've already loaded this collection, we will just bail out since we do
-		// not want to load it again. Once items are loaded a first time they will
-		// stay kept in memory within this class and not loaded from disk again.
-		if (isset($this->afterLoad[$namespace]))
-		{
-			$items = $this->callAfterLoad($namespace, $group, $items);
-		}
+        // If we've already loaded this collection, we will just bail out since we do
+        // not want to load it again. Once items are loaded a first time they will
+        // stay kept in memory within this class and not loaded from disk again.
+        if (isset($this->afterLoad[$namespace]))
+        {
+            $items = $this->callAfterLoad($namespace, $group, $items);
+        }
 
-		$this->items[$collection] = $items;
-	}
+        $this->items[$collection] = $items;
+    }
 
-	/**
-	 * Call the after load callback for a namespace.
-	 *
-	 * @param  string  $namespace
-	 * @param  string  $group
-	 * @param  array   $items
-	 * @return array
-	 */
-	protected function callAfterLoad($namespace, $group, $items)
-	{
-		$callback = $this->afterLoad[$namespace];
+    /**
+     * Call the after load callback for a namespace.
+     *
+     * @param  string  $namespace
+     * @param  string  $group
+     * @param  array   $items
+     * @return array
+     */
+    protected function callAfterLoad($namespace, $group, $items)
+    {
+        $callback = $this->afterLoad[$namespace];
 
-		return call_user_func($callback, $this, $group, $items);
-	}
+        return call_user_func($callback, $this, $group, $items);
+    }
 
-	/**
-	 * Parse an array of namespaced segments.
-	 *
-	 * @param  string  $key
-	 * @return array
-	 */
-	protected function parseNamespacedSegments($key)
-	{
-		list($namespace, $item) = explode('::', $key);
+    /**
+     * Parse an array of namespaced segments.
+     *
+     * @param  string  $key
+     * @return array
+     */
+    protected function parseNamespacedSegments($key)
+    {
+        list($namespace, $item) = explode('::', $key);
 
-		// If the namespace is registered as a package, we will just assume the group
-		// is equal to the namespace since all packages cascade in this way having
-		// a single file per package, otherwise we'll just parse them as normal.
-		if (in_array($namespace, $this->packages))
-		{
-			return $this->parsePackageSegments($key, $namespace, $item);
-		}
+        // If the namespace is registered as a package, we will just assume the group
+        // is equal to the namespace since all packages cascade in this way having
+        // a single file per package, otherwise we'll just parse them as normal.
+        if (in_array($namespace, $this->packages))
+        {
+            return $this->parsePackageSegments($key, $namespace, $item);
+        }
 
-		return parent::parseNamespacedSegments($key);
-	}
+        return parent::parseNamespacedSegments($key);
+    }
 
-	/**
-	 * Parse the segments of a package namespace.
-	 *
-	 * @param  string  $namespace
-	 * @param  string  $item
-	 * @return array
-	 */
-	protected function parsePackageSegments($key, $namespace, $item)
-	{
-		$itemSegments = explode('.', $item);
+    /**
+     * Parse the segments of a package namespace.
+     *
+     * @param  string  $namespace
+     * @param  string  $item
+     * @return array
+     */
+    protected function parsePackageSegments($key, $namespace, $item)
+    {
+        $itemSegments = explode('.', $item);
 
-		// If the configuration file doesn't exist for the given package group we can
-		// assume that we should implicitly use the config file matching the name
-		// of the namespace. Generally packages should use one type or another.
-		if ( ! $this->loader->exists($itemSegments[0], $namespace))
-		{
-			return array($namespace, 'config', $item);
-		}
+        // If the configuration file doesn't exist for the given package group we can
+        // assume that we should implicitly use the config file matching the name
+        // of the namespace. Generally packages should use one type or another.
+        if ( ! $this->loader->exists($itemSegments[0], $namespace))
+        {
+            return array($namespace, 'config', $item);
+        }
 
-		return parent::parseNamespacedSegments($key);
-	}
+        return parent::parseNamespacedSegments($key);
+    }
 
-	/**
-	 * Register a package for cascading configuration.
-	 *
-	 * @param  string  $package
-	 * @param  string  $hint
-	 * @param  string  $namespace
-	 * @return void
-	 */
-	public function package($package, $hint, $namespace = null)
-	{
-		$namespace = $this->getPackageNamespace($package, $namespace);
+    /**
+     * Register a package for cascading configuration.
+     *
+     * @param  string  $package
+     * @param  string  $hint
+     * @param  string  $namespace
+     * @return void
+     */
+    public function package($package, $hint, $namespace = null)
+    {
+        $namespace = $this->getPackageNamespace($package, $namespace);
 
-		$this->packages[] = $namespace;
+        $this->packages[] = $namespace;
 
-		// First we will simply register the namespace with the repository so that it
-		// can be loaded. Once we have done that we'll register an after namespace
-		// callback so that we can cascade an application package configuration.
-		$this->addNamespace($namespace, $hint);
+        // First we will simply register the namespace with the repository so that it
+        // can be loaded. Once we have done that we'll register an after namespace
+        // callback so that we can cascade an application package configuration.
+        $this->addNamespace($namespace, $hint);
 
-		$this->afterLoading($namespace, function($me, $group, $items) use ($package)
-		{
-			$env = $me->getEnvironment();
+        $this->afterLoading($namespace, function($me, $group, $items) use ($package)
+        {
+            $env = $me->getEnvironment();
 
-			$loader = $me->getLoader();
+            $loader = $me->getLoader();
 
-			return $loader->cascadePackage($env, $package, $group, $items);
-		});
-	}
+            return $loader->cascadePackage($env, $package, $group, $items);
+        });
+    }
 
-	/**
-	 * Get the configuration namespace for a package.
-	 *
-	 * @param  string  $package
-	 * @param  string  $namespace
-	 * @return string
-	 */
-	protected function getPackageNamespace($package, $namespace)
-	{
-		if (is_null($namespace))
-		{
-			list($vendor, $namespace) = explode('/', $package);
-		}
+    /**
+     * Get the configuration namespace for a package.
+     *
+     * @param  string  $package
+     * @param  string  $namespace
+     * @return string
+     */
+    protected function getPackageNamespace($package, $namespace)
+    {
+        if (is_null($namespace))
+        {
+            list($vendor, $namespace) = explode('/', $package);
+        }
 
-		return $namespace;
-	}
+        return $namespace;
+    }
 
-	/**
-	 * Register an after load callback for a given namespace.
-	 *
-	 * @param  string   $namespace
-	 * @param  Closure  $callback
-	 * @return void
-	 */
-	public function afterLoading($namespace, Closure $callback)
-	{
-		$this->afterLoad[$namespace] = $callback;
-	}
+    /**
+     * Register an after load callback for a given namespace.
+     *
+     * @param  string   $namespace
+     * @param  Closure  $callback
+     * @return void
+     */
+    public function afterLoading($namespace, Closure $callback)
+    {
+        $this->afterLoad[$namespace] = $callback;
+    }
 
-	/**
-	 * Get the collection identifier.
-	 *
-	 * @param  string  $group
-	 * @param  string  $namespace
-	 * @return string
-	 */
-	protected function getCollection($group, $namespace = null)
-	{
-		$namespace = $namespace ?: '*';
+    /**
+     * Get the collection identifier.
+     *
+     * @param  string  $group
+     * @param  string  $namespace
+     * @return string
+     */
+    protected function getCollection($group, $namespace = null)
+    {
+        $namespace = $namespace ?: '*';
 
-		return $namespace.'::'.$group;
-	}
+        return $namespace.'::'.$group;
+    }
 
-	/**
-	 * Add a new namespace to the loader.
-	 *
-	 * @param  string  $namespace
-	 * @param  string  $hint
-	 * @return void
-	 */
-	public function addNamespace($namespace, $hint)
-	{
-		return $this->loader->addNamespace($namespace, $hint);
-	}
+    /**
+     * Add a new namespace to the loader.
+     *
+     * @param  string  $namespace
+     * @param  string  $hint
+     * @return void
+     */
+    public function addNamespace($namespace, $hint)
+    {
+        return $this->loader->addNamespace($namespace, $hint);
+    }
 
-	/**
-	 * Returns all registered namespaces with the config
-	 * loader.
-	 *
-	 * @return array
-	 */
-	public function getNamespaces()
-	{
-		return $this->loader->getNamespaces();
-	}
+    /**
+     * Returns all registered namespaces with the config
+     * loader.
+     *
+     * @return array
+     */
+    public function getNamespaces()
+    {
+        return $this->loader->getNamespaces();
+    }
 
-	/**
-	 * Get the loader implementation.
-	 *
-	 * @return \Illuminate\Config\LoaderInterface
-	 */
-	public function getLoader()
-	{
-		return $this->loader;
-	}
-	
-	/**
-	 * Set the loader implementation.
-	 *
-	 * @param \Illuminate\Config\LoaderInterface  $loader
-	 * @return void
-	 */
-	public function setLoader(LoaderInterface $loader)
-	{
-		$this->loader = $loader;
-	}
+    /**
+     * Get the loader implementation.
+     *
+     * @return \Illuminate\Config\LoaderInterface
+     */
+    public function getLoader()
+    {
+        return $this->loader;
+    }
 
-	/**
-	 * Get the current configuration environment.
-	 *
-	 * @return string
-	 */
-	public function getEnvironment()
-	{
-		return $this->environment;
-	}
+    /**
+     * Set the loader implementation.
+     *
+     * @param \Illuminate\Config\LoaderInterface  $loader
+     * @return void
+     */
+    public function setLoader(LoaderInterface $loader)
+    {
+        $this->loader = $loader;
+    }
 
-	/**
-	 * Get the after load callback array.
-	 *
-	 * @return array
-	 */
-	public function getAfterLoadCallbacks()
-	{
-		return $this->afterLoad;
-	}
+    /**
+     * Get the current configuration environment.
+     *
+     * @return string
+     */
+    public function getEnvironment()
+    {
+        return $this->environment;
+    }
 
-	/**
-	 * Get all of the configuration items.
-	 *
-	 * @return array
-	 */
-	public function getItems()
-	{
-		return $this->items;
-	}
+    /**
+     * Get the after load callback array.
+     *
+     * @return array
+     */
+    public function getAfterLoadCallbacks()
+    {
+        return $this->afterLoad;
+    }
 
-	/**
-	 * Determine if the given configuration option exists.
-	 *
-	 * @param  string  $key
-	 * @return bool
-	 */
-	public function offsetExists($key)
-	{
-		return $this->has($key);
-	}
+    /**
+     * Get all of the configuration items.
+     *
+     * @return array
+     */
+    public function getItems()
+    {
+        return $this->items;
+    }
 
-	/**
-	 * Get a configuration option.
-	 *
-	 * @param  string  $key
-	 * @return bool
-	 */
-	public function offsetGet($key)
-	{
-		return $this->get($key);
-	}
+    /**
+     * Determine if the given configuration option exists.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function offsetExists($key)
+    {
+        return $this->has($key);
+    }
 
-	/**
-	 * Set a configuration option.
-	 *
-	 * @param  string  $key
-	 * @param  string  $value
-	 * @return void
-	 */
-	public function offsetSet($key, $value)
-	{
-		$this->set($key, $value);
-	}
+    /**
+     * Get a configuration option.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function offsetGet($key)
+    {
+        return $this->get($key);
+    }
 
-	/**
-	 * Unset a configuration option.
-	 *
-	 * @param  string  $key
-	 * @return void
-	 */
-	public function offsetUnset($key)
-	{
-		$this->set($key, null);
-	}
+    /**
+     * Set a configuration option.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return void
+     */
+    public function offsetSet($key, $value)
+    {
+        $this->set($key, $value);
+    }
+
+    /**
+     * Unset a configuration option.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function offsetUnset($key)
+    {
+        $this->set($key, null);
+    }
 
 }

--- a/tests/Config/ConfigRepositoryTest.php
+++ b/tests/Config/ConfigRepositoryTest.php
@@ -4,131 +4,142 @@ use Mockery as m;
 
 class ConfigRepositoryTest extends PHPUnit_Framework_TestCase {
 
-	public function tearDown()
-	{
-		m::close();
-	}
+    public function tearDown()
+    {
+        m::close();
+    }
 
 
-	public function testHasGroupIndicatesIfConfigGroupExists()
-	{
-		$config = $this->getRepository();
-		$config->getLoader()->shouldReceive('exists')->once()->with('group', 'namespace')->andReturn(false);
-		$this->assertFalse($config->hasGroup('namespace::group'));
-	}
+    public function testHasGroupIndicatesIfConfigGroupExists()
+    {
+        $config = $this->getRepository();
+        $config->getLoader()->shouldReceive('exists')->once()->with('group', 'namespace')->andReturn(false);
+        $this->assertFalse($config->hasGroup('namespace::group'));
+    }
 
 
-	public function testGetReturnsBasicItems()
-	{
-		$config = $this->getRepository();
-		$options = $this->getDummyOptions();
-		$config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
+    public function testHasOnTrueReturnsTrue()
+    {
+        $config = $this->getRepository();
+        $options = $this->getDummyOptions();
+        $config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
 
-		$this->assertEquals('bar', $config->get('app.foo'));
-		$this->assertEquals('breeze', $config->get('app.baz.boom'));
-		$this->assertEquals('blah', $config->get('app.code', 'blah'));
-		$this->assertEquals('blah', $config->get('app.code', function() { return 'blah'; }));
-	}
+        $this->assertTrue($config->has('app.bing'));
+        $this->assertEquals(true,$config->get('app.bing'));
+    }
 
 
-	public function testEntireArrayCanBeReturned()
-	{
-		$config = $this->getRepository();
-		$options = $this->getDummyOptions();
-		$config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
+    public function testGetReturnsBasicItems()
+    {
+        $config = $this->getRepository();
+        $options = $this->getDummyOptions();
+        $config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
 
-		$this->assertEquals($options, $config->get('app'));
-	}
-
-
-	public function testLoaderGetsCalledCorrectForNamespaces()
-	{
-		$config = $this->getRepository();
-		$options = $this->getDummyOptions();
-		$config->getLoader()->shouldReceive('load')->once()->with('production', 'options', 'namespace')->andReturn($options);
-
-		$this->assertEquals('bar', $config->get('namespace::options.foo'));
-		$this->assertEquals('breeze', $config->get('namespace::options.baz.boom'));
-		$this->assertEquals('blah', $config->get('namespace::options.code', 'blah'));
-		$this->assertEquals('blah', $config->get('namespace::options.code', function() { return 'blah'; }));
-	}
+        $this->assertEquals('bar', $config->get('app.foo'));
+        $this->assertEquals('breeze', $config->get('app.baz.boom'));
+        $this->assertEquals('blah', $config->get('app.code', 'blah'));
+        $this->assertEquals('blah', $config->get('app.code', function() { return 'blah'; }));
+    }
 
 
-	public function testNamespacedAccessedAndPostNamespaceLoadEventIsFired()
-	{
-		$config = $this->getRepository();
-		$options = $this->getDummyOptions();
-		$config->getLoader()->shouldReceive('load')->once()->with('production', 'options', 'namespace')->andReturn($options);
-		$config->afterLoading('namespace', function($repository, $group, $items)
-		{
-			$items['dayle'] = 'rees';
-			return $items;
-		});
+    public function testEntireArrayCanBeReturned()
+    {
+        $config = $this->getRepository();
+        $options = $this->getDummyOptions();
+        $config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
 
-		$this->assertEquals('bar', $config->get('namespace::options.foo'));
-		$this->assertEquals('breeze', $config->get('namespace::options.baz.boom'));
-		$this->assertEquals('blah', $config->get('namespace::options.code', 'blah'));
-		$this->assertEquals('blah', $config->get('namespace::options.code', function() { return 'blah'; }));
-		$this->assertEquals('rees', $config->get('namespace::options.dayle'));
-	}
+        $this->assertEquals($options, $config->get('app'));
+    }
 
 
-	public function testLoaderUsesNamespaceAsGroupWhenUsingPackagesAndGroupDoesntExist()
-	{
-		$config = $this->getRepository();
-		$options = $this->getDummyOptions();
-		$config->getLoader()->shouldReceive('addNamespace')->with('namespace', __DIR__);
-		$config->getLoader()->shouldReceive('cascadePackage')->andReturnUsing(function($env, $package, $group, $items) { return $items; });
-		$config->getLoader()->shouldReceive('exists')->once()->with('foo', 'namespace')->andReturn(false);
-		$config->getLoader()->shouldReceive('exists')->once()->with('baz', 'namespace')->andReturn(false);
-		$config->getLoader()->shouldReceive('load')->once()->with('production', 'config', 'namespace')->andReturn($options);
+    public function testLoaderGetsCalledCorrectForNamespaces()
+    {
+        $config = $this->getRepository();
+        $options = $this->getDummyOptions();
+        $config->getLoader()->shouldReceive('load')->once()->with('production', 'options', 'namespace')->andReturn($options);
 
-		$config->package('foo/namespace', __DIR__);
-		$this->assertEquals('bar', $config->get('namespace::foo'));
-		$this->assertEquals('breeze', $config->get('namespace::baz.boom'));
-	}
+        $this->assertEquals('bar', $config->get('namespace::options.foo'));
+        $this->assertEquals('breeze', $config->get('namespace::options.baz.boom'));
+        $this->assertEquals('blah', $config->get('namespace::options.code', 'blah'));
+        $this->assertEquals('blah', $config->get('namespace::options.code', function() { return 'blah'; }));
+    }
 
 
-	public function testItemsCanBeSet()
-	{
-		$config = $this->getRepository();
-		$options = $this->getDummyOptions();
-		$config->getLoader()->shouldReceive('load')->once()->with('production', 'foo', null)->andReturn(array('name' => 'dayle'));
+    public function testNamespacedAccessedAndPostNamespaceLoadEventIsFired()
+    {
+        $config = $this->getRepository();
+        $options = $this->getDummyOptions();
+        $config->getLoader()->shouldReceive('load')->once()->with('production', 'options', 'namespace')->andReturn($options);
+        $config->afterLoading('namespace', function($repository, $group, $items)
+        {
+            $items['dayle'] = 'rees';
+            return $items;
+        });
 
-		$config->set('foo.name', 'taylor');
-		$this->assertEquals('taylor', $config->get('foo.name'));
-
-		$config = $this->getRepository();
-		$options = $this->getDummyOptions();
-		$config->getLoader()->shouldReceive('load')->once()->with('production', 'foo', 'namespace')->andReturn(array('name' => 'dayle'));
-
-		$config->set('namespace::foo.name', 'taylor');
-		$this->assertEquals('taylor', $config->get('namespace::foo.name'));
-	}
-
-
-	public function testPackageRegistersNamespaceAndSetsUpAfterLoadCallback()
-	{
-		$config = $this->getMock('Illuminate\Config\Repository', array('addNamespace'), array(m::mock('Illuminate\Config\LoaderInterface'), 'production'));
-		$config->expects($this->once())->method('addNamespace')->with($this->equalTo('rees'), $this->equalTo(__DIR__));
-		$config->getLoader()->shouldReceive('cascadePackage')->once()->with('production', 'dayle/rees', 'group', array('foo'))->andReturn(array('bar'));
-		$config->package('dayle/rees', __DIR__);
-		$afterLoad = $config->getAfterLoadCallbacks();
-		$results = call_user_func($afterLoad['rees'], $config, 'group', array('foo'));
-
-		$this->assertEquals(array('bar'), $results);
-	}
+        $this->assertEquals('bar', $config->get('namespace::options.foo'));
+        $this->assertEquals('breeze', $config->get('namespace::options.baz.boom'));
+        $this->assertEquals('blah', $config->get('namespace::options.code', 'blah'));
+        $this->assertEquals('blah', $config->get('namespace::options.code', function() { return 'blah'; }));
+        $this->assertEquals('rees', $config->get('namespace::options.dayle'));
+    }
 
 
-	protected function getRepository()
-	{
-		return new Illuminate\Config\Repository(m::mock('Illuminate\Config\LoaderInterface'), 'production');
-	}
+    public function testLoaderUsesNamespaceAsGroupWhenUsingPackagesAndGroupDoesntExist()
+    {
+        $config = $this->getRepository();
+        $options = $this->getDummyOptions();
+        $config->getLoader()->shouldReceive('addNamespace')->with('namespace', __DIR__);
+        $config->getLoader()->shouldReceive('cascadePackage')->andReturnUsing(function($env, $package, $group, $items) { return $items; });
+        $config->getLoader()->shouldReceive('exists')->once()->with('foo', 'namespace')->andReturn(false);
+        $config->getLoader()->shouldReceive('exists')->once()->with('baz', 'namespace')->andReturn(false);
+        $config->getLoader()->shouldReceive('load')->once()->with('production', 'config', 'namespace')->andReturn($options);
+
+        $config->package('foo/namespace', __DIR__);
+        $this->assertEquals('bar', $config->get('namespace::foo'));
+        $this->assertEquals('breeze', $config->get('namespace::baz.boom'));
+    }
 
 
-	protected function getDummyOptions()
-	{
-		return array('foo' => 'bar', 'baz' => array('boom' => 'breeze'));
-	}
+    public function testItemsCanBeSet()
+    {
+        $config = $this->getRepository();
+        $options = $this->getDummyOptions();
+        $config->getLoader()->shouldReceive('load')->once()->with('production', 'foo', null)->andReturn(array('name' => 'dayle'));
+
+        $config->set('foo.name', 'taylor');
+        $this->assertEquals('taylor', $config->get('foo.name'));
+
+        $config = $this->getRepository();
+        $options = $this->getDummyOptions();
+        $config->getLoader()->shouldReceive('load')->once()->with('production', 'foo', 'namespace')->andReturn(array('name' => 'dayle'));
+
+        $config->set('namespace::foo.name', 'taylor');
+        $this->assertEquals('taylor', $config->get('namespace::foo.name'));
+    }
+
+
+    public function testPackageRegistersNamespaceAndSetsUpAfterLoadCallback()
+    {
+        $config = $this->getMock('Illuminate\Config\Repository', array('addNamespace'), array(m::mock('Illuminate\Config\LoaderInterface'), 'production'));
+        $config->expects($this->once())->method('addNamespace')->with($this->equalTo('rees'), $this->equalTo(__DIR__));
+        $config->getLoader()->shouldReceive('cascadePackage')->once()->with('production', 'dayle/rees', 'group', array('foo'))->andReturn(array('bar'));
+        $config->package('dayle/rees', __DIR__);
+        $afterLoad = $config->getAfterLoadCallbacks();
+        $results = call_user_func($afterLoad['rees'], $config, 'group', array('foo'));
+
+        $this->assertEquals(array('bar'), $results);
+    }
+
+
+    protected function getRepository()
+    {
+        return new Illuminate\Config\Repository(m::mock('Illuminate\Config\LoaderInterface'), 'production');
+    }
+
+
+    protected function getDummyOptions()
+    {
+        return array('foo' => 'bar', 'baz' => array('boom' => 'breeze'), 'bing' => true);
+    }
 
 }

--- a/tests/Config/ConfigRepositoryTest.php
+++ b/tests/Config/ConfigRepositoryTest.php
@@ -4,142 +4,142 @@ use Mockery as m;
 
 class ConfigRepositoryTest extends PHPUnit_Framework_TestCase {
 
-    public function tearDown()
-    {
-        m::close();
-    }
+	public function tearDown()
+	{
+		m::close();
+	}
 
 
-    public function testHasGroupIndicatesIfConfigGroupExists()
-    {
-        $config = $this->getRepository();
-        $config->getLoader()->shouldReceive('exists')->once()->with('group', 'namespace')->andReturn(false);
-        $this->assertFalse($config->hasGroup('namespace::group'));
-    }
+	public function testHasGroupIndicatesIfConfigGroupExists()
+	{
+		$config = $this->getRepository();
+		$config->getLoader()->shouldReceive('exists')->once()->with('group', 'namespace')->andReturn(false);
+		$this->assertFalse($config->hasGroup('namespace::group'));
+	}
 
 
-    public function testHasOnTrueReturnsTrue()
-    {
-        $config = $this->getRepository();
-        $options = $this->getDummyOptions();
-        $config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
+	public function testHasOnTrueReturnsTrue()
+	{
+		$config = $this->getRepository();
+		$options = $this->getDummyOptions();
+		$config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
 
-        $this->assertTrue($config->has('app.bing'));
-        $this->assertEquals(true,$config->get('app.bing'));
-    }
-
-
-    public function testGetReturnsBasicItems()
-    {
-        $config = $this->getRepository();
-        $options = $this->getDummyOptions();
-        $config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
-
-        $this->assertEquals('bar', $config->get('app.foo'));
-        $this->assertEquals('breeze', $config->get('app.baz.boom'));
-        $this->assertEquals('blah', $config->get('app.code', 'blah'));
-        $this->assertEquals('blah', $config->get('app.code', function() { return 'blah'; }));
-    }
+		$this->assertTrue($config->has('app.bing'));
+		$this->assertEquals(true,$config->get('app.bing'));
+	}
 
 
-    public function testEntireArrayCanBeReturned()
-    {
-        $config = $this->getRepository();
-        $options = $this->getDummyOptions();
-        $config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
+	public function testGetReturnsBasicItems()
+	{
+		$config = $this->getRepository();
+		$options = $this->getDummyOptions();
+		$config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
 
-        $this->assertEquals($options, $config->get('app'));
-    }
-
-
-    public function testLoaderGetsCalledCorrectForNamespaces()
-    {
-        $config = $this->getRepository();
-        $options = $this->getDummyOptions();
-        $config->getLoader()->shouldReceive('load')->once()->with('production', 'options', 'namespace')->andReturn($options);
-
-        $this->assertEquals('bar', $config->get('namespace::options.foo'));
-        $this->assertEquals('breeze', $config->get('namespace::options.baz.boom'));
-        $this->assertEquals('blah', $config->get('namespace::options.code', 'blah'));
-        $this->assertEquals('blah', $config->get('namespace::options.code', function() { return 'blah'; }));
-    }
+		$this->assertEquals('bar', $config->get('app.foo'));
+		$this->assertEquals('breeze', $config->get('app.baz.boom'));
+		$this->assertEquals('blah', $config->get('app.code', 'blah'));
+		$this->assertEquals('blah', $config->get('app.code', function() { return 'blah'; }));
+	}
 
 
-    public function testNamespacedAccessedAndPostNamespaceLoadEventIsFired()
-    {
-        $config = $this->getRepository();
-        $options = $this->getDummyOptions();
-        $config->getLoader()->shouldReceive('load')->once()->with('production', 'options', 'namespace')->andReturn($options);
-        $config->afterLoading('namespace', function($repository, $group, $items)
-        {
-            $items['dayle'] = 'rees';
-            return $items;
-        });
+	public function testEntireArrayCanBeReturned()
+	{
+		$config = $this->getRepository();
+		$options = $this->getDummyOptions();
+		$config->getLoader()->shouldReceive('load')->once()->with('production', 'app', null)->andReturn($options);
 
-        $this->assertEquals('bar', $config->get('namespace::options.foo'));
-        $this->assertEquals('breeze', $config->get('namespace::options.baz.boom'));
-        $this->assertEquals('blah', $config->get('namespace::options.code', 'blah'));
-        $this->assertEquals('blah', $config->get('namespace::options.code', function() { return 'blah'; }));
-        $this->assertEquals('rees', $config->get('namespace::options.dayle'));
-    }
+		$this->assertEquals($options, $config->get('app'));
+	}
 
 
-    public function testLoaderUsesNamespaceAsGroupWhenUsingPackagesAndGroupDoesntExist()
-    {
-        $config = $this->getRepository();
-        $options = $this->getDummyOptions();
-        $config->getLoader()->shouldReceive('addNamespace')->with('namespace', __DIR__);
-        $config->getLoader()->shouldReceive('cascadePackage')->andReturnUsing(function($env, $package, $group, $items) { return $items; });
-        $config->getLoader()->shouldReceive('exists')->once()->with('foo', 'namespace')->andReturn(false);
-        $config->getLoader()->shouldReceive('exists')->once()->with('baz', 'namespace')->andReturn(false);
-        $config->getLoader()->shouldReceive('load')->once()->with('production', 'config', 'namespace')->andReturn($options);
+	public function testLoaderGetsCalledCorrectForNamespaces()
+	{
+		$config = $this->getRepository();
+		$options = $this->getDummyOptions();
+		$config->getLoader()->shouldReceive('load')->once()->with('production', 'options', 'namespace')->andReturn($options);
 
-        $config->package('foo/namespace', __DIR__);
-        $this->assertEquals('bar', $config->get('namespace::foo'));
-        $this->assertEquals('breeze', $config->get('namespace::baz.boom'));
-    }
+		$this->assertEquals('bar', $config->get('namespace::options.foo'));
+		$this->assertEquals('breeze', $config->get('namespace::options.baz.boom'));
+		$this->assertEquals('blah', $config->get('namespace::options.code', 'blah'));
+		$this->assertEquals('blah', $config->get('namespace::options.code', function() { return 'blah'; }));
+	}
 
 
-    public function testItemsCanBeSet()
-    {
-        $config = $this->getRepository();
-        $options = $this->getDummyOptions();
-        $config->getLoader()->shouldReceive('load')->once()->with('production', 'foo', null)->andReturn(array('name' => 'dayle'));
+	public function testNamespacedAccessedAndPostNamespaceLoadEventIsFired()
+	{
+		$config = $this->getRepository();
+		$options = $this->getDummyOptions();
+		$config->getLoader()->shouldReceive('load')->once()->with('production', 'options', 'namespace')->andReturn($options);
+		$config->afterLoading('namespace', function($repository, $group, $items)
+		{
+			$items['dayle'] = 'rees';
+			return $items;
+		});
 
-        $config->set('foo.name', 'taylor');
-        $this->assertEquals('taylor', $config->get('foo.name'));
-
-        $config = $this->getRepository();
-        $options = $this->getDummyOptions();
-        $config->getLoader()->shouldReceive('load')->once()->with('production', 'foo', 'namespace')->andReturn(array('name' => 'dayle'));
-
-        $config->set('namespace::foo.name', 'taylor');
-        $this->assertEquals('taylor', $config->get('namespace::foo.name'));
-    }
-
-
-    public function testPackageRegistersNamespaceAndSetsUpAfterLoadCallback()
-    {
-        $config = $this->getMock('Illuminate\Config\Repository', array('addNamespace'), array(m::mock('Illuminate\Config\LoaderInterface'), 'production'));
-        $config->expects($this->once())->method('addNamespace')->with($this->equalTo('rees'), $this->equalTo(__DIR__));
-        $config->getLoader()->shouldReceive('cascadePackage')->once()->with('production', 'dayle/rees', 'group', array('foo'))->andReturn(array('bar'));
-        $config->package('dayle/rees', __DIR__);
-        $afterLoad = $config->getAfterLoadCallbacks();
-        $results = call_user_func($afterLoad['rees'], $config, 'group', array('foo'));
-
-        $this->assertEquals(array('bar'), $results);
-    }
+		$this->assertEquals('bar', $config->get('namespace::options.foo'));
+		$this->assertEquals('breeze', $config->get('namespace::options.baz.boom'));
+		$this->assertEquals('blah', $config->get('namespace::options.code', 'blah'));
+		$this->assertEquals('blah', $config->get('namespace::options.code', function() { return 'blah'; }));
+		$this->assertEquals('rees', $config->get('namespace::options.dayle'));
+	}
 
 
-    protected function getRepository()
-    {
-        return new Illuminate\Config\Repository(m::mock('Illuminate\Config\LoaderInterface'), 'production');
-    }
+	public function testLoaderUsesNamespaceAsGroupWhenUsingPackagesAndGroupDoesntExist()
+	{
+		$config = $this->getRepository();
+		$options = $this->getDummyOptions();
+		$config->getLoader()->shouldReceive('addNamespace')->with('namespace', __DIR__);
+		$config->getLoader()->shouldReceive('cascadePackage')->andReturnUsing(function($env, $package, $group, $items) { return $items; });
+		$config->getLoader()->shouldReceive('exists')->once()->with('foo', 'namespace')->andReturn(false);
+		$config->getLoader()->shouldReceive('exists')->once()->with('baz', 'namespace')->andReturn(false);
+		$config->getLoader()->shouldReceive('load')->once()->with('production', 'config', 'namespace')->andReturn($options);
+
+		$config->package('foo/namespace', __DIR__);
+		$this->assertEquals('bar', $config->get('namespace::foo'));
+		$this->assertEquals('breeze', $config->get('namespace::baz.boom'));
+	}
 
 
-    protected function getDummyOptions()
-    {
-        return array('foo' => 'bar', 'baz' => array('boom' => 'breeze'), 'bing' => true);
-    }
+	public function testItemsCanBeSet()
+	{
+		$config = $this->getRepository();
+		$options = $this->getDummyOptions();
+		$config->getLoader()->shouldReceive('load')->once()->with('production', 'foo', null)->andReturn(array('name' => 'dayle'));
+
+		$config->set('foo.name', 'taylor');
+		$this->assertEquals('taylor', $config->get('foo.name'));
+
+		$config = $this->getRepository();
+		$options = $this->getDummyOptions();
+		$config->getLoader()->shouldReceive('load')->once()->with('production', 'foo', 'namespace')->andReturn(array('name' => 'dayle'));
+
+		$config->set('namespace::foo.name', 'taylor');
+		$this->assertEquals('taylor', $config->get('namespace::foo.name'));
+	}
+
+
+	public function testPackageRegistersNamespaceAndSetsUpAfterLoadCallback()
+	{
+		$config = $this->getMock('Illuminate\Config\Repository', array('addNamespace'), array(m::mock('Illuminate\Config\LoaderInterface'), 'production'));
+		$config->expects($this->once())->method('addNamespace')->with($this->equalTo('rees'), $this->equalTo(__DIR__));
+		$config->getLoader()->shouldReceive('cascadePackage')->once()->with('production', 'dayle/rees', 'group', array('foo'))->andReturn(array('bar'));
+		$config->package('dayle/rees', __DIR__);
+		$afterLoad = $config->getAfterLoadCallbacks();
+		$results = call_user_func($afterLoad['rees'], $config, 'group', array('foo'));
+
+		$this->assertEquals(array('bar'), $results);
+	}
+
+
+	protected function getRepository()
+	{
+		return new Illuminate\Config\Repository(m::mock('Illuminate\Config\LoaderInterface'), 'production');
+	}
+
+
+	protected function getDummyOptions()
+	{
+		return array('foo' => 'bar', 'baz' => array('boom' => 'breeze'), 'bing' => true);
+	}
 
 }


### PR DESCRIPTION
When you have a true value in your config like `'bing' => true`, then Laravel fails to detect the value with `Config::has()` due to the weak comparison it does on the has method.

I have updated the method to a strong comparison and added two new tests for this behaviour.
