### PR TITLE
Throw ErrorException so developers can catch it.

### DIFF
--- a/src/Illuminate/Exception/Handler.php
+++ b/src/Illuminate/Exception/Handler.php
@@ -252,6 +252,14 @@ class Handler {
 				$response = $this->formatException($e);
 			}
 
+			// If the handler returns an Exception object, it is safe to say we intentionally 
+			// want to throw an exception from the handler itself. Let's throw it now so that 
+			// it can be caught.
+			if ($response instanceof \Exception)
+			{
+				throw $response;
+			}
+
 			// If this handler returns a "non-null" response, we will return it so it will
 			// get sent back to the browsers. Once the handler returns a valid response
 			// we will cease iterating through them and calling these other handlers.


### PR DESCRIPTION
This is a far more elegant solution than #1959 which addresses the problem in #1807. 

Simply return a derivative of an Exception from the custom error handler and it will be thrown.

This is particularly useful if I want to allow this:

``` php
try {
    $throwsPhpError = 2 / 0;
}
catch (\ErrorException $ex) {
    // Do nothing
}
```

Possible by defining

``` php
App::error(function(\ErrorException $exception, $code)
{
    return $exception;
});
```

It's simple. It's clean. And it works!
