### PR TITLE
Fixed a typo of "mixed"

### DIFF
--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -55,7 +55,7 @@ class GenericUser implements UserInterface {
 	 * Dynamically set an attribute on the user.
 	 *
 	 * @param  string  $key
-	 * @param  mied    $value
+	 * @param  mixed   $value
 	 * @return void
 	 */
 	public function __set($key, $value)


### PR DESCRIPTION
There is a typo at https://github.com/laravel/framework/blob/master/src/Illuminate/Auth/GenericUser.php#L58.
