### PR TITLE
Change strtolower to camel_case in BelongsToMany::guessInverseRelation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -843,7 +843,7 @@ class BelongsToMany extends Relation {
 	 */
 	protected function guessInverseRelation()
 	{
-		return strtolower(str_plural(class_basename($this->getParent())));
+		return camel_case(str_plural(class_basename($this->getParent())));
 	}
 
 	/**


### PR DESCRIPTION
Just something I spotted... As relations are named in camel case this should make sense, right?

EDIT: wrong branch
