### PR TITLE
Allow environment variables to be accessed via `getenv()` function.

### DIFF
--- a/src/Illuminate/Config/EnvironmentVariables.php
+++ b/src/Illuminate/Config/EnvironmentVariables.php
@@ -37,6 +37,8 @@ class EnvironmentVariables {
 			$_ENV[$key] = $value;
 
 			$_SERVER[$key] = $value;
+
+			putenv("{$key}={$value}");
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: crynobone crynobone@gmail.com
