### PR TITLE
Adding support for /resource/{id}/delete route for Route::resource()

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -108,7 +108,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 *
 	 * @var array
 	 */
-	protected $resourceDefaults = array('index', 'create', 'store', 'show', 'edit', 'update', 'destroy');
+	protected $resourceDefaults = array('index', 'create', 'store', 'show', 'edit', 'update', 'delete', 'destroy');
 
 	/**
 	 * Create a new Router instance.
@@ -577,6 +577,22 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		$uri = $this->getResourceUri($name).'/{'.$base.'}/edit';
 
 		return $this->get($uri, $this->getResourceAction($name, $controller, 'edit', $options));
+	}
+
+	/**
+	 * Add the delete method for a resourceful route.
+	 *
+	 * @param  string  $name
+	 * @param  string  $base
+	 * @param  string  $controller
+	 * @param  array   $options
+	 * @return void
+	 */
+	protected function addResourceDelete($name, $base, $controller, $options)
+	{
+		$uri = $this->getResourceUri($name).'/{'.$base.'}/delete';
+
+		return $this->get($uri, $this->getResourceAction($name, $controller, 'delete', $options));
 	}
 
 	/**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -489,7 +489,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$router = $this->getRouter();
 		$router->resource('foo', 'FooController');
 		$routes = $router->getRoutes();
-		$this->assertEquals(8, count($routes));
+		$this->assertEquals(9, count($routes));
 
 		$router = $this->getRouter();
 		$router->resource('foo', 'FooController', array('only' => array('show', 'destroy')));

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -501,7 +501,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$router->resource('foo', 'FooController', array('except' => array('show', 'destroy')));
 		$routes = $router->getRoutes();
 
-		$this->assertEquals(6, count($routes));
+		$this->assertEquals(7, count($routes));
 
 		$router = $this->getRouter();
 		$router->resource('foo-bars', 'FooController', array('only' => array('show')));
@@ -531,6 +531,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.edit'));
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.update'));
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.destroy'));
+		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.delete'));
 
 		$router = $this->getRouter();
 		$router->resource('foo.bar', 'FooController');
@@ -542,6 +543,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.edit'));
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.update'));
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.destroy'));
+		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.delete'));
 
 		$router = $this->getRouter();
 		$router->resource('foo', 'FooController', array('names' => array(


### PR DESCRIPTION
This adds a delete route that can be used to display a confirm delete form, before actually deleting the resource with the destroy route.
