### PR TITLE
[Proposal] Fix for recent fillableFromArray commit 03f8744b

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -322,7 +322,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	protected function fillableFromArray(array $attributes)
 	{
-		if (count($this->fillable) > 0)
+		if (count($this->fillable) > 0 && static::$unguarded === false)
 		{
 			return array_intersect_key($attributes, array_flip($this->fillable));
 		}


### PR DESCRIPTION
Given:

``` php
$fillable = [ 'foo' ];
$unguarded = true; // perhaps after Eloquent::unguard()
$attributes = [ 'foo' => true, 'bar' => true ];
```

Broken behavior in 03f8744b

``` php
CustomModel::create($attributes); // resulting in [ 'foo' => true ]
```

Workaround for broken behavior in 03f8744b

``` php
$model = new CustomModel;
$model->fillable(array());
$model->fill($attributes);
$model->save(); // resulting in [ 'foo' => true, 'bar' => true ]
```

After this patch:

``` php
CustomModel::create($attributes); // resulting in [ 'foo' => true, 'bar' => true ]
```

And it still works like 03f8744b when `$unguarded = false`.
