### PR TITLE
reuse closure when creating and testing

### DIFF
--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -21,19 +21,21 @@ class ValidationFactoryTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('baz' => array('boom')), $validator->getRules());
 
 		$presence = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-		$factory->extend('foo', function() {});
-		$factory->extendImplicit('implicit', function() {});
+		$noop1 = function() {};
+		$noop2 = function() {};
+		$factory->extend('foo', $noop1);
+		$factory->extendImplicit('implicit', $noop2);
 		$factory->setPresenceVerifier($presence);
 		$validator = $factory->make(array(), array());
-		$this->assertEquals(array('foo' => function() {}, 'implicit' => function() {}), $validator->getExtensions());
+		$this->assertEquals(array('foo' => $noop1, 'implicit' => $noop2), $validator->getExtensions());
 		$this->assertEquals($presence, $validator->getPresenceVerifier());
 
 		$presence = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-		$factory->extend('foo', function() {}, 'foo!');
-		$factory->extendImplicit('implicit', function() {}, 'implicit!');
+		$factory->extend('foo', $noop1, 'foo!');
+		$factory->extendImplicit('implicit', $noop2, 'implicit!');
 		$factory->setPresenceVerifier($presence);
 		$validator = $factory->make(array(), array());
-		$this->assertEquals(array('foo' => function() {}, 'implicit' => function() {}), $validator->getExtensions());
+		$this->assertEquals(array('foo' => $noop1, 'implicit' => $noop2), $validator->getExtensions());
 		$this->assertEquals(array('foo' => 'foo!', 'implicit' => 'implicit!'), $validator->getFallbackMessages());
 		$this->assertEquals($presence, $validator->getPresenceVerifier());
 	}


### PR DESCRIPTION
HHVM makes different closures objects that don't compare to the original functions.

```
1) ValidationFactoryTest::testMakeMethodCreatesValidValidator
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    'foo' => Closure$ValidationFactoryTest::testMakeMethodCreatesValidValidator#3 Object ()
-    'implicit' => Closure$ValidationFactoryTest::testMakeMethodCreatesValidValidator#4 Object ()
+    'foo' => Closure$ValidationFactoryTest::testMakeMethodCreatesValidValidator Object ()
+    'implicit' => Closure$ValidationFactoryTest::testMakeMethodCreatesValidValidator#2 Object ()
 )
```

Instead I think this test really wants to make sure the same closure went in and came out again.
