### PR TITLE
Allows routes to be specified as "http".

### DIFF
--- a/src/Illuminate/Routing/Matching/SchemeValidator.php
+++ b/src/Illuminate/Routing/Matching/SchemeValidator.php
@@ -14,7 +14,7 @@ class SchemeValidator implements ValidatorInterface {
 	 */
 	public function matches(Route $route, Request $request)
 	{
-		return $route->secure() ? $request->secure() : true;
+		return $route->secure() ? $request->secure() : $route->nonsecure() ? !$request->secure() : true;
 	}
 
 }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -654,6 +654,16 @@ class Route {
 		return in_array('https', $this->action);
 	}
 
+    /**
+	 * Determine if the route only responds to HTTP requests.
+	 *
+	 * @return bool
+	 */
+	public function nonsecure()
+	{
+		return in_array('http', $this->action);
+	}
+
 	/**
 	 * Get the domain defined for the route.
 	 *

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -403,7 +403,7 @@ class UrlGenerator {
 	 */
 	protected function getRouteRoot($route, $domain)
 	{
-		$secure = $route->secure() ?: null;
+		$secure = $route->secure() ?: $route->nonsecure() ?: null;
 
 		return $this->getRootUrl($this->getScheme($secure), $domain);
 	}


### PR DESCRIPTION
https://github.com/laravel/laravel/issues/2536 fixed an issue where URL::to()  couldn't be used to create
http URLs from an https page.  This is a fix to a similar but different
issue where URL::route() also can't be used to create routes that are
http if the current page is https.

In order to properly fix this issue with consistency for Laravel route
design, it was necessary to add an "http" route option (an "https"
option already existed, but there was no "http" option).

So with this commit, it is now possible to specify 'http' in a route
declaration, which behaves exactly as the 'https' option does, forcing
generated route URLs to use http, and only responding to http requests
for the route.
