### PR TITLE
Artisan optimize timeout

### DIFF
--- a/src/Illuminate/Foundation/Composer.php
+++ b/src/Illuminate/Foundation/Composer.php
@@ -79,7 +79,9 @@ class Composer {
 	 */
 	protected function getProcess()
 	{
-		return new Process('', $this->workingPath);
+		$process = new Process('', $this->workingPath);
+		$process->setTimeout(null);
+		return $process;
 	}
 
 	/**


### PR DESCRIPTION
Fixed issue where artisan optimize would sometimes time out when generating classes.

This issue has been flagged before in #1050 but it doesn't look like it was fixed back then
