### PR TITLE
Made `freshTimestamp` return a Carbon object instead of DateTime

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1349,11 +1349,11 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	/**
 	 * Get a fresh timestamp for the model.
 	 *
-	 * @return DateTime
+	 * @return Carbon
 	 */
 	public function freshTimestamp()
 	{
-		return new DateTime;
+		return new Carbon;
 	}
 
 	/**


### PR DESCRIPTION
as Carbon is already used in database I think this is useful for unit testing

I can do `Carbon::setTestNow(Carbon::createFromDate(2000, 1, 1));` to fake the "created_at" field in an easier way.

I hope this will be merged in
