### PR TITLE
Make HtmlBuilder and FormBuilder use self-closing tags (also, fix typo)

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -228,14 +228,14 @@ class FormBuilder {
 			$value = $this->getValueAttribute($name, $value);
 		}
 
-		// Once we have the type, value, and ID we can marge them into the rest of the
+		// Once we have the type, value, and ID we can merge them into the rest of the
 		// attributes array so we can convert them into their HTML attribute format
 		// when creating the HTML element. Then, we will return the entire input.
 		$merge = compact('type', 'value', 'id');
 
 		$options = array_merge($options, $merge);
 
-		return '<input'.$this->html->attributes($options).'>';
+		return '<input'.$this->html->attributes($options).' />';
 	}
 
 	/**

--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -92,7 +92,7 @@ class HtmlBuilder {
 
 		$attributes['href'] = $this->url->asset($url);
 
-		return '<link'.$this->attributes($attributes).'>'.PHP_EOL;
+		return '<link'.$this->attributes($attributes).' />'.PHP_EOL;
 	}
 
 	/**
@@ -107,7 +107,7 @@ class HtmlBuilder {
 	{
 		$attributes['alt'] = $alt;
 
-		return '<img src="'.$this->url->asset($url).'"'.$this->attributes($attributes).'>';
+		return '<img src="'.$this->url->asset($url).'"'.$this->attributes($attributes).' />';
 	}
 
 	/**

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -39,10 +39,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
 
 		$this->assertEquals('<form method="GET" action="http://localhost/foo" accept-charset="UTF-8">', $form1);
-		$this->assertEquals('<form method="POST" action="http://localhost/foo" accept-charset="UTF-8" class="form" id="id-form"><input name="_token" type="hidden" value="">', $form2);
+		$this->assertEquals('<form method="POST" action="http://localhost/foo" accept-charset="UTF-8" class="form" id="id-form"><input name="_token" type="hidden" value="" />', $form2);
 		$this->assertEquals('<form method="GET" action="http://localhost/foo" accept-charset="UTF-16">', $form3);
 		$this->assertEquals('<form method="GET" action="http://localhost/foo" accept-charset="UTF-16" enctype="multipart/form-data">', $form4);
-		$this->assertEquals('<form method="POST" action="http://localhost/foo" accept-charset="UTF-8"><input name="_method" type="hidden" value="PUT"><input name="_token" type="hidden" value="">', $form5);
+		$this->assertEquals('<form method="POST" action="http://localhost/foo" accept-charset="UTF-8"><input name="_method" type="hidden" value="PUT" /><input name="_token" type="hidden" value="" />', $form5);
 	}
 
 
@@ -68,9 +68,9 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form2 = $this->formBuilder->input('text', 'foo', 'foobar');
 		$form3 = $this->formBuilder->input('date', 'foobar', null, array('class' => 'span2'));
 
-		$this->assertEquals('<input name="foo" type="text">', $form1);
-		$this->assertEquals('<input name="foo" type="text" value="foobar">', $form2);
-		$this->assertEquals('<input class="span2" name="foobar" type="date">', $form3);
+		$this->assertEquals('<input name="foo" type="text" />', $form1);
+		$this->assertEquals('<input name="foo" type="text" value="foobar" />', $form2);
+		$this->assertEquals('<input class="span2" name="foobar" type="date" />', $form3);
 	}
 
 
@@ -82,7 +82,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
 		$form1 = $this->formBuilder->password('password');
 
-		$this->assertEquals('<input name="password" type="password" value="">', $form1);
+		$this->assertEquals('<input name="password" type="password" value="" />', $form1);
 	}
 
 	public function testFilesNotFilled()
@@ -93,7 +93,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
 		$form = $this->formBuilder->file('img');
 
-		$this->assertEquals('<input name="img" type="file">', $form);
+		$this->assertEquals('<input name="img" type="file" />', $form);
 	}
 
 
@@ -104,10 +104,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form3 = $this->formBuilder->text('foo', 'foobar');
 		$form4 = $this->formBuilder->text('foo', null, array('class' => 'span2'));
 
-		$this->assertEquals('<input name="foo" type="text">', $form1);
+		$this->assertEquals('<input name="foo" type="text" />', $form1);
 		$this->assertEquals($form1, $form2);
-		$this->assertEquals('<input name="foo" type="text" value="foobar">', $form3);
-		$this->assertEquals('<input class="span2" name="foo" type="text">', $form4);
+		$this->assertEquals('<input name="foo" type="text" value="foobar" />', $form3);
+		$this->assertEquals('<input class="span2" name="foo" type="text" />', $form4);
 	}
 
 
@@ -118,11 +118,11 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
 		$session->shouldReceive('getOldInput')->twice()->with('name_with_dots')->andReturn('some value');
 		$input = $this->formBuilder->text('name.with.dots', 'default value');
-		$this->assertEquals('<input name="name.with.dots" type="text" value="some value">', $input);
+		$this->assertEquals('<input name="name.with.dots" type="text" value="some value" />', $input);
 
 		$session->shouldReceive('getOldInput')->once()->with('text.key.sub')->andReturn(null);
 		$input = $this->formBuilder->text('text[key][sub]', 'default value');
-		$this->assertEquals('<input name="text[key][sub]" type="text" value="default value">', $input);
+		$this->assertEquals('<input name="text[key][sub]" type="text" value="default value" />', $input);
 
 		$session->shouldReceive('getOldInput')->with('relation.key')->andReturn(null);
 		$input1 = $this->formBuilder->text('relation[key]');
@@ -130,7 +130,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->setModel($model, false);
 		$input2 = $this->formBuilder->text('relation[key]');
 
-		$this->assertEquals('<input name="relation[key]" type="text" value="attribute">', $input1);
+		$this->assertEquals('<input name="relation[key]" type="text" value="attribute" />', $input1);
 		$this->assertEquals($input1, $input2);
 	}
 
@@ -140,8 +140,8 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form1 = $this->formBuilder->password('foo');
 		$form2 = $this->formBuilder->password('foo', array('class' => 'span2'));
 
-		$this->assertEquals('<input name="foo" type="password" value="">', $form1);
-		$this->assertEquals('<input class="span2" name="foo" type="password" value="">', $form2);
+		$this->assertEquals('<input name="foo" type="password" value="" />', $form1);
+		$this->assertEquals('<input class="span2" name="foo" type="password" value="" />', $form2);
 	}
 
 
@@ -151,9 +151,9 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form2 = $this->formBuilder->hidden('foo', 'foobar');
 		$form3 = $this->formBuilder->hidden('foo', null, array('class' => 'span2'));
 
-		$this->assertEquals('<input name="foo" type="hidden">', $form1);
-		$this->assertEquals('<input name="foo" type="hidden" value="foobar">', $form2);
-		$this->assertEquals('<input class="span2" name="foo" type="hidden">', $form3);
+		$this->assertEquals('<input name="foo" type="hidden" />', $form1);
+		$this->assertEquals('<input name="foo" type="hidden" value="foobar" />', $form2);
+		$this->assertEquals('<input class="span2" name="foo" type="hidden" />', $form3);
 	}
 
 
@@ -163,9 +163,9 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form2 = $this->formBuilder->email('foo', 'foobar');
 		$form3 = $this->formBuilder->email('foo', null, array('class' => 'span2'));
 
-		$this->assertEquals('<input name="foo" type="email">', $form1);
-		$this->assertEquals('<input name="foo" type="email" value="foobar">', $form2);
-		$this->assertEquals('<input class="span2" name="foo" type="email">', $form3);
+		$this->assertEquals('<input name="foo" type="email" />', $form1);
+		$this->assertEquals('<input name="foo" type="email" value="foobar" />', $form2);
+		$this->assertEquals('<input class="span2" name="foo" type="email" />', $form3);
 	}
 
 
@@ -174,8 +174,8 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form1 = $this->formBuilder->file('foo');
 		$form2 = $this->formBuilder->file('foo', array('class' => 'span2'));
 
-		$this->assertEquals('<input name="foo" type="file">', $form1);
-		$this->assertEquals('<input class="span2" name="foo" type="file">', $form2);
+		$this->assertEquals('<input name="foo" type="file" />', $form1);
+		$this->assertEquals('<input class="span2" name="foo" type="file" />', $form2);
 	}
 
 
@@ -287,10 +287,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form3 = $this->formBuilder->checkbox('foo', 'foobar', true);
 		$form4 = $this->formBuilder->checkbox('foo', 'foobar', false, array('class' => 'span2'));
 
-		$this->assertEquals('<input name="foo" type="checkbox">', $form1);
-		$this->assertEquals('<input name="foo" type="checkbox" value="1">', $form2);
-		$this->assertEquals('<input checked="checked" name="foo" type="checkbox" value="foobar">', $form3);
-		$this->assertEquals('<input class="span2" name="foo" type="checkbox" value="foobar">', $form4);
+		$this->assertEquals('<input name="foo" type="checkbox" />', $form1);
+		$this->assertEquals('<input name="foo" type="checkbox" value="1" />', $form2);
+		$this->assertEquals('<input checked="checked" name="foo" type="checkbox" value="foobar" />', $form3);
+		$this->assertEquals('<input class="span2" name="foo" type="checkbox" value="foobar" />', $form4);
 	}
 
 
@@ -301,20 +301,20 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
 		$session->shouldReceive('getOldInput')->once()->with('check')->andReturn(null);
 		$check = $this->formBuilder->checkbox('check', 1, true);
-		$this->assertEquals('<input name="check" type="checkbox" value="1">', $check);
+		$this->assertEquals('<input name="check" type="checkbox" value="1" />', $check);
 
 		$session->shouldReceive('getOldInput')->with('check.key')->andReturn('yes');
 		$check = $this->formBuilder->checkbox('check[key]', 'yes');
-		$this->assertEquals('<input checked="checked" name="check[key]" type="checkbox" value="yes">', $check);
+		$this->assertEquals('<input checked="checked" name="check[key]" type="checkbox" value="yes" />', $check);
 
 		$session->shouldReceive('getOldInput')->with('multicheck')->andReturn(array(1, 3));
 		$check1 = $this->formBuilder->checkbox('multicheck[]', 1);
 		$check2 = $this->formBuilder->checkbox('multicheck[]', 2, true);
 		$check3 = $this->formBuilder->checkbox('multicheck[]', 3);
 
-		$this->assertEquals('<input checked="checked" name="multicheck[]" type="checkbox" value="1">', $check1);
-		$this->assertEquals('<input name="multicheck[]" type="checkbox" value="2">', $check2);
-		$this->assertEquals('<input checked="checked" name="multicheck[]" type="checkbox" value="3">', $check3);
+		$this->assertEquals('<input checked="checked" name="multicheck[]" type="checkbox" value="1" />', $check1);
+		$this->assertEquals('<input name="multicheck[]" type="checkbox" value="2" />', $check2);
+		$this->assertEquals('<input checked="checked" name="multicheck[]" type="checkbox" value="3" />', $check3);
 	}
 
 
@@ -325,10 +325,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form3 = $this->formBuilder->radio('foo', 'foobar', true);
 		$form4 = $this->formBuilder->radio('foo', 'foobar', false, array('class' => 'span2'));
 
-		$this->assertEquals('<input name="foo" type="radio">', $form1);
-		$this->assertEquals('<input name="foo" type="radio" value="foo">', $form2);
-		$this->assertEquals('<input checked="checked" name="foo" type="radio" value="foobar">', $form3);
-		$this->assertEquals('<input class="span2" name="foo" type="radio" value="foobar">', $form4);
+		$this->assertEquals('<input name="foo" type="radio" />', $form1);
+		$this->assertEquals('<input name="foo" type="radio" value="foo" />', $form2);
+		$this->assertEquals('<input checked="checked" name="foo" type="radio" value="foobar" />', $form3);
+		$this->assertEquals('<input class="span2" name="foo" type="radio" value="foobar" />', $form4);
 	}
 
 
@@ -341,8 +341,8 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$radio1 = $this->formBuilder->radio('radio', 1);
 		$radio2 = $this->formBuilder->radio('radio', 2, true);
 
-		$this->assertEquals('<input checked="checked" name="radio" type="radio" value="1">', $radio1);
-		$this->assertEquals('<input name="radio" type="radio" value="2">', $radio2);
+		$this->assertEquals('<input checked="checked" name="radio" type="radio" value="1" />', $radio1);
+		$this->assertEquals('<input name="radio" type="radio" value="2" />', $radio2);
 	}
 
 
@@ -351,8 +351,8 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form1 = $this->formBuilder->submit('foo');
 		$form2 = $this->formBuilder->submit('foo', array('class' => 'span2'));
 
-		$this->assertEquals('<input type="submit" value="foo">', $form1);
-		$this->assertEquals('<input class="span2" type="submit" value="foo">', $form2);
+		$this->assertEquals('<input type="submit" value="foo" />', $form1);
+		$this->assertEquals('<input class="span2" type="submit" value="foo" />', $form2);
 	}
 
 
@@ -369,7 +369,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testResetInput()
 	{
 		$resetInput = $this->formBuilder->reset('foo');
-		$this->assertEquals('<input type="reset" value="foo">', $resetInput);
+		$this->assertEquals('<input type="reset" value="foo" />', $resetInput);
 	}
 
 
@@ -378,7 +378,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$url = 'http://laravel.com/';
 		$image = $this->formBuilder->image($url);
 
-		$this->assertEquals('<input src="'. $url .'" type="image">', $image);
+		$this->assertEquals('<input src="'. $url .'" type="image" />', $image);
 	}
 
 	protected function setModel(array $data, $object = true)


### PR DESCRIPTION
Using self-closing tags is defined within the HTML5 spec, and is not confined to XHTML only.
Using self-closing tags by default has the benefit of allowing developers to use the Builder classes with XHTML if they choose to, but at the same time has no disadvantage when using HTML5 (and, in fact, still IS HTML5), since it is entirely within the spec.

See [Section 9 of the HTML5 spec](http://www.w3.org/TR/html5/the-xhtml-syntax.html) for more information about self-closing tags in HTML5.

In addition, I fixed a minor typo I found in a comment in the FormBuilder.
