### PR TITLE
Fixes #2286: Use fully qualified columns while softDeleting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -274,7 +274,7 @@ class Builder {
 	{
 		if ( ! $this->model->usesTimestamps()) return $values;
 
-		$column = $this->model->getUpdatedAtColumn();
+		$column = $this->model->getQualifiedUpdatedAtColumn();
 
 		return array_add($values, $column, $this->model->freshTimestampString());
 	}
@@ -303,7 +303,7 @@ class Builder {
 	 */
 	protected function softDelete()
 	{
-		$column = $this->model->getDeletedAtColumn();
+		$column = $this->model->getQualifiedDeletedAtColumn();
 
 		return $this->update(array($column => $this->model->freshTimestampString()));
 	}
@@ -327,7 +327,7 @@ class Builder {
 	{
 		if ($this->model->isSoftDeleting())
 		{
-			$column = $this->model->getDeletedAtColumn();
+			$column = $this->model->getQualifiedDeletedAtColumn();
 
 			return $this->update(array($column => null));
 		}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1340,6 +1340,16 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
+	 * Get the fully qualified "updated at" column.
+	 *
+	 * @return string
+	 */
+	public function getQualifiedUpdatedAtColumn()
+	{
+		return $this->getTable().'.'.$this->getUpdatedAtColumn();
+	}
+
+	/**
 	 * Get a fresh timestamp for the model.
 	 *
 	 * @return DateTime


### PR DESCRIPTION
Fixes this issue: https://github.com/laravel/laravel/issues/2286 for both softDeletes and restoration by using fully qualified names.
