### PR TITLE
Job scheduling with DateTime objects

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -51,14 +51,15 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 	/**
 	 * Push a new job onto the queue after a delay.
 	 *
-	 * @param  int     $delay
-	 * @param  string  $job
-	 * @param  mixed   $data
-	 * @param  string  $queue
+	 * @param  \DateTime|int  $delay
+	 * @param  string         $job
+	 * @param  mixed          $data
+	 * @param  string         $queue
 	 * @return mixed
 	 */
 	public function later($delay, $job, $data = '', $queue = null)
 	{
+		$delay = $this->calculateSeconds($delay);
 		$payload = $this->createPayload($job, $data);
 
 		$pheanstalk = $this->pheanstalk->useTube($this->getQueue($queue));

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -71,14 +71,15 @@ class IronQueue extends Queue implements QueueInterface {
 	/**
 	 * Push a new job onto the queue after a delay.
 	 *
-	 * @param  int     $delay
-	 * @param  string  $job
-	 * @param  mixed   $data
-	 * @param  string  $queue
+	 * @param  \DateTime|int  $delay
+	 * @param  string         $job
+	 * @param  mixed          $data
+	 * @param  string         $queue
 	 * @return mixed
 	 */
 	public function later($delay, $job, $data = '', $queue = null)
 	{
+		$delay = $this->calculateSeconds($delay);
 		$payload = $this->createPayload($job, $data);
 
 		return $this->iron->postMessage($this->getQueue($queue), $payload, compact('delay'))->id;

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -1,6 +1,8 @@
 <?php namespace Illuminate\Queue;
 
 use Closure;
+use DateTime;
+use Carbon\Carbon;
 use Illuminate\Container\Container;
 use Illuminate\Support\SerializableClosure;
 
@@ -54,6 +56,22 @@ abstract class Queue {
 		$closure = serialize(new SerializableClosure($job));
 
 		return array('job' => 'IlluminateQueueClosure', 'data' => compact('closure'));
+	}
+
+	/**
+	 * Calculate the number of seconds from a DateTime object.
+	 *
+	 * @param  \DateTime|int  $delay
+	 * @return int
+	 */
+	protected function calculateSeconds($delay)
+	{
+		if ($delay instanceof DateTime)
+		{
+			return Carbon::instance($delay)->diffInSeconds();
+		}
+
+		return intval($delay);
 	}
 
 	/**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -2,7 +2,6 @@
 
 use Closure;
 use DateTime;
-use Carbon\Carbon;
 use Illuminate\Container\Container;
 use Illuminate\Support\SerializableClosure;
 
@@ -68,7 +67,7 @@ abstract class Queue {
 	{
 		if ($delay instanceof DateTime)
 		{
-			return Carbon::instance($delay)->diffInSeconds();
+			return $delay->getTimestamp() - now();
 		}
 
 		return intval($delay);

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -67,7 +67,8 @@ abstract class Queue {
 	{
 		if ($delay instanceof DateTime)
 		{
-			return $delay->getTimestamp() - now();
+			$seconds = $delay->getTimestamp() - now();
+			return max(0, $seconds);
 		}
 
 		return intval($delay);

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -67,7 +67,7 @@ abstract class Queue {
 	{
 		if ($delay instanceof DateTime)
 		{
-			$seconds = $delay->getTimestamp() - now();
+			$seconds = $delay->getTimestamp() - time();
 			return max(0, $seconds);
 		}
 

--- a/src/Illuminate/Queue/QueueInterface.php
+++ b/src/Illuminate/Queue/QueueInterface.php
@@ -15,10 +15,10 @@ interface QueueInterface {
 	/**
 	 * Push a new job onto the queue after a delay.
 	 *
-	 * @param  int     $delay
-	 * @param  string  $job
-	 * @param  mixed   $data
-	 * @param  string  $queue
+	 * @param  \DateTime|int  $delay
+	 * @param  string         $job
+	 * @param  mixed          $data
+	 * @param  string         $queue
 	 * @return mixed
 	 */
 	public function later($delay, $job, $data = '', $queue = null);

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -52,14 +52,15 @@ class SqsQueue extends Queue implements QueueInterface {
 	/**
 	 * Push a new job onto the queue after a delay.
 	 *
-	 * @param  int     $delay
-	 * @param  string  $job
-	 * @param  mixed   $data
-	 * @param  string  $queue
+	 * @param  \DateTime|int  $delay
+	 * @param  string         $job
+	 * @param  mixed          $data
+	 * @param  string         $queue
 	 * @return mixed
 	 */
 	public function later($delay, $job, $data = '', $queue = null)
 	{
+		$delay = $this->calculateSeconds($delay);
 		$payload = $this->createPayload($job, $data);
 
 		return $this->sqs->sendMessage(array(

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -20,10 +20,10 @@ class SyncQueue extends Queue implements QueueInterface {
 	/**
 	 * Push a new job onto the queue after a delay.
 	 *
-	 * @param  int     $delay
-	 * @param  string  $job
-	 * @param  mixed   $data
-	 * @param  string  $queue
+	 * @param  \DateTime|int  $delay
+	 * @param  string         $job
+	 * @param  mixed          $data
+	 * @param  string         $queue
 	 * @return mixed
 	 */
 	public function later($delay, $job, $data = '', $queue = null)

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -13,8 +13,7 @@
         "illuminate/container": "4.1.x",
         "illuminate/http": "4.1.x",
         "illuminate/support": "4.1.x",
-        "symfony/process": "2.3.*",
-        "nesbot/carbon": "1.*"
+        "symfony/process": "2.3.*"
     },
     "require-dev": {
         "aws/aws-sdk-php": "2.1.*",

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -13,7 +13,8 @@
         "illuminate/container": "4.1.x",
         "illuminate/http": "4.1.x",
         "illuminate/support": "4.1.x",
-        "symfony/process": "2.3.*"
+        "symfony/process": "2.3.*",
+        "nesbot/carbon": "1.*"
     },
     "require-dev": {
         "aws/aws-sdk-php": "2.1.*",


### PR DESCRIPTION
As discussed yesterday during Taylor's session at Laracon, it would be kinda cool to schedule queue jobs by passing a `DateTime` object instead of a delay to the `later()` method. I implemented that here, using Carbon for the date calculation.

Two things are remaining:
- Not entirely sure how to test this, will have to do some digging.
- Time differences are currently absolute, which means you can pass a `DateTime` object that represents yesterday, and instead the event will be scheduled for the next day. What would be a sensible behavior for past dates?
