### PR TITLE
Added capsule manager for Queue.

### DIFF
--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -1,0 +1,210 @@
+<?php namespace Illuminate\Queue\Capsule;
+
+use Illuminate\Container\Container;
+use Illuminate\Queue\QueueManager;
+use Illuminate\Queue\QueueServiceProvider;
+use Illuminate\Support\Fluent;
+
+class Manager {
+
+    /**
+     * The current globally used instance.
+     *
+     * @var \Illuminate\Queue\Capsule\Manager
+     */
+    protected static $instance;
+
+    /**
+     * The queue manager instance.
+     *
+     * @var \Illuminate\Queue\QueueManager
+     */
+    protected $manager;
+
+    /**
+     * Create a new queue capsule manager.
+     *
+     * @param  \Illuminate\Container\Container  $container
+     * @return void
+     */
+    public function __construct(Container $container = null)
+    {
+        $this->setupContainer($container);
+
+        // Once we have the container setup, we will setup the default configuration
+        // options in the container "config" binding. This will make the queue
+        // manager behave correctly since all the correct binding are in place.
+        $this->setupDefaultConfiguration();
+
+        $this->setupManager();
+
+        $this->registerConnectors();
+    }
+
+    /**
+     * Setup the IoC container instance.
+     *
+     * @param  \Illuminate\Container\Container  $container
+     * @return void
+     */
+    protected function setupContainer($container)
+    {
+        $this->container = $container ?: new Container;
+
+        $this->container->instance('config', new Fluent);
+    }
+
+    /**
+     * Setup the default queue configuration options.
+     *
+     * @return void
+     */
+    protected function setupDefaultConfiguration()
+    {
+        $this->container['config']['queue.default'] = 'default';
+    }
+
+    /**
+     * Build the queue manager instance.
+     *
+     * @return void
+     */
+    protected function setupManager()
+    {
+        $this->manager = new QueueManager($this->container);
+    }
+
+    protected function registerConnectors()
+    {
+        $provider = new QueueServiceProvider($this->container);
+        $provider->registerConnectors($this->manager);
+    }
+
+    /**
+     * Get a connection instance from the global manager.
+     *
+     * @param  string  $connection
+     * @return \Illuminate\Queue\QueueInterface
+     */
+    public static function connection($connection = null)
+    {
+        return static::$instance->getConnection($connection);
+    }
+
+    /**
+     * Push a new job onto the queue.
+     *
+     * @param  string  $job
+     * @param  mixed   $data
+     * @param  string  $queue
+     * @return mixed
+     */
+    public static function push($job, $data = '', $queue = null, $connection = null)
+    {
+        return static::$instance->connection($connection)->push($job, $data, $queue);
+    }
+
+    /**
+     * Push a new an array of jobs onto the queue.
+     *
+     * @param  array  $jobs
+     * @param  mixed  $data
+     * @param  string  $queue
+     * @return mixed
+     */
+    public static function bulk($jobs, $data = '', $queue = null, $connection = null)
+    {
+        return static::$instance->connection($connection)->bulk($jobs, $data, $queue);
+    }
+
+    /**
+     * Push a new job onto the queue after a delay.
+     *
+     * @param  \DateTime|int  $delay
+     * @param  string  $job
+     * @param  mixed  $data
+     * @param  string  $queue
+     * @return mixed
+     */
+    public static function later($delay, $job, $data = '', $queue = null, $connection = null)
+    {
+        return static::$instance->connection($connection)->later($delay, $job, $data, $queue);
+    }
+
+    /**
+     * Get a registered connection instance.
+     *
+     * @param  string  $name
+     * @return \Illuminate\Queue\QueueInterface
+     */
+    public function getConnection($name = null)
+    {
+        return $this->manager->connection($name);
+    }
+
+    /**
+     * Register a connection with the manager.
+     *
+     * @param  array   $config
+     * @param  string  $name
+     * @return void
+     */
+    public function addConnection(array $config, $name = 'default')
+    {
+        $this->container['config']["queue.connections.{$name}"] = $config;
+    }
+
+    /**
+     * Make this capsule instance available globally.
+     *
+     * @return void
+     */
+    public function setAsGlobal()
+    {
+        static::$instance = $this;
+    }
+
+    /**
+     * Get the queue manager instance.
+     *
+     * @return \Illuminate\Queue\Manager
+     */
+    public function getQueueManager()
+    {
+        return $this->manager;
+    }
+
+    /**
+     * Get the IoC container instance.
+     *
+     * @return \Illuminate\Container\Container
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
+     * Set the IoC container instance.
+     *
+     * @param  \Illuminate\Container\Container  $container
+     * @return void
+     */
+    public function setContainer(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Dynamically pass methods to the default connection.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     */
+    public static function __callStatic($method, $parameters)
+    {
+        return call_user_func_array(array(static::connection(), $method), $parameters);
+    }
+
+}

--- a/src/Illuminate/Queue/README.md
+++ b/src/Illuminate/Queue/README.md
@@ -1,0 +1,30 @@
+## Illuminate Queue
+
+The Laravel Queue component provides a unified API across a variety of different queue services. Queues allow you to defer the processing of a time consuming task, such as sending an e-mail, until a later time, thus drastically speeding up the web requests to your application.
+
+### Usage Instructions
+
+First, create a new "Capsule" manager instance. Capsule aims to make configuring the library for usage outside of the Laravel framework as easy as possible.
+
+```PHP
+use Illuminate\Queue\Capsule\Manager as Capsule;
+
+$capsule = new Capsule;
+
+$capsule->addConnection([
+    'driver' => 'beanstalkd',
+    'host'   => 'localhost',
+    'queue'  => 'default',
+]);
+
+// Make this Capsule instance available globally via static methods... (optional)
+$capsule->setAsGlobal();
+```
+
+Once the Capsule instance has been registered. You may use it like so:
+
+```PHP
+$users = Capsule::push('SendEmail', array('message' => $message));
+```
+
+For further documentation on using the queue, consult the [Laravel framework documentation](http://laravel.com/docs).


### PR DESCRIPTION
Added a capsule manager for the Queue component to simplify usage outside of Laravel. It only supports the pushing side of the component since the listener is really dependant of artisan.
