### PR TITLE
#3104 fixed

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -289,16 +289,24 @@ class UrlGenerator {
 	 */
 	protected function getRouteQueryString(array $parameters)
 	{
-		if (count($parameters) == 0) return '';
+        if (count($parameters) == 0) return '';
 
-		$query = http_build_query($keyed = $this->getStringParameters($parameters));
+        $query = http_build_query($keyed = $this->getStringParameters($parameters));
 
-		if (count($keyed) < count($parameters))
-		{
-			$query .= '&'.implode('&', $this->getNumericParameters($parameters));
-		}
+        if ($query == '')
+        {
+            // All parameters are numeric indexed - return "nice" uri string
+            return '/'.implode('/', $parameters);
+        }
+        else
+        {
+            if (count($keyed) < count($parameters))
+            {
+                $query .= '&'.implode('&', $this->getNumericParameters($parameters));
+            }
 
-		return '?'.trim($query, '&');
+            return '?'.trim($query, '&');
+        }
 	}
 
 	/**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -84,6 +84,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('/foo/bar/taylor/breeze/otwell?fly=wall', $url->route('bar', array('taylor', 'otwell', 'fly' => 'wall'), false));
 		$this->assertEquals('https://www.foo.com/foo/bar', $url->route('baz'));
 		$this->assertEquals('http://www.foo.com/foo/bar', $url->action('foo@bar'));
+		$this->assertEquals('http://www.foo.com/foo/bar/fly/wall', $url->action('foo@bar', array('fly', 'wall')));
 	}
 
 


### PR DESCRIPTION
Got in a fix and test for this one.

Calling URL::action() with an array of strings will now generate a nice url instead of a url with a query string.

I.e.: URL::action('DataController@getIndex',array('fly', 'wall')); will output something like  http://www.foo.com/foo/bar/fly/wall
