### PR TITLE
Default intended fallback

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -92,7 +92,7 @@ class Redirector {
 	 * @param  bool    $secure
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	public function intended($default, $status = 302, $headers = array(), $secure = null)
+	public function intended($default = '/', $status = 302, $headers = array(), $secure = null)
 	{
 		$path = $this->session->get('url.intended', $default);
 


### PR DESCRIPTION
It would be useful if when there's no default passed to `Redirect::intended()`, and there's no intended URL, it should redirect to `/`.
