### PR TITLE
Fixed custom validator extensions when using Validator::extend

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1582,9 +1582,12 @@ class Validator implements MessageProviderInterface {
 	 */
 	public function addExtensions(array $extensions)
 	{
-		$keys = array_map('snake_case', array_keys($extensions));
+		if ($extensions)
+		{
+			$keys = array_map('snake_case', array_keys($extensions));
 
-		$extensions = array_combine($keys, array_values($extensions));
+			$extensions = array_combine($keys, array_values($extensions));
+		}
 
 		$this->extensions = array_merge($this->extensions, $extensions);
 	}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -863,7 +863,7 @@ class Validator implements MessageProviderInterface {
 			$extra[$segments[$i]] = $segments[$i + 1];
 		}
 
-		return $extra;	
+		return $extra;
 	}
 
 	/**
@@ -1105,7 +1105,7 @@ class Validator implements MessageProviderInterface {
 
 		if ($key != ($value = $this->translator->trans($key)))
 		{
-			return $value; 
+			return $value;
 		}
 
 		return $this->getInlineMessage(
@@ -1582,6 +1582,10 @@ class Validator implements MessageProviderInterface {
 	 */
 	public function addExtensions(array $extensions)
 	{
+		$keys = array_map('snake_case', array_keys($extensions));
+
+		$extensions = array_combine($keys, array_values($extensions));
+
 		$this->extensions = array_merge($this->extensions, $extensions);
 	}
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -803,6 +803,14 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($v->passes());
 		$v->messages()->setFormat(':message');
 		$this->assertEquals('foo!', $v->messages()->first('name'));
+
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('name' => 'taylor'), array('name' => 'foo_bar'));
+		$v->addExtensions(array('FooBar' => function() { return false; }));
+		$v->setFallbackMessages(array('foo_bar' => 'foo!'));
+		$this->assertFalse($v->passes());
+		$v->messages()->setFormat(':message');
+		$this->assertEquals('foo!', $v->messages()->first('name'));
 	}
 
 


### PR DESCRIPTION
Your initial fix only applied when using the `addExtension` method once you already had a `Validator` instance. I've applied it to the `addExtensions` method as well so that when the extensions are passed from the factory to the new instance they are snake cased.
