### PR TITLE
Fixed Application::loadDeferredProvider() expecting a service name but instead given the service provider class.

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -354,8 +354,6 @@ class Application extends Container implements HttpKernelInterface, ResponsePrep
 	 */
 	public function loadDeferredProviders()
 	{
-		$me = $this;
-
 		// We will simply spin through each of the deferred providers and register each
 		// one and boot them if the application has booted. This should make each of
 		// the remaining services available to this application for immediate use.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -357,9 +357,9 @@ class Application extends Container implements HttpKernelInterface, ResponsePrep
 		// We will simply spin through each of the deferred providers and register each
 		// one and boot them if the application has booted. This should make each of
 		// the remaining services available to this application for immediate use.
-		foreach ($this->deferredServices as $provider)
+		foreach ($this->deferredServices as $service => $provider)
 		{
-			$this->loadDeferredProvider($provider);
+			$this->loadDeferredProvider($service);
 		}
 
 		$this->deferredServices = array();


### PR DESCRIPTION
Had a problem using `$app['artisan']->call()` which triggers `Application::loadDeferredProviders()`. The problem is that  loadDeferedProvider should receive the instance name (`$service`) and not the service provider class name (`$provider`) which is what happening at https://travis-ci.org/orchestral/testbench/jobs/12097378 

Same method works fine in 4.0
