### PR TITLE
Require mcrypt extension in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "classpreloader/classpreloader": "1.0.*",
         "doctrine/dbal": "2.4.x",
         "ircmaxell/password-compat": "1.0.*",
+        "ext-mcrypt": "*",
         "filp/whoops": "1.0.7",
         "monolog/monolog": "1.5.*",
         "nesbot/carbon": "1.*",

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -9,7 +9,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.0.x"
+        "illuminate/support": "4.0.x",
+        "ext-mcrypt": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Since `start.php` errors out on this, it would make sense to catch the problem at `composer install` already.
