### PR TITLE
Allow for override of operator list.

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -274,7 +274,7 @@ class Builder {
 	 * @param  string  $boolean
 	 * @return \Illuminate\Database\Query\Builder|static
 	 */
-	public function where($column, $operator = null, $value = null, $boolean = 'and')
+	public function where($column, $operator = null, $value = null, $boolean = 'and', $forceOperator = false)
 	{
 		if ($this->invalidOperatorAndValue($operator, $value))
 		{
@@ -292,7 +292,7 @@ class Builder {
 		// If the given operator is not found in the list of valid operators we will
 		// assume that the developer is just short-cutting the '=' operators and
 		// we will set the operators to '=' and set the values appropriately.
-		if ( ! in_array(strtolower($operator), $this->operators, true))
+		if ( ! in_array(strtolower($operator), $this->operators, true) && ! $forceOperator)
 		{
 			list($value, $operator) = array($operator, '=');
 		}


### PR DESCRIPTION
Should be possible for targeted solutions which need special operators, such as REGEXP in MySQL, to use Query Builder's where(). As different databases have their own specific operators beyond what is allowed in operators array, allowing an option to override the "whitelist" seemed the most feasible and safe solution.
