### PR TITLE
[PROPOSAL] Add loadEnvironmentFile() function

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -262,6 +262,26 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 		return $this['env'] = with(new EnvironmentDetector())->detect($envs, $args);
 	}
 
+    /**
+     * Include environment file located at the root of the project diretory.
+     *
+     * @return void
+     */
+    public function loadEnvironmentFile()
+    {
+        $environment_file = $this['path.base'].'/.env.php';
+
+        if ($this['env'] != 'production')
+        {
+            $environment_file = $this['path.base'].'/.env.'.$this['env'].'.php';
+        }
+
+        if (file_exists($environment_file))
+        {
+            $_ENV = array_merge($_ENV, include $environment_file);
+        }
+    }
+
 	/**
 	 * Determine if we are running in the console.
 	 *


### PR DESCRIPTION
This functions allows to load `.env.php` (for production) or `.env.{environment_name}.php` (for other environments), if they exists.
These files are located at the root of the project directory.

This files return an array, that can complement or override `$_ENV`
