### PR TITLE
Feature/bound alias

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -88,6 +88,8 @@ class Container implements ArrayAccess {
 		// without being forced to state their classes in both of the parameter.
 		unset($this->instances[$abstract]);
 
+		// Just in case an $abstract was previously defined as an alias, we need to
+		// remove the alias from the container.
 		if ($this->isAlias($abstract))
 		{
 			$this->dropAlias($abstract);
@@ -244,6 +246,13 @@ class Container implements ArrayAccess {
 			list($abstract, $alias) = $this->extractAlias($abstract);
 
 			$this->alias($abstract, $alias);
+		}
+
+		// Just in case an $abstract was previously defined as an alias, we need to
+		// remove the alias from the container.
+		if ($this->isAlias($abstract))
+		{
+			$this->dropAlias($abstract);
 		}
 
 		// We'll check to determine if this type has been bound before, and if it has

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -88,6 +88,11 @@ class Container implements ArrayAccess {
 		// without being forced to state their classes in both of the parameter.
 		unset($this->instances[$abstract]);
 
+		if ($this->isAlias($abstract))
+		{
+			$this->dropAlias($abstract);
+		}
+
 		if (is_null($concrete))
 		{
 			$concrete = $abstract;
@@ -275,6 +280,31 @@ class Container implements ArrayAccess {
 	protected function extractAlias(array $definition)
 	{
 		return array(key($definition), current($definition));
+	}
+
+	/**
+	 * Identifies if the value is an alias within the container.
+	 *
+	 * @param  string $alias
+	 * @return boolan
+	 */
+	public function isAlias($alias)
+	{
+		return isset($this->aliases[$alias]);
+	}
+
+	/**
+	 * Removes the alias from the container
+	 *
+	 * @param string $alias
+	 * @return void
+	 */
+	public function dropAlias($alias)
+	{
+		if ($this->isAlias($alias))
+		{
+			unset($this->aliases[$alias]);
+		}
 	}
 
 	/**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -59,6 +59,7 @@ class Container implements ArrayAccess {
 	 */
 	public function bound($abstract)
 	{
+		$abstract = $this->getAlias($abstract);
 		return isset($this[$abstract]) or isset($this->instances[$abstract]);
 	}
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -104,13 +104,53 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('wow', $container->make('zing'));
 	}
 
-	public function testBound()
+	public function testIsAlias()
+	{
+		$container = new Container;
+		$container['foo'] = 'bar';
+		$container->alias('foo', 'baz');
+		$this->assertFalse($container->isAlias('foo'));
+		$this->assertTrue($container->isAlias('baz'));
+	}
+
+	public function testDropAlias()
+	{
+		$container = new Container;
+		$container['foo'] = 'bar';
+		$container->alias('foo', 'baz');
+		
+		$this->assertTrue($container->isAlias('baz'));
+
+		$container->dropAlias('baz');
+
+		$this->assertFalse($container->isAlias('baz'));
+		$this->assertFalse($container->bound('baz'));
+	}
+
+	public function testBoundAliases()
 	{
 		$container = new Container;
 		$container['foo'] = 'bar';
 		$this->assertTrue($container->bound('foo'));
 		$container->alias('foo', 'baz');
 		$this->assertTrue($container->bound('baz'));
+	}
+
+	public function testBoundAliasCanBeOverridden()
+	{
+		$container = new Container;
+		$container['foo'] = 'bar';
+		$container->alias('foo', 'baz');
+
+		$this->assertEquals($container['baz'], $container['foo']);
+		$this->assertFalse($container->offsetExists('baz'));
+
+		$container['baz'] = 'boom';
+
+		$this->assertTrue($container->offsetExists('baz'));
+		$this->assertNotEquals($container['baz'], $container['foo']);
+
+		$this->assertEquals('boom', $container['baz']);
 	}
 
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -104,6 +104,15 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('wow', $container->make('zing'));
 	}
 
+	public function testBound()
+	{
+		$container = new Container;
+		$container['foo'] = 'bar';
+		$this->assertTrue($container->bound('foo'));
+		$container->alias('foo', 'baz');
+		$this->assertTrue($container->bound('baz'));
+	}
+
 
 	public function testShareMethod()
 	{

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -21,6 +21,15 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('Taylor', $container->make('name'));
 	}
 
+	public function testBindIfDoesRegisterIfAliasAlreadyRegistered()
+	{
+		$container = new Container;
+		$container->bind(array('name', 'developer'), function() { return 'Taylor'; });
+		$container->bindIf('developer', function() { return 'Dayle'; });
+
+		$this->assertEquals('Dayle', $container->make('developer'));
+	}
+
 
 	public function testSharedClosureResolution()
 	{
@@ -134,6 +143,24 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($container->bound('foo'));
 		$container->alias('foo', 'baz');
 		$this->assertTrue($container->bound('baz'));
+	}
+
+	public function testInstanceAliasCanBeOverridden()
+	{
+		$class1 = new StdClass;
+		$class2 = new StdClass;
+
+		$container = new Container;
+		$container->instance(array('foo' => 'bar'), $class1);
+
+		$this->assertTrue($container->bound('foo'));
+		$this->assertTrue($container->bound('bar'));
+
+		$this->assertSame($container->make('bar'), $container->make('foo'));
+
+		$container->instance('bar', $class2);
+
+		$this->assertNotSame($container->make('bar'), $container->make('foo'));
 	}
 
 	public function testBoundAliasCanBeOverridden()


### PR DESCRIPTION
I have updated how aliases function within the Container class.  You can see the proposal here (https://github.com/laravel/framework/issues/2438).

I changed three specific behaviours.

First, when the container is asked if value is bound it will resolve any alias first.

Second, I updated the bind method to remove any previously defined alias, when binding a new abstract with the same name as the alias. So essentially the bindings take precedence over any defined alias.

Third, is similar to the second however it relates to instances being bound to the container.

I created other "helper" methods to check if a value is defined as an alias, and the removal of any alias.  I made those methods public ( probably should be protected ) so that I can demonstrate the functionality easily within my unit tests.

Please let me know if I need to do anything else.
