### PR TITLE
doReplacements() added is_callable() verification

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1156,8 +1156,10 @@ class Validator implements MessageProviderInterface {
 	protected function doReplacements($message, $attribute, $rule, $parameters)
 	{
 		$message = str_replace(':attribute', $this->getAttribute($attribute), $message);
+		
+		$replacer = "replace{$rule}";
 
-		if (method_exists($this, $replacer = "replace{$rule}"))
+		if (method_exists($this, $replacer) || is_callable(array($this, $replacer)))
 		{
 			$message = $this->$replacer($message, $attribute, $rule, $parameters);
 		}


### PR DESCRIPTION
Thus, when extend the class, you can call methods replace_Rule_() dynamically on the __call().

Ex:

``` php
class CustomValidator extends \Illuminate\Validation\Validator
{
    // ...
    // ...  
    public function __call($method, $parameters)
    {
        // ...
        // ...  
        if(preg_match('/^replace/', $method)) {
            return $this->doMessageReplacement($parameters);
        }
        // ...
        // ...  

        parent::__call($method, $parameters);
    }

// ...
// ...
```
