### PR TITLE
Fix Router.php to behave on App::error

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1407,7 +1407,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	public function currentRouteName()
 	{
-		return $this->current()->getName();
+		return ($this->current()) ? $this->current()->getName() : null;
 	}
 
 	/**
@@ -1418,7 +1418,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	public function currentRouteNamed($name)
 	{
-		return $this->current()->getName() == $name;
+		return ($this->current()) ? $this->current()->getName() == $name : false;
 	}
 
 	/**


### PR DESCRIPTION
When App::error is triggered, Route is empty. When you try to access Route::currentRouteNamed($string), it fails because Route::current() is empty and does not have a getName() method.
