### PR TITLE
Allow queries to be supplied as tables

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -225,7 +225,9 @@ class Connection implements ConnectionInterface {
 
 		$query = new Query\Builder($this, $this->getQueryGrammar(), $processor);
 
-		return $query->from($table);
+		return func_num_args() == 1
+			? $query->from($table)
+			: call_user_func_array(array($query, 'from'), func_get_args());
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -210,7 +210,16 @@ class Builder {
 	 */
 	public function from($table)
 	{
-		$this->from = $table;
+		if (func_num_args() == 1)
+		{
+			$this->from = $table;
+		}
+		else if (func_get_arg(1) instanceof Builder)
+		{
+			$query = func_get_arg(1);
+			$this->from = $this->getConnection()->raw(sprintf('(%s) as `%s`', $query->toSql(), $table));
+			$this->mergeBindings($query);
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
Problem described here: http://laravel.io/forum/02-04-2014-select-from-query

This update allows a query to be passed through as the table to query from, in the format of:
DB::table('alias', $query)
