### PR TITLE
Fixes for relationships and checkboxes #2548

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -452,7 +452,9 @@ class Builder {
 		// also set the proper connection name for the model after we create it.
 		foreach ($results as $result)
 		{
-			$models[] = $model = $this->model->newFromBuilder($result);
+			$model = $this->model->newFromBuilder($result);
+
+			$models[$model->getKey()] = $model;
 
 			$model->setConnection($connection);
 		}

--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -936,7 +936,7 @@ class FormBuilder {
 	 */
 	public function oldInputIsEmpty()
 	{
-		return (isset($this->session) && count($this->session->getOldInput()) == 0);
+		return (!isset($this->session) || count($this->session->getOldInput()) == 0);
 	}
 
 	/**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -637,12 +637,18 @@ if ( ! function_exists('object_get'))
 
 		foreach (explode('.', $key) as $segment)
 		{
-			if ( ! is_object($object) || ! isset($object->{$segment}))
+			if ( is_numeric($segment) && (is_array($object) || $object instanceof ArrayAccess) && isset($object[$segment]) )
+			{
+				$object = $object[$segment];
+			}
+			elseif ( ! is_object($object) || ! isset($object->{$segment}))
 			{
 				return value($default);
 			}
-
-			$object = $object->{$segment};
+			else
+			{
+				$object = $object->{$segment};
+			}
 		}
 
 		return $object;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -165,8 +165,8 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testGetModelsProperlyHydratesModels()
 	{
 		$builder = $this->getMock('Illuminate\Database\Eloquent\Builder', array('get'), $this->getMocks());
-		$records[] = array('name' => 'taylor', 'age' => 26);
-		$records[] = array('name' => 'dayle', 'age' => 28);
+		$records[] = array('id' => 1, 'name' => 'taylor', 'age' => 26);
+		$records[] = array('id' => 2, 'name' => 'dayle', 'age' => 28);
 		$builder->getQuery()->shouldReceive('get')->once()->with(array('foo'))->andReturn($records);
 		$model = m::mock('Illuminate\Database\Eloquent\Model[getTable,getConnectionName,newInstance]');
 		$model->shouldReceive('getTable')->once()->andReturn('foobars');
@@ -176,12 +176,12 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$model->shouldReceive('newInstance')->andReturnUsing(function() { return new EloquentBuilderTestModelStub; });
 		$models = $builder->getModels(array('foo'));
 
-		$this->assertEquals('taylor', $models[0]->name);
-		$this->assertEquals($models[0]->getAttributes(), $models[0]->getOriginal());
-		$this->assertEquals('dayle', $models[1]->name);
+		$this->assertEquals('taylor', $models[1]->name);
 		$this->assertEquals($models[1]->getAttributes(), $models[1]->getOriginal());
-		$this->assertEquals('foo_connection', $models[0]->getConnectionName());
+		$this->assertEquals('dayle', $models[2]->name);
+		$this->assertEquals($models[2]->getAttributes(), $models[2]->getOriginal());
 		$this->assertEquals('foo_connection', $models[1]->getConnectionName());
+		$this->assertEquals('foo_connection', $models[2]->getConnectionName());
 	}
 
 

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -425,11 +425,6 @@ class FormBuilderModelStub {
 		return $this->data[$key];
 	}
 
-	public function __set($key, $value)
-	{
-		$this->data[$key] = $value;
-	}
-
 	public function __isset($key)
 	{
 		return isset($this->data[$key]);

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -381,6 +381,23 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<input src="'. $url .'" type="image">', $image);
 	}
 
+
+	public function testCollectionCheckboxes()
+	{
+		$this->setModel(array(
+			'relations' => new Illuminate\Support\Collection(array(
+				2 => new FormBuilderModelStub(array('id' => 2, 'foo' => 'bar'))
+			))
+		));
+
+		$checkbox = $this->formBuilder->checkbox('relations[1]');
+		$this->assertEquals('<input name="relations[1]" type="checkbox" value="1">', $checkbox);
+
+		$checkbox = $this->formBuilder->checkbox('relations[2]');
+		$this->assertEquals('<input checked="checked" name="relations[2]" type="checkbox" value="1">', $checkbox);
+	}
+
+
 	protected function setModel(array $data, $object = true)
 	{
 		if ($object) $data = new FormBuilderModelStub($data);
@@ -406,6 +423,11 @@ class FormBuilderModelStub {
 	public function __get($key)
 	{
 		return $this->data[$key];
+	}
+
+	public function __set($key, $value)
+	{
+		$this->data[$key] = $value;
 	}
 
 	public function __isset($key)


### PR DESCRIPTION
Unfortunately this is an issue that's spread over many parts of Laravel. First, the form builder wasn't always telling the truth on whether or not it had old session input. Second, object_get wasn't working well with numeric segments and arrays/collections (for example `object_get($obj, 'relation.2')`). Third, Eloquent collections don't index by model key when being fetched from the database, so you can't do a simple array lookup.

This is a dirty as all hell fix for issue #2548, but seems to work and no unit tests are breaking. You'll have to do `Form::checkbox("relation[$relation->id]")` and `array_keys(Input::get('relation'))` to get an array of keys which you can then use to sync the relations.
