### PR TITLE
Autodetect namespace in Eloquent relationships if necessary

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -5,6 +5,7 @@ use DateTime;
 use ArrayAccess;
 use Carbon\Carbon;
 use LogicException;
+use ReflectionClass;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -851,14 +852,14 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			return new $className;
 		}	
 
-		// Get the namespace of the calling class.
 		$namespace = substr(get_class($this), 0, strrpos(get_class($this), '\\'));
-		
+
 		// Try prepending the namespace first, in case there is a global class
 		// with the same name.
-		if (class_exists($namespacedClass = "{$namespace}\\{$className}"))
+		$namespacedClass = $namespace . '\\' . $className;
+		if (class_exists($namespacedClass))
 		{
-			$className = $namespacedClass;
+			return new $namespacedClass;
 		}
 
 		return new $className;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -702,7 +702,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		$secondKey = $secondKey ?: $through->getForeignKey();
 
-		return new HasManyThrough(with($this->newRelated($related))->newQuery(), $this, $through, $firstKey, $secondKey);
+		return new HasManyThrough($this->newRelated($related)->newQuery(), $this, $through, $firstKey, $secondKey);
 	}
 
 	/**
@@ -839,23 +839,25 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
-	 * Create an instance of the related object, detecting the namespace if necessary
-	 * @param  string $className
+	 * Create an instance of the related object, detecting the namespace if necessary.
+	 * @param  string  $className
 	 * @return \Illuminate\Database\Eloquent\Model
 	 */
 	protected function newRelated($className)
 	{
-		// If class name starts with "\", assume it is fully qualified
-		if (starts_with($className, '\\')) {
+		// If class name starts with "\", assume it is fully qualified.
+		if (starts_with($className, '\\'))
+		{
 			return new $className;
 		}	
 
-		// Get the namespace of the calling class
-		$namespace = substr(get_called_class(), 0, strrpos(get_called_class(), '\\'));
+		// Get the namespace of the calling class.
+		$namespace = substr(get_class($this), 0, strrpos(get_class($this), '\\'));
 		
 		// Try prepending the namespace first, in case there is a global class
-		// with the same name
-		if (class_exists($namespacedClass = "{$namespace}\\{$className}")) {
+		// with the same name.
+		if (class_exists($namespacedClass = "{$namespace}\\{$className}"))
+		{
 			$className = $namespacedClass;
 		}
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -591,6 +591,14 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('save_stub.foo', $relation->getForeignKey());
 		$this->assertTrue($relation->getParent() === $model);
 		$this->assertTrue($relation->getQuery()->getModel() instanceof EloquentModelSaveStub);
+
+		require_once __DIR__.'/stubs/NamespacedStubs.php';
+		$model = new Foo\Bar\EloquentModelStub;
+		$this->addMockConnection($model);
+		$relation = $model->hasOne('EloquentModelSaveStub', 'foo');
+		$this->assertEquals('save_stub.foo', $relation->getForeignKey());
+		$this->assertTrue($relation->getParent() === $model);
+		$this->assertTrue($relation->getQuery()->getModel() instanceof Foo\Bar\EloquentModelSaveStub);
 	}
 
 
@@ -618,6 +626,14 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('save_stub.foo', $relation->getForeignKey());
 		$this->assertTrue($relation->getParent() === $model);
 		$this->assertTrue($relation->getQuery()->getModel() instanceof EloquentModelSaveStub);
+
+		require_once __DIR__.'/stubs/NamespacedStubs.php';
+		$model = new Foo\Bar\EloquentModelStub;
+		$this->addMockConnection($model);
+		$relation = $model->hasMany('EloquentModelSaveStub', 'foo');
+		$this->assertEquals('save_stub.foo', $relation->getForeignKey());
+		$this->assertTrue($relation->getParent() === $model);
+		$this->assertTrue($relation->getQuery()->getModel() instanceof Foo\Bar\EloquentModelSaveStub);
 	}
 
 
@@ -640,6 +656,14 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('belongs_to_stub_id', $relation->getForeignKey());
 		$this->assertTrue($relation->getParent() === $model);
 		$this->assertTrue($relation->getQuery()->getModel() instanceof EloquentModelSaveStub);
+
+		require_once __DIR__.'/stubs/NamespacedStubs.php';
+		$model = new Foo\Bar\EloquentModelStub;
+		$this->addMockConnection($model);
+		$relation = $model->belongsToStub();
+		$this->assertEquals('belongs_to_stub_id', $relation->getForeignKey());
+		$this->assertTrue($relation->getParent() === $model);
+		$this->assertTrue($relation->getQuery()->getModel() instanceof Foo\Bar\EloquentModelSaveStub);
 
 		$model = new EloquentModelStub;
 		$this->addMockConnection($model);
@@ -679,6 +703,15 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('table.other', $relation->getOtherKey());
 		$this->assertTrue($relation->getParent() === $model);
 		$this->assertTrue($relation->getQuery()->getModel() instanceof EloquentModelSaveStub);
+
+		require_once __DIR__.'/stubs/NamespacedStubs.php';
+		$model = new Foo\Bar\EloquentModelStub;
+		$this->addMockConnection($model);
+		$relation = $model->belongsToMany('EloquentModelSaveStub', 'table', 'foreign', 'other');
+		$this->assertEquals('table.foreign', $relation->getForeignKey());
+		$this->assertEquals('table.other', $relation->getOtherKey());
+		$this->assertTrue($relation->getParent() === $model);
+		$this->assertTrue($relation->getQuery()->getModel() instanceof Foo\Bar\EloquentModelSaveStub);
 	}
 
 
@@ -687,7 +720,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model = new EloquentModelWithoutTableStub;
 		$this->assertEquals('eloquent_model_without_table_stubs', $model->getTable());
 
-		require_once __DIR__.'/stubs/EloquentModelNamespacedStub.php';
+		require_once __DIR__.'/stubs/NamespacedStubs.php';
 		$namespacedModel = new Foo\Bar\EloquentModelNamespacedStub;
 		$this->assertEquals('eloquent_model_namespaced_stubs', $namespacedModel->getTable());
 	}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -599,6 +599,13 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('save_stub.foo', $relation->getForeignKey());
 		$this->assertTrue($relation->getParent() === $model);
 		$this->assertTrue($relation->getQuery()->getModel() instanceof Foo\Bar\EloquentModelSaveStub);
+
+		$model = new Foo\Bar\EloquentModelStub;
+		$this->addMockConnection($model);
+		$relation = $model->hasOne('\EloquentModelSaveStub', 'foo');
+		$this->assertEquals('save_stub.foo', $relation->getForeignKey());
+		$this->assertTrue($relation->getParent() === $model);
+		$this->assertTrue($relation->getQuery()->getModel() instanceof EloquentModelSaveStub);
 	}
 
 

--- a/tests/Database/stubs/EloquentModelNamespacedStub.php
+++ b/tests/Database/stubs/EloquentModelNamespacedStub.php
@@ -1,7 +1,0 @@
-<?php namespace Foo\Bar;
-
-use Illuminate\Database\Eloquent\Model;
-
-class EloquentModelNamespacedStub extends Model {
-
-}

--- a/tests/Database/stubs/NamespacedStubs.php
+++ b/tests/Database/stubs/NamespacedStubs.php
@@ -1,0 +1,7 @@
+<?php namespace Foo\Bar;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelNamespacedStub extends Model {}
+class EloquentModelStub extends \EloquentModelStub {}
+class EloquentModelSaveStub extends \EloquentModelSaveStub {}


### PR DESCRIPTION
Got sick of writing fully qualified namespaces when defining relationships between classes that were in the same namespace.

This PR allows you to specify just the classname in a relationship. If it's necessary to namespace that class for the relationship to work, it will be done automatically.

``` php
<?php namespace Foo\Bar;

class Post extends \Eloquent {

    public function user()
    {
        // Will use User class from global namespace no matter what
        return $this->belongsTo('\User');

        // Will first try to use \Foo\Bar\User and fallback to \User if the
        // namespaced version doesn't exist
        return $this->belongsTo('User');

        // Will immediately use \Foo\Bar\User
        return $this->belongsTo('\Foo\Bar\User');

        // First attempts \Foo\Bar\Foo\Bar\User but falls back to \Foo\Bar\User
        // since Foo\Bar\Foo\Bar\User does not exist
        return $this->belongsTo('Foo\Bar\User');
    }
}
```
