### PR TITLE
Fix for #2404

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -46,17 +46,17 @@ class SQLiteGrammar extends Grammar {
 		// row inserts in SQLite. However, if there are multiples, we'll continue.
 		if (count($values) == 1)
 		{
-			return parent::compileInsert($query, $values[0]);
+			return parent::compileInsert($query, reset($values));
 		}
 
-		$names = $this->columnize(array_keys($values[0]));
+		$names = $this->columnize(array_keys(reset($values));
 
 		$columns = array();
 
 		// SQLite requires us to build the multi-row insert as a listing of select with
 		// unions joining them together. So we'll build out this list of columns and
 		// then join them all together with select unions to complete the queries.
-		foreach (array_keys($values[0]) as $column)
+		foreach (array_keys(reset($values)) as $column)
 		{
 			$columns[] = '? as '.$this->wrap($column);
 		}

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -49,7 +49,7 @@ class SQLiteGrammar extends Grammar {
 			return parent::compileInsert($query, reset($values));
 		}
 
-		$names = $this->columnize(array_keys(reset($values));
+		$names = $this->columnize(array_keys(reset($values)));
 
 		$columns = array();
 


### PR DESCRIPTION
The implementation of compileInsert in SQLiteGrammar uses
array_keys($values[0]) to build column names. It should use
reset($values) like in the default implementation.
