### PR TITLE
Parent key methods visiblity

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -276,7 +276,7 @@ abstract class HasOneOrMany extends Relation {
 	 *
 	 * @return mixed
 	 */
-	protected function getParentKey()
+	public function getParentKey()
 	{
 		return $this->parent->getAttribute($this->localKey);
 	}
@@ -286,7 +286,7 @@ abstract class HasOneOrMany extends Relation {
 	 *
 	 * @return string
 	 */
-	protected function getQualifiedParentKeyName()
+	public function getQualifiedParentKeyName()
 	{
 		return $this->parent->getTable().'.'.$this->localKey;
 	}


### PR DESCRIPTION
These methods are useful for scope methods that build dynamic joins out of the relation. Would be useful to have them as public.
