### PR TITLE
Add Carbon/Datetime argument to cache

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -2,6 +2,8 @@
 
 use Closure;
 use ArrayAccess;
+use DateTime;
+use Carbon\Carbon;
 
 class Repository implements ArrayAccess {
 
@@ -55,11 +57,26 @@ class Repository implements ArrayAccess {
 	}
 
 	/**
+	 * Store an item in the cache.
+	 *
+	 * @param  string              $key
+	 * @param  mixed               $value
+	 * @param  Carbon|Datetime|int $minutes
+	 * @return void
+	 */
+	public function put($key, $value, $minutes)
+	{
+		$minutes = $this->getMinutes($minutes);
+
+		$this->store->put($key, $value, $minutes);
+	}
+
+	/**
 	 * Store an item in the cache if the key does not exist.
 	 *
-	 * @param  string  $key
-	 * @param  mixed   $value
-	 * @param  int     $minutes
+	 * @param  string              $key
+	 * @param  mixed               $value
+	 * @param  Carbon|Datetime|int $minutes
 	 * @return void
 	 */
 	public function add($key, $value, $minutes)
@@ -70,9 +87,9 @@ class Repository implements ArrayAccess {
 	/**
 	 * Get an item from the cache, or store the default value.
 	 *
-	 * @param  string   $key
-	 * @param  int      $minutes
-	 * @param  Closure  $callback
+	 * @param  string              $key
+	 * @param  Carbon|Datetime|int $minutes
+	 * @param  Closure             $callback
 	 * @return mixed
 	 */
 	public function remember($key, $minutes, Closure $callback)
@@ -198,6 +215,29 @@ class Repository implements ArrayAccess {
 	public function offsetUnset($key)
 	{
 		return $this->forget($key);
+	}
+
+	/**
+	 * Calculate the number of minutes with the given duration.
+	 *
+	 * @param  Carbon|DateTime|int  $duration
+	 * @return int
+	 */
+	protected function getMinutes($duration)
+	{
+		if ($duration instanceof DateTime)
+		{
+			$duration = Carbon::instance($duration);
+		}
+
+		if ($duration instanceof Carbon)
+		{
+			return max(0, Carbon::now()->diffInMinutes(false));
+		}
+		else
+		{
+			return intval($duration);
+		}
 	}
 
 	/**

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -9,7 +9,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.x"
+        "illuminate/support": "4.1.x",
+        "nesbot/carbon": "1.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
Allows to cache for a number a minutes but also until a specific date.
$minutes argument can now be an integer or an instance of Carbon or Datetime.
This PR references proposal https://github.com/laravel/framework/issues/2541
