### PR TITLE
Explicitly suppress filesystem error on `forget()`

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -152,7 +152,12 @@ class FileStore implements StoreInterface {
 	 */
 	public function forget($key)
 	{
-		$this->files->delete($this->path($key));
+		$file = $this->path($key);
+
+		if ($this->files->exists($file))
+		{
+			$this->files->delete($file);
+		}
 	}
 
 	/**

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -74,6 +74,7 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 		$store->forever('foo', 'Hello World', 10);
 	}
 
+
 	public function testRemoveDeletesFileDoesntExist()
 	{
 		$files = $this->mockFilesystem();
@@ -83,6 +84,7 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 		$store = new FileStore($files, __DIR__);
 		$store->forget('foobull');
 	}
+
 
 	public function testRemoveDeletesFile()
 	{
@@ -95,6 +97,7 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 		$files->expects($this->once())->method('delete')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$md5));
 		$store->forget('foobar');
 	}
+
 
 	public function testFlushCleansDirectory()
 	{

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -74,17 +74,27 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 		$store->forever('foo', 'Hello World', 10);
 	}
 
+	public function testRemoveDeletesFileDoesntExist()
+	{
+		$files = $this->mockFilesystem();
+		$md5 = md5('foobull');
+		$cache_dir = substr($md5, 0, 2).'/'.substr($md5, 2, 2);
+		$files->expects($this->once())->method('exists')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$md5))->will($this->returnValue(false));
+		$store = new FileStore($files, __DIR__);
+		$store->forget('foobull');
+	}
 
 	public function testRemoveDeletesFile()
 	{
 		$files = $this->mockFilesystem();
-		$md5 = md5('foo');
+		$md5 = md5('foobar');
 		$cache_dir = substr($md5, 0, 2).'/'.substr($md5, 2, 2);
-		$files->expects($this->once())->method('delete')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$md5));
 		$store = new FileStore($files, __DIR__);
-		$store->forget('foo');
+		$store->put('foobar', 'Hello Baby', 10);
+		$files->expects($this->once())->method('exists')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$md5))->will($this->returnValue(true));
+		$files->expects($this->once())->method('delete')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$md5));
+		$store->forget('foobar');
 	}
-
 
 	public function testFlushCleansDirectory()
 	{


### PR DESCRIPTION
When forgetting a cache key that doesn't exist in the filesystem an error will be thrown if error suppression fails.

As per `Illuminate\Filesystem\Filesystem` (:128)

``` php
foreach ($paths as $path) { if ( ! @unlink($path)) $success = false; }
```

Where `@unlink` error suppression fails, resulting exception:

```
dev.ERROR: exception 'ErrorException' with message 'unlink(/app/storage/cache/e1/76/e1768c1bb7ebb703a94dc92669bcdacf): No such file or directory' in /vendor/laravel/framework/src/Illuminate/Filesystem/Filesystem.php:128
```

This PR will update the driver to check the file existence first because there is no instance (afaik) where the user would want to see this error message.
