### PR TITLE
Use falsy values to test old input

### DIFF
--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -74,16 +74,18 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 	{
 		$session = $this->getSession();
 		$session->put('boom', 'baz');
-		$session->flashInput(array('foo' => 'bar'));
+		$session->flashInput(array('foo' => 'bar', 'bar' => 0));
 
 		$this->assertTrue($session->hasOldInput('foo'));
 		$this->assertEquals('bar', $session->getOldInput('foo'));
+		$this->assertEquals(0, $session->getOldInput('bar'));
 		$this->assertFalse($session->hasOldInput('boom'));
 
 		$session->ageFlashData();
 
 		$this->assertTrue($session->hasOldInput('foo'));
 		$this->assertEquals('bar', $session->getOldInput('foo'));
+		$this->assertEquals(0, $session->getOldInput('bar'));
 		$this->assertFalse($session->hasOldInput('boom'));
 	}
 
@@ -92,14 +94,17 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 	{
 		$session = $this->getSession();
 		$session->flash('foo', 'bar');
+		$session->flash('bar', 0);
 
 		$this->assertTrue($session->has('foo'));
 		$this->assertEquals('bar', $session->get('foo'));
+		$this->assertEquals(0, $session->get('bar'));
 
 		$session->ageFlashData();
 
 		$this->assertTrue($session->has('foo'));
 		$this->assertEquals('bar', $session->get('foo'));
+		$this->assertEquals(0, $session->get('bar'));
 
 		$session->ageFlashData();
 


### PR DESCRIPTION
This would have caught [this bug](https://github.com/laravel/framework/commit/e134a92136add9b313fdfcf4823de12c0e6c8d14).
