### PR TITLE
Fix issue in Str::finish() with multicharacter cap.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -74,7 +74,9 @@ class Str {
 	 */
 	public static function finish($value, $cap)
 	{
-		return rtrim($value, $cap).$cap;
+		$quoted = preg_quote($cap, '/');
+
+		return preg_replace('/(?:'.$quoted.')+$/', '', $value).$cap;
 	}
 
 	/**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -72,4 +72,11 @@ class SupportStrTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('Class', 'foo'), Str::parseCallback('Class', 'foo'));
 	}
 
+
+	public function testFinish()
+	{
+		$this->assertEquals('abbc', Str::finish('ab', 'bc'));
+		$this->assertEquals('abbc', Str::finish('abbcbc', 'bc'));
+	}
+
 }


### PR DESCRIPTION
Because the 2nd argument of `trim()` is handled as a character list, and not as a word, `str_finish('ab', 'bc')` was resulting in `abc` instead of the expected `abbc`.

Concerning performances, my proposed method is about 80 % slower than the current one, which I think is still reasonable. For the record, I wrote a version without regex, using some `substr()` and a `while`, but it revealed to be 145 % slower than the current one.
