### PR TITLE
Update Mockery dependency to 0.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "aws/aws-sdk-php": "2.5.*",
         "iron-io/iron_mq": "1.4.*",
         "pda/pheanstalk": "2.1.*",
-        "mockery/mockery": "0.8.0",
+        "mockery/mockery": "0.9.0",
         "phpunit/phpunit": "3.7.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "aws/aws-sdk-php": "2.5.*",
         "iron-io/iron_mq": "1.4.*",
         "pda/pheanstalk": "2.1.*",
-        "mockery/mockery": "0.9.0",
+        "mockery/mockery": "0.9",
         "phpunit/phpunit": "3.7.*"
     },
     "autoload": {

--- a/src/Illuminate/Remote/composer.json
+++ b/src/Illuminate/Remote/composer.json
@@ -13,7 +13,7 @@
         "phpseclib/phpseclib": "0.3.*"
     },
     "require-dev": {
-        "mockery/mockery": "0.9.0"
+        "mockery/mockery": "0.9"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Remote/composer.json
+++ b/src/Illuminate/Remote/composer.json
@@ -13,7 +13,7 @@
         "phpseclib/phpseclib": "0.3.*"
     },
     "require-dev": {
-        "mockery/mockery": "0.8.0"
+        "mockery/mockery": "0.9.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "illuminate/console": "4.1.*",
-        "mockery/mockery": "0.8.0",
+        "mockery/mockery": "0.9.0",
         "phpunit/phpunit": "3.7.*"
     },
     "autoload": {

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "illuminate/console": "4.1.*",
-        "mockery/mockery": "0.9.0",
+        "mockery/mockery": "0.9",
         "phpunit/phpunit": "3.7.*"
     },
     "autoload": {


### PR DESCRIPTION
Changes since last pull request:
- against 4.1, not master
- change all the composer.json files

```
find -name composer.json | grep -v vendor | xargs sed -i
's,"mockery/mockery": "0.8.0","mockery/mockery": "0.9.0",'
```

Mockery 0.9.0 supports HHVM 2.4.0 - Laravel gets a 100% pass with it. Will
still fail on Travis, as they're running 2.3.
