### PR TITLE
Update Model.php function asDateTime: startofDay(00:00:00) if from Y-m-d...

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2244,7 +2244,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// fields on the database, while still supporting Carbonized conversion.
 		elseif (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $value))
 		{
-			return Carbon::createFromFormat('Y-m-d', $value);
+			return Carbon::createFromFormat('Y-m-d', $value)->startOfDay();
 		}
 
 		// Finally, we will just assume this date is in the format used by default on


### PR DESCRIPTION
As the pull request https://github.com/laravel/framework/pull/2227 was closed but the startOfDay() was only inserted in the function fromDateTime, this pull request adds startOfDay() also to the accessor function (asDateTime), so you can compare two dates without the automatically added incorrect time of the current moment.
