### PR TITLE
Throw exception on invalid type

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -36,12 +36,18 @@ abstract class Grammar {
 	/**
 	 * Wrap a value in keyword identifiers.
 	 *
-	 * @param  string  $value
+	 * @param  \Illuminate\Database\Query\Expression|string  $value
 	 * @return string
 	 */
 	public function wrap($value)
 	{
 		if ($this->isExpression($value)) return $this->getValue($value);
+
+		if (is_array($value) || is_object($value))
+		{
+			$type = is_object($value) ? get_class($value) : 'Array';
+			throw new \InvalidArgumentException("Argument 1 of wrap() expects a string or Illuminate\Database\Query\Expression, got $type");
+		}
 
 		// If the value being wrapped has a column alias we will need to separate out
 		// the pieces so we can wrap each of the segments of the expression on it


### PR DESCRIPTION
If you at some point add a value to a query builder that is an object it can be pretty hard to trace down. Currently you get `strtolower() expects parameter 1 to be string, object given`. This improves slightly by adding the name of the class.

I had this problem when I thought I was adding a query expression as a select, but turns out it wasn't.
