### PR TITLE
Fixes “ErrorException: Undefined property: Illuminate\Session\Store::$started” from unit testing environment.

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -22,6 +22,13 @@ class Store implements SessionInterface {
 	protected $name;
 
 	/**
+	 * Session store started status.
+	 *
+	 * @var bool
+	 */
+	protected $started = false;
+
+	/**
 	 * The session attributes.
 	 *
 	 * @var array


### PR DESCRIPTION
Signed-off-by: crynobone crynobone@gmail.com
