### PR TITLE
Remove tag method

### DIFF
--- a/src/Illuminate/Cache/TaggableStore.php
+++ b/src/Illuminate/Cache/TaggableStore.php
@@ -10,7 +10,7 @@ abstract class TaggableStore {
 	 */
 	public function section($name)
 	{
-		return $this->tag($name);
+		return $this->tags($name);
 	}
 
 	/**

--- a/src/Illuminate/Cache/TaggableStore.php
+++ b/src/Illuminate/Cache/TaggableStore.php
@@ -16,17 +16,6 @@ abstract class TaggableStore {
 	/**
 	 * Begin executing a new tags operation.
 	 *
-	 * @param  string  $name
-	 * @return \Illuminate\Cache\TaggedCache
-	 */
-	public function tag($name)
-	{
-		return $this->tags(array($name));
-	}
-
-	/**
-	 * Begin executing a new tags operation.
-	 *
 	 * @param  array|dynamic  $names
 	 * @return \Illuminate\Cache\TaggedCache
 	 */

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -38,7 +38,7 @@ class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase {
 		$store->tags($tags1)->put('foo', 'bar', 10);
 		$tags2 = array('bam', 'pow');
 		$store->tags($tags2)->put('foo', 'bar', 10);
-		$store->tag('zap')->flush();
+		$store->tags('zap')->flush();
 		$this->assertNull($store->tags($tags1)->get('foo'));
 		$this->assertEquals('bar', $store->tags($tags2)->get('foo'));
 	}


### PR DESCRIPTION
I originally wrote the tag method as a shorthand so that when a cache had only one tag, it wouldn't be necessary to type ->tags(array($tag)).  With the revision of tags to take strings or arrays, the tag function has become unnecessary--I'd suggest removing it before the launch of 4.1.
