### PR TITLE
Add support for release and attempts on pushed iron jobs

### DIFF
--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -59,11 +59,12 @@ class IronQueue extends Queue implements QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed   $data
 	 * @param  string  $queue
+	 * @param  integer $attempt
 	 * @return mixed
 	 */
-	public function push($job, $data = '', $queue = null)
+	public function push($job, $data = '', $queue = null, $attempt = null)
 	{
-		return $this->later(0, $job, $data, $queue);
+		return $this->later(0, $job, $data, $queue, $attempt);
 	}
 
 	/**
@@ -71,15 +72,16 @@ class IronQueue extends Queue implements QueueInterface {
 	 *
 	 * @param  \DateTime|int  $delay
 	 * @param  string  $job
-	 * @param  mixed  data
+	 * @param  mixed   $data
 	 * @param  string  $queue
+	 * @param  integer $attempt
 	 * @return mixed
 	 */
-	public function later($delay, $job, $data = '', $queue = null)
+	public function later($delay, $job, $data = '', $queue = null, $attempt = null)
 	{
 		$delay = $this->getSeconds($delay);
 
-		$payload = $this->createPayload($job, $data);
+		$payload = $this->createPayload($job, $data, $attempt);
 
 		return $this->iron->postMessage($this->getQueue($queue), $payload, compact('delay'))->id;
 	}
@@ -154,9 +156,9 @@ class IronQueue extends Queue implements QueueInterface {
 	 * @param  mixed   $data
 	 * @return string
 	 */
-	protected function createPayload($job, $data = '')
+	protected function createPayload($job, $data = '', $attempt = null)
 	{
-		return $this->crypt->encrypt(parent::createPayload($job, $data));
+		return $this->crypt->encrypt(parent::createPayload($job, $data, $attempt));
 	}
 
 	/**

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -63,9 +63,7 @@ class IronQueue extends Queue implements QueueInterface {
 	 */
 	public function push($job, $data = '', $queue = null)
 	{
-		$payload = $this->createPayload($job, $data);
-
-		return $this->iron->postMessage($this->getQueue($queue), $payload)->id;
+		return $this->later(0, $job, $data, $queue);
 	}
 
 	/**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -43,20 +43,28 @@ abstract class Queue {
 	/**
 	 * Create a payload string from the given job and data.
 	 *
-	 * @param  string  $job
-	 * @param  mixed   $data
+	 * @param  string   $job
+	 * @param  mixed    $data
+	 * @param  integer  $attempt
 	 * @return string
 	 */
-	protected function createPayload($job, $data = '')
+	protected function createPayload($job, $data = '', $attempt = null)
 	{
 		if ($job instanceof Closure)
 		{
-			return json_encode($this->createClosurePayload($job, $data));
+			$payload = $this->createClosurePayload($job, $data);
 		}
 		else
 		{
-			return json_encode(array('job' => $job, 'data' => $data));
+			$payload = compact('job', 'data');
 		}
+
+		if ( ! is_null($attempt))
+		{
+			$payload['attempt'] = max(1, $attempt);
+		}
+
+		return json_encode($payload);
 	}
 
 	/**

--- a/tests/Queue/QueueIronQueueTest.php
+++ b/tests/Queue/QueueIronQueueTest.php
@@ -53,7 +53,7 @@ class QueueIronQueueTest extends PHPUnit_Framework_TestCase {
 	public function testPopProperlyPopsJobOffOfIron()
 	{
 		$queue = new Illuminate\Queue\IronQueue($iron = m::mock('IronMQ'), $crypt = m::mock('Illuminate\Encryption\Encrypter'), m::mock('Illuminate\Http\Request'), 'default');
-		$queue->setContainer(m::mock('Illuminate\Container\Container'));		
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
 		$iron->shouldReceive('getMessage')->once()->with('default')->andReturn($job = m::mock('IronMQ_Message'));
 		$job->body = 'foo';
 		$crypt->shouldReceive('decrypt')->once()->with('foo')->andReturn('foo');
@@ -67,10 +67,11 @@ class QueueIronQueueTest extends PHPUnit_Framework_TestCase {
 	{
 		$queue = $this->getMock('Illuminate\Queue\IronQueue', array('createPushedIronJob'), array($iron = m::mock('IronMQ'), $crypt = m::mock('Illuminate\Encryption\Encrypter'), $request = m::mock('Illuminate\Http\Request'), 'default'));
 		$request->shouldReceive('header')->once()->with('iron-message-id')->andReturn('message-id');
+		$request->shouldReceive('header')->once()->with('Iron-Subscriber-Message-Url')->andReturn('https://foo-host.com/1/projects/foo-id/queues/test-queue/other-foo');
 		$request->shouldReceive('getContent')->once()->andReturn($content = json_encode(array('foo' => 'bar')));
 		$crypt->shouldReceive('decrypt')->once()->with($content)->andReturn($content);
 		$job = (object) array('id' => 'message-id', 'body' => json_encode(array('foo' => 'bar')), 'pushed' => true);
-		$queue->expects($this->once())->method('createPushedIronJob')->with($this->equalTo($job))->will($this->returnValue($mockIronJob = m::mock('StdClass')));
+		$queue->expects($this->once())->method('createPushedIronJob')->with($this->equalTo($job), 'test-queue')->will($this->returnValue($mockIronJob = m::mock('StdClass')));
 		$mockIronJob->shouldReceive('fire')->once();
 
 		$response = $queue->marshal();

--- a/tests/Queue/QueueIronQueueTest.php
+++ b/tests/Queue/QueueIronQueueTest.php
@@ -14,7 +14,7 @@ class QueueIronQueueTest extends PHPUnit_Framework_TestCase {
 	{
 		$queue = new Illuminate\Queue\IronQueue($iron = m::mock('IronMQ'), $crypt = m::mock('Illuminate\Encryption\Encrypter'), m::mock('Illuminate\Http\Request'), 'default');
 		$crypt->shouldReceive('encrypt')->once()->with(json_encode(array('job' => 'foo', 'data' => array(1, 2, 3))))->andReturn('encrypted');
-		$iron->shouldReceive('postMessage')->once()->with('default', 'encrypted')->andReturn((object) array('id' => 1));
+		$iron->shouldReceive('postMessage')->once()->with('default', 'encrypted', array('delay' => 0))->andReturn((object) array('id' => 1));
 		$queue->push('foo', array(1, 2, 3));
 	}
 
@@ -25,7 +25,7 @@ class QueueIronQueueTest extends PHPUnit_Framework_TestCase {
 		$name = 'Foo';
 		$closure = new Illuminate\Support\SerializableClosure($innerClosure = function() use ($name) { return $name; });
 		$crypt->shouldReceive('encrypt')->once()->with(json_encode(array('job' => 'IlluminateQueueClosure', 'data' => array('closure' => serialize($closure)))))->andReturn('encrypted');
-		$iron->shouldReceive('postMessage')->once()->with('default', 'encrypted')->andReturn((object) array('id' => 1));
+		$iron->shouldReceive('postMessage')->once()->with('default', 'encrypted', array('delay' => 0))->andReturn((object) array('id' => 1));
 		$queue->push($innerClosure);
 	}
 


### PR DESCRIPTION
Since the Iron queue does not allow pushed messages to be `release`d back onto the queue, we can instead create a new job on the queue. We can also inject the attempt count into the payload, so that we can later return that from the `attempts` method.

---

In its current form, the Iron message class always uses the default queue name when creating pushed jobs. This might cause some problems when trying to release a message back onto the queue, since it might go onto a different queue than the one it came from.

This PR also aims to fix that, by using the `Iron-Subscriber-Message-Url` header sent with the pushed request. Here's a chat I had with the Iron support team: http://i.imgur.com/5y01EVI.png

---

I split this PR into 4 separate commits, so that it's pretty clear what has been changed. I hope it's clear enough.
