### PR TITLE
Throw ViewNotFoundException when view not found

### DIFF
--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -168,7 +168,7 @@ class Environment {
 		{
 			$this->finder->find($view);
 		}
-		catch (\InvalidArgumentException $e)
+		catch (ViewNotFoundException $e)
 		{
 			return false;
 		}

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -101,12 +101,12 @@ class FileViewFinder implements ViewFinderInterface {
 
 		if (count($segments) != 2)
 		{
-			throw new \InvalidArgumentException("View [$name] has an invalid name.");
+			throw new ViewNotFoundException("View [$name] has an invalid name.");
 		}
 
 		if ( ! isset($this->hints[$segments[0]]))
 		{
-			throw new \InvalidArgumentException("No hint path defined for [{$segments[0]}].");
+			throw new ViewNotFoundException("No hint path defined for [{$segments[0]}].");
 		}
 
 		return $segments;
@@ -132,7 +132,7 @@ class FileViewFinder implements ViewFinderInterface {
 			}
 		}
 
-		throw new \InvalidArgumentException("View [$name] not found.");
+		throw new ViewNotFoundException("View [$name] not found.");
 	}
 
 	/**

--- a/src/Illuminate/View/ViewNotFoundException.php
+++ b/src/Illuminate/View/ViewNotFoundException.php
@@ -1,3 +1,3 @@
 <?php namespace Illuminate\View;
 
-class ViewNotFoundException extends \RuntimeException {}
+class ViewNotFoundException extends \InvalidArgumentException {}

--- a/src/Illuminate/View/ViewNotFoundException.php
+++ b/src/Illuminate/View/ViewNotFoundException.php
@@ -1,0 +1,3 @@
+<?php namespace Illuminate\View;
+
+class ViewNotFoundException extends \RuntimeException {}

--- a/tests/View/ViewEnvironmentTest.php
+++ b/tests/View/ViewEnvironmentTest.php
@@ -34,7 +34,7 @@ class ViewEnvironmentTest extends PHPUnit_Framework_TestCase {
 	public function testExistsPassesAndFailsViews()
 	{
 		$env = $this->getEnvironment();
-		$env->getFinder()->shouldReceive('find')->once()->with('foo')->andThrow('InvalidArgumentException');
+		$env->getFinder()->shouldReceive('find')->once()->with('foo')->andThrow('Illuminate\View\ViewNotFoundException');
 		$env->getFinder()->shouldReceive('find')->once()->with('bar')->andReturn('path.php');
 
 		$this->assertFalse($env->exists('foo'));

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -75,7 +75,7 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 
 
 	/**
-	 * @expectedException InvalidArgumentException
+	 * @expectedException Illuminate\View\ViewNotFoundException
 	 */
 	public function testExceptionThrownWhenViewNotFound()
 	{
@@ -88,7 +88,7 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 
 
 	/**
-	 * @expectedException InvalidArgumentException
+	 * @expectedException Illuminate\View\ViewNotFoundException
 	 */
 	public function testExceptionThrownOnInvalidViewName()
 	{
@@ -98,7 +98,7 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 
 
 	/**
-	 * @expectedException InvalidArgumentException
+	 * @expectedException Illuminate\View\ViewNotFoundException
 	 */
 	public function testExceptionThrownWhenNoHintPathIsRegistered()
 	{


### PR DESCRIPTION
Currently when trying to do View::make(view) on a view that doesn't exist, an InvalidArgumentException is thrown. Now that is completely correct but I find that a little too generic in terms of catching it. This PR adds a specific Exception `ViewNotFoundException` for that.

Aiming to 4.2 as people may be catching `InvalidArgumentException` currently in their code.
