### PR TITLE
Return service provider instance from App::register()

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -365,7 +365,7 @@ class Application extends Container implements HttpKernelInterface, ResponsePrep
 	 *
 	 * @param  \Illuminate\Support\ServiceProvider|string  $provider
 	 * @param  array  $options
-	 * @return void
+	 * @return \Illuminate\Support\ServiceProvider
 	 */
 	public function register($provider, $options = array())
 	{

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -390,6 +390,8 @@ class Application extends Container implements HttpKernelInterface, ResponsePrep
 		$this->serviceProviders[] = $provider;
 
 		$this->loadedProviders[get_class($provider)] = true;
+
+		return $provider;
 	}
 
 	/**


### PR DESCRIPTION
Which allow 4.0 user to manually run boot(), which mean now you can do:

``` php
$service = App::make('SomeFooServiceProvider');
$service->boot();
```

Signed-off-by: crynobone crynobone@gmail.com
