### PR TITLE
Update foreign key generation in belongsTo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -621,15 +621,14 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			$relation = $caller['function'];
 		}
 
-		// If no foreign key was supplied, we can use a backtrace to guess the proper
-		// foreign key name by using the name of the relationship function, which
-		// when combined with an "_id" should conventionally match the columns.
+		$instance = new $related;
+
+		// If no foreign key is supplied, we will get the foreign key of the related
+		// model and use that as the local key for a belongsTo relationship.
 		if (is_null($foreignKey))
 		{
-			$foreignKey = snake_case($relation).'_id';
+			$foreignKey = $instance->getForeignKey();
 		}
-
-		$instance = new $related;
 
 		// Once we have the foreign key names, we'll just create a new Eloquent query
 		// for the related models and returns the relationship instance which will


### PR DESCRIPTION
Now uses the `getForeignKey` method on the related model. This is useful when subclassing Eloquent and overriding key names while working with non-standard column names.

For example, if you have a BaseModel such as…

``` php
<?php

class BaseModel extends Eloquent {

  /**
   * Get the default foreign key name for the model.
   *
   * @return string
   */
  public function getForeignKey()
  {
    return lcfirst(class_basename($this)).'Id';
  }

}
```

With this subclass you can then use key names such as `authorId` or `userId` without needing to pass the foreign keys on every relationship declaration.
