### PR TITLE
Added prependNamespace() to prepend a view namespace hint to beginning...

### DIFF
--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -627,6 +627,18 @@ class Environment {
 	}
 
 	/**
+	 * Prepend a new namespace to the loader.
+	 *
+	 * @param  string  $namespace
+	 * @param  string|array  $hints
+	 * @return void
+	 */
+	public function prependNamespace($namespace, $hints)
+	{
+		$this->finder->prependNamespace($namespace, $hints);
+	}
+
+	/**
 	 * Register a valid view extension and its engine.
 	 *
 	 * @param  string   $extension

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -185,6 +185,25 @@ class FileViewFinder implements ViewFinderInterface {
 	}
 
 	/**
+	 * Prepends a namespace hint to the finder.
+	 *
+	 * @param  string  $namespace
+	 * @param  string|array  $hints
+	 * @return void
+	 */
+	public function prependNamespace($namespace, $hints)
+	{
+		$hints = (array) $hints;
+
+		if (isset($this->hints[$namespace]))
+		{
+			$hints = array_merge($hints, $this->hints[$namespace]);
+		}
+
+		$this->hints[$namespace] = $hints;
+	}
+
+	/**
 	 * Register an extension with the view finder.
 	 *
 	 * @param  string  $extension


### PR DESCRIPTION
...of the view loader.

This is useful for overriding i.e. package views with your own views. Currently this isn't available as it will addNamespace will append to the end of the array and therefore will always resolve the packages view first.
