### PR TITLE
Route bindings stored whilst being parsed

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -211,24 +211,22 @@ class Route extends BaseRoute {
 		// If we have already parsed the parameters, we will just return the listing
 		// that we already parsed as some of these may have been resolved through
 		// a binder that uses a database repository and shouldn't be run again.
-		if (isset($this->parsedParameters))
+		if (!isset($this->parsedParameters))
 		{
-			return $this->parsedParameters;
+			$variables = $this->compile()->getVariables();
+
+			// To get the parameter array, we need to spin the names of the variables on
+			// the compiled route and match them to the parameters that we got when a
+			// route is matched by the router, as routes instances don't have them.
+			$this->parsedParameters = array();
+
+			foreach ($variables as $variable)
+			{
+				$this->parsedParameters[$variable] = $this->resolveParameter($variable);
+			}
 		}
 
-		$variables = $this->compile()->getVariables();
-
-		// To get the parameter array, we need to spin the names of the variables on
-		// the compiled route and match them to the parameters that we got when a
-		// route is matched by the router, as routes instances don't have them.
-		$parameters = array();
-
-		foreach ($variables as $variable)
-		{
-			$parameters[$variable] = $this->resolveParameter($variable);
-		}
-
-		return $this->parsedParameters = $parameters;
+		return $this->parsedParameters;
 	}
 
 	/**


### PR DESCRIPTION
This allows the developer to access already parsed bound variables to ensure correct loading of resources.

Currently it's not possible to construct urls in the form of /foo/{foo}/bar/{bar} where {bar} is specific to {foo}, e.g.
/person/jon/child/tim would load the same child as /person/bill/child/tim

With this update, when resolving the 'child' variable, we can test what was discovered for the parent, and load the appropriate child, ala
Child::where('name', $name)->where('parent', $route->getParameter('parent')->name)

Currently attempting to do so leads to an infinite recursion loop
