### PR TITLE
Fixed incorrect keys for Redis queue names

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -96,6 +96,8 @@ class RedisQueue extends Queue implements QueueInterface {
 	 */
 	public function pop($queue = null)
 	{
+		$queueName = $queue ?: $this->default;
+
 		$this->migrateAllExpiredJobs($queue = $this->getQueue($queue));
 
 		$job = $this->redis->lpop($queue);
@@ -104,7 +106,7 @@ class RedisQueue extends Queue implements QueueInterface {
 		{
 			$this->redis->zadd($queue.':reserved', $this->getTime() + 60, $job);
 
-			return new RedisJob($this->container, $this, $job, $queue);
+			return new RedisJob($this->container, $this, $job, $queueName);
 		}
 	}
 
@@ -117,7 +119,7 @@ class RedisQueue extends Queue implements QueueInterface {
 	 */
 	public function deleteReserved($queue, $job)
 	{
-		$this->redis->zrem($queue.':reserved', $job);
+		$this->redis->zrem($this->getQueue($queue).':reserved', $job);
 	}
 
 	/**


### PR DESCRIPTION
Fixed a bug in the Redis queue driver where the keys incorrectly was set to "queues:queues:default" instead of "queues:default".
