### PR TITLE
Add getLastAttempted method to Auth\Guard class

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -618,4 +618,14 @@ class Guard {
 		return $this->viaRemember;
 	}
 
+	/**
+	 * Get the last user that was attempted to be retrieved.
+	 *
+	 * @return \Illuminate\Auth\UserInterface
+	 */
+	public function getLastAttempted()
+	{
+		return $this->lastAttempted;
+	}
+
 }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -271,7 +271,7 @@ class BelongsToMany extends Relation {
 
 		$key = $this->wrap($this->getQualifiedParentKeyName());
 
-		return $query->where($hash.'.person_id', '=', new \Illuminate\Database\Query\Expression($key));
+		return $query->where($hash.'.'.$this->foreignKey, '=', new \Illuminate\Database\Query\Expression($key));
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -324,7 +324,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	 * @param  string  $provider
 	 * @return \Illuminate\Support\ServiceProvider
 	 */
-	protected function resolveProviderClass($provider)
+	public function resolveProviderClass($provider)
 	{
 		return new $provider($this);
 	}

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -26,7 +26,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	 *
 	 * @var string
 	 */
-	const VERSION = '4.1.12';
+	const VERSION = '4.1.13';
 
 	/**
 	 * Indicates if the application has "booted".

--- a/src/Illuminate/Foundation/Console/ViewPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewPublishCommand.php
@@ -97,7 +97,7 @@ class ViewPublishCommand extends Command {
 	protected function getOptions()
 	{
 		return array(
-			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to the view files.', null),
+			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to the source view files.', null),
 		);
 	}
 

--- a/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
@@ -60,8 +60,9 @@ class ConsoleSupportServiceProvider extends ServiceProvider {
 	{
 		$provides = array();
 
-		foreach ($this->instances as $instance)
+		foreach ($this->providers as $provider)
 		{
+			$instance = $this->app->resolveProviderClass($provider);
 			$provides = array_merge($provides, $instance->provides());
 		}
 

--- a/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
@@ -63,6 +63,7 @@ class ConsoleSupportServiceProvider extends ServiceProvider {
 		foreach ($this->providers as $provider)
 		{
 			$instance = $this->app->resolveProviderClass($provider);
+
 			$provides = array_merge($provides, $instance->provides());
 		}
 

--- a/src/Illuminate/Foundation/ViewPublisher.php
+++ b/src/Illuminate/Foundation/ViewPublisher.php
@@ -47,7 +47,7 @@ class ViewPublisher {
 	 */
 	public function publish($package, $source)
 	{
-		$destination = $this->publishPath."/{$package}";
+		$destination = $this->publishPath."/packages/{$package}";
 
 		$this->makeDestination($destination);
 

--- a/src/Illuminate/Foundation/changes.json
+++ b/src/Illuminate/Foundation/changes.json
@@ -74,7 +74,8 @@
 		{"message": "Added --seeder option to migrate:refresh Artisan command.", "backport": null},
 		{"message": "Added 'cacheDriver' method to query builder.", "backport": null},
 		{"message": "Added support for whereHas on belongsTo relationships.", "backport": null},
-		{"message": "Added groupBy to Collection class.", "backport": null}
+		{"message": "Added groupBy to Collection class.", "backport": null},
+		{"message": "Added the View::composers method.", "backport": null}
 	],
 	"4.0.x": [
 		{"message": "Added implode method to query builder and Collection class.", "backport": null},

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -68,6 +68,8 @@ abstract class Controller {
 	{
 		$parameters = array();
 
+		$original = $filter;
+
 		if ($filter instanceof Closure)
 		{
 			$filter = $this->registerClosureFilter($filter);
@@ -81,7 +83,7 @@ abstract class Controller {
 			list($filter, $parameters) = Route::parseFilter($filter);
 		}
 
-		return compact('filter', 'parameters', 'options');
+		return compact('original', 'filter', 'parameters', 'options');
 	}
 
 	/**

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -135,7 +135,7 @@ class ControllerDispatcher {
 			// router take care of calling these filters so we do not duplicate logics.
 			if ($this->filterApplies($filter, $request, $method))
 			{
-				$route->after($filter['filter']);
+				$route->after($filter['original']);
 			}
 		}
 	}

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Routing;
 
+use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Container\Container;
 
@@ -135,9 +136,20 @@ class ControllerDispatcher {
 			// router take care of calling these filters so we do not duplicate logics.
 			if ($this->filterApplies($filter, $request, $method))
 			{
-				$route->after($filter['original']);
+				$route->after($this->getAssignableAfter($filter));
 			}
 		}
+	}
+
+	/**
+	 * Get the assignable after filter for the route.
+	 *
+	 * @param  Closure|string  $filter
+	 * @return string
+	 */
+	protected function getAssignableAfter($filter)
+	{
+		return $filter['original'] instanceof Closure ? $filter['filter'] : $filter['original'];
 	}
 
 	/**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -45,34 +45,6 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
-	 * Determine if an item exists in the collection by key.
-	 *
-	 * @param  mixed  $key
-	 * @return bool
-	 */
-	public function has($key)
-	{
-		return array_key_exists($key, $this->items);
-	}
-
-	/**
-	 * Get an item from the collection by key.
-	 *
-	 * @param  mixed  $key
-	 * @param  mixed  $default
-	 * @return mixed
-	 */
-	public function get($key, $default = null)
-	{
-		if (array_key_exists($key, $this->items))
-		{
-			return $this->items[$key];
-		}
-
-		return value($default);
-	}
-
-	/**
 	 * Get all of the items in the collection.
 	 *
 	 * @return array
@@ -83,15 +55,66 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
-	 * Put an item in the collection by key.
+	 * Collapse the collection items into a single array.
 	 *
-	 * @param  mixed  $key
-	 * @param  mixed  $value
-	 * @return void
+	 * @return \Illuminate\Support\Collection
 	 */
-	public function put($key, $value)
+	public function collapse()
 	{
-		$this->items[$key] = $value;
+		$results = array();
+
+		foreach ($this->items as $values)
+		{
+			$results = array_merge($results, $values);
+		}
+
+		return new static($results);
+	}
+
+	/**
+	 * Diff the collection with the given items.
+	 *
+	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function diff($items)
+	{
+		return new static(array_diff($this->items, $this->getArrayableItems($items)));
+	}
+
+	/**
+	 * Execute a callback over each item.
+	 *
+	 * @param  Closure  $callback
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function each(Closure $callback)
+	{
+		array_map($callback, $this->items);
+
+		return $this;
+	}
+
+	/**
+	 * Fetch a nested element of the collection.
+	 *
+	 * @param  string  $key
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function fetch($key)
+	{
+		return new static(array_fetch($this->items, $key));
+	}
+
+	/**
+	 * Run a filter over each of the items.
+	 *
+	 * @param  Closure  $callback
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function filter(Closure $callback)
+	{
+		return new static(array_filter($this->items, $callback));
 	}
 
 	/**
@@ -114,6 +137,110 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Get a flattened array of the items in the collection.
+	 *
+	 * @return array
+	 */
+	public function flatten()
+	{
+		return new static(array_flatten($this->items));
+	}
+
+	/**
+	 * Remove an item from the collection by key.
+	 *
+	 * @param  mixed  $key
+	 * @return void
+	 */
+	public function forget($key)
+	{
+		unset($this->items[$key]);
+	}
+
+	/**
+	 * Get an item from the collection by key.
+	 *
+	 * @param  mixed  $key
+	 * @param  mixed  $default
+	 * @return mixed
+	 */
+	public function get($key, $default = null)
+	{
+		if (array_key_exists($key, $this->items))
+		{
+			return $this->items[$key];
+		}
+
+		return value($default);
+	}
+
+	/**
+	 * Group an associative array by a field or Closure value.
+	 *
+	 * @param  callable|string  $groupBy
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function groupBy($groupBy)
+	{
+		$results = array();
+
+		foreach ($this->items as $key => $value)
+		{
+			$key = is_callable($groupBy) ? $groupBy($value, $key) : array_get($value, $groupBy);
+
+			$results[$key][] = $value;
+		}
+
+		return new static($results);
+	}
+
+	/**
+	 * Determine if an item exists in the collection by key.
+	 *
+	 * @param  mixed  $key
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		return array_key_exists($key, $this->items);
+	}
+
+	/**
+	 * Concatenate values of a given key as a string.
+	 *
+	 * @param  string  $value
+	 * @param  string  $glue
+	 * @return string
+	 */
+	public function implode($value, $glue = null)
+	{
+		if (is_null($glue)) return implode($this->lists($value));
+
+		return implode($glue, $this->lists($value));
+	}
+
+	/**
+	 * Intersect the collection with the given items.
+	 *
+ 	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function intersect($items)
+	{
+		return new static(array_intersect($this->items, $this->getArrayableItems($items)));
+	}
+
+	/**
+	 * Determine if the collection is empty or not.
+	 *
+	 * @return bool
+	 */
+	public function isEmpty()
+	{
+		return empty($this->items);
+	}
+
+	/**
 	* Get the last item from the collection.
 	*
 	* @return mixed|null
@@ -124,13 +251,47 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
-	 * Get and remove the first item from the collection.
+	 * Get an array with the values of a given key.
+	 *
+	 * @param  string  $value
+	 * @param  string  $key
+	 * @return array
+	 */
+	public function lists($value, $key = null)
+	{
+		return array_pluck($this->items, $value, $key);
+	}
+
+	/**
+	 * Run a map over each of the items.
+	 *
+	 * @param  Closure  $callback
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function map(Closure $callback)
+	{
+		return new static(array_map($callback, $this->items, array_keys($this->items)));
+	}
+
+	/**
+	 * Merge the collection with the given items.
+	 *
+	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function merge($items)
+	{
+		return new static(array_merge($this->items, $this->getArrayableItems($items)));
+	}
+
+	/**
+	 * Get and remove the last item from the collection.
 	 *
 	 * @return mixed|null
 	 */
-	public function shift()
+	public function pop()
 	{
-		return array_shift($this->items);
+		return array_pop($this->items);
 	}
 
 	/**
@@ -156,24 +317,15 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
-	 * Get and remove the last item from the collection.
-	 *
-	 * @return mixed|null
-	 */
-	public function pop()
-	{
-		return array_pop($this->items);
-	}
-
-	/**
-	 * Remove an item from the collection by key.
+	 * Put an item in the collection by key.
 	 *
 	 * @param  mixed  $key
+	 * @param  mixed  $value
 	 * @return void
 	 */
-	public function forget($key)
+	public function put($key, $value)
 	{
-		unset($this->items[$key]);
+		$this->items[$key] = $value;
 	}
 
 	/**
@@ -188,52 +340,50 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 		return array_reduce($this->items, $callback, $initial);
 	}
 
+    /**
+     * Get one or more items randomly from the collection.
+     *
+     * @param  int $amount
+     * @return mixed
+     */
+    public function random($amount = 1)
+    {
+        $keys = array_rand($this->items, $amount);
+
+        return is_array($keys) ? array_intersect_key($this->items, $keys) : $this->items[$keys];
+    }
+
 	/**
-	 * Execute a callback over each item.
+	 * Reverse items order.
 	 *
-	 * @param  Closure  $callback
 	 * @return \Illuminate\Support\Collection
 	 */
-	public function each(Closure $callback)
+	public function reverse()
 	{
-		array_map($callback, $this->items);
-
-		return $this;
+		return new static(array_reverse($this->items));
 	}
 
 	/**
-	 * Run a map over each of the items.
+	 * Get and remove the first item from the collection.
 	 *
-	 * @param  Closure  $callback
-	 * @return \Illuminate\Support\Collection
+	 * @return mixed|null
 	 */
-	public function map(Closure $callback)
+	public function shift()
 	{
-		return new static(array_map($callback, $this->items, array_keys($this->items)));
+		return array_shift($this->items);
 	}
 
 	/**
-	 * Transform each item in the collection using a callback.
+	 * Slice the underlying collection array.
 	 *
-	 * @param  Closure  $callback
+	 * @param  int   $offset
+	 * @param  int   $length
+	 * @param  bool  $preserveKeys
 	 * @return \Illuminate\Support\Collection
 	 */
-	public function transform(Closure $callback)
+	public function slice($offset, $length = null, $preserveKeys = false)
 	{
-		$this->items = array_map($callback, $this->items);
-
-		return $this;
-	}
-
-	/**
-	 * Run a filter over each of the items.
-	 *
-	 * @param  Closure  $callback
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function filter(Closure $callback)
-	{
-		return new static(array_filter($this->items, $callback));
+		return new static(array_slice($this->items, $offset, $length, $preserveKeys));
 	}
 
 	/**
@@ -286,142 +436,6 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
-	 * Reverse items order.
-	 *
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function reverse()
-	{
-		return new static(array_reverse($this->items));
-	}
-
-	/**
-	 * Reset the keys on the underlying array.
-	 *
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function values()
-	{
-		$this->items = array_values($this->items);
-
-		return $this;
-	}
-
-	/**
-	 * Fetch a nested element of the collection.
-	 *
-	 * @param  string  $key
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function fetch($key)
-	{
-		return new static(array_fetch($this->items, $key));
-	}
-
-	/**
-	 * Get a flattened array of the items in the collection.
-	 *
-	 * @return array
-	 */
-	public function flatten()
-	{
-		return new static(array_flatten($this->items));
-	}
-
-	/**
-	 * Collapse the collection items into a single array.
-	 *
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function collapse()
-	{
-		$results = array();
-
-		foreach ($this->items as $values)
-		{
-			$results = array_merge($results, $values);
-		}
-
-		return new static($results);
-	}
-
-	/**
-	 * Group an associative array by a field or Closure value.
-	 *
-	 * @param  callable|string  $groupBy
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function groupBy($groupBy)
-	{
-		$results = array();
-
-		foreach ($this->items as $key => $value)
-		{
-			$key = is_callable($groupBy) ? $groupBy($value, $key) : array_get($value, $groupBy);
-
-			$results[$key][] = $value;
-		}
-
-		return new static($results);
-	}
-
-	/**
-	 * Merge the collection with the given items.
-	 *
-	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function merge($items)
-	{
-		return new static(array_merge($this->items, $this->getArrayableItems($items)));
-	}
-
-	/**
-	 * Diff the collection with the given items.
-	 *
-	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function diff($items)
-	{
-		return new static(array_diff($this->items, $this->getArrayableItems($items)));
-	}
-
-	/**
-	 * Intersect the collection with the given items.
-	 *
- 	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function intersect($items)
-	{
-		return new static(array_intersect($this->items, $this->getArrayableItems($items)));
-	}
-
-	/**
-	 * Return only unique items from the collection array.
-	 *
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function unique()
-	{
-		return new static(array_unique($this->items));
-	}
-
-	/**
-	 * Slice the underlying collection array.
-	 *
-	 * @param  int   $offset
-	 * @param  int   $length
-	 * @param  bool  $preserveKeys
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function slice($offset, $length = null, $preserveKeys = false)
-	{
-		return new static(array_slice($this->items, $offset, $length, $preserveKeys));
-	}
-
-	/**
 	 * Splice portion of the underlying collection array.
 	 *
 	 * @param  int    $offset
@@ -447,53 +461,39 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 		return $this->slice(0, $limit);
 	}
 
-    /**
-     * Get one or more items randomly from the collection.
-     *
-     * @param  int $amount
-     * @return mixed
-     */
-    public function random($amount = 1)
-    {
-        $keys = array_rand($this->items, $amount);
-
-        return is_array($keys) ? array_intersect_key($this->items, $keys) : $this->items[$keys];
-    }
-
 	/**
-	 * Get an array with the values of a given key.
+	 * Transform each item in the collection using a callback.
 	 *
-	 * @param  string  $value
-	 * @param  string  $key
-	 * @return array
+	 * @param  Closure  $callback
+	 * @return \Illuminate\Support\Collection
 	 */
-	public function lists($value, $key = null)
+	public function transform(Closure $callback)
 	{
-		return array_pluck($this->items, $value, $key);
+		$this->items = array_map($callback, $this->items);
+
+		return $this;
 	}
 
 	/**
-	 * Concatenate values of a given key as a string.
+	 * Return only unique items from the collection array.
 	 *
-	 * @param  string  $value
-	 * @param  string  $glue
-	 * @return string
+	 * @return \Illuminate\Support\Collection
 	 */
-	public function implode($value, $glue = null)
+	public function unique()
 	{
-		if (is_null($glue)) return implode($this->lists($value));
-
-		return implode($glue, $this->lists($value));
+		return new static(array_unique($this->items));
 	}
 
 	/**
-	 * Determine if the collection is empty or not.
+	 * Reset the keys on the underlying array.
 	 *
-	 * @return bool
+	 * @return \Illuminate\Support\Collection
 	 */
-	public function isEmpty()
+	public function values()
 	{
-		return empty($this->items);
+		$this->items = array_values($this->items);
+
+		return $this;
 	}
 
 	/**

--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -286,17 +286,17 @@ class Environment {
 	}
 
 	/**
-	 * Register multiple View composers via an array.
+	 * Register multiple view composers via an array.
 	 *
-	 * @param array $composers
-	 *
+	 * @param array  $composers
 	 * @return array
 	 */
 	public function composers(array $composers)
 	{
 		$registered = array();
 
-		foreach ($composers as $callback => $views) {
+		foreach ($composers as $callback => $views)
+		{
 			$registered += $this->composer($views, $callback);
 		}
 

--- a/src/Illuminate/View/Environment.php
+++ b/src/Illuminate/View/Environment.php
@@ -286,6 +286,24 @@ class Environment {
 	}
 
 	/**
+	 * Register multiple View composers via an array.
+	 *
+	 * @param array $composers
+	 *
+	 * @return array
+	 */
+	public function composers(array $composers)
+	{
+		$registered = array();
+
+		foreach ($composers as $callback => $views) {
+			$registered += $this->composer($views, $callback);
+		}
+
+		return $registered;
+	}
+
+	/**
 	 * Register a view composer event.
 	 *
 	 * @param  array|string  $views

--- a/tests/Foundation/FoundationViewPublisherTest.php
+++ b/tests/Foundation/FoundationViewPublisherTest.php
@@ -15,15 +15,15 @@ class FoundationViewPublisherTest extends PHPUnit_Framework_TestCase {
 		$pub = new Illuminate\Foundation\ViewPublisher($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
 		$pub->setPackagePath(__DIR__.'/vendor');
 		$files->shouldReceive('isDirectory')->once()->with(__DIR__.'/vendor/foo/bar/src/views')->andReturn(true);
-		$files->shouldReceive('isDirectory')->once()->with(__DIR__.'/foo/bar')->andReturn(true);
-		$files->shouldReceive('copyDirectory')->once()->with(__DIR__.'/vendor/foo/bar/src/views', __DIR__.'/foo/bar')->andReturn(true);
+		$files->shouldReceive('isDirectory')->once()->with(__DIR__.'/packages/foo/bar')->andReturn(true);
+		$files->shouldReceive('copyDirectory')->once()->with(__DIR__.'/vendor/foo/bar/src/views', __DIR__.'/packages/foo/bar')->andReturn(true);
 
 		$this->assertTrue($pub->publishPackage('foo/bar'));
 
 		$pub = new Illuminate\Foundation\ViewPublisher($files2 = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
 		$files2->shouldReceive('isDirectory')->once()->with(__DIR__.'/custom-packages/foo/bar/src/views')->andReturn(true);
-		$files2->shouldReceive('isDirectory')->once()->with(__DIR__.'/foo/bar')->andReturn(true);
-		$files2->shouldReceive('copyDirectory')->once()->with(__DIR__.'/custom-packages/foo/bar/src/views', __DIR__.'/foo/bar')->andReturn(true);
+		$files2->shouldReceive('isDirectory')->once()->with(__DIR__.'/packages/foo/bar')->andReturn(true);
+		$files2->shouldReceive('copyDirectory')->once()->with(__DIR__.'/custom-packages/foo/bar/src/views', __DIR__.'/packages/foo/bar')->andReturn(true);
 
 		$this->assertTrue($pub->publishPackage('foo/bar', __DIR__.'/custom-packages'));
 	}

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -130,6 +130,16 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('filtered', $router->dispatch(Request::create('baz', 'GET'))->getContent());
 
 
+		unset($_SERVER['__test.after.filter']);
+		$router = $this->getRouter();
+		$router->filter('qux', function()
+		{
+			$_SERVER['__test.after.filter'] = true;
+		});
+		$router->get('qux', 'RouteTestControllerDispatchStub@qux');
+		$this->assertEquals('qux', $router->dispatch(Request::create('qux', 'GET'))->getContent());
+		$this->assertTrue($_SERVER['__test.after.filter']);
+
 		/**
 		 * Test filters disabled...
 		 */
@@ -587,6 +597,7 @@ class RouteTestControllerDispatchStub extends Illuminate\Routing\Controller {
 	{
 		$this->beforeFilter('foo', array('only' => 'bar'));
 		$this->beforeFilter('@filter', array('only' => 'baz'));
+		$this->afterFilter('qux', array('only' => 'qux'));
 	}
 	public function foo()
 	{
@@ -603,6 +614,10 @@ class RouteTestControllerDispatchStub extends Illuminate\Routing\Controller {
 	public function baz()
 	{
 		return 'baz';
+	}
+	public function qux()
+	{
+		return 'qux';
 	}
 }
 

--- a/tests/View/ViewEnvironmentTest.php
+++ b/tests/View/ViewEnvironmentTest.php
@@ -173,7 +173,7 @@ class ViewEnvironmentTest extends PHPUnit_Framework_TestCase {
 		$env->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
 		$composers = $env->composers(array(
 			'foo' => 'bar',
-			'baz@baz' => ['qux', 'foo'],
+			'baz@baz' => array('qux', 'foo'),
 		));
 
 		$reflections = array(

--- a/tests/View/ViewEnvironmentTest.php
+++ b/tests/View/ViewEnvironmentTest.php
@@ -165,6 +165,26 @@ class ViewEnvironmentTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testComposersCanBeMassRegistered()
+	{
+		$env = $this->getEnvironment();
+		$env->getDispatcher()->shouldReceive('listen')->once()->with('composing: bar', m::type('Closure'));
+		$env->getDispatcher()->shouldReceive('listen')->once()->with('composing: qux', m::type('Closure'));
+		$env->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
+		$composers = $env->composers(array(
+			'foo' => 'bar',
+			'baz@baz' => ['qux', 'foo'],
+		));
+
+		$reflections = array(
+			new ReflectionFunction($composers[0]),
+			new ReflectionFunction($composers[1]),
+		);
+		$this->assertEquals(array('class' => 'foo', 'method' => 'compose', 'container' => null), $reflections[0]->getStaticVariables());
+		$this->assertEquals(array('class' => 'baz', 'method' => 'baz', 'container' => null), $reflections[1]->getStaticVariables());
+	}
+
+
 	public function testClassCallbacks()
 	{
 		$env = $this->getEnvironment();


### PR DESCRIPTION
I am trying to implement a legacy password upgrader in my current application. 
If `Auth::attempt()` fails, I want to compare a legacy hash of the entered password against the password in the database. If it is a legacy password, it gets updated to a new hashed password in the database.

As it currently stands there is no way to get the last retrieved user from the Auth class, as `$lastAttempted` is protected and has no getter method. This forces me to either extend the `Guard` class, or re-retrieve the user from the database.

This pull request solves this issue by implementing a getter method for the `$lastAttempted` property.
