### PR TITLE
Allow raw regex filters

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1255,7 +1255,8 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 			}
 		}
 
-		foreach ($this->regexFilters as $pattern => $filters) {
+		foreach ($this->regexFilters as $pattern => $filters)
+		{
 			if (preg_match($pattern, $request->path()))
 			{
 				$merge = $this->patternsByMethod($method, $filters);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -76,6 +76,13 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	protected $patternFilters = array();
 
 	/**
+	 * The registered regex based filters.
+	 *
+	 * @var array
+	 */
+	protected $regexFilters = array();
+
+	/**
 	 * The reigstered route value binders.
 	 *
 	 * @var array
@@ -1103,6 +1110,21 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	}
 
 	/**
+	 * Register a regex-based filter with the router.
+	 *
+	 * @param  string     $pattern
+	 * @param  string     $name
+	 * @param  array|null $methods
+	 * @return void
+	 */
+	public function regexWhen($pattern, $name, $methods = null)
+	{
+		if ( ! is_null($methods)) $methods = array_map('strtoupper', (array) $methods);
+
+		$this->regexFilters[$pattern][] = compact('name', 'methods');
+	}
+
+	/**
 	 * Register a model binder for a wildcard.
 	 *
 	 * @param  string  $key
@@ -1226,6 +1248,15 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 			// registered patterns against the path info for the current request to this
 			// applications, and when it matches we will merge into these middlewares.
 			if (str_is($pattern, $request->path()))
+			{
+				$merge = $this->patternsByMethod($method, $filters);
+
+				$results = array_merge($results, $merge);
+			}
+		}
+
+		foreach ($this->regexFilters as $pattern => $filters) {
+			if (preg_match($pattern, $request->path()))
 			{
 				$merge = $this->patternsByMethod($method, $filters);
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -295,6 +295,32 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRegexBasedFilters()
+	{
+		$router = $this->getRouter();
+		$router->get('foo/bar', function() { return 'hello'; });
+		$router->get('bar/foo', function() { return 'hello'; });
+		$router->get('baz/foo', function() { return 'hello'; });
+		$router->filter('foo', function($route, $request, $bar) { return 'foo'.$bar; });
+		$router->regexWhen('/^(foo|bar).*/', 'foo:bar');
+		$this->assertEquals('foobar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+		$this->assertEquals('foobar', $router->dispatch(Request::create('bar/foo', 'GET'))->getContent());
+		$this->assertEquals('hello', $router->dispatch(Request::create('baz/foo', 'GET'))->getContent());
+	}
+
+
+	public function testRegexBasedFiltersWithVariables()
+	{
+		$router = $this->getRouter();
+		$router->get('{var}/bar', function($var) { return 'hello'; });
+		$router->filter('foo', function($route, $request, $bar) { return 'foo'.$bar; });
+		$router->regexWhen('/^(foo|bar).*/', 'foo:bar');
+		$this->assertEquals('foobar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+		$this->assertEquals('foobar', $router->dispatch(Request::create('bar/bar', 'GET'))->getContent());
+		$this->assertEquals('hello', $router->dispatch(Request::create('baz/bar', 'GET'))->getContent());
+	}
+
+
 	public function testMatchesMethodAgainstRequests()
 	{
 		/**


### PR DESCRIPTION
I want to write a raw regex pattern filter but it is currently not possible. This fixes it in a backwards compatible way.
