### PR TITLE
Allows load to be chained

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -34,6 +34,8 @@ class Collection extends BaseCollection {
 
 			$this->items = $query->eagerLoadRelations($this->items);
 		}
+
+		return $this;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -440,6 +440,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		$query = $this->newQuery()->with($relations);
 
 		$query->eagerLoadRelations(array($this));
+
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
Previously the following wouldn't work because `->load()` didn't return anything. This PR fixes that and allows you to load relationships onto the `Auth::user()` model, for example.

``` php
$user = Auth::user()->load('posts')
```

In addition, it felt prudent to add it in to the similarly named `Collection::load()` method as well.
