### PR TITLE
Add 'except' and 'only' methods to Eloquent Collection class.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -195,6 +195,32 @@ class Collection extends BaseCollection {
 	}
 
 	/**
+	 * Returns all models in the collection except the models with specified keys.
+	 *
+	 * @param  mixed  $keys
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function except($keys)
+	{
+	    $dictionary = array_except($this->getDictionary($this), $keys);
+
+	    return new static(array_values($dictionary));
+	}
+
+	/**
+	 * Returns only the models from the collection with the specified keys.
+	 *
+	 * @param  mixed  $keys
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function only($keys)
+	{
+		$dictionary = array_only($this->getDictionary($this), $keys);
+
+		return new static(array_values($dictionary));
+	}
+
+	/**
 	 * Get a dictionary keyed by primary keys.
 	 *
 	 * @param  \Illuminate\Support\Collection  $collection

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -181,4 +181,37 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('foo', 'bar'), $data->lists('email'));
 	}
 
+	public function testOnlyReturnsCollectionWithGivenModelKeys()
+	{
+		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one->shouldReceive('getKey')->andReturn(1);
+
+		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two->shouldReceive('getKey')->andReturn(2);
+
+		$three = m::mock('Illuminate\Database\Eloquent\Model');
+		$three->shouldReceive('getKey')->andReturn(3);
+
+		$c = new Collection(array($one, $two, $three));
+
+		$this->assertEquals(new Collection(array($one)), $c->only(1));
+		$this->assertEquals(new Collection(array($two, $three)), $c->only(array(2, 3)));
+	}
+
+	public function testExceptReturnsCollectionWithoutGivenModelKeys()
+	{
+		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one->shouldReceive('getKey')->andReturn(1);
+
+		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two->shouldReceive('getKey')->andReturn(2);
+
+		$three = m::mock('Illuminate\Database\Eloquent\Model');
+		$three->shouldReceive('getKey')->andReturn(3);
+
+		$c = new Collection(array($one, $two, $three));
+
+		$this->assertEquals(new Collection(array($two, $three)), $c->except(1));
+		$this->assertEquals(new Collection(array($one)), $c->except(array(2, 3)));
+	}
 }


### PR DESCRIPTION
This pull requests adds `except` and `only` methods to the Eloquent `Collection` class. 

**Use case**: I am currently working on a system that has projects. Each of these projects have multiple clients, one of which is the 'primary client / project owner'. It's more efficient to pull in all these clients in one query and then filter the collection when needed, than to fire two queries. With these methods I can easily filter the collection by either excluding the primary client from the collection, or only fetching that client from the collection.
