### PR TITLE
[Proposal] Alternative way for easier custom rule definition for Validator

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -232,6 +232,7 @@ class Validator implements MessageProviderInterface {
 	 * 
 	 * @param string $attribute
 	 * @param array  $rules
+	 * @return void
 	 */
 	protected function passAttribute($attribute, $rules)
 	{

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -233,14 +233,15 @@ class Validator implements MessageProviderInterface {
 	 * @param string $attribute
 	 * @param array  $rules
 	 */
-	public function passAttribute($attribute, $rules)
+	protected function passAttribute($attribute, $rules)
 	{
 		foreach ($rules as $rule => $closure)
 		{
 			if ($closure instanceof \Closure) 
 			{
 				$this->addExtension($rule, $closure);			
-			} else
+			} 
+			else
 			{
 				// if the value of the array is not a closure
 				// this means the value of the array is the rule name.
@@ -259,7 +260,7 @@ class Validator implements MessageProviderInterface {
 	{
 		return ! $this->passes();
 	}
-	
+
 	/**
 	 * Validate a given attribute against a rule.
 	 *

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -221,13 +221,33 @@ class Validator implements MessageProviderInterface {
 		// the other error messages, returning true if we don't have messages.
 		foreach ($this->rules as $attribute => $rules)
 		{
-			foreach ($rules as $rule)
-			{
-				$this->validate($attribute, $rule);
-			}
+			$this->passAttribute($attribute, $rules);
 		}
 
 		return count($this->messages->all()) === 0;
+	}
+	
+	/**
+	 * Validate a single attribute against all the rules
+	 * 
+	 * @param string $attribute
+	 * @param array  $rules
+	 */
+	public function passAttribute($attribute, $rules)
+	{
+		foreach ($rules as $rule => $closure)
+		{
+			if ($closure instanceof \Closure) 
+			{
+				$this->addExtension($rule, $closure);			
+			} else
+			{
+				// if the value of the array is not a closure
+				// this means the value of the array is the rule name.
+				$rule = $closure;
+			}
+			$this->validate($attribute, $rule);
+		}
 	}
 
 	/**
@@ -239,7 +259,7 @@ class Validator implements MessageProviderInterface {
 	{
 		return ! $this->passes();
 	}
-
+	
 	/**
 	 * Validate a given attribute against a rule.
 	 *

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -921,6 +921,31 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo!', $v->messages()->first('name'));
 	}
 
+	public function testFailedClosureBasedCustomRule() 
+	{
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('foo' => 'bar'), array('foo' => 
+			array(
+			    'baz' => function($attribute, $value, $parameters) {
+				return false;
+			    }
+			)
+		    ));
+		$this->assertFalse($v->passes());	
+	}
+	
+	public function testSuccessfulClosureBasedCustomRule() 
+	{
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('foo' => 'bar'), array('foo' => 
+			array(
+			    'baz' => function($attribute, $value, $parameters) {
+				return true;
+			    }
+			)
+		    ));
+		$this->assertTrue($v->passes());	
+	}
 
 	public function testCustomImplicitValidators()
 	{


### PR DESCRIPTION
I am not sure this makes sense to everyone but I'd like to propose an another option to define a custom rule for `Validator`.

**Example code:**

``` php
Validator::make(Input::all(), array('name' => array(
    'custom_rule' => function($attribute, $value, $parameters) {
        return true;
    }
)))
```
