### PR TITLE
Removed redundant strtolower() since it's done in snake_case().

### DIFF
--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -153,7 +153,7 @@ class Factory {
 	{
 		$this->extensions[$rule] = $extension;
 
-		if ($message) $this->fallbackMessages[strtolower(snake_case($rule))] = $message;
+		if ($message) $this->fallbackMessages[snake_case($rule)] = $message;
 	}
 
 	/**
@@ -168,7 +168,7 @@ class Factory {
 	{
 		$this->implicitExtensions[$rule] = $extension;
 
-		if ($message) $this->fallbackMessages[strtolower(snake_case($rule))] = $message;
+		if ($message) $this->fallbackMessages[snake_case($rule)] = $message;
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: Jason Lewis jason.lewis1991@gmail.com
