### PR TITLE
Fix provides () in ConsoleSupportServiceProvider

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -324,7 +324,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	 * @param  string  $provider
 	 * @return \Illuminate\Support\ServiceProvider
 	 */
-	protected function resolveProviderClass($provider)
+	public function resolveProviderClass($provider)
 	{
 		return new $provider($this);
 	}

--- a/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
@@ -60,8 +60,9 @@ class ConsoleSupportServiceProvider extends ServiceProvider {
 	{
 		$provides = array();
 
-		foreach ($this->instances as $instance)
+		foreach ($this->providers as $provider)
 		{
+			$instance = $this->app->resolveProviderClass($provider);
 			$provides = array_merge($provides, $instance->provides());
 		}
 


### PR DESCRIPTION
As described in #2996, the provides() method in ConsoleSupportServiceProvider always returns an empty array, because the provides() method is called before any instances are registered and will fail to load deferred service providers (when called from web).
This will actually return the correct provides() array, based on all the providers.
