### PR TITLE
Return command output in Remote\Connection::run

### DIFF
--- a/src/Illuminate/Remote/Connection.php
+++ b/src/Illuminate/Remote/Connection.php
@@ -64,7 +64,7 @@ class Connection implements ConnectionInterface {
 	 * @param  string  $username
 	 * @param  array   $auth
 	 * @param  \Illuminate\Remote\GatewayInterface
-	 * @param  
+	 * @param
 	 */
 	public function __construct($name, $host, $username, array $auth, GatewayInterface $gateway = null)
 	{
@@ -106,7 +106,7 @@ class Connection implements ConnectionInterface {
 	 *
 	 * @param  string|array  $commands
 	 * @param  \Closure  $callback
-	 * @return void
+	 * @return string
 	 */
 	public function run($commands, Closure $callback = null)
 	{
@@ -122,12 +122,16 @@ class Connection implements ConnectionInterface {
 		// After running the commands against the server, we will continue to ask for
 		// the next line of output that is available, and write it them out using
 		// our callback. Once we hit the end of output, we'll bail out of here.
+		$output = null;
 		while (true)
 		{
 			if (is_null($line = $gateway->nextLine())) break;
 
+			$output .= $line;
 			call_user_func($callback, $line, $this);
 		}
+
+		return trim($output);
 	}
 
 	/**


### PR DESCRIPTION
Currently the only way to get the actual output of a `SSH::run('ls')` per example is to do this :

``` php
$output = '';
SSH::run('ls', function ($line) use (&$output) {
  $output .= $line;
});

dd($output);
```

I thought this was a lot of going around for something the `run` command can just return, so that's what this PR does :

``` php
$output = SSH::run('ls');
dd($output);
```
