### PR TITLE
Update Model.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1798,8 +1798,12 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function getForeignKey()
 	{
-		return snake_case(class_basename($this)).'_id';
-	}
+		if(is_null($this->table))
+		{
+			return snake_case(class_basename($this)).'_id';
+		}
+		
+		return  snake_case(str_singular($this->table)).'_id' ;	}
 
 	/**
 	 * Get the hidden attributes for the model.


### PR DESCRIPTION
If we specify/map $table name, same rule should apply for the foreign key rule.

But when class extends Eloquent and its name differs from the table name (when using Repositories), then we need to explicitly specify the relation's foreign key. $this->('someModel', 'table_fk'). Otherwise, it eats memory.
