### PR TITLE
Minor Clarity and Type-enforcement Fixes

### DIFF
--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -20,10 +20,10 @@ class TagSet {
 	 * Create a new TagSet instance.
 	 *
 	 * @param  \Illuminate\Cache\StoreInterface  $store
-	 * @param  string  $names
+	 * @param  array  $names
 	 * @return void
 	 */
-	public function __construct(StoreInterface $store, $names)
+	public function __construct(StoreInterface $store, array $names = array())
 	{
 		$this->store = $store;
 		$this->names = $names;

--- a/src/Illuminate/Cookie/Queue.php
+++ b/src/Illuminate/Cookie/Queue.php
@@ -17,7 +17,7 @@ class Queue implements HttpKernelInterface {
 	 *
 	 * @var \Illuminate\Cookie\CookieJar
 	 */
-	protected $encrypter;
+	protected $cookies;
 
 	/**
 	 * Create a new CookieQueue instance.

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -24,11 +24,18 @@ class Manager {
 	 * @var \Illuminate\Database\DatabaseManager
 	 */
 	protected $manager;
+	
+	/**
+	 * The container instance.
+	 * 
+	 * @var \Illuminate\Container\Container
+	 */
+	protected $container;
 
 	/**
 	 * Create a new database capsule manager.
 	 *
-	 * @param  \Illuminate\Container\Container  $container
+	 * @param  \Illuminate\Container\Container|null  $container
 	 * @return void
 	 */
 	public function __construct(Container $container = null)
@@ -46,7 +53,7 @@ class Manager {
 	/**
 	 * Setup the IoC container instance.
 	 *
-	 * @param  \Illuminate\Container\Container  $container
+	 * @param  \Illuminate\Container\Container|null  $container
 	 * @return void
 	 */
 	protected function setupContainer($container)

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -370,7 +370,7 @@ class Connection implements ConnectionInterface {
 	 */
 	public function unprepared($query)
 	{
-		return $this->run($query, array(), function($me, $query, $bindings)
+		return $this->run($query, array(), function($me, $query)
 		{
 			if ($me->pretending()) return true;
 

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -206,7 +206,7 @@ class ConnectionFactory {
 	 *
 	 * @throws \InvalidArgumentException
 	 */
-	protected function createConnection($driver, PDO $connection, $database, $prefix = '', $config = null)
+	protected function createConnection($driver, PDO $connection, $database, $prefix = '', array $config = array())
 	{
 		if ($this->container->bound($key = "db.connection.{$driver}"))
 		{

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -480,10 +480,9 @@ class Builder {
 	 *
 	 * @param  string  $column
 	 * @param  array   $values
-	 * @param  bool  $not
 	 * @return \Illuminate\Database\Query\Builder|static
 	 */
-	public function orWhereBetween($column, array $values, $not = false)
+	public function orWhereBetween($column, array $values)
 	{
 		return $this->whereBetween($column, $values, 'or');
 	}

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -119,8 +119,6 @@ class SqlServerGrammar extends Grammar {
 		// Next we need to calculate the constraints that should be placed on the query
 		// to get the right offset and limit from our query but if there is no limit
 		// set we will just handle the offset only since that is all that matters.
-		$start = $query->offset + 1;
-
 		$constraint = $this->compileRowConstraint($query);
 
 		$sql = $this->concatenate($components);


### PR DESCRIPTION
A few minor tweaks in this PR:
1. Forced `array` type for second parameter of `Illuminate\Cache\Tagset::__construct()`, given that it creates an instance member variable that has array-only functions used over it.
2. Renamed `$encrypter` instance member variable to `$cookies` in in `Illuminate\Cookie\Queue` because `$encrypter` property is never used while undefined `$cookies` property is. Note that, given PHP's implicit member variable rules, visibility was changed from `protected` to `public` per semantic versioning in case someone is actually using this property.
3. Added an instance member variable `$container` to `Illuminate\Database\Capsule\Manager` as it is used implicitly. As with above, `public` visibility to avoid breaking anyone who might have been using this because of its implicit definition.
4. Added enforcement of method argument type in protected method `Illuminate\Database\Connectors\ConnectionFactory->createConnection()` based on strict requirements for this variable as imposed by `\Illuminate\Database\Connection`, which is called from this method without this variable otherwise being changed to match signature.
5. Removed unused method argument in `Illuminate\Database\Query\Builder->orWhereBetween()`, which also aligns it with the argument signature of `Illuminate\Database\Query\Builder->orWhereNotBetween()`.
6. Removed unused local variable in `Illuminate\Database\Query\Grammars\SqlServerGrammar->compileAnsiOffset()`.
7. Removed unused argument of closure used internally within in `Illuminate\Database\Connection->unprepared()`.
8. Added phpdoc to annotate magic method calls available in `Illuminate\Cache\CacheManager` based on `Illuminate\Cache\StoreInterface`, which is the interface implemented by all the cache drivers.
9. Fixed phpdoc to denote null-accepting arguments in `Illuminate\Database\Capsule\Manager`.

Minor fixes, sure, but was just digging around a bit this morning so figured might as well..
