### PR TITLE
[PROPOSAL] array_enkey()

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -464,6 +464,33 @@ if ( ! function_exists('array_where'))
 	}
 }
 
+if ( ! function_exists('array_enkey'))
+{
+    /**
+     * Return a keyed array using a specific value.
+     *
+     * @param  array  $array
+     * @param  string $key
+     * @param  bool   $preserve
+     *
+     * @return array
+     */
+    function array_enkey($array, $key, $preserve = true)
+    {
+        $keys = array_fetch($array, $key);
+
+        if ( ! $preserve)
+        {
+            foreach ($array as &$item)
+            {
+                array_forget($item, $key);
+            }
+        }
+
+        return array_combine($keys, $array);
+    }
+}
+
 if ( ! function_exists('asset'))
 {
 	/**


### PR DESCRIPTION
Add `array_enkey()` function.
I like a lot Eloquent Collection `lists()` function and  `array_enkey()` has in a way the same approach.

For this array:

``` php
// sample users
$users = array(
    array(
        'id'        => 'to',
        'firstname' => 'Taylor',
        'lastname'  => 'Otwell',
        'email'     => 'taylorotwell@gmail.com',
    ),
    array(
        'id'       => 'lm',
        'name'     => 'Lucas',
        'lastname' => 'Michot',
        'email'    => 'lucas@semalead.com',
    ),
);

// we choose to "enkey" this array using the email, and decide to preserve it
$preserved_keyed_users = array_enkey($users, 'email', true);

// printr_r($preserved_keyed_users);
array(
    'taylorotwell@gmail.com' => array(
        'id'        => 'to',
        'firstname' => 'Taylor',
        'lastname'  => 'Otwell',
        'email'     => 'taylorotwell@gmail.com',
    ),
    'lucas@semalead.com'     => array(
        'id'       => 'lm',
        'name'     => 'Lucas',
        'lastname' => 'Michot',
        'email'    => 'lucas@semalead.com',
    ),
);

// we "enkey" this array using the email, but we do not preserve it
$unpreserved_keyed_users = array_enkey($users, 'email', false);

// printr_r($unpreserved_keyed_users);
array(
    'taylorotwell@gmail.com' => array(
        'id'        => 'to',
        'firstname' => 'Taylor',
        'lastname'  => 'Otwell',
    ),
    'lucas@semalead.com'     => array(
        'id'       => 'lm',
        'name'     => 'Lucas',
        'lastname' => 'Michot',
    ),
);
```

**Note:**
This is a PR for 4.1 branch as this is not a breaking change.
