### PR TITLE
Update Mockery dependency to 0.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "aws/aws-sdk-php": "2.5.*",
         "iron-io/iron_mq": "1.4.*",
         "pda/pheanstalk": "2.1.*",
-        "mockery/mockery": "0.8.0",
+        "mockery/mockery": "0.9.0",
         "phpunit/phpunit": "3.7.*"
     },
     "autoload": {


### PR DESCRIPTION
This gets Laravel a 100% pass rate on HHVM 2.4.0 (see #3377)

This will fail against HHVM on Travis as they're still using 2.3
