### PR TITLE
Add unique() methods to Support and Eloquent collections to return only unique items

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -174,4 +174,24 @@ class Collection extends BaseCollection {
 		return $intersect;
 	}
 
+	/**
+	 * Return only unique items from the collection.
+	 *
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function unique()
+	{
+		$unique = new static;
+
+		foreach ($this->items as $item)
+		{
+			if ( ! $unique->contains($item->getKey()))
+			{
+				$unique->add($item);
+			}
+		}
+
+		return $unique;
+	}
+
 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -379,6 +379,16 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Return only unique items from the collection array.
+	 *
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function unique()
+	{
+		return new static(array_unique($this->items));
+	}
+
+	/**
 	 * Slice the underlying collection array.
 	 *
 	 * @param  int   $offset

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -144,6 +144,20 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testCollectionReturnsUniqueItems()
+	{
+		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one->shouldReceive('getKey')->andReturn(1);
+
+		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two->shouldReceive('getKey')->andReturn(2);
+
+		$c = new Collection(array($one, $two, $two));
+
+		$this->assertEquals(new Collection(array($one, $two)), $c->unique());
+	}
+
+
 	public function testLists()
 	{
 		$data = new Collection(array((object) array('name' => 'taylor', 'email' => 'foo'), (object) array('name' => 'dayle', 'email' => 'bar')));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -168,6 +168,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testUnique()
+	{
+		$c = new Collection(array('Hello', 'World', 'World'));
+		$this->assertEquals(array('Hello', 'World'), $c->unique()->all());
+	}
+
+
 	public function testCollapse()
 	{
 		$data = new Collection(array(array($object1 = new StdClass), array($object2 = new StdClass)));


### PR DESCRIPTION
The unique method on Support\Collection uses the inbuilt PHP array functions while the method on Eloquent\Collection uses the `getKey()` method on Eloquent models to determine uniqueness. This works in much the same way as the `diff()`, `merge()` and `intersect()` functions I proposed earlier this week.

Tests included.
