### PR TITLE
Addition of new event trigger in Illuminate\Routing\Router prior to response generation.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -979,6 +979,9 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	{
 		$route = $this->findRoute($request);
 
+        // Inform event subscribers that a route has been found.
+        $this->events->fire('router.routed', array($request, $route));
+
 		// Once we have successfully matched the incoming request to a given route we
 		// can call the before filters on that route. This works similar to global
 		// filters in that if a response is returned we will not call the route.

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -625,6 +625,35 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+    public function testRouterFiresRoutedEvent()
+    {
+        $events = new Illuminate\Events\Dispatcher();
+        $router = new Router($events);
+        $router->get('foo/bar', function() { return ''; });
+
+        $request = Request::create('http://foo.com/foo/bar', 'GET');
+        $route   = new Route('GET', 'foo/bar', array('http', function() {}));
+
+        $_SERVER['__router.request'] = null;
+        $_SERVER['__router.route']   = null;
+
+        $events->listen('router.routed', function($request, $route){
+            $_SERVER['__router.request'] = $request;
+            $_SERVER['__router.route']   = $route;
+        });
+
+        $router->dispatchToRoute($request);
+
+        $this->assertInstanceOf('Illuminate\Http\Request', $_SERVER['__router.request']);
+        $this->assertEquals($_SERVER['__router.request'], $request);
+        unset($_SERVER['__router.request']);
+
+        $this->assertInstanceOf('Illuminate\Routing\Route', $_SERVER['__router.route']);
+        $this->assertEquals($_SERVER['__router.route']->getUri(), $route->getUri());
+        unset($_SERVER['__router.route']);
+    }
+
+
 	protected function getRouter()
 	{
 		return new Router(new Illuminate\Events\Dispatcher);


### PR DESCRIPTION
I've run into a few cases where it would be useful to hook into route dispatch process without using filters. The best example I can think of is a route-based menu system where the matched route is used to flag a particular menu item as being active _before_ the response is generated. Such functionality IS possible using a 'before' filter but it's far from elegant and a blatent misuse of this feature.

This is why I'm proposing that a new event is fired immediately after the call to $this->findRoute($request) in Illuminate/Routing/Router. I've also included a test to ensure that the event is triggered with the expected response and route parameters though it could be a little over-complicated.

Hope this makes sense!
