### PR TITLE
Signed-off-by: Daniele Salvatore Albano <d.albano@gmail.com>

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -105,9 +105,10 @@ abstract class ServiceProvider {
 	 */
 	public function guessPackagePath()
 	{
-		$path = with(new ReflectionClass($this))->getFileName();
+		$class = with(new ReflectionClass($this));
+		$path = substr(dirname($class->getFileName()), 0, -strlen(dirname($class->name)));
 
-		return realpath(dirname($path).'/../../');
+		return realpath($path);
 	}
 
 	/**


### PR DESCRIPTION
Remove partial hardcoded path from Illuminate\Support\ServiceProvider->guessPackagePath (in Illuminate/Support/ServiceProvider.php), now the base package path is determined correctly even when the package namespace is deeper than two.
