### PR TITLE
[4.1.x] Renamed `Model::tags($cacheTags)` to `Model::cacheTags($cacheTags)`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1227,7 +1227,7 @@ class Builder {
 	{
 		$cache = $this->connection->getCacheManager();
 
-		return $this->cacheTags ? $cache->cacheTags($this->cacheTags) : $cache;
+		return $this->cacheTags ? $cache->tags($this->cacheTags) : $cache;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1105,7 +1105,7 @@ class Builder {
 	 * @param  array|dynamic  $cacheTags
 	 * @return \Illuminate\Database\Query\Builder|static
 	 */
-	public function tags($cacheTags)
+	public function cacheTags($cacheTags)
 	{
 		$this->cacheTags = $cacheTags;
 
@@ -1227,7 +1227,7 @@ class Builder {
 	{
 		$cache = $this->connection->getCacheManager();
 
-		return $this->cacheTags ? $cache->tags($this->cacheTags) : $cache;
+		return $this->cacheTags ? $cache->cacheTags($this->cacheTags) : $cache;
 	}
 
 	/**

--- a/src/Illuminate/Foundation/changes.json
+++ b/src/Illuminate/Foundation/changes.json
@@ -68,7 +68,8 @@
 		{"message": "Added 'renderSections' method to the View.", "backport": null},
 		{"message": "Added pessimistic locking to query builder via 'lock', 'lockForUpdate', and 'sharedLock'.", "backport": null},
 		{"message": "Closure can now be passed to Collection->first, functions similarly to array_first.", "backport": null},
-		{"message": "Added Mail::failures to get the failed recipients for a message.", "backport": null}
+		{"message": "Added Mail::failures to get the failed recipients for a message.", "backport": null},
+		{"message": "Renamed `Model::tags($cacheTags)` to `Model::cacheTags($cacheTags)`", "backport": null}
 	],
 	"4.0.x": [
 		{"message": "Added implode method to query builder and Collection class.", "backport": null},

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -80,13 +80,13 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$taggedCache = m::mock('StdClass');
 		$cache = m::mock('stdClass');
-		$cache->shouldReceive('tags')
+		$cache->shouldReceive('cacheTags')
 				->once()
 				->with(array('foo','bar'))
 				->andReturn($taggedCache);
 
 		$query = $this->setupCacheTestQuery($cache);
-		$query = $query->tags(array('foo', 'bar'))->remember(5);
+		$query = $query->cacheTags(array('foo', 'bar'))->remember(5);
 
 		$taggedCache->shouldReceive('remember')
 						->once()


### PR DESCRIPTION
As discussed in issue #2849
