### PR TITLE
[Fix] Avoid recalculating count() for each iteration.

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -895,8 +895,9 @@ class Validator implements MessageProviderInterface {
 	protected function getExtraConditions(array $segments)
 	{
 		$extra = array();
+		$count = count($segments);
 
-		for ($i = 0; $i < count($segments); $i = $i + 2)
+		for ($i = 0; $i < $count; $i = $i + 2)
 		{
 			$extra[$segments[$i]] = $segments[$i + 1];
 		}


### PR DESCRIPTION
Since the value of `count($segments)` will never change during the method execution, cache it to avoid recalculating it for each iteration of the loop.
