### PR TITLE
[Http][Response] Add the remember function

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -6,6 +6,13 @@ use Illuminate\Support\Contracts\JsonableInterface;
 class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {
 
 	/**
+	 * The request instance.
+	 *
+	 * @var \Illuminate\Http\Request
+	 */
+	protected $request;
+
+	/**
 	 * Get the json_decoded data from the response
 	 *
 	 * @param  bool $assoc
@@ -57,20 +64,49 @@ class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {
 	}
 
 	/**
-	 * Set ETag and/or Last-Modified and check against current request if a not modified response should be returned.
+	 * Remember a response.
 	 *
-	 * @param string|null           $etag
+	 * If $etag is set to true, an etag will be automatically generated.
+	 *
+	 * @param string|bool|null      $etag
 	 * @param \Datetime|Carbon|null $lastModified
 	 *
 	 * @return \Illuminate\Http\Response
 	 */
-	public function remember($etag = null, $lastModified = null)
+	public function remember($etag = true, $lastModified = null)
 	{
+		if ($etag === true)
+		{
+			$etag = sha1(json_encode($this->content));
+		}
+
 		$this->setEtag($etag)->setLastModified($lastModified);
 
-		$this->isNotModified(\Request::instance());
+		$this->isNotModified($this->getRequest());
 
 		return $this;
+	}
+
+	/**
+	 * Get the request instance.
+	 *
+	 * @return \Illuminate\Http\Request
+	 */
+	public function getRequest()
+	{
+		return $this->request;
+	}
+
+	/**
+	 * Set the request instance.
+	 *
+	 * @param \Illuminate\Http\Request $request
+	 *
+	 * @return void
+	 */
+	public function setRequest(Request $request)
+	{
+		$this->request = $request;
 	}
 
 }

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -56,4 +56,21 @@ class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {
 		return $this;
 	}
 
+	/**
+	 * Set ETag and/or Last-Modified and check against current request if a not modified response should be returned.
+	 *
+	 * @param string|null           $etag
+	 * @param \Datetime|Carbon|null $lastModified
+	 *
+	 * @return \Illuminate\Http\Response
+	 */
+	public function remember($etag = null, $lastModified = null)
+	{
+		$this->setEtag($etag)->setLastModified($lastModified);
+
+		$this->isNotModified(\Request::instance());
+
+		return $this;
+	}
+
 }

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -109,4 +109,21 @@ class Response extends \Symfony\Component\HttpFoundation\Response {
 		return $this->original;
 	}
 
+	/**
+	 * Set ETag and/or Last-Modified and check against current request if a not modified response should be returned.
+	 *
+	 * @param string|null           $etag
+	 * @param \Datetime|Carbon|null $lastModified
+	 *
+	 * @return \Illuminate\Http\Response
+	 */
+	public function remember($etag = null, $lastModified = null)
+	{
+		$this->setEtag($etag)->setLastModified($lastModified);
+
+		$this->isNotModified(\Request::instance());
+
+		return $this;
+	}
+
 }

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -8,6 +8,13 @@ use Illuminate\Support\Contracts\RenderableInterface;
 class Response extends \Symfony\Component\HttpFoundation\Response {
 
 	/**
+	 * The request instance.
+	 *
+	 * @var \Illuminate\Http\Request
+	 */
+	protected $request;
+
+	/**
 	 * The original content of the response.
 	 *
 	 * @var mixed
@@ -110,20 +117,49 @@ class Response extends \Symfony\Component\HttpFoundation\Response {
 	}
 
 	/**
-	 * Set ETag and/or Last-Modified and check against current request if a not modified response should be returned.
+	 * Remember a response.
 	 *
-	 * @param string|null           $etag
+	 * If $etag is set to true, an etag will be automatically generated.
+	 *
+	 * @param string|bool|null      $etag
 	 * @param \Datetime|Carbon|null $lastModified
 	 *
 	 * @return \Illuminate\Http\Response
 	 */
-	public function remember($etag = null, $lastModified = null)
+	public function remember($etag = true, $lastModified = null)
 	{
+		if ($etag === true)
+		{
+			$etag = sha1(json_encode($this->content));
+		}
+
 		$this->setEtag($etag)->setLastModified($lastModified);
 
-		$this->isNotModified(\Request::instance());
+		$this->isNotModified($this->getRequest());
 
 		return $this;
+	}
+
+	/**
+	 * Get the request instance.
+	 *
+	 * @return \Illuminate\Http\Request
+	 */
+	public function getRequest()
+	{
+		return $this->request;
+	}
+
+	/**
+	 * Set the request instance.
+	 *
+	 * @param \Illuminate\Http\Request $request
+	 *
+	 * @return void
+	 */
+	public function setRequest(Request $request)
+	{
+		$this->request = $request;
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -26,7 +26,11 @@ class Response {
 	 */
 	public static function make($content = '', $status = 200, array $headers = array())
 	{
-		return new IlluminateResponse($content, $status, $headers);
+		$response = new IlluminateResponse($content, $status, $headers);
+		$app      = Facade::getFacadeApplication();
+		$response->setRequest($app['request']);
+
+		return $response;
 	}
 
 	/**
@@ -60,7 +64,11 @@ class Response {
 			$data = $data->toArray();
 		}
 
-		return new JsonResponse($data, $status, $headers);
+		$response = new JsonResponse($data, $status, $headers);
+		$app      = Facade::getFacadeApplication();
+		$response->setRequest($app['request']);
+
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #3030 |

This feature adds the `remember` function to `JsonResponse.php` and `Response.php`. This function allows to:
- Set `ETag` and/or `Last-Modified` `Response` header.
- Check against the `Request` instance if the `Response` has been modified.
- If so, set the `Response` as not modified (`304`).
