### PR TITLE
[4.1] Fixed  scope isn't available in PHP 5.3

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -334,7 +334,7 @@ class Application extends Container implements HttpKernelInterface, ResponsePrep
 		// the remaining services available to this application for immediate use.
 		array_walk($this->deferredServices, function($p) use ($me)
 		{
-			$this->registerDeferredProvider($p);
+			$me->registerDeferredProvider($p);
 		});
 
 		$this->deferredServices = array();


### PR DESCRIPTION
Signed-off-by: crynobone crynobone@gmail.com
