### PR TITLE
Removed case conversion on custom validator extensions

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1073,9 +1073,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function getMessage($attribute, $rule)
 	{
-		$lowerRule = strtolower(snake_case($rule));
-
-		$inlineMessage = $this->getInlineMessage($attribute, $lowerRule);
+		$inlineMessage = $this->getInlineMessage($attribute, $rule);
 
 		// First we will retrieve the custom message for the validation rule if one
 		// exists. If a custom validation message is being used we'll return the
@@ -1085,7 +1083,7 @@ class Validator implements MessageProviderInterface {
 			return $inlineMessage;
 		}
 
-		$customKey = "validation.custom.{$attribute}.{$lowerRule}";
+		$customKey = "validation.custom.{$attribute}.{$rule}";
 
 		$customMessage = $this->translator->trans($customKey);
 
@@ -1110,7 +1108,7 @@ class Validator implements MessageProviderInterface {
 		// messages out of the translator service for this validation rule.
 		else
 		{
-			$key = "validation.{$lowerRule}";
+			$key = "validation.{$rule}";
 
 			return $this->translator->trans($key);
 		}
@@ -1120,12 +1118,12 @@ class Validator implements MessageProviderInterface {
 	 * Get the inline message for a rule if it exists.
 	 *
 	 * @param  string  $attribute
-	 * @param  string  $lowerRule
+	 * @param  string  $rule
 	 * @return string
 	 */
-	protected function getInlineMessage($attribute, $lowerRule)
+	protected function getInlineMessage($attribute, $rule)
 	{
-		$keys = array("{$attribute}.{$lowerRule}", $lowerRule);
+		$keys = array("{$attribute}.{$rule}", $rule);
 
 		// First we will check for a custom message for an attribute specific rule
 		// message for the fields, then we will check for a general custom line
@@ -1148,14 +1146,12 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function getSizeMessage($attribute, $rule)
 	{
-		$lowerRule = strtolower(snake_case($rule));
-
 		// There are three different types of size validations. The attribute may be
 		// either a number, file, or string so we will check a few things to know
 		// which type of value it is and return the correct line for that type.
 		$type = $this->getAttributeType($attribute);
 
-		$key = "validation.{$lowerRule}.{$type}";
+		$key = "validation.{$rule}.{$type}";
 
 		return $this->translator->trans($key);
 	}
@@ -1550,7 +1546,7 @@ class Validator implements MessageProviderInterface {
 			$parameters = $this->parseParameters($rule, $parameter);
 		}
 
-		return array(studly_case($rule), $parameters);
+		return array($rule, $parameters);
 	}
 
 	/**
@@ -1600,7 +1596,7 @@ class Validator implements MessageProviderInterface {
 
 		foreach ($extensions as $rule => $extension)
 		{
-			$this->implicitRules[] = studly_case($rule);
+			$this->implicitRules[] = $rule;
 		}
 	}
 
@@ -1627,7 +1623,7 @@ class Validator implements MessageProviderInterface {
 	{
 		$this->addExtension($rule, $extension);
 
-		$this->implicitRules[] = studly_case($rule);
+		$this->implicitRules[] = $rule;
 	}
 
 	/**
@@ -1877,7 +1873,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	public function __call($method, $parameters)
 	{
-		$rule = snake_case(substr($method, 8));
+		$rule = substr($method, 8);
 
 		if (isset($this->extensions[$rule]))
 		{


### PR DESCRIPTION
Reference laravel/framework#2482

Rule name was being converted between snake_case and StudlyCaps throughout the code unnecessarily when using Validate::extend(). This forced the user to define custom validation rule names in snake_case only, otherwise it would throw an exception. Removed all case conversion throughout so user can define rule names as desired.

The only reason the case conversion seemed to make any sense is that the rule name gets concatenated into a magic method and called in validate() (line 257). Didn't seem that important to have proper method camelCasing just for this. It also seemed simpler to remove the conversions than adding a bunch more when the rule was added, and also throughout the validation message handling.
