### PR TITLE
Fixed collection reference, as this fails if you pass through a subclass

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -318,7 +318,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 */
 	public function merge($items)
 	{
-		if ($items instanceof Collection)
+		if ($items instanceof \Illuminate\Support\Collection)
 		{
 			$items = $items->all();
 		}


### PR DESCRIPTION
Instantiation Illuminate\Support\Collection as a new object, and attempting to merge query results (Model\Collection) fails.

This fix allows that to work
