### PR TITLE
Remove strict Eloquent getDirty() comparison

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2529,7 +2529,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		foreach ($this->attributes as $key => $value)
 		{
-			if ( ! array_key_exists($key, $this->original) || $value !== $this->original[$key])
+			if ( ! array_key_exists($key, $this->original) || $value != $this->original[$key])
 			{
 				$dirty[$key] = $value;
 			}


### PR DESCRIPTION
I think this should be removed.
because if we have integer fields, like country_id, it will always return as changed, because it will be compairing int vs string. as items coming from mysql are all strings
