### PR TITLE
Type check of relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -4,6 +4,7 @@ use Closure;
 use DateTime;
 use ArrayAccess;
 use Carbon\Carbon;
+use LogicException;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -2201,9 +2202,15 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		if (method_exists($this, $camelKey))
 		{
-			$relations = $this->$camelKey()->getResults();
+			$relations = $this->$camelKey();
 
-			return $this->relations[$key] = $relations;
+			if ( ! $relations instanceof Relation)
+			{
+				throw new LogicException('Relationship method must return an object of type '
+					. 'Illuminate\Database\Eloquent\Relations\Relation');
+			}
+
+			return $this->relations[$key] = $relations->getResults();
 		}
 	}
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -731,6 +731,16 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	/**
+	 * @expectedException LogicException
+	 */
+	public function testGetModelAttributeMethodThrowsExepcitonIfNotRelation()
+	{
+		$model = new EloquentModelStub;
+		$relation = $model->incorrect_relation_stub;
+	}
+
+
 	protected function addMockConnection($model)
 	{
 		$model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
@@ -775,6 +785,10 @@ class EloquentModelStub extends Illuminate\Database\Eloquent\Model {
 	public function belongsToExplicitKeyStub()
 	{
 		return $this->belongsTo('EloquentModelSaveStub', 'foo');
+	}
+	public function incorrectRelationStub()
+	{
+		return 'foo';
 	}
 	public function getDates()
 	{


### PR DESCRIPTION
Suggestion by @robclancy - would potentially give a more sane error when a relationship function doesn't return what it should, which often happens by people appending something like get() or first() inside the method, or forgetting to return the `$this->someRelation()` statement.

Exception message is wrapped over two lines to not go above the 120 character hard limit. The following example would throw the exception.

``` php
public function related()
{
    return $this->hasMany('Other')->get(); // or first(), count()...
}

$result = $model->related;
```
