### PR TITLE
Ensure there are dirty fields when performing update

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1341,9 +1341,11 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			// models are updated, giving them a chance to do any special processing.
 			$dirty = $this->getDirty();
 
-			$this->setKeysForSaveQuery($query)->update($dirty);
+			if (count($dirty) > 0) {
+				$this->setKeysForSaveQuery($query)->update($dirty);
 
-			$this->fireModelEvent('updated', false);
+				$this->fireModelEvent('updated', false);
+			}
 		}
 
 		return true;


### PR DESCRIPTION
It's possible that the 'updating' or 'saving' events could cause fields on the model to 'reset' (i.e. revert back to their original values). Since the dirty fields are pulled again before performing an update, we must make sure there are fields there to update, otherwise it could generate an invalid query in the form of:
UPDATE table SET _nothing_ WHERE id = 123

Was originally submitted in #2825 for 4.0, but ticket was closed and only partially implemented in 4.1
