### PR TITLE
Option to set a different field, other than the primary key when defining BelongsTo and HasOneOrMany relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -550,15 +550,16 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 *
 	 * @param  string  $related
 	 * @param  string  $foreignKey
+	 * @param  string  $otherKey
 	 * @return \Illuminate\Database\Eloquent\Relations\HasOne
 	 */
-	public function hasOne($related, $foreignKey = null)
+	public function hasOne($related, $foreignKey = null, $otherKey = null)
 	{
 		$foreignKey = $foreignKey ?: $this->getForeignKey();
 
 		$instance = new $related;
 
-		return new HasOne($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey);
+		return new HasOne($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $otherKey);
 	}
 
 	/**
@@ -586,9 +587,10 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 *
 	 * @param  string  $related
 	 * @param  string  $foreignKey
+	 * @param  string  $otherKey
 	 * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
 	 */
-	public function belongsTo($related, $foreignKey = null)
+	public function belongsTo($related, $foreignKey = null, $otherKey = null)
 	{
 		list(, $caller) = debug_backtrace(false);
 
@@ -609,7 +611,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		$query = $instance->newQuery();
 
-		return new BelongsTo($query, $this, $foreignKey, $relation);
+		return new BelongsTo($query, $this, $foreignKey, $relation, $otherKey);
 	}
 
 	/**
@@ -647,15 +649,16 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 *
 	 * @param  string  $related
 	 * @param  string  $foreignKey
+	 * @param  string  $otherKey
 	 * @return \Illuminate\Database\Eloquent\Relations\HasMany
 	 */
-	public function hasMany($related, $foreignKey = null)
+	public function hasMany($related, $foreignKey = null, $otherKey = null)
 	{
 		$foreignKey = $foreignKey ?: $this->getForeignKey();
 
 		$instance = new $related;
 
-		return new HasMany($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey);
+		return new HasMany($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $otherKey);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -15,6 +15,13 @@ class BelongsTo extends Relation {
 	protected $foreignKey;
 
 	/**
+	 * The foreign key of the relation model.
+	 *
+	 * @var string
+	 */
+	protected $otherKey;
+
+	/**
 	 * The name of the relationship.
 	 *
 	 * @var string
@@ -28,12 +35,14 @@ class BelongsTo extends Relation {
 	 * @param  \Illuminate\Database\Eloquent\Model  $parent
 	 * @param  string  $foreignKey
 	 * @param  string  $relation
+	 * @param  string  $otherKey
 	 * @return void
 	 */
-	public function __construct(Builder $query, Model $parent, $foreignKey, $relation)
+	public function __construct(Builder $query, Model $parent, $foreignKey, $relation, $otherKey = null)
 	{
 		$this->relation = $relation;
 		$this->foreignKey = $foreignKey;
+		$this->otherKey = $otherKey;
 
 		parent::__construct($query, $parent);
 	}
@@ -60,7 +69,14 @@ class BelongsTo extends Relation {
 			// For belongs to relationships, which are essentially the inverse of has one
 			// or has many relationships, we need to actually query on the primary key
 			// of the related models matching on the foreign key that's on a parent.
-			$key = $this->related->getKeyName();
+			if (is_null($this->otherKey))
+			{
+				$key = $this->related->getKeyName();
+			}
+			else
+			{
+				$key = $this->otherKey;
+			}
 
 			$table = $this->related->getTable();
 
@@ -216,6 +232,16 @@ class BelongsTo extends Relation {
 	public function getForeignKey()
 	{
 		return $this->foreignKey;
+	}
+
+	/**
+	 * Get the other foreign key of the relationship.
+	 *
+	 * @return string
+	 */
+	public function getOtherKey()
+	{
+		return $this->otherKey;
 	}
 
 }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -130,12 +130,21 @@ class BelongsTo extends Relation {
 	{
 		$keys = array();
 
+		if (is_null($this->otherKey))
+		{
+			$key = $this->foreignKey;
+		}
+		else
+		{
+			$key = $this->otherKey;
+		}
+
 		// First we need to gather all of the keys from the parent models so we know what
 		// to query for via the eager loading query. We will add them to an array then
 		// execute a "where in" statement to gather up all of those related records.
 		foreach ($models as $model)
 		{
-			if ( ! is_null($value = $model->{$this->foreignKey}))
+			if ( ! is_null($value = $model->{$key}))
 			{
 				$keys[] = $value;
 			}

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -103,10 +103,17 @@ class BelongsTo extends Relation {
 	 */
 	public function addEagerConstraints(array $models)
 	{
-		// We'll grab the primary key name of the related models since it could be set to
-		// a non-standard name and not "id". We will then construct the constraint for
-		// our eagerly loading query so it returns the proper models from execution.
-		$key = $this->related->getKeyName();
+		if (is_null($this->otherKey))
+		{
+			// We'll grab the primary key name of the related models since it could be set to
+			// a non-standard name and not "id". We will then construct the constraint for
+			// our eagerly loading query so it returns the proper models from execution.
+			$key = $this->related->getKeyName();
+		}
+		else
+		{
+			$key = $this->otherKey;
+		}
 
 		$key = $this->related->getTable().'.'.$key;
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -15,16 +15,25 @@ abstract class HasOneOrMany extends Relation {
 	protected $foreignKey;
 
 	/**
+	 * The foreign key of the relation model.
+	 *
+	 * @var string
+	 */
+	protected $otherKey;
+
+	/**
 	 * Create a new has many relationship instance.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $query
 	 * @param  \Illuminate\Database\Eloquent\Model  $parent
 	 * @param  string  $foreignKey
+	 * @param  string  $otherKey
 	 * @return void
 	 */
-	public function __construct(Builder $query, Model $parent, $foreignKey)
+	public function __construct(Builder $query, Model $parent, $foreignKey, $otherKey = null)
 	{
 		$this->foreignKey = $foreignKey;
+		$this->otherKey = $otherKey;
 
 		parent::__construct($query, $parent);
 	}
@@ -38,7 +47,14 @@ abstract class HasOneOrMany extends Relation {
 	{
 		if (static::$constraints)
 		{
-			$key = $this->parent->getKey();
+			if (is_null($this->otherKey))
+			{
+				$key = $this->parent->getKey();
+			}
+			else
+			{
+				$key = $this->otherKey;
+			}
 
 			$this->query->where($this->foreignKey, '=', $key);
 		}
@@ -242,6 +258,16 @@ abstract class HasOneOrMany extends Relation {
 	public function getForeignKey()
 	{
 		return $this->foreignKey;
+	}
+
+	/**
+	 * Get the other foreign key for the relationship.
+	 *
+	 * @return string
+	 */
+	public function getOtherKey()
+	{
+		return $this->otherKey;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -53,7 +53,7 @@ abstract class HasOneOrMany extends Relation {
 			}
 			else
 			{
-				$key = $this->otherKey;
+				$key = $this->parent->{$this->otherKey};
 			}
 
 			$this->query->where($this->foreignKey, '=', $key);
@@ -174,7 +174,16 @@ abstract class HasOneOrMany extends Relation {
 	 */
 	public function save(Model $model)
 	{
-		$model->setAttribute($this->getPlainForeignKey(), $this->parent->getKey());
+		if (is_null($this->otherKey))
+		{
+			$key = $this->parent->getKey();
+		}
+		else
+		{
+			$key = $this->parent->{$this->otherKey};
+		}
+
+		$model->setAttribute($this->getPlainForeignKey(), $key);
 
 		return $model->save() ? $model : false;
 	}
@@ -200,8 +209,17 @@ abstract class HasOneOrMany extends Relation {
 	 */
 	public function create(array $attributes)
 	{
+		if (is_null($this->otherKey))
+		{
+			$key = $this->parent->getKey();
+		}
+		else
+		{
+			$key = $this->parent->{$this->otherKey};
+		}
+
 		$foreign = array(
-			$this->getPlainForeignKey() => $this->parent->getKey()
+			$this->getPlainForeignKey() => $key
 		);
 
 		// Here we will set the raw attributes to avoid hitting the "fill" method so

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -24,10 +24,31 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testUpdateMethodRetrievesModelAndUpdatesWithOtherKey()
+	{
+		$relation = $this->getRelation(null, 'other_key');
+		$mock = m::mock('Illuminate\Database\Eloquent\Model');
+		$mock->shouldReceive('fill')->once()->with(array('attributes'))->andReturn($mock);
+		$mock->shouldReceive('save')->once()->andReturn(true);
+		$relation->getQuery()->shouldReceive('first')->once()->andReturn($mock);
+
+		$this->assertTrue($relation->update(array('attributes')));
+	}
+
+
 	public function testEagerConstraintsAreProperlyAdded()
 	{
 		$relation = $this->getRelation();
 		$relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', array('foreign.value', 'foreign.value.two'));
+		$models = array(new EloquentBelongsToModelStub, new EloquentBelongsToModelStub, new AnotherEloquentBelongsToModelStub);
+		$relation->addEagerConstraints($models);
+	}
+
+
+	public function testEagerConstraintsAreProperlyAddedWithOtherKey()
+	{
+		$relation = $this->getRelation(null, 'other_key');
+		$relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.other_key', array('other.value', 'other.value.two'));
 		$models = array(new EloquentBelongsToModelStub, new EloquentBelongsToModelStub, new AnotherEloquentBelongsToModelStub);
 		$relation->addEagerConstraints($models);
 	}
@@ -44,9 +65,38 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRelationIsProperlyInitializedWithOtherKey()
+	{
+		$relation = $this->getRelation(null, 'other_key');
+		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model->shouldReceive('setRelation')->once()->with('foo', null);
+		$models = $relation->initRelation(array($model), 'foo');
+
+		$this->assertEquals(array($model), $models);
+	}
+
+
 	public function testModelsAreProperlyMatchedToParents()
 	{
 		$relation = $this->getRelation();
+		$result1 = m::mock('stdClass');
+		$result1->shouldReceive('getKey')->andReturn(1);
+		$result2 = m::mock('stdClass');
+		$result2->shouldReceive('getKey')->andReturn(2);
+		$model1 = new EloquentBelongsToModelStub;
+		$model1->foreign_key = 1;
+		$model2 = new EloquentBelongsToModelStub;
+		$model2->foreign_key = 2;
+		$models = $relation->match(array($model1, $model2), new Collection(array($result1, $result2)), 'foo');
+
+		$this->assertEquals(1, $models[0]->foo->getKey());
+		$this->assertEquals(2, $models[1]->foo->getKey());
+	}
+
+
+	public function testModelsAreProperlyMatchedToParentsWithOtherKey()
+	{
+		$relation = $this->getRelation(null, 'other_key');
 		$result1 = m::mock('stdClass');
 		$result1->shouldReceive('getKey')->andReturn(1);
 		$result2 = m::mock('stdClass');
@@ -76,16 +126,36 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	protected function getRelation($parent = null)
+	public function testAssociateMethodSetsForeignKeyOnModelWithOtherKey()
 	{
+		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+		$relation = $this->getRelation($parent, 'other_key');
+		$associate = m::mock('Illuminate\Database\Eloquent\Model');
+		$associate->shouldReceive('getKey')->once()->andReturn(1);
+		$parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
+		$parent->shouldReceive('setRelation')->once()->with('relation', $associate);
+
+		$relation->associate($associate);
+	}
+
+
+	protected function getRelation($parent = null, $otherKey = null)
+	{
+		$relation = $otherKey ?: 'id';
+
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
-		$builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
+		$builder->shouldReceive('where')->with('relation.'.$relation, '=', 'foreign.value');
 		$related = m::mock('Illuminate\Database\Eloquent\Model');
-		$related->shouldReceive('getKeyName')->andReturn('id');
+
+		if (is_null($otherKey)) {
+			$related->shouldReceive('getKeyName')->andReturn('id');
+		}
+
 		$related->shouldReceive('getTable')->andReturn('relation');
 		$builder->shouldReceive('getModel')->andReturn($related);
 		$parent = $parent ?: new EloquentBelongsToModelStub;
-		return new BelongsTo($builder, $parent, 'foreign_key', 'relation');
+		return new BelongsTo($builder, $parent, 'foreign_key', 'relation', $otherKey);
 	}
 
 }
@@ -93,11 +163,13 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 class EloquentBelongsToModelStub extends Illuminate\Database\Eloquent\Model {
 
 	public $foreign_key = 'foreign.value';
+	public $other_key = 'other.value';
 
 }
 
 class AnotherEloquentBelongsToModelStub extends Illuminate\Database\Eloquent\Model {
 
 	public $foreign_key = 'foreign.value.two';
+	public $other_key = 'other.value.two';
 
 }

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -14,19 +14,17 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 
 	public function testUpdateMethodRetrievesModelAndUpdates()
 	{
-		$relation = $this->getRelation();
-		$mock = m::mock('Illuminate\Database\Eloquent\Model');
-		$mock->shouldReceive('fill')->once()->with(array('attributes'))->andReturn($mock);
-		$mock->shouldReceive('save')->once()->andReturn(true);
-		$relation->getQuery()->shouldReceive('first')->once()->andReturn($mock);
-
-		$this->assertTrue($relation->update(array('attributes')));
+		$this->doUpdateMethodRetrievesModelAndUpdate();
 	}
-
 
 	public function testUpdateMethodRetrievesModelAndUpdatesWithOtherKey()
 	{
-		$relation = $this->getRelation(null, 'other_key');
+		$this->doUpdateMethodRetrievesModelAndUpdate('other_key');
+	}
+
+	protected function doUpdateMethodRetrievesModelAndUpdate($otherKey = null)
+	{
+		$relation = $this->getRelation(null, $otherKey);
 		$mock = m::mock('Illuminate\Database\Eloquent\Model');
 		$mock->shouldReceive('fill')->once()->with(array('attributes'))->andReturn($mock);
 		$mock->shouldReceive('save')->once()->andReturn(true);
@@ -44,7 +42,6 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 		$relation->addEagerConstraints($models);
 	}
 
-
 	public function testEagerConstraintsAreProperlyAddedWithOtherKey()
 	{
 		$relation = $this->getRelation(null, 'other_key');
@@ -56,18 +53,17 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 
 	public function testRelationIsProperlyInitialized()
 	{
-		$relation = $this->getRelation();
-		$model = m::mock('Illuminate\Database\Eloquent\Model');
-		$model->shouldReceive('setRelation')->once()->with('foo', null);
-		$models = $relation->initRelation(array($model), 'foo');
-
-		$this->assertEquals(array($model), $models);
+		$this->doRelationIsProperlyInitialized();
 	}
-
 
 	public function testRelationIsProperlyInitializedWithOtherKey()
 	{
-		$relation = $this->getRelation(null, 'other_key');
+		$this->doRelationIsProperlyInitialized('other_key');
+	}
+
+	protected function doRelationIsProperlyInitialized($otherKey = null)
+	{
+		$relation = $this->getRelation(null, $otherKey);
 		$model = m::mock('Illuminate\Database\Eloquent\Model');
 		$model->shouldReceive('setRelation')->once()->with('foo', null);
 		$models = $relation->initRelation(array($model), 'foo');
@@ -78,25 +74,17 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 
 	public function testModelsAreProperlyMatchedToParents()
 	{
-		$relation = $this->getRelation();
-		$result1 = m::mock('stdClass');
-		$result1->shouldReceive('getKey')->andReturn(1);
-		$result2 = m::mock('stdClass');
-		$result2->shouldReceive('getKey')->andReturn(2);
-		$model1 = new EloquentBelongsToModelStub;
-		$model1->foreign_key = 1;
-		$model2 = new EloquentBelongsToModelStub;
-		$model2->foreign_key = 2;
-		$models = $relation->match(array($model1, $model2), new Collection(array($result1, $result2)), 'foo');
-
-		$this->assertEquals(1, $models[0]->foo->getKey());
-		$this->assertEquals(2, $models[1]->foo->getKey());
+		$this->doModelsAreProperlyMatchedToParents();
 	}
-
 
 	public function testModelsAreProperlyMatchedToParentsWithOtherKey()
 	{
-		$relation = $this->getRelation(null, 'other_key');
+		$this->doModelsAreProperlyMatchedToParents('other_key');
+	}
+
+	protected function doModelsAreProperlyMatchedToParents($otherKey = null)
+	{
+		$relation = $this->getRelation(null, $otherKey);
 		$result1 = m::mock('stdClass');
 		$result1->shouldReceive('getKey')->andReturn(1);
 		$result2 = m::mock('stdClass');
@@ -114,23 +102,19 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 
 	public function testAssociateMethodSetsForeignKeyOnModel()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
-		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
-		$relation = $this->getRelation($parent);
-		$associate = m::mock('Illuminate\Database\Eloquent\Model');
-		$associate->shouldReceive('getKey')->once()->andReturn(1);
-		$parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
-		$parent->shouldReceive('setRelation')->once()->with('relation', $associate);
-
-		$relation->associate($associate);
+		$this->doAssociateMethodSetsForeignKeyOnModel();
 	}
-
 
 	public function testAssociateMethodSetsForeignKeyOnModelWithOtherKey()
 	{
+		$this->doAssociateMethodSetsForeignKeyOnModel('other_key');
+	}
+
+	protected function doAssociateMethodSetsForeignKeyOnModel($otherKey = null)
+	{
 		$parent = m::mock('Illuminate\Database\Eloquent\Model');
 		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
-		$relation = $this->getRelation($parent, 'other_key');
+		$relation = $this->getRelation($parent, $otherKey);
 		$associate = m::mock('Illuminate\Database\Eloquent\Model');
 		$associate->shouldReceive('getKey')->once()->andReturn(1);
 		$parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
@@ -155,6 +139,7 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 		$related->shouldReceive('getTable')->andReturn('relation');
 		$builder->shouldReceive('getModel')->andReturn($related);
 		$parent = $parent ?: new EloquentBelongsToModelStub;
+		
 		return new BelongsTo($builder, $parent, 'foreign_key', 'relation', $otherKey);
 	}
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -14,7 +14,17 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testCreateMethodProperlyCreatesNewModel()
 	{
-		$relation = $this->getRelation();
+		$this->doCreateMethodProperlyCreatesNewModel();
+	}
+
+	public function testCreateMethodProperlyCreatesNewModelWithOtherKey()
+	{
+		$this->doCreateMethodProperlyCreatesNewModel('other_key');
+	}
+
+	protected function doCreateMethodProperlyCreatesNewModel($otherKey = null)
+	{
+		$relation = $this->getRelation($otherKey);
 		$created = $this->getMock('Illuminate\Database\Eloquent\Model', array('save', 'getKey', 'setRawAttributes'));
 		$created->expects($this->once())->method('save')->will($this->returnValue(true));
 		$relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($created);
@@ -23,9 +33,20 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($created, $relation->create(array('name' => 'taylor')));
 	}
 
+
 	public function testUpdateMethodUpdatesModelsWithTimestamps()
 	{
-		$relation = $this->getRelation();
+		$this->doUpdateMethodUpdatesModelsWithTimestamps();
+	}
+
+	public function testUpdateMethodUpdatesModelsWithTimestampsWithOtherKey()
+	{
+		$this->doUpdateMethodUpdatesModelsWithTimestamps('other_key');
+	}
+
+	protected function doUpdateMethodUpdatesModelsWithTimestamps($otherKey = null)
+	{
+		$relation = $this->getRelation($otherKey);
 		$relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
 		$relation->getRelated()->shouldReceive('freshTimestamp')->once()->andReturn(100);
 		$relation->getRelated()->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
@@ -37,7 +58,17 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testRelationIsProperlyInitialized()
 	{
-		$relation = $this->getRelation();
+		$this->doRelationIsProperlyInitialized();
+	}
+
+	public function testRelationIsProperlyInitializedWithOtherKey()
+	{
+		$this->doRelationIsProperlyInitialized('other_key');
+	}
+
+	protected function doRelationIsProperlyInitialized($otherKey = null)
+	{
+		$relation = $this->getRelation($otherKey);
 		$model = m::mock('Illuminate\Database\Eloquent\Model');
 		$relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function($array = array()) { return new Collection($array); });
 		$model->shouldReceive('setRelation')->once()->with('foo', m::type('Illuminate\Database\Eloquent\Collection'));
@@ -49,7 +80,17 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testEagerConstraintsAreProperlyAdded()
 	{
-		$relation = $this->getRelation();
+		$this->doEagerConstraintsAreProperlyAdded();
+	}
+
+	public function testEagerConstraintsAreProperlyAddedWithOtherKey()
+	{
+		$this->doEagerConstraintsAreProperlyAdded('other_key');
+	}
+
+	protected function doEagerConstraintsAreProperlyAdded($otherKey = null)
+	{
+		$relation = $this->getRelation($otherKey);
 		$relation->getQuery()->shouldReceive('whereIn')->once()->with('table.foreign_key', array(1, 2));
 		$model1 = new EloquentHasManyModelStub;
 		$model1->id = 1;
@@ -61,7 +102,17 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testModelsAreProperlyMatchedToParents()
 	{
-		$relation = $this->getRelation();
+		$this->doModelsAreProperlyMatchedToParents();
+	}
+
+	public function testModelsAreProperlyMatchedToParentsWithOtherKey()
+	{
+		$this->doModelsAreProperlyMatchedToParents('other_key');
+	}
+
+	protected function doModelsAreProperlyMatchedToParents($otherKey = null)
+	{
+		$relation = $this->getRelation($otherKey);
 
 		$result1 = new EloquentHasManyModelStub;
 		$result1->foreign_key = 1;
@@ -89,17 +140,24 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	protected function getRelation()
+	protected function getRelation($otherKey = null)
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
 		$builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
 		$related = m::mock('Illuminate\Database\Eloquent\Model');
 		$builder->shouldReceive('getModel')->andReturn($related);
 		$parent = m::mock('Illuminate\Database\Eloquent\Model');
-		$parent->shouldReceive('getKey')->andReturn(1);
+
+		if (is_null($otherKey)) {
+			$parent->shouldReceive('getKey')->andReturn(1);
+		} else {
+			$parent->shouldReceive('getAttribute')->andReturn(1);
+		}
+
 		$parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
 		$parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-		return new HasMany($builder, $parent, 'table.foreign_key');
+
+		return new HasMany($builder, $parent, 'table.foreign_key', $otherKey);
 	}
 
 }

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -14,7 +14,17 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
 	public function testSaveMethodSetsForeignKeyOnModel()
 	{
-		$relation = $this->getRelation();
+		$this->doSaveMethodSetsForeignKeyOnModel();
+	}
+
+	public function testSaveMethodSetsForeignKeyOnModelWithOtherKey()
+	{
+		$this->doSaveMethodSetsForeignKeyOnModel('other_key');
+	}
+
+	protected function doSaveMethodSetsForeignKeyOnModel($otherKey = null)
+	{
+		$relation = $this->getRelation($otherKey);
 		$mockModel = $this->getMock('Illuminate\Database\Eloquent\Model', array('save'));
 		$mockModel->expects($this->once())->method('save')->will($this->returnValue(true));
 		$result = $relation->save($mockModel);
@@ -26,7 +36,17 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
 	public function testCreateMethodProperlyCreatesNewModel()
 	{
-		$relation = $this->getRelation();
+		$this->doCreateMethodProperlyCreatesNewModel();
+	}
+
+	public function testCreateMethodProperlyCreatesNewModelWithOtherKey()
+	{
+		$this->doCreateMethodProperlyCreatesNewModel('other_key');
+	}
+
+	protected function doCreateMethodProperlyCreatesNewModel($otherKey = null)
+	{
+		$relation = $this->getRelation($otherKey);
 		$created = $this->getMock('Illuminate\Database\Eloquent\Model', array('save', 'getKey', 'setRawAttributes'));
 		$created->expects($this->once())->method('save')->will($this->returnValue(true));
 		$relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($created);
@@ -38,7 +58,17 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
 	public function testUpdateMethodUpdatesModelsWithTimestamps()
 	{
-		$relation = $this->getRelation();
+		$this->doUpdateMethodUpdatesModelsWithTimestamps();
+	}
+
+	public function testUpdateMethodUpdatesModelsWithTimestampsWithOtherKey()
+	{
+		$this->doUpdateMethodUpdatesModelsWithTimestamps('other_key');
+	}
+
+	protected function doUpdateMethodUpdatesModelsWithTimestamps($otherKey = null)
+	{
+		$relation = $this->getRelation($otherKey);
 		$relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
 		$relation->getRelated()->shouldReceive('freshTimestamp')->once()->andReturn(100);
 		$relation->getRelated()->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
@@ -50,7 +80,17 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
 	public function testRelationIsProperlyInitialized()
 	{
-		$relation = $this->getRelation();
+		$this->doRelationIsProperlyInitialized();
+	}
+
+	public function testRelationIsProperlyInitializedWithOtherKey()
+	{
+		$this->doRelationIsProperlyInitialized('other_key');
+	}
+
+	protected function doRelationIsProperlyInitialized($otherKey = null)
+	{
+		$relation = $this->getRelation($otherKey);
 		$model = m::mock('Illuminate\Database\Eloquent\Model');
 		$model->shouldReceive('setRelation')->once()->with('foo', null);
 		$models = $relation->initRelation(array($model), 'foo');
@@ -61,7 +101,17 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
 	public function testEagerConstraintsAreProperlyAdded()
 	{
-		$relation = $this->getRelation();
+		$this->doEagerConstraintsAreProperlyAdded();
+	}
+
+	public function testEagerConstraintsAreProperlyAddedWithOtherKey()
+	{
+		$this->doEagerConstraintsAreProperlyAdded('other_key');
+	}
+
+	protected function doEagerConstraintsAreProperlyAdded($otherKey = null)
+	{
+		$relation = $this->getRelation($otherKey);
 		$relation->getQuery()->shouldReceive('whereIn')->once()->with('table.foreign_key', array(1, 2));
 		$model1 = new EloquentHasOneModelStub;
 		$model1->id = 1;
@@ -73,7 +123,17 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
 	public function testModelsAreProperlyMatchedToParents()
 	{
-		$relation = $this->getRelation();
+		$this->doModelsAreProperlyMatchedToParents();
+	}
+
+	public function testModelsAreProperlyMatchedToParentsWithOtherKey()
+	{
+		$this->doModelsAreProperlyMatchedToParents('other_key');
+	}
+
+	protected function doModelsAreProperlyMatchedToParents($otherKey = null)
+	{
+		$relation = $this->getRelation($otherKey);
 
 		$result1 = new EloquentHasOneModelStub;
 		$result1->foreign_key = 1;
@@ -97,7 +157,17 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
 	public function testRelationCountQueryCanBeBuilt()
 	{
-		$relation = $this->getRelation();
+		$this->doRelationCountQueryCanBeBuilt();
+	}
+
+	public function testRelationCountQueryCanBeBuiltWithOtherKey()
+	{
+		$this->doRelationCountQueryCanBeBuilt('other_key');
+	}
+
+	protected function doRelationCountQueryCanBeBuilt($otherKey = null)
+	{
+		$relation = $this->getRelation($otherKey);
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$query->shouldReceive('select')->once()->with(m::type('Illuminate\Database\Query\Expression'));
 		$relation->getParent()->shouldReceive('getQualifiedKeyName')->andReturn('foo');
@@ -110,17 +180,24 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	protected function getRelation()
+	protected function getRelation($otherKey = null)
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
 		$builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
 		$related = m::mock('Illuminate\Database\Eloquent\Model');
 		$builder->shouldReceive('getModel')->andReturn($related);
 		$parent = m::mock('Illuminate\Database\Eloquent\Model');
-		$parent->shouldReceive('getKey')->andReturn(1);
+
+		if (is_null($otherKey)) {
+			$parent->shouldReceive('getKey')->andReturn(1);
+		} else {
+			$parent->shouldReceive('getAttribute')->andReturn(1);
+		}
+
 		$parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
 		$parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-		return new HasOne($builder, $parent, 'table.foreign_key');
+
+		return new HasOne($builder, $parent, 'table.foreign_key', $otherKey);
 	}
 
 }


### PR DESCRIPTION
Eloquent currently assumes that you would want to always join onto the primary key field of the relation table. This may not always be the case (in my case we are using a legacy database design where some tables do not even have a "normal" primary key).

This PR allows the developer to define a `hasMany`, `hasOne` or `belongsTo` relationship using a specific field to join to as a 3rd parameter on the corresponding methods.

Usage:

app/models/Book.php

``` php
class Book extends Eloquent
{
    // ...

    public function author()
    {
        return $this->belongsTo('Author', 'author_code', 'code');
    }
}
```

app/models/Author.php

``` php
class Author extends Eloquent
{
    protected $primaryKey = 'id';

    // ...

    public function books()
    {
        return $this->hasMany('Books', 'author_code', 'code');
    }
}
```

If this gets merged I shall update the documentation and API guide.
