### PR TITLE
Use alternative mockery syntax to create partials

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -731,7 +731,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$method     = 'whereFooBarAndBazOrQux';
 		$parameters = array('corge', 'waldo', 'fred');
-		$builder    = m::mock('Illuminate\Database\Query\Builder[where]');
+		$builder    = m::mock('Illuminate\Database\Query\Builder')->makePartial();
 
 		$builder->shouldReceive('where')->with('foo_bar', '=', $parameters[0], 'and')->once()->andReturn($builder);
 		$builder->shouldReceive('where')->with('baz', '=', $parameters[1], 'and')->once()->andReturn($builder);
@@ -745,7 +745,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$method     = 'whereIosVersionAndAndroidVersionOrOrientation';
 		$parameters = array('6.1', '4.2', 'Vertical');
-		$builder    = m::mock('Illuminate\Database\Query\Builder[where]');
+		$builder    = m::mock('Illuminate\Database\Query\Builder')->makePartial();
 
 		$builder->shouldReceive('where')->with('ios_version', '=', '6.1', 'and')->once()->andReturn($builder);
 		$builder->shouldReceive('where')->with('android_version', '=', '4.2', 'and')->once()->andReturn($builder);

--- a/tests/Foundation/ProviderRepositoryTest.php
+++ b/tests/Foundation/ProviderRepositoryTest.php
@@ -15,7 +15,7 @@ class ProviderRepositoryTest extends PHPUnit_Framework_TestCase {
 		$repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,shouldRecompile]', array(m::mock('Illuminate\Filesystem\Filesystem'), array(__DIR__)));
 		$repo->shouldReceive('loadManifest')->once()->andReturn(array('eager' => array('foo'), 'deferred' => array('deferred'), 'providers' => array('providers')));
 		$repo->shouldReceive('shouldRecompile')->once()->andReturn(false);
-		$app = m::mock('Illuminate\Foundation\Application[register,setDeferredServices,runningInConsole]');
+		$app = m::mock('Illuminate\Foundation\Application')->makePartial();
 		$provider = m::mock('Illuminate\Support\ServiceProvider');
 		$repo->shouldReceive('createProvider')->once()->with($app, 'foo')->andReturn($provider);
 		$app->shouldReceive('register')->once()->with($provider);
@@ -31,7 +31,7 @@ class ProviderRepositoryTest extends PHPUnit_Framework_TestCase {
 		$repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,shouldRecompile]', array(m::mock('Illuminate\Filesystem\Filesystem'), array(__DIR__)));
 		$repo->shouldReceive('loadManifest')->once()->andReturn(array('eager' => array('foo'), 'deferred' => array('deferred'), 'providers' => array('providers')));
 		$repo->shouldReceive('shouldRecompile')->once()->andReturn(false);
-		$app = m::mock('Illuminate\Foundation\Application[register,setDeferredServices,runningInConsole]');
+		$app = m::mock('Illuminate\Foundation\Application')->makePartial();
 		$provider = m::mock('Illuminate\Support\ServiceProvider');
 		$repo->shouldReceive('createProvider')->once()->with($app, 'providers')->andReturn($provider);
 		$app->shouldReceive('register')->once()->with($provider);

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -12,9 +12,9 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase {
 
 	public function testRunProcessCallsProcess()
 	{
-		$process = m::mock('Symfony\Component\Process\Process[run]');
+		$process = m::mock('Symfony\Component\Process\Process')->makePartial();
 		$process->shouldReceive('run')->once();
-		$listener = m::mock('Illuminate\Queue\Listener[memoryExceeded]');
+		$listener = m::mock('Illuminate\Queue\Listener')->makePartial();
 		$listener->shouldReceive('memoryExceeded')->once()->with(1)->andReturn(false);
 
 		$listener->runProcess($process, 1);
@@ -23,9 +23,9 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase {
 
 	public function testListenerStopsWhenMemoryIsExceeded()
 	{
-		$process = m::mock('Symfony\Component\Process\Process[run]');
+		$process = m::mock('Symfony\Component\Process\Process')->makePartial();
 		$process->shouldReceive('run')->once();
-		$listener = m::mock('Illuminate\Queue\Listener[memoryExceeded,stop]');
+		$listener = m::mock('Illuminate\Queue\Listener')->makePartial();
 		$listener->shouldReceive('memoryExceeded')->once()->with(1)->andReturn(true);
 		$listener->shouldReceive('stop')->once();
 


### PR DESCRIPTION
As of padraic/mockery@deff698, if you use the [] partial syntax, mockery will
call the mock target's constructor regardless of any args being specified.
