### PR TITLE
prevent `must be an array, null given` error with Session::reflash()

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -170,7 +170,7 @@ class Store extends SymfonySession {
 	 */
 	public function reflash()
 	{
-		$this->mergeNewFlashes($this->get('flash.old'));
+		$this->mergeNewFlashes($this->get('flash.old', array()));
 
 		$this->put('flash.old', array());
 	}


### PR DESCRIPTION
Where I use `Session::reflash()` with an empty session I get 
`Argument 1 passed to Illuminate\Session\Store::mergeNewFlashes() must be an array, null given`
