### PR TITLE
fix breaking change by adding function back w/ updated logic

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1376,15 +1376,15 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		return $this->current()->getName() == $name;
 	}
 
-	/**
-     * Get the current route action.
-     *
-     * @return string|null
-     */
+    /**
+	 * Get the current route action.
+	 *
+	 * @return string|null
+	 */
     public function currentRouteAction()
     {
         $current = $this->current()->getAction();
-    
+
         return isset($action['controller']) ? $action['controller'] : null;
     }
 
@@ -1398,7 +1398,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	{
 		$current = $this->current()->getAction();
 
-		return isset($current['controller']) && $current['controller'] == $action;
+		return $this->currentRouteAction() == $action;
 	}
 
 	/**


### PR DESCRIPTION
`Route::currentRouteAction()` got removed, this PR adds the function back with logic to correctly return the same data to make the change non-breaking
