### PR TITLE
added --environment-variables option to artisan ServeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -38,7 +38,14 @@ class ServeCommand extends Command {
 
 		$this->info("Laravel development server started on http://{$host}:{$port}");
 
-		passthru('"'.PHP_BINARY.'"'." -S {$host}:{$port} -t \"{$public}\" server.php");
+		$evariables = '';
+
+		if ( $this->input->getOption('environment-variables') )
+		{
+			$evariables = '-d variables_order=EGPCS';
+		}
+		
+		passthru("php {$evariables} -S {$host}:{$port} -t \"{$public}\" server.php");
 	}
 
 	/**
@@ -67,6 +74,8 @@ class ServeCommand extends Command {
 			array('host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', 'localhost'),
 
 			array('port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', 8000),
+
+			array('environment-variables', null, InputOption::VALUE_NONE, 'Pass current environment variables through.'),
 		);
 	}
 


### PR DESCRIPTION
 so you can pass them through to the running server, see issue #3086

``` bash
export SOME_VAR=foo
php artisan serve --environment-variables
```

For me this is useful since I've added an override to the default hostname-based environment detection routine, which is based on an environment variable (too many "environments" , I know!)

The point is just to actually specify the `variables_order` command line switch to PHP, since it misses "E" by default.

I guess you could update this to actually customise `variables_order` to ones liking, but I think `EGPCS` is fairly normal.
