### PR TITLE
Improve Illuminate\Cookie\CookieJar test coverage

### DIFF
--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -29,6 +29,10 @@ class CookieTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($c2->isSecure());
 		$this->assertEquals('/domain', $c2->getDomain());
 		$this->assertEquals('/path', $c2->getPath());
+		
+		$c3 = $cookie->forget('color');
+		$this->assertTrue($c3->getValue() === null);
+		$this->assertTrue($c3->getExpiresTime() < time());
 	}
 
 
@@ -49,9 +53,15 @@ class CookieTest extends PHPUnit_Framework_TestCase {
 	{
 		$cookie = $this->getCreator();
 		$this->assertEmpty($cookie->getQueuedCookies());
+		$this->assertFalse($cookie->hasQueued('foo'));
 		$cookie->queue($cookie->make('foo','bar'));
 		$this->assertArrayHasKey('foo', $cookie->getQueuedCookies());
+		$this->assertTrue($cookie->hasQueued('foo'));
 		$this->assertInstanceOf('Symfony\Component\HttpFoundation\Cookie', $cookie->queued('foo'));
+		$cookie->queue('qu','ux');
+		$this->assertArrayHasKey('qu', $cookie->getQueuedCookies());
+		$this->assertTrue($cookie->hasQueued('qu'));
+		$this->assertInstanceOf('Symfony\Component\HttpFoundation\Cookie', $cookie->queued('qu'));
 	}
 
 	public function testUnqueue()


### PR DESCRIPTION
This pull request increases test coverage in `CookieTest` for `Illuminate\Cookie\CookieJar`.

Before (4.1 @ 42470f7274d6dcae1b75a3bf83eecd5eb2284514):

```
\Illuminate\Cookie::CookieJar
  Methods:  80.00% ( 8/10)   Lines:  85.00% ( 17/ 20)
```

After:

```
\Illuminate\Cookie::CookieJar
  Methods: 100.00% (10/10)   Lines: 100.00% ( 20/ 20)
```
