### PR TITLE
Improvements for cloning Eloquent query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -776,4 +776,14 @@ class Builder {
 		return in_array($method, $this->passthru) ? $result : $this;
 	}
 
+	/**
+	 * Force a clone of the underlying query builder when cloning.
+	 *
+	 * @return void
+	 */
+	public function __clone()
+	{
+		$this->builder = clone $this->builder;
+	}
+
 }

--- a/src/Illuminate/Foundation/changes.json
+++ b/src/Illuminate/Foundation/changes.json
@@ -32,6 +32,7 @@
 		{"message": "Added new 'Auth::viaRemember method to determine if user was authed via 'remember me' cookie.", "backport": null},
 		{"message": "Allow passing a view name to paginator's 'links' method.", "backport": null},
 		{"message": "Added new hasManyThrough relationship type.", "backport": null}
+		{"message": "Allow for easier cloning of Eloquent query builders.", "backport": null}
 	],
 	"4.0.x": [
 		{"message": "Added implode method to query builder and Collection class.", "backport": null},

--- a/src/Illuminate/Foundation/changes.json
+++ b/src/Illuminate/Foundation/changes.json
@@ -31,7 +31,7 @@
 		{"message": "A new packages directory within `lang` can now override package language files.", "backport": null},
 		{"message": "Added new 'Auth::viaRemember method to determine if user was authed via 'remember me' cookie.", "backport": null},
 		{"message": "Allow passing a view name to paginator's 'links' method.", "backport": null},
-		{"message": "Added new hasManyThrough relationship type.", "backport": null}
+		{"message": "Added new hasManyThrough relationship type.", "backport": null},
 		{"message": "Allow for easier cloning of Eloquent query builders.", "backport": null}
 	],
 	"4.0.x": [


### PR DESCRIPTION
Currently, if you clone an Eloquent query builder, the new builder still has a reference to the old query builder, so any changes to the Eloquent builder clone will also affect the original.
