### PR TITLE
Add Connection::setPdo

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -650,6 +650,16 @@ class Connection implements ConnectionInterface {
 	}
 
 	/**
+	 * Change the value of the currently used PDO connection.
+	 *
+	 * @param mixed $pdo
+	 */
+	public function setPdo($pdo)
+	{
+		$this->pdo = $pdo;
+	}
+
+	/**
 	 * Get the database connection name.
 	 *
 	 * @return string|null

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -652,9 +652,9 @@ class Connection implements ConnectionInterface {
 	/**
 	 * Change the value of the currently used PDO connection.
 	 *
-	 * @param mixed $pdo
+	 * @param PDO|null $pdo
 	 */
-	public function setPdo($pdo)
+	public function setPdo(PDO $pdo = null)
 	{
 		$this->pdo = $pdo;
 	}


### PR DESCRIPTION
As PDO doesn't have a `close` method, the only way to actively close a PDO connection is to destroy the object holding said connection or set it to `null` – which was currently impossible.

This is not as much for live applications than for testing where hitting a lot of routes causes a `Too many connections` error which can thus be solved by a `DB::connection()->setPdo(null)` in the tearDown.
