### PR TITLE
Feature for passing objects in URL::route

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -270,6 +270,14 @@ class UrlGenerator {
 	protected function replaceRouteParameter($path, $key, $value, array &$parameters)
 	{
 		$pattern = is_string($key) ? '/\{'.$key.'[\?]?\}/' : '/\{.*?\}/';
+		
+		// When the value is an object implementing the getKey() method 
+		// it means that it must be an instance of a model and that we 
+		// should insert its key in the path
+		if (method_exists($value, 'getKey'))
+		{
+	    		$value = $value->getKey():
+		}
 
 		$path = preg_replace($pattern, $value, $path, 1, $count);
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -276,7 +276,7 @@ class UrlGenerator {
 		// should insert its key in the path
 		if (method_exists($value, 'getKey'))
 		{
-	    		$value = $value->getKey():
+	    		$value = $value->getKey();
 		}
 
 		$path = preg_replace($pattern, $value, $path, 1, $count);


### PR DESCRIPTION
Add the possibility to generate the URL for a route like
`['path' => '/users/{user}', 'name' => 'users.index']`
with this call:
`URL::route('users.index', ['user' => User::first()])`
instead of this one:
`URL::route('users.index', ['user' => User::first()->id])`

_It is just a little simplification..._
