### PR TITLE
Allow an environment name to be passed to App::environment directly

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -230,13 +230,14 @@ class Application extends Container implements HttpKernelInterface, ResponsePrep
 	}
 
 	/**
-	 * Get the current application environment.
+	 * Get or check the current application environment.
 	 *
-	 * @return string
+	 * @param string
+	 * @return string|bool
 	 */
-	public function environment()
+	public function environment($environment = null)
 	{
-		return $this['env'];
+		return $environment ? $environment == $this['env'] : $this['env'];
 	}
 
 	/**


### PR DESCRIPTION
It would be nice to not have to do the comparison in the conditional:

```
if (App::environment('local'))
{
    // some dev stuff
}
```

instead of currently doing this:

```
if (App::environment() == 'local')
{
    // some dev stuff
}
```
