### PR TITLE
Check for page name in Paginator::addQuery

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -265,7 +265,10 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	 */
 	public function addQuery($key, $value)
 	{
-		$this->query[$key] = $value;
+		if ($key !== $this->env->getPageName())
+		{
+			$this->query[$key] = $value;
+		}
 
 		return $this;
 	}

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -100,11 +100,13 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 	public function testGetUrlProperlyFormatsUrl()
 	{
 		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('foo', 'bar', 'baz'), 3, 2);
-		$env->shouldReceive('getCurrentUrl')->twice()->andReturn('http://foo.com');
-		$env->shouldReceive('getPageName')->twice()->andReturn('page');
+		$env->shouldReceive('getCurrentUrl')->times(3)->andReturn('http://foo.com');
+		$env->shouldReceive('getPageName')->andReturn('page');
 
 		$this->assertEquals('http://foo.com?page=1', $p->getUrl(1));
 		$p->addQuery('foo', 'bar');
+		$this->assertEquals('http://foo.com?page=1&foo=bar', $p->getUrl(1));
+		$p->addQuery('page', 99);
 		$this->assertEquals('http://foo.com?page=1&foo=bar', $p->getUrl(1));
 	}
 
@@ -137,7 +139,7 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 	{
 		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('foo', 'bar', 'baz'), 3, 2);
 		$env->shouldReceive('getCurrentUrl')->twice()->andReturn('http://foo.com');
-		$env->shouldReceive('getPageName')->twice()->andReturn('page');
+		$env->shouldReceive('getPageName')->andReturn('page');
 
 		$p->fragment("a-fragment");
 


### PR DESCRIPTION
This will allow you to do `$paginator->appends(Request::query())->links()` without the ?page=x interfering - very useful for ordering/filtering parameters. Currently, if you do this, the page variable will be the same for every link.
