### PR TITLE
[Proposal] Add descending order for Collection::sortBy

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -254,9 +254,10 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 *
 	 * @param  \Closure  $callback
 	 * @param  int  $options
+	 * @param  bool  $descending
 	 * @return \Illuminate\Support\Collection
 	 */
-	public function sortBy(Closure $callback, $options = SORT_REGULAR)
+	public function sortBy(Closure $callback, $options = SORT_REGULAR, $descending = false)
 	{
 		$results = array();
 
@@ -268,7 +269,14 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 			$results[$key] = $callback($value);
 		}
 
-		asort($results, $options);
+		if (!$descending)
+		{
+			asort($results, $options);
+		}
+		else
+		{
+			arsort($results, $options);
+		}
 
 		// Once we have sorted all of the keys in the array, we will loop through them
 		// and grab the corresponding model so we can set the underlying items list

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -204,6 +204,11 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$data->sortBy(function($x) { return $x; });
 
 		$this->assertEquals(array('dayle', 'taylor'), array_values($data->all()));
+		
+		$data = new Collection(array('dayle', 'taylor'));
+		$data->sortBy(function($x) { return $x; }, SORT_REGULAR, true);
+		
+		$this->assertEquals(array('taylor', 'dayle'), array_values($data->all()));
 	}
 
 


### PR DESCRIPTION
When scouring through the source for `Collection`, I couldn't find a descending sort function (both `sort` and `sortBy` use `asort` internally). There are two alternatives:

```
$collection->sortBy(function($item) { return PHP_INT_MAX - $item->sortableColumn });
// or
$collection->sortBy(function($item) { return $item->sortableColumn; })->reverse();
```

The first is mediocre (albeit not very explicit about its behavior) and only (sanely) works for integers/floats (theoretically, you could covert a string to its ordinals, subtract them from the max ordinal number, and glue the string back together, but this would be a tad absurd). And, the second performs poorly (PHP internally traverses the array at least twice) and creates a new collection.

I propose adding an optional argument to the sort functions that reverses order:

```
$collection->sortBy(function($item) { return $item->sortableColumn; }, true);
```

If an optional argument isn't explicit enough, perhaps `sortByDescending` and `sortDescending` functions would be more suitable.
