### PR TITLE
Separate query bindings to fix their order

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -396,7 +396,7 @@ class Builder {
 
 		if ( ! $value instanceof Expression)
 		{
-			$this->bindings['where'][] = $value;
+			$this->addBinding($value, 'where');
 		}
 
 		return $this;
@@ -443,7 +443,7 @@ class Builder {
 
 		$this->wheres[] = compact('type', 'sql', 'boolean');
 
-		$this->bindings['where'] = array_merge($this->bindings['where'], $bindings);
+		$this->addBinding($bindings, 'where');
 
 		return $this;
 	}
@@ -475,7 +475,7 @@ class Builder {
 
 		$this->wheres[] = compact('column', 'type', 'boolean', 'not');
 
-		$this->bindings['where'] = array_merge($this->bindings['where'], $values);
+		$this->addBinding($values, 'where');
 
 		return $this;
 	}
@@ -671,7 +671,7 @@ class Builder {
 
 		$this->wheres[] = compact('type', 'column', 'values', 'boolean');
 
-		$this->bindings['where'] = array_merge($this->bindings['where'], $values);
+		$this->addBinding($values, 'where');
 
 		return $this;
 	}
@@ -940,7 +940,7 @@ class Builder {
 
 		$this->havings[] = compact('type', 'column', 'operator', 'value');
 
-		$this->bindings['having'][] = $value;
+		$this->addBinding($value, 'having');
 
 		return $this;
 	}
@@ -959,7 +959,7 @@ class Builder {
 
 		$this->havings[] = compact('type', 'sql', 'boolean');
 
-		$this->bindings['having'] = array_merge($this->bindings['having'], $bindings);
+		$this->addBinding($bindings, 'having');
 
 		return $this;
 	}
@@ -1027,7 +1027,7 @@ class Builder {
 
 		$this->orders[] = compact('type', 'sql');
 
-		$this->bindings['order'] = array_merge($this->bindings['order'], $bindings);
+		$this->addBinding($bindings, 'order');
 
 		return $this;
 	}
@@ -1884,7 +1884,7 @@ class Builder {
 	 */
 	public function setBindings(array $bindings, $type = 'where')
 	{
-		if (!array_key_exists($type, $this->bindings))
+		if ( ! array_key_exists($type, $this->bindings))
 		{
 			throw new \InvalidArgumentException("Invalid binding type: $type");
 		}
@@ -1903,12 +1903,19 @@ class Builder {
 	 */
 	public function addBinding($value, $type = 'where')
 	{
-		if (!array_key_exists($type, $this->bindings))
+		if ( ! array_key_exists($type, $this->bindings))
 		{
 			throw new \InvalidArgumentException("Invalid binding type: $type");
 		}
 
-		$this->bindings[$type][] = $value;
+		if (is_array($value))
+		{
+			$this->bindings[$type] = array_values(array_merge($this->bindings[$type], $value));
+		}
+		else
+		{
+			$this->bindings[$type][] = $value;
+		}
 
 		return $this;
 	}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -846,7 +846,7 @@ class Builder {
 	{
 		$this->wheres[] = compact('column', 'type', 'boolean', 'operator', 'value');
 
-		$this->bindings[] = $value;
+		$this->addBinding($value, 'where');
 
 		return $this;
 	}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -36,9 +36,10 @@ class Builder {
 	 */
 	protected $bindings = array(
 		'select' => array(),
-		'where' => array(),
+		'join'   => array(),
+		'where'  => array(),
 		'having' => array(),
-		'order' => array(),
+		'order'  => array(),
 	);
 
 	/**

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -59,7 +59,7 @@ class JoinClause {
 	{
 		$this->clauses[] = compact('first', 'operator', 'second', 'boolean', 'where');
 
-		if ($where) $this->query->addBinding($second);
+		if ($where) $this->query->addBinding($second, 'join');
 
 		return $this;
 	}

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1041,6 +1041,47 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAddBindingWithArrayMergesBindings()
+	{
+		$builder = $this->getBuilder();
+		$builder->addBinding(array('foo', 'bar'));
+		$builder->addBinding(array('baz'));
+		$this->assertEquals(array('foo', 'bar', 'baz'), $builder->getBindings());
+	}
+
+
+	public function testAddBindingWithArrayMergesBindingsInCorrectOrder()
+	{
+		$builder = $this->getBuilder();
+		$builder->addBinding(array('bar', 'baz'), 'having');
+		$builder->addBinding(array('foo'), 'where');
+		$this->assertEquals(array('foo', 'bar', 'baz'), $builder->getBindings());
+	}
+
+
+	public function testMergeBuilders()
+	{
+		$builder = $this->getBuilder();
+		$builder->addBinding(array('foo', 'bar'));
+		$otherBuilder = $this->getBuilder();
+		$otherBuilder->addBinding(array('baz'));
+		$builder->mergeBindings($otherBuilder);
+		$this->assertEquals(array('foo', 'bar', 'baz'), $builder->getBindings());
+	}
+
+
+	public function testMergeBuildersBindingOrder()
+	{
+		$builder = $this->getBuilder();
+		$builder->addBinding('foo', 'where');
+		$builder->addBinding('baz', 'having');
+		$otherBuilder = $this->getBuilder();
+		$otherBuilder->addBinding('bar', 'where');
+		$builder->mergeBindings($otherBuilder);
+		$this->assertEquals(array('foo', 'bar', 'baz'), $builder->getBindings());
+	}
+
+
 	protected function getBuilder()
 	{
 		$grammar = new Illuminate\Database\Query\Grammars\Grammar;


### PR DESCRIPTION
This is a new implementation of #884.

Currently it's near impossible to add a sub select, having or order by clause to a query builder as long as it has a binding - the order of the query binding gets completely messed up because all bindings are put into a single flat array. Therefore I propose this change which separates the bindings into 4 different categories.

It seems to pass all unit tests. The default `$type` value of 'where' on the various binding manipulation methods and the new `getBindings` method should ensure decent backwards compatibility. I had to modify one unrelated one, but it didn't make much sense to begin with - expecting the bindings to be `array('foo' => 'bar')` is stupid when we're using unnamed parameters (`?` as opposed to `:foo`). Nevertheless this is a pretty big change so I thought it best to target the master branch.

As an extension of this I would love to implement a selectSub and/or selectRaw method.
