### PR TITLE
Fix missing table prefix on hasColumn method

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -58,6 +58,8 @@ class Builder {
 	{
 		$schema = $this->connection->getDoctrineSchemaManager();
 
+		$table = $this->connection->getTablePrefix().$table;
+
 		return in_array($column, array_keys($schema->listTableColumns($table)));
 	}
 


### PR DESCRIPTION
The is similar to what happened with the hasTable method recently.
