### PR TITLE
Make NotFoundHttpException only be thrown when dispatching and not internally by the controller

### DIFF
--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -1,7 +1,6 @@
 <?php namespace Illuminate\Routing;
 
 use Closure;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 abstract class Controller {
 
@@ -125,29 +124,6 @@ abstract class Controller {
 	public static function setFilterer(RouteFiltererInterface $filterer)
 	{
 		static::$filterer = $filterer;
-	}
-
-	/**
-	 * Handle calls to missing methods on the controller.
-	 *
-	 * @param  array  $parameters
-	 * @return mixed
-	 */
-	public function missingMethod($parameters)
-	{
-		throw new NotFoundHttpException("Controller method not found.");
-	}
-
-	/**
-	 * Handle calls to missing methods on the controller.
-	 *
-	 * @param  string  $method
-	 * @param  array   $parameters
-	 * @return mixed
-	 */
-	public function __call($method, $parameters)
-	{
-		return $this->missingMethod($parameters);
 	}
 
 }

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Container\Container;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ControllerDispatcher {
 
@@ -87,9 +88,14 @@ class ControllerDispatcher {
      */
     protected function call($instance, $route, $method)
     {
-        $parameters = $route->parametersWithoutNulls();
+        if (is_callable(array($instance, $method)))
+        {
+            $parameters = $route->parametersWithoutNulls();
 
-        return call_user_func_array(array($instance, $method), $parameters);
+            return call_user_func_array(array($instance, $method), $parameters);
+        }
+
+        throw new NotFoundHttpException;
     }
 
     /**

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -27,207 +27,206 @@ class ControllerDispatcher {
 	 * @param  \Illuminate\Container\Container  $container
 	 * @return void
 	 */
-	public function __construct(RouteFiltererInterface $filterer,
-                                Container $container = null)
-    {
+	public function __construct(RouteFiltererInterface $filterer, Container $container = null)
+	{
 		$this->filterer = $filterer;
 		$this->container = $container;
-    }
+	}
 
-    /**
-     * Dispatch a request to a given controller and method.
-     *
-     * @param  \Illuminate\Routing\Route  $route
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $controller
-     * @param  string  $method
-     * @return mixed
-     */
-    public function dispatch(Route $route, Request $request, $controller, $method)
-    {
-        // First we will make an instance of this controller via the IoC container instance
-        // so that we can call the methods on it. We will also apply any "after" filters
-        // to the route so that they will be run by the routers after this processing.
-        $instance = $this->makeController($controller);
+	/**
+	 * Dispatch a request to a given controller and method.
+	 *
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $controller
+	 * @param  string  $method
+	 * @return mixed
+	 */
+	public function dispatch(Route $route, Request $request, $controller, $method)
+	{
+		// First we will make an instance of this controller via the IoC container instance
+		// so that we can call the methods on it. We will also apply any "after" filters
+		// to the route so that they will be run by the routers after this processing.
+		$instance = $this->makeController($controller);
 
-        $this->assignAfter($instance, $route, $request, $method);
+		$this->assignAfter($instance, $route, $request, $method);
 
-    	$response = $this->before($instance, $route, $request, $method);
+		$response = $this->before($instance, $route, $request, $method);
 
-        // If no before filters returned a response we'll call the method on the controller
-        // to get the response to be returned to the router. We will then return it back
-        // out for processing by this router and the after filters can be called then.
-    	if (is_null($response))
-    	{
-            $response = $this->call($instance, $route, $method);
-    	}
+		// If no before filters returned a response we'll call the method on the controller
+		// to get the response to be returned to the router. We will then return it back
+		// out for processing by this router and the after filters can be called then.
+		if (is_null($response))
+		{
+			$response = $this->call($instance, $route, $method);
+		}
 
-    	return $response;
-    }
+		return $response;
+	}
 
-    /**
-     * Make a controller instance via the IoC container.
-     *
-     * @param  string  $controller
-     * @return mixed
-     */
-    protected function makeController($controller)
-    {
-        Controller::setFilterer($this->filterer);
+	/**
+	 * Make a controller instance via the IoC container.
+	 *
+	 * @param  string  $controller
+	 * @return mixed
+	 */
+	protected function makeController($controller)
+	{
+		Controller::setFilterer($this->filterer);
 
-        return $this->container->make($controller);
-    }
+		return $this->container->make($controller);
+	}
 
-    /**
-     * Call the given controller instance method.
-     *
-     * @param  \Illuminate\Routing\Controller  $instance
-     * @param  \Illuminate\Routing\Route  $route
-     * @param  string  $method
-     * @return mixed
-     */
-    protected function call($instance, $route, $method)
-    {
-        if (is_callable(array($instance, $method)))
-        {
-            $parameters = $route->parametersWithoutNulls();
+	/**
+	 * Call the given controller instance method.
+	 *
+	 * @param  \Illuminate\Routing\Controller  $instance
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @param  string  $method
+	 * @return mixed
+	 */
+	protected function call($instance, $route, $method)
+	{
+		if (is_callable(array($instance, $method)))
+		{
+			$parameters = $route->parametersWithoutNulls();
 
-            return call_user_func_array(array($instance, $method), $parameters);
-        }
+			return call_user_func_array(array($instance, $method), $parameters);
+		}
 
-        throw new NotFoundHttpException;
-    }
+		throw new NotFoundHttpException;
+	}
 
-    /**
-     * Call the "before" filters for the controller.
-     *
-     * @param  \Illuminate\Routing\Controller  $instance
-     * @param  \Illuminate\Routing\Route  $route
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $method
-     * @return mixed
-     */
-    protected function before($instance, $route, $request, $method)
-    {
-    	foreach ($instance->getBeforeFilters() as $filter)
-        {
-            if ($this->filterApplies($filter, $request, $method))
-            {
-                // Here we will just check if the filter applies. If it does we will call the filter
-                // and return the responses if it isn't null. If it is null, we will keep hitting
-                // them until we get a response or are finished iterating through this filters.
-                $response = $this->callFilter($filter, $route, $request);
+	/**
+	 * Call the "before" filters for the controller.
+	 *
+	 * @param  \Illuminate\Routing\Controller  $instance
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $method
+	 * @return mixed
+	 */
+	protected function before($instance, $route, $request, $method)
+	{
+		foreach ($instance->getBeforeFilters() as $filter)
+		{
+			if ($this->filterApplies($filter, $request, $method))
+			{
+				// Here we will just check if the filter applies. If it does we will call the filter
+				// and return the responses if it isn't null. If it is null, we will keep hitting
+				// them until we get a response or are finished iterating through this filters.
+				$response = $this->callFilter($filter, $route, $request);
 
-                if ( ! is_null($response)) return $response;
-            }
-        }
-    }
+				if ( ! is_null($response)) return $response;
+			}
+		}
+	}
 
-    /**
-     * Apply the applicable after filters to the route.
-     *
-     * @param  \Illuminate\Routing\Controller  $instance
-     * @param  \Illuminate\Routing\Route  $route
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $method
-     * @return mixed
-     */
-    protected function assignAfter($instance, $route, $request, $method)
-    {
-        foreach ($instance->getAfterFilters() as $filter)
-        {
-            // If the filter applies, we will add it to the route, since it has already been
-            // registered on the filterer by the controller, and will just let the normal
-            // router take care of calling these filters so we do not duplicate logics.
-            if ($this->filterApplies($filter, $request, $method))
-            {
-                $route->after($filter['filter']);
-            }
-        }
-    }
+	/**
+	 * Apply the applicable after filters to the route.
+	 *
+	 * @param  \Illuminate\Routing\Controller  $instance
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $method
+	 * @return mixed
+	 */
+	protected function assignAfter($instance, $route, $request, $method)
+	{
+		foreach ($instance->getAfterFilters() as $filter)
+		{
+			// If the filter applies, we will add it to the route, since it has already been
+			// registered on the filterer by the controller, and will just let the normal
+			// router take care of calling these filters so we do not duplicate logics.
+			if ($this->filterApplies($filter, $request, $method))
+			{
+				$route->after($filter['filter']);
+			}
+		}
+	}
 
-    /**
-     * Determine if the given filter applies to the request.
-     *
-     * @param  array  $filter
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $method
-     */
-    protected function filterApplies($filter, $request, $method)
-    {
-        foreach (array('Only', 'Except', 'On') as $type)
-        {
-            if ($this->{"filterFails{$type}"}($filter, $request, $method))
-            {
-                return false;
-            }
-        }
+	/**
+	 * Determine if the given filter applies to the request.
+	 *
+	 * @param  array  $filter
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $method
+	 */
+	protected function filterApplies($filter, $request, $method)
+	{
+		foreach (array('Only', 'Except', 'On') as $type)
+		{
+			if ($this->{"filterFails{$type}"}($filter, $request, $method))
+			{
+				return false;
+			}
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Determine if the filter fails the "only" cosntraint.
-     *
-     * @param  array  $filter
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $method
-     */
-    protected function filterFailsOnly($filter, $request, $method)
-    {
-        if ( ! isset($filter['options']['only'])) return false;
+	/**
+	 * Determine if the filter fails the "only" cosntraint.
+	 *
+	 * @param  array  $filter
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $method
+	 */
+	protected function filterFailsOnly($filter, $request, $method)
+	{
+		if ( ! isset($filter['options']['only'])) return false;
 
-        return ! in_array($method, (array) $filter['options']['only']);
-    }
+		return ! in_array($method, (array) $filter['options']['only']);
+	}
 
-    /**
-     * Determine if the filter fails the "except" cosntraint.
-     *
-     * @param  array  $filter
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $method
-     */
-    protected function filterFailsExcept($filter, $request, $method)
-    {
-        if ( ! isset($filter['options']['except'])) return false;
+	/**
+	 * Determine if the filter fails the "except" cosntraint.
+	 *
+	 * @param  array  $filter
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $method
+	 */
+	protected function filterFailsExcept($filter, $request, $method)
+	{
+		if ( ! isset($filter['options']['except'])) return false;
 
-        return in_array($method, (array) $filter['options']['except']);
-    }
+		return in_array($method, (array) $filter['options']['except']);
+	}
 
-    /**
-     * Determine if the filter fails the "on" cosntraint.
-     *
-     * @param  array  $filter
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $method
-     */
-    protected function filterFailsOn($filter, $request, $method)
-    {
-        $on = array_get($filter, 'options.on', null);
+	/**
+	 * Determine if the filter fails the "on" cosntraint.
+	 *
+	 * @param  array  $filter
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $method
+	 */
+	protected function filterFailsOn($filter, $request, $method)
+	{
+		$on = array_get($filter, 'options.on', null);
 
-        if (is_null($on)) return false;
+		if (is_null($on)) return false;
 
-        // If the "on" is a string, we will explode it on the pipe so you can set any
-        // amount of methods on the filter constraints and it will still work like
-        // you specified an array. Then we will check if the method is in array.
-        if (is_string($on)) $on = explode('|', $on);
+		// If the "on" is a string, we will explode it on the pipe so you can set any
+		// amount of methods on the filter constraints and it will still work like
+		// you specified an array. Then we will check if the method is in array.
+		if (is_string($on)) $on = explode('|', $on);
 
-        return ! in_array(strtolower($request->getMethod()), $on);
-    }
+		return ! in_array(strtolower($request->getMethod()), $on);
+	}
 
-    /**
-     * Call the given controller filter method.
-     *
-     * @param  array  $filter
-     * @param  \Illuminate\Routing\Route  $route
-     * @param  \Illuminate\Http\Request  $request
-     * @return mixed
-     */
-    protected function callFilter($filter, $route, $request)
-    {
-        extract($filter);
+	/**
+	 * Call the given controller filter method.
+	 *
+	 * @param  array  $filter
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @param  \Illuminate\Http\Request  $request
+	 * @return mixed
+	 */
+	protected function callFilter($filter, $route, $request)
+	{
+		extract($filter);
 
-        return $this->filterer->callRouteFilter($filter, $parameters, $route, $request);
-    }
+		return $this->filterer->callRouteFilter($filter, $parameters, $route, $request);
+	}
 
 }

--- a/tests/Routing/RoutingControllerDispatcherTest.php
+++ b/tests/Routing/RoutingControllerDispatcherTest.php
@@ -25,6 +25,29 @@ class RoutingControllerDispatcherTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('getIndex', $response);
 	}
 
+	/**
+	 * @expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+	 */
+	public function testDispatchToMethodThatDoesntExist()
+	{
+		$request = Request::create('controller');
+		$route = new Route(array('GET'), 'controller', array('uses' => function() {}));
+		$route->bind($request);
+		$dispatcher = new ControllerDispatcher(m::mock('Illuminate\Routing\RouteFiltererInterface'), new Container);
+		$dispatcher->dispatch($route, $request, 'ControllerDispatcherTestControllerStub', 'getDragon');
+	}
+
+	/**
+	 * @expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+	 */
+	public function testDispatchToProtectedMethod()
+	{
+		$request = Request::create('controller');
+		$route = new Route(array('GET'), 'controller', array('uses' => function() {}));
+		$route->bind($request);
+		$dispatcher = new ControllerDispatcher(m::mock('Illuminate\Routing\RouteFiltererInterface'), new Container);
+		$dispatcher->dispatch($route, $request, 'ControllerDispatcherTestControllerStub', 'getFoo');
+	}
 }
 
 
@@ -35,7 +58,7 @@ class ControllerDispatcherTestControllerStub extends Controller {
 		return __FUNCTION__;
 	}
 
-	public function getFoo()
+	protected function getFoo()
 	{
 		return __FUNCTION__;
 	}


### PR DESCRIPTION
Basically the `__call` overloading in the controller to throw the `NotFoundHttpException` feels hacky and like a left over from the old routing system. It causes issues in controllers where if you make a typo or something when calling a method in the controller you will get a not found exception instead of a normal undefined method error. Very misleading and annoying.

Added tests and then the new code with `is_callable` in the dispatcher instead.
