### PR TITLE
Make extend() return manager instance.

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -98,11 +98,13 @@ abstract class Manager {
 	 *
 	 * @param  string   $driver
 	 * @param  Closure  $callback
-	 * @return void
+	 * @return \Illuminate\Support\Manager|static
 	 */
 	public function extend($driver, Closure $callback)
 	{
 		$this->customCreators[$driver] = $callback;
+		
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
Related to #2608. Turning code like this:

```
$this->app->extend('auth', function($auth, $app)
{
    $auth->extend('fluxbb1', function($app)
    {
        $connector = $app['fluxbb1.db.connector'];
        $provider = new UserProvider($connector->connection());

        return new Guard($provider, $app['fluxbb1.cookie.storage']);
    });
    return $auth;
});
```

Into this:

```
$this->app->extend('auth', function($auth, $app)
{
    return $auth->extend('fluxbb1', function($app)
    {
        $connector = $app['fluxbb1.db.connector'];
        $provider = new UserProvider($connector->connection());

        return new Guard($provider, $app['fluxbb1.cookie.storage']);
    });
});
```

Resulting in less boilerplate when extending container bindings.
