### PR TITLE
[Proposal] Change password reset to use the user id instead of email

### DIFF
--- a/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
+++ b/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
@@ -92,7 +92,7 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	{
 		$reminder = $this->getTable()->where('token', $token)->first();
 
-		return ($reminder and ! $this->reminderExpired($reminder) ? array('id' => $reminder->user_id) : false);
+		return ($reminder and ! $this->reminderExpired($reminder)) ? array('id' => $reminder->id) : false;
 	}
 
 	/**

--- a/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
+++ b/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
@@ -58,14 +58,14 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	 */
 	public function create(RemindableInterface $user)
 	{
-		$email = $user->getAuthIdentifier();
+		$id = $user->getAuthIdentifier();
 
 		// We will create a new, random token for the user so that we can e-mail them
 		// a safe link to the password reset form. Then we will insert a record in
 		// the database so that we can verify the token within the actual reset.
 		$token = $this->createNewToken($user);
 
-		$this->getTable()->insert($this->getPayload($email, $token));
+		$this->getTable()->insert($this->getPayload($id, $token));
 
 		return $token;
 	}

--- a/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
+++ b/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
@@ -58,7 +58,7 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	 */
 	public function create(RemindableInterface $user)
 	{
-		$email = $user->getReminderEmail();
+		$email = $user->getAuthIdentifier();
 
 		// We will create a new, random token for the user so that we can e-mail them
 		// a safe link to the password reset form. Then we will insert a record in
@@ -73,29 +73,26 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	/**
 	 * Build the record payload for the table.
 	 *
-	 * @param  string  $email
+	 * @param  int  $id
 	 * @param  string  $token
 	 * @return array
 	 */
-	protected function getPayload($email, $token)
+	protected function getPayload($id, $token)
 	{
-		return array('email' => $email, 'token' => $token, 'created_at' => new Carbon);
+		return array('id' => $id, 'token' => $token, 'created_at' => new Carbon);
 	}
 
 	/**
-	 * Determine if a reminder record exists and is valid.
+	 * Determine if the token exsists, amd returns the id of the user if has not expired
 	 *
-	 * @param  \Illuminate\Auth\RemindableInterface  $user
 	 * @param  string  $token
-	 * @return bool
+	 * @return int|bool
 	 */
-	public function exists(RemindableInterface $user, $token)
+	public function exists($token)
 	{
-		$email = $user->getReminderEmail();
+		$reminder = $this->getTable()->where('token', $token)->first();
 
-		$reminder = $this->getTable()->where('email', $email)->where('token', $token)->first();
-
-		return $reminder && ! $this->reminderExpired($reminder);
+		return ($reminder and ! $this->reminderExpired($reminder) ? $reminder->user_id : false);
 	}
 
 	/**

--- a/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
+++ b/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
@@ -92,7 +92,7 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	{
 		$reminder = $this->getTable()->where('token', $token)->first();
 
-		return ($reminder and ! $this->reminderExpired($reminder) ? $reminder->user_id : false);
+		return ($reminder and ! $this->reminderExpired($reminder) ? array('id' => $reminder->user_id) : false);
 	}
 
 	/**

--- a/src/Illuminate/Auth/Reminders/PasswordBroker.php
+++ b/src/Illuminate/Auth/Reminders/PasswordBroker.php
@@ -165,7 +165,7 @@ class PasswordBroker {
 			return $this->makeErrorRedirect('password');
 		}
 
-        if (is_null($user = $this->getUser(array('id' => $userId))))
+        if (is_null($user = $this->getUser($userId)))
         {
             return $this->makeErrorRedirect('user');
         }

--- a/src/Illuminate/Auth/Reminders/PasswordBroker.php
+++ b/src/Illuminate/Auth/Reminders/PasswordBroker.php
@@ -120,16 +120,15 @@ class PasswordBroker {
 	/**
 	 * Reset the password for the given token.
 	 *
-	 * @param  array    $credentials
 	 * @param  Closure  $callback
 	 * @return mixed
 	 */
-	public function reset(array $credentials, Closure $callback)
+	public function reset(Closure $callback)
 	{
 		// If the responses from the validate method is not a user instance, we will
 		// assume that it is a redirect and simply return it from this method and
 		// the user is properly redirected having an error message on the post.
-		$user = $this->validateReset($credentials);
+		$user = $this->validateReset();
 
 		if ( ! $user instanceof RemindableInterface)
 		{
@@ -151,25 +150,25 @@ class PasswordBroker {
 	/**
 	 * Validate a password reset for the given credentials.
 	 *
-	 * @param  array  $credentials
 	 * @return \Illuminate\Auth\RemindableInterface
 	 */
-	protected function validateReset(array $credentials)
+	protected function validateReset()
 	{
-		if (is_null($user = $this->getUser($credentials)))
-		{
-			return $this->makeErrorRedirect('user');
-		}
+        $userId = $this->reminders->exists($this->getToken());
+        if ($userId === false)
+        {
+            return $this->makeErrorRedirect('token');
+        }
 
 		if ( ! $this->validNewPasswords())
 		{
 			return $this->makeErrorRedirect('password');
 		}
 
-		if ( ! $this->reminders->exists($user, $this->getToken()))
-		{
-			return $this->makeErrorRedirect('token');
-		}
+        if (is_null($user = $this->getUser(array('id' => $userId))))
+        {
+            return $this->makeErrorRedirect('user');
+        }
 
 		return $user;
 	}

--- a/src/Illuminate/Auth/Reminders/RemindableInterface.php
+++ b/src/Illuminate/Auth/Reminders/RemindableInterface.php
@@ -8,5 +8,12 @@ interface RemindableInterface {
 	 * @return string
 	 */
 	public function getReminderEmail();
+    
+	/**
+	 * Get the id of the user
+	 *
+	 * @return int
+	 */
+    public function getAuthIdentifier();
 
 }


### PR DESCRIPTION
This is a long shot but I think that storing the id of the user instead of the email address is a better way to handle password reset. This way when the token is created and stored, the id of the user is stored with it instead of the email. When the token is submitted the id of the user in question is returned and that user is updated. This saves having to pass in the email address of the user in question and therefore can be used without passing in any credentials.

Of course this can be also achieved while still using the email address but in the interests of efficient DB design ints are more efficient than varchars.

It simplifies calling `reset` from:

``` php
$credentials = array(
    'email' => Input::get('email'),
    'password' => Input::get('password'),
    'password_confirmation' => Input::get('password_confirmation')
);

return Password::reset($credentials, function($user, $password)
{
    $user->password = Hash::make($password);
    $user->save();
    return Redirect::to('home');
});
```

To:

``` php
return Password::reset(function ($user, $password) {
    $user->password = Hash::make($password);
    $user->save();
    return Redirect::to('login');
});
```

Of course the `auth:reminders` migration will have to be changed as well to use an int for the id instead of a varchar. I'm using the following table:

``` SQL
CREATE TABLE `password_reminders` (
  `id` int(10) unsigned NOT NULL,
  `token` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
  `created_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
  KEY `token` (`token`),
  KEY `id` (`id`),
  CONSTRAINT `password_reminders_ibfk_1` FOREIGN KEY (`id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci
```
