### PR TITLE
setAttribute mutator can now return value to be set on the attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2219,7 +2219,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		{
 			$method = 'set'.studly_case($key).'Attribute';
 
-			return $this->{$method}($value);
+			$value = $this->{$method}($value);
 		}
 
 		// If an attribute is listed as a "date", we'll convert it from a DateTime
@@ -2234,6 +2234,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		}
 
 		$this->attributes[$key] = $value;
+		
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
The purpose of the _set mutator_ is to change the value before setting it to the attribute. It would be easier to do so if you could just return the new value from the `set...Attribute` method.

Right now you have to write `$this->attributes[$key] = your_processing($value);`

The `return $this->{$method}($value);` makes not much sense, as the only thing you would most likely want to return from setter is `$this`, which can be done later at the end of `setAttribute` method.
