### PR TITLE
Prevent multiple register() / boot() calls on service providers used by multiple packages

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -295,6 +295,19 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 		// a more convenient way of specifying your service provider classes.
 		if (is_string($provider))
 		{
+
+			// If this provider has already been registered, return the previous instance.
+			// This is to prevent repeat register() / boot() calls on providers used by
+			// multiple packages.
+			if (array_key_exists($provider, $this->loadedProviders))
+			{
+				return array_first($this->serviceProviders, function($key, $value) use ($provider)
+				{
+					return get_class($value) == $provider;
+				});
+			}
+
+			// This provider was not found, so instantiate it.
 			$provider = $this->resolveProviderClass($provider);
 		}
 


### PR DESCRIPTION
Currently, if two packages have a dependency on the same package and they use `Illuminate\Foundation\Application->register()` to register the service provider for that dependency, the dependency's service provider gets instantiated twice.  For example, PackageA and PackageB both make use of PackageC.  I believe PackageC's service provider should only be registered and booted once.

This pull request adds a check to make sure service providers haven't already been loaded before instantiating a new instance of a service provider.
