### PR TITLE
[bugfix] Add table_shema to getColumnListing select query

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -43,9 +43,9 @@ class MySqlGrammar extends Grammar {
 	 * @param  string  $table
 	 * @return string
 	 */
-	public function compileColumnExists($table)
+	public function compileColumnExists()
 	{
-		return "select column_name from information_schema.columns where table_name = '$table'";
+		return "select column_name from information_schema.columns where table_schema = ? and table_name = ?";
 	}
 
 	/**

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -19,4 +19,22 @@ class MySqlBuilder extends Builder {
 		return count($this->connection->select($sql, array($database, $table))) > 0;
 	}
 
+	/**
+	 * Get the column listing for a given table.
+	 *
+	 * @param  string  $table
+	 * @return array
+	 */
+	protected function getColumnListing($table)
+	{
+		$sql = $this->grammar->compileColumnExists();
+
+		$database = $this->connection->getDatabaseName();
+
+		$table = $this->connection->getTablePrefix().$table;
+
+		$results = $this->connection->select($sql, array($database, $table));
+
+		return $this->connection->getPostProcessor()->processColumnListing($results);
+	}
 }


### PR DESCRIPTION
The hasColumn method on the Builder class can return incorrect information.
It currently only verifies if the column exists in the information_schema.columns table.
So if you have multiple databases, that have the same table and column name it will return true, even if the column does not exist in the current database.
