### PR TITLE
Fix paginator limit equals zero

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -869,7 +869,7 @@ class Builder {
 	 */
 	public function offset($value)
 	{
-		$this->offset = $value;
+		if($value > 0) $this->offset = $value;
 
 		return $this;
 	}

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -87,7 +87,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 		$this->env = $env;
 		$this->items = $items;
 		$this->total = (int) $total;
-		$this->perPage = (int) $perPage;
+		$this->perPage = (int) $perPage > 0 ? $perPage : $this->total;
 	}
 
 	/**


### PR DESCRIPTION
Omitting the LIMIT and OFFSET clause when `DB::table()->paginate()`, limit per page is set to less or equal zero.
