### PR TITLE
[Proposal] Adding the ability to use ->comment() on a Fluent object when using MySQL

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -18,7 +18,7 @@ class MySqlGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $modifiers = array('Unsigned', 'Nullable', 'Default', 'Increment', 'After');
+	protected $modifiers = array('Unsigned', 'Nullable', 'Default', 'Increment', 'After', 'Comment');
 
 	/**
 	 * The possible column serials
@@ -560,6 +560,21 @@ class MySqlGrammar extends Grammar {
 		if ( ! is_null($column->after))
 		{
 			return ' after '.$this->wrap($column->after);
+		}
+	}
+
+	/**
+	 * Get the SQL for a "comment" column modifier.
+	 *
+	 * @param \Illuminate\Database\Schema\Blueprint  $blueprint
+	 * @param \Illuminate\Support\Fluent  $column
+	 * @return string|null
+	 */
+	protected function modifyComment(Blueprint $blueprint, Fluent $column)
+	{
+		if ( ! is_null($column->comment))
+		{
+			return " comment '".strval($column->comment)."'";
 		}
 	}
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -574,7 +574,7 @@ class MySqlGrammar extends Grammar {
 	{
 		if ( ! is_null($column->comment))
 		{
-			return " comment '".strval(mysql_real_escape_string(column->comment))."'";
+			return " comment '".strval(mysql_real_escape_string($column->comment))."'";
 		}
 	}
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -574,7 +574,7 @@ class MySqlGrammar extends Grammar {
 	{
 		if ( ! is_null($column->comment))
 		{
-			return " comment '".strval($column->comment)."'";
+			return " comment '".strval(mysql_real_escape_string(column->comment))."'";
 		}
 	}
 


### PR DESCRIPTION
I know that in #93 it has been expressed that there is not much interest in implementing this ability.  However, as I needed it, I wrote it and have been using it.  Thus if you have any interest in a quick addition, I have availed this pull request to you :)

Note: It is, as stated in the title, only for the `MySqlGrammar` class.
