### PR TITLE
Regression in route URL generation

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -200,11 +200,14 @@ class UrlGenerator {
 	{
 		$domain = $this->getRouteDomain($route, $parameters);
 
-		$path = preg_replace_sub('/\{.*?\}/', $parameters, $route->uri());
+		$routeParams = $this->extractRouteParams($route, $parameters);
+
+		$path = preg_replace_sub('/\{.*?\}/', $routeParams, $route->uri());
 
 		$url = $this->trimUrl($this->getRouteRoot($route, $domain), $path);
 
-		if ($query = $this->getQueryString($parameters))
+		// if any parameters remain, they will be appended as a query string
+		if ($parameters && $query = $this->getQueryString($parameters))
 		{
 			$url .= $query;
 		}
@@ -279,6 +282,35 @@ class UrlGenerator {
 	protected function getRouteRoot($route, $domain)
 	{
 		return $this->getRootUrl($this->getScheme($route->secure()), $domain);
+	}
+
+	/**
+	 * Given a certain route, get only the route parameters from an array.
+	 *
+	 * @param  \Illuminate\Routing\Route $route
+	 * @param  array $parameters
+	 *
+	 * @return array
+	 */
+	protected function extractRouteParams($route, &$parameters)
+	{
+		$routeParams = $route->parameterNames();
+		$result = array();
+
+		foreach ($routeParams as $param)
+		{
+			if (isset($parameters[$param]))
+			{
+				$result[$param] = $parameters[$param];
+				unset($parameters[$param]);
+			}
+			else
+			{
+				$result[$param] = array_shift($parameters);
+			}
+		}
+
+		return $result;
 	}
 
 	/**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -204,7 +204,8 @@ class UrlGenerator {
 
 		$url = $this->trimUrl($this->getRouteRoot($route, $domain), $path);
 
-		if ($query = $this->getQueryString($parameters)) {
+		if ($query = $this->getQueryString($parameters))
+		{
 			$url .= $query;
 		}
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -132,4 +132,21 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param' => 'param', 'opt' => 'opt', 'foo' => 'bar', 'baz')));
 	}
 
+
+	public function testGenerateWithQueryStrings2()
+	{
+		$url = new UrlGenerator(
+			$routes = new Illuminate\Routing\RouteCollection,
+			$request = Illuminate\Http\Request::create('http://www.foo.com/')
+		);
+
+		$fooRoute = new Illuminate\Routing\Route(array('GET'), 'foo/{param}', array('as' => 'foo'));
+		$routes->add($fooRoute);
+		$barRoute = new Illuminate\Routing\Route(array('GET'), 'bar', array('as' => 'bar'));
+		$routes->add($barRoute);
+
+		$this->assertEquals('http://www.foo.com/foo/param', $url->route('foo', 'param'));
+		$this->assertEquals('http://www.foo.com/bar?param', $url->route('bar', 'param'));
+	}
+
 }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -129,6 +129,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$routes->add($route);
 
 		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param', 'opt', 'foo' => 'bar', 'baz')));
+		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param' => 'param', 'opt' => 'opt', 'foo' => 'bar', 'baz')));
 	}
 
 }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -130,6 +130,9 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param', 'opt', 'foo' => 'bar', 'baz')));
 		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param' => 'param', 'opt' => 'opt', 'foo' => 'bar', 'baz')));
+		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('foo' => 'bar', 'param' => 'param', 'opt' => 'opt', 'baz')));
+		$this->assertEquals('http://www.foo.com/foo/param/opt', $url->route('foo', array('param' => 'param', 'opt' => 'opt')));
+		$this->assertEquals('http://www.foo.com/foo/param/opt', $url->route('foo', array('opt' => 'opt', 'param' => 'param')));
 	}
 
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -78,7 +78,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
 	public function testRoutesWithDomains()
 	{
-			$url = new UrlGenerator(
+		$url = new UrlGenerator(
 			$routes = new Illuminate\Routing\RouteCollection,
 			$request = Illuminate\Http\Request::create('http://www.foo.com/')
 		);
@@ -99,7 +99,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
 	public function testRoutesWithDomainsAndPorts()
 	{
-			$url = new UrlGenerator(
+		$url = new UrlGenerator(
 			$routes = new Illuminate\Routing\RouteCollection,
 			$request = Illuminate\Http\Request::create('http://www.foo.com:8080/')
 		);

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -117,4 +117,18 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://sub.taylor.com:8080/foo/bar/otwell', $url->route('bar', array('taylor', 'otwell')));
 	}
 
+
+	public function testGenerateWithQueryStrings()
+	{
+		$url = new UrlGenerator(
+			$routes = new Illuminate\Routing\RouteCollection,
+			$request = Illuminate\Http\Request::create('http://www.foo.com/')
+		);
+
+		$route = new Illuminate\Routing\Route(array('GET'), 'foo/{param}/{opt?}', array('as' => 'foo'));
+		$routes->add($route);
+
+		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param', 'opt', 'foo' => 'bar', 'baz')));
+	}
+
 }


### PR DESCRIPTION
In 4.0, `URL::route` and `URL::action` generates query strings out of extra parameters. This is missing in 4.1, so I took a stab at implementing it.

``` php
Route::get('foo/{param}/{opt?}', array('as' => 'foo', function($p, $o) { ... });

// http://mysite.com/foo/param/opt?foo=bar&baz
URL::route('foo', array('param', 'opt', 'foo' => 'bar', 'baz'));
```

In 4.0 'baz' would be appended as '&0=baz' because symfony's url generator simply calls http_build_query - I improved a little on it (in my opinion) by differentiating between array members with a numeric and non-numeric key, though at the cost of performance.
