### PR TITLE
Allow SQL Server datetimes with microseconds

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -193,7 +193,7 @@ class SqlServerGrammar extends Grammar {
 	 */
 	public function getDateFormat()
 	{
-		return 'Y-m-d H:i:s.000';
+		return 'Y-m-d H:i:s.u';
 	}
 
 }


### PR DESCRIPTION
If a `created_at` or `updated_at` field ends in a value other than '.000' in SQL Server, Carbon is unable to parse the date with error "The format separator does not match" because of the hardcoded microsecond portion of the format returned by `getDateFormat()`.
