### PR TITLE
Disassociate on BelongsTo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -205,6 +205,18 @@ class BelongsTo extends Relation {
 	}
 
 	/**
+	 * Remove the relation from the parent.
+	 *
+	 * @return \Illuminate\Database\Eloquebt\Model
+	 */
+	public function disassociate()
+	{
+		$this->parent->setAttribute($this->foreignKey, null);
+
+		return $this->parent->setRelation($this->relation, null);
+	}
+
+	/**
 	 * Update the parent model on the relationship.
 	 *
 	 * @param  array  $attributes

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -76,6 +76,18 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDisassociateRemovesForeignKeyOnModel()
+	{
+		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+		$relation = $this->getRelation($parent);
+		$parent->shouldReceive('setAttribute')->once()->with('foreign_key', null);
+		$parent->shouldReceive('setRelation')->once()->with('relation', null);
+
+		$relation->disassociate();
+	}
+
+
 	protected function getRelation($parent = null)
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');


### PR DESCRIPTION
Currently you have to manually set the foreign key attribute to null, which is annoying if you later down the road decide to change the foreign key. A disassociate method is a simple, non-intrusive way to solve this small issue.
