### PR TITLE
Making "with" function instantiate an object if parameter is string

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -930,6 +930,8 @@ if ( ! function_exists('with'))
 	 */
 	function with($object)
 	{
+		if (is_string($object)) return new $object;
+
 		return $object;
 	}
 }


### PR DESCRIPTION
Making the "with" function more helpful.
I'd enjoy a lot being able to simply:
    with('Whistle')->blow();
    with('Ferrari')->run();
    with('Pencil')->write();
...and so on.

Details of the real use case:

I had a static method and wanted to make it not static.
My calling code was
    City::named('Bauru');
Instead of one-liner
    with(new City)->named('Bauru');
...which does not sound true, as the method fetches an existing city from database... it would sound way much better like this:
    with('City')->named('Bauru');

Maybe I should just keep the method static?
