### PR TITLE
tinyint should have its default (3) and not (1)

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -361,7 +361,7 @@ class MySqlGrammar extends Grammar {
 	 */
 	protected function typeTinyInteger(Fluent $column)
 	{
-		return 'tinyint(1)';
+		return 'tinyint';
 	}
 
 	/**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -357,7 +357,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table `users` add `foo` tinyint(1) not null', $statements[0]);
+		$this->assertEquals('alter table `users` add `foo` tinyint not null', $statements[0]);
 	}
 
 


### PR DESCRIPTION
While typeBoolean should be a "tinyint(1)", typeTinyInteger itself should be a plain "tinyint" with default (3) value (-128 +127).
