### PR TITLE
[Proposal] Queued cookies

### DIFF
--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -11,15 +11,6 @@ class AuthServiceProvider extends ServiceProvider {
 	 */
 	protected $defer = true;
 
-	/**
-	 * Bootstrap the application events.
-	 *
-	 * @return void
-	 */
-	public function boot()
-	{
-		$this->registerAuthEvents();
-	}
 
 	/**
 	 * Register the service provider.
@@ -36,33 +27,6 @@ class AuthServiceProvider extends ServiceProvider {
 			$app['auth.loaded'] = true;
 
 			return new AuthManager($app);
-		});
-	}
-
-	/**
-	 * Register the events needed for authentication.
-	 *
-	 * @return void
-	 */
-	protected function registerAuthEvents()
-	{
-		$app = $this->app;
-
-		$app->after(function($request, $response) use ($app)
-		{
-			// If the authentication service has been used, we'll check for any cookies
-			// that may be queued by the service. These cookies are all queued until
-			// they are attached onto Response objects at the end of the requests.
-			if (isset($app['auth.loaded']))
-			{
-				foreach ($app['auth']->getDrivers() as $driver)
-				{
-					foreach ($driver->getQueuedCookies() as $cookie)
-					{
-						$response->headers->setCookie($cookie);
-					}
-				}
-			}
 		});
 	}
 

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -37,13 +37,6 @@ class Guard {
 	protected $cookie;
 
 	/**
-	 * The cookies queued by the guards.
-	 *
-	 * @var array
-	 */
-	protected $queuedCookies = array();
-
-	/**
 	 * The event dispatcher instance.
 	 *
 	 * @var Illuminate\Events\Dispatcher
@@ -198,7 +191,7 @@ class Guard {
 		// identifier. We will then decrypt this later to retrieve the users.
 		if ($remember)
 		{
-			$this->queuedCookies[] = $this->createRecaller($id);
+            $this->getCookieJar()->queue($this->createRecaller($id));
 		}
 
 		// If we have an event dispatcher instance set we will fire an event so that
@@ -265,7 +258,7 @@ class Guard {
 
 		$recaller = $this->getRecallerName();
 
-		$this->queuedCookies[] = $this->getCookieJar()->forget($recaller);
+        $this->getCookieJar()->queue($this->getCookieJar()->forget($recaller));
 	}
 
 	/**
@@ -322,16 +315,6 @@ class Guard {
 	public function getSession()
 	{
 		return $this->session;
-	}
-
-	/**
-	 * Get the cookies queued by the guard.
-	 *
-	 * @return array
-	 */
-	public function getQueuedCookies()
-	{
-		return $this->queuedCookies;
 	}
 
 	/**

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -29,6 +29,15 @@ class CookieJar {
 	 */
 	protected $defaults = array();
 
+    /**
+     * A list of queued cookies to send later, keyed by cookie name
+     *
+     * @var array
+     */
+    protected $queued = array();
+
+
+
 	/**
 	 * Create a new cookie manager instance.
 	 *
@@ -168,5 +177,38 @@ class CookieJar {
 	{
 		return $this->encrypter;
 	}
+
+    /**
+     * Queue a cookie to send with the next response
+     *
+     * If a cookie with this name already exists, overrite it
+     *
+     * @param Cookie $cookie
+     */
+    public function queue(Cookie $cookie)
+    {
+       $this->queued[$cookie->getName()] = $cookie;
+    }
+
+    /**
+     * Remove a cookie from the queue (if it has been set)
+     *
+     * @param $cookieName
+     */
+    public function unqueue($cookieName) {
+        if (array_key_exists($cookieName,$this->queued))
+        {
+            unset($this->queued[$cookieName]);
+        }
+    }
+
+    /**
+     * Get the cookies which have been queued for the next request
+     *
+     * @return array
+     */
+    public function getQueuedCookies() {
+        return $this->queued;
+    }
 
 }

--- a/src/Illuminate/Cookie/CookieServiceProvider.php
+++ b/src/Illuminate/Cookie/CookieServiceProvider.php
@@ -11,6 +11,7 @@ class CookieServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
+
 		$this->app['cookie.defaults'] = $this->cookieDefaults();
 
 		// The Illuminate cookie creator is just a convenient way to make cookies
@@ -22,7 +23,19 @@ class CookieServiceProvider extends ServiceProvider {
 
 			return new CookieJar($app['request'], $app['encrypter'], $options);
 		});
-	}
+
+        //now add an after filter to send the queued cookies
+        $app = $this->app;
+        $this->app->after(function($request, $response) use ($app)
+        {
+            $queuedCookies = $app['cookie']->getQueuedCookies();
+            foreach ($queuedCookies as $cookie)
+            {
+                $response->headers->setCookie($cookie);
+            }
+        });
+
+    }
 
 	/**
 	 * Get the default cookie options.

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -123,7 +123,10 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		$user = m::mock('Illuminate\Auth\UserInterface');
 		$mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
 		$mock->expects($this->once())->method('getRecallerName')->will($this->returnValue('bar'));
-		$cookies->shouldReceive('forget')->once()->with('bar');
+
+        $cookie = m::mock('Symfony\Component\HttpFoundation\Cookie');
+        $cookies->shouldReceive('forget')->once()->with('bar')->andReturn($cookie);
+		$cookies->shouldReceive('queue')->once()->with($cookie);
 		$mock->getSession()->shouldReceive('forget')->once()->with('foo');
 		$mock->setUser($user);
 		$mock->logout();
@@ -147,19 +150,15 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	public function testLoginMethodQueuesCookieWhenRemembering()
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
-		$cookie = m::mock('Illuminate\Cookie\CookieJar');
 		$guard = new Illuminate\Auth\Guard($provider, $session, $request);
 		$guard->setCookieJar($cookie);
-		$cookie->shouldReceive('forever')->once()->with($guard->getRecallerName(), 'foo')->andReturn(new Symfony\Component\HttpFoundation\Cookie($guard->getRecallerName(), 'foo'));
+        $foreverCookie = new Symfony\Component\HttpFoundation\Cookie($guard->getRecallerName(), 'foo');
+		$cookie->shouldReceive('forever')->once()->with($guard->getRecallerName(), 'foo')->andReturn($foreverCookie);
+        $cookie->shouldReceive('queue')->once()->with($foreverCookie);
 		$guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
 		$user = m::mock('Illuminate\Auth\UserInterface');
 		$user->shouldReceive('getAuthIdentifier')->once()->andReturn('foo');
 		$guard->login($user, true);
-
-		$cookies = $guard->getQueuedCookies();
-		$this->assertEquals(1, count($cookies));
-		$this->assertEquals('foo', $cookies[0]->getValue());
-		$this->assertEquals($cookies[0]->getName(), $guard->getRecallerName());
 	}
 
 

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -49,6 +49,25 @@ class CookieTest extends PHPUnit_Framework_TestCase {
 		$this->assertNull($cookie->get('foo'));
 	}
 
+    public function testQueuedCookies()
+    {
+        $cookie = $this->getCreator();
+        $this->assertEmpty($cookie->getQueuedCookies()); // better not be anything in the array yet
+        $cookie->queue($cookie->make('foo','bar'));
+        $this->assertArrayHasKey('foo',$cookie->getQueuedCookies());
+
+    }
+
+    public function testUnqueue() {
+        $cookie = $this->getCreator();
+        $cookie->queue($cookie->make('foo','bar'));
+        $this->assertArrayHasKey('foo',$cookie->getQueuedCookies());
+        $cookie->unqueue('foo');
+        $this->assertEmpty($cookie->getQueuedCookies());
+
+    }
+
+
 
 	public function getCreator()
 	{


### PR DESCRIPTION
Sometimes you want to set a cookie in a class that's not directly sending a response.  This pull request implements Cookie::queue($cookie) to do that.  It essentially does what is (was) done in the Auth\Guard class: creates an array of queued cookies which an after filter (now in the CookieServiceProvider) bundles up with the response.

This pull request also updates the Auth classes to use the new queue() method.
