### PR TITLE
Add Route::setUri()

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -643,6 +643,19 @@ class Route {
 	}
 
 	/**
+	 * Set the URI that the route responds to.
+	 *
+	 * @param  string  $uri
+	 * @return $this
+	 */
+	public function setUri($uri)
+	{
+		$this->uri = $uri;
+
+		return $this;
+	}
+
+	/**
 	 * Get the name of the route instance.
 	 *
 	 * @return string


### PR DESCRIPTION
Currently there is no setter method for `Route::$uri`. This is useful during scenarios where you are cloning the current `Route` object and need to make a modification.

This is something that is done in the current @cartalyst/api package, but I'm not sure if this change will help them migrate the package to 4.1 any quicker or not.

For now I have a hacked implementation of this package, but I had to extend `Route` and `Router` just so I can have `setUri()` available.

Cheers,
Andrew
