### PR TITLE
Reuse nop closure in DatabaseEloquentBuildertest.php

### DIFF
--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -188,8 +188,10 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testEagerLoadRelationsLoadTopLevelRelationships()
 	{
 		$builder = $this->getMock('Illuminate\Database\Eloquent\Builder', array('loadRelation'), $this->getMocks());
-		$builder->setEagerLoads(array('foo' => function() {}, 'foo.bar' => function() {}));
-		$builder->expects($this->once())->method('loadRelation')->with($this->equalTo(array('models')), $this->equalTo('foo'), $this->equalTo(function() {}))->will($this->returnValue(array('foo')));
+		$nop1 = function() {};
+		$nop2 = function() {};
+		$builder->setEagerLoads(array('foo' => $nop1, 'foo.bar' => $nop2));
+		$builder->expects($this->once())->method('loadRelation')->with($this->equalTo(array('models')), $this->equalTo('foo'), $this->equalTo($nop1)->will($this->returnValue(array('foo')));
 		$results = $builder->eagerLoadRelations(array('models'));
 
 		$this->assertEquals(array('foo'), $results);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -191,7 +191,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$nop1 = function() {};
 		$nop2 = function() {};
 		$builder->setEagerLoads(array('foo' => $nop1, 'foo.bar' => $nop2));
-		$builder->expects($this->once())->method('loadRelation')->with($this->equalTo(array('models')), $this->equalTo('foo'), $this->equalTo($nop1)->will($this->returnValue(array('foo')));
+		$builder->expects($this->once())->method('loadRelation')->with($this->equalTo(array('models')), $this->equalTo('foo'), $this->equalTo($nop1))->will($this->returnValue(array('foo')));
 		$results = $builder->eagerLoadRelations(array('models'));
 
 		$this->assertEquals(array('foo'), $results);


### PR DESCRIPTION
Continued from https://github.com/laravel/framework/pull/2729

HHVM reuses closures if they have the same body, causing DatabaseEloquentBuilderTest::testEagerLoadRelationsLoadTopLevelRelationships() to fail. Instead, save the closures to variables and use those.
