### PR TITLE
Remove composer.lock from ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /vendor
 composer.phar
-composer.lock
 .DS_Store


### PR DESCRIPTION
composer.lock should be committed as it says here: http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file

To make sure you're installing the same dependancies on the production.
