### PR TITLE
Modify Input::all() to work with nested input arrays

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -174,7 +174,7 @@ class Request extends SymfonyRequest {
 	 */
 	public function all()
 	{
-		return $this->input() + $this->files->all();
+		return array_merge_recursive($this->input(), $this->files->all());
 	}
 
 	/**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -238,6 +238,14 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAllInputReturnsNestedInputAndFiles()
+	{
+		$file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', null, array(__FILE__, 'photo.jpg'));
+		$request = Request::create('/?boom=breeze', 'GET', array('foo' => array('bar' => 'baz')), array(), array('foo' => array('photo' => $file)));
+		$this->assertEquals(array('foo' => array('bar' => 'baz', 'photo' => $file), 'boom' => 'breeze'), $request->all());
+	}
+
+
 	public function testOldMethodCallsSession()
 	{
 		$request = Request::create('/', 'GET');


### PR DESCRIPTION
This change keeps the previous behavior of `$this->input()` not being overwritten by `$this->files->all()` if they have matching keys.
