### PR TITLE
Try to fix aliases and deferred service providers.

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -450,6 +450,8 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	 */
 	public function make($abstract, $parameters = array())
 	{
+		$abstract = $this->getAlias($abstract);
+		
 		if (isset($this->deferredServices[$abstract]))
 		{
 			$this->loadDeferredProvider($abstract);


### PR DESCRIPTION
As seen in #3252, automatic resolution did not work for aliases that referenced deferred services. This should fix it.

There are more problems with deferred services, I think (remember our discussion about the `extend()` method?), I'll take another look at these.
