### PR TITLE
using arrays to specify rules in sometimes method of validation class

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -193,6 +193,8 @@ class Validator implements MessageProviderInterface {
 	protected function mergeRules($attribute, $rules)
 	{
 		$current = array_get($this->rules, $attribute, array());
+		
+		$rules = (is_string($rules)) ? $rules : array_get($rules, $attribute, array());
 
 		$merge = head($this->explodeRules(array($rules)));
 


### PR DESCRIPTION
now we can use only string, for example:

``` php
$v->sometimes(array('reason', 'cost'), 'required', function($input)
{
    return $input->games >= 100;
});
```

after this edition, we can use arrays to specify rules:

``` php
$v->sometimes(array('reason', 'cost'), array('reason' => 'required', 'cost' => 'in:100,200'), function($input)
{
    return $input->games >= 100;
});
```
