### PR TITLE
made the name of the testing environment configurable

### DIFF
--- a/src/Illuminate/Exception/Handler.php
+++ b/src/Illuminate/Exception/Handler.php
@@ -82,7 +82,7 @@ class Handler {
 
 		$this->registerExceptionHandler();
 
-		if ($environment != 'testing') $this->registerShutdownHandler();
+		if ($environment != $this->responsePreparer['env.unitTesting']) $this->registerShutdownHandler();
 	}
 
 	/**

--- a/src/Illuminate/Exception/Handler.php
+++ b/src/Illuminate/Exception/Handler.php
@@ -82,7 +82,7 @@ class Handler {
 
 		$this->registerExceptionHandler();
 
-		if ($environment != $this->responsePreparer['env.unitTesting']) $this->registerShutdownHandler();
+		if ($environment != $this->responsePreparer['env.testing']) $this->registerShutdownHandler();
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -279,7 +279,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	 */
 	public function runningUnitTests()
 	{
-		return $this['env'] == $this['env.unitTesting'];
+		return $this['env'] == $this['env.testing'];
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -279,7 +279,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	 */
 	public function runningUnitTests()
 	{
-		return $this['env'] == 'testing';
+		return $this['env'] == $this['env.unitTesting'];
 	}
 
 	/**

--- a/src/Illuminate/Foundation/start.php
+++ b/src/Illuminate/Foundation/start.php
@@ -74,7 +74,7 @@ $app->instance('app', $app);
 
 if (isset($unitTesting))
 {
-	$app['env'] = $env = $testEnvironment;
+	$app['env'] = $env = $app['env.unitTesting'];
 }
 
 /*
@@ -149,7 +149,7 @@ $app->instance('config', $config = new Config(
 
 $app->startExceptionHandling();
 
-if ($env != 'testing') ini_set('display_errors', 'Off');
+if ($env != $app['env.unitTesting']) ini_set('display_errors', 'Off');
 
 /*
 |--------------------------------------------------------------------------

--- a/src/Illuminate/Foundation/start.php
+++ b/src/Illuminate/Foundation/start.php
@@ -74,7 +74,7 @@ $app->instance('app', $app);
 
 if (isset($unitTesting))
 {
-	$app['env'] = $env = $app['env.unitTesting'];
+	$app['env'] = $env = $app['env.testing'];
 }
 
 /*
@@ -149,7 +149,7 @@ $app->instance('config', $config = new Config(
 
 $app->startExceptionHandling();
 
-if ($env != $app['env.unitTesting']) ini_set('display_errors', 'Off');
+if ($env != $app['env.testing']) ini_set('display_errors', 'Off');
 
 /*
 |--------------------------------------------------------------------------

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -32,7 +32,7 @@ class RoutingServiceProvider extends ServiceProvider {
 			// If the current application environment is the unitTesting environment, 
 			// disable the routing filters, since they can be tested independently of the 
 			// routes and just get in the way of our typical controller testing concerns.
-			if ($app['env'] == $app['env.unitTesting'])
+			if ($app['env'] == $app['env.testing'])
 			{
 				$router->disableFilters();
 			}

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -29,10 +29,10 @@ class RoutingServiceProvider extends ServiceProvider {
 		{
 			$router = new Router($app['events'], $app);
 
-			// If the current application environment is "testing", we will disable the
-			// routing filters, since they can be tested independently of the routes
-			// and just get in the way of our typical controller testing concerns.
-			if ($app['env'] == 'testing')
+			// If the current application environment is the unitTesting environment, 
+			// disable the routing filters, since they can be tested independently of the 
+			// routes and just get in the way of our typical controller testing concerns.
+			if ($app['env'] == $app['env.unitTesting'])
 			{
 				$router->disableFilters();
 			}


### PR DESCRIPTION
everywhere i've ever worked has called their QA environment "testing", and their automated testing environment something else, whether it be "integration" or "phpunit" or whatever.

we had to rename our environment and process documents to "work" with laravel.

i've tried to make it configurable here, with a matching pull request in laravel/laravel, so that people can call the testing environment whatever they want simply by modifying 1 line in start.php
