### PR TITLE
Schema builder missing useful parameters for other integer types

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -425,33 +425,39 @@ class Blueprint {
 	 * Create a new medium integer column on the table.
 	 *
 	 * @param  string  $column
+	 * @param  bool  $autoIncrement
+	 * @param  bool  $unsigned
 	 * @return \Illuminate\Support\Fluent
 	 */
-	public function mediumInteger($column)
+	public function mediumInteger($column, $autoIncrement = false, $unsigned = false)
 	{
-		return $this->addColumn('mediumInteger', $column);
+		return $this->addColumn('mediumInteger', $column, compact('autoIncrement', 'unsigned'));
 	}
 
 	/**
 	 * Create a new tiny integer column on the table.
 	 *
 	 * @param  string  $column
+	 * @param  bool  $autoIncrement
+	 * @param  bool  $unsigned
 	 * @return \Illuminate\Support\Fluent
 	 */
-	public function tinyInteger($column)
+	public function tinyInteger($column, $autoIncrement = false, $unsigned = false)
 	{
-		return $this->addColumn('tinyInteger', $column);
+		return $this->addColumn('tinyInteger', $column, compact('autoIncrement', 'unsigned'));
 	}
 
 	/**
 	 * Create a new small integer column on the table.
 	 *
 	 * @param  string  $column
+	 * @param  bool  $autoIncrement
+	 * @param  bool  $unsigned
 	 * @return \Illuminate\Support\Fluent
 	 */
-	public function smallInteger($column)
+	public function smallInteger($column, $autoIncrement = false, $unsigned = false)
 	{
-		return $this->addColumn('smallInteger', $column);
+		return $this->addColumn('smallInteger', $column, compact('autoIncrement', 'unsigned'));
 	}
 
 	/**


### PR DESCRIPTION
I understand these arguments may have been intentionally omitted due to the unusual usage of incrementing smaller integer types, but this functionality doesn't break anything and is more consistent with integer() and bigInteger().
