### PR TITLE
fix count when the key is an attribute written in dot notation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -581,7 +581,7 @@ class Validator implements MessageProviderInterface {
 
 		foreach ($attributes as $key)
 		{
-			if (isset($this->data[$key]) || isset($this->files[$key]))
+			if ( ! is_null(array_get($this->data, $key, null)) || ! is_null(array_get($this->files, $key, null)))
 			{
 				$count++;
 			}


### PR DESCRIPTION
example:

..the view:

``` html
<input name="users[0][first_name]" value="" />
<input name="users[0][last_name]" value="Bar" />
<input name="users[1][first_name]" value="Foo" />
<input name="users[1][last_name]" value="Bar" />
```

..the controller:

``` php
// $input = array(
//     'users' => array(
//         array(
//             'first_name' => '',
//             'last_name' => 'Bar'
//         ),
//         array(
//             'first_name' => 'Foo',
//             'last_name' => 'Bar'
//         )
//     )
// );
$input = Input::all();
$rules = array(
    'users.0.first_name' => 'required_with:users.0.last_name', // without a fix this validation rule will fail
    'users.0.last_name' => '',
    'users.1.first_name' => 'required_with:users.1.last_name',
    'users.1.last_name' => ''
);
$validator = Validator::make($input, $rules);
```
