### PR TITLE
Add getLastAttempted method to Auth\Guard class.

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -618,4 +618,14 @@ class Guard {
 		return $this->viaRemember;
 	}
 
+	/**
+	 * Get the last user that was attempted to be retrieved.
+	 *
+	 * @return \Illuminate\Auth\UserInterface
+	 */
+	public function getLastAttempted()
+	{
+		return $this->lastAttempted;
+	}
+
 }


### PR DESCRIPTION
_Sorry, I accidentally submitted my last pull request against the Master branch instead of the 4.1 branch._

---

I am trying to implement a legacy password upgrader in my current application.
If Auth::attempt() fails, I want to compare a legacy hash of the entered password against the password in the database. If it is a legacy password, it gets updated to a new hashed password in the database.

As it currently stands there is no way to get the last retrieved user from the Auth class, as $lastAttempted is protected and has no getter method. This forces me to either extend the Guard class, or re-retrieve the user from the database.

This pull request solves this issue by implementing a getter method for the $lastAttempted property.
