### PR TITLE
Check IoC for custom Connector instances

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -171,6 +171,11 @@ class ConnectionFactory {
 			throw new \InvalidArgumentException("A driver must be specified.");
 		}
 
+		if ($this->container->bound($key = "db.connector.{$config['driver']}"))
+		{
+			return $this->container->make($key);
+		}
+
 		switch ($config['driver'])
 		{
 			case 'mysql':


### PR DESCRIPTION
Similar to how the ConnectionFactory checks for a custom connection bound to the IoC container in createConnection, you might sometimes want to make your own custom connector. This makes it a bit easier to replace the default one or add your own.
