### PR TITLE
Added sort flag to Collection::sortBy()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -220,9 +220,10 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Sort the collection using the given Closure.
 	 *
 	 * @param  \Closure  $callback
+	 * @param int $sort_flags
 	 * @return \Illuminate\Support\Collection
 	 */
-	public function sortBy(Closure $callback)
+	public function sortBy(Closure $callback, $sort_flags = SORT_REGULAR)
 	{
 		$results = array();
 
@@ -234,7 +235,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 			$results[$key] = $callback($value);
 		}
 
-		asort($results);
+		asort($results, $sort_flags);
 
 		// Once we have sorted all of the keys in the array, we will loop through them
 		// and grab the corresponding model so we can set the underlying items list

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -220,10 +220,10 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Sort the collection using the given Closure.
 	 *
 	 * @param  \Closure  $callback
-	 * @param int $sort_flags
+	 * @param  int  $options
 	 * @return \Illuminate\Support\Collection
 	 */
-	public function sortBy(Closure $callback, $sort_flags = SORT_REGULAR)
+	public function sortBy(Closure $callback, $options = SORT_REGULAR)
 	{
 		$results = array();
 
@@ -235,7 +235,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 			$results[$key] = $callback($value);
 		}
 
-		asort($results, $sort_flags);
+		asort($results, $options);
 
 		// Once we have sorted all of the keys in the array, we will loop through them
 		// and grab the corresponding model so we can set the underlying items list


### PR DESCRIPTION
Allows collections/related objects to be sorted by a non-standard comparison (e.g. natural case sort, which can sort numbers properly, as opposed to crudely where 10 follows 1, instead of following 9)
