### PR TITLE
[Pull Request] Add ability to extend DB by driver name as well as by database name

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -84,6 +84,12 @@ class DatabaseManager implements ConnectionResolverInterface {
 			return call_user_func($this->extensions[$name], $config);
 		}
 
+		$driver = $config['driver'];
+		if (isset($this->extensions[$driver]))
+		{
+			return call_user_func($this->extensions[$driver], $config);
+		}
+
 		return $this->factory->make($config);
 	}
 


### PR DESCRIPTION
Right now, the if you want to add a new db driver to Laravel, you have to call `DB::extend` for each named database.  I'd rather call `DB::extend('odbc')` once and be able to then use `'driver'=>'odbc'` in my config file.  (In my case, I have a named database that has different configs (and drivers) on dev, test, and prod.  Registering the extension by name is complicated for me, but adding drivers is easy.)
