### PR TITLE
Fix bug in view publisher

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewPublishCommand.php
@@ -97,7 +97,7 @@ class ViewPublishCommand extends Command {
 	protected function getOptions()
 	{
 		return array(
-			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to the view files.', null),
+			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to the source view files.', null),
 		);
 	}
 

--- a/src/Illuminate/Foundation/ViewPublisher.php
+++ b/src/Illuminate/Foundation/ViewPublisher.php
@@ -47,7 +47,7 @@ class ViewPublisher {
 	 */
 	public function publish($package, $source)
 	{
-		$destination = $this->publishPath."/{$package}";
+		$destination = $this->publishPath."/packages/{$package}";
 
 		$this->makeDestination($destination);
 

--- a/tests/Foundation/FoundationViewPublisherTest.php
+++ b/tests/Foundation/FoundationViewPublisherTest.php
@@ -15,15 +15,15 @@ class FoundationViewPublisherTest extends PHPUnit_Framework_TestCase {
 		$pub = new Illuminate\Foundation\ViewPublisher($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
 		$pub->setPackagePath(__DIR__.'/vendor');
 		$files->shouldReceive('isDirectory')->once()->with(__DIR__.'/vendor/foo/bar/src/views')->andReturn(true);
-		$files->shouldReceive('isDirectory')->once()->with(__DIR__.'/foo/bar')->andReturn(true);
-		$files->shouldReceive('copyDirectory')->once()->with(__DIR__.'/vendor/foo/bar/src/views', __DIR__.'/foo/bar')->andReturn(true);
+		$files->shouldReceive('isDirectory')->once()->with(__DIR__.'/packages/foo/bar')->andReturn(true);
+		$files->shouldReceive('copyDirectory')->once()->with(__DIR__.'/vendor/foo/bar/src/views', __DIR__.'/packages/foo/bar')->andReturn(true);
 
 		$this->assertTrue($pub->publishPackage('foo/bar'));
 
 		$pub = new Illuminate\Foundation\ViewPublisher($files2 = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
 		$files2->shouldReceive('isDirectory')->once()->with(__DIR__.'/custom-packages/foo/bar/src/views')->andReturn(true);
-		$files2->shouldReceive('isDirectory')->once()->with(__DIR__.'/foo/bar')->andReturn(true);
-		$files2->shouldReceive('copyDirectory')->once()->with(__DIR__.'/custom-packages/foo/bar/src/views', __DIR__.'/foo/bar')->andReturn(true);
+		$files2->shouldReceive('isDirectory')->once()->with(__DIR__.'/packages/foo/bar')->andReturn(true);
+		$files2->shouldReceive('copyDirectory')->once()->with(__DIR__.'/custom-packages/foo/bar/src/views', __DIR__.'/packages/foo/bar')->andReturn(true);
 
 		$this->assertTrue($pub->publishPackage('foo/bar', __DIR__.'/custom-packages'));
 	}


### PR DESCRIPTION
Fix bug in view publisher where it didn't publish to the correct directory (should be `app/views/packages/{vendor}/{package}/` not `app/views/{vendor}/{package}/`).

This is against 4.0 as it's a bugfix and 4.0 is the earliest base, but should be able to be imported to 4.1 and master with cherry-pick or a merge.
