### PR TITLE
Dirty fields need to be refreshed after updating event fired to accommodate additional changed fields

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1191,12 +1191,15 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			// Refresh dirty fields in case the updating event updated other fields
 			$dirty = $this->getDirty();
 
-			// Once we have run the update operation, we will fire the "updated" event for
-			// this model instance. This will allow developers to hook into these after
-			// models are updated, giving them a chance to do any special processing.
-			$this->setKeysForSaveQuery($query)->update($dirty);
+			// Make sure our fields are still dirty (our updating event might have changed our state)
+			if (count($dirty) > 0) {
+				// Once we have run the update operation, we will fire the "updated" event for
+				// this model instance. This will allow developers to hook into these after
+				// models are updated, giving them a chance to do any special processing.
+				$this->setKeysForSaveQuery($query)->update($dirty);
 
-			$this->fireModelEvent('updated', false);
+				$this->fireModelEvent('updated', false);
+			}
 		}
 
 		return true;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1186,9 +1186,10 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			if ($this->timestamps)
 			{
 				$this->updateTimestamps();
-
-				$dirty = $this->getDirty();
 			}
+
+			// Refresh dirty fields in case the updating event updated other fields
+			$dirty = $this->getDirty();
 
 			// Once we have run the update operation, we will fire the "updated" event for
 			// this model instance. This will allow developers to hook into these after


### PR DESCRIPTION
The updating model event may be used to contextually changed other model fields. Unfortunately, these changes do not get saved as the array of dirty values isn't refreshed after firing the event, except in the case where timestamps are used.

This update ensures that dirty fields are always refreshed just before the update process takes place.
