### PR TITLE
Improved fail messages on assertSessionHas(Errors)

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -266,7 +266,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 		if (is_null($value))
 		{
-			$this->assertTrue($this->app['session.store']->has($key));
+			$this->assertTrue($this->app['session.store']->has($key), "Session missing key: $key");
 		}
 		else
 		{
@@ -314,7 +314,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		{
 			if (is_int($key))
 			{
-				$this->assertTrue($errors->has($value));
+				$this->assertTrue($errors->has($value), "Session missing error: $value");
 			}
 			else
 			{


### PR DESCRIPTION
Currently if an assertion on the session fails you only get "Failed to assert that false is true."
