### PR TITLE
[BugFix] Collection.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -23,14 +23,16 @@ class Collection extends BaseCollection {
 	/**
 	 * Load a set of relationships onto the collection.
 	 *
-	 * @param  dynamic  string
+	 * @param  dynamic  $relations
 	 * @return void
 	 */
-	public function load()
+	public function load($relations)
 	{
 		if (count($this->items) > 0)
 		{
-			$query = $this->first()->newQuery()->with(func_get_args());
+			if (is_string($relations)) $relations = func_get_args();
+
+			$query = $this->first()->newQuery()->with($relations);
 
 			$this->items = $query->eagerLoadRelations($this->items);
 		}


### PR DESCRIPTION
To enable Lazy Eager Loading with Constraints.

When I now use something like this it fails:

``` php
$users = User::all();
$users->load(array('posts' => function($query)
{
    $query->where('title', 'like', '%first%');
}))->get();
```

The problem I think is the handling with func_get_args(), it puts the relations array into another array.
