### PR TITLE
Added group() method to Translator class

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -102,6 +102,22 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	}
 
 	/**
+	* Retrieve a group from the loaded array.
+	*
+	* @param  string  $group
+	* @param  string  $locale
+	* @return array
+	*/
+	public function group($group, $locale)
+	{
+		list($namespace, $group) = $this->parseKey($group);
+
+		$this->load($namespace, $group, $locale);
+
+		return $this->loaded[$namespace][$group][$locale];
+	}
+
+	/**
 	 * Make the place-holder replacements on a line.
 	 *
 	 * @param  string  $line


### PR DESCRIPTION
The group() method returns the entire array of a translation "group". This allows for possibilities such as offering a current copy of an application's translations through an administration area within the app.
