### PR TITLE
Update Redirector.php

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -56,6 +56,29 @@ class Redirector {
 	}
 
 	/**
+	 * Create a new redirect response to the previous location
+	 * or fallback to a supplied route when referer does not exist.
+	 *
+	 * @param  string $fallback
+	 * @param  int    $status
+	 * @param  array  $headers
+	 * @return \Illuminate\Http\RedirectResponse
+	 */
+	public function backWithFallback($fallback, $status = 302, $headers = array())
+	{
+		$back = $this->generator->getRequest()->headers->get('referer');
+		
+		if ( $back )
+		{
+			return $this->createRedirect($back, $status, $headers);
+		}
+		else
+		{
+			return $this->createRedirect($fallback, $status, $headers);
+		}
+	}
+
+	/**
 	 * Create a new redirect response to the current URI.
 	 *
 	 * @param  int    $status


### PR DESCRIPTION
Redirect::back() often fails for me because there's no referrer. I'd rather not make an assumption about what route to redirect to because that assumption is sometimes false. I'd like Redirect::back() to work like Redirect::intended() in that you can supply a fallback route to redirect to if referrer doesn't exist.
