### PR TITLE
Pass config name to database extensions

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -111,7 +111,7 @@ class DatabaseManager implements ConnectionResolverInterface {
 		// Closure and pass it the config allowing it to resolve the connection.
 		if (isset($this->extensions[$name]))
 		{
-			return call_user_func($this->extensions[$name], $config);
+			return call_user_func($this->extensions[$name], $config, $name);
 		}
 
 		$driver = $config['driver'];
@@ -121,7 +121,7 @@ class DatabaseManager implements ConnectionResolverInterface {
 		// resolver for the drivers themselves which applies to all connections.
 		if (isset($this->extensions[$driver]))
 		{
-			return call_user_func($this->extensions[$driver], $config);
+			return call_user_func($this->extensions[$driver], $config, $name);
 		}
 
 		return $this->factory->make($config, $name);


### PR DESCRIPTION
This gives database connection and driver extensions a way to access the name of the configuration being used so it can be included in the config array that is eventually passed to the Connection class.
