### PR TITLE
Add Collection::groupBy

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -344,6 +344,25 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Group an associative array by a field
+	 *
+	 * @param string $attribute
+	 *
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function groupBy($attribute)
+	{
+		$results = array();
+
+		foreach ($this->items as $item)
+		{
+			$results[$item[$attribute]][] = $item;
+		}
+
+		return new static($results);
+	}
+
+	/**
 	 * Merge the collection with the given items.
 	 *
 	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -346,17 +346,18 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	/**
 	 * Group an associative array by a field
 	 *
-	 * @param string $attribute
+	 * @param string $groupBy
 	 *
 	 * @return \Illuminate\Support\Collection
 	 */
-	public function groupBy($attribute)
+	public function groupBy($groupBy)
 	{
 		$results = array();
 
 		foreach ($this->items as $item)
 		{
-			$results[$item[$attribute]][] = $item;
+			$attribute = array_get($item, $groupBy);
+			$results[$attribute][] = $item;
 		}
 
 		return new static($results);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -310,6 +310,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('default', $result);
 	}
 
+	public function testGroupByAttribute()
+	{
+		$data = new Collection(array(array('rating' => 1, 'name' => '1'), array('rating' => 1, 'name' => '2'), array('rating' => 2, 'name' => '3')));
+		$result = $data->groupBy('rating');
+		$this->assertEquals(array(1 => array(array('rating' => 1, 'name' => '1'), array('rating' => 1, 'name' => '2')), 2 => array(array('rating' => 2, 'name' => '3'))), $result->toArray());
+	}
+
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
This allows to group a Collection's items by one of their attributes :

``` php
$comments = new Collection(array(
    ['name' => 'foo', 'rating' => 1],
    ['name' => 'bar', 'rating' => 2],
    ['name' => 'baz', 'rating' => 1],
));

$results = $comments->groupBy('rating');

array(
    1 => array(
        ['name' => 'foo', 'rating' => 1],
        ['name' => 'baz', 'rating' => 1],
    ),
    2 => array(
        ['name' => 'bar', 'rating' => 2],
    ),
);
```

I seemed to remember something similar being proposed by couldn't find anything in the issues or on Collection/helpers, so I must have imagined it.
