### PR TITLE
Allow for custom timestamp fields in pivot tables.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -892,9 +892,9 @@ class BelongsToMany extends Relation {
 	 *
 	 * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
 	 */
-	public function withTimestamps()
+	public function withTimestamps($createdAt = null, $updatedAt = null)
 	{
-		return $this->withPivot($this->createdAt(), $this->updatedAt());
+		return $this->withPivot($createdAt ?: $this->createdAt(), $updatedAt ?: $this->updatedAt());
 	}
 
 	/**


### PR DESCRIPTION
These timestamps don't necessarily need to be the same as the timestamps in the tables which have many-to-many relations using this pivot table.
