### PR TITLE
Run totallyGuarded() once outside of loop.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -316,6 +316,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function fill(array $attributes)
 	{
+		$totallyGuarded = $this->totallyGuarded();
+		
 		foreach ($this->fillableFromArray($attributes) as $key => $value)
 		{
 			$key = $this->removeTableFromKey($key);
@@ -327,7 +329,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			{
 				$this->setAttribute($key, $value);
 			}
-			elseif ($this->totallyGuarded())
+			elseif ($totallyGuarded)
 			{
 				throw new MassAssignmentException($key);
 			}


### PR DESCRIPTION
The boolean returned by totallyGuarded() will never change during the loop. Running the method outside of the foreach avoids one unnecessary count() and two checks for each iteration.
