### PR TITLE
cast $reminder to object

### DIFF
--- a/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
+++ b/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
@@ -93,7 +93,7 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	{
 		$email = $user->getReminderEmail();
 
-		$reminder = $this->getTable()->where('email', $email)->where('token', $token)->first();
+		$reminder = (object) $this->getTable()->where('email', $email)->where('token', $token)->first();
 
 		return $reminder && ! $this->reminderExpired($reminder);
 	}


### PR DESCRIPTION
$reminder (ln:96) is expected to be an object. found this out because I have my PDO Fetch Style set to PDO::FETCH_ASSOC
