### PR TITLE
#2276 Added `disconnect()` method to DatabaseManager.

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -88,13 +88,13 @@ class DatabaseManager implements ConnectionResolverInterface {
 	 * Disconnect from the given database.
 	 *
 	 * @param  string  $name
-	 * @return boolean
+	 * @return void
 	 */
 	public function disconnect($name = null)
 	{
 		$name = $name ?: $this->getDefaultConnection();
 
-		return unset($this->connections[$name]);
+		unset($this->connections[$name]);
 	}
 
 	/**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -79,9 +79,22 @@ class DatabaseManager implements ConnectionResolverInterface {
 	{
 		$name = $name ?: $this->getDefaultConnection();
 
-		unset($this->connections[$name]);
+		$this->disconnect($name);
 
 		return $this->connection($name);
+	}
+	
+	/**
+	 * Disconnect from the given database.
+	 *
+	 * @param  string  $name
+	 * @return boolean
+	 */
+	public function disconnect($name = null)
+	{
+		$name = $name ?: $this->getDefaultConnection();
+
+		return unset($this->connections[$name]);
 	}
 
 	/**


### PR DESCRIPTION
This method helps with unit testing where multiple connections are opened during a single PHPUnit process. Calling `DB::disconnect($name)` provides access to the protected `$connections` variable in a similar manner to `DB::reconnect($name)` but without recreating the connection. This prevents PDO Max Connection errors during database-heavy unit testing.
