### PR TITLE
Added $withBindings parameter to Builder::toSql()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -942,16 +942,12 @@ class Builder {
 
 		if ($withBindings)
 		{
-			$bindings = $this->bindings;
-			$pdo = $this->connection->getPdo();
+			$conn = $this->connection;
+			$bindings = $conn->prepareBindings($this->bindings);
+			$pdo = $conn->getPdo();
 
 			foreach ($bindings as $i => $binding)
 			{
-				if ($binding instanceof \DateTime)
-				{
-					$binding = $binding->format('Y-m-d H:i:s');
-				}
-
 				$bindings[$i] = $pdo->quote($binding) ?: sprintf("'%s'", str_replace("'", "\'", $binding));
 			}
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -933,11 +933,34 @@ class Builder {
 	/**
 	 * Get the SQL representation of the query.
 	 *
+     * @param  bool  $withBindings
 	 * @return string
 	 */
-	public function toSql()
+	public function toSql($withBindings = false)
 	{
-		return $this->grammar->compileSelect($this);
+		$sql = $this->grammar->compileSelect($this);
+
+		if ($withBindings)
+		{
+			$bindings = $this->bindings;
+			foreach ($bindings as $i => $binding)
+			{
+				if ($binding instanceof \DateTime)
+				{
+					$bindings[$i] = $binding->format('\'Y-m-d H:i:s\'');
+				}
+				else if (is_string($binding))
+				{
+					$bindings[$i] = sprintf("'%s'", str_replace("'", "\'", $binding));
+				}
+			}
+
+			// Insert bindings into query
+			$sql = str_replace(array('%', '?'), array('%%', '%s'), $sql);
+			$sql = vsprintf($sql, $bindings);
+        }
+
+		return $sql;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -949,7 +949,7 @@ class Builder {
 			{
 				if ($binding instanceof \DateTime)
 				{
-					$bindings = $binding->format('Y-m-d H:i:s');
+					$binding = $binding->format('Y-m-d H:i:s');
 				}
 
 				$bindings[$i] = $pdo->quote($binding) ?: sprintf("'%s'", str_replace("'", "\'", $binding));

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -943,16 +943,16 @@ class Builder {
 		if ($withBindings)
 		{
 			$bindings = $this->bindings;
+			$pdo = $this->connection->getPdo();
+
 			foreach ($bindings as $i => $binding)
 			{
 				if ($binding instanceof \DateTime)
 				{
-					$bindings[$i] = $binding->format('\'Y-m-d H:i:s\'');
+					$bindings = $binding->format('Y-m-d H:i:s');
 				}
-				else if (is_string($binding))
-				{
-					$bindings[$i] = sprintf("'%s'", str_replace("'", "\'", $binding));
-				}
+
+				$bindings[$i] = $pdo->quote($binding) ?: sprintf("'%s'", str_replace("'", "\'", $binding));
 			}
 
 			// Insert bindings into query

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -958,7 +958,7 @@ class Builder {
 			// Insert bindings into query
 			$sql = str_replace(array('%', '?'), array('%%', '%s'), $sql);
 			$sql = vsprintf($sql, $bindings);
-        }
+		}
 
 		return $sql;
 	}


### PR DESCRIPTION
Adds a $withBindings parameter so that the SQL returned by toSql() can be executed directly, or passed through to DB::raw() etc
