### PR TITLE
Fixed Eloquent query builder withTrashed method when used with nested where or whereRaw.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -427,7 +427,7 @@ class Builder {
 	 */
 	protected function isSoftDeleteConstraint(array $where, $column)
 	{
-		return $where['column'] == $column && $where['type'] == 'Null';
+		return $where['type'] == 'Null' && $where['column'] == $column;
 	}
 
 	/**


### PR DESCRIPTION
`Illuminate\Database\Eloquent\Builder::isSoftDeleteConstraint` method checks for `$where['column']`, which is not set for nested or raw wheres, reversed the condition to check for `$where['type']` first.
