### PR TITLE
Bump the default cost factor for bcrypt from 8 to 10

### DIFF
--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -7,7 +7,7 @@ class BcryptHasher implements HasherInterface {
 	 *
 	 * @var bool
 	 */
-	protected $rounds = 8;
+	protected $rounds = 10;
 
 	/**
 	 * Hash the given value.


### PR DESCRIPTION
Bcrypt's current [default cost factor in PHP is 10](https://github.com/ircmaxell/password_compat/blob/master/lib/password.php#L40) but Laravel reduces this to 8. 

ircmaxell (the author of PHP's password hashing API) [recommends at least 9](http://blog.ircmaxell.com/2012/12/seven-ways-to-screw-up-bcrypt.html).
