### PR TITLE
[4.2] Don't allow relations to be accessed via snake case

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2233,11 +2233,9 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// If the "attribute" exists as a method on the model, we will just assume
 		// it is a relationship and will load and return results from the query
 		// and hydrate the relationship's value on the "relationships" array.
-		$camelKey = camel_case($key);
-
-		if (method_exists($this, $camelKey))
+		if (method_exists($this, $key))
 		{
-			return $this->getRelationshipFromMethod($key, $camelKey);
+			return $this->getRelationshipFromMethod($key);
 		}
 	}
 
@@ -2287,13 +2285,12 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	/**
 	 * Get a relationship value from a method.
 	 *
-	 * @param  string  $key
-	 * @param  string  $camelKey
+	 * @param  string  $method
 	 * @return mixed
 	 */
-	protected function getRelationshipFromMethod($key, $camelKey)
+	protected function getRelationshipFromMethod($method)
 	{
-		$relations = $this->$camelKey();
+		$relations = $this->$method();
 
 		if ( ! $relations instanceof Relation)
 		{
@@ -2301,7 +2298,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 				. 'Illuminate\Database\Eloquent\Relations\Relation');
 		}
 
-		return $this->relations[$key] = $relations->getResults();
+		return $this->relations[$method] = $relations->getResults();
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -745,7 +745,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	public function testGetModelAttributeMethodThrowsExceptionIfNotRelation()
 	{
 		$model = new EloquentModelStub;
-		$relation = $model->incorrect_relation_stub;
+		$relation = $model->incorrectRelationStub;
 	}
 
 


### PR DESCRIPTION
This is just a weird inconsistency that will catch you off guard. If you eager load a multi-word relationship (using camel case function names of course) but access it via snake case, it will bypass the eager loading.

The alternative is to move the converting of $key to camel case before checking if the key exists in the already loaded relations.
