### PR TITLE
Update CacheManager.php

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -78,8 +78,10 @@ class CacheManager extends Manager {
 	protected function createRedisDriver()
 	{
 		$redis = $this->app['redis'];
-
-		return $this->repository(new RedisStore($redis, $this->getPrefix()));
+		
+		$connection = $this->app['config']['cache.connection'];
+		
+		return $this->repository(new RedisStore($redis, $this->getPrefix(), $connection));
 	}
 
 	/**


### PR DESCRIPTION
when use cache as the redis driver,and I want to set the redis to link the cache connection ,but it does't work as I want.then I edit the CacheManager.php to support it.
'redis' => array(

```
    'cluster' => false,

    'default' => array(
        'host'     => 192.168.1.120',
        'port'     => 6379,
        'database' => 0,
    ),

    'cache' => array(
        'host'     => '192.168.1.120',
        'port'     => 6379,
        'database' => 1,
    ),

    'session' => array(
        'host'     => '192.168.1.120',
        'port'     => 6379,
        'database' => 2,
    ),
```
