### PR TITLE
[PROPOSAL] Cache::macro()

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -22,6 +22,13 @@ class Repository implements ArrayAccess {
 	protected $default = 60;
 
 	/**
+	 * An array of registered Cache macros.
+	 *
+	 * @var array
+	 */
+	protected $macros = array();
+
+	/**
 	 * Create a new cache repository instance.
 	 *
 	 * @param  \Illuminate\Cache\StoreInterface  $store
@@ -243,7 +250,7 @@ class Repository implements ArrayAccess {
 	}
 
 	/**
-	 * Dynamically pass missing methods to the store.
+	 * Handle dynamic calls into Cache macros or pass missing methods to the store.
 	 *
 	 * @param  string  $method
 	 * @param  array   $parameters
@@ -251,7 +258,23 @@ class Repository implements ArrayAccess {
 	 */
 	public function __call($method, $parameters)
 	{
+		if (isset($this->macros[$method]))
+		{
+			return call_user_func_array($this->macros[$method], $parameters);
+		}
+
 		return call_user_func_array(array($this->store, $method), $parameters);
 	}
 
+	/**
+	 * Register a macro with the Cache class.
+	 *
+	 * @param  string $name
+	 * @param  callable $callback
+	 * @return void
+	 */
+	public function macro($name, $callback)
+	{
+		$this->macros[$name] = $callback;
+	}
 }


### PR DESCRIPTION
Allows the usage of `Cache::macro()` function.
This way I can register a Cache macro one time and use it everywhere in my code.

Below an example usage:

``` php
// create a 'getItem' macro
Cache::macro('getItem', function ($id)
{
  return Cache::get('my-item-'. $key);
}):

// use the 'getItem' macro
echo Cache::getItem(42);
```
