### PR TITLE
Added missing integer types to auto increment whitelists

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -25,7 +25,7 @@ class MySqlGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $serials = array('bigInteger', 'integer');
+	protected $serials = array('bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger');
 
 	/**
 	 * Compile the query to determine if a table exists.

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -24,7 +24,7 @@ class PostgresGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $serials = array('bigInteger', 'integer');
+	protected $serials = array('bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger');
 
 	/**
 	 * Compile the query to determine if a table exists.
@@ -292,7 +292,7 @@ class PostgresGrammar extends Grammar {
 	 */
 	protected function typeMediumInteger(Fluent $column)
 	{
-		return 'integer';
+		return $column->autoIncrement ? 'serial' : 'integer';
 	}
 
 	/**
@@ -303,7 +303,7 @@ class PostgresGrammar extends Grammar {
 	 */
 	protected function typeTinyInteger(Fluent $column)
 	{
-		return 'smallint';
+		return $column->autoIncrement ? 'smallserial' : 'smallint';
 	}
 
 	/**
@@ -314,7 +314,7 @@ class PostgresGrammar extends Grammar {
 	 */
 	protected function typeSmallInteger(Fluent $column)
 	{
-		return 'smallint';
+		return $column->autoIncrement ? 'smallserial' : 'smallint';
 	}
 
 	/**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -25,7 +25,7 @@ class SQLiteGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $serials = array('bigInteger', 'integer');
+	protected $serials = array('bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger');
 
 	/**
 	 * Compile the query to determine if a table exists.

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -24,7 +24,7 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $serials = array('bigInteger', 'integer');
+	protected $serials = array('bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger');
 
 	/**
 	 * Compile the query to determine if a table exists.


### PR DESCRIPTION
The schema blueprint supports auto-incrementing/serial options for smaller integer types, but the various grammars' whitelists only contain the larger data types.
