### PR TITLE
Use unsigned integer in Blueprint::morphs()

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -654,7 +654,7 @@ class Blueprint {
 	 */
 	public function morphs($name)
 	{
-		$this->integer("{$name}_id");
+		$this->unsignedInteger("{$name}_id");
 
 		$this->string("{$name}_type");
 	}

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -650,13 +650,14 @@ class Blueprint {
 	 * Add the proper columns for a polymorphic table.
 	 *
 	 * @param  string  $name
+	 * @param  bool    $nullable
 	 * @return void
 	 */
-	public function morphs($name)
+	public function morphs($name, $nullable = false)
 	{
-		$this->unsignedInteger("{$name}_id");
+		$this->unsignedInteger("{$name}_id")->nullable($nullable);
 
-		$this->string("{$name}_type");
+		$this->string("{$name}_type")->nullable($nullable);
 	}
 
 	/**


### PR DESCRIPTION
Since `imageable_id` is a foreign key, though it can't be established for a particular table, it's still should match a primary key type.
