### PR TITLE
Allows Seeder execution absent of a Command object

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -36,7 +36,10 @@ class Seeder {
 	{
 		$this->resolve($class)->run();
 
-		$this->command->getOutput()->writeln("<info>Seeded:</info> $class");
+                if (isset($this->command))
+                {
+			$this->command->getOutput()->writeln("<info>Seeded:</info> $class");
+                }
 	}
 
 	/**

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -36,10 +36,10 @@ class Seeder {
 	{
 		$this->resolve($class)->run();
 
-                if (isset($this->command))
-                {
+		if (isset($this->command))
+		{
 			$this->command->getOutput()->writeln("<info>Seeded:</info> $class");
-                }
+		}
 	}
 
 	/**


### PR DESCRIPTION
I might like to execute a Seed file outside the context of an artisan command. Eg:

``` php
$seeder = App::make('My\Seeder\Class');
$seeder->run();
```

At the moment this fails because the seeder requires a command object for sending some output.

```
Call to a member function getOutput() on a non-object
```

This PR makes the command object optional.
