### PR TITLE
Fixed routing with non ASCII characters.

### DIFF
--- a/src/Illuminate/Routing/Matching/UriValidator.php
+++ b/src/Illuminate/Routing/Matching/UriValidator.php
@@ -16,7 +16,7 @@ class UriValidator implements ValidatorInterface {
 	{
 		$path = $request->path() == '/' ? '/' : '/'.$request->path();
 
-		return preg_match($route->getCompiled()->getRegex(), $path);
+		return preg_match($route->getCompiled()->getRegex(), rawurldecode($path));
 	}
 
 }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -359,7 +359,7 @@ class Route {
 	 */
 	public function bindParameters(Request $request)
 	{
-		preg_match($this->compiled->getRegex(), '/'.$request->path(), $matches);
+		preg_match($this->compiled->getRegex(), '/'.rawurldecode($request->path()), $matches);
 
 		$parameters = $this->combineMatchesWithKeys(array_slice($matches, 1));
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -64,26 +64,29 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$router->get('foo/bar', function() { return 'first'; });
 		$router->get('foo/bar', function() { return 'second'; });
 		$this->assertEquals('second', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+
+		$router = $this->getRouter();
+		$router->get('foo/bar/åαф', function() { return 'hello'; });
+		$this->assertEquals('hello', $router->dispatch(Request::create('foo/bar/%C3%A5%CE%B1%D1%84', 'GET'))->getContent());
 	}
 
 
-        public function testNonGreedyMatches()
-        {
-            $route = new Route('GET', 'images/{id}.{ext}', function() {});
+	public function testNonGreedyMatches()
+	{
+		$route = new Route('GET', 'images/{id}.{ext}', function() {});
 
-            $request1 = Request::create('images/1.png', 'GET');
-            $this->assertTrue($route->matches($request1));
-            $route->bind($request1);
-            $this->assertEquals('1', $route->parameter('id'));
-            $this->assertEquals('png', $route->parameter('ext'));
+		$request1 = Request::create('images/1.png', 'GET');
+		$this->assertTrue($route->matches($request1));
+		$route->bind($request1);
+		$this->assertEquals('1', $route->parameter('id'));
+		$this->assertEquals('png', $route->parameter('ext'));
 
-            $request2 = Request::create('images/12.png', 'GET');
-            $this->assertTrue($route->matches($request2));
-            $route->bind($request2);
-            $this->assertEquals('12', $route->parameter('id'));
-            $this->assertEquals('png', $route->parameter('ext'));
-        }
-
+		$request2 = Request::create('images/12.png', 'GET');
+		$this->assertTrue($route->matches($request2));
+		$route->bind($request2);
+		$this->assertEquals('12', $route->parameter('id'));
+		$this->assertEquals('png', $route->parameter('ext'));
+	}
 
 	/**
 	 * @expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -69,10 +69,17 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$route = new Illuminate\Routing\Route(array('GET'), 'foo/bar', array('controller' => 'foo@bar'));
 		$routes->add($route);
 
+        /**
+         * Non ASCII routes
+         */
+        $route = new Illuminate\Routing\Route(array('GET'), 'foo/bar/åαф/{baz}', array('as' => 'foobarbaz'));
+        $routes->add($route);
+
 		$this->assertEquals('http://www.foo.com/foo/bar', $url->route('foo'));
 		$this->assertEquals('http://www.foo.com/foo/bar/taylor/breeze/otwell?fly=wall', $url->route('bar', array('taylor', 'otwell', 'fly' => 'wall')));
 		$this->assertEquals('https://www.foo.com/foo/bar', $url->route('baz'));
 		$this->assertEquals('http://www.foo.com/foo/bar', $url->action('foo@bar'));
+        $this->assertEquals('http://www.foo.com/foo/bar/%C3%A5%CE%B1%D1%84/%C3%A5%CE%B1%D1%84', $url->route('foobarbaz', array('baz' => 'åαф')));
 	}
 
 


### PR DESCRIPTION
fixes #2946

This should work now.
(also fixed some indentation issues from a previous commit)
