### PR TITLE
[Proposal] Coveralls Integration with Travis CI

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
 
-script: phpunit -d memory_limit=1024M
+script: phpunit -d memory_limit=1024M --coverage-clover build/logs/clover.xml
+
+after_script: php vendor/bin/coveralls
 
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
         "iron-io/iron_mq": "1.4.*",
         "pda/pheanstalk": "2.1.*",
         "mockery/mockery": "0.8.0",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.7.*",
+        "satooshi/php-coveralls": "dev-master"
     },
     "autoload": {
         "classmap": [

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## Laravel Framework (Kernel)
 
-[![Latest Stable Version](https://poser.pugx.org/laravel/framework/version.png)](https://packagist.org/packages/laravel/framework) [![Total Downloads](https://poser.pugx.org/laravel/framework/d/total.png)](https://packagist.org/packages/laravel/framework) [![Build Status](https://travis-ci.org/laravel/framework.png)](https://travis-ci.org/laravel/framework) [![Dependency Status](https://www.versioneye.com/php/laravel:framework/badge.png)](https://www.versioneye.com/php/laravel:framework)
+[![Latest Stable Version](https://poser.pugx.org/laravel/framework/version.png)](https://packagist.org/packages/laravel/framework) [![Total Downloads](https://poser.pugx.org/laravel/framework/d/total.png)](https://packagist.org/packages/laravel/framework) [![Build Status](https://travis-ci.org/laravel/framework.png)](https://travis-ci.org/laravel/framework) [![Coverage Status](https://coveralls.io/repos/laravel/framework/badge.png)](https://coveralls.io/r/laravel/framework) [![Dependency Status](https://www.versioneye.com/php/laravel:framework/badge.png)](https://www.versioneye.com/php/laravel:framework)
 
 > **Note:** This repository contains the core code of the Laravel framework. If you want to build an application using Laravel 4, visit the main [Laravel repository](https://github.com/laravel/laravel).
 


### PR DESCRIPTION
[Coveralls.io](https://coveralls.io) can be used to expose test coverage info on a webpage and as a badge.

An example of the webpage (using my fork):

> https://coveralls.io/r/ebollens/laravel-framework?branch=master

An example of the badge (also using my fork):

> [![Coverage Status](https://coveralls.io/repos/ebollens/laravel-framework/badge.png?branch=master)](https://coveralls.io/r/ebollens/laravel-framework?branch=master)

This pull request will do the following:
- Adds `php-coveralls` as a dev dependency in `composer.json`
- Adds `--coverage-clover build/logs/clover.xml` to the PHPUnit invocation in `.travis.yml`
- Adds `php vendor/bin/coveralls` invocation after script in `.travis.yml`
- Adds badge referencing `master` branch in `readme.md`
