### PR TITLE
permit where != null

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -352,7 +352,7 @@ class Builder {
 	{
 		$isOperator = in_array($operator, $this->operators);
 
-		return ($isOperator and $operator != '=' and is_null($value));
+		return ($isOperator and !in_array($operator, array('=','!=')) and is_null($value));
 	}
 
 	/**


### PR DESCRIPTION
`$query->where('foo','=',null)` is ok but `$query->where('foo','!=',null)` threw exception.
