### PR TITLE
Fixed bug with lang::choice

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -147,7 +147,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	{
 		$line = $this->get($key, $replace, $locale = $locale ?: $this->locale);
 
-		array_unshift($replace, $number);
+		$replace['count'] = $number;
 
 		return $this->makeReplacements($this->getSelector()->choose($line, $number, $locale), $replace);
 	}


### PR DESCRIPTION
The documentation currently says %count% is automatically replaced with the count when using `Lang::choice`, but this is wrong.

The current function adds a keyless item to the $replace array containing $number - if you don't provide an array of other strings to replace, it will be `[0] => $number`.

The way Laravel does replacement in translation, this obviously does nothing. With this change, `:count` will be replaced with $number. I'm not sure if this is desired behavior or not, but the current implementation surely can't be intentional.
