### PR TITLE
Support for controller instance method filters using @filter syntax, proposal #2432

### DIFF
--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -64,6 +64,10 @@ abstract class Controller {
 		{
 			$filter = $this->registerClosureFilter($filter);
 		}
+		elseif ($this->isInstanceFilter($filter))
+		{
+			$filter = $this->registerInstanceFilter($filter);
+		}
 		else
 		{
 			list($filter, $parameters) = Route::parseFilter($filter);
@@ -83,6 +87,30 @@ abstract class Controller {
 		$this->getFilterer()->filter($name = spl_object_hash($filter), $filter);
 
 		return $name;
+	}
+
+	/**
+	 * Check if a filter is a local method
+	 * @param  mixed  $filter
+	 * @return boolean
+	 */
+	protected function isInstanceFilter($filter)
+	{
+		return is_string($filter) and starts_with($filter, '@');
+	}
+
+	/**
+	 * Register a controller instance method as a filter.
+	 *
+	 * @param  string  $filter
+	 * @return string
+	 */
+	protected function registerInstanceFilter($filter)
+	{
+		$name = substr($filter, 1);
+		$this->getFilterer()->filter($filter, array($controller = $this, $name));
+
+		return $filter;
 	}
 
 	/**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -71,6 +71,10 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		});
 		$router->get('bar', 'RouteTestControllerDispatchStub@bar');
 		$this->assertEquals('filter', $router->dispatch(Request::create('bar', 'GET'))->getContent());
+		
+		$router = $this->getRouter();
+		$router->get('baz', 'RouteTestControllerDispatchStub@baz');
+		$this->assertEquals('filtered', $router->dispatch(Request::create('baz', 'GET'))->getContent());
 
 
 		/**
@@ -512,12 +516,21 @@ class RouteTestControllerDispatchStub extends Illuminate\Routing\Controller {
 	public function __construct()
 	{
 		$this->beforeFilter('foo', array('only' => 'bar'));
+		$this->beforeFilter('@filter', array('only' => 'baz'));
 	}
 	public function foo()
 	{
 		return 'bar';
 	}
 	public function bar()
+	{
+		return 'baz';
+	}
+	public function filter()
+	{
+		return 'filtered';
+	}
+	public function baz()
 	{
 		return 'baz';
 	}


### PR DESCRIPTION
Makes it very fast and easy to use instance methods on your controller as filters. Helpful in cases where maybe you need to do a permission check (like checking if the logged in user actually owns the post they are trying to delete for example) on several actions, and you don't want to register a global filter since the functionality is localized to that controller. A lot cleaner than using closures.

``` php
public function __construct()
{
    $this->beforeFilter('@hasPermission');
}

protected function hasPermission($route)
{   
    $id = $route->getParameter('id');

    if (! Auth::user()->ownsPost($id)) {
        return Response::make('You are not authorized', 401);
    }
}
```
