### PR TITLE
fixup the Route facade

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -10,7 +10,7 @@ class Route extends Facade {
 	 */
 	public static function is($name)
 	{
-		return static::$app['router']->currentRouteNamed($name);
+		return static::$app['router']->current()->getName() == $name;
 	}
 
 	/**
@@ -21,7 +21,8 @@ class Route extends Facade {
 	 */
 	public static function uses($action)
 	{
-		return static::$app['router']->currentRouteUses($action);
+		$currentAction = $app['router']->current()->getAction();
+		return isset($currentAction['controller']) && $currentAction['controller'] == $action;
 	}
 
 	/**


### PR DESCRIPTION
the `Illuminate\Routing\Router::currentRouteNamed` and `currentRouteUses` methods don't exist anymore since a4d8d950e49dc7d0de153513994a23e9343cfd4e

This should restore the `Route::is` and `Route::uses` methods.

Arthur
