### PR TITLE
Allow Eloquent\Collection::find and contains to work with models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -13,6 +13,11 @@ class Collection extends BaseCollection {
 	 */
 	public function find($key, $default = null)
 	{
+		if ($key instanceof Model)
+		{
+			$key = $key->getKey();
+		}
+
 		return array_first($this->items, function($itemKey, $model) use ($key)
 		{
 			return $model->getKey() == $key;

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -33,6 +33,22 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testContainsIndicatesIfModelInArray()
+	{
+		$mockModel = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel->shouldReceive('getKey')->andReturn(1);
+		$mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel2->shouldReceive('getKey')->andReturn(2);
+		$mockModel3 = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel3->shouldReceive('getKey')->andReturn(3);
+		$c = new Collection(array($mockModel, $mockModel2));
+
+		$this->assertTrue($c->contains($mockModel));
+		$this->assertTrue($c->contains($mockModel2));
+		$this->assertFalse($c->contains($mockModel3));
+	}
+
+
 	public function testContainsIndicatesIfKeyedModelInArray()
 	{
 		$mockModel = m::mock('Illuminate\Database\Eloquent\Model');


### PR DESCRIPTION
Allows doing `$collection->contains($model)`. Small improvement but it's a really small change too.
