### PR TITLE
Remove password length validation from reset

### DIFF
--- a/src/Illuminate/Auth/Reminders/PasswordBroker.php
+++ b/src/Illuminate/Auth/Reminders/PasswordBroker.php
@@ -185,7 +185,7 @@ class PasswordBroker {
 
 		$confirm = $this->getConfirmedPassword();
 
-		return $password and strlen($password) >= 6 and $password == $confirm;
+		return $password and $password == $confirm;
 	}
 
 	/**


### PR DESCRIPTION
All password validation rules should be enforced separately by the validator before resetting the password.
