### PR TITLE
Form checkbox builder deal with model relationships

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -3,6 +3,7 @@
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Html\HtmlBuilder as Html;
 use Illuminate\Session\Store as Session;
+use Illuminate\Database\Eloquent\Collection;
 
 class FormBuilder {
 
@@ -633,9 +634,20 @@ class FormBuilder {
 
 		if ($this->missingOldAndModel($name)) return $checked;
 
-		$posted = $this->getValueAttribute($name);
+		$posted = $this->getValueAttribute($name, $checked);
 
-		return is_array($posted) ? in_array($value, $posted) : (bool) $posted;
+		if (is_array($posted))
+		{
+			return in_array($value, $posted);
+		}
+		elseif ($posted instanceOf Collection)
+		{
+			return $posted->contains($value);
+		}
+		else
+		{
+			return (bool) $posted;
+		}
 	}
 
 	/**

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -6,6 +6,7 @@ use Illuminate\Html\HtmlBuilder;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Http\Request;
 use Symfony\Component\Routing\RouteCollection;
+use Illuminate\Database\Eloquent\Collection;
 
 class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
@@ -315,6 +316,30 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<input checked="checked" name="multicheck[]" type="checkbox" value="1">', $check1);
 		$this->assertEquals('<input name="multicheck[]" type="checkbox" value="2">', $check2);
 		$this->assertEquals('<input checked="checked" name="multicheck[]" type="checkbox" value="3">', $check3);
+	}
+
+
+	public function testFormCheckboxWithModelRelation()
+	{
+		$this->formBuilder->setSessionStore($session = m::mock('Illuminate\Session\Store'));
+		$session->shouldReceive('getOldInput')->withNoArgs()->andReturn(array());
+		$session->shouldReceive('getOldInput')->with('items')->andReturn(null);
+
+		$mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel2->shouldReceive('getKey')->andReturn(2);
+		$mockModel3 = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel3->shouldReceive('getKey')->andReturn(3);
+		$this->setModel(array('items' => new Collection(array($mockModel2, $mockModel3))));
+
+		$check1 = $this->formBuilder->checkbox('items[]', 1);
+		$check2 = $this->formBuilder->checkbox('items[]', 2);
+		$check3 = $this->formBuilder->checkbox('items[]', 3, false);
+		$check4 = $this->formBuilder->checkbox('items[]', 4, true);
+
+		$this->assertEquals('<input name="items[]" type="checkbox" value="1">', $check1);
+		$this->assertEquals('<input checked="checked" name="items[]" type="checkbox" value="2">', $check2);
+		$this->assertEquals('<input name="items[]" type="checkbox" value="3">', $check3);
+		$this->assertEquals('<input checked="checked" name="items[]" type="checkbox" value="4">', $check4);
 	}
 
 


### PR DESCRIPTION
First of all, there is a bug fix. When a checkbox had the same name than a model relation, the state of the checkbox was incoherent because the method `getCheckboxCheckedState` was not designed for this use case :

``` PHP
// Old method. If $name is the name of a has many relationships, $posted is an instance of Collection and the method return true
$posted = $this->getValueAttribute($name);

return is_array($posted) ? in_array($value, $posted) : (bool) $posted;
```

Hard to debug... An other issue of this method is that no default value is given to `getValueAttribute`, even if the `$checked` argument is set in the `Form::checkbox` method. In the case where the checkbox had the same name than the model relation, the "checked" state manually defined was not considered.

Then, you can see my solution below. Because I was dealing with form model relationships here, I took the opportunity to improve the method and automatically set the checkbox to the good state. I think it's a common use case.

Just say if there is a misunderstanding or if this could be improved. Should be merged with `4.1` and `master` branches too.
