### PR TITLE
Modify setBindings to return the Builder object

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1588,11 +1588,13 @@ class Builder {
 	 * Set the bindings on the query builder.
 	 *
 	 * @param  array  $bindings
-	 * @return void
+	 * @return \Illuminate\Database\Query\Builder
 	 */
 	public function setBindings(array $bindings)
 	{
 		$this->bindings = $bindings;
+		
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
Given how the `mergeBindings(...)` method:
1. modifies the bindings
2. returns the builder object
I think it would be more consistent and useful for `setBindings(...)` to also return the Builder object instead of not returning anything.

With the current code a user needs to do the following if they want to add bindings and execute a builder object:

```
$builder = (/* builder object */);
$builder->setBindings(array(...));
$result = $builder->get();
```

With the proposed change the statement is simplified to the following:

```
$result = (/* builder object */)->setBindings(array(...))->get();
```

Which is far more intuitive and matches the general convention of how methods that modify builder objects flow.

Please also note that the proposed should be backwards compatible given how most users would be using setBindings() (as in the 'current' example)
