### PR TITLE
Added view:publish command, fixes #2146

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewPublishCommand.php
@@ -1,44 +1,44 @@
 <?php namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Foundation\ConfigPublisher;
+use Illuminate\Foundation\ViewPublisher;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
-class ConfigPublishCommand extends Command {
+class ViewPublishCommand extends Command {
 
 	/**
 	 * The console command name.
 	 *
 	 * @var string
 	 */
-	protected $name = 'config:publish';
+	protected $name = 'view:publish';
 
 	/**
 	 * The console command description.
 	 *
 	 * @var string
 	 */
-	protected $description = "Publish a package's configuration to the application";
+	protected $description = "Publish a package's views to the application";
 
 	/**
-	 * The config publisher instance.
+	 * The view publisher instance.
 	 *
-	 * @var \Illuminate\Foundation\ConfigPublisher
+	 * @var \Illuminate\Foundation\ViewPublisher
 	 */
-	protected $config;
+	protected $view;
 
 	/**
-	 * Create a new configuration publish command instance.
+	 * Create a new view publish command instance.
 	 *
-	 * @param  \Illuminate\Foundation\ConfigPublisher  $config
+	 * @param  \Illuminate\Foundation\ViewPublisher  $view
 	 * @return void
 	 */
-	public function __construct(ConfigPublisher $config)
+	public function __construct(ViewPublisher $view)
 	{
 		parent::__construct();
 
-		$this->config = $config;
+		$this->view = $view;
 	}
 
 	/**
@@ -52,14 +52,14 @@ class ConfigPublishCommand extends Command {
 
 		if ( ! is_null($path = $this->getPath()))
 		{
-			$this->config->publish($package, $path);
+			$this->view->publish($package, $path);
 		}
 		else
 		{
-			$this->config->publishPackage($package);
+			$this->view->publishPackage($package);
 		}
 
-		$this->output->writeln('<info>Configuration published for package:</info> '.$package);
+		$this->output->writeln('<info>Views published for package:</info> '.$package);
 	}
 
 	/**
@@ -97,7 +97,7 @@ class ConfigPublishCommand extends Command {
 	protected function getOptions()
 	{
 		return array(
-			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to the configuration files.', null),
+			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to the view files.', null),
 		);
 	}
 

--- a/src/Illuminate/Foundation/Providers/PublisherServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/PublisherServiceProvider.php
@@ -3,8 +3,10 @@
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\AssetPublisher;
 use Illuminate\Foundation\ConfigPublisher;
+use Illuminate\Foundation\ViewPublisher;
 use Illuminate\Foundation\Console\AssetPublishCommand;
 use Illuminate\Foundation\Console\ConfigPublishCommand;
+use Illuminate\Foundation\Console\ViewPublishCommand;
 
 class PublisherServiceProvider extends ServiceProvider {
 
@@ -26,7 +28,9 @@ class PublisherServiceProvider extends ServiceProvider {
 
 		$this->registerConfigPublisher();
 
-		$this->commands('command.asset.publish', 'command.config.publish');
+		$this->registerViewPublisher();
+
+		$this->commands('command.asset.publish', 'command.config.publish', 'command.view.publish');
 	}
 
 	/**
@@ -104,6 +108,43 @@ class PublisherServiceProvider extends ServiceProvider {
 	}
 
 	/**
+	 * Register the view publisher class and command.
+	 *
+	 * @return void
+	 */
+	protected function registerViewPublisher()
+	{
+		$this->registerViewPublishCommand();
+
+		$this->app['view.publisher'] = $this->app->share(function($app)
+		{
+			$viewPath = $app['path'].'/views';
+
+			// Once we have created the view publisher, we will set the default
+			// package path on the object so that it knows where to find the packages
+			// that are installed for the application and can move them to the app.
+			$publisher = new ViewPublisher($app['files'], $viewPath);
+
+			$publisher->setPackagePath($app['path.base'].'/vendor');
+
+			return $publisher;
+		});
+	}
+
+	/**
+	 * Register the view publish console command.
+	 *
+	 * @return void
+	 */
+	protected function registerViewPublishCommand()
+	{
+		$this->app['command.view.publish'] = $this->app->share(function($app)
+		{
+			return new ViewPublishCommand($app['view.publisher']);
+		});
+	}
+
+	/**
 	 * Get the services provided by the provider.
 	 *
 	 * @return array
@@ -114,7 +155,9 @@ class PublisherServiceProvider extends ServiceProvider {
 			'asset.publisher',
 			'command.asset.publish',
 			'config.publisher',
-			'command.config.publish'
+			'command.config.publish',
+			'view.publisher',
+			'command.view.publish'
 		);
 	}
 

--- a/src/Illuminate/Foundation/ViewPublisher.php
+++ b/src/Illuminate/Foundation/ViewPublisher.php
@@ -1,0 +1,123 @@
+<?php namespace Illuminate\Foundation;
+
+use Illuminate\Filesystem\Filesystem;
+
+class ViewPublisher {
+
+	/**
+	 * The filesystem instance.
+	 *
+	 * @var \Illuminate\Filesystem\Filesystem
+	 */
+	protected $files;
+
+	/**
+	 * The destination of the view files.
+	 *
+	 * @var string
+	 */
+	protected $publishPath;
+
+	/**
+	 * The path to the application's packages.
+	 *
+	 * @var string
+	 */
+	protected $packagePath;
+
+	/**
+	 * Create a new view publisher instance.
+	 *
+	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  string  $publishPath
+	 * @return void
+	 */
+	public function __construct(Filesystem $files, $publishPath)
+	{
+		$this->files = $files;
+		$this->publishPath = $publishPath;
+	}
+
+	/**
+	 * Publish view files from a given path.
+	 *
+	 * @param  string  $package
+	 * @param  string  $source
+	 * @return void
+	 */
+	public function publish($package, $source)
+	{
+		$destination = $this->publishPath."/{$package}";
+
+		$this->makeDestination($destination);
+
+		return $this->files->copyDirectory($source, $destination);
+	}
+
+	/**
+	 * Publish the view files for a package.
+	 *
+	 * @param  string  $package
+	 * @param  string  $packagePath
+	 * @return void
+	 */
+	public function publishPackage($package, $packagePath = null)
+	{
+		list($vendor, $name) = explode('/', $package);
+
+		// First we will figure out the source of the package's views location
+		// which we do by convention. Once we have that we will move the files over
+		// to the "main" views directory for this particular application.
+		$path = $packagePath ?: $this->packagePath;
+
+		$source = $this->getSource($package, $name, $path);
+
+		return $this->publish($package, $source);
+	}
+
+	/**
+	 * Get the source views directory to publish.
+	 *
+	 * @param  string  $package
+	 * @param  string  $name
+	 * @param  string  $packagePath
+	 * @return string
+	 */
+	protected function getSource($package, $name, $packagePath)
+	{
+		$source = $packagePath."/{$package}/src/views";
+
+		if ( ! $this->files->isDirectory($source))
+		{
+			throw new \InvalidArgumentException("Views not found.");
+		}
+
+		return $source;
+	}
+
+	/**
+	 * Create the destination directory if it doesn't exist.
+	 *
+	 * @param  string  $destination
+	 * @return void
+	 */
+	protected function makeDestination($destination)
+	{
+		if ( ! $this->files->isDirectory($destination))
+		{
+			$this->files->makeDirectory($destination, 0777, true);
+		}
+	}
+
+	/**
+	 * Set the default package path.
+	 *
+	 * @param  string  $packagePath
+	 * @return void
+	 */
+	public function setPackagePath($packagePath)
+	{
+		$this->packagePath = $packagePath;
+	}
+
+}

--- a/tests/Foundation/FoundationViewPublishCommandTest.php
+++ b/tests/Foundation/FoundationViewPublishCommandTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Mockery as m;
+
+class FoundationViewPublishCommandTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testCommandCallsPublisherWithProperPackageName()
+	{
+		$command = new Illuminate\Foundation\Console\ViewPublishCommand($pub = m::mock('Illuminate\Foundation\ViewPublisher'));
+		$pub->shouldReceive('publishPackage')->once()->with('foo');
+		$command->run(new Symfony\Component\Console\Input\ArrayInput(array('package' => 'foo')), new Symfony\Component\Console\Output\NullOutput);
+	}
+
+}

--- a/tests/Foundation/FoundationViewPublisherTest.php
+++ b/tests/Foundation/FoundationViewPublisherTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Mockery as m;
+
+class FoundationViewPublisherTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testPackageViewPublishing()
+	{
+		$pub = new Illuminate\Foundation\ViewPublisher($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+		$pub->setPackagePath(__DIR__.'/vendor');
+		$files->shouldReceive('isDirectory')->once()->with(__DIR__.'/vendor/foo/bar/src/views')->andReturn(true);
+		$files->shouldReceive('isDirectory')->once()->with(__DIR__.'/foo/bar')->andReturn(true);
+		$files->shouldReceive('copyDirectory')->once()->with(__DIR__.'/vendor/foo/bar/src/views', __DIR__.'/foo/bar')->andReturn(true);
+
+		$this->assertTrue($pub->publishPackage('foo/bar'));
+
+		$pub = new Illuminate\Foundation\ViewPublisher($files2 = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+		$files2->shouldReceive('isDirectory')->once()->with(__DIR__.'/custom-packages/foo/bar/src/views')->andReturn(true);
+		$files2->shouldReceive('isDirectory')->once()->with(__DIR__.'/foo/bar')->andReturn(true);
+		$files2->shouldReceive('copyDirectory')->once()->with(__DIR__.'/custom-packages/foo/bar/src/views', __DIR__.'/foo/bar')->andReturn(true);
+
+		$this->assertTrue($pub->publishPackage('foo/bar', __DIR__.'/custom-packages'));
+	}
+
+}


### PR DESCRIPTION
- Fixed copy+paste errors in ConfigPublishCommand
- Added ViewPublisher
- Added ViewPublishCommand
- Modified PublisherServiceProvider to include references to new ViewPublisher and ViewPublisherCommand
- Added tests for ViewPublisher and ViewPublishCommand

Unit tests run correctly, and I have tested in an actual app environment too.

These changes will also work against 4.1 (master) branch.
