### PR TITLE
array_first functionality in Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -97,11 +97,20 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	/**
 	 * Get the first item from the collection.
 	 *
+	 * @param  \Closure   $callback
+	 * @param  mixed      $default
 	 * @return mixed|null
 	 */
-	public function first()
+	public function first(Closure $callback = null, $default = null)
 	{
-		return count($this->items) > 0 ? reset($this->items) : null;
+		if (is_null($callback))
+		{
+			return count($this->items) > 0 ? reset($this->items) : null;
+		}
+		else
+		{
+			return array_first($this->items, $callback, $default);
+		}
 	}
 
 	/**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -294,6 +294,22 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('rolyat', 'niloc', 'nwahs'), array_values($data->all()));
 	}
 
+
+	public function testFirstWithCallback()
+	{
+		$data = new Collection(array('foo', 'bar', 'baz'));
+		$result = $data->first(function($key, $value) { return $value === 'bar'; });
+		$this->assertEquals('bar', $result);
+	}
+
+
+	public function testFirstWithCallbackAndDefault()
+	{
+		$data = new Collection(array('foo', 'bar'));
+		$result = $data->first(function($key, $value) { return $value === 'baz'; }, 'default');
+		$this->assertEquals('default', $result);
+	}
+
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
Optional parameters that allow collections to have a `first()` method that utilizes `array_first`.
