### PR TITLE
Improve HTTP test coverage

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -113,12 +113,12 @@ class Request extends SymfonyRequest {
 	}
 
 	/**
-	 * Determine if the current request URI matches a pattern.
+	 * Determine if the current request URI matches a pattern, accepting 
+	 * patterns to test as function arguments.
 	 *
-	 * @param  string  $pattern
 	 * @return bool
 	 */
-	public function is($pattern)
+	public function is(/* [$pattern1, [pattern2, [..] ] ] */)
 	{
 		foreach (func_get_args() as $pattern)
 		{

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -9,6 +9,20 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	{
 		m::close();
 	}
+	
+	
+	public function testInstanceMethod()
+	{
+		$request = Request::create('', 'GET');
+		$this->assertTrue($request === $request->instance());
+	}
+	
+	
+	public function testRootMethod()
+	{
+		$request = Request::create('http://example.com/foo/bar/script.php?test');
+		$this->assertEquals('http://example.com', $request->root());
+	}
 
 
 	public function testPathMethod()
@@ -18,6 +32,13 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 
 		$request = Request::create('/foo/bar', 'GET');
 		$this->assertEquals('foo/bar', $request->path());
+	}
+	
+	
+	public function testDecodedPathMethod()
+	{
+		$request = Request::create('/foo%20bar');
+		$this->assertEquals('foo bar', $request->decodedPath());
 	}
 
 
@@ -69,10 +90,29 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($request->is('foo*'));
 		$this->assertFalse($request->is('bar*'));
 		$this->assertTrue($request->is('*bar*'));
+		$this->assertTrue($request->is('bar*', 'foo*', 'baz'));
 
 		$request = Request::create('/', 'GET');
 
 		$this->assertTrue($request->is('/'));
+	}
+	
+	
+	public function testAjaxMethod()
+	{
+		$request = Request::create('/', 'GET');
+		$this->assertFalse($request->ajax());
+		$request = Request::create('/', 'GET', array(), array(), array(), array('HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'), '{}');
+		$this->assertTrue($request->ajax());
+	}
+	
+	
+	public function testSecureMethod()
+	{
+		$request = Request::create('http://example.com', 'GET');
+		$this->assertFalse($request->secure());
+		$request = Request::create('https://example.com', 'GET');
+		$this->assertTrue($request->secure());
 	}
 
 
@@ -122,6 +162,8 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$request = Request::create('/', 'GET', array('name' => 'Taylor'));
 		$this->assertEquals('Taylor', $request->query('name'));
 		$this->assertEquals('Bob', $request->query('foo', 'Bob'));
+		$all = $request->query(null);
+		$this->assertEquals('Taylor', $all['name']);
 	}
 
 
@@ -130,6 +172,16 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$request = Request::create('/', 'GET', array(), array('name' => 'Taylor'));
 		$this->assertEquals('Taylor', $request->cookie('name'));
 		$this->assertEquals('Bob', $request->cookie('foo', 'Bob'));
+		$all = $request->cookie(null);
+		$this->assertEquals('Taylor', $all['name']);
+	}
+	
+	
+	public function testHasCookieMethod()
+	{
+		$request = Request::create('/', 'GET', array(), array('foo' => 'bar'));
+		$this->assertTrue($request->hasCookie('foo'));
+		$this->assertFalse($request->hasCookie('qu'));
 	}
 
 
@@ -173,6 +225,8 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$request = Request::create('/', 'GET', array(), array(), array(), array('foo' => 'bar'));
 		$this->assertEquals('bar', $request->server('foo'));
 		$this->assertEquals('bar', $request->server('foo.doesnt.exist', 'bar'));
+		$all = $request->server(null);
+		$this->assertEquals('bar', $all['foo']);
 	}
 
 
@@ -200,6 +254,8 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	{
 		$request = Request::create('/', 'GET', array(), array(), array(), array('HTTP_DO_THIS' => 'foo'));
 		$this->assertEquals('foo', $request->header('do-this'));
+		$all = $request->header(null);
+		$this->assertEquals('foo', $all['do-this'][0]);
 	}
 
 
@@ -260,9 +316,23 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	{
 		$request = Request::create('/', 'GET', array(), array(), array(), array('HTTP_ACCEPT' => 'application/json'));
 		$this->assertEquals('json', $request->format());
+		$this->assertTrue($request->wantsJson());
 
 		$request = Request::create('/', 'GET', array(), array(), array(), array('HTTP_ACCEPT' => 'application/atom+xml'));
 		$this->assertEquals('atom', $request->format());
+		$this->assertFalse($request->wantsJson());
+		
+		$request = Request::create('/', 'GET', array(), array(), array(), array('HTTP_ACCEPT' => 'is/not/known'));
+		$this->assertEquals('html', $request->format());
+		$this->assertEquals('foo', $request->format('foo'));
+	}
+
+
+	public function testSessionMethod()
+	{
+		$this->setExpectedException('RuntimeException');
+		$request = Request::create('/', 'GET');
+		$request->session();
 	}
 
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -312,6 +312,16 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testFlushMethodCallsSession()
+	{
+		$request = Request::create('/', 'GET');
+		$session = m::mock('Illuminate\Session\Store');
+		$session->shouldReceive('flashInput')->once();
+		$request->setSession($session);
+		$request->flush();
+	}
+
+
 	public function testFormatReturnsAcceptableFormat()
 	{
 		$request = Request::create('/', 'GET', array(), array(), array(), array('HTTP_ACCEPT' => 'application/json'));

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -18,6 +18,11 @@ class HttpResponseTest extends PHPUnit_Framework_TestCase {
 		$response = new Illuminate\Http\Response(new JsonableStub);
 		$this->assertEquals('foo', $response->getContent());
 		$this->assertEquals('application/json', $response->headers->get('Content-Type'));
+		
+		$response = new Illuminate\Http\Response();
+		$response->setContent(array('foo'=>'bar'));
+		$this->assertEquals('{"foo":"bar"}', $response->getContent());
+		$this->assertEquals('application/json', $response->headers->get('Content-Type'));
 	}
 
 
@@ -27,6 +32,40 @@ class HttpResponseTest extends PHPUnit_Framework_TestCase {
 		$mock->shouldReceive('render')->once()->andReturn('foo');
 		$response = new Illuminate\Http\Response($mock);
 		$this->assertEquals('foo', $response->getContent());		
+	}
+	
+	
+	public function testHeader()
+	{
+		$response = new Illuminate\Http\Response();
+		$this->assertNull($response->headers->get('foo'));
+		$response->header('foo', 'bar');
+		$this->assertEquals('bar', $response->headers->get('foo'));
+		$response->header('foo', 'baz', false);
+		$this->assertEquals('bar', $response->headers->get('foo'));
+		$response->header('foo', 'baz');
+		$this->assertEquals('baz', $response->headers->get('foo'));
+	}
+	
+	
+	public function testWithCookie()
+	{
+		$response = new Illuminate\Http\Response();
+		$this->assertEquals(0, count($response->headers->getCookies()));
+		$this->assertEquals($response, $response->withCookie(new \Symfony\Component\HttpFoundation\Cookie('foo', 'bar')));
+		$cookies = $response->headers->getCookies();
+		$this->assertEquals(1, count($cookies));
+		$this->assertEquals('foo', $cookies[0]->getName());
+		$this->assertEquals('bar', $cookies[0]->getValue());
+	}
+	
+	
+	public function testGetOriginalContent()
+	{
+		$arr = array('foo'=>'bar');
+		$response = new Illuminate\Http\Response();
+		$response->setContent($arr);
+		$this->assertTrue($arr === $response->getOriginalContent());
 	}
 
 

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -67,6 +67,41 @@ class HttpResponseTest extends PHPUnit_Framework_TestCase {
 		$response->setContent($arr);
 		$this->assertTrue($arr === $response->getOriginalContent());
 	}
+	
+	
+	public function testHeaderOnRedirect()
+	{
+		$response = new RedirectResponse('foo.bar');
+		$this->assertNull($response->headers->get('foo'));
+		$response->header('foo', 'bar');
+		$this->assertEquals('bar', $response->headers->get('foo'));
+		$response->header('foo', 'baz', false);
+		$this->assertEquals('bar', $response->headers->get('foo'));
+		$response->header('foo', 'baz');
+		$this->assertEquals('baz', $response->headers->get('foo'));
+	}
+	
+	
+	public function testWithOnRedirect()	
+{
+        $response = new RedirectResponse('foo.bar');
+        $response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
+        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $session->shouldReceive('flash')->twice();
+		$response->with(array('name', 'age'));
+	}
+	
+	
+	public function testWithCookieOnRedirect()
+	{
+		$response = new RedirectResponse('foo.bar');
+		$this->assertEquals(0, count($response->headers->getCookies()));
+		$this->assertEquals($response, $response->withCookie(new \Symfony\Component\HttpFoundation\Cookie('foo', 'bar')));
+		$cookies = $response->headers->getCookies();
+		$this->assertEquals(1, count($cookies));
+		$this->assertEquals('foo', $cookies[0]->getName());
+		$this->assertEquals('bar', $cookies[0]->getValue());
+	}
 
 
     public function testInputOnRedirect()
@@ -109,7 +144,23 @@ class HttpResponseTest extends PHPUnit_Framework_TestCase {
         $provider->shouldReceive('getMessageBag')->once()->andReturn(array('foo' => 'bar'));
         $response->withErrors($provider);
     }
+	
+	
+	public function testSettersGettersOnRequest()
+	{
+		$response = new RedirectResponse('foo.bar');
+		$this->assertNull($response->getRequest());
+		$this->assertNull($response->getSession());
+		
+		$request = Request::create('/', 'GET');
+		$session = m::mock('Illuminate\Session\Store');
+		$response->setRequest($request);
+		$response->setSession($session);
+		$this->assertTrue($request === $response->getRequest());
+		$this->assertTrue($session === $response->getSession());
+	}
 
+	
     public function testRedirectWithErrorsArrayConvertsToMessageBag()
     {
         $response = new RedirectResponse('foo.bar');
@@ -119,6 +170,24 @@ class HttpResponseTest extends PHPUnit_Framework_TestCase {
         $provider = array('foo' => 'bar');
         $response->withErrors($provider);
     }
+	
+	
+	public function testMagicCall()
+	{
+		$response = new RedirectResponse('foo.bar');
+        $response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
+        $response->setSession($session = m::mock('Illuminate\Session\Store'));
+        $session->shouldReceive('flash')->once()->with('foo', 'bar');
+		$response->withFoo('bar');
+	}
+
+
+	public function testMagicCallException()
+	{
+		$this->setExpectedException('BadMethodCallException');
+		$response = new RedirectResponse('foo.bar');
+		$response->doesNotExist('bar');
+	}
 
 }
 


### PR DESCRIPTION
This pull request increases test coverage in `HttpRequestTest` and `HttpResponseTest` for `Illuminate\HTTP\Request`, `Illuminate\HTTP\Response` and `Illuminate\HTTP\RedirectResponse`.

Before:

```
\Illuminate\Http::RedirectResponse
  Methods:  58.33% ( 7/12)   Lines:  61.29% ( 19/ 31)
\Illuminate\Http::Request
  Methods:  69.23% (27/39)   Lines:  71.43% ( 65/ 91)
\Illuminate\Http::Response
  Methods:  50.00% ( 3/ 6)   Lines:  70.00% ( 14/ 20)
```

After:

```
\Illuminate\Http::RedirectResponse
  Methods: 100.00% (12/12)   Lines: 100.00% ( 31/ 31)
\Illuminate\Http::Request
  Methods:  89.74% (35/39)   Lines:  86.81% ( 79/ 91)
\Illuminate\Http::Response
  Methods: 100.00% ( 6/ 6)   Lines: 100.00% ( 20/ 20)
```

Branching properties in `Illuminate\Http\Request::createFromBase()` made it hard to get at, and the flash methods in `Illuminate\Http\Request` were also neglected, but otherwise, all methods previously marked by PHPUnit as uncovered for these three classes should now be covered.

Additionally, unused method argument for `Illuminate\Http\Request->is()` was removed and the comment updated to reference its actual usage.
