### PR TITLE
Changed filter method to create proper indexes in resulting collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -224,7 +224,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 */
 	public function filter(Closure $callback)
 	{
-		return new static(array_filter($this->items, $callback));
+		return new static(array_values(array_filter($this->items, $callback)));
 	}
 
 	/**


### PR DESCRIPTION
`array_filter` messes up the indices of the resulting array, and the new collection being formed using that method would've had messed up indices. Wrapping the `array_filter` call in `array_values` would solve this issue.
