### PR TITLE
Allow for the name of the relation on belongsToMany to be manually defined

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -520,14 +520,17 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * @param  string  $foreignKey
 	 * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
 	 */
-	public function belongsTo($related, $foreignKey = null)
+	public function belongsTo($related, $foreignKey = null, $relation = null)
 	{
-		list(, $caller) = debug_backtrace(false);
+		if(is_null($relation))
+		{
+			list(, $caller) = debug_backtrace(false);
 
-		// If no foreign key was supplied, we can use a backtrace to guess the proper
-		// foreign key name by using the name of the relationship function, which
-		// when combined with an "_id" should conventionally match the columns.
-		$relation = $caller['function'];
+			// If no foreign key was supplied, we can use a backtrace to guess the proper
+			// foreign key name by using the name of the relationship function, which
+			// when combined with an "_id" should conventionally match the columns.
+			$relation = $caller['function'];
+		}
 
 		if (is_null($foreignKey))
 		{

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -619,9 +619,13 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * @param  string  $otherKey
 	 * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
 	 */
-	public function belongsToMany($related, $table = null, $foreignKey = null, $otherKey = null)
+	public function belongsToMany($related, $table = null, $foreignKey = null, $otherKey = null, $name = null)
 	{
-		$caller = $this->getBelongsToManyCaller();
+		if (is_null($name))
+		{
+			$caller = $this->getBelongsToManyCaller();
+			$name = $caller['function'];
+		}
 
 		// First, we'll need to determine the foreign key and "other key" for the
 		// relationship. Once we have determined the keys we'll make the query
@@ -645,7 +649,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// appropriate query constraint and entirely manages the hydrations.
 		$query = $instance->newQuery();
 
-		return new BelongsToMany($query, $this, $table, $foreignKey, $otherKey, $caller['function']);
+		return new BelongsToMany($query, $this, $table, $foreignKey, $otherKey, $name);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -649,7 +649,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 		$model = new EloquentModelStub;
 		$this->addMockConnection($model);
-		$relation = $model->belongsToMany('EloquentModelSaveStub', 'table', 'foreign', 'other');
+		$relation = $model->belongsToMany('EloquentModelSaveStub', 'table', 'foreign', 'other', 'eloquentModelSaveStub');
 		$this->assertEquals('table.foreign', $relation->getForeignKey());
 		$this->assertEquals('table.other', $relation->getOtherKey());
 		$this->assertTrue($relation->getParent() === $model);


### PR DESCRIPTION
As other relationships allow for the name of the relationships to be manually defined, it makes sense for belongsToMany to have that same functionality. If the call to the method is from a magic method using $callers['function'] will not suffice. 
