### PR TITLE
Pass the token into the password reminder email callback

### DIFF
--- a/src/Illuminate/Auth/Reminders/PasswordBroker.php
+++ b/src/Illuminate/Auth/Reminders/PasswordBroker.php
@@ -140,11 +140,11 @@ class PasswordBroker {
 		// so that it may be displayed for an user to click for password reset.
 		$view = $this->reminderView;
 
-		return $this->mailer->send($view, compact('token', 'user'), function($m) use ($user, $callback)
+		return $this->mailer->send($view, compact('token', 'user'), function($m) use ($user, $callback, $token)
 		{
 			$m->to($user->getReminderEmail());
 
-			if ( ! is_null($callback)) call_user_func($callback, $m, $user);
+			if ( ! is_null($callback)) call_user_func($callback, $m, $user, $token);
 		});
 	}
 


### PR DESCRIPTION
Sending a reminder normally looks like this:

```
    return Password::remind($credentials, function($message, $user){
        $message
            ->subject('Reset your password - read this')
    });
```

The template/view configured in auth.reminder.email is used to generate the HTML body of the message sent. It is passed the user and the token. The view then decides how to present them to the user.

To add a text part to the reminder, you would need to do this:

```
    return Password::remind($credentials, function($message, $user){
        $message
            ->subject('Recover your password here now')
            ->addPart("your text version template", 'text/plain');
    });
```

Your text part template can be passed the same user, but access to the token is not available here. This means no URL can be added to the email sent out to the user for them to follow and reset their password.

With the proposed change, the token is available:

```
    return Password::remind($credentials, function($message, $user, $token){
        $message
            ->subject('Reset your password here - even better')
            ->addPart("The token is $token etc.", 'text/plain');
    });
```

You would call up a view rather than hard-code the string of the text/plain body like this, but you get the idea. Now the text/plain part can have a URL in it.

In my tests, having only a HTML and no TEXT part to the registration/reminder emails, adds a full poiint (1 out of 5) to the SPAM rating. Many of my Hotmail and Yahoo users are not seeing the registration email, and anything that pushed the SPAM rating over the edge should be avoided.

So, what do you think? It works well for me, and I cannot see any drawbacks.
