### PR TITLE
Fix #2013 RemoteManager being coupled to Application

### DIFF
--- a/src/Illuminate/Remote/RemoteManager.php
+++ b/src/Illuminate/Remote/RemoteManager.php
@@ -125,7 +125,7 @@ class RemoteManager {
 	 */
 	protected function setOutput(Connection $connection)
 	{
-		$output = $this->app->runningInConsole() ? new ConsoleOutput : new NullOutput;
+		$output = php_sapi_name() == 'cli' ? new ConsoleOutput : new NullOutput;
 
 		$connection->setOutput($output);
 	}


### PR DESCRIPTION
Otherwise the remote component can' be used outside of Laravel. See #2013 
