### PR TITLE
Add support for {{ $foo or 'bar' }} in Laravel 4.0.*.

### DIFF
--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -81,7 +81,7 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('{{ $name }}', $compiler->compileString('@{{ $name }}'));
 		$this->assertEquals('{{
 			$name
-		}}', 
+		}}',
 		$compiler->compileString('@{{
 			$name
 		}}'));
@@ -100,6 +100,15 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 			$name
 		}}}'));
 	}
+
+
+	public function testEchosWithDefaultValuesAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$this->assertEquals('<?php echo isset($foo) ? $foo : \'bar\'; ?>', $compiler->compileString('{{ $foo or \'bar\' }}'));
+		$this->assertEquals('<?php echo e(isset($foo) ? $foo : \'bar\'); ?>', $compiler->compileString('{{{ $foo or \'bar\' }}}'));
+	}
+
 
 	public function testExtendsAreCompiled()
 	{
@@ -194,16 +203,16 @@ breeze
 <?php endif; ?>';
 		$this->assertEquals($expected, $compiler->compileString($string));
 	}
-	
-	
-	public function testStatementThatContainsNonConsecutiveParanthesisAreCompiled() 
+
+
+	public function testStatementThatContainsNonConsecutiveParanthesisAreCompiled()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
 		$string = "Foo @lang(function_call('foo(blah)')) bar";
 		$expected = "Foo <?php echo \Illuminate\Support\Facades\Lang::get(function_call('foo(blah)')); ?> bar";
 		$this->assertEquals($expected, $compiler->compileString($string));
 	}
-	
+
 
 	public function testIncludesAreCompiled()
 	{

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -68,9 +68,45 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{{$name}}}'));
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{$name}}'));
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{ $name }}'));
-		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{ 
+		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{
 			$name
 		}}'));
+
+		$this->assertEquals('<?php echo isset($name) ? $name : "foo"; ?>', $compiler->compileString('{{ $name or "foo" }}'));
+		$this->assertEquals('<?php echo isset($user->name) ? $user->name : "foo"; ?>', $compiler->compileString('{{ $user->name or "foo" }}'));
+		$this->assertEquals('<?php echo isset($name) ? $name : "foo"; ?>', $compiler->compileString('{{$name or "foo"}}'));
+		$this->assertEquals('<?php echo isset($name) ? $name : "foo"; ?>', $compiler->compileString('{{
+			$name or "foo"
+		}}'));
+
+		$this->assertEquals('<?php echo isset($name) ? $name : \'foo\'; ?>', $compiler->compileString('{{ $name or \'foo\' }}'));
+		$this->assertEquals('<?php echo isset($name) ? $name : \'foo\'; ?>', $compiler->compileString('{{$name or \'foo\'}}'));
+		$this->assertEquals('<?php echo isset($name) ? $name : \'foo\'; ?>', $compiler->compileString('{{
+			$name or \'foo\'
+		}}'));
+
+		$this->assertEquals('<?php echo isset($age) ? $age : 90; ?>', $compiler->compileString('{{ $age or 90 }}'));
+		$this->assertEquals('<?php echo isset($age) ? $age : 90; ?>', $compiler->compileString('{{$age or 90}}'));
+		$this->assertEquals('<?php echo isset($age) ? $age : 90; ?>', $compiler->compileString('{{
+			$age or 90
+		}}'));
+
+		$this->assertEquals('<?php echo "Hello world or foo"; ?>', $compiler->compileString('{{ "Hello world or foo" }}'));
+		$this->assertEquals('<?php echo "Hello world or foo"; ?>', $compiler->compileString('{{"Hello world or foo"}}'));
+		$this->assertEquals('<?php echo $foo + $or + $baz; ?>', $compiler->compileString('{{$foo + $or + $baz}}'));
+		$this->assertEquals('<?php echo "Hello world or foo"; ?>', $compiler->compileString('{{
+			"Hello world or foo"
+		}}'));
+
+		$this->assertEquals('<?php echo \'Hello world or foo\'; ?>', $compiler->compileString('{{ \'Hello world or foo\' }}'));
+		$this->assertEquals('<?php echo \'Hello world or foo\'; ?>', $compiler->compileString('{{\'Hello world or foo\'}}'));
+		$this->assertEquals('<?php echo \'Hello world or foo\'; ?>', $compiler->compileString('{{
+			\'Hello world or foo\'
+		}}'));
+
+		$this->assertEquals('<?php echo myfunc(\'foo or bar\'); ?>', $compiler->compileString('{{ myfunc(\'foo or bar\') }}'));
+		$this->assertEquals('<?php echo myfunc("foo or bar"); ?>', $compiler->compileString('{{ myfunc("foo or bar") }}'));
+		$this->assertEquals('<?php echo myfunc("$name or \'foo\'"); ?>', $compiler->compileString('{{ myfunc("$name or \'foo\'") }}'));
 	}
 
 
@@ -99,14 +135,6 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{{ 
 			$name
 		}}}'));
-	}
-
-
-	public function testEchosWithDefaultValuesAreCompiled()
-	{
-		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
-		$this->assertEquals('<?php echo isset($foo) ? $foo : \'bar\'; ?>', $compiler->compileString('{{ $foo or \'bar\' }}'));
-		$this->assertEquals('<?php echo e(isset($foo) ? $foo : \'bar\'); ?>', $compiler->compileString('{{{ $foo or \'bar\' }}}'));
 	}
 
 


### PR DESCRIPTION
Hi,

Without breaking any backwards compatibility, I thought it would be extremely nifty and would certainly reduce a lot of code in people's projects to have the `{{ $foo or 'bar' }}` (variable fallback / default) functionality back ported to Laravel 4.0.

~~I also added tests which could be merged back into 4.1 development if you'd like.~~ **Scrap that, they are. I'll put those specific tests into my PR and update it.**
