### PR TITLE
Implements cache tags for query builder from issue #2630

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -135,6 +135,13 @@ class Builder {
 	protected $cacheMinutes;
 
 	/**
+	 * The tags for the query cache.
+	 *
+	 * @var array
+	 */
+	protected $cacheTags;
+
+	/**
 	 * All of the available clause operators.
 	 *
 	 * @var array
@@ -1047,6 +1054,19 @@ class Builder {
 	}
 
 	/**
+	 * Indicate that the results, if cached, should use the passed tags for cache invalidation
+	 * 
+	 * @param  array|dynamic  $cacheTags
+	 * @return \Illuminate\Database\Query\Builder|static
+	 */
+	public function tags($cacheTags)
+	{
+		$this->cacheTags = $cacheTags;
+
+		return $this;
+	}
+
+	/**
 	 * Execute a query for a single record by ID.
 	 *
 	 * @param  int    $id
@@ -1135,7 +1155,7 @@ class Builder {
 		// that are used on this query, providing great convenience when caching.
 		list($key, $minutes) = $this->getCacheInfo();
 
-		$cache = $this->connection->getCacheManager();
+		$cache = $this->getCache();
 
 		$callback = $this->getCacheCallback($columns);
 
@@ -1150,6 +1170,18 @@ class Builder {
 		{
 			return $cache->remember($key, $minutes, $callback);
 		}
+	}
+
+	/**
+	 * Get the cache object with tags assigned, if applicable
+	 * 
+	 * @return \Illuminate\Cache\StoreInterface
+	 */
+	protected function getCache()
+	{
+		$cache = $this->connection->getCacheManager();
+
+		return $this->cacheTags ? $cache->tags($this->cacheTags) : $cache;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1175,7 +1175,7 @@ class Builder {
 	/**
 	 * Get the cache object with tags assigned, if applicable
 	 * 
-	 * @return \Illuminate\Cache\StoreInterface
+	 * @return \Illuminate\Cache\CacheManager
 	 */
 	protected function getCache()
 	{


### PR DESCRIPTION
Also refactors builder tests for cache.

The syntax is
`$users = DB::table('users')->remember(10)->tags(array('foo','bar'))->get();`
and
`$users = DB::table('users')->rememberForever()->tags(array('foo','bar'))->get();`

The placement of the call to tags is irrelevant, as long as it is after table() and before get().
tags() will take either an array of tags, or a single string, just like the tags() method in the caching system.
If neither remember() nor rememberForever() are called at all, the call to tags() will be ignored.

Also, I wrote an integration test which used the ArrayStore directly, just to make myself feel a bit more confident that it would work. I didn't check it in because you usually don't have integration tests among your unit tests, but I can provide it if you're interested.
