### PR TITLE
Remove whitespace at the end of truncated portion in Str::limit()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -123,7 +123,7 @@ class Str {
 	{
 		if (mb_strlen($value) <= $limit) return $value;
 
-		return mb_substr($value, 0, $limit, 'UTF-8').$end;
+		return rtrim(mb_substr($value, 0, $limit, 'UTF-8')).$end;
 	}
 
 	/**


### PR DESCRIPTION
The truncated portion of Str::limit often has whitespace at the end, so you end up with something like this:

```
Welcome to my ...
```

The above can look a bit ugly and should instead probably read:

```
Welcome to my...
```

I've added rtrim() to the truncated string to apply this behaviour.
