### PR TITLE
Add key => value support to array_pluck, and use that in Collection::lists()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -353,40 +353,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 */
 	public function lists($value, $key = null)
 	{
-		$results = array();
-
-		foreach ($this->items as $item)
-		{
-			$itemValue = $this->getListValue($item, $value);
-
-			// If the key is "null", we will just append the value to the array and keep
-			// looping. Otherwise we will key the array using the value of the key we
-			// received from the developer. Then we'll return the final array form.
-			if (is_null($key))
-			{
-				$results[] = $itemValue;
-			}
-			else
-			{
-				$itemKey = $this->getListValue($item, $key);
-
-				$results[$itemKey] = $itemValue;
-			}
-		}
-
-		return $results;
-	}
-
-	/**
-	 * Get the value of a list item object.
-	 *
-	 * @param  mixed  $item
-	 * @param  mixed  $key
-	 * @return mixed
-	 */
-	protected function getListValue($item, $key)
-	{
-		return is_object($item) ? $item->{$key} : $item[$key];
+		return array_pluck($this->items, $value, $key);
 	}
 
 	/**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -259,7 +259,7 @@ if ( ! function_exists('array_get'))
 	function array_get($array, $key, $default = null)
 	{
 		if (is_null($key)) return $array;
-		
+
 		if (isset($array[$key])) return $array[$key];
 
 		foreach (explode('.', $key) as $segment)
@@ -297,16 +297,34 @@ if ( ! function_exists('array_pluck'))
 	 * Pluck an array of values from an array.
 	 *
 	 * @param  array   $array
+	 * @param  string  $value
 	 * @param  string  $key
 	 * @return array
 	 */
-	function array_pluck($array, $key)
+	function array_pluck($array, $value, $key = null)
 	{
-		return array_map(function($value) use ($key)
-		{
-			return is_object($value) ? $value->$key : $value[$key];
+		$results = array();
 
-		}, $array);
+		foreach ($array as $item)
+		{
+			$itemValue = is_object($item) ? $item->{$value} : $item[$value];
+
+			// If the key is "null", we will just append the value to the array and keep
+			// looping. Otherwise we will key the array using the value of the key we
+			// received from the developer. Then we'll return the final array form.
+			if (is_null($key))
+			{
+				$results[] = $itemValue;
+			}
+			else
+			{
+				$itemKey = is_object($item) ? $item->{$key} : $item[$key];
+
+				$results[$itemKey] = $itemValue;
+			}
+		}
+
+		return $results;
 	}
 }
 
@@ -615,7 +633,7 @@ if ( ! function_exists('object_get'))
 	function object_get($object, $key, $default = null)
 	{
 		if (is_null($key)) return $object;
-		
+
 		foreach (explode('.', $key) as $segment)
 		{
 			if ( ! is_object($object) or ! isset($object->{$segment}))

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -44,10 +44,11 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testArrayPluck()
+	public function testArrayPluckWithArrayAndObjectValues()
 	{
-		$array = array(array('name' => 'taylor'), array('name' => 'dayle'));
+		$array = array((object) array('name' => 'taylor', 'email' => 'foo'), array('name' => 'dayle', 'email' => 'bar'));
 		$this->assertEquals(array('taylor', 'dayle'), array_pluck($array, 'name'));
+		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), array_pluck($array, 'email', 'name'));
 	}
 
 


### PR DESCRIPTION
Adds support for `key => value` extraction to `array_pluck`:

``` php
$array = [
    ['framework' => 'Laravel', 'creator' => 'Taylor Otwell'],
    ['framework' => 'Codeigniter', 'creator' => 'Rick Ellis']
];

$data = array_pluck($array, 'creator', 'framework');
```

The above would return:

``` php
['Laravel' => 'Taylor Otwell', 'Codeigniter' => 'Rick Ellis']
```

The [`Collection::lists()`](https://github.com/laravel/framework/blob/master/src/Illuminate/Support/Collection.php#L367) method had a very similar implementation, so it now just calls `array_pluck` directly.

---

In PHP 5.5, there's a similar function called [`array_column`](http://php.net/manual/en/function.array-column.php). The key difference is that `array_column` only supports array items, while `array_pluck` also supports object items.
