### PR TITLE
don't use the same name for a param and a usevar

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -13,7 +13,7 @@ class Collection extends BaseCollection {
 	 */
 	public function find($key, $default = null)
 	{
-		return array_first($this->items, function($key, $model) use ($key)
+		return array_first($this->items, function($_, $model) use ($key)
 		{
 			return $model->getKey() == $key;
 


### PR DESCRIPTION
HHVM and php-src disagree on what to do here (IMHO we should just throw an exception). Lets just not have to deal with the ambiguity.
