### PR TITLE
added call to UploadedFile::isValid to validateMax function

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Fluent;
 use Illuminate\Support\MessageBag;
 use Illuminate\Container\Container;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Translation\TranslatorInterface;
 use Illuminate\Support\Contracts\MessageProviderInterface;
 
@@ -632,6 +633,15 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateMax($attribute, $value, $parameters)
 	{
+		// check file upload is valid first, before checking size
+		// if the upload did not succeed, we don't know the real size
+		// of the file (size returns 0 for invalid uploads), so rather
+		// than returning a misleading result, best to fail early
+		if (($value instanceof UploadedFile) AND !$value->isValid())
+		{
+			return false;
+		}
+
 		return $this->getSize($attribute, $value) <= $parameters[0];
 	}
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4,6 +4,7 @@ use Mockery as m;
 use Illuminate\Validation\Validator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
@@ -472,15 +473,23 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => array(1, 2, 3)), array('foo' => 'Array|Max:2'));
 		$this->assertFalse($v->passes());
 
-		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));
-		$file->expects($this->any())->method('getSize')->will($this->returnValue(3072));
+		$file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', array('isValid', 'getSize'), array(__FILE__, basename(__FILE__)));
+		$file->expects($this->at(0))->method('isValid')->will($this->returnValue(true));
+		$file->expects($this->at(1))->method('getSize')->will($this->returnValue(3072));
 		$v = new Validator($trans, array(), array('photo' => 'Max:10'));
 		$v->setFiles(array('photo' => $file));
 		$this->assertTrue($v->passes());
 
-		$file = $this->getMock('Symfony\Component\HttpFoundation\File\File', array('getSize'), array(__FILE__, false));
-		$file->expects($this->any())->method('getSize')->will($this->returnValue(4072));
+		$file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', array('isValid', 'getSize'), array(__FILE__, basename(__FILE__)));
+		$file->expects($this->at(0))->method('isValid')->will($this->returnValue(true));
+		$file->expects($this->at(1))->method('getSize')->will($this->returnValue(4072));
 		$v = new Validator($trans, array(), array('photo' => 'Max:2'));
+		$v->setFiles(array('photo' => $file));
+		$this->assertFalse($v->passes());
+
+		$file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', array('isValid'), array(__FILE__, basename(__FILE__)));
+		$file->expects($this->any())->method('isValid')->will($this->returnValue(false));
+		$v = new Validator($trans, array(), array('photo' => 'Max:10'));
 		$v->setFiles(array('photo' => $file));
 		$this->assertFalse($v->passes());
 	}


### PR DESCRIPTION
Failed uploads (specifically, files larger than PHP's file size limits), report zero size - not sure if this is a bug, or expected behaviour. This leads to incorrect success for this validation, `getSize` always reports 0 for a failed upload, so `validateMax` always succeeds for very large files.

This pull request fixes #2433

One question to be considered before merging this commit is whether the correct response to an invalid upload is to fail validations which assume you have a valid file. My argument is that uploading a 10MB file when PHP's limit is 8MB should _not_ result in validateMax succeeding.

Note that any other validations for files which rely on getSize (ie `validateMin`, `validateSize`, `validateBetween`), will all fail (correctly?) with a return value of zero, so this call to `isValid` is probably not required in those methods, other than perhaps to be overly cautious.

Another question is whether we should instead throw an exception when trying to validate a failed upload, thus making it obvious why the validation failed. This would both get around this problem of incorrect validation success, while also forcing the developer to check for a valid upload before validating the upload!? Not sure of the best approach there.
