### PR TITLE
Allow custom constraints on a detach clause

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -719,14 +719,24 @@ class BelongsToMany extends Relation {
 	 * Detach models from the relationship.
 	 *
 	 * @param  int|array  $ids
-	 * @param  bool  $touch
+	 * @param  bool       $touch
+	 * @param  array      $attributes
 	 * @return int
 	 */
-	public function detach($ids = array(), $touch = true)
+	public function detach($ids = array(), $touch = true, $attributes = array())
 	{
 		if ($ids instanceof Model) $ids = (array) $ids->getKey();
 
 		$query = $this->newPivotQuery();
+
+		// Here we add the possible extra constraints on the query
+		if ($attributes)
+		{
+			foreach ($attributes as $attribute => $value)
+			{
+				$query->where($attribute, $value);
+			}
+		}
 
 		// If associated IDs were passed to the method we will only delete those
 		// associations, otherwise all of the association ties will be broken.

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -730,7 +730,7 @@ class BelongsToMany extends Relation {
 		$query = $this->newPivotQuery();
 
 		// Here we add the possible extra constraints on the query
-		if ($callable)
+		if ($callable and is_callable($callable))
 		{
 			$query = $callable($query);
 		}

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -718,24 +718,21 @@ class BelongsToMany extends Relation {
 	/**
 	 * Detach models from the relationship.
 	 *
-	 * @param  int|array  $ids
-	 * @param  bool       $touch
-	 * @param  array      $attributes
+	 * @param  int|array              $ids
+	 * @param  bool                   $touch
+	 * @param  \Closure|array|string  $callable
 	 * @return int
 	 */
-	public function detach($ids = array(), $touch = true, $attributes = array())
+	public function detach($ids = array(), $touch = true, $callable = null)
 	{
 		if ($ids instanceof Model) $ids = (array) $ids->getKey();
 
 		$query = $this->newPivotQuery();
 
 		// Here we add the possible extra constraints on the query
-		if ($attributes)
+		if ($callable)
 		{
-			foreach ($attributes as $attribute => $value)
-			{
-				$query->where($attribute, $value);
-			}
+			$query = $callable($query);
 		}
 
 		// If associated IDs were passed to the method we will only delete those

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -190,6 +190,23 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDetachCanHaveAdditionalConstraints()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$query = m::mock('stdClass');
+		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
+		$query->shouldReceive('where')->once()->with('type', 'test_type')->andReturn($query);
+		$query->shouldReceive('whereIn')->once()->with('role_id', array(1));
+		$query->shouldReceive('delete')->once()->andReturn(true);
+		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+		$relation->expects($this->once())->method('touchIfTouching');
+
+		$this->assertTrue($relation->detach(1, true, array('type' => 'test_type')));
+	}
+
+
 	public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
 	{
 		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -203,7 +203,9 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
 		$relation->expects($this->once())->method('touchIfTouching');
 
-		$this->assertTrue($relation->detach(1, true, array('type' => 'test_type')));
+		$this->assertTrue($relation->detach(1, true, function($query) {
+			return $query->where('type', 'test_type');
+		}));
 	}
 
 


### PR DESCRIPTION
If per example you have an `user_user` table where you store friends, following, starred etc in a `type` column, you can thus now detach a particular relation link without detaching all the others.
