### PR TITLE
Add dropSoftDeletes method to migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -270,6 +270,16 @@ class Blueprint {
 	}
 
 	/**
+	* Indicate that the soft delete column should be dropped.
+	*
+	* @return void
+	*/
+	public function dropSoftDeletes()
+	{
+		$this->dropColumn('deleted_at');
+	}
+
+	/**
 	 * Rename the table to a given name.
 	 *
 	 * @param  string  $to


### PR DESCRIPTION
Keeps consistency with `dropTimestamps()` method and keeps the column name out of migrations.

Fixes #2448 

Signed-off-by: Daniel Bondergaard danielboendergaard@gmail.com
