### PR TITLE
Urlencode parameters to linkRoute, for a valid URL

### DIFF
--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -181,7 +181,8 @@ class HtmlBuilder {
 	 */
 	public function linkRoute($name, $title = null, $parameters = array(), $attributes = array())
 	{
-		return $this->link($this->url->route($name, $parameters), $title, $attributes);
+		if (!is_array($parameters)) $parameters = array($parameters);
+		return $this->link($this->url->route($name, array_map('urlencode', $parameters)), $title, $attributes);
 	}
 
 	/**


### PR DESCRIPTION
Without urlencoding these parameters

```
link_to_route('resources.edit', "Link text", 'some id with spaces')
```

will fail: the generated URL will have the scheme and host repeated since isValidUrl choked on the space character.

See https://github.com/laravel/laravel/issues/2490 and https://github.com/laravel/laravel/issues/2491
