### PR TITLE
[Proposal] Remember found view files in FileViewFinder

### DIFF
--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -66,11 +66,13 @@ class FileViewFinder implements ViewFinderInterface {
 	 */
 	public function find($name)
 	{
-		if (isset($this->found[$name])) {
+		if (isset($this->found[$name])) 
+		{
 			return $this->found[$name];
 		}
 		
-		if (strpos($name, '::') !== false) {
+		if (strpos($name, '::') !== false) 
+		{
 			return $this->found[$name] = $this->findNamedPathView($name);
 		}
 

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -31,6 +31,13 @@ class FileViewFinder implements ViewFinderInterface {
 	 * @var array
 	 */
 	protected $extensions = array('blade.php', 'php');
+	
+	/**
+	 * The array of already found view files.
+	 * 
+	 * @var array
+	 */
+	protected $found = array();
 
 	/**
 	 * Create a new file view loader instance.
@@ -59,9 +66,15 @@ class FileViewFinder implements ViewFinderInterface {
 	 */
 	public function find($name)
 	{
-		if (strpos($name, '::') !== false) return $this->findNamedPathView($name);
+		if (isset($this->found[$name])) {
+			return $this->found[$name];
+		}
+		
+		if (strpos($name, '::') !== false) {
+			return $this->found[$name] = $this->findNamedPathView($name);
+		}
 
-		return $this->findInPaths($name, $this->paths);
+		return $this->found[$name] = $this->findInPaths($name, $this->paths);
 	}
 
 	/**


### PR DESCRIPTION
Consider this example:

``` html
<div class="users">
@each('user.item', $users, 'user')
</div>
```

For each user `View::make` is called and each time `ViewFinder` finds the view. More users we have, more times we find view that has been found already.

`FileViewFinder` now caches already found view files to fix this performance issue.
