### PR TITLE
[Fix] Container not removing bound instances on unset

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -225,7 +225,7 @@ class Container implements ArrayAccess {
 		// so the developer can keep using the same objects instance every time.
 		if (isset($this->instances[$abstract]))
 		{
-			return $this->instances[$abstract];	
+			return $this->instances[$abstract];
 		}
 
 		$concrete = $this->getConcrete($abstract);
@@ -529,6 +529,7 @@ class Container implements ArrayAccess {
 	public function offsetUnset($key)
 	{
 		unset($this->bindings[$key]);
+		unset($this->instances[$key]);
 	}
 
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -204,6 +204,15 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('taylor', $instance->name);
 	}
 
+	public function testUnsetRemoveBoundInstances()
+	{
+		$container = new Container;
+		$container->instance('object', new StdClass);
+		unset($container['object']);
+
+		$this->assertFalse($container->bound('object'));
+	}
+
 }
 
 class ContainerConcreteStub {}


### PR DESCRIPTION
This is problematic because apart from `unset` there is no way to remove something in the container.
