### PR TITLE
Updated File::deleteDirectory function

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -381,6 +381,8 @@ class Filesystem {
 		}
 
 		if ( ! $preserve) @rmdir($directory);
+		
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
I don't know why File::deleteDirectory function doesn't return true on success. In my opinion It should.
