### PR TITLE
Set the app key in the config after updating it

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -48,6 +48,8 @@ class KeyGenerateCommand extends Command {
 
 		$this->files->put($path, $contents);
 
+		$this->laravel['config']['app.key'] = $key;
+
 		$this->info("Application key [$key] set successfully.");
 	}
 


### PR DESCRIPTION
Set the app key in the config after updating it. This means we can access the app key after setting it with the command.

Currently this code:

```
$this->line(Config::get('app.key'));
$this->call('key:generate');
$this->line(Config::get('app.key'));
```

will produce:

```
YourSecretKey!!!
Application key [bnoEpWg645Ttdew6YJVuQv658NMbgkQ4] set successfully.
YourSecretKey!!!
```

but a better behaviour would be to do this:

```
YourSecretKey!!!
Application key [bnoEpWg645Ttdew6YJVuQv658NMbgkQ4] set successfully.
bnoEpWg645Ttdew6YJVuQv658NMbgkQ4
```
