### PR TITLE
Making nested where query not exclude deleted

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -593,7 +593,7 @@ class Builder {
 	{
 		if ($column instanceof Closure)
 		{
-			$query = $this->model->newQuery();
+			$query = $this->model->newQuery(false);
 
 			call_user_func($column, $query);
 


### PR DESCRIPTION
Let's say we have a model with  $softDelete = true;

The query builder automatically accounts for the deleted_at column.

This:

```
    $titles = Title::select(array('titles.id', 'titles.name', 'titles.date_published', 'titles.publisher'));

    $titles->where(function($query) {
        $query->orWhere('titles.id', '=', 1);
        $query->orWhere('titles.name', '=', 'Test');
    });
```

Currently generates this query:

select `titles`.`id`, `titles`.`name`, `titles`.`date_published`, `titles`.`publisher` from `titles` where `titles`.`deleted_at` is null and (`titles`.`deleted_at` is null or `titles`.`id` = `1` or `titles`.`name` = `Test`)

The nested where query includes a duplicate check for deleted_at being null.

When this new nested query is created, it should be set to not exclude deleted.  With my change, the following query is now returned.

select `titles`.`id`, `titles`.`name`, `titles`.`date_published`, `titles`.`publisher` from `titles` where `titles`.`deleted_at` is null and (`titles`.`id` = `1` or `titles`.`name` = `Test`)
