### PR TITLE
Updated pagination slider view for Bootstrap 3

### DIFF
--- a/src/Illuminate/Pagination/views/slider.php
+++ b/src/Illuminate/Pagination/views/slider.php
@@ -3,9 +3,7 @@
 ?>
 
 <?php if ($paginator->getLastPage() > 1): ?>
-	<div class="pagination">
-		<ul>
-			<?php echo $presenter->render(); ?>
-		</ul>
-	</div>
+	<ul class="pagination">
+		<?php echo $presenter->render(); ?>
+	</ul>
 <?php endif; ?>


### PR DESCRIPTION
The 'pagination' class is no longer applied to a wrapper div, but to the ul itself, in Bootstrap 3.
