### PR TITLE
Workbench starter should follow symlinks

### DIFF
--- a/src/Illuminate/Workbench/Starter.php
+++ b/src/Illuminate/Workbench/Starter.php
@@ -18,7 +18,7 @@ class Starter {
 		// the appropriate classes and file used by the given workbench package.
 		$files = $files ?: new \Illuminate\Filesystem\Filesystem;
 
-		$autoloads = $finder->in($path)->files()->name('autoload.php')->depth('<= 3');
+		$autoloads = $finder->in($path)->files()->name('autoload.php')->depth('<= 3')->followLinks();
 
 		foreach ($autoloads as $file)
 		{


### PR DESCRIPTION
Currently you can't symlink a package to the `workbench` directory as the Symfony finder does not follow symlinks by default. This PR simply tells the finder to follow symlinks.

Cheers.
