### PR TITLE
Update MySqlConnector.php to fix a bug when the unix_socket param is used

### DIFF
--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -29,6 +29,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(array('options')))->will($this->returnValue($connection));
 		$connection->shouldReceive('prepare')->once()->with('set names \'utf8\' collate \'utf8_unicode_ci\'')->andReturn($connection);
 		$connection->shouldReceive('execute')->once();
+		$connection->shouldReceive('exec');
 		$result = $connector->connect($config);
 
 		$this->assertTrue($result === $connection);
@@ -39,8 +40,8 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 	{
 		return array(
 			array('mysql:host=foo;dbname=bar', array('host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
-			array('mysql:host=foo;dbname=bar;port=111', array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
-			array('mysql:host=foo;dbname=bar;port=111;unix_socket=baz', array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
+			array('mysql:host=foo;port=111;dbname=bar', array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
+			array('mysql:unix_socket=baz;dbname=bar', array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
 		);
 	}
 


### PR DESCRIPTION
Fix a bug when the unix_socket param is used.
1/ According to the PHP doc, unix_socket and host[port] should not be used together. This bug causes an error on the Google App Engine platform that needs the use of the unix_socket param.
2/ When the unix_socket param is used, the dbname param is ignored by the PDO object used underneath. the connect() function has been updated to call explicitly the 'use dbname' mysql command in this case.

The test case DatabaseConnectorTest has been updated to follow these changes.
