### PR TITLE
Fixed password_confirmation being passed during Password::reset() goes to validateReset() -> getUser() -> UserProvider::retrieveByCredential()

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/controller.stub
+++ b/src/Illuminate/Auth/Console/stubs/controller.stub
@@ -19,7 +19,7 @@ class RemindersController extends Controller {
 	 */
 	public function postRemind()
 	{
-		switch (Password::remind(Input::only('email')))
+		switch ($reason = Password::remind(Input::only('email')))
 		{
 			case Password::INVALID_USER:
 				return Redirect::back()->with('error', Lang::get($reason));

--- a/src/Illuminate/Auth/Reminders/PasswordBroker.php
+++ b/src/Illuminate/Auth/Reminders/PasswordBroker.php
@@ -255,7 +255,7 @@ class PasswordBroker {
 	 */
 	public function getUser(array $credentials)
 	{
-		$credentials = array_except($credentials, array('token'));
+		$credentials = array_except($credentials, array('password_confirmation', 'token'));
 
 		$user = $this->users->retrieveByCredentials($credentials);
 

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -89,7 +89,7 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 	{
 		$creds = array('password' => 'foo', 'password_confirmation' => 'bar');
 		$broker = $this->getBroker($mocks = $this->getMocks());
-		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
+		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(array_except($creds, array('password_confirmation')))->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
 
 		$this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function() {}));
 	}
@@ -99,7 +99,7 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 	{
 		$creds = array('password' => null, 'password_confirmation' => null);
 		$broker = $this->getBroker($mocks = $this->getMocks());
-		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
+		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(array_except($creds, array('password_confirmation')))->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
 
 		$this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function() {}));
 	}
@@ -109,7 +109,7 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 	{
 		$creds = array('password' => 'abc', 'password_confirmation' => 'abc');
 		$broker = $this->getBroker($mocks = $this->getMocks());
-		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
+		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(array_except($creds, array('password_confirmation')))->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
 
 		$this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function() {}));
 	}
@@ -120,7 +120,7 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 		$creds = array('password' => 'abcdef', 'password_confirmation' => 'abcdef');
 		$broker = $this->getBroker($mocks = $this->getMocks());
 		$broker->validator(function($credentials) { return strlen($credentials['password']) >= 7; });
-		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
+		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(array_except($creds, array('password_confirmation')))->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
 
 		$this->assertEquals(PasswordBroker::INVALID_PASSWORD, $broker->reset($creds, function() {}));
 	}


### PR DESCRIPTION
Signed-off-by: crynobone crynobone@gmail.com
