### PR TITLE
Ability to retrieve failed message recipients

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -54,6 +54,13 @@ class Mailer {
 	protected $pretending = false;
 
 	/**
+	 * Array of failed recipients.
+	 *
+	 * @var array
+	 */
+	protected $failedRecipients = array();
+
+	/**
 	 * Create a new Mailer instance.
 	 *
 	 * @param  \Illuminate\View\Environment  $views
@@ -290,7 +297,7 @@ class Mailer {
 	{
 		if ( ! $this->pretending)
 		{
-			return $this->swift->send($message);
+			return $this->swift->send($message, $this->failedRecipients);
 		}
 		elseif (isset($this->logger))
 		{
@@ -395,6 +402,16 @@ class Mailer {
 	public function getSwiftMailer()
 	{
 		return $this->swift;
+	}
+
+	/**
+	 * Get the array of failed recipients.
+	 *
+	 * @return array
+	 */
+	public function getFailedRecipients()
+	{
+		return $this->failedRecipients;
 	}
 
 	/**

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -23,7 +23,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase {
 		$message->shouldReceive('setFrom')->never();
 		$mailer->setSwiftMailer(m::mock('StdClass'));
 		$message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
-		$mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, m::any());
+		$mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, array());
 		$mailer->send('foo', array('data'), function($m) { $_SERVER['__mailer.test'] = $m; });
 		unset($_SERVER['__mailer.test']);
 	}


### PR DESCRIPTION
SwiftMailer's send method accepts a second parameter which is a reference to an array. Failed recipients will be appended to this array. With this small change you can easily do `Mail::getFailedRecipients()` after sending a batch of emails.

https://github.com/swiftmailer/swiftmailer/blob/master/lib/classes/Swift/Mailer.php#L75
