### PR TITLE
Update MorphPivot.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
 class MorphPivot extends Pivot {
 
@@ -10,7 +11,7 @@ class MorphPivot extends Pivot {
 	 * @param  \Illuminate\Database\Eloquent\Builder
 	 * @return \Illuminate\Database\Eloquent\Builder
 	 */
-	protected function setKeysForSaveQuery($query)
+	protected function setKeysForSaveQuery(Builder $query)
 	{
 		$query->where($this->morphType, $this->getAttribute($this->morphType));
 


### PR DESCRIPTION
Missing Builder...

Got this error without:

```
ErrorException
Declaration of Illuminate\Database\Eloquent\Relations\MorphPivot::setKeysForSaveQuery() should be compatible with that of Illuminate\Database\Eloquent\Relations\Pivot::setKeysForSaveQuery()
open: /home/site/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
    public function setMorphType($morphType)
    {
        $this->morphType = $morphType;

        return $this;
    }

}
```
