### PR TITLE
Update Validator.php

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -612,7 +612,7 @@ class Validator implements MessageProviderInterface {
 		// entire length of the string will be considered the attribute size.
 		if (is_numeric($value) and $hasNumeric)
 		{
-			return $this->data[$attribute];
+			return array_get($this->data, $attribute);
 		}
 		elseif (is_array($value))
 		{


### PR DESCRIPTION
If a validation rule was set for a specific array key (array.key), a fatal "undefined index" error was being thrown. Using array_get allows for dot syntax to properly find and validate the value
