### PR TITLE
Make public BelongsToMany::updateExistingPivot and BelongsToMany::newPivotStatementForId

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -578,7 +578,7 @@ class BelongsToMany extends Relation {
 	 * @param  bool   $touch
 	 * @return void
 	 */
-	protected function updateExistingPivot($id, array $attributes, $touch)
+	public function updateExistingPivot($id, array $attributes, $touch)
 	{
 		if (in_array($this->updatedAt(), $this->pivotColumns))
 		{
@@ -808,7 +808,7 @@ class BelongsToMany extends Relation {
 	 * @param  mixed  $id
 	 * @return \Illuminate\Database\Query\Builder
 	 */
-	protected function newPivotStatementForId($id)
+	public function newPivotStatementForId($id)
 	{
 		$pivot = $this->newPivotStatement();
 


### PR DESCRIPTION
I moved two methods to public : `updateExistingPivot` and `newPivotStatementForId` – those methods are really useful for working with pivot table attributes but they're protected, and `newPivotStatement` is already public so I thought it'd be a good idea.

I pointed this to master since it's not a bugfix or anything, not sure if that'd be better to 4.0 ?
