### PR TITLE
New method: Collection->process()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -196,11 +196,23 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Run a map over each of the items.
 	 *
 	 * @param  Closure  $callback
-	 * @return array
+	 * @return \Illuminate\Support\Collection
 	 */
 	public function map(Closure $callback)
 	{
 		return new static(array_map($callback, $this->items, array_keys($this->items)));
+	}
+
+	/**
+	 * Process each of the items using a callback.
+	 *
+	 * @param  Closure  $callback
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function process(Closure $callback)
+	{
+		$this->items = array_map($callback, $this->items);
+		return $this;
 	}
 
 	/**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -204,12 +204,12 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
-	 * Process each of the items using a callback.
+	 * Transform each item in the collection using a callback.
 	 *
 	 * @param  Closure  $callback
 	 * @return \Illuminate\Support\Collection
 	 */
-	public function process(Closure $callback)
+	public function transform(Closure $callback)
 	{
 		$this->items = array_map($callback, $this->items);
 		return $this;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -265,6 +265,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('foo', 'bar'), $data->lists('some'));
 	}
 
+	public function testProcess()
+	{
+		$data = new Collection(array('taylor', 'colin', 'shawn'));
+		$data->process(function($item) { return strrev($item); });
+		$this->assertEquals(array('rolyat', 'niloc', 'nwahs'), array_values($data->all()));
+	}
+
 }
 
 class TestAccessorEloquentTestStub

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -265,10 +265,10 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('foo', 'bar'), $data->lists('some'));
 	}
 
-	public function testProcess()
+	public function testTransform()
 	{
 		$data = new Collection(array('taylor', 'colin', 'shawn'));
-		$data->process(function($item) { return strrev($item); });
+		$data->transform(function($item) { return strrev($item); });
 		$this->assertEquals(array('rolyat', 'niloc', 'nwahs'), array_values($data->all()));
 	}
 


### PR DESCRIPTION
Runs the given callback over all the collection's elements, replacing them "inline" with the result of the callback.  Basically, a shortcut for doing:

``` php
$collection = $collection->map( $callback )
```
