### PR TITLE
Fixed bug in default parameters that treat numeric 0 as null (or 'empty')

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -106,7 +106,7 @@ class Route {
 	 */
 	public function run()
 	{
-		$parameters = array_filter($this->parameters());
+		$parameters = array_filter($this->parameters(), function($p) { return isset($p); });
 
 		return call_user_func_array($this->action['uses'], $parameters);
 	}
@@ -356,7 +356,7 @@ class Route {
 	{
 		foreach ($parameters as $key => &$value)
 		{
-			$value = $value ?: array_get($this->defaults, $key);
+			$value = isset($value) ? $value : array_get($this->defaults, $key);
 		}
 
 		return $parameters;


### PR DESCRIPTION
The shortcuts used in run() and replaceDefaults() will assume 0 as NULL and thus not send the parameters to the action.
