### PR TITLE
Removal of incorrect or duplicated comments

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -823,7 +823,6 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * @param  string  $table
 	 * @param  string  $foreignKey
 	 * @param  string  $otherKey
-	 * @param  string  $morphClass
 	 * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
 	 */
 	public function morphedByMany($related, $name, $table = null, $foreignKey = null, $otherKey = null)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1576,10 +1576,6 @@ class Builder {
 		{
 			$values = array($values);
 		}
-
-		// Since every insert gets treated like a batch insert, we will make sure the
-		// bindings are structured in a way that is convenient for building these
-		// inserts statements by verifying the elements are actually an array.
 		else
 		{
 			foreach ($values as $key => $value)


### PR DESCRIPTION
While trying to figure out the M:M polymorphic relations I noticed the parameter comments had one additional (which wasn't supplied to function) and also a duplicated comment on the query builder (a few lines after the same comment). Removed them for clarity :-)
