### PR TITLE
Changed supportBoris to check for pcntl

### DIFF
--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -118,7 +118,7 @@ class TinkerCommand extends Command {
 	 */
 	protected function supportsBoris()
 	{
-		return (extension_loaded('readline') and extension_loaded('posix'));
+		return (extension_loaded('readline') and extension_loaded('posix') and extension_loaded('pcntl'));
 	}
 
 }


### PR DESCRIPTION
Boris also requires the pcntl php extension, so we should check if its there before using Boris for tinkering. Since my Mac doesn't have pcntl I'd like it to fall back to the old tinker. I'm putting this in the 4.1 branch because Taylor asked me to. Thanks.
