### PR TITLE
Stop replacing X-Frame-Options header in FrameGuard

### DIFF
--- a/src/Illuminate/Http/FrameGuard.php
+++ b/src/Illuminate/Http/FrameGuard.php
@@ -37,7 +37,7 @@ class FrameGuard implements HttpKernelInterface {
 	{
 		$response = $this->app->handle($request, $type, $catch);
 
-		$response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+		$response->headers->set('X-Frame-Options', 'SAMEORIGIN', false);
 
 		return $response;
 	}


### PR DESCRIPTION
Fix for the change discussed in #1725
