### PR TITLE
Added support for syncing a collection of models instead of just IDs

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -518,14 +518,19 @@ class BelongsToMany extends Relation {
 	}
 
 	/**
-	 * Sync the intermediate tables with a list of IDs.
+	 * Sync the intermediate tables with a list of IDs or collection of models.
 	 *
-	 * @param  array  $ids
+	 * @param  $ids
 	 * @param  bool   $detaching
 	 * @return void
 	 */
-	public function sync(array $ids, $detaching = true)
+	public function sync($ids, $detaching = true)
 	{
+		// If we have a collection of models, get the keys.
+		if ($ids instanceof Collection) {
+			$ids = $ids->lists($this->otherKey);
+		}
+		
 		// First we need to attach any of the associated models that are not currently
 		// in this joining table. We'll spin through the given IDs, checking to see
 		// if they exist in the array of current ones, and if not we will insert.

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -293,6 +293,23 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testSyncMethodConvertsCollectionToArrayOfKeys()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach', 'touchIfTouching', 'formatSyncList'), $this->getRelationArguments());
+		$query = m::mock('stdClass');
+		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
+		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+		$query->shouldReceive('lists')->once()->with('role_id')->andReturn(array(1, 2, 3));
+
+		$collection = m::mock('Illuminate\Database\Eloquent\Collection');
+		$collection->shouldReceive('lists')->once()->andReturn(array(1, 2, 3));
+		$relation->expects($this->once())->method('formatSyncList')->with(array(1, 2, 3))->will($this->returnValue(array(1 => array(),2 => array(),3 => array())));
+		$relation->sync($collection);
+	}
+
+
 	public function getRelation()
 	{
 		list($builder, $parent) = $this->getRelationArguments();


### PR DESCRIPTION
Currently with a belongsToMany relationship, you can only `sync` an array of IDs, but can `attach` a model OR ID. 

Other relationships in Laravel tend to use a model when inserting (`$user->posts()->save($post)` rather than `$user->posts()->save(1)`) so it seemed in the interest of consistency to allow passing a collection of models to sync on a belongsToMany relationship in addition to just passing an array of IDs.
