### PR TITLE
Fix date parsing format for PGSQL 9.3

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -172,5 +172,15 @@ class PostgresGrammar extends Grammar {
 	{
 		return array('truncate '.$this->wrapTable($query->from).' restart identity' => array());
 	}
+	
+	/**
+	 * Get the format for database stored dates.
+	 *
+	 * @return string
+	 */
+	public function getDateFormat()
+	{
+		return 'Y-m-d H:i:s.000';
+	}
 
 }


### PR DESCRIPTION
On PostgreSQL 9.3, the default timestamp format is `Y-m-d H:i:s.000` like that of SQL Server, causing `IllegalArgumentException: Trailing data` when attempting to read timestamp columns from Eloquent models. This commit overrides the default behavior for correct parsing of timestamps.
