### PR TITLE
fix - trim the output of the fully rendered php to ensure that DOCTYPE is on the first line (fixes #2479)

### DIFF
--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -42,7 +42,7 @@ class PhpEngine implements EngineInterface {
 			$this->handleViewException($e);
 		}
 
-		return ob_get_clean();
+		return ltrim(ob_get_clean());
 	}
 
 	/**

--- a/tests/View/fixtures/basic.php
+++ b/tests/View/fixtures/basic.php
@@ -1,1 +1,2 @@
+
 Hello World


### PR DESCRIPTION
Added a blank line to the top of the basic test view in order to test `ltrim()` on `ob_get_clean()`.

Fixes #2479.
