### PR TITLE
Allow Illuminate\Support\Fluent to implement ArrayableInterface and JsonableInterface.

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -1,8 +1,10 @@
 <?php namespace Illuminate\Support;
 
 use ArrayAccess;
+use Illuminate\Support\Contracts\ArrayableInterface;
+use Illuminate\Support\Contracts\JsonableInterface;
 
-class Fluent implements ArrayAccess {
+class Fluent implements ArrayAccess, ArrayableInterface, JsonableInterface {
 
 	/**
 	 * All of the attributes set on the container.
@@ -154,6 +156,27 @@ class Fluent implements ArrayAccess {
 	public function __unset($key)
 	{
 		unset($this->attributes[$key]);
+	}
+
+	/**
+	 * Get the attributes as a plain array.
+	 *
+	 * @return array
+	 */
+	public function toArray()
+	{
+		return $this->attributes;
+	}
+
+	/**
+	 * Get the attributes as JSON.
+	 *
+	 * @param  int  $options
+	 * @return string
+	 */
+	public function toJson($options = 0)
+	{
+		return json_encode($this->toArray(), $options);
 	}
 
 }

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 use Illuminate\Support\Fluent;
 
@@ -71,5 +71,24 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 		unset($fluent->name);
 
 		$this->assertFalse(isset($fluent->name));
+	}
+
+
+	public function testToArrayReturnsAttribute()
+	{
+		$array  = array('name' => 'Taylor', 'age' => 25);
+		$fluent = new Fluent($array);
+
+		$this->assertEquals($array, $fluent->toArray());
+	}
+
+
+	public function testToJsonEncodesTheToArrayResult()
+	{
+		$fluent = $this->getMock('Illuminate\Support\Fluent', array('toArray'));
+		$fluent->expects($this->once())->method('toArray')->will($this->returnValue('foo'));
+		$results = $fluent->toJson();
+
+		$this->assertEquals(json_encode('foo'), $results);
 	}
 }


### PR DESCRIPTION
With this changes you can now do multiple stuff with `Illuminate\Support\Fluent`.

``` php

Route::get('/', function() {
     $data = new Illuminate\Support\Fluent(['laravel' => 'awesome']);

     return Response::json($data, 200);
});
```

``` php

use Illuminate\Support\Collection;
use Illuminate\Support\Fluent;

Route::get('/', function() {
    $collection = new Collection([
        new Fluent(['name' => 'Taylor Otwell']),
        new Fluent(['name' => 'Dayle Reese']),
    ]);

    return $collection;
});
```

Signed-off-by: crynobone crynobone@gmail.com
