### PR TITLE
Encrypt the payload for recreated jobs

### DIFF
--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -105,7 +105,7 @@ class IronQueue extends Queue implements QueueInterface {
 		{
 			$job->body = $this->crypt->decrypt($job->body);
 
-			return new IronJob($this->container, $this->iron, $job);
+			return new IronJob($this->container, $this->iron, $this->crypt, $job);
 		}
 	}
 
@@ -145,7 +145,7 @@ class IronQueue extends Queue implements QueueInterface {
 	 */
 	protected function createPushedIronJob($job)
 	{
-		return new IronJob($this->container, $this->iron, $job, true);
+		return new IronJob($this->container, $this->iron, $this->crypt, $job, true);
 	}
 
 	/**


### PR DESCRIPTION
When recreating a job from the **IronJob** class, we must encrypt the payload so that it can be decrypted when we process the job.

---

P.S. All of this handwringing can be avoided if we were to recreate this new job through the **IronQueue** class, as I did it in the original pull request #2267.
