### PR TITLE
Exception on missing argument for View::withSomething

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -371,6 +371,12 @@ class View implements ArrayAccess, Renderable {
 	{
 		if (starts_with($method, 'with'))
 		{
+			if ( ! isset($parameters[0]))
+			{
+				$class = get_class($this);
+				throw new \InvalidArgumentException("Missing argument 1 for {$class}::{$method}");
+			}
+
 			return $this->with(snake_case(substr($method, 4)), $parameters[0]);
 		}
 


### PR DESCRIPTION
The number 1 culprit here is new people doing `View::make(...)->withInput()`. Currently if you do this you get a fatal error of `undefined index: 0`
