### PR TITLE
Type casting paginator current and last pages

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -118,7 +118,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	 */
 	protected function calculateCurrentAndLastPages()
 	{
-		$this->lastPage = ceil($this->total / $this->perPage);
+		$this->lastPage = (int) ceil($this->total / $this->perPage);
 
 		$this->currentPage = $this->calculateCurrentPage($this->lastPage);
 	}
@@ -284,7 +284,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 		}
 		else
 		{
-			return min($this->currentPage, ceil($total / $this->perPage));
+			return min($this->currentPage, (int) ceil($total / $this->perPage));
 		}
 	}
 


### PR DESCRIPTION
I noticed that when I invoke Paginator::getLastPage(), the return value is a float (not an int).

This came up when I was writing an API responder that automatically handles paginated data and tells the caller where the next resource list is:

<pre>
$current_page = $paginator->getCurrentPage();
$last_page    = $paginator->getLastPage();

$next_endpoint = ($current_page !== $last_page) ? $paginator->getUrl($current_page + 1) : null;
</pre>


The strict equality check fails because calculateCurrentAndLastPages sends us a float for lastPage and an int for currentPage.
