### PR TITLE
[Proposal] Specify Query Cache Driver

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -149,6 +149,13 @@ class Builder {
 	protected $cacheTags;
 
 	/**
+	 * The driver for the query cache.
+	 *
+	 * @var string
+	 */
+	protected $cacheDriver;
+
+	/**
 	 * All of the available clause operators.
 	 *
 	 * @var array
@@ -1113,6 +1120,19 @@ class Builder {
 	}
 
 	/**
+	 * Indicate that the results, if cached, should use the given cache driver.
+	 *
+	 * @param  string  $cacheDriver
+	 * @return \Illuminate\Database\Query\Builder|static
+	 */
+	public function cacheDriver($cacheDriver)
+	{
+		$this->cacheDriver = $cacheDriver;
+
+		return $this;
+	}
+
+	/**
 	 * Execute a query for a single record by ID.
 	 *
 	 * @param  int    $id
@@ -1225,7 +1245,7 @@ class Builder {
 	 */
 	protected function getCache()
 	{
-		$cache = $this->connection->getCacheManager();
+		$cache = $this->connection->getCacheManager()->driver($this->cacheDriver);
 
 		return $this->cacheTags ? $cache->tags($this->cacheTags) : $cache;
 	}

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -48,10 +48,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testSelectWithCaching()
 	{
 		$cache = m::mock('stdClass');
-		$query = $this->setupCacheTestQuery($cache);
+		$driver = m::mock('stdClass');
+		$query = $this->setupCacheTestQuery($cache, $driver);
+
 		$query = $query->remember(5);
 
-		$cache->shouldReceive('remember')
+		$driver->shouldReceive('remember')
 						 ->once()
 						 ->with($query->getCacheKey(), 5, m::type('Closure'))
 						 ->andReturnUsing(function($key, $minutes, $callback) { return $callback(); });
@@ -63,10 +65,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testSelectWithCachingForever()
 	{
 		$cache = m::mock('stdClass');
-		$query = $this->setupCacheTestQuery($cache);
+		$driver = m::mock('stdClass');
+		$query = $this->setupCacheTestQuery($cache, $driver);
+
 		$query = $query->rememberForever();
 
-		$cache->shouldReceive('rememberForever')
+		$driver->shouldReceive('rememberForever')
 												->once()
 												->with($query->getCacheKey(), m::type('Closure'))
 												->andReturnUsing(function($key, $callback) { return $callback(); });
@@ -80,12 +84,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$taggedCache = m::mock('StdClass');
 		$cache = m::mock('stdClass');
-		$cache->shouldReceive('tags')
+		$driver = m::mock('stdClass');
+
+		$driver->shouldReceive('tags')
 				->once()
 				->with(array('foo','bar'))
 				->andReturn($taggedCache);
 
-		$query = $this->setupCacheTestQuery($cache);
+		$query = $this->setupCacheTestQuery($cache, $driver);
 		$query = $query->cacheTags(array('foo', 'bar'))->remember(5);
 
 		$taggedCache->shouldReceive('remember')
@@ -852,11 +858,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->noValidMethodHere();
 	}
 
-	public function setupCacheTestQuery($cache)
+	public function setupCacheTestQuery($cache, $driver)
 	{
 		$connection = m::mock('Illuminate\Database\ConnectionInterface');
 		$connection->shouldReceive('getName')->andReturn('connection_name');
 		$connection->shouldReceive('getCacheManager')->once()->andReturn($cache);
+		$cache->shouldReceive('driver')->once()->andReturn($driver);
 		$grammar = new Illuminate\Database\Query\Grammars\Grammar;
 		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
 


### PR DESCRIPTION
It would be really cool if we could specify the cache driver to use for caching queries. It would be particularly useful if you wanted to cache a query for just the single request, because we could specify to use the array driver. I have written an implementation here.
