### PR TITLE
[Proposal] Travis Fast Finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script: phpunit -d memory_limit=1024M
 matrix:
   allow_failures:
     - php: hhvm
+  fast_finish: true


### PR DESCRIPTION
#### What does this mean?

Travis fast finish allows the build as whole to be marked as green if all builds have passed except those marked as allowed to fail, even if those builds marked as allowed to fail are still running.
#### How does this apply?

Laravel specifies that the hhvm build is allowed to fail, so by enabling this feature, if the php 5.3/5.4/5.5 builds get the green light, but the hhvm build is still running, the whole build is marked as passed.
#### Why is this useful?

Because we specified we aren't too bothered if the hhvm build fails, why allow it to hold us up getting the greed/red light from the other builds? Enabling this allows us to get a faster response from the tests that we really care about.
#### Where can I read more?

More information is available on the travis docs at http://about.travis-ci.org/docs/user/build-configuration/#Fast-finishing.
