### PR TITLE
Rename columns without doctrine (MySQL)

### DIFF
--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -15,4 +15,20 @@ class MySqlProcessor extends Processor {
 		return array_map(function($r) { return $r->column_name; }, $results);
 	}
 
+	/**
+	 * Process the results of a column description query.
+	 *
+	 * @param  object $results
+	 * @return array
+	 */
+	public function processColumnType($results)
+	{
+		return array(
+			'type'     => $results[0]->Type,
+			'nullable' => $results[0]->Null === 'YES',
+			'default'  => $results[0]->Default === 'NULL' ? null : $results[0]->Default,
+			'extra'    => $results[0]->Extra
+		);
+	}
+
 }

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -277,6 +277,71 @@ class MySqlGrammar extends Grammar {
 	}
 
 	/**
+	 * Compile a describe query.
+	 *
+	 * @param  string $table
+	 * @param  string $column
+	 * @return string
+	 */
+	public function compileDescribe($table, $column = null)
+	{
+		$sql = 'describe ' . $this->wrapTable($table);
+
+		if ( ! is_null($column))
+		{
+			$sql .= ' ' . $this->wrap($column);
+		}
+
+		return $sql;
+	}
+
+	/**
+	 * Compile a rename column command.
+	 *
+	 * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+	 * @param  \Illuminate\Support\Fluent  $command
+	 * @param  \Illuminate\Database\Connection  $connection
+	 * @return string
+	 */
+	public function compileRenameColumn(Blueprint $blueprint, Fluent $command, Connection $connection)
+	{
+		$table = $this->wrapTable($blueprint);
+		$from = $this->wrap($command->from);
+		$to = $this->wrap($command->to);
+		$type = $this->compileType($connection->getSchemaBuilder()->getColumnType($blueprint->getTable(), $command->from));
+
+		return "alter table {$table} change {$from} {$to} {$type}";
+	}
+
+	/**
+	 * Compile a column's type from a describe statement.
+	 *
+	 * @param  array $column
+	 * @return string
+	 */
+	public function compileType($column)
+	{
+		$type = $column['type'];
+
+		if ( ! $column['nullable'])
+		{
+			$type .= ' not null';
+		}
+
+		if ($column['default'])
+		{
+			$type .= ' default ' . $column['default'];
+		}
+
+		if ( ! empty($column['extra']))
+		{
+			$type .= ' ' . $column['extra'];
+		}
+
+		return $type;
+	}
+
+	/**
 	 * Create the column definition for a string type.
 	 *
 	 * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -38,4 +38,22 @@ class MySqlBuilder extends Builder {
 		return $this->connection->getPostProcessor()->processColumnListing($results);
 	}
 
+	/**
+	 * Get a full string representation of a column's type.
+	 *
+	 * @param  string  $table
+	 * @param  string  $column
+	 * @return string
+	 */
+	public function getColumnType($table, $column)
+	{
+		$sql = $this->grammar->compileDescribe($table, $column);
+
+		$result = $this->connection->select($sql);
+
+		$column = $this->connection->getPostProcessor()->processColumnType($result);
+
+		return $this->grammar->compileType($column);
+	}
+
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -177,13 +177,13 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	{
 		$connection = $this->getConnection();
 		$connection->shouldReceive('getSchemaBuilder->getColumnType')->once()->with('users', 'foo')->andReturnUsing(function($table, $column) {
-			$column = new StdClass;
-			$column->Type = 'int(10) unsigned';
-			$column->Null = 'NO';
-			$column->Default = '100';
-			$column->Extra = 'auto_increment';
+			$result = new StdClass;
+			$result->Type = 'int(10) unsigned';
+			$result->Null = 'NO';
+			$result->Default = '100';
+			$result->Extra = 'auto_increment';
 			$processor = new \Illuminate\Database\Query\Processors\MySqlProcessor;
-			return $processor->processColumnType(array($column));
+			return $processor->processColumnType(array($result));
 		});
 		$blueprint = new Blueprint('users');
 		$blueprint->renameColumn('foo', 'bar');

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -173,6 +173,27 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRenameColumn()
+	{
+		$connection = $this->getConnection();
+		$connection->shouldReceive('getSchemaBuilder->getColumnType')->once()->with('users', 'foo')->andReturnUsing(function($table, $column) {
+			$column = new StdClass;
+			$column->Type = 'int(10) unsigned';
+			$column->Null = 'NO';
+			$column->Default = '100';
+			$column->Extra = 'auto_increment';
+			$processor = new \Illuminate\Database\Query\Processors\MySqlProcessor;
+			return $processor->processColumnType(array($column));
+		});
+		$blueprint = new Blueprint('users');
+		$blueprint->renameColumn('foo', 'bar');
+		$statements = $blueprint->toSql($connection, $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` change `foo` `bar` int(10) unsigned not null default 100 auto_increment', $statements[0]);
+	}
+
+
 	public function testAddingPrimaryKey()
 	{
 		$blueprint = new Blueprint('users');


### PR DESCRIPTION
Here's a sample implementation of renaming columns without depending on Doctrine DBAL. A bit messy and a lot of cross-referencing, but hopefully a start. Maybe someone feels inspired to do the same for Postgres and MSSQL.

This should be possible to merge into 4.1 if wanted.
