### PR TITLE
exception displayers should not ignore custom headers

### DIFF
--- a/src/Illuminate/Exception/PlainDisplayer.php
+++ b/src/Illuminate/Exception/PlainDisplayer.php
@@ -15,8 +15,9 @@ class PlainDisplayer implements ExceptionDisplayerInterface {
 	public function display(Exception $exception)
 	{
 		$status = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
+		$headers = $exception instanceof HttpExceptionInterface ? $exception->getHeaders() : array();
 
-		return new Response(file_get_contents(__DIR__.'/resources/plain.html'), $status);
+		return new Response(file_get_contents(__DIR__.'/resources/plain.html'), $status, $headers);
 	}
 
 }

--- a/src/Illuminate/Exception/WhoopsDisplayer.php
+++ b/src/Illuminate/Exception/WhoopsDisplayer.php
@@ -43,8 +43,9 @@ class WhoopsDisplayer implements ExceptionDisplayerInterface {
 	public function display(Exception $exception)
 	{
 		$status = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
+		$headers = $exception instanceof HttpExceptionInterface ? $exception->getHeaders() : array();
 
-		return new Response($this->whoops->handleException($exception), $status);
+		return new Response($this->whoops->handleException($exception), $status, $headers);
 	}
 
 }

--- a/tests/Exception/PlainDisplayerTest.php
+++ b/tests/Exception/PlainDisplayerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Exception\PlainDisplayer;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class PlainDisplayerTest extends PHPUnit_Framework_TestCase {
+
+	public function testStatusAndHeadersAreSetInResponse()
+	{
+		$displayer = new PlainDisplayer;
+		$headers = array('X-My-Test-Header' => 'HeaderValue');
+		$exception = new HttpException(401, 'Unauthorized', null, $headers);
+		$response = $displayer->display($exception);
+
+		$this->assertTrue($response->headers->has('X-My-Test-Header'), "response headers should include headers provided to the exception");
+		$this->assertEquals('HeaderValue', $response->headers->get('X-My-Test-Header'), "response header values should match those provided to the exception");
+		$this->assertEquals(401, $response->getStatusCode(), "response status should match the status provided to the exception");
+	}
+
+}

--- a/tests/Exception/WhoopsDisplayerTest.php
+++ b/tests/Exception/WhoopsDisplayerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Exception\WhoopsDisplayer;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Whoops\Run;
+use Mockery as m;
+
+class WhoopsDisplayerTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function testStatusAndHeadersAreSetInResponse()
+	{
+		$mockWhoops = m::mock('Whoops\Run[handleException]');
+		$mockWhoops->shouldReceive('handleException')->andReturn('response content');
+		$displayer = new WhoopsDisplayer($mockWhoops, false);
+		$headers = array('X-My-Test-Header' => 'HeaderValue');
+		$exception = new HttpException(401, 'Unauthorized', null, $headers);
+		$response = $displayer->display($exception);
+
+		$this->assertTrue($response->headers->has('X-My-Test-Header'), "response headers should include headers provided to the exception");
+		$this->assertEquals('HeaderValue', $response->headers->get('X-My-Test-Header'), "response header values should match those provided to the exception");
+		$this->assertEquals(401, $response->getStatusCode(), "response status should match the status provided to the exception");
+	}
+
+}


### PR DESCRIPTION
When attempting to send headers to an `App::abort()` the correct status is set in the response, but the headers are not. For example:

```
App::abort(401, '', array('X-Some-Custom-Header' => 'Bazinga'));
```

This results in the proper `HTTP/1.1 401 Unauthorized` response, and automatic headers like `X-Frame-Options` and `Set-Cookie` are set. However the custom headers provided to `App::abort()` are ignored.

The problem seems to be in `Illuminate\Exception\WhoopsDisplayer` (when in debug mode) and `Illuminate\Exception\PlainDisplayer` (when not in debug mode). They are correctly reading the status code from the `HttpException` and setting it in the response, but they are not doing so for the `HttpException`'s headers.
