### PR TITLE
Add 'otherKey' methods to BelongsTo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -240,4 +240,24 @@ class BelongsTo extends Relation {
 		return $this->parent->getTable().'.'.$this->foreignKey;
 	}
 
+	/**
+	 * Get the associated key of the relationship.
+	 *
+	 * @return string
+	 */
+	public function getOtherKey()
+	{
+		return $this->otherKey;
+	}
+
+	/**
+	 * Get the fully qualified associated key of the relationship.
+	 *
+	 * @return string
+	 */
+	public function getQualifiedOtherKeyName()
+	{
+		return $this->related->getTable().'.'.$this->otherKey;
+	}
+
 }


### PR DESCRIPTION
Useful for building dynamic relation queries or joins.

My use case, which would break if I change the relation otherKey:

``` php
public function getAdmins($company = null)
{
  $relation = $this->model->company();
  $foreignKey = $relation->getForeignKey();

  if ($company !== null) {
    // $otherKey = $relation->getOtherKey();
    $otherKey = $company->getKeyName();
    $include = $company->getAttribute($otherKey);
  } else {
    $include = null;
  }

  $query = $this->model->newQuery()
    ->where(function($query) use($foreignKey, $include) {
      $query->whereNull($foreignKey);
      if ($include !== null) {
        $query->orWhere($foreignKey, '=', $include);
      }
    });

  return $query->get();
}
```
