### PR TITLE
Added "booting" and "booted" events to a model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -242,8 +242,12 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		if ( ! isset(static::$booted[get_class($this)]))
 		{
 			static::$booted[get_class($this)] = true;
+			
+			$this->fireModelEvent('booting', false);
 
 			static::boot();
+			
+			$this->fireModelEvent('booted', false);
 		}
 
 		$this->syncOriginal();


### PR DESCRIPTION
I have a use-case where, I would like to hook into the booting event of any given model, without touching that model itself (such as, hooking into the boot sequence of all [including third party] models).

This PR should add that functionality.
