### PR TITLE
@define: Fallback values for Blade variables

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -34,6 +34,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 		'SectionStart',
 		'SectionStop',
 		'SectionOverwrite',
+		'Definitions',
 	);
 
 	/**
@@ -389,6 +390,19 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 		$pattern = $this->createPlainMatcher('overwrite');
 
 		return preg_replace($pattern, '$1<?php $__env->stopSection(true); ?>$2', $value);
+	}
+
+	/**
+	 * Compile fallback definition statements into valid PHP.
+	 *
+	 * @param  string  $value
+	 * @return string
+	 */
+	protected function compileDefinitions($value)
+	{
+		$pattern = '/(?<!\w)(\s*)@define\((\$[^,]+),\s*(.+)\)/';
+		
+		return preg_replace($pattern, '$1<?php if ( ! isset($2)) $2 = $3; ?>', $value);
 	}
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -134,6 +134,14 @@ this is a comment
  */ ?>';
 		$this->assertEquals($expected, $compiler->compileString($string));
 	}
+	
+	public function testDefinitionsAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$string = '@define($foo, "bar")';
+		$expected = '<?php if ( ! isset($foo)) $foo = "bar"; ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
 
 
 	public function testIfStatementsAreCompiled()


### PR DESCRIPTION
As proposed and discussed in #2283, I implemented default values for variables in Blade templates.
At the top of your Blade file, simply add code like this:

```
@define($variable, 'value')
```

That way, if `$variable` was not passed to the template, it will be set to "value". Very useful for titles and whatnot.
One statement per line.

Sent this to master so that we get some additional testing in before release.

I'm open for discussion regarding the name of the tag. I also like `@default` or `@fallback`. I think somebody recommended `@def` or `@assign`. Taylor, you're the naming expert...
