### PR TITLE
Issue 2005, DSN should be constructed differently between Windows and *nix

### DIFF
--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -42,7 +42,17 @@ class SqlServerConnector extends Connector implements ConnectorInterface {
 		// First we will create the basic DSN setup as well as the port if it is in
 		// in the configuration options. This will give us the basic DSN we will
 		// need to establish the PDO connections and return them back for use.
-		$port = isset($config['port']) ? ','.$port : '';
+
+                // Windows prefers a comma separating the host and port
+                // while *unix FreeTDS/DBlib requires a colon
+                if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+                {
+                        $port = isset($config['port']) ? ','.$port : '';
+                }
+                else
+                {
+                        $port = isset($config['port']) ? ':'.$port : '';
+                }
 
 		if (in_array('dblib', $this->getAvailableDrivers()))
 		{

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -123,7 +123,16 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 	{
 		extract($config);
 
-		$port = isset($config['port']) ? ','.$port : '';
+                // Windows prefers a comma separating the host and port
+                // while *unix FreeTDS/DBlib requires a colon
+                if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+                {
+                        $port = isset($config['port']) ? ','.$port : '';
+                }
+                else
+                {
+                        $port = isset($config['port']) ? ':'.$port : '';
+                }
 
 		if (in_array('dblib', PDO::getAvailableDrivers()))
 		{


### PR DESCRIPTION
Issue #2005

The dsn should be constructed differently between these 2 platforms.

Windows uses a comma before a port number, *nix uses a colon. Otherwise, users receive an  'Unknown host machine name' error.

References:

http://php.net/manual/de/ref.pdo-dblib.connection.php
http://forums.laravel.io/viewtopic.php?id=11033

My last PR was closed because it inadvertently  included a .gitignore file

I am re-submitting a proper PR
