### PR TITLE
Session::hasOldInput() should return false if there's no old input

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -265,7 +265,9 @@ class Store implements SessionInterface {
 	 */
 	public function hasOldInput($key = null)
 	{
-		return ! is_null($this->getOldInput($key));
+		$old = $this->getOldInput($key);
+
+		return ! empty($old);
 	}
 
 	/**

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -108,6 +108,17 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testHasOldInputWithoutKey ()
+	{
+		$session = $this->getSession();
+		$session->flash('boom', 'baz');
+		$this->assertFalse($session->hasOldInput());
+
+		$session->flashInput(array('foo' => 'bar'));
+		$this->assertTrue($session->hasOldInput());
+	}
+
+
 	public function getSession()
 	{
 		$reflection = new ReflectionClass('Illuminate\Session\Store');


### PR DESCRIPTION
Calling `Session::hasOldInput()` without providing a key should return false if there's no old input.
