### PR TITLE
Authentication improvements

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -284,14 +284,11 @@ class Guard {
 		// and ask the provider to validate it against the given credentials,
 		// and if they are in fact valid we'll log the users into the
 		// application and return true.
-		if ( ! is_null($user))
+		if ( ! is_null($user) && $this->provider->validateCredentials($user, $credentials))
 		{
-			if ($this->provider->validateCredentials($user, $credentials))
-			{
-				if ($login) $this->login($user, $remember);
+			if ($login) $this->login($user, $remember);
 
-				return true;
-			}
+			return true;
 		}
 
 		return false;

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -280,10 +280,11 @@ class Guard {
 
 		$this->lastAttempted = $user = $this->provider->retrieveByCredentials($credentials);
 
-		// If an implementation of UserInterface was returned, we'll ask the provider
-		// to validate the user against the given credentials, and if they are in
-		// fact valid we'll log the users into the application and return true.
-		if ($user instanceof UserInterface)
+		// If something was returned, we can assume it implements UserInterface
+		// and ask the provider to validate it against the given credentials,
+		// and if they are in fact valid we'll log the users into the
+		// application and return true.
+		if ( ! is_null($user))
 		{
 			if ($this->provider->validateCredentials($user, $credentials))
 			{

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -78,7 +78,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		$mock = $this->getGuard();
 		$mock->setDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
 		$events->shouldReceive('fire')->once()->with('auth.attempt', array(array('foo'), false, true));
-		$mock->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn('foo');
+		$mock->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn(null);
 		$this->assertFalse($mock->attempt(array('foo')));
 	}
 


### PR DESCRIPTION
By checking for null instead of if it implements UserInterface, you'll more easily catch errors where your User model doesn't implement the required UserInterface.

An alternative is to manually check for the interface in the EloquentUserProvider and throw an exception, which may produce a more descriptive error (stack trace and so on), but I thought this was more concise - and the error you get should be clear enough.
#3009
