### PR TITLE
Updated Model dirty checks to ignore numerically equivilent values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2371,9 +2371,14 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		foreach ($this->attributes as $key => $value)
 		{
-			if ( ! array_key_exists($key, $this->original) or $value !== $this->original[$key])
-			{
+			if ( ! array_key_exists($key, $this->original)) {
 				$dirty[$key] = $value;
+			}
+			else if ($value !== $this->original[$key]) {
+				// two equivilent numerical fields shouldn't match as 'dirty', e.g. 1 and "1"
+				if (!is_numeric($value) || !is_numeric($this->original[$key]) || strcmp((string) $value, (string) $this->original[$key]) != 0) {
+					$dirty[$key] = $value;
+				}
 			}
 		}
 


### PR DESCRIPTION
Changing a field value from an (int) to a numerically equal string should not cause the field to appear 'dirty', i.e. "1" == 1 should be fine and not return true for isDirty() as this could lead to some unexpected behaviour - especially when the field is read out of the database and saved on the model as a string (despite being pulled from an int type field), and then the model is later updated with an int value which is the same. In reality it hasn't been updated, but it still amounts to a change
