### PR TITLE
Conditional setQueue on Mailer

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -31,7 +31,12 @@ class MailServiceProvider extends ServiceProvider {
 			// for maximum testability on said classes instead of passing Closures.
 			$mailer = new Mailer($app['view'], $app['swift.mailer']);
 
-			$mailer->setLogger($app['log'])->setQueue($app['queue']);
+			$mailer->setLogger($app['log']);
+
+			if ($app->bound('queue'))
+			{
+				$mailer->setQueue($app['queue']);
+			}
 
 			$mailer->setContainer($app);
 


### PR DESCRIPTION
It's currently not possible to use the mailer without the queue manager being invoked. I have apps where I want to send mail but will never need the queue functionality.
