### PR TITLE
Fix nested Eloquent queries and softdeletes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -593,8 +593,6 @@ class Builder {
 	{
 		if ($column instanceof Closure)
 		{
-			// Get a new query builder instance but avoid including any soft
-			// delete constraints that could mess up the nested query.
 			$query = $this->model->newQuery(false);
 
 			call_user_func($column, $query);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -593,7 +593,9 @@ class Builder {
 	{
 		if ($column instanceof Closure)
 		{
-			$query = $this->model->newQuery();
+			// Get a new query builder instance but avoid including any soft
+			// delete constraints that could mess up the nested query.
+			$query = $this->model->newQuery(false);
 
 			call_user_func($column, $query);
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -339,7 +339,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$nestedRawQuery = $this->getMockQueryBuilder();
 		$nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
 		$model = $this->getMockModel()->makePartial();
-		$model->shouldReceive('newQuery')->once()->andReturn($nestedQuery);
+		$model->shouldReceive('newQuery')->with(false)->once()->andReturn($nestedQuery);
 		$builder = $this->getBuilder();
 		$builder->getQuery()->shouldReceive('from');
 		$builder->setModel($model);


### PR DESCRIPTION
Fixes #3403, possibly #3308

Currently the nested query builder will also have the soft delete "where", causing each nested where clause to have the same `where table.deleted_at is null`.
