### PR TITLE
Added `findMany` to Eloquent\Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -59,10 +59,29 @@ class Builder {
 	 */
 	public function find($id, $columns = array('*'))
 	{
+		if (is_array($id))
+		{
+		    return $this->findMany($id, $columns);
+		}
+
 		$this->query->where($this->model->getKeyName(), '=', $id);
 
 		return $this->first($columns);
 	}
+
+	/**
+	 * Find a model by its primary key.
+	 *
+	 * @param  array  $id
+	 * @param  array  $columns
+	 * @return \Illuminate\Database\Eloquent\Model|Collection|static
+	 */
+	public function findMany($id, $columns = array('*'))
+	{
+		$this->query->whereIn($this->model->getKeyName(), $id);
+
+    	return $this->get($columns);
+    }
 
 	/**
 	 * Find a model by its primary key or throw an exception.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -412,11 +412,6 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	{
 		$instance = new static;
 
-		if (is_array($id))
-		{
-			return $instance->newQuery()->whereIn($instance->getKeyName(), $id)->get($columns);
-		}
-
 		return $instance->newQuery()->find($id, $columns);
 	}
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -26,6 +26,21 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('baz', $result);
 	}
 
+	public function testFindWithMany()
+	{
+		$query = m::mock('Illuminate\Database\Query\Builder');
+		$query->shouldReceive('whereIn')->once()->with('foo', array(1, 2));
+		$builder = $this->getMock('Illuminate\Database\Eloquent\Builder', array('get'), array($query));
+		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model->shouldReceive('getKeyName')->once()->andReturn('foo');
+		$model->shouldReceive('getTable')->once()->andReturn('table');
+		$query->shouldReceive('from')->once()->with('table');
+		$builder->setModel($model);
+		$builder->expects($this->once())->method('get')->with($this->equalTo(array('column')))->will($this->returnValue('baz'));
+		$result = $builder->find(array(1, 2), array('column'));
+		$this->assertEquals('baz', $result);
+	}
+
 
 	public function testFirstMethod()
 	{

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -806,8 +806,7 @@ class EloquentModelFindManyStub extends Illuminate\Database\Eloquent\Model {
 	public function newQuery($excludeDeleted = true)
 	{
 		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
-		$mock->shouldReceive('whereIn')->once()->with('id', array(1, 2))->andReturn($mock);
-		$mock->shouldReceive('get')->once()->with(array('*'))->andReturn('foo');
+		$mock->shouldReceive('find')->once()->with(array(1, 2), array('*'))->andReturn('foo');
 		return $mock;
 	}
 }


### PR DESCRIPTION
`Model::with('relationship')->find(array(1, 2))` was not working correctly so I moved the `is_array($id)` logic to the query builder and adjusted the tests accordingly.

This is the correct version of https://github.com/laravel/framework/pull/2323
