### PR TITLE
When the content returned by a controller extends ArrayObject, serialize it as Json

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Http;
 
+use ArrayObject;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Support\Contracts\JsonableInterface;
 use Illuminate\Support\Contracts\RenderableInterface;
@@ -93,7 +94,7 @@ class Response extends \Symfony\Component\HttpFoundation\Response {
 	 */
 	protected function shouldBeJson($content)
 	{
-		return $content instanceof JsonableInterface or is_array($content);
+		return $content instanceof JsonableInterface || $content instanceof ArrayObject || is_array($content);
 	}
 
 	/**


### PR DESCRIPTION
`json_encode` always encode an empty array as `[]`. So currently the only way to have a controller return a json response `{}` is to create a custom object implementing `JsonableInterface`.

The `ArrayObject` solve perfectly that problem since PHP 5.0, as long as the Laravel `Response` serialize them as JSON.

So this pull request add `ArrayObject` to the list of controller responses that get cast as JSON automatically (along with `JsonableInterface` and raw arrays)
