### PR TITLE
Only specify column in SQLite schema grammar as NULL if defined as such.

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -489,7 +489,7 @@ class SQLiteGrammar extends Grammar {
 	 */
 	protected function modifyNullable(Blueprint $blueprint, Fluent $column)
 	{
-		return ' null';
+		return $column->nullable ? ' null' : ' not null';
 	}
 
 	/**

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -20,7 +20,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('create table "users" ("id" integer null primary key autoincrement, "email" varchar null)', $statements[0]);
+		$this->assertEquals('create table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
 
 		$blueprint = new Blueprint('users');
 		$blueprint->increments('id');
@@ -29,8 +29,8 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(2, count($statements));
 		$expected = array(
-			'alter table "users" add column "id" integer null primary key autoincrement',
-			'alter table "users" add column "email" varchar null',
+			'alter table "users" add column "id" integer not null primary key autoincrement',
+			'alter table "users" add column "email" varchar not null',
 		);
 		$this->assertEquals($expected, $statements);
 	}
@@ -119,7 +119,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('create table "users" ("foo" varchar null, primary key ("foo"))', $statements[0]);
+		$this->assertEquals('create table "users" ("foo" varchar not null, primary key ("foo"))', $statements[0]);
 	}
 
 
@@ -133,7 +133,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('create table "users" ("foo" varchar null, "order_id" varchar null, foreign key("order_id") references "orders"("id"), primary key ("foo"))', $statements[0]);
+		$this->assertEquals('create table "users" ("foo" varchar not null, "order_id" varchar not null, foreign key("order_id") references "orders"("id"), primary key ("foo"))', $statements[0]);
 	}
 
 
@@ -166,7 +166,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "id" integer null primary key autoincrement', $statements[0]);
+		$this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
 	}
 
 
@@ -177,7 +177,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "id" integer null primary key autoincrement', $statements[0]);
+		$this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
 	}
 
 
@@ -188,14 +188,14 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" varchar null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
 
 		$blueprint = new Blueprint('users');
 		$blueprint->string('foo', 100);
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" varchar null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
 
 		$blueprint = new Blueprint('users');
 		$blueprint->string('foo', 100)->nullable()->default('bar');
@@ -213,7 +213,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" text null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" text not null', $statements[0]);
 	}
 
 
@@ -224,14 +224,14 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" integer null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
 
 		$blueprint = new Blueprint('users');
 		$blueprint->bigInteger('foo', true);
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" integer null primary key autoincrement', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
 	}
 
 
@@ -242,14 +242,14 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" integer null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
 
 		$blueprint = new Blueprint('users');
 		$blueprint->integer('foo', true);
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" integer null primary key autoincrement', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
 	}
 
 
@@ -260,7 +260,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" integer null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
 	}
 
 
@@ -271,7 +271,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" integer null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
 	}
 
 
@@ -282,7 +282,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" integer null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
 	}
 
 
@@ -293,7 +293,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" float null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" float not null', $statements[0]);
 	}
 
 
@@ -304,7 +304,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" float null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" float not null', $statements[0]);
 	}
 
 
@@ -315,7 +315,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" tinyint null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" tinyint not null', $statements[0]);
 	}
 
 
@@ -326,7 +326,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" varchar null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
 	}
 
 
@@ -337,7 +337,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" date null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" date not null', $statements[0]);
 	}
 
 
@@ -348,7 +348,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" datetime null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" datetime not null', $statements[0]);
 	}
 
 
@@ -359,7 +359,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" time null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" time not null', $statements[0]);
 	}
 
 
@@ -370,7 +370,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" datetime null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" datetime not null', $statements[0]);
 	}
 
 
@@ -382,8 +382,8 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(2, count($statements));
 		$expected = array(
-			'alter table "users" add column "created_at" datetime null',
-			'alter table "users" add column "updated_at" datetime null'
+			'alter table "users" add column "created_at" datetime not null',
+			'alter table "users" add column "updated_at" datetime not null'
 		);
 		$this->assertEquals($expected, $statements);
 	}
@@ -396,7 +396,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" blob null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" blob not null', $statements[0]);
 	}
 
 


### PR DESCRIPTION
When using an SQLite database, all columns are currently defined as nullable. In other words:

``` php
Schema::create('foo', function($table) {
    $table->increments('id');
    $table->integer('bar');
    $table->integer('baz')->nullable();
});
```

Results in:

``` sql
create table "foo" ("id" integer null primary key autoincrement, "bar" integer null, "baz" integer null)
```

Instead of the expected:

``` sql
create table "foo" ("id" integer not null primary key autoincrement, "bar" integer not null, "baz" integer null)
```

This commit fixes that.
