### PR TITLE
Adding Response()'s header method to RedirectResponse()

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -22,6 +22,21 @@ class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectRespons
 	protected $session;
 
 	/**
+	 * Set a header on the Response.
+	 *
+	 * @param  string  $key
+	 * @param  string  $value
+	 * @param  bool    $replace
+	 * @return \Illuminate\Http\Response
+	 */
+	public function header($key, $value, $replace = true)
+	{
+		$this->headers->set($key, $value, $replace);
+
+		return $this;
+	}
+
+	/**
 	 * Flash a piece of data to the session.
 	 *
 	 * @param  string  $key


### PR DESCRIPTION
The use case for this is if you have an App::after() defined that adds a custom header to the whole app with $response->header(), all Redirects break because RedirectResponse() currently lacks the header() method
