### PR TITLE
Updated File::allFiles Method

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -261,7 +261,7 @@ class Filesystem {
 	 */
 	public function allFiles($directory)
 	{
-		return iterator_to_array(Finder::create()->files()->in($directory), false);
+		return Finder::create()->files()->in($directory);
 	}
 
 	/**


### PR DESCRIPTION
Since `getIterator` method of Symfony's `Finder` class returns an `AppendIterator` instead of `ArrayIterator`, `iterator_to_array` function doesn't work as expected. Though it wasn't needed anyways because the keys of what's returned from `Finder` is the full path of files, so they won't conflict.
