### PR TITLE
Add diff and intersect to Support\Collection and merge, diff and intersect to Eloquent\Collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -165,7 +165,7 @@ class Collection extends BaseCollection {
 
 		foreach ($this->items as $item)
 		{
-			if ( $collection->contains($item->getKey()))
+			if ($collection->contains($item->getKey()))
 			{
 				$intersect->add($item);
 			}

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -119,7 +119,7 @@ class Collection extends BaseCollection {
 	 * @param  \Illuminate\Support\Collection  $collection
 	 * @return \Illuminate\Support\Collection
 	 */
-	public function mergeCollection(Collection $collection)
+	public function merge($collection)
 	{
 		foreach ($collection as $item)
 		{
@@ -138,7 +138,7 @@ class Collection extends BaseCollection {
 	 * @param  \Illuminate\Support\Collection  $collection
 	 * @return \Illuminate\Support\Collection
 	 */
-	public function diffCollection(Collection $collection)
+	public function diff($collection)
 	{
 		$diff = new static;
 
@@ -159,7 +159,7 @@ class Collection extends BaseCollection {
 	 * @param  \Illuminate\Support\Collection  $collection
 	 * @return \Illuminate\Support\Collection
 	 */
-	public function intersectCollection(Collection $collection)
+	public function intersect($collection)
 	{
 		$intersect = new static;
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -113,4 +113,65 @@ class Collection extends BaseCollection {
 		return array_map(function($m) { return $m->getKey(); }, $this->items);
 	}
 
+	/**
+	 * Merge collection with another collection.
+	 *
+	 * @param  \Illuminate\Support\Collection  $collection
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function mergeCollection(Collection $collection)
+	{
+		foreach ($collection as $item)
+		{
+			if ( ! $this->contains($item->getKey()))
+			{
+				$this->add($item);
+			}
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Diff collection with another collection.
+	 *
+	 * @param  \Illuminate\Support\Collection  $collection
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function diffCollection(Collection $collection)
+	{
+		$diff = new static;
+
+		foreach ($this->items as $item)
+		{
+			if ( ! $collection->contains($item->getKey()))
+			{
+				$diff->add($item);
+			}
+		}
+
+		return $diff;
+	}
+
+	/**
+	 * Intersect collection with another collection.
+	 *
+	 * @param  \Illuminate\Support\Collection  $collection
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function intersectCollection(Collection $collection)
+	{
+		$intersect = new static;
+
+		foreach ($this->items as $item)
+		{
+			if ( $collection->contains($item->getKey()))
+			{
+				$intersect->add($item);
+			}
+		}
+
+		return $intersect;
+	}
+
 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -355,6 +355,50 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 		return new static($results);
 	}
 
+	/** 
+	 * Diff items with the collection items.
+	 *
+	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function diff($items)
+	{
+		if ($items instanceof Collection)
+		{
+			$items = $items->all();
+		}
+		elseif ($items instanceof ArrayableInterface)
+		{
+			$items = $items->toArray();
+		}
+
+		$results = array_diff($this->items, $items);
+
+		return new static($results);
+	}
+
+	/**
+	 * Intersect items with the collection items.
+	 *
+ 	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function intersect($items)
+	{
+		if ($items instanceof Collection)
+		{
+			$items = $items->all();
+		}
+		elseif ($items instanceof ArrayableInterface)
+		{
+			$tiems = $items->toArray();
+		}
+
+		$results = array_intersect($this->items, $items);
+
+		return new static($results);
+	}
+
 	/**
 	 * Slice the underlying collection array.
 	 *

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -341,14 +341,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 */
 	public function merge($items)
 	{
-		if ($items instanceof Collection)
-		{
-			$items = $items->all();
-		}
-		elseif ($items instanceof ArrayableInterface)
-		{
-			$items = $items->toArray();
-		}
+		$items = $this->getArrayableItems($items);
 
 		$results = array_merge($this->items, $items);
 
@@ -363,14 +356,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 */
 	public function diff($items)
 	{
-		if ($items instanceof Collection)
-		{
-			$items = $items->all();
-		}
-		elseif ($items instanceof ArrayableInterface)
-		{
-			$items = $items->toArray();
-		}
+		$items = $this->getArrayableItems($items);
 
 		$results = array_diff($this->items, $items);
 
@@ -385,14 +371,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 */
 	public function intersect($items)
 	{
-		if ($items instanceof Collection)
-		{
-			$items = $items->all();
-		}
-		elseif ($items instanceof ArrayableInterface)
-		{
-			$tiems = $items->toArray();
-		}
+		$items = $this->getArrayableItems($items);
 
 		$results = array_intersect($this->items, $items);
 
@@ -589,6 +568,26 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	public function __toString()
 	{
 		return $this->toJson();
+	}
+
+	/**
+	 * Results array of items from Collection or ArrayableInterface. 
+	 *
+  	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
+	 * @return array
+	 */
+	private function getArrayableItems($items)
+	{
+		if ($items instanceof Collection)
+		{
+			$items = $items->all();
+		}
+		elseif ($items instanceof ArrayableInterface)
+		{
+			$tiems = $items->toArray();
+		}
+
+		return $items;
 	}
 
 }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -89,6 +89,56 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(1,2,3), $c->modelKeys());
 	}
 
+	public function testCollectionMergesWithGivenCollection()
+	{
+		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one->shouldReceive('getKey')->andReturn(1);
+
+		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two->shouldReceive('getKey')->andReturn(2);
+
+		$three = m::mock('Illuminate\Database\Eloquent\Model');
+		$three->shouldReceive('getKey')->andReturn(3);
+
+		$c1 = new Collection(array($one, $two));
+		$c2 = new Collection(array($two, $three));
+
+		$this->assertEquals(new Collection(array($one, $two, $three)), $c1->mergeCollection($c2));
+	}
+
+	public function testCollectionDiffsWithGivenCollection()
+	{
+		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one->shouldReceive('getKey')->andReturn(1);
+
+		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two->shouldReceive('getKey')->andReturn(2);
+
+		$three = m::mock('Illuminate\Database\Eloquent\Model');
+		$three->shouldReceive('getKey')->andReturn(3);
+
+		$c1 = new Collection(array($one, $two));
+		$c2 = new Collection(array($two, $three));
+
+		$this->assertEquals(new Collection(array($one)), $c1->diffCollection($c2));
+	}
+
+	public function testCollectionIntersectsWithGivenCollection()
+	{
+		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one->shouldReceive('getKey')->andReturn(1);
+
+		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two->shouldReceive('getKey')->andReturn(2);
+
+		$three = m::mock('Illuminate\Database\Eloquent\Model');
+		$three->shouldReceive('getKey')->andReturn(3);
+
+		$c1 = new Collection(array($one, $two));
+		$c2 = new Collection(array($two, $three));
+
+		$this->assertEquals(new Collection(array($two)), $c1->intersectCollection($c2));
+	}
 
 	public function testLists()
 	{

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -89,6 +89,7 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(1,2,3), $c->modelKeys());
 	}
 
+
 	public function testCollectionMergesWithGivenCollection()
 	{
 		$one = m::mock('Illuminate\Database\Eloquent\Model');
@@ -103,8 +104,9 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 		$c1 = new Collection(array($one, $two));
 		$c2 = new Collection(array($two, $three));
 
-		$this->assertEquals(new Collection(array($one, $two, $three)), $c1->mergeCollection($c2));
+		$this->assertEquals(new Collection(array($one, $two, $three)), $c1->merge($c2));
 	}
+
 
 	public function testCollectionDiffsWithGivenCollection()
 	{
@@ -120,8 +122,9 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 		$c1 = new Collection(array($one, $two));
 		$c2 = new Collection(array($two, $three));
 
-		$this->assertEquals(new Collection(array($one)), $c1->diffCollection($c2));
+		$this->assertEquals(new Collection(array($one)), $c1->diff($c2));
 	}
+
 
 	public function testCollectionIntersectsWithGivenCollection()
 	{
@@ -137,8 +140,9 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 		$c1 = new Collection(array($one, $two));
 		$c2 = new Collection(array($two, $three));
 
-		$this->assertEquals(new Collection(array($two)), $c1->intersectCollection($c2));
+		$this->assertEquals(new Collection(array($two)), $c1->intersect($c2));
 	}
+
 
 	public function testLists()
 	{

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -154,6 +154,20 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDiffCollection()
+	{
+		$c = new Collection(array('id' => 1, 'first_word' => 'Hello'));
+		$this->assertEquals(array('id' => 1), $c->diff(new Collection(array('first_word' => 'Hello', 'last_word' => 'World')))->all());
+	}
+
+
+	public function testIntersectCollection()
+	{
+		$c = new Collection(array('id' => 1, 'first_word' => 'Hello'));
+		$this->assertEquals(array('first_word' => 'Hello'), $c->intersect(new Collection(array('first_world' => 'Hello', 'last_word' => 'World')))->all());
+	}
+
+
 	public function testCollapse()
 	{
 		$data = new Collection(array(array($object1 = new StdClass), array($object2 = new StdClass)));


### PR DESCRIPTION
The diff and intersect functions on `Illuminate\Support\Collection` use native PHP functions while merge, diff and intersect functions on `Illuminate\Eloquent\Collection' work by using the primary key of provided models.

Tests included.
