### PR TITLE
Added whereEquals(array) and findBy(array) to query builder and Eloquent. 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -83,6 +83,19 @@ class Builder {
     }
 
 	/**
+	 * Find a single using an array of column to value pairs.
+	 *
+	 * @param  array  $constraints
+	 * @param  array  $columns
+	 * @return \Illuminate\Database\Eloquent\Model|static|null
+	 */
+	public function findBy(array $constraints, $columns = array('*'))
+	{
+		$this->whereEquals($constraints);
+		return $this->first($columns);
+	}
+
+	/**
 	 * Find a model by its primary key or throw an exception.
 	 *
 	 * @param  mixed  $id

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -765,6 +765,21 @@ class Builder {
 	}
 
 	/**
+	 * Add multiple "where equals" clauses using an array.
+	 *
+	 * @param  array  $constraints
+	 * @return \Illuminate\Database\Query\Builder|static
+	 */
+	public function whereEquals(array $constraints)
+	{
+		foreach ($constraints as $column => $value)
+		{
+			$this->where($column, '=', $value);
+		}
+		return $this;
+	}
+
+	/**
 	 * Handles dynamic "where" clauses to the query.
 	 *
 	 * @param  string  $method
@@ -1140,6 +1155,19 @@ class Builder {
 	public function find($id, $columns = array('*'))
 	{
 		return $this->where('id', '=', $id)->first($columns);
+	}
+
+	/**
+	 * Find a single record using an array of column to value pairs.
+	 *
+	 * @param  array  $constraints
+	 * @param  array  $columns
+	 * @return mixed|static
+	 */
+	public function findBy(array $constraints, $columns = array('*'))
+	{
+		$this->whereEquals($constraints);
+		return $this->first($columns);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -26,6 +26,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('baz', $result);
 	}
 
+
 	public function testThatFindByMethod()
 	{
 		$query = m::mock('Illuminate\Database\Query\Builder');
@@ -39,6 +40,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$result = $builder->findBy(array('name' => 'Taylor', 'homie' => 'Dayle'), array('column'));
 		$this->assertEquals('baz', $result);
 	}
+
 
 	public function testFindWithMany()
 	{

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -16,7 +16,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$query = m::mock('Illuminate\Database\Query\Builder');
 		$query->shouldReceive('where')->once()->with('foo', '=', 'bar');
 		$builder = $this->getMock('Illuminate\Database\Eloquent\Builder', array('first'), array($query));
- 		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model = m::mock('Illuminate\Database\Eloquent\Model');
 		$model->shouldReceive('getKeyName')->once()->andReturn('foo');
 		$model->shouldReceive('getTable')->once()->andReturn('table');
 		$query->shouldReceive('from')->once()->with('table');
@@ -27,12 +27,12 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testThatFindByMethod()
+	public function testFindByMethod()
 	{
 		$query = m::mock('Illuminate\Database\Query\Builder');
 		$query->shouldReceive('whereEquals')->once()->with(array('name' => 'Taylor', 'homie' => 'Dayle'));
 		$builder = $this->getMock('Illuminate\Database\Eloquent\Builder', array('first'), array($query));
- 		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model = m::mock('Illuminate\Database\Eloquent\Model');
 		$model->shouldReceive('getTable')->once()->andReturn('table');
 		$query->shouldReceive('from')->once()->with('table');
 		$builder->setModel($model);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -26,6 +26,20 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('baz', $result);
 	}
 
+	public function testThatFindByMethod()
+	{
+		$query = m::mock('Illuminate\Database\Query\Builder');
+		$query->shouldReceive('whereEquals')->once()->with(array('name' => 'Taylor', 'homie' => 'Dayle'));
+		$builder = $this->getMock('Illuminate\Database\Eloquent\Builder', array('first'), array($query));
+ 		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model->shouldReceive('getTable')->once()->andReturn('table');
+		$query->shouldReceive('from')->once()->with('table');
+		$builder->setModel($model);
+		$builder->expects($this->once())->method('first')->with($this->equalTo(array('column')))->will($this->returnValue('baz'));
+		$result = $builder->findBy(array('name' => 'Taylor', 'homie' => 'Dayle'), array('column'));
+		$this->assertEquals('baz', $result);
+	}
+
 	public function testFindWithMany()
 	{
 		$query = m::mock('Illuminate\Database\Query\Builder');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -195,6 +195,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testWhereEquals()
+	{
+		$builder = $this->getBuilder();
+		$builder->whereEquals(array('name' => 'Taylor', 'homie' => 'Dayle'));
+		$this->assertEquals('select * where "name" = ? and "homie" = ?', $builder->toSql());
+	}
+
+
 	public function testUnions()
 	{
 		$builder = $this->getBuilder();
@@ -473,6 +481,16 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "id" = ? limit 1', array(1))->andReturn(array(array('foo' => 'bar')));
 		$builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, array(array('foo' => 'bar')))->andReturnUsing(function($query, $results) { return $results; });
 		$results = $builder->from('users')->find(1);
+		$this->assertEquals(array('foo' => 'bar'), $results);
+	}
+
+
+	public function testFindByReturnsFirstResultByArrayOfConstraints()
+	{
+		$builder = $this->getBuilder();
+		$builder->getConnection()->shouldReceive('select')->once()->with('select * from "users" where "name" = ? and "homie" = ? limit 1', array('Taylor', 'Dayle'))->andReturn(array(array('foo' => 'bar')));
+		$builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, array(array('foo' => 'bar')))->andReturnUsing(function($query, $results) { return $results; });
+		$results = $builder->from('users')->findBy(array('name' => 'Taylor', 'homie' => 'Dayle'));
 		$this->assertEquals(array('foo' => 'bar'), $results);
 	}
 


### PR DESCRIPTION
This PR replicates a feature I liked in Doctrine, where records or models could be retrieved by providing an array of where equals columns and values. For example:

``` php
$user = User::findBy(['name' => 'Bob', 'job' = 'Builder']);
```

and to add the constraints without returning a single result:

``` php
$users = User::whereEquals(['age' => '37', 'job' = 'Builder'])->get();
```

Tests are provided.

Thanks!
