### PR TITLE
use PHP_BINARY to serve development server

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -38,7 +38,7 @@ class ServeCommand extends Command {
 
 		$this->info("Laravel development server started on http://{$host}:{$port}");
 
-		passthru("php -S {$host}:{$port} -t \"{$public}\" server.php");
+		passthru(PHP_BINARY." -S {$host}:{$port} -t \"{$public}\" server.php");
 	}
 
 	/**


### PR DESCRIPTION
Sometimes I do need an alternate php interpreter to make it play nicely with laravel. 

eg.

``` bash
php-5.4 artisan serve
```

or even 

``` bash
/usr/local/php-5.4/bin/php artisan serve
```

It totally works fine except the `artisan serve` command since it uses system php interpreter (not the one actually running) to serve the development server. In my case, my system php version is 5.2.17 and it has no server feature yet. 

Since `PHP_BINARY` is bundled with php5.4, it should work fine here.
