### PR TITLE
Allow doing --create=tablename instead of --table=tablename --create with migrate:make

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MakeCommand.php
@@ -65,6 +65,12 @@ class MakeCommand extends BaseCommand {
 		$table = $this->input->getOption('table');
 
 		$create = $this->input->getOption('create');
+		
+		if ( ! $table and is_string($create))
+		{
+			$table = $create;
+		}
+
 
 		// Now we are ready to write the migration out to disk. Once we've written
 		// the migration out, we will dump-autoload for the entire framework to
@@ -113,7 +119,7 @@ class MakeCommand extends BaseCommand {
 		return array(
 			array('bench', null, InputOption::VALUE_OPTIONAL, 'The workbench the migration belongs to.', null),
 
-			array('create', null, InputOption::VALUE_NONE, 'The table needs to be created.'),
+			array('create', null, InputOption::VALUE_OPTIONAL, 'The table to be created.'),
 
 			array('package', null, InputOption::VALUE_OPTIONAL, 'The package the migration belongs to.', null),
 


### PR DESCRIPTION
As title. Don't know if this is how you would want to code to be done but you now have this PR to remind you of it.
