### PR TITLE
Update TailCommand.php

### DIFF
--- a/src/Illuminate/Foundation/Console/TailCommand.php
+++ b/src/Illuminate/Foundation/Console/TailCommand.php
@@ -19,7 +19,7 @@ class TailCommand extends Command {
 	 *
 	 * @var string
 	 */
-	protected $description = "Tail a log file on a remote server";
+	protected $description = "Tail a log file. Note: will not work on Windows servers.";
 
 	/**
 	 * Execute the console command.


### PR DESCRIPTION
The "tail" command used by this artisan command does not exist on Windows machines. It should be noted in the command, so people dont try it and wonder why it does not work.

So whilst it is not a 'bug' with Laravel, it is a compatibility issue that should be easily identified.
