### PR TITLE
Eloquent date mutators should not use the current time for date fields

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2142,16 +2142,16 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	protected function asDateTime($value)
 	{
 		// If this value is an integer, we will assume it is a UNIX timestamp's value
-		// and format a Carbon object from this timestamp. This allows flexibility
+		// and create a Carbon object from this timestamp. This allows flexibility
 		// when defining your date fields as they might be UNIX timestamps here.
 		if (is_numeric($value))
 		{
 			return Carbon::createFromTimestamp($value);
 		}
 
-		// If the value is in simply year, month, day format, we will instantiate the
-		// Carbon instances from that fomrat. Again, this provides for simple date
-		// fields on the database, while still supporting Carbonized conversion.
+		// If the value is in simply year-month-day format, we will create a new
+		// Carbon object from that format. Again, this provides for simple date
+		// fields in the database, while still supporting Carbonized conversion.
 		elseif (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value))
 		{
 			return Carbon::createFromFormat('Y-m-d', $value)->setTime(0, 0, 0);
@@ -2159,7 +2159,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		// Finally, we will just assume this date is in the format used by default on
 		// the database connection and use that format to create the Carbon object
-		// that is returned back out to the developers after we convert it here.
+		// that is returned back out to the developer after we convert it here.
 		elseif ( ! $value instanceof DateTime)
 		{
 			$format = $this->getDateFormat();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -99,7 +99,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 	/**
 	 * The accessors to append to the model's array form.
-	 * 
+	 *
 	 * @var array
 	 */
 	protected $appends = array();
@@ -1926,7 +1926,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			return array_intersect_key($values, array_flip($this->visible));
 		}
 
-		return array_diff_key($values, array_flip($this->hidden));	
+		return array_diff_key($values, array_flip($this->hidden));
 	}
 
 	/**
@@ -2154,7 +2154,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// fields on the database, while still supporting Carbonized conversion.
 		elseif (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $value))
 		{
-			return Carbon::createFromFormat('Y-m-d', $value);
+			return Carbon::createFromFormat('Y-m-d', $value)->setTime(0, 0, 0);
 		}
 
 		// Finally, we will just assume this date is in the format used by default on
@@ -2275,7 +2275,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 	/**
 	 * Get all the loaded relations for the instance.
-	 * 
+	 *
 	 * @return array
 	 */
 	public function getRelations()

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2152,7 +2152,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// If the value is in simply year, month, day format, we will instantiate the
 		// Carbon instances from that fomrat. Again, this provides for simple date
 		// fields on the database, while still supporting Carbonized conversion.
-		elseif (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $value))
+		elseif (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value))
 		{
 			return Carbon::createFromFormat('Y-m-d', $value)->setTime(0, 0, 0);
 		}


### PR DESCRIPTION
@taylorotwell This is the same pull request as #1754, but should be easier to merge.
