### PR TITLE
Add support for using IAM Roles for SQS queues.

### DIFF
--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -13,11 +13,9 @@ class SqsConnector implements ConnectorInterface {
 	 */
 	public function connect(array $config)
 	{
-		$sqs = SqsClient::factory(array(
+		$sqsConfig = array_only($config, array('key', 'secret', 'region', 'default_cache_config'));
 
-			'key' => $config['key'], 'secret' => $config['secret'], 'region' => $config['region'],
-
-		));
+		$sqs = SqsClient::factory($sqsConfig);
 
 		return new SqsQueue($sqs, $config['queue']);
 	}


### PR DESCRIPTION
The AWS PHP SDK allows for specifying a location on EC2 instances that will allow the instance to assume an IAM role and connect to different services. You just need to add a `default_cache_config` option to the config array for queues using the SQS driver.
