### PR TITLE
Add database prefix to renameColumn

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -23,7 +23,9 @@ abstract class Grammar extends BaseGrammar {
 	{
 		$schema = $connection->getDoctrineSchemaManager();
 
-		$column = $connection->getDoctrineColumn($blueprint->getTable(), $command->from);
+		$table = $this->getTablePrefix() . $blueprint->getTable();
+
+		$column = $connection->getDoctrineColumn($table, $command->from);
 
 		$tableDiff = $this->getRenamedDiff($blueprint, $command, $column, $schema);
 
@@ -255,9 +257,11 @@ abstract class Grammar extends BaseGrammar {
 	 */
 	protected function getDoctrineTableDiff(Blueprint $blueprint, SchemaManager $schema)
 	{
-		$tableDiff = new TableDiff($blueprint->getTable());
+		$table = $this->getTablePrefix() . $blueprint->getTable();
 
-		$tableDiff->fromTable = $schema->listTableDetails($blueprint->getTable());
+		$tableDiff = new TableDiff($table);
+
+		$tableDiff->fromTable = $schema->listTableDetails($table);
 
 		return $tableDiff;
 	}


### PR DESCRIPTION
Fixes an issue where renameColumn throws an exception if a database prefix is set.

Signed-off-by: Suhayb El Wardany me@suw.me
