### PR TITLE
Removed contents trimming at View.php

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -78,7 +78,7 @@ class View implements ArrayAccess, Renderable {
 
 		$env->callComposer($this);
 
-		$contents = trim($this->getContents());
+		$contents = $this->getContents();
 
 		// Once we've finished rendering the view, we'll decrement the render count
 		// then if we are at the bottom of the stack we'll flush out sections as


### PR DESCRIPTION
If the user wants leading and trailing white-spaces / line-breaks in the contents, by any reason, they shouldn't be forcefully removed.
