### PR TITLE
Add setModel method to FormBuilder

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -151,6 +151,17 @@ class FormBuilder {
 	}
 
 	/**
+	 * Set model on form builder.
+	 *
+	 * @param  mixed  $model
+	 * @return void
+	 */
+	public function setModel($model)
+	{
+		$this->model = $model;
+	}
+
+	/**
 	 * Close the current form.
 	 *
 	 * @return string


### PR DESCRIPTION
Pull request for issue #3063

Let me know if you would like me to add this to the open method as well:

``` php
public function model($model, array $options = array())
{
        $this->setModel($model);

        return $this->open($options);
}
```

Thanks! :+1: 
