### PR TITLE
Add $dates array to Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -134,6 +134,13 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	protected $with = array();
 
 	/**
+	 * The columns to return as Carbon objects.
+	 *
+	 * @var array
+	 */
+	protected $dates = array();
+
+	/**
 	 * Indicates if the model exists.
 	 *
 	 * @var bool
@@ -2119,7 +2126,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function getDates()
 	{
-		return array(static::CREATED_AT, static::UPDATED_AT, static::DELETED_AT);
+		return array_merge($this->dates, array(static::CREATED_AT, static::UPDATED_AT, static::DELETED_AT));
 	}
 
 	/**


### PR DESCRIPTION
As it stands at the moment getDates() is only setting the default Eloquent timestamps to be formatted with Carbon, this would allow users to add columns to the $dates array that will be returned as Carbon objects.
