### PR TITLE
Use custom Whoops CSS even when using custom vendor path

### DIFF
--- a/src/Illuminate/Exception/ExceptionServiceProvider.php
+++ b/src/Illuminate/Exception/ExceptionServiceProvider.php
@@ -170,9 +170,7 @@ class ExceptionServiceProvider extends ServiceProvider {
 	 */
 	protected function getResourcePath()
 	{
-		$base = $this->app['path.base'];
-
-		return $base.'/vendor/laravel/framework/src/Illuminate/Exception/resources';
+		return __DIR__.'/resources';
 	}
 
 }


### PR DESCRIPTION
Noticed that when configuring a custom vendor path, Dayle's nifty orange Whoops page was showing up with the default colors instead. Just a tiny change but allows you to still use the custom styling even after configuring a custom vendor path.
