### PR TITLE
Add plus character to route wildcard regexes

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -63,21 +63,21 @@ class Route {
 	 *
 	 * @var string
 	 */
-	protected static $wildcard = '(?P<$1>([a-zA-Z0-9\.\,\-_%=]+))';
+	protected static $wildcard = '(?P<$1>([a-zA-Z0-9\.\,\-_%=+]+))';
 
 	/**
 	 * The regular expression for an optional wildcard.
 	 *
 	 * @var string
 	 */
-	protected static $optional = '(?:/(?P<$1>([a-zA-Z0-9\.\,\-_%=]+))';
+	protected static $optional = '(?:/(?P<$1>([a-zA-Z0-9\.\,\-_%=+]+))';
 
 	/**
 	 * The regular expression for a leading optional wildcard.
 	 *
 	 * @var string
 	 */
-	protected static $leadingOptional = '(\/$|^(?:(?P<$2>([a-zA-Z0-9\.\,\-_%=]+)))';
+	protected static $leadingOptional = '(\/$|^(?:(?P<$2>([a-zA-Z0-9\.\,\-_%=+]+)))';
 
 	/**
 	 * The validators used by the routes.


### PR DESCRIPTION
The plus character is a urlencoded version of the space character, so this will commonly appear in wildcards for routes to resources with string primary keys.

See https://github.com/laravel/laravel/issues/2491
