### PR TITLE
Clear expired reminders from Artisan

### DIFF
--- a/src/Illuminate/Auth/Console/ClearRemindersCommand.php
+++ b/src/Illuminate/Auth/Console/ClearRemindersCommand.php
@@ -1,0 +1,56 @@
+<?php namespace Illuminate\Auth\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Illuminate\Auth\Reminders\ReminderRepositoryInterface;
+
+class ClearRemindersCommand extends Command {
+
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'auth:clear-reminders';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Flush expired reminders.';
+
+	/**
+	 * The password reminder repository.
+	 *
+	 * @var \Illuminate\Auth\Reminders\ReminderRepositoryInterface  $reminders
+	 */
+	protected $reminders;
+
+	/**
+	 * Create a new reminder clear command instance.
+	 *
+	 * @param  \Illuminate\Auth\Reminders\ReminderRepositoryInterface  $reminders
+	 * @return void
+	 */
+	public function __construct(ReminderRepositoryInterface $reminders)
+	{
+		parent::__construct();
+
+		$this->reminders = $reminders;
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return void
+	 */
+	public function fire()
+	{
+		$this->reminders->deleteExpired();
+
+		$this->info('Expired reminders cleared!');
+	}
+
+}

--- a/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
+++ b/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
@@ -1,6 +1,6 @@
 <?php namespace Illuminate\Auth\Reminders;
 
-use DateTime;
+use Carbon\Carbon;
 use Illuminate\Database\Connection;
 
 class DatabaseReminderRepository implements ReminderRepositoryInterface {
@@ -39,7 +39,7 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	 * @param  \Illuminate\Database\Connection  $connection
 	 * @param  string  $table
 	 * @param  string  $hashKey
-	 * @param  int  $expires 
+	 * @param  int  $expires
 	 * @return void
 	 */
 	public function __construct(Connection $connection, $table, $hashKey, $expires = 60)
@@ -79,7 +79,7 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	 */
 	protected function getPayload($email, $token)
 	{
-		return array('email' => $email, 'token' => $token, 'created_at' => new DateTime);
+		return array('email' => $email, 'token' => $token, 'created_at' => new Carbon);
 	}
 
 	/**
@@ -130,6 +130,18 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	public function delete($token)
 	{
 		$this->getTable()->where('token', $token)->delete();
+	}
+
+	/**
+	 * Delete expired reminders.
+	 *
+	 * @return void
+	 */
+	public function deleteExpired()
+	{
+		$expired = Carbon::now()->addSeconds($this->expires);
+
+		$this->getTable()->where('created_at', '<', $expired)->delete();
 	}
 
 	/**

--- a/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
+++ b/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
@@ -139,7 +139,7 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	 */
 	public function deleteExpired()
 	{
-		$expired = Carbon::now()->addSeconds($this->expires);
+		$expired = Carbon::now()->subSeconds($this->expires);
 
 		$this->getTable()->where('created_at', '<', $expired)->delete();
 	}

--- a/src/Illuminate/Auth/Reminders/ReminderRepositoryInterface.php
+++ b/src/Illuminate/Auth/Reminders/ReminderRepositoryInterface.php
@@ -27,4 +27,11 @@ interface ReminderRepositoryInterface {
 	 */
 	public function delete($token);
 
+	/**
+	 * Delete expired reminders.
+	 *
+	 * @return void
+	 */
+	public function deleteExpired();
+
 }

--- a/src/Illuminate/Auth/Reminders/ReminderServiceProvider.php
+++ b/src/Illuminate/Auth/Reminders/ReminderServiceProvider.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Auth\Console\MakeRemindersCommand;
+use Illuminate\Auth\Console\ClearRemindersCommand;
 use Illuminate\Auth\Reminders\DatabaseReminderRepository as DbRepository;
 
 class ReminderServiceProvider extends ServiceProvider {
@@ -96,7 +97,12 @@ class ReminderServiceProvider extends ServiceProvider {
 			return new MakeRemindersCommand($app['files']);
 		});
 
-		$this->commands('command.auth.reminders');
+		$app['command.auth.reminders.clear'] = $app->share(function($app)
+		{
+			return new ClearRemindersCommand($app['auth.reminder.repository']);
+		});
+
+		$this->commands('command.auth.reminders', 'command.auth.reminders.clear');
 	}
 
 	/**

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -15,7 +15,8 @@
         "illuminate/hashing": "4.0.x",
         "illuminate/http": "4.0.x",
         "illuminate/session": "4.0.x",
-        "illuminate/support": "4.0.x"
+        "illuminate/support": "4.0.x",
+        "nesbot/carbon": "1.*"
     },
     "require-dev": {
         "illuminate/console": "4.0.x",

--- a/tests/Auth/AuthDatabaseReminderRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseReminderRepositoryTest.php
@@ -79,6 +79,17 @@ class AuthDatabaseReminderRepositoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDeleteExpiredMethodDeletesExpiredTokens()
+	{
+		$repo = $this->getRepo();
+		$repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
+		$query->shouldReceive('where')->once()->with('created_at', '<', m::any())->andReturn($query);
+		$query->shouldReceive('delete')->once();
+
+		$repo->deleteExpired();
+	}
+
+
 	protected function getRepo()
 	{
 		return new Illuminate\Auth\Reminders\DatabaseReminderRepository(m::mock('Illuminate\Database\Connection'), 'table', 'key');


### PR DESCRIPTION
Added a new command 'auth:clear-reminders' that will clear the expired tokens.
