### PR TITLE
PHPUnit 3.8 For Laravel 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "iron-io/iron_mq": "1.4.*",
         "pda/pheanstalk": "2.1.*",
         "mockery/mockery": "0.8.0",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "classmap": [

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "illuminate/console": "4.2.*",
         "illuminate/routing": "4.2.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {"Illuminate\\Auth": ""}

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -13,7 +13,7 @@
         "nesbot/carbon": "1.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "3.8.*",
         "illuminate/database": "4.2.*",
         "illuminate/encryption": "4.2.*",
         "illuminate/filesystem": "4.2.*",

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -13,7 +13,7 @@
         "illuminate/support": "4.2.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {"Illuminate\\Config": ""}

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -11,7 +11,7 @@
         "symfony/console": "2.4.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -11,7 +11,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -22,7 +22,7 @@
         "illuminate/pagination": "4.2.*",
         "illuminate/support": "4.2.*",
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -12,7 +12,7 @@
         "illuminate/support": "4.2.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Exception/composer.json
+++ b/src/Illuminate/Exception/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "monolog/monolog": "1.6.*",
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -13,7 +13,7 @@
         "symfony/finder": "2.4.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -13,7 +13,7 @@
         "ircmaxell/password-compat": "1.0.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Html/composer.json
+++ b/src/Illuminate/Html/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "illuminate/events": "4.2.*",
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "illuminate/queue": "4.2.*",
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -19,7 +19,7 @@
         "illuminate/events": "4.2.*",
         "aws/aws-sdk-php": "2.5.*",
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -20,7 +20,7 @@
         "illuminate/console": "4.2.*",
         "illuminate/filesystem": "4.2.*",
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "illuminate/console": "4.2.*",
         "mockery/mockery": "0.8.0",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -13,7 +13,7 @@
     "require-dev": {
         "patchwork/utf8": "1.1.*",
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "illuminate/database": "4.2.*",
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Workbench/composer.json
+++ b/src/Illuminate/Workbench/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "illuminate/console": "4.2.*",
         "mockery/mockery": "0.7.2",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.8.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
PHPUnit 3.8 brings some new features and improved hhvm support. The offical release date for PHPUnit 3.8 is 7th March 2014, so it should be pretty solid before the release of Laravel 4.2 at the end of May.
