### PR TITLE
Fix for correct overriding of Package's view path

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -80,7 +80,7 @@ abstract class ServiceProvider {
 		// Next, we will see if the application view folder contains a folder for the
 		// package and namespace. If it does, we'll give that folder precedence on
 		// the loader list for the views so the package views can be overridden.
-		$appView = $this->getAppViewPath($package, $namespace);
+		$appView = $this->getAppViewPath($package, null);
 
 		if ($this->app['files']->isDirectory($appView))
 		{


### PR DESCRIPTION
Passing both package and namespace to getAppViewPath() were leading to laravel looking for paths like this : ../views/packages/cartalyst/sentry/cartalyst/sentry. As the views doesn't belong to a namespace, this doesn't make sense.
