### PR TITLE
Added request method in Request object

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -234,6 +234,18 @@ class Request extends SymfonyRequest {
 	}
 
 	/**
+	 * Retrieve a request item from the request.
+	 *
+	 * @param  string  $key
+	 * @param  mixed   $default
+	 * @return string
+	 */
+	public function request($key = null, $default = null)
+	{
+		return $this->retrieveItem('request', $key, $default);
+	}
+
+	/**
 	 * Retrieve a cookie from the request.
 	 *
 	 * @param  string  $key


### PR DESCRIPTION
To be able to use "item[x][y][z]" in requests, (Commonly called subform data in other frameworks i think) I was forced to use query() method instead of get(). Sadly, query() is only for query variables and not for posted request variables. 

I added request() to mimic the query() features provided by the Symfony HTTPFoundation but it maps to request variables instead of query variables. This way, nothing is broken but we get a new data access feature.

See: http://stackoverflow.com/questions/18704067/how-do-you-work-with-sub-forms-in-laravel-4
