### PR TITLE
Change Auth::guest() to call the check() method.

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -96,7 +96,7 @@ class Guard {
 	 */
 	public function guest()
 	{
-		return is_null($this->user());
+		return ! $this->check();
 	}
 
 	/**


### PR DESCRIPTION
Instead of reimplementing the logic of the Auth::check() method, we can call and negate it. 

When creating new auth drivers, it is sometimes necessary to extend the Guard class, too. This small change makes creating those subclasses easier, as only the `check()` method will have to be overwritten. `guest()` will still work.

For example, I had to do this because in my existing system guest users did have an ID 1 instead of no entry in the database at all.
