### PR TITLE
Bug: Incorrect error checking of bcrypt hashes

### DIFF
--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -24,7 +24,7 @@ class BcryptHasher implements HasherInterface {
 
 		$hash = password_hash($value, PASSWORD_BCRYPT, array('cost' => $cost));
 
-		if ($hash === false)
+		if (!$hash)
 		{
 			throw new \RuntimeException("Bcrypt hashing not supported.");
 		}


### PR DESCRIPTION
The method `BcryptHasher::make()` does a strict check for `false` to see if the function call `password_hash()` went wrong. However, this function may also return `null` on error. In that case, the return value will be accepted despite the error.

The strict comparison generally makes no sense, because no falsy return value could possibly be valid. Anything other than a string with 60 ASCII characters means that the hashing has failed.
