### PR TITLE
Simplify Str::is() by removing useless special handling of '/'

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -93,14 +93,7 @@ class Str {
 		// Asterisks are translated into zero-or-more regular expression wildcards
 		// to make it convenient to check if the strings starts with the given
 		// pattern such as "library/*", making any string check convenient.
-		if ($pattern !== '/')
-		{
-			$pattern = str_replace('\*', '.*', $pattern).'\z';
-		}
-		else
-		{
-			$pattern = '/$';
-		}
+		$pattern = str_replace('\*', '.*', $pattern).'\z';
 
 		return (bool) preg_match('#^'.$pattern.'#', $value);
 	}


### PR DESCRIPTION
The **only** change is that `str_is('/', "/\n")` now returns false. Which is better btw.
