### PR TITLE
Collection::random() not actually random

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -350,7 +350,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
     {
         $keys = array_rand($this->items, $amount);
 
-        return is_array($keys) ? array_intersect_key($this->items, $keys) : $this->items[$keys];
+        return is_array($keys) ? array_intersect_key($this->items, array_flip($keys)) : $this->items[$keys];
     }
 
 	/**


### PR DESCRIPTION
array_intersect_key() is incorrectly using the output of array_rand() which is an array with zero based, consecutive keys (e.g. [0=>n, 1=>n, 2=>n, 3=>n]) of length $amount as the challenge. this resulting in identical results with calls on identical collections. flipping the output of array_rand() so that the random values are used as challenging keys with array_intersect_key() fixes this issue.
