### PR TITLE
Add layout to 4.1 controller

### DIFF
--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -18,6 +18,13 @@ abstract class Controller {
 	 * @var array
 	 */
 	protected $afterFilters = array();
+    
+    /**
+     * The layout used by the controller.
+     *
+     * @var \Illuminate\View\View
+     */
+    protected $layout;
 
 	/**
 	 * The route filterer implementation.
@@ -27,6 +34,16 @@ abstract class Controller {
 	protected static $filterer;
 
 	/**
+     * Create a new Controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->setupLayout();
+    }
+    
+    /**
 	 * Register a "before" filter on the controler.
 	 *
 	 * @param  \Closure|string  $name
@@ -161,6 +178,23 @@ abstract class Controller {
 	{
 		static::$filterer = $filterer;
 	}
+    
+    /**
+     * Get the layout used by the controler.
+     *
+     * @return \Illuminate\View\View|null
+     */
+    public function getLayout()
+    {
+        return $this->layout;
+    }
+    
+    /**
+     * Setup the layout used by the controller.
+     *
+     * @return void
+     */
+    protected function setupLayout() {}
 
 	/**
 	 * Handle calls to missing methods on the controller.

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -18,13 +18,13 @@ abstract class Controller {
 	 * @var array
 	 */
 	protected $afterFilters = array();
-    
-    /**
-     * The layout used by the controller.
-     *
-     * @var \Illuminate\View\View
-     */
-    protected $layout;
+
+	/**
+	 * The layout used by the controller.
+	 *
+	 * @var \Illuminate\View\View
+	 */
+	protected $layout;
 
 	/**
 	 * The route filterer implementation.
@@ -34,16 +34,16 @@ abstract class Controller {
 	protected static $filterer;
 
 	/**
-     * Create a new Controller instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        $this->setupLayout();
-    }
-    
-    /**
+	 * Create a new Controller instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		$this->setupLayout();
+	}
+
+	/**
 	 * Register a "before" filter on the controler.
 	 *
 	 * @param  \Closure|string  $name
@@ -178,23 +178,23 @@ abstract class Controller {
 	{
 		static::$filterer = $filterer;
 	}
-    
-    /**
-     * Get the layout used by the controler.
-     *
-     * @return \Illuminate\View\View|null
-     */
-    public function getLayout()
-    {
-        return $this->layout;
-    }
-    
-    /**
-     * Setup the layout used by the controller.
-     *
-     * @return void
-     */
-    protected function setupLayout() {}
+
+	/**
+	 * Get the layout used by the controler.
+	 *
+	 * @return \Illuminate\View\View|null
+	 */
+	public function getLayout()
+	{
+		return $this->layout;
+	}
+
+	/**
+	 * Setup the layout used by the controller.
+	 *
+	 * @return void
+	 */
+	protected function setupLayout() {}
 
 	/**
 	 * Handle calls to missing methods on the controller.

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -60,14 +60,14 @@ class ControllerDispatcher {
     	{
             $response = $this->call($instance, $route, $method);
     	}
-        
-        // If no response is returned from the controller action and a layout is being
-        // used we will assume we want to just return the layout view as any nested
-        // views were probably bound on this view during this controller actions.
-        if (is_null($response) && ! is_null($instance->getLayout()))
-        {
-            $response = $instance->getLayout();
-        }
+
+		// If no response is returned from the controller action and a layout is being
+		// used we will assume we want to just return the layout view as any nested
+		// views were probably bound on this view during this controller actions.
+		if (is_null($response) && ! is_null($instance->getLayout()))
+		{
+			$response = $instance->getLayout();
+		}
 
     	return $response;
     }

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -60,6 +60,14 @@ class ControllerDispatcher {
     	{
             $response = $this->call($instance, $route, $method);
     	}
+        
+        // If no response is returned from the controller action and a layout is being
+        // used we will assume we want to just return the layout view as any nested
+        // views were probably bound on this view during this controller actions.
+        if (is_null($response) && ! is_null($instance->getLayout()))
+        {
+            $response = $instance->getLayout();
+        }
 
     	return $response;
     }


### PR DESCRIPTION
Used `Controller::__construct()` to call `setupLayout()` so it doesn't have to be made public, making 4.0->4.1 migration easier.
Otherwise it's the same as is in 4.0.
