### PR TITLE
Added limit() and offset() to Query Builder.

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -806,11 +806,22 @@ class Builder {
 	 * @param  int  $value
 	 * @return \Illuminate\Database\Query\Builder|static
 	 */
-	public function skip($value)
+	public function offset($value)
 	{
 		$this->offset = $value;
 
 		return $this;
+	}
+
+	/**
+	 * Alias to set the "offset" value of the query.
+	 *
+	 * @param  int  $value
+	 * @return \Illuminate\Database\Query\Builder|static
+	 */
+	public function skip($value)
+	{
+		return $this->offset($value);
 	}
 
 	/**
@@ -819,11 +830,22 @@ class Builder {
 	 * @param  int  $value
 	 * @return \Illuminate\Database\Query\Builder|static
 	 */
-	public function take($value)
+	public function limit($value)
 	{
 		if ($value > 0) $this->limit = $value;
 
 		return $this;
+	}
+
+	/**
+	 * Alias to set the "limit" value of the query.
+	 *
+	 * @param  int  $value
+	 * @return \Illuminate\Database\Query\Builder|static
+	 */
+	public function take($value)
+	{
+		return $this->limit($value);
 	}
 
 	/**
@@ -851,7 +873,7 @@ class Builder {
 		{
 			call_user_func($query, $query = $this->newQuery());
 		}
-		
+
 		$this->unions[] = compact('query', 'all');
 
 		return $this->mergeBindings($query);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -269,6 +269,10 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testLimitsAndOffsets()
 	{
 		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->offset(5)->limit(10);
+		$this->assertEquals('select * from "users" limit 10 offset 5', $builder->toSql());
+
+		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->skip(5)->take(10);
 		$this->assertEquals('select * from "users" limit 10 offset 5', $builder->toSql());
 


### PR DESCRIPTION
I get quite a few messages for support asking how to limit or offset a query. Granted the information is in the documentation, and the `take()` and `skip()` methods do sound kinda cool, but I think offering both will allow users to 'guess' the syntax and choose their own methods. This will ease the learning experience.

I felt it made sense to have the SQL terms as the 'real' methods and 'take' and 'skip' as the aliases so I swapped them around. I realise the tests are essentially covering the same code, but I added them incase someone fiddles with one of the methods later.
