### PR TITLE
Add autoincrement to tiny/small/mediumInteger

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -25,7 +25,7 @@ class MySqlGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $serials = array('bigInteger', 'integer');
+	protected $serials = array('tinyInteger','smallInteger','mediumInteger','bigInteger', 'integer');
 
 	/**
 	 * Compile the query to determine the list of tables.

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -337,6 +337,13 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table `users` add `foo` mediumint not null', $statements[0]);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->mediumInteger('foo',true);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` add `foo` mediumint not null auto_increment primary key', $statements[0]);
 	}
 
 
@@ -348,6 +355,13 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table `users` add `foo` smallint not null', $statements[0]);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->smallInteger('foo',true);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` add `foo` smallint not null auto_increment primary key', $statements[0]);
 	}
 
 	public function testAddingTinyInteger()
@@ -358,6 +372,13 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table `users` add `foo` tinyint not null', $statements[0]);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->tinyInteger('foo',true);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` add `foo` tinyint not null auto_increment primary key', $statements[0]);
 	}
 
 


### PR DESCRIPTION
The MySQL Schema Builder ignored the autoincrement flag (second parameter) in $table->tiny/small/mediumInteger(). This PR fixes this by expanding the $serials array in the MySQL Grammar only. 3 new tests included.
