### PR TITLE
Add basic Pagination mode.

### DIFF
--- a/src/Illuminate/Pagination/Environment.php
+++ b/src/Illuminate/Pagination/Environment.php
@@ -93,12 +93,12 @@ class Environment {
 	/**
 	 * Get a new paginator instance.
 	 *
-	 * @param  array  $items
-	 * @param  int    $total
-	 * @param  int    $perPage
+	 * @param  array     $items
+	 * @param  int       $total
+	 * @param  int|null  $perPage
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	public function make(array $items, $total, $perPage)
+	public function make(array $items, $total, $perPage = null)
 	{
 		$paginator = new Paginator($this, $items, $total, $perPage);
 

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -19,6 +19,14 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(2, $p->getLastPage());
 		$this->assertEquals(1, $p->getCurrentPage());
+
+		// Test Paginator without setting total items (perPage param goes instead of total).
+		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('foo', 'bar', 'baz'), 2);
+		$env->shouldReceive('getCurrentPage')->once()->andReturn(1);
+		$p->setupPaginationContext();
+
+		$this->assertEquals(2, $p->getLastPage());
+		$this->assertEquals(1, $p->getCurrentPage());
 	}
 
 
@@ -106,6 +114,14 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://foo.com?page=1', $p->getUrl(1));
 		$p->addQuery('foo', 'bar');
 		$this->assertEquals('http://foo.com?page=1&foo=bar', $p->getUrl(1));
+	}
+
+
+	public function testItemsAndPageItemsAccess()
+	{
+		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('foo', 'bar', 'baz'), 3, 2);
+		$this->assertEquals(array('foo', 'bar', 'baz'), $p->getItems());
+		$this->assertEquals(array('foo', 'bar'), $p->getPageItems());
 	}
 
 


### PR DESCRIPTION
This PR tries to solve problem of pagination for heavy databases with huge amount of data rows when you can't just use `SELECT COUNT(*) FROM table` to get total number of rows for current version of Paginator. All of it, while keeping current behavior intact.

Right now this proposition is only for Paginator with plans to add extra method to Eloquent or a rewrite for `paginate()`.

In addition to basic mode, there're two extra methods: `getPageCollection()` and `getPageItems()` which will help to get items limited by perPage param (since in basic mode you have to provide perPage + 1 items).

Details on PR in the following picture.

![paginate](https://f.cloud.github.com/assets/578455/1696445/9a86856a-5ec4-11e3-89cc-5f43a9bdb63e.jpg)
