### PR TITLE
Make Paginator decorate Collection methods

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -98,6 +98,18 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	}
 
 	/**
+	 * Call a method on the underlying Collection
+	 *
+	 * @param string $method
+	 * @param array  $arguments
+	 * @return mixed
+	 */
+	public function __call($method, $arguments)
+	{
+		return call_user_func_array(array($this->getCollection(), $method), $arguments);
+	}
+
+	/**
 	 * Setup the pagination context (current and last page).
 	 *
 	 * @return \Illuminate\Pagination\Paginator

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -149,7 +149,7 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 
 	public function testPaginatorDecoratesCollection()
 	{
-		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('a', 'b', 'c'), 3, 2);
+		$p = new Paginator(m::mock('Illuminate\Pagination\Environment'), array('a', 'b', 'c'), 3, 2);
 		$last = $p->last();
 
 		$this->assertEquals('c', $last);

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -146,4 +146,13 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://foo.com?page=1&foo=bar#a-fragment', $p->getUrl(1));
 	}
 
+
+	public function testPaginatorDecoratesCollection()
+	{
+		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('a', 'b', 'c'), 3, 2);
+		$last = $p->last();
+
+		$this->assertEquals('c', $last);
+	}
+
 }


### PR DESCRIPTION
Right now when obtaining a result from Eloquent queries – apart from aggregates like `sum` and such – the result is either an `Eloquent\Collection` or a `Paginator` instance.

When the class making use of these results has no knowledge of the logic behind the query, it's hard to work consistently with the output because you can't trust what methods will be available. This pull requests makes Paginator delegate unknown methods to the underlying Collection instance so that you can work consistently with query results without having to check for instances of Paginator beforehand.
