### PR TITLE
Reintroducing Lost Routes Overriding (#2848)

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -169,7 +169,7 @@ class RouteCollection implements Countable, IteratorAggregate {
 	 */
 	protected function check(array $routes, $request)
 	{
-		return array_first($routes, function($key, $value) use ($request)
+		return array_last($routes, function($key, $value) use ($request)
 		{
 			return $value->matches($request);
 		});

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -198,6 +198,22 @@ if ( ! function_exists('array_first'))
 	}
 }
 
+if ( ! function_exists('array_last'))
+{
+	/**
+	 * Return the last element in an array passing a given truth test.
+	 *
+	 * @param  array    $array
+	 * @param  Closure  $callback
+	 * @param  mixed    $default
+	 * @return mixed
+	 */
+	function array_last($array, $callback, $default = null)
+	{
+		return array_first(array_reverse($array), $callback, $default);
+	}
+}
+
 if ( ! function_exists('array_flatten'))
 {
 	/**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -57,6 +57,11 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$router = $this->getRouter();
 		$router->any('foo/bar', function() { return 'hello'; });
 		$this->assertEquals('', $router->dispatch(Request::create('foo/bar', 'HEAD'))->getContent());
+
+		$router = $this->getRouter();
+		$router->get('foo/bar', function() { return 'first'; });
+		$router->get('foo/bar', function() { return 'second'; });
+		$this->assertEquals('second', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 	}
 
 


### PR DESCRIPTION
In Laravel 4.0, the Symfony routing layer allowed you to redeclare a given route and it would become the responder for a request, not the original.

There's two solid examples (both of which I'm hitting) where this is useful:
1. Say you would like to use a 3rd party Laravel package who specifies routes, but would like to customise the functionality of that. This was possible in 4.0 and is not in 4.1.
2. (Based on the previous example), say you were building an extendible system, such as a CMS, you would like drop-in code (let's call theme "extensions") to be able to override other extensions. This was possible, now it is not.

This PR breaks no backwards compatibility, but rather reinstates it. I have also included tests as proof of concept that this behaviour is working as expected again.

This PR fixes #2848.
