### PR TITLE
Fix Eloquent's builder attempting to iterate over null in withTrashed

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -76,7 +76,7 @@ class Builder {
 	 *
 	 * @var array
 	 */
-	public $wheres;
+	public $wheres = array();
 
 	/**
 	 * The groupings for the query.


### PR DESCRIPTION
When eager-loading a query that contains soft-deleted records, e.g.:

```
class Model extends Eloquent {
  public function related() { return $this->belongsTo('M')->withTrashed(); }
}
Model::with('related')->get();
```

`Eloquent\Builder::withTrashed()` (line 388) will attempt to iterate over `Query\Builder::$wheres`, which is null by default.

Also fixes laravel/laravel#2225
