### PR TITLE
Added missing tests for Tagged Caches

### DIFF
--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -44,6 +44,23 @@ class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testTagsWithStringArgument()
+	{
+		$store = new ArrayStore;
+		$store->tags('bop')->put('foo', 'bar', 10);
+		$this->assertEquals('bar', $store->tags('bop')->get('foo'));
+	}
+
+
+	public function testTagsCacheForever()
+	{
+		$store = new ArrayStore;
+		$tags = array('bop', 'zap');
+		$store->tags($tags)->forever('foo', 'bar');
+		$this->assertEquals('bar', $store->tags($tags)->get('foo'));
+	}
+
+
 	public function testRedisCacheTagsPushForeverKeysCorrectly()
 	{
 		$store = m::mock('Illuminate\Cache\StoreInterface');


### PR DESCRIPTION
Just two tests I wrote trying to reproduce the issue #2635.  I wasn't able to reproduce the bug, but I may have ruled out some potential issues. Seemed worth pushing the test cases, since they test previously uncovered code, I think.
