### PR TITLE
ModelNotFoundException to include setter and getter for model name.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -95,7 +95,7 @@ class Builder {
 	{
 		if ( ! is_null($model = $this->find($id, $columns))) return $model;
 
-		throw new ModelNotFoundException;
+		throw with(new ModelNotFoundException)->setModel(get_class($this->model));
 	}
 
 	/**
@@ -121,7 +121,7 @@ class Builder {
 	{
 		if ( ! is_null($model = $this->first($columns))) return $model;
 
-		throw new ModelNotFoundException;
+		throw with(new ModelNotFoundException)->setModel(get_class($this->model));
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -520,7 +520,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	{
 		if ( ! is_null($model = static::find($id, $columns))) return $model;
 
-		throw new ModelNotFoundException(get_called_class().' model not found');
+		throw with(new ModelNotFoundException)->setModel(get_called_class());
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -17,7 +17,7 @@ class ModelNotFoundException extends \RuntimeException {
 	public function setModel($model)
 	{
 		$this->model = $model;
-		$this->message = "{$model} not found";
+		$this->message = "{$model} model not found";
 
 		return $this;
 	}

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -1,3 +1,35 @@
 <?php namespace Illuminate\Database\Eloquent;
 
-class ModelNotFoundException extends \RuntimeException {}
+class ModelNotFoundException extends \RuntimeException {
+	/**
+	 * Name of the affected eloquent model.
+	 *
+	 * @var string
+	 */
+	protected $model;
+
+	/**
+	 * Set the affected eloquent model.
+	 *
+	 * @param  string   $model
+	 * @return ModelNotFoundException
+	 */
+	public function setModel($model)
+	{
+		$this->model = $model;
+		$this->message = "{$model} not found";
+
+		return $this;
+	}
+
+	/**
+	 * Get the affected eloquent model.
+	 *
+	 * @return string
+	 */
+	public function getModel()
+	{
+		return $this->model;
+	}
+
+}

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -26,6 +26,38 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('baz', $result);
 	}
 
+	/**
+	 * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
+	 */
+	public function testFindOrFailMethodThrowsModelNotFoundException()
+	{
+		$query = m::mock('Illuminate\Database\Query\Builder');
+		$query->shouldReceive('where')->once()->with('foo', '=', 'bar');
+		$builder = $this->getMock('Illuminate\Database\Eloquent\Builder', array('first'), array($query));
+ 		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model->shouldReceive('getKeyName')->once()->andReturn('foo');
+		$model->shouldReceive('getTable')->once()->andReturn('table');
+		$query->shouldReceive('from')->once()->with('table');
+		$builder->setModel($model);
+		$builder->expects($this->once())->method('first')->with($this->equalTo(array('column')))->will($this->returnValue(null));
+		$result = $builder->findOrFail('bar', array('column'));
+	}
+
+	/**
+	 * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
+	 */
+	public function testFirstOrFailMethodThrowsModelNotFoundException()
+	{
+		$query = m::mock('Illuminate\Database\Query\Builder');
+		$builder = $this->getMock('Illuminate\Database\Eloquent\Builder', array('first'), array($query));
+ 		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model->shouldReceive('getTable')->once()->andReturn('table');
+		$query->shouldReceive('from')->once()->with('table');
+		$builder->setModel($model);
+		$builder->expects($this->once())->method('first')->with($this->equalTo(array('column')))->will($this->returnValue(null));
+		$result = $builder->firstOrFail(array('column'));
+	}
+
 	public function testFindWithMany()
 	{
 		$query = m::mock('Illuminate\Database\Query\Builder');

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -69,7 +69,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
-	 * @expectedExceptionMessage EloquentModelFindNotFoundStub not found
+	 * @expectedExceptionMessage EloquentModelFindNotFoundStub model not found
 	 */
 	public function testFindOrFailMethodThrowsModelNotFoundException()
 	{

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -67,6 +67,15 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo', $result);
 	}
 
+	/**
+	 * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
+	 * @expectedExceptionMessage EloquentModelFindNotFoundStub not found
+	 */
+	public function testFindOrFailMethodThrowsModelNotFoundException()
+	{
+		$result = EloquentModelFindNotFoundStub::findOrFail(1);
+	}
+
 
 	public function testFindMethodWithArrayCallsQueryBuilderCorrectly()
 	{
@@ -826,6 +835,15 @@ class EloquentModelFindStub extends Illuminate\Database\Eloquent\Model {
 	{
 		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
 		$mock->shouldReceive('find')->once()->with(1, array('*'))->andReturn('foo');
+		return $mock;
+	}
+}
+
+class EloquentModelFindNotFoundStub extends Illuminate\Database\Eloquent\Model {
+	public function newQuery($excludeDeleted = true)
+	{
+		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
+		$mock->shouldReceive('find')->once()->with(1, array('*'))->andReturn(null);
 		return $mock;
 	}
 }


### PR DESCRIPTION
This would allow identifying the model name much easier without having to have additional string parser, and at the same time preserve the current message.

Signed-off-by: crynobone crynobone@gmail.com

Improvement to #2715

p/s: I'm not sure if the @taylorotwell would prefer this syntax. I'm open to other approach.
