### PR TITLE
Add primary key for migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -122,6 +122,8 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 			$table->string('migration');
 
 			$table->integer('batch');
+
+            $table->primary('migration');
 		});
 	}
 


### PR DESCRIPTION
Without primary key, at the Windows this is queries is equivalent:

``` SQL
SELECT * FROM migrations ORDER BY migration DESC
SELECT * FROM migrations ORDER BY migration ASC
```

hence the order wrong during migrations rollback

Tested on Windows 8 + MySQL 5.5
