### PR TITLE
Update Dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "classpreloader/classpreloader": "1.0.*",
         "d11wtq/boris": "1.0.*",
         "ircmaxell/password-compat": "1.0.*",
-        "filp/whoops": "1.0.9",
+        "filp/whoops": "1.0.10",
         "jeremeamia/superclosure": "1.0.*",
         "monolog/monolog": "1.*",
         "nesbot/carbon": "1.*",
@@ -65,7 +65,7 @@
         "illuminate/workbench": "self.version"
     },
     "require-dev": {
-        "aws/aws-sdk-php": "2.4.*",
+        "aws/aws-sdk-php": "2.5.*",
         "iron-io/iron_mq": "1.4.*",
         "pda/pheanstalk": "2.1.*",
         "mockery/mockery": "0.8.0",

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "illuminate/events": "4.1.*",
-        "aws/aws-sdk-php": "2.4.*",
+        "aws/aws-sdk-php": "2.5.*",
         "mockery/mockery": "0.7.2",
         "phpunit/phpunit": "3.7.*"
     },


### PR DESCRIPTION
Use flip/whoops 1.0.10 - no breaking changes there as far as i can see, just minor things, and an xml response handler.

Use aws/aws-sdk-php 2.5.\* - a few changes there, you might want to check out https://github.com/aws/aws-sdk-php/blob/master/UPGRADING.md to make sure i haven't missed anything, but i don't think we need any code changes.
