### PR TITLE
Update to Validator->validateAccepted(), accounts for (int) 0 values ensuring that they do not validate

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -560,7 +560,7 @@ class Validator implements MessageProviderInterface {
 	{
 		$acceptable = array('yes', 'on', 1);
 
-		return ($this->validateRequired($attribute, $value) && in_array($value, $acceptable));
+		return ($this->validateRequired($attribute, $value) && in_array($value, $acceptable) && $value !== 0);
 	}
 
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -353,6 +353,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array(), array('foo' => 'Accepted'));
 		$this->assertFalse($v->passes());
 
+		$v = new Validator($trans, array('foo' => 0), array('foo' => 'Accepted'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('foo' => 'yes'), array('foo' => 'Accepted'));
 		$this->assertTrue($v->passes());
 


### PR DESCRIPTION
Currently an (int) 0 value will pass validation when the "Accepted" validation rule is applied.  It's my understanding that the intent of this rule is to strictly validate on 'yes', 'on' and (int) 1 values.

This fix adds an additional check to ensure that validation fails when the evaluated value is an exact match for (int) 0.  
