### PR TITLE
Suppress error in case contents are corrupt

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -66,7 +66,7 @@ class FileStore implements StoreInterface {
 			return $this->forget($key);
 		}
 
-		return unserialize(substr($contents, 10));
+		return @unserialize(substr($contents, 10));
 	}
 
 	/**


### PR DESCRIPTION
Just fortifying this class a bit.

I'm not sure how it happened but the cache file became corrupt, resulting error:

```
unserialize(): Error at offset 2 of 3870 bytes
```

Using an error control operator fixes its wagon!
