### PR TITLE
Make model relationship creates filtered by fillable array

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -193,12 +193,12 @@ abstract class HasOneOrMany extends Relation {
 			$this->getPlainForeignKey() => $this->getParentKey(),
 		);
 
-		// Here we will set the raw attributes to avoid hitting the "fill" method so
-		// that we do not have to worry about a mass accessor rules blocking sets
-		// on the models. Otherwise, some of these attributes will not get set.
+		// First fill the attributes with input data
+		// Then override them with foreign keys and other data that is not in fillable array
 		$instance = $this->related->newInstance();
 
-		$instance->setRawAttributes(array_merge($attributes, $foreign));
+		$instance->fill($attributes);
+		$instance->setRawAttributes(array_merge($instance->getAttributes(), $foreign));
 
 		$instance->save();
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -194,7 +194,7 @@ abstract class HasOneOrMany extends Relation {
 		);
 
 		// First fill the attributes with input data
-		// Then override them with foreign keys and other data that is not in fillable array
+		// Then override them with foreign keys and data already filtered by fillable
 		$instance = $this->related->newInstance();
 
 		$instance->fill($attributes);

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -15,12 +15,13 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 	public function testCreateMethodProperlyCreatesNewModel()
 	{
 		$relation = $this->getRelation();
-		$created = $this->getMock('Illuminate\Database\Eloquent\Model', array('save', 'getKey', 'setRawAttributes'));
-		$created->expects($this->once())->method('save')->will($this->returnValue(true));
+		$created = new EloquentHasManyRelationStub;
 		$relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($created);
-		$created->expects($this->once())->method('setRawAttributes')->with($this->equalTo(array('name' => 'taylor', 'foreign_key' => 1)));
-
-		$this->assertEquals($created, $relation->create(array('name' => 'taylor')));
+		$related = $relation->create(array('name' => 'taylor', 'foo' => 'bar'));
+		$this->assertEquals('taylor', $related->name);
+		$this->assertNull($related->foo);
+		$this->assertEquals(1, $related->foreign_key);
+		$this->assertTrue($related->exists);
 	}
 
 	public function testUpdateMethodUpdatesModelsWithTimestamps()
@@ -106,4 +107,13 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 
 class EloquentHasManyModelStub extends Illuminate\Database\Eloquent\Model {
 	public $foreign_key = 'foreign.value';
+}
+
+class EloquentHasManyRelationStub extends Illuminate\Database\Eloquent\Model {
+	protected $fillable = array('name');
+	public function save(array $options = array())
+	{
+		$this->exists = true;
+		return true;
+	}
 }

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -27,12 +27,13 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 	public function testCreateMethodProperlyCreatesNewModel()
 	{
 		$relation = $this->getRelation();
-		$created = $this->getMock('Illuminate\Database\Eloquent\Model', array('save', 'getKey', 'setRawAttributes'));
-		$created->expects($this->once())->method('save')->will($this->returnValue(true));
+		$created = new EloquentHasOneRelationStub;
 		$relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($created);
-		$created->expects($this->once())->method('setRawAttributes')->with($this->equalTo(array('name' => 'taylor', 'foreign_key' => 1)));
-
-		$this->assertEquals($created, $relation->create(array('name' => 'taylor')));
+		$related = $relation->create(array('name' => 'taylor', 'foo' => 'bar'));
+		$this->assertEquals('taylor', $related->name);
+		$this->assertNull($related->foo);
+		$this->assertEquals(1, $related->foreign_key);
+		$this->assertTrue($related->exists);
 	}
 
 
@@ -127,4 +128,13 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
 class EloquentHasOneModelStub extends Illuminate\Database\Eloquent\Model {
 	public $foreign_key = 'foreign.value';
+}
+
+class EloquentHasOneRelationStub extends Illuminate\Database\Eloquent\Model {
+	protected $fillable = array('name');
+	public function save(array $options = array())
+	{
+		$this->exists = true;
+		return true;
+	}
 }


### PR DESCRIPTION
Currently, when creating instances in a model relationship,  attribute `$fillable = array(...)` of the relationship is ignored. As stated by the comment, it's done so to allow foreign keys to be automatically set. Now it allows us to do this as it fills attributes beforehand with `fill()` and then sets merged raw attributes filtered by `fill()` with foreign keys, thus, we may now do things like

```
$contactData = [
    'type' => 'qwe',
    'value' => 'qwe',
    'foo' => 999
];
$client = Client::find(1);
$client->contacts()->create($contactData);
```

which is much more clean than

```
$contactData = [
    'type' => 'qwe',
    'value' => 'qwe',
    'foo' => 999
];

$client = Client::find(1);
$clientContact = ClientContact::create($contactData);
$client->contacts()->save($clientContact);
```

In the examples above `'foo'` database table column does not exist and because of that we get the SQL error if we don't `fill()`.
