### PR TITLE
Retrieve JSON as Collection instead of ParameterBag.

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Http;
 
+use Illuminate\Support\Collection;
 use Illuminate\Session\Store as SessionStore;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class Request extends SymfonyRequest {
@@ -430,7 +430,7 @@ class Request extends SymfonyRequest {
 	{
 		if ( ! isset($this->json))
 		{
-			$this->json = new ParameterBag((array) json_decode($this->getContent(), true));
+			$this->json = new Collection((array) json_decode($this->getContent(), true));
 		}
 
 		if (is_null($key)) return $this->json;
@@ -441,7 +441,7 @@ class Request extends SymfonyRequest {
 	/**
 	 * Get the input source for the request.
 	 *
-	 * @return \Symfony\Component\HttpFoundation\ParameterBag
+	 * @return mixed
 	 */
 	protected function getInputSource()
 	{


### PR DESCRIPTION
Previously the `Input::json()` was retrieved as a `Symfony ParameterBag` which meant that it was missing a number of retrieval methods that the Request uses for POST/GET data. Namely `only()` and `except()`.

I have replaced this with an `Illuminate\Support\Collection` to grant these new retrieval methods. All tests are passing, and the most useful methods of the parameterbag are present on the collection. It should offer a seamless move, unless someone is doing something very fiddly with it. :)
