### PR TITLE
[Pull Request] Support for double data type in schema builder.

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -492,6 +492,21 @@ class Blueprint {
 	}
 
 	/**
+	 * Create a new double column on the table.
+	 *
+	 * @param  string   $column
+	 * @param  int|null	$total
+	 * @param  int|null $places
+	 *
+	 * @return \Illuminate\Support\Fluent
+	 *
+	 */
+	public function double($column, $total = null, $places = null)
+	{
+		return $this->addColumn('double', $column, compact('total', 'places'));
+	}
+
+	/**
 	 * Create a new decimal column on the table.
 	 *
 	 * @param  string  $column

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -376,6 +376,27 @@ class MySqlGrammar extends Grammar {
 	}
 
 	/**
+	 * Create the column definition for a float type.
+	 *
+	 * @param  \Illuminate\Support\Fluent  $column
+	 * @return string
+	 */
+	protected function typeDouble(Fluent $column)
+	{
+        // Optionally use MySQL's nonstandard syntax, DOUBLE(M,N).
+        if ($column->total and $column->places)
+        {
+            $sql = "double({$column->total}, {$column->places})";
+        }
+        else
+        {
+            $sql = "double";
+        }
+
+        return $sql;
+	}
+
+	/**
 	 * Create the column definition for a decimal type.
 	 *
 	 * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -329,6 +329,17 @@ class PostgresGrammar extends Grammar {
 	}
 
 	/**
+	 * Create the column definition for a double type.
+	 *
+	 * @param  \Illuminate\Support\Fluent  $column
+	 * @return string
+	 */
+	protected function typeDouble(Fluent $column)
+	{
+		return 'double precision';
+	}
+
+	/**
 	 * Create the column definition for a decimal type.
 	 *
 	 * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -393,6 +393,17 @@ class SQLiteGrammar extends Grammar {
 	}
 
 	/**
+	 * Create the column definition for a double type.
+	 *
+	 * @param  \Illuminate\Support\Fluent  $column
+	 * @return string
+	 */
+	protected function typeDouble(Fluent $column)
+	{
+		return 'float';
+	}
+
+	/**
 	 * Create the column definition for a decimal type.
 	 *
 	 * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -325,6 +325,17 @@ class SqlServerGrammar extends Grammar {
 	}
 
 	/**
+	 * Create the column definition for a double type.
+	 *
+	 * @param  \Illuminate\Support\Fluent  $column
+	 * @return string
+	 */
+	protected function typeDouble(Fluent $column)
+	{
+		return 'float';
+	}
+
+	/**
 	 * Create the column definition for a decimal type.
 	 *
 	 * @param  \Illuminate\Support\Fluent  $column

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -372,6 +372,28 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAddingDouble()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->double('foo');
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` add `foo` double not null', $statements[0]);
+	}
+
+
+	public function testAddingDoubleSpecifyingPrecision()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->double('foo', 15, 8);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` add `foo` double(15, 8) not null', $statements[0]);
+	}
+
+
 	public function testAddingDecimal()
 	{
 		$blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -315,6 +315,17 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAddingDouble()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->double('foo', 15, 8);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table "users" add column "foo" double precision not null', $statements[0]);
+	}
+
+
 	public function testAddingDecimal()
 	{
 		$blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -297,6 +297,17 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAddingDouble()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->double('foo', 15, 8);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table "users" add column "foo" float null', $statements[0]);
+	}
+
+
 	public function testAddingDecimal()
 	{
 		$blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -305,6 +305,17 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAddingDouble()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->double('foo', 15, 2);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table "users" add "foo" float not null', $statements[0]);
+	}
+
+
 	public function testAddingDecimal()
 	{
 		$blueprint = new Blueprint('users');


### PR DESCRIPTION
I've implemented the feature discussed in issue #1955. This patch extends the Schema Builder syntax to include double support for columns. This means the following syntax is possible:

``` php
Schema::create('table', function($table) {
    $table->increments('id');
    $table->double('double_col_1');
    $table->double('double_col_2', 15, 8);
});
```

You'll notice there are two different ways to declare a double, with a specified precision or without. In addition to the simple double syntax, MySQL supports a second, nonstandard syntax.

From MySQL documentation:

> MySQL permits a nonstandard syntax: FLOAT(M,D) or REAL(M,D) or DOUBLE PRECISION(M,D). Here, “(M,D)” means than values can be stored with up to M digits in total, of which D digits may be after the decimal point. For example, a column defined as FLOAT(7,4) will look like -999.9999 when displayed. MySQL performs rounding when storing values, so if you insert 999.00009 into a FLOAT(7,4) column, the approximate result is 999.0001.

Both of these syntaxes are supported in this patch, as you'll see in the examples below. It is important to support both syntaxes because documentation for the default `M,D` in the extended syntax [is surprisingly nonspecific](http://dev.mysql.com/doc/refman/5.5/en/floating-point-types.html), and those of use working on systems that already make use of the standard syntax might lose precision migrating to the extended `M,D` notation.
## Examples

Standard SQL DOUBLE syntax in MySQL is:

``` php
$table->double('double_col_1');
```

Which is translated into:

```
alter table `table` add `double_col_1` double not null
```

And the nonstandard MySQL DOUBLE syntax option expressed as:

``` php
$table->double('double_col_2', 15, 8);
```

Which is translated into:

```
alter table `table` add `double_col_2` double(15, 8) not null
```
