### PR TITLE
route() no longer accepts non-array $parameters

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -176,6 +176,8 @@ class UrlGenerator {
 	{
 		$route = $route ?: $this->routes->getByName($name);
 
+		$parameters = (array) $parameters;
+
 		if ( ! is_null($route))
 		{
 			return $this->toRoute($route, $parameters);


### PR DESCRIPTION
In Laravel 4.0 `route('page', 'about')` was valid, but now I get:

```
ErrorException
array_shift() expects parameter 1 to be array, string given
```

I believe this is because in a4d8d95 this line was removed from UrlGenerator::route():

```
$parameters = (array) $parameters;
```

https://github.com/laravel/framework/commit/a4d8d950e49dc7d0de153513994a23e9343cfd4e?w=1#diff-6926964bffefabcf82a60e0e8c327739L185
