### PR TITLE
#3270 Database connection to return the read PDO connection if in transaction

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -649,6 +649,11 @@ class Connection implements ConnectionInterface {
 	 */
 	public function getReadPdo()
 	{
+		if ($this->transactions >= 1) 
+		{
+			return $this->getPdo();
+		}
+
 		return $this->readPdo ?: $this->pdo;
 	}
 


### PR DESCRIPTION
This is a proposed fixed for #3270.

`getReadPdo()` now checks if the query is within a transaction, and in that case returns the same PDO connection as the write.
