### PR TITLE
[Fix] Don't attempt validation on an empty rule

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -202,6 +202,10 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validate($attribute, $rule)
 	{
+		if ($rule == '') {
+			return;
+		}
+		
 		list($rule, $parameters) = $this->parseRule($rule);
 
 		// We will get the value for the given attribute from the array of data and then


### PR DESCRIPTION
I had a case where I had rules set as:

```
array(
  'title' => 'required',
  'blurb' => ''
)
```

When I manually do a validation check with the following:

```
$validator = \Validator::make($this->attributes, $rules);
$boards[$boardName] = $validator->passes();
```

If I have the value "myblurb" stored for the items blurb value, I get an error telling me the method `validateMyblurb` does not exist, it seems that this function calls itself in cases where no validation rules are set and tries to create a $method based on the concatenation of 'method' and the original value

This check simply stops this from happening.
