### PR TITLE
Fixed Backward Compatibility when using Controller::setupLayout() introduced in #2624

### DIFF
--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -34,16 +34,6 @@ abstract class Controller {
 	protected $layout;
 
 	/**
-	 * Create a new Controller instance.
-	 *
-	 * @return void
-	 */
-	public function __construct()
-	{
-		$this->setupLayout();
-	}
-
-	/**
 	 * Register a "before" filter on the controler.
 	 *
 	 * @param  \Closure|string  $name
@@ -187,6 +177,30 @@ abstract class Controller {
 	protected function setupLayout() {}
 
 	/**
+	 * Execute an action on the controller.
+	 *
+	 * @param string  $method
+	 * @param array   $parameters
+	 * @return \Symfony\Component\HttpFoundation\Response
+	 */
+	public function callAction($method, $parameters)
+	{
+		$this->setupLayout();
+
+		$response = call_user_func_array(array($this, $method), $parameters);
+
+		// If no response is returned from the controller action and a layout is being
+		// used we will assume we want to just return the layout view as any nested
+		// views were probably bound on this view during this controller actions.
+		if (is_null($response) and ! is_null($this->layout))
+		{
+			$response = $this->layout;
+		}
+
+		return $response;
+	}
+
+	/**
 	 * Get the layout used by the controller.
 	 *
 	 * @return \Illuminate\View\View|null
@@ -200,7 +214,7 @@ abstract class Controller {
 	 * Handle calls to missing methods on the controller.
 	 *
 	 * @param  string  $method
-	 * @param  array  $parameters
+	 * @param  array   $parameters
 	 * @return mixed
 	 */
 	public function missingMethod($method, $parameters)

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -201,16 +201,6 @@ abstract class Controller {
 	}
 
 	/**
-	 * Get the layout used by the controller.
-	 *
-	 * @return \Illuminate\View\View|null
-	 */
-	public function getLayout()
-	{
-		return $this->layout;
-	}
-
-	/**
 	 * Handle calls to missing methods on the controller.
 	 *
 	 * @param  string  $method

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -27,209 +27,209 @@ class ControllerDispatcher {
 	 * @return void
 	 */
 	public function __construct(RouteFiltererInterface $filterer,
-                                Container $container = null)
-    {
+								Container $container = null)
+	{
 		$this->filterer = $filterer;
 		$this->container = $container;
-    }
+	}
 
-    /**
-     * Dispatch a request to a given controller and method.
-     *
-     * @param  \Illuminate\Routing\Route  $route
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $controller
-     * @param  string  $method
-     * @return mixed
-     */
-    public function dispatch(Route $route, Request $request, $controller, $method)
-    {
-        // First we will make an instance of this controller via the IoC container instance
-        // so that we can call the methods on it. We will also apply any "after" filters
-        // to the route so that they will be run by the routers after this processing.
-        $instance = $this->makeController($controller);
+	/**
+	 * Dispatch a request to a given controller and method.
+	 *
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $controller
+	 * @param  string  $method
+	 * @return mixed
+	 */
+	public function dispatch(Route $route, Request $request, $controller, $method)
+	{
+		// First we will make an instance of this controller via the IoC container instance
+		// so that we can call the methods on it. We will also apply any "after" filters
+		// to the route so that they will be run by the routers after this processing.
+		$instance = $this->makeController($controller);
 
-        $this->assignAfter($instance, $route, $request, $method);
+		$this->assignAfter($instance, $route, $request, $method);
 
-    	$response = $this->before($instance, $route, $request, $method);
+		$response = $this->before($instance, $route, $request, $method);
 
-        // If no before filters returned a response we'll call the method on the controller
-        // to get the response to be returned to the router. We will then return it back
-        // out for processing by this router and the after filters can be called then.
-    	if (is_null($response))
-    	{
-            $response = $this->call($instance, $route, $method);
-    	}
+		// If no before filters returned a response we'll call the method on the controller
+		// to get the response to be returned to the router. We will then return it back
+		// out for processing by this router and the after filters can be called then.
+		if (is_null($response))
+		{
+			$response = $this->call($instance, $route, $method);
+		}
 
-        // If no response has been returned thus far and a controller "layout" has been set
-        // then we will go ahead and set the layout as the response to the method, which
-        // lets a controller define a single layout and append to it from all methods.
+		// If no response has been returned thus far and a controller "layout" has been set
+		// then we will go ahead and set the layout as the response to the method, which
+		// lets a controller define a single layout and append to it from all methods.
 		if (is_null($response) && ! is_null($instance->getLayout()))
 		{
 			$response = $instance->getLayout();
 		}
 
-    	return $response;
-    }
+		return $response;
+	}
 
-    /**
-     * Make a controller instance via the IoC container.
-     *
-     * @param  string  $controller
-     * @return mixed
-     */
-    protected function makeController($controller)
-    {
-        Controller::setFilterer($this->filterer);
+	/**
+	 * Make a controller instance via the IoC container.
+	 *
+	 * @param  string  $controller
+	 * @return mixed
+	 */
+	protected function makeController($controller)
+	{
+		Controller::setFilterer($this->filterer);
 
-        return $this->container->make($controller);
-    }
+		return $this->container->make($controller);
+	}
 
-    /**
-     * Call the given controller instance method.
-     *
-     * @param  \Illuminate\Routing\Controller  $instance
-     * @param  \Illuminate\Routing\Route  $route
-     * @param  string  $method
-     * @return mixed
-     */
-    protected function call($instance, $route, $method)
-    {
-        $parameters = $route->parametersWithoutNulls();
+	/**
+	 * Call the given controller instance method.
+	 *
+	 * @param  \Illuminate\Routing\Controller  $instance
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @param  string  $method
+	 * @return mixed
+	 */
+	protected function call($instance, $route, $method)
+	{
+		$parameters = $route->parametersWithoutNulls();
 
-        return call_user_func_array(array($instance, $method), $parameters);
-    }
+		return call_user_func_array(array($instance, $method), $parameters);
+	}
 
-    /**
-     * Call the "before" filters for the controller.
-     *
-     * @param  \Illuminate\Routing\Controller  $instance
-     * @param  \Illuminate\Routing\Route  $route
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $method
-     * @return mixed
-     */
-    protected function before($instance, $route, $request, $method)
-    {
-    	foreach ($instance->getBeforeFilters() as $filter)
-        {
-            if ($this->filterApplies($filter, $request, $method))
-            {
-                // Here we will just check if the filter applies. If it does we will call the filter
-                // and return the responses if it isn't null. If it is null, we will keep hitting
-                // them until we get a response or are finished iterating through this filters.
-                $response = $this->callFilter($filter, $route, $request);
+	/**
+	 * Call the "before" filters for the controller.
+	 *
+	 * @param  \Illuminate\Routing\Controller  $instance
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $method
+	 * @return mixed
+	 */
+	protected function before($instance, $route, $request, $method)
+	{
+		foreach ($instance->getBeforeFilters() as $filter)
+		{
+			if ($this->filterApplies($filter, $request, $method))
+			{
+				// Here we will just check if the filter applies. If it does we will call the filter
+				// and return the responses if it isn't null. If it is null, we will keep hitting
+				// them until we get a response or are finished iterating through this filters.
+				$response = $this->callFilter($filter, $route, $request);
 
-                if ( ! is_null($response)) return $response;
-            }
-        }
-    }
+				if ( ! is_null($response)) return $response;
+			}
+		}
+	}
 
-    /**
-     * Apply the applicable after filters to the route.
-     *
-     * @param  \Illuminate\Routing\Controller  $instance
-     * @param  \Illuminate\Routing\Route  $route
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $method
-     * @return mixed
-     */
-    protected function assignAfter($instance, $route, $request, $method)
-    {
-        foreach ($instance->getAfterFilters() as $filter)
-        {
-            // If the filter applies, we will add it to the route, since it has already been
-            // registered on the filterer by the controller, and will just let the normal
-            // router take care of calling these filters so we do not duplicate logics.
-            if ($this->filterApplies($filter, $request, $method))
-            {
-                $route->after($filter['filter']);
-            }
-        }
-    }
+	/**
+	 * Apply the applicable after filters to the route.
+	 *
+	 * @param  \Illuminate\Routing\Controller  $instance
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $method
+	 * @return mixed
+	 */
+	protected function assignAfter($instance, $route, $request, $method)
+	{
+		foreach ($instance->getAfterFilters() as $filter)
+		{
+			// If the filter applies, we will add it to the route, since it has already been
+			// registered on the filterer by the controller, and will just let the normal
+			// router take care of calling these filters so we do not duplicate logics.
+			if ($this->filterApplies($filter, $request, $method))
+			{
+				$route->after($filter['filter']);
+			}
+		}
+	}
 
-    /**
-     * Determine if the given filter applies to the request.
-     *
-     * @param  array  $filter
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $method
-     */
-    protected function filterApplies($filter, $request, $method)
-    {
-        foreach (array('Only', 'Except', 'On') as $type)
-        {
-            if ($this->{"filterFails{$type}"}($filter, $request, $method))
-            {
-                return false;
-            }
-        }
+	/**
+	 * Determine if the given filter applies to the request.
+	 *
+	 * @param  array  $filter
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $method
+	 */
+	protected function filterApplies($filter, $request, $method)
+	{
+		foreach (array('Only', 'Except', 'On') as $type)
+		{
+			if ($this->{"filterFails{$type}"}($filter, $request, $method))
+			{
+				return false;
+			}
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Determine if the filter fails the "only" cosntraint.
-     *
-     * @param  array  $filter
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $method
-     */
-    protected function filterFailsOnly($filter, $request, $method)
-    {
-        if ( ! isset($filter['options']['only'])) return false;
+	/**
+	 * Determine if the filter fails the "only" cosntraint.
+	 *
+	 * @param  array  $filter
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $method
+	 */
+	protected function filterFailsOnly($filter, $request, $method)
+	{
+		if ( ! isset($filter['options']['only'])) return false;
 
-        return ! in_array($method, (array) $filter['options']['only']);
-    }
+		return ! in_array($method, (array) $filter['options']['only']);
+	}
 
-    /**
-     * Determine if the filter fails the "except" cosntraint.
-     *
-     * @param  array  $filter
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $method
-     */
-    protected function filterFailsExcept($filter, $request, $method)
-    {
-        if ( ! isset($filter['options']['except'])) return false;
+	/**
+	 * Determine if the filter fails the "except" cosntraint.
+	 *
+	 * @param  array  $filter
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $method
+	 */
+	protected function filterFailsExcept($filter, $request, $method)
+	{
+		if ( ! isset($filter['options']['except'])) return false;
 
-        return in_array($method, (array) $filter['options']['except']);
-    }
+		return in_array($method, (array) $filter['options']['except']);
+	}
 
-    /**
-     * Determine if the filter fails the "on" cosntraint.
-     *
-     * @param  array  $filter
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $method
-     */
-    protected function filterFailsOn($filter, $request, $method)
-    {
-        $on = array_get($filter, 'options.on', null);
+	/**
+	 * Determine if the filter fails the "on" cosntraint.
+	 *
+	 * @param  array  $filter
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  string  $method
+	 */
+	protected function filterFailsOn($filter, $request, $method)
+	{
+		$on = array_get($filter, 'options.on', null);
 
-        if (is_null($on)) return false;
+		if (is_null($on)) return false;
 
-        // If the "on" is a string, we will explode it on the pipe so you can set any
-        // amount of methods on the filter constraints and it will still work like
-        // you specified an array. Then we will check if the method is in array.
-        if (is_string($on)) $on = explode('|', $on);
+		// If the "on" is a string, we will explode it on the pipe so you can set any
+		// amount of methods on the filter constraints and it will still work like
+		// you specified an array. Then we will check if the method is in array.
+		if (is_string($on)) $on = explode('|', $on);
 
-        return ! in_array(strtolower($request->getMethod()), $on);
-    }
+		return ! in_array(strtolower($request->getMethod()), $on);
+	}
 
-    /**
-     * Call the given controller filter method.
-     *
-     * @param  array  $filter
-     * @param  \Illuminate\Routing\Route  $route
-     * @param  \Illuminate\Http\Request  $request
-     * @return mixed
-     */
-    protected function callFilter($filter, $route, $request)
-    {
-        extract($filter);
+	/**
+	 * Call the given controller filter method.
+	 *
+	 * @param  array  $filter
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @param  \Illuminate\Http\Request  $request
+	 * @return mixed
+	 */
+	protected function callFilter($filter, $route, $request)
+	{
+		extract($filter);
 
-        return $this->filterer->callRouteFilter($filter, $parameters, $route, $request);
-    }
+		return $this->filterer->callRouteFilter($filter, $parameters, $route, $request);
+	}
 
 }

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -97,7 +97,7 @@ class ControllerDispatcher {
 	{
 		$parameters = $route->parametersWithoutNulls();
 
-		return call_user_func_array(array($instance, $method), $parameters);
+		return $instance->callAction($method, $parameters);
 	}
 
 	/**

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -61,14 +61,6 @@ class ControllerDispatcher {
 			$response = $this->call($instance, $route, $method);
 		}
 
-		// If no response has been returned thus far and a controller "layout" has been set
-		// then we will go ahead and set the layout as the response to the method, which
-		// lets a controller define a single layout and append to it from all methods.
-		if (is_null($response) && ! is_null($instance->getLayout()))
-		{
-			$response = $instance->getLayout();
-		}
-
 		return $response;
 	}
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -223,80 +223,80 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		return $this->addRoute($methods, $uri, $action);
 	}
 
-    /**
-     * Register an array of controllers with wildcard routing.
-     *
-     * @param  array  $controllers
-     * @return void
-     */
-    public function controllers(array $controllers)
-    {
-            foreach ($controllers as $uri => $name)
-            {
-                    $this->controller($uri, $name);
-            }
-    }
+	/**
+	 * Register an array of controllers with wildcard routing.
+	 *
+	 * @param  array  $controllers
+	 * @return void
+	 */
+	public function controllers(array $controllers)
+	{
+		foreach ($controllers as $uri => $name)
+		{
+			$this->controller($uri, $name);
+		}
+	}
 
-    /**
-     * Route a controller to a URI with wildcard routing.
-     *
-     * @param  string  $uri
-     * @param  string  $controller
-     * @param  array   $names
-     * @return \Illuminate\Routing\Route
-     */
-    public function controller($uri, $controller, $names = array())
-    {
-            $routable = $this->getInspector()->getRoutable($controller, $uri);
+	/**
+	 * Route a controller to a URI with wildcard routing.
+	 *
+	 * @param  string  $uri
+	 * @param  string  $controller
+	 * @param  array   $names
+	 * @return \Illuminate\Routing\Route
+	 */
+	public function controller($uri, $controller, $names = array())
+	{
+		$routable = $this->getInspector()->getRoutable($controller, $uri);
 
-            // When a controller is routed using this method, we use Reflection to parse
-            // out all of the routable methods for the controller, then register each
-            // route explicitly for the developers, so reverse routing is possible.
-            foreach ($routable as $method => $routes)
-            {
-                    foreach ($routes as $route)
-                    {
-                            $this->registerInspected($route, $controller, $method, $names);
-                    }
-            }
+		// When a controller is routed using this method, we use Reflection to parse
+		// out all of the routable methods for the controller, then register each
+		// route explicitly for the developers, so reverse routing is possible.
+		foreach ($routable as $method => $routes)
+		{
+			foreach ($routes as $route)
+			{
+				$this->registerInspected($route, $controller, $method, $names);
+			}
+		}
 
-            $this->addFallthroughRoute($controller, $uri);
-    }
+		$this->addFallthroughRoute($controller, $uri);
+	}
 
-    /**
-     * Register an inspected controller route.
-     *
-     * @param  array   $route
-     * @param  string  $controller
-     * @param  string  $method
-     * @param  array   $names
-     * @return void
-     */
-    protected function registerInspected($route, $controller, $method, &$names)
-    {
-            $action = array('uses' => $controller.'@'.$method);
+	/**
+	 * Register an inspected controller route.
+	 *
+	 * @param  array   $route
+	 * @param  string  $controller
+	 * @param  string  $method
+	 * @param  array   $names
+	 * @return void
+	 */
+	protected function registerInspected($route, $controller, $method, &$names)
+	{
+		$action = array('uses' => $controller.'@'.$method);
 
-            // If a given controller method has been named, we will assign the name to the
-            // controller action array, which provides for a short-cut to method naming
-            // so you don't have to define an individual route for these controllers.
-            $action['as'] = array_pull($names, $method);
+		// If a given controller method has been named, we will assign the name to the
+		// controller action array, which provides for a short-cut to method naming
+		// so you don't have to define an individual route for these controllers.
+		$action['as'] = array_pull($names, $method);
 
-            $this->{$route['verb']}($route['uri'], $action);
-    }
+		$this->{$route['verb']}($route['uri'], $action);
+	}
 
-    /**
-     * Add a fallthrough route for a controller.
-     *
-     * @param  string  $controller
-     * @param  string  $uri
-     * @return void
-     */
-    protected function addFallthroughRoute($controller, $uri)
-    {
-            $missing = $this->any($uri.'/{_missing}', $controller.'@missingMethod');
+	/**
+	 * Add a fallthrough route for a controller.
+	 *
+	 * @param  string  $controller
+	 * @param  string  $uri
+	 * @return void
+	 */
+	protected function addFallthroughRoute($controller, $uri)
+	{
+		$missing = $this->any($uri.'/{_missing}', $controller.'@missingMethod');
 
-            $missing->where('_missing', '(.*)');
-    }
+		$missing->where('_missing', '(.*)');
+	}
 
 	/**
 	 * Route a resource to a controller.

--- a/tests/Routing/RoutingControllerDispatcherTest.php
+++ b/tests/Routing/RoutingControllerDispatcherTest.php
@@ -9,8 +9,15 @@ use Illuminate\Routing\ControllerDispatcher;
 
 class RoutingControllerDispatcherTest extends PHPUnit_Framework_TestCase {
 
+	public function setUp()
+	{
+		$_SERVER['ControllerDispatcherTestControllerStub'] = null;
+	}
+
+
 	public function tearDown()
 	{
+		unset($_SERVER['ControllerDispatcherTestControllerStub']);
 		m::close();
 	}
 
@@ -21,14 +28,28 @@ class RoutingControllerDispatcherTest extends PHPUnit_Framework_TestCase {
 		$route = new Route(array('GET'), 'controller', array('uses' => function() {}));
 		$route->bind($request);
 		$dispatcher = new ControllerDispatcher(m::mock('Illuminate\Routing\RouteFiltererInterface'), new Container);
+
+		$this->assertNull($_SERVER['ControllerDispatcherTestControllerStub']);
+
 		$response = $dispatcher->dispatch($route, $request, 'ControllerDispatcherTestControllerStub', 'getIndex');
 		$this->assertEquals('getIndex', $response);
+		$this->assertEquals('setupLayout', $_SERVER['ControllerDispatcherTestControllerStub']);
 	}
 
 }
 
 
 class ControllerDispatcherTestControllerStub extends Controller {
+
+	public function __construct()
+	{
+		// construct shouldn't affect setupLayout.
+	}
+
+	protected function setupLayout()
+	{
+		$_SERVER['ControllerDispatcherTestControllerStub'] = __FUNCTION__;
+	}
 
 	public function getIndex()
 	{


### PR DESCRIPTION
A few note:
- Fixed multiple tabs vs spaces indentation for the ocd, to view except whitespace changes see https://github.com/laravel/framework/pull/2629/files?w=1.
- Re-add `Illuminate\Routing\Controller::callAction()` to 4.1, except it doesn't handle filters (now managed from the new `ControllerDispatcher`), this is safer since the method exist in 4.0.
- This is slightly less breaking than introducing `getLayout` method. E.g: I could have `GET foo/layout` and goes to `FooController@getLayout`.
- Add supporting test cases.

Feel free to come out with alternative implementation without merging this PR :+1:, No drama needed. :smile: 
