### PR TITLE
Response macro call $parameters instead of func_get_args()

### DIFF
--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -121,7 +121,7 @@ class Response {
 	{
 		if (isset(static::$macros[$method]))
 		{
-			return call_user_func_array(static::$macros[$method], func_get_args());
+			return call_user_func_array(static::$macros[$method], $parameters);
 		}
 
 		throw new \BadMethodCallException("Call to undefined method $method");


### PR DESCRIPTION
I see called func_get_args () is silly :)

Ex:

``` php
Response::macro('error', function($message = null, $redirect = null)
{
    var_dump($message);  // "error"
    var_dump($redirect); // Array parameters
});
```
