### PR TITLE
Prevents the PHPUnit tests the Illuminate\Foundation\Testing\TestCase class

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -3,7 +3,7 @@
 use Illuminate\View\View;
 use Illuminate\Auth\UserInterface;
 
-class TestCase extends \PHPUnit_Framework_TestCase {
+abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * The Illuminate application instance.


### PR DESCRIPTION
...g\TestCase classes

This would avoid the errors that are displayed when running unit tests in application based on phpunit.xml

Error displayed:
PHPUnit_Framework_AssertionFailedError : No tests found in class "Illuminate\Foundation\Testing\TestCase".
