### PR TITLE
Ensure Eloquent date attributes are output in the same DateTime format in toArray as when directly accessed

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2085,6 +2085,16 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	{
 		$attributes = $this->getArrayableAttributes();
 
+		// Convert all attributes listed as dates to DateTime instances, then back
+		// to a string. This allows us to output date attributes in the same format
+		// as if we were to access them directly on the object.
+		foreach ($this->getDates() as $key)
+		{
+			if ( ! array_key_exists($key, $attributes)) continue;
+
+			$attributes[$key] = (string) $this->asDateTime($attributes[$key]);
+		}
+
 		// We want to spin through all the mutated attributes for this model and call
 		// the mutator for the attribute. We cache off every mutated attributes so
 		// we don't have to constantly check on attributes that actually change.

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -9,6 +9,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		m::close();
 
 		Illuminate\Database\Eloquent\Model::unsetEventDispatcher();
+		Carbon\Carbon::resetToStringFormat();
 	}
 
 
@@ -455,6 +456,38 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->setAppends(array('appendable'));
 		$array = $model->toArray();
 		$this->assertEquals('appended', $array['appendable']);
+	}
+
+
+	public function testToArrayIncludesDefaultFormattedTimestamps()
+	{
+		$model = new EloquentDateModelStub;
+		$model->setRawAttributes(array(
+			'created_at'	=> '2012-12-04',
+			'updated_at'	=> '2012-12-05',
+		));
+
+		$array = $model->toArray();
+
+		$this->assertEquals('2012-12-04 00:00:00', $array['created_at']);
+		$this->assertEquals('2012-12-05 00:00:00', $array['updated_at']);
+	}
+
+
+	public function testToArrayIncludesCustomFormattedTimestamps()
+	{
+		Carbon\Carbon::setToStringFormat('d-m-y');
+
+		$model = new EloquentDateModelStub;
+		$model->setRawAttributes(array(
+			'created_at'	=> '2012-12-04',
+			'updated_at'	=> '2012-12-05',
+		));
+
+		$array = $model->toArray();
+
+		$this->assertEquals('04-12-12', $array['created_at']);
+		$this->assertEquals('05-12-12', $array['updated_at']);
 	}
 
 


### PR DESCRIPTION
When converting an Eloquent model to an array, the format of the date attributes may differ from when accessing the attribute directly on the model. This pull request essentially allows you to customise the format in which DateTime fields are displayed in a JSON response.

Example of current behaviour. It's not simple to change the format of dates in a JSON/array response. They differ from the format when accessing the attribute directly:

``` php
Carbon::setToStringFormat('d-m-y');

class Order extends Eloquent {
}

$model = Order::find(1);

get_class($model->created_at);
// "Carbon\\Carbon"

(string) $model->created_at;
// "23-01-14"

(string) $model;
// '{"id":1,"created_at":"2014-01-23 16:30:00"}'
```

With the pull request, the behaviour is changed:

``` php
Carbon::setToStringFormat('d-m-y');

class Order extends Eloquent {
}

$model = Order::find(1);

get_class($model->created_at);
// Carbon\\Carbon

(string) $model->created_at;
// 23-01-14

(string) $model;
// '{"id":1,"created_at":"23-01-14"}'
```

Note that if the user doesn't call `setToStringFormat`, no functionality is changed. Dates are output exactly as they were before. Only once they change the format, _everything_ changes, as you'd expect.

Perhaps it would be suitable to add the default DateTime format to Config, which can configure Carbon during application boot?
