### PR TITLE
[Bug] detectEnvironment no longer returning environment string

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -242,6 +242,8 @@ class Application extends Container implements HttpKernelInterface, ResponsePrep
 			$environments, $this->runningInConsole()
 
 		);
+
+		return $this['env'];
 	}
 
 	/**
@@ -568,7 +570,7 @@ class Application extends Container implements HttpKernelInterface, ResponsePrep
 
 			if ( ! is_null($response)) return $this->prepareResponse($response, $request);
 		}
-		
+
 		return $this['router']->dispatch($this->prepareRequest($request));
 	}
 


### PR DESCRIPTION
`app/bootstrap/start.php`'s assignment of the global `$env` is failing because
`detectEnvironment` is no longer returning the environment string it's
supposed to.
