### PR TITLE
[Fix Bug] Error when trying validate (getSize) a value of specific array...

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -612,7 +612,7 @@ class Validator implements MessageProviderInterface {
 		// entire length of the string will be considered the attribute size.
 		if (is_numeric($value) and $hasNumeric)
 		{
-			return $this->data[$attribute];
+			return array_get($this->data, $attribute);
 		}
 		elseif (is_array($value))
 		{

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -361,6 +361,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => array(1, 2, 3)), array('foo' => 'Array|Size:4'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('foo' => array('bar' => 3)), array('foo.bar' => 'Numeric|Size:3'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('foo' => array('bar' => 4)), array('foo.bar' => 'Numeric|Size:3'));
+		$this->assertFalse($v->passes());
+
 		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));
 		$file->expects($this->any())->method('getSize')->will($this->returnValue(3072));
 		$v = new Validator($trans, array(), array('photo' => 'Size:3'));


### PR DESCRIPTION
``` php
// rules
$rules = array(
 'child.name'   => 'required',
 'child.age'    => 'required|numeric|between:1,11',
 'child.gender' => 'required',
);

// dump Input::all()
array(1) {
  ["child"]=>
  array(3) {
    ["name"]=>
    string(4) "test"
    ["age"]=>
    string(2) "10"
    ["gender"]=>
    string(4) "male"
  }
}
```

```
// it will return an error :
ErrorException
Undefined index: child.age
```
