### PR TITLE
Added sum() which gets the sum of values for a given key in a Collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -109,6 +109,20 @@ class Collection extends BaseCollection {
 	}
 
 	/**
+	 * Get the sum of values for a given key
+	 *
+	 * @param string $key
+	 * @return mixed
+	 */
+	public function sum($key)
+	{
+		return $this->reduce(function($result, $item) use ($key)
+		{
+			return $result += $item->{$key};
+		}, 0);
+	}
+
+	/**
 	 * Get the array of primary keys
 	 *
 	 * @return array

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -32,6 +32,17 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(10, $c->min('foo'));
 	}
 
+	public function testGettingSumFromCollection()
+	{
+		$c = new Collection(array((object) array('foo' => 10), (object) array('foo' => 20)));
+		$this->assertEquals(30, $c->sum('foo'));
+	}
+
+	public function testGettingSumFromEmptyCollection()
+	{
+		$c = new Collection();
+		$this->assertEquals(0, $c->sum('foo'));
+	}
 
 	public function testContainsIndicatesIfModelInArray()
 	{


### PR DESCRIPTION
I think it would be useful to have a simple sum() method on Collections. Very often you have to iterate over a collection of items, and also use the total value of one field somewhere. Of course you can issues a query with sum aggregate but that's not necessary since we already hold all of the information in the collection.

Since there are already min() and max() methods I think it's only logical to have sum() as well :)
