### PR TITLE
[Proposal] Let BelongsToMany->sync return affected IDs 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -492,10 +492,13 @@ class BelongsToMany extends Relation {
 	 *
 	 * @param  array  $ids
 	 * @param  bool   $detaching
-	 * @return void
+	 * @return array  Array with attached, detatched and updated relation IDs
 	 */
 	public function sync(array $ids, $detaching = true)
 	{
+		// Keep track of what is changed
+		$changes = array('attached' => array(), 'detached' => array(), 'updated' => array());
+
 		// First we need to attach any of the associated models that are not currently
 		// in this joining table. We'll spin through the given IDs, checking to see
 		// if they exist in the array of current ones, and if not we will insert.
@@ -511,14 +514,17 @@ class BelongsToMany extends Relation {
 		if ($detaching && count($detach) > 0)
 		{
 			$this->detach($detach);
+			$changes['detached'] = (array) array_walk($detach, 'intval');
 		}
 
 		// Now we are finally ready to attach the new records. Note that we'll disable
 		// touching until after the entire operation is complete so we don't fire a
 		// ton of touch operations until we are totally done syncing the records.
-		$this->attachNew($records, $current, false);
+		$changes = array_merge($changes, $this->attachNew($records, $current, false));
 
 		$this->touchIfTouching();
+
+		return $changes;
 	}
 
 	/**
@@ -550,10 +556,13 @@ class BelongsToMany extends Relation {
 	 * @param  array  $records
 	 * @param  array  $current
 	 * @param  bool   $touch
-	 * @return void
+	 * @return array  Array with newly attached and updated relation IDs
 	 */
 	protected function attachNew(array $records, array $current, $touch = true)
 	{
+		// Keep track of what is changed
+		$changes = array('attached' => array(), 'updated' => array());
+
 		foreach ($records as $id => $attributes)
 		{
 			// If the ID is not in the list of existing pivot IDs, we will insert a new pivot
@@ -562,12 +571,15 @@ class BelongsToMany extends Relation {
 			if ( ! in_array($id, $current))
 			{
 				$this->attach($id, $attributes, $touch);
+				$changes['attached'][] = (int) $id;
 			}
 			elseif (count($attributes) > 0)
 			{
 				$this->updateExistingPivot($id, $attributes, $touch);
+				$changes['updated'][] = (int) $id;
 			}
 		}
+		return $changes;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -488,11 +488,12 @@ class BelongsToMany extends Relation {
 	}
 
 	/**
-	 * Sync the intermediate tables with a list of IDs.
+	 * Sync the intermediate tables with a list of IDs, and return
+	 * an array with the detached, attached and updated IDs
 	 *
 	 * @param  array  $ids
 	 * @param  bool   $detaching
-	 * @return array  Array with attached, detatched and updated relation IDs
+	 * @return array
 	 */
 	public function sync(array $ids, $detaching = true)
 	{
@@ -551,12 +552,13 @@ class BelongsToMany extends Relation {
 	}
 
 	/**
-	 * Attach all of the IDs that aren't in the current array.
+	 * Attach all of the IDs that aren't in the current array, and return
+	 * an array with the newly attached and updated IDs
 	 *
 	 * @param  array  $records
 	 * @param  array  $current
 	 * @param  bool   $touch
-	 * @return array  Array with newly attached and updated relation IDs
+	 * @return array
 	 */
 	protected function attachNew(array $records, array $current, $touch = true)
 	{

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -235,7 +235,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation->getRelated()->shouldReceive('touches')->andReturn(false);
 		$relation->getParent()->shouldReceive('touches')->andReturn(false);
 
-		$relation->sync($list);
+		$this->assertEquals(array('attached' => array(4), 'detached' => array(1), 'updated' => array()), $relation->sync($list));
 	}
 
 
@@ -250,7 +250,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testSyncMethodSyncsIntermediateTableWithGivenArrayAndAttributes()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach', 'touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach', 'touchIfTouching', 'updateExistingPivot'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -258,10 +258,11 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
 		$query->shouldReceive('lists')->once()->with('role_id')->andReturn(array(1, 2, 3));
 		$relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(array('foo' => 'bar')), $this->equalTo(false));
+		$relation->expects($this->once())->method('updateExistingPivot')->with($this->equalTo(3), $this->equalTo(array('baz' => 'qux')), $this->equalTo(false));
 		$relation->expects($this->once())->method('detach')->with($this->equalTo(array(1)));
 		$relation->expects($this->once())->method('touchIfTouching');
 
-		$relation->sync(array(2, 3, 4 => array('foo' => 'bar')));
+		$this->assertEquals(array('attached' => array(4), 'detached' => array(1), 'updated' => array(3)), $relation->sync(array(2, 3 => array('baz' => 'qux'), 4 => array('foo' => 'bar'))));
 	}
 
 


### PR DESCRIPTION
I think a useful feature would be if the sync method somehow returned the IDs of the relationships affected by the sync.

The only way I could think of would be to return an array containing sub-arrays like this

``` php
array(
    // The IDs that were newly attached because of the sync
    'attached' => array(1,2,3),

    // The IDs that were detached during the sync
    'detached' => array(4,5),

    // The synced IDs that already existed, but had attributes, 
    // thus being updated
    'updated'  => array(6,7)
);
```

This solution feels a little clumsy, and not that elegant, but it's the simplest solution I've come to think of yet.
