### PR TITLE
QueryException improvements

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -534,7 +534,7 @@ class Connection implements ConnectionInterface {
 		// If an exception occurs when attempting to run a query, we'll format the error
 		// message to include the bindings with SQL, which will make this exception a
 		// lot more helpful to the developer instead of just the database's errors.
-		catch (\Exception $e)
+		catch (\PDOException $e)
 		{
 			throw new QueryException($query, $bindings, $e);
 		}

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -534,7 +534,7 @@ class Connection implements ConnectionInterface {
 		// If an exception occurs when attempting to run a query, we'll format the error
 		// message to include the bindings with SQL, which will make this exception a
 		// lot more helpful to the developer instead of just the database's errors.
-		catch (\PDOException $e)
+		catch (\Exception $e)
 		{
 			throw new QueryException($query, $bindings, $e);
 		}

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -45,7 +45,7 @@ class QueryException extends PDOException {
 	 *
 	 * @param  string  $sql
 	 * @param  array  $bindings
-	 * @param  \PDOException $previous
+	 * @param  \Exception $previous
 	 * @return string
 	 */
 	protected function formatMessage($sql, $bindings, $previous)

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -1,6 +1,8 @@
 <?php namespace Illuminate\Database;
 
-class QueryException extends \PDOException {
+use PDOException;
+
+class QueryException extends PDOException {
 
 	/**
 	 * The SQL for the query.
@@ -21,7 +23,7 @@ class QueryException extends \PDOException {
 	 *
 	 * @param  string  $sql
 	 * @param  array  $bindings
-	 * @param  \PDOException $previous
+	 * @param  \Exception $previous
 	 * @return void
 	 */
 	public function __construct($sql, array $bindings, $previous)
@@ -30,8 +32,12 @@ class QueryException extends \PDOException {
 		$this->bindings = $bindings;
 		$this->previous = $previous;
 		$this->code = $previous->getCode();
-		$this->errorInfo = $previous->errorInfo;
 		$this->message = $this->formatMessage($sql, $bindings, $previous);
+
+		if ($previous instanceof PDOException)
+		{
+			$this->errorInfo = $previous->errorInfo;
+		}
 	}
 
 	/**


### PR DESCRIPTION
QueryException expects the previous exception to be a PDOException - if it's not, the exception itself causes a fatal error because `$previous->errorInfo` is not defined. By adding an if check to the QueryException's constructor it should work with normal Exceptions as well. Alternatively, if a connection statement being ran causes an exception that's not a PDOException it could just be passed on through the app - i.e. only catch PDOExceptions, not all exceptions.

Common causes that would be helped by this would be if you have incorrect statement bindings - for example, trying to pass a multidimensional array as query bindings. However, in this case, formatMessage will fail becase str_replace_array won't accept multidimensional arrays either, but at least the exception will have a decent stack trace. Replacing multidimensional arrays with the word 'Array' could be a possible fix for this when debugging - thoughts?
