### PR TITLE
Make Collection splice return new static.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -378,7 +378,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 */
 	public function splice($offset, $length = 0, $replacement = array())
 	{
-		array_splice($this->items, $offset, $length, $replacement);
+		return new static(array_splice($this->items, $offset, $length, $replacement));
 	}
 
 	/**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -245,15 +245,16 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	{
 		$data = new Collection(array('foo', 'baz'));
 		$data->splice(1, 0, 'bar');
-		$this->assertEquals(array('foo', 'bar', 'baz'), array_values($data->all()));
+		$this->assertEquals(array('foo', 'bar', 'baz'), $data->all());
 
 		$data = new Collection(array('foo', 'baz'));
 		$data->splice(1, 1);
-		$this->assertEquals(array('foo'), array_values($data->all()));
+		$this->assertEquals(array('foo'), $data->all());
 
 		$data = new Collection(array('foo', 'baz'));
-		$data->splice(1, 1, 'bar');
-		$this->assertEquals(array('foo', 'bar'), array_values($data->all()));
+		$cut = $data->splice(1, 1, 'bar');
+		$this->assertEquals(array('foo', 'bar'), $data->all());
+		$this->assertEquals(array('baz'), $cut->all());
 	}
 
 	public function testGetListValueWithAccessors()


### PR DESCRIPTION
Simulate array_splice function behavior when it returns cut out part as new Collection.
