### PR TITLE
Fixes “Class Illuminate\Http\Cookie does not exist” when it should been Symfony\Component\HttpFoundation\Cookie.

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -1,6 +1,5 @@
 <?php namespace Illuminate\Http;
 
-use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Support\Contracts\JsonableInterface;
 
 class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -1,7 +1,6 @@
 <?php namespace Illuminate\Http;
 
 use ArrayObject;
-use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Support\Contracts\JsonableInterface;
 use Illuminate\Support\Contracts\RenderableInterface;
 

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -1,5 +1,7 @@
 <?php namespace Illuminate\Http;
 
+use Symfony\Component\HttpFoundation\Cookie;
+
 trait ResponseTrait {
 
 	/**


### PR DESCRIPTION
Found this error while testing on a package on 4.2 (see orchestral/resources#9 for detail).

Signed-off-by: crynobone crynobone@gmail.com
