### PR TITLE
Pass through raw() to query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -35,7 +35,7 @@ class Builder {
 	 */
 	protected $passthru = array(
 		'toSql', 'lists', 'insert', 'insertGetId', 'pluck',
-		'count', 'min', 'max', 'avg', 'sum', 'exists',
+		'count', 'min', 'max', 'avg', 'sum', 'exists', 'raw',
 	);
 
 	/**


### PR DESCRIPTION
Minor inconvenience.. I'm extending the Eloquent query builder and would like to do `$this->raw()` instead of `$this->getQuery()->raw()`.
