### PR TITLE
Pass the token into the password reminder email callback

### DIFF
--- a/src/Illuminate/Auth/Reminders/PasswordBroker.php
+++ b/src/Illuminate/Auth/Reminders/PasswordBroker.php
@@ -140,11 +140,11 @@ class PasswordBroker {
 		// so that it may be displayed for an user to click for password reset.
 		$view = $this->reminderView;
 
-		return $this->mailer->send($view, compact('token', 'user'), function($m) use ($user, $callback)
+		return $this->mailer->send($view, compact('token', 'user'), function($m) use ($user, $callback, $token)
 		{
 			$m->to($user->getReminderEmail());
 
-			if ( ! is_null($callback)) call_user_func($callback, $m, $user);
+			if ( ! is_null($callback)) call_user_func($callback, $m, $user, $token);
 		});
 	}
 


### PR DESCRIPTION
When a password reminder is sent, only one email part can be added (a html view email.auth.reminder). The callback can be used to add a text view if needed (and it helps with SPAM score a lot in my experience) but the token used in the html part is not available to the callback. This simple change makes it available, and it works like a charm.
