### PR TITLE
Fix Typos

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -416,7 +416,7 @@ class MySqlGrammar extends Grammar {
 	}
 
 	/**
-	 * Create the column definition for a enum type.
+	 * Create the column definition for an enum type.
 	 *
 	 * @param  \Illuminate\Support\Fluent  $column
 	 * @return string

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -426,7 +426,7 @@ class SQLiteGrammar extends Grammar {
 	}
 
 	/**
-	 * Create the column definition for a enum type.
+	 * Create the column definition for an enum type.
 	 *
 	 * @param  \Illuminate\Support\Fluent  $column
 	 * @return string

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -358,7 +358,7 @@ class SqlServerGrammar extends Grammar {
 	}
 
 	/**
-	 * Create the column definition for a enum type.
+	 * Create the column definition for an enum type.
 	 *
 	 * @param  \Illuminate\Support\Fluent  $column
 	 * @return string

--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -44,7 +44,7 @@ class TinkerCommand extends Command {
 
 			// If an exception occurs, we will just display the message and keep this
 			// loop going so we can keep executing commands. However, when a fatal
-			// a error occurs we have no choice but to bail out of the routines.
+			// error occurs we have no choice but to bail out of the routines.
 			catch (\Exception $e)
 			{
 				$this->error($e->getMessage());

--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -103,7 +103,7 @@ class Environment {
 	}
 
 	/**
-	 * Get an evaluated view contents for the given view.
+	 * Get the evaluated view contents for the given view.
 	 *
 	 * @param  string  $view
 	 * @param  array   $data
@@ -133,7 +133,7 @@ class Environment {
 	}
 
 	/**
-	 * Get an evaluated view contents for a named view.
+	 * Get the evaluated view contents for a named view.
 	 *
 	 * @param string $view
 	 * @param mixed $data

--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -103,7 +103,7 @@ class Environment {
 	}
 
 	/**
-	 * Get a evaluated view contents for the given view.
+	 * Get an evaluated view contents for the given view.
 	 *
 	 * @param  string  $view
 	 * @param  array   $data
@@ -133,7 +133,7 @@ class Environment {
 	}
 
 	/**
-	 * Get a evaluated view contents for a named view.
+	 * Get an evaluated view contents for a named view.
 	 *
 	 * @param string $view
 	 * @param mixed $data


### PR DESCRIPTION
- Fix 1 - _"a evaluated"_ should read _"the evaluated"_
- Fix 2 - _"a enum"_ should read _"an enum"_
- Fix 3 - removed an extra _"a"_
