### PR TITLE
Added indexes to CreatePasswordRemindersTable migration to improve performance

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/reminders.stub
+++ b/src/Illuminate/Auth/Console/stubs/reminders.stub
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 class CreatePasswordRemindersTable extends Migration {
@@ -11,11 +12,11 @@ class CreatePasswordRemindersTable extends Migration {
 	 */
 	public function up()
 	{
-		Schema::create('password_reminders', function($t)
+		Schema::create('password_reminders', function(Blueprint $table)
 		{
-			$t->string('email');
-			$t->string('token');
-			$t->timestamp('created_at');
+			$table->string('email')->index();
+			$table->string('token')->index();
+			$table->timestamp('created_at');
 		});
 	}
 


### PR DESCRIPTION
Added indexes to 'email' and 'token' fields to improve the performance. Also added type hinting and changed `$t` to `$table` to be more consistent with the migrations generated by artisan.

Signed-off-by: Isern Palaus ipalaus@ipalaus.com
