### PR TITLE
Fix a bug introduced in #2710 where values could no longer be injected in views

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -97,7 +97,7 @@ class View implements ArrayAccess, Renderable {
 	}
 
 	/**
-	 * Get the sectiosn of the view.
+	 * Get the sections of the rendered view.
 	 *
 	 * @return array
 	 */

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\View;
 
 use ArrayAccess;
+use Closure;
 use Illuminate\Support\MessageBag;
 use Illuminate\View\Engines\EngineInterface;
 use Illuminate\Support\Contracts\MessageProviderInterface;
@@ -67,13 +68,12 @@ class View implements ArrayAccess, Renderable {
 	/**
 	 * Get the string contents of the view.
 	 *
+	 * @param  \Closure  $callback
 	 * @return string
 	 */
-	public function render()
+	public function render(Closure $callback = null)
 	{
 		$env = $this->environment;
-
-		if ($env->doneRendering()) $env->flushSections();
 
 		// We will keep track of the amount of views being rendered so we can flush
 		// the section after the complete rendering operation is done. This will
@@ -89,19 +89,26 @@ class View implements ArrayAccess, Renderable {
 		// no old sections are staying around in the memory of an environment.
 		$env->decrementRender();
 
-		return $contents;
+		$response = isset($callback) ? $callback($this, $contents) : null;
+
+		if ($env->doneRendering()) $env->flushSections();
+
+		return $response !== null ? $response : $contents;
 	}
 
 	/**
-	 * Get the sections from the view.
+	 * Get the sectiosn of the view.
 	 *
 	 * @return array
 	 */
-	 public function renderSections()
-	 {
-		$this->render();
+	public function renderSections()
+	{
+		$env = $this->environment;
 
-		return $this->getEnvironment()->getSections();
+		return $this->render(function($view) use ($env)
+		{
+			return $env->getSections();
+		});
 	}
 
 	/**

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -29,15 +29,34 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 	public function testRenderProperlyRendersView()
 	{
 		$view = $this->getView();
-		$view->getEnvironment()->shouldReceive('incrementRender')->once();
-		$view->getEnvironment()->shouldReceive('callComposer')->once()->with($view);
+		$view->getEnvironment()->shouldReceive('incrementRender')->once()->ordered();
+		$view->getEnvironment()->shouldReceive('callComposer')->once()->ordered()->with($view);
 		$view->getEnvironment()->shouldReceive('getShared')->once()->andReturn(array('shared' => 'foo'));
 		$view->getEngine()->shouldReceive('get')->once()->with('path', array('foo' => 'bar', 'shared' => 'foo'))->andReturn('contents');
-		$view->getEnvironment()->shouldReceive('decrementRender')->once();
-		$view->getEnvironment()->shouldReceive('doneRendering')->once()->andReturn(true);
-		$view->getEnvironment()->shouldReceive('flushSections')->once();
+		$view->getEnvironment()->shouldReceive('decrementRender')->once()->ordered();
+		$view->getEnvironment()->shouldReceive('doneRendering')->once()->ordered()->andReturn(true);
+		$view->getEnvironment()->shouldReceive('flushSections')->once()->ordered();
 
-		$this->assertEquals('contents', $view->render());
+		$me = $this;
+		$callback = function(View $rendered, $contents) use ($me, $view)
+		{
+			$me->assertEquals($view, $rendered);
+			$me->assertEquals('contents', $contents);
+		};
+
+		$this->assertEquals('contents', $view->render($callback));
+	}
+
+
+	public function testRenderSectionsReturnsEnvironmentSections()
+	{
+		$view = m::mock('Illuminate\View\View[render]');
+		$view->__construct(m::mock('Illuminate\View\Environment'), m::mock('Illuminate\View\Engines\EngineInterface'), 'view', 'path', array());
+
+		$view->shouldReceive('render')->with(m::type('Closure'))->once()->andReturn($sections = array('foo' => 'bar'));
+		$view->getEnvironment()->shouldReceive('getSections')->once()->andReturn($sections);
+
+		$this->assertEquals($sections, $view->renderSections());
 	}
 
 


### PR DESCRIPTION
An accidental side effect of #2710 was that environment sections were flushed before a view was rendered. The issue lies in that, `View::inject()` sets up an environment section before rendering happens. By wiping this out, we're no longer accessing the injected values.

I decided it was appropriate to pass an optional closure into `render()`. If a value was returned, anything other than `null`, that value would be returned as a result, rather than the view's contents. The `$view` instance as well as the rendered `$contents` are given to this closure, allowing for some pretty powerful manipulation.

One implementation I provided was that of #2710, `renderSections()`, which will return the rendered sections of the view as an array, using this callback functionality.

![screen shot 2013-12-03 at 12 34 14 pm](https://f.cloud.github.com/assets/181919/1660367/348c3086-5bbb-11e3-8a9a-b7536738dcaa.png)

Finally, I have added further constraints to a couple of tests (in addition to adding tests for this new functionality) to hopefully ensure that the rendering process does not get broken again in the future.
