### PR TITLE
set firstByAttributes to public

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -439,7 +439,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * @param  array  $attributes
 	 * @return \Illuminate\Database\Eloquent\Model|null
 	 */
-	protected static function firstByAttributes($attributes)
+	public static function firstByAttributes($attributes)
 	{
 		$query = static::query();
 


### PR DESCRIPTION
There are occasions where it would be convenient to be able to use firstByAttributes outside of the firstOrCreate or firstOrNew functions.
