### PR TITLE
Added the URL::base() function found in laravel 3 because it is useful.

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -65,6 +65,16 @@ class UrlGenerator {
 	}
 
 	/**
+	 * Get the base URL for the current request.
+	 *
+	 * @return string
+	 */
+	public function base($secure = null)
+	{
+		return $this->to(null, array(), $secure);
+	}
+
+	/**
 	 * Generate a absolute URL to the given path.
 	 *
 	 * @param  string  $path


### PR DESCRIPTION
Either this or allow $path default to null in the URL::to() function. However, it would be nice to bring back a little laravel 3.
