### PR TITLE
[Bug] Send the application Container to the ControllerDispatcher if available

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -113,7 +113,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	public function __construct(Dispatcher $events, Container $container = null)
 	{
 		$this->events = $events;
-		$this->container = $container;
+		$this->container = $container ?: new Container;
 		$this->routes = new RouteCollection;
 	}
 
@@ -1228,7 +1228,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	{
 		if (is_null($this->controllerDispatcher))
 		{
-			$this->controllerDispatcher = new ControllerDispatcher($this, new Container);
+			$this->controllerDispatcher = new ControllerDispatcher($this, $this->container);
 		}
 
 		return $this->controllerDispatcher;


### PR DESCRIPTION
By passing a `new Container` to the `ControllerDispatcher`, the
instantiation of controller instances can't properly perform dependency
resolution for bindings on the main application `Container`.

This fixes that issue, and still leaves the default `$controller`
property value as `new Controller` to keep the tests passing.
