### PR TITLE
Escape regex wildcards during matching of routes

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -63,7 +63,7 @@ class Route {
 	 *
 	 * @var string
 	 */
-	protected static $wildcard = '(?P<$1>([a-zA-Z0-9\.\,\-_%=+]+))';
+	protected static $wildcard = '(?P<$1>([a-zA-Z0-9\.\,\-_%=+]+?))';
 
 	/**
 	 * The regular expression for an optional wildcard.

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -63,7 +63,7 @@ class Route {
 	 *
 	 * @var string
 	 */
-	protected static $wildcard = '(?P<$1>([a-zA-Z0-9\.\,\-_%=+]+?))';
+	protected static $wildcard = '(?P<$1>([a-zA-Z0-9\.\,\-_%=+]+))';
 
 	/**
 	 * The regular expression for an optional wildcard.
@@ -276,7 +276,7 @@ class Route {
 	 */
 	public function parametersWithoutNulls()
 	{
-        return array_filter($this->parameters(), function($p) { return ! is_null($p); });
+		return array_filter($this->parameters(), function($p) { return ! is_null($p); });
 	}
 
 	/**
@@ -440,9 +440,21 @@ class Route {
 	 */
 	public static function compileString($value, $delimit = true, array $wheres = array())
 	{
+		$value = static::prepareString($value);
 		$value = static::compileOptional(static::compileParameters($value, $wheres), $wheres);
 
 		return $delimit ? static::delimit($value) : $value;
+	}
+	
+	/**
+	 * Prepare a string for use as regular expression.
+	 * 
+	 * @param  string  $value
+	 * @return string
+	 */
+	protected static function prepareString($value)
+	{
+		return str_replace('.', '\.', $value);
 	}
 
 	/**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -350,11 +350,13 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		
 		$request1 = Request::create('images/1.png', 'GET');
 		$this->assertTrue($route->matches($request1));
+		$route->bind($request1);
 		$this->assertEquals('1', $route->parameter('id'));
 		$this->assertEquals('png', $route->parameter('ext'));
 		
 		$request2 = Request::create('images/12.png', 'GET');
 		$this->assertTrue($route->matches($request2));
+		$route->bind($request2);
 		$this->assertEquals('12', $route->parameter('id'));
 		$this->assertEquals('png', $route->parameter('ext'));
 		

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -342,6 +342,23 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$route->where('bar', '[0-9]+');
 		$this->assertFalse($route->matches($request));
 	}
+	
+	
+	public function testDotDoesNotMatchEverything()
+	{
+		$route = new Route('GET', 'images/{id}.{ext}', function() {});
+		
+		$request1 = Request::create('images/1.png', 'GET');
+		$this->assertTrue($route->matches($request1));
+		$this->assertEquals('1', $route->parameter('id'));
+		$this->assertEquals('png', $route->parameter('ext'));
+		
+		$request2 = Request::create('images/12.png', 'GET');
+		$this->assertTrue($route->matches($request2));
+		$this->assertEquals('12', $route->parameter('id'));
+		$this->assertEquals('png', $route->parameter('ext'));
+		
+	}
 
 
 	public function testRouteBinding()


### PR DESCRIPTION
Dots in routes were wildcards when turned into regexes, thus sometimes causing problems when matching.

This fixes #2935.
