### PR TITLE
Translator now translates a string containing the character 0

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -98,7 +98,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	{
 		$line = array_get($this->loaded[$namespace][$group][$locale], $item);
 
-		if ($line) return $this->makeReplacements($line, $replace);
+		if ($line != '') return $this->makeReplacements($line, $replace);
 	}
 
 	/**


### PR DESCRIPTION
The equivalence of (bool) "0" to false in PHP causes translations containing "0" to incorrectly return the translation key. Since translations should be strings, checking against an empty string makes more sense.
