### PR TITLE
ModelNotFoundException() : include called class name

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -513,7 +513,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	{
 		if ( ! is_null($model = static::find($id, $columns))) return $model;
 
-		throw new ModelNotFoundException;
+		throw new ModelNotFoundException(get_called_class().': model not found');
 	}
 
 	/**


### PR DESCRIPTION
There is no way to know which model is throwing `ModelNotFoundException()`.
With this simple code change, the following is now possible:

``` php
<?php
// routes.php

use Illuminate\Database\Eloquent\ModelNotFoundException;

Route::get('/dummy-package', function ()
{
    $package = Package::findOrFail('unknown_id')->toArray();

    return Response::view('package.show', array('package' => $package));
});

App::error(function (ModelNotFoundException $e, $code)
{
    $model = substr($e->getMessage(), 0, strpos($e->getMessage(), ':'));

    switch ($model)
    {
        case 'User':
            return Response::view('_errors.user_not_found', 404);

        case 'Project':
            return Response::view('_errors.project_not_found', 404);

        default:
            return Response::view('_errors.404', 404);
    }
});
```
