### PR TITLE
Bug fix: random() method was in fact returning first n items.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -350,7 +350,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
     {
         $keys = array_rand($this->items, $amount);
 
-        return is_array($keys) ? array_intersect_key($this->items, $keys) : $this->items[$keys];
+        return is_array($keys) ? array_intersect_key($this->items, array_flip($keys)) : $this->items[$keys];
     }
 
 	/**


### PR DESCRIPTION
Where n = $amount, and n > 1.

It was intersecting `$this->items` with the array `[0, 1, 2...n]` instead of the actual keys found by `array_rand()`. Looks like the solution was insufficiently [copied](http://stackoverflow.com/a/4240153/443219).
