### PR TITLE
Queue\Worker: do not release the job back to the Queue when it has been deleted

### DIFF
--- a/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
+++ b/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
@@ -54,6 +54,7 @@ class BeanstalkdJob extends Job {
 	 */
 	public function delete()
 	{
+		parent::delete();
 		$this->pheanstalk->delete($this->job);
 	}
 

--- a/src/Illuminate/Queue/Jobs/IronJob.php
+++ b/src/Illuminate/Queue/Jobs/IronJob.php
@@ -73,6 +73,7 @@ class IronJob extends Job {
 	 */
 	public function delete()
 	{
+		parent::delete();
 		if (isset($this->job->pushed)) return;
 
 		$this->iron->deleteMessage($this->queue, $this->job->id);

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -17,6 +17,13 @@ abstract class Job {
 	protected $container;
 
 	/**
+	 * Has the job been deleted for the backend
+	 *
+	 * @var bool
+	 */
+	protected $deleted = false;
+
+	/**
 	 * Fire the job.
 	 *
 	 * @return void
@@ -28,7 +35,20 @@ abstract class Job {
 	 *
 	 * @return void
 	 */
-	abstract public function delete();
+	public function delete()
+	{
+		$this->deleted = true;
+	}
+
+	/**
+	 * Has this job been deleted from the backend
+	 *
+	 * @return bool
+	 */
+	public function isDeleted()
+	{
+		return $this->deleted;
+	}
 
 	/**
 	 * Release the job back into the queue.

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -60,6 +60,7 @@ class RedisJob extends Job {
 	 */
 	public function delete()
 	{
+		parent::delete();
 		$this->redis->deleteReserved($this->queue, $this->job);
 	}
 

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -63,6 +63,7 @@ class SqsJob extends Job {
 	 */
 	public function delete()
 	{
+		parent::delete();
 		$this->sqs->deleteMessage(array(
 
 			'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],

--- a/src/Illuminate/Queue/Jobs/SyncJob.php
+++ b/src/Illuminate/Queue/Jobs/SyncJob.php
@@ -58,6 +58,7 @@ class SyncJob extends Job {
 	 */
 	public function delete()
 	{
+		parent::delete();
 		//
 	}
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -75,7 +75,7 @@ class Worker {
 			// If we catch an exception, we will attempt to release the job back onto
 			// the queue so it is not lost. This will let is be retried at a later
 			// time by another listener (or the same one). We will do that here.
-			$job->release($delay);
+			if (!$job->isDeleted()) $job->release($delay);
 
 			throw $e;
 		}

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -67,7 +67,23 @@ class QueueWorkerTest extends PHPUnit_Framework_TestCase {
 		$worker = new Illuminate\Queue\Worker(m::mock('Illuminate\Queue\QueueManager'));
 		$job = m::mock('Illuminate\Queue\Jobs\Job');
 		$job->shouldReceive('fire')->once()->andReturnUsing(function() { throw new RuntimeException; });
+		$job->shouldReceive('isDeleted')->once()->andReturn(false);
 		$job->shouldReceive('release')->once()->with(5);
+
+		$worker->process($job, 5);
+	}
+
+
+	/**
+	 * @expectedException RuntimeException
+	 */
+	public function testJobIsNotReleasedWhenExceptionIsThrownButJobIsDeleted()
+	{
+		$worker = new Illuminate\Queue\Worker(m::mock('Illuminate\Queue\QueueManager'));
+		$job = m::mock('Illuminate\Queue\Jobs\Job');
+		$job->shouldReceive('fire')->once()->andReturnUsing(function() { throw new RuntimeException; });
+		$job->shouldReceive('isDeleted')->once()->andReturn(true);
+		$job->shouldReceive('release')->never();
 
 		$worker->process($job, 5);
 	}


### PR DESCRIPTION
Releasing a job back to the queue when the job has been deleted by the worker leads to an exception at least with the Beanstalkd backend.

Our use-case is that we want to be able to delete the job as soon as a worker gets his hands on it and forget about it even if the worker fails.
