### PR TITLE
Fix exception handling in Boris CLI

### DIFF
--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -44,6 +44,15 @@ class TinkerCommand extends Command {
 	 */
 	protected function runBorisShell()
 	{
+		// Disable the exception/error handlers so Boris can handle them
+		restore_error_handler();
+		restore_exception_handler();
+		$this->laravel->make('artisan')->setCatchExceptions(false);
+
+		// Stop the shutdown handler outputting a JSON error object
+		$this->laravel->error(function() { return ''; });
+
+		// Run Boris
 		with(new \Boris\Boris('> '))->start();
 
 		return;


### PR DESCRIPTION
The new Boris integration is great, but the Laravel exception handlers interfere with it. For example if you type an undefined constant it quits with an exception:

```
$ art tinker
[1] > d;



  [ErrorException]
  Use of undefined constant d - assumed 'd'



tinker

$
```

This PR disables all the Laravel exception handlers so Boris can handle them correctly:

```
$ art tinker
[1] > d;
PHP Notice:  Use of undefined constant d - assumed 'd' in /home/www/intranet.kes.davejamesmiller.com/repo/vendor/d11wtq/boris/lib/Boris/EvalWorker.php(133) : eval()'d code on line 1
PHP Stack trace:
PHP   1. {main}() /home/www/intranet.kes.davejamesmiller.com/repo/artisan:0
PHP   2. Symfony\Component\Console\Application->run() /home/www/intranet.kes.davejamesmiller.com/repo/artisan:59
PHP   3. Symfony\Component\Console\Application->doRun() /home/www/intranet.kes.davejamesmiller.com/repo/vendor/symfony/console/Symfony/Component/Console/Application.php:124
PHP   4. Symfony\Component\Console\Application->doRunCommand() /home/www/intranet.kes.davejamesmiller.com/repo/vendor/symfony/console/Symfony/Component/Console/Application.php:194
PHP   5. Illuminate\Console\Command->run() /home/www/intranet.kes.davejamesmiller.com/repo/vendor/symfony/console/Symfony/Component/Console/Application.php:888
PHP   6. Symfony\Component\Console\Command\Command->run() /home/www/intranet.kes.davejamesmiller.com/repo/vendor/laravel/framework/src/Illuminate/Console/Command.php:96
PHP   7. Illuminate\Console\Command->execute() /home/www/intranet.kes.davejamesmiller.com/repo/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:245
PHP   8. Illuminate\Foundation\Console\TinkerCommand->fire() /home/www/intranet.kes.davejamesmiller.com/repo/vendor/laravel/framework/src/Illuminate/Console/Command.php:108
PHP   9. Illuminate\Foundation\Console\TinkerCommand->runBorisShell() /home/www/intranet.kes.davejamesmiller.com/repo/vendor/laravel/framework/src/Illuminate/Foundation/Console/TinkerCommand.php:30
PHP  10. Boris\Boris->start() /home/www/intranet.kes.davejamesmiller.com/repo/vendor/laravel/framework/src/Illuminate/Foundation/Console/TinkerCommand.php:56
PHP  11. Boris\EvalWorker->start() /home/www/intranet.kes.davejamesmiller.com/repo/vendor/d11wtq/boris/lib/Boris/Boris.php:171
PHP  12. eval() /home/www/intranet.kes.davejamesmiller.com/repo/vendor/d11wtq/boris/lib/Boris/EvalWorker.php:133
 → 'd'
[2] > 
```

(The code is copied from my [Laravel Boris](https://github.com/davejamesmiller/laravel-boris) package for 4.0.)
