### PR TITLE
This updated the MySqlConnector.php so that you can either use unix_sock...

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -41,26 +41,31 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 	 */
 	protected function getDsn(array $config)
 	{
-		// First we will create the basic DSN setup as well as the port if it is in
-		// in the configuration options. This will give us the basic DSN we will
-		// need to establish the PDO connections and return them back for use.
 		extract($config);
-
-		$dsn = "mysql:host={$host};dbname={$database}";
-
-		if (isset($config['port']))
-		{
-			$dsn .= ";port={$port}";
-		}
-
-		// Sometimes the developer may specify the specific UNIX socket that should
-		// be used. If that is the case we will add that option to the string we
-		// have created so that it gets utilized while the connection is made.
+ 
+		// Sometimes the developer may specify the specific UNIX socket that should be used
 		if (isset($config['unix_socket']))
 		{
-			$dsn .= ";unix_socket={$config['unix_socket']}";
+			$dsn = "unix_socket={$config['unix_socket']}";
 		}
-
+		else
+		{
+			// But more often a single hostname is supplied with an optionnal port number.
+			// Warning : when 'localhost' is used, the mysql driver will use the default 
+			//			unix socket value, use '127.0.0.1' instead.
+			// Note :	according to the PHP documentation the unix_socket option and the 
+			//			host[port] option should not be used together.
+			$dsn = "host={$host}";
+ 
+			if (isset($config['port']))
+			{
+				$dsn .= ";port={$port}";
+			}
+		}
+ 
+		// Finally, the 'mysql:' prefix as well as the database name are added
+		$dsn = "mysql:{$dsn};dbname={$database}";
+ 
 		return $dsn;
 	}
 


### PR DESCRIPTION
...et or host[port] but not both and it gives presedence to unix_socket.

This was causing me and others issues on Google Appengine as its accessed via unix_socket.
