### PR TITLE
Add tested intended redirector which takes a route name instead of a path

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -102,6 +102,26 @@ class Redirector {
 	}
 
 	/**
+	 * Create a new redirect resonse to the previously intended location defaulting to a named route.
+	 *
+	 * @param  string  $default
+	 * @param  int     $status
+	 * @param  array   $headers
+	 * @param  bool    $secure
+	 * @return \Illuminate\Http\RedirectResponse
+	 */
+	public function intendedWithRoute($route, $parameters = array(), $status = 302, $headers = array(), $secure = null)
+	{
+		$route = $this->generator->route($route, $parameters);
+
+		$path = $this->session->get('url.intended', $route);
+
+		$this->session->forget('url.intended');
+
+		return $this->to($path, $status, $headers, $secure);
+	}
+
+	/**
 	 * Create a new redirect response to the given path.
 	 *
 	 * @param  string  $path

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -95,6 +95,29 @@ class RoutingRedirectorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testIntendedWithRouteRedirectToIntendedUrlInSession()
+	{
+		$this->url->shouldReceive('route')->with('home', array())->andReturn('http://foo.com/bar');
+
+		$this->session->shouldReceive('get')->with('url.intended', 'http://foo.com/bar')->andReturn('/');
+		$this->session->shouldReceive('forget')->with('url.intended');
+
+		$response = $this->redirect->intendedWithRoute('home');
+		$this->assertEquals('http://foo.com/', $response->getTargetUrl());
+	}
+
+	public function testIntendedWithRouteWithoutIntendedUrlInSession()
+	{
+		$this->url->shouldReceive('route')->with('home', array())->andReturn('http://foo.com/bar');
+
+		$this->session->shouldReceive('get')->with('url.intended', 'http://foo.com/bar')->andReturn('http://foo.com/bar');
+		$this->session->shouldReceive('forget')->with('url.intended');
+
+		$response = $this->redirect->intendedWithRoute('home');
+		$this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
+	}
+
+
 	public function testRefreshRedirectToCurrentUrl()
 	{
 		$this->request->shouldReceive('path')->andReturn('http://foo.com/bar');


### PR DESCRIPTION
The `intended` method on the redirector but I got caught by an issue this weekend where we had changed the path of a named route but the redirector would still go to the old path because it was hard-coded in. This pull request adds a `intendedWithRoute` method which lets you pass a named route and parameters in for the same effect.
