### PR TITLE
[Bug] Pattern filters with uppercase method names

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1198,7 +1198,7 @@ class Router {
 	{
 		foreach ((array) $names as $name)
 		{
-			if ( ! is_null($methods)) $methods = array_change_key_case((array) $methods);
+			if ( ! is_null($methods)) $methods = array_map('strtolower', (array) $methods);
 
 			$this->patternFilters[$pattern][] = compact('name', 'methods');
 		}

--- a/tests/Routing/RoutingTest.php
+++ b/tests/Routing/RoutingTest.php
@@ -335,6 +335,13 @@ class RoutingTest extends PHPUnit_Framework_TestCase {
 		$router->filter('filter', function() { return 'filtered!'; });
 		$request = Request::create('/foo', 'GET');
 		$this->assertEquals('filtered!', $router->dispatch($request)->getContent());
+
+		$router = new Router;
+		$router->get('/foo', function() { return 'bar'; });
+		$router->when('f*', 'filter', array('GET'));
+		$router->filter('filter', function() { return 'filtered!'; });
+		$request = Request::create('/foo', 'GET');
+		$this->assertEquals('filtered!', $router->dispatch($request)->getContent());
 	}
 
 


### PR DESCRIPTION
When a pattern based filter is defined like this:

``` php
Route::when('*', 'csrf', array('POST'));
```

it will never be matched, where:

``` php
Route::when('*', 'csrf', array('post'));
```

will work like a charm (because `array_change_key_case` is operating on keys, instead of array values).
