### PR TITLE
Fix bug with numeric keys in URL generator

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -261,7 +261,7 @@ class UrlGenerator {
 
 		if (count($keyed) < count($parameters))
 		{
-			$query .= '&'.implode($this->getNumericParameters($parameters));
+			$query .= '&'.implode('&', $this->getNumericParameters($parameters));
 		}
 
 		return '?'.trim($query, '&');

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -116,7 +116,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
 	public function testRoutesWithDomainsAndPorts()
 	{
-			$url = new UrlGenerator(
+		$url = new UrlGenerator(
 			$routes = new Illuminate\Routing\RouteCollection,
 			$request = Illuminate\Http\Request::create('http://www.foo.com:8080/')
 		);
@@ -135,33 +135,33 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-        public function testGenerateWithQueryStrings()
-        {
-                $url = new UrlGenerator(
-                        $routes = new Illuminate\Routing\RouteCollection,
-                        $request = Illuminate\Http\Request::create('http://www.foo.com/')
-                );
+	public function testGenerateWithQueryStrings()
+	{
+		$url = new UrlGenerator(
+			$routes = new Illuminate\Routing\RouteCollection,
+			$request = Illuminate\Http\Request::create('http://www.foo.com/')
+		);
 
-                $route = new Illuminate\Routing\Route(array('GET'), 'foo/{param}/{opt?}', array('as' => 'foo'));
-                $routes->add($route);
+		$route = new Illuminate\Routing\Route(array('GET'), 'foo/{param}/{opt?}', array('as' => 'foo'));
+		$routes->add($route);
 
-                $this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param', 'opt', 'foo' => 'bar', 'baz')));
-                $this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param' => 'param', 'opt' => 'opt', 'foo' => 'bar', 'baz')));
-                $this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz&extra', $url->route('foo', array('extra', 'foo' => 'bar', 'opt' => 'opt', 'param' => 'param', 'baz')));
+		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param', 'opt', 'foo' => 'bar', 'baz')));
+		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param' => 'param', 'opt' => 'opt', 'foo' => 'bar', 'baz')));
+		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz&extra', $url->route('foo', array('extra', 'foo' => 'bar', 'opt' => 'opt', 'param' => 'param', 'baz')));
 
 
-                $url = new UrlGenerator(
-                        $routes = new Illuminate\Routing\RouteCollection,
-                        $request = Illuminate\Http\Request::create('http://www.foo.com/')
-                );
+		$url = new UrlGenerator(
+			$routes = new Illuminate\Routing\RouteCollection,
+			$request = Illuminate\Http\Request::create('http://www.foo.com/')
+		);
 
-                $fooRoute = new Illuminate\Routing\Route(array('GET'), 'foo/{param}', array('as' => 'foo'));
-                $routes->add($fooRoute);
-                $barRoute = new Illuminate\Routing\Route(array('GET'), 'bar', array('as' => 'bar'));
-                $routes->add($barRoute);
+		$fooRoute = new Illuminate\Routing\Route(array('GET'), 'foo/{param}', array('as' => 'foo'));
+		$routes->add($fooRoute);
+		$barRoute = new Illuminate\Routing\Route(array('GET'), 'bar', array('as' => 'bar'));
+		$routes->add($barRoute);
 
-                $this->assertEquals('http://www.foo.com/foo/param', $url->route('foo', 'param'));
-                $this->assertEquals('http://www.foo.com/bar?param', $url->route('bar', 'param'));
-        }
+		$this->assertEquals('http://www.foo.com/foo/param', $url->route('foo', 'param'));
+		$this->assertEquals('http://www.foo.com/bar?param', $url->route('bar', 'param'));
+	}
 
 }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -147,6 +147,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
                 $this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param', 'opt', 'foo' => 'bar', 'baz')));
                 $this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param' => 'param', 'opt' => 'opt', 'foo' => 'bar', 'baz')));
+                $this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz&extra', $url->route('foo', array('extra', 'foo' => 'bar', 'opt' => 'opt', 'param' => 'param', 'baz')));
 
 
                 $url = new UrlGenerator(

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -147,7 +147,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param', 'opt', 'foo' => 'bar', 'baz')));
 		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz', $url->route('foo', array('param' => 'param', 'opt' => 'opt', 'foo' => 'bar', 'baz')));
-		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz&extra', $url->route('foo', array('extra', 'foo' => 'bar', 'opt' => 'opt', 'param' => 'param', 'baz')));
+		$this->assertEquals('http://www.foo.com/foo/param/opt?foo=bar&baz&extra', $url->route('foo', array('foo' => 'bar', 'opt' => 'opt', 'param' => 'param', 'baz', 'extra')));
 
 
 		$url = new UrlGenerator(


### PR DESCRIPTION
There was an ampersand missing in the implode of numeric keyed parameters, so they wouldn't be joined correctly. I also updated the tests to better reflect the possibilities of the url generator now.

See first commit for actual changes, the indentation update in the second commit makes it hard to spot the differences otherwise.
