### PR TITLE
Update PHPDoc for fire method (command.stub)

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/command.stub
+++ b/src/Illuminate/Foundation/Console/stubs/command.stub
@@ -33,7 +33,7 @@ class {{class}} extends Command {
 	/**
 	 * Execute the console command.
 	 *
-	 * @return void
+	 * @return mixed
 	 */
 	public function fire()
 	{


### PR DESCRIPTION
You can return `null` or some integer from `fire` method as return code of execution
