### PR TITLE
made changes to decrypt(), array based cookies now usable

### DIFF
--- a/src/Illuminate/Cookie/Guard.php
+++ b/src/Illuminate/Cookie/Guard.php
@@ -63,7 +63,15 @@ class Guard implements HttpKernelInterface {
 		{
 			try
 			{
-				$request->cookies->set($key, $this->encrypter->decrypt($c));
+				if(is_array($c))
+				{
+					foreach ($c as $name => $value)
+						$$request->cookies->set($key[$name], $this->encrypter->decrypt($value));
+				}
+				else
+				{
+					$request->cookies->set($key, $this->encrypter->decrypt($c));
+				}
 			}
 			catch (DecryptException $e)
 			{


### PR DESCRIPTION
Made changes to decrypt(), can now use array based cookies, as in MyBB.

This function was at /vendor/laravel/framework/src/Illuminate/Cookie/Guard.php 

Please review the code 4 times before merging.

I have also made a issue for this. #3192
