### PR TITLE
Allow Route::any() to handle HEAD verbs request.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -205,7 +205,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	public function any($uri, $action)
 	{
-		$verbs = array('GET', 'POST', 'PUT', 'PATCH', 'DELETE');
+		$verbs = array('GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE');
 
 		return $this->addRoute($verbs, $uri, $action);
 	}

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -49,6 +49,14 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('fred25', $router->dispatch(Request::create('fred', 'GET'))->getContent());
 		$this->assertEquals('fred30', $router->dispatch(Request::create('fred/30', 'GET'))->getContent());
 		$this->assertTrue($router->currentRouteNamed('foo'));
+
+		$router = $this->getRouter();
+		$router->get('foo/bar', function() { return 'hello'; });
+		$this->assertEquals('', $router->dispatch(Request::create('foo/bar', 'HEAD'))->getContent());
+
+		$router = $this->getRouter();
+		$router->any('foo/bar', function() { return 'hello'; });
+		$this->assertEquals('', $router->dispatch(Request::create('foo/bar', 'HEAD'))->getContent());
 	}
 
 


### PR DESCRIPTION
Fixed #2724
