### PR TITLE
Add View::composers to register several composers at once

### DIFF
--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -286,6 +286,24 @@ class Environment {
 	}
 
 	/**
+	 * Register multiple View composers via an array.
+	 *
+	 * @param array $composers
+	 *
+	 * @return array
+	 */
+	public function composers(array $composers)
+	{
+		$registered = array();
+
+		foreach ($composers as $callback => $views) {
+			$registered += $this->composer($views, $callback);
+		}
+
+		return $registered;
+	}
+
+	/**
 	 * Register a view composer event.
 	 *
 	 * @param  array|string  $views

--- a/tests/View/ViewEnvironmentTest.php
+++ b/tests/View/ViewEnvironmentTest.php
@@ -173,7 +173,7 @@ class ViewEnvironmentTest extends PHPUnit_Framework_TestCase {
 		$env->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
 		$composers = $env->composers(array(
 			'foo' => 'bar',
-			'baz@baz' => ['qux', 'foo'],
+			'baz@baz' => array('qux', 'foo'),
 		));
 
 		$reflections = array(

--- a/tests/View/ViewEnvironmentTest.php
+++ b/tests/View/ViewEnvironmentTest.php
@@ -165,6 +165,26 @@ class ViewEnvironmentTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testComposersCanBeMassRegistered()
+	{
+		$env = $this->getEnvironment();
+		$env->getDispatcher()->shouldReceive('listen')->once()->with('composing: bar', m::type('Closure'));
+		$env->getDispatcher()->shouldReceive('listen')->once()->with('composing: qux', m::type('Closure'));
+		$env->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
+		$composers = $env->composers(array(
+			'foo' => 'bar',
+			'baz@baz' => ['qux', 'foo'],
+		));
+
+		$reflections = array(
+			new ReflectionFunction($composers[0]),
+			new ReflectionFunction($composers[1]),
+		);
+		$this->assertEquals(array('class' => 'foo', 'method' => 'compose', 'container' => null), $reflections[0]->getStaticVariables());
+		$this->assertEquals(array('class' => 'baz', 'method' => 'baz', 'container' => null), $reflections[1]->getStaticVariables());
+	}
+
+
 	public function testClassCallbacks()
 	{
 		$env = $this->getEnvironment();


### PR DESCRIPTION
Even when using classes as Composer, when you start to accumulate a lot it can get tedious and unclean to have this kind of things :

``` php
View::composer('views', 'Class@method');
View::composer('views', 'Class@method');
View::composer('views', 'Class@method');
View::composer('views', 'Class@method');
View::composer('views', 'Class@method');
View::composer('views', 'Class@method');
View::composer('views', 'Class@method');
```

This pull request simply adds a wrapper shortcut :

``` php
View::composers(array(
    'Class@method' => 'view',
    'Class@method' => 'view',
    'Class@method' => 'view',
    'Class@method' => ['view', 'view'],
    // etc.
));
```
