### PR TITLE
Ensure Doctrine to map MySQL enum type

### DIFF
--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -3,6 +3,23 @@
 class MySqlConnection extends Connection {
 
 	/**
+	 * Get the Doctrine DBAL database connection instance.
+	 *
+	 * @return \Doctrine\DBAL\Connection
+	 */
+	public function getDoctrineConnection()
+	{
+		$connection = parent::getDoctrineConnection();
+
+		// Since schema builder explicitely support enum type, 
+		// then we need to ensure Doctrine to map the MySQL enum type to a Doctrine type.
+		// @see http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/cookbook/mysql-enums.html
+		$connection->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+
+		return $connection;
+	}
+
+	/**
 	 * Get a schema builder instance for the connection.
 	 *
 	 * @return \Illuminate\Database\Schema\Builder


### PR DESCRIPTION
I receive `[Doctrine\DBAL\DBALException]                                                                    
  Unknown database type enum requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it.` error while running the migration. 

How to reproduce :
- Create a migration to build a table that contains `enum` column like :

``` php
<?php

use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Schema\Blueprint;

class CreateVideosTable extends Migration {

    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::create('videos', function(Blueprint $table) {
            $table->engine = 'MyISAM';

            $table->increments('id');
            $table->string('name')->unique();
            $table->string('slug')->unique();
            $table->enum('visibility', array('public', 'private'))->default('public');
            $table->timestamps();
        });
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::drop('videos');
    }

}

```
- Run above migration.
- Create another migration to alter these table that contains a call to `Schema::hasCollumn` method :

``` php
<?php

use Illuminate\Database\Migrations\Migration;

class AlterVideosTable extends Migration {

    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        if ( ! Schema::hasColumn('videos', 'embed'))
        {
            Schema::table('videos', function($table)
            {
                $table->text('embed');
            });
        }
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        if (Schema::hasColumn('videos', 'embed'))
        {
            Schema::table('videos', function($table)
            {
                $table->dropColumn('embed');
            });
        }
    }

}
```
- Run migration again.

This patch ensure Doctrine to map MySQL enum type by overides `getDoctrineConnection` from `Illuminate\Database\Connection` class.

Thanks.
