### PR TITLE
Missing namespace

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/blank.stub
+++ b/src/Illuminate/Database/Migrations/stubs/blank.stub
@@ -1,5 +1,7 @@
 <?php
 
+
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 class {{class}} extends Migration {


### PR DESCRIPTION
[ErrorException]
must be an instance of Blueprint, instance of Illuminate\Database\Schema\Blueprint given
