### PR TITLE
[4.1] Correct syntax in workbench composer.json stub

### DIFF
--- a/src/Illuminate/Workbench/stubs/composer.json
+++ b/src/Illuminate/Workbench/stubs/composer.json
@@ -9,14 +9,14 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.x"
+        "illuminate/support": "4.1.*"
     },
     "autoload": {
         "classmap": [
             "src/migrations"
         ],
         "psr-0": {
-            "{{vendor}}\\{{name}}": "src/"
+            "{{vendor}}\\{{name}}\\": "src/"
         }
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
Version constraint should use asterisk (`*`) not `x` as that will only match dev versions (according to [Igor Wiedler](https://igor.io/) ([on IRC](http://colabti.org/irclogger/irclogger_log/composer?date=2013-10-23#l401))).

Additionally, the namespace matching string in `psr-0` should contain the final `\` to ensure the most correct match (see [composer docs](http://getcomposer.org/doc/04-schema.md#psr-0)).
