### PR TITLE
Pass constructor arguments to mockery so it can use them

### DIFF
--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -49,8 +49,13 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 
 	public function testRenderSectionsReturnsEnvironmentSections()
 	{
-		$view = m::mock('Illuminate\View\View[render]');
-		$view->__construct(m::mock('Illuminate\View\Environment'), m::mock('Illuminate\View\Engines\EngineInterface'), 'view', 'path', array());
+		$view = m::mock('Illuminate\View\View[render]', array(
+			m::mock('Illuminate\View\Environment'),
+			m::mock('Illuminate\View\Engines\EngineInterface'),
+			'view',
+			'path',
+			array()
+		));
 
 		$view->shouldReceive('render')->with(m::type('Closure'))->once()->andReturn($sections = array('foo' => 'bar'));
 		$view->getEnvironment()->shouldReceive('getSections')->once()->andReturn($sections);


### PR DESCRIPTION
This makes the full test suite compatible with mockery's master branch, I'm hoping to tag a release in a week or so. Against mockery master, I'm now seeing the suite run at least 2x faster with 80% less memory usage without xdebug, a slightly less memory saving with xdebug.

As for this PR, if you pass an indexed array as an argument (other than the first arg) to `mock`, it assumes they are constructor parameters and uses them.
