### PR TITLE
Support for lazy eager loading polymorphic relationships from a collection.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -596,7 +596,9 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		$localKey = $localKey ?: $this->getKeyName();
 
-		return new MorphOne($instance->newQuery(), $this, $table.'.'.$type, $table.'.'.$id, $localKey);
+		$relation = new MorphOne($instance->newQuery(), $this, $table.'.'.$type, $table.'.'.$id, $localKey);
+		$relation->polymorph = array('type' => $type, 'id' => $id);
+		return $relation;
 	}
 
 	/**
@@ -667,7 +669,9 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		$class = $this->$type;
 
-		return $this->belongsTo($class, $id);
+		$relation = $this->belongsTo($class, $id);
+		$relation->polymorph = array('type' => $type, 'id' => $id);
+		return $relation;
 	}
 
 	/**
@@ -732,7 +736,9 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		$localKey = $localKey ?: $this->getKeyName();
 
-		return new MorphMany($instance->newQuery(), $this, $table.'.'.$type, $table.'.'.$id, $localKey);
+		$relation = new MorphMany($instance->newQuery(), $this, $table.'.'.$type, $table.'.'.$id, $localKey);
+		$relation->polymorph = array('type' => $type, 'id' => $id);
+		return $relation;
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -79,7 +79,7 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 	{
 		$c = $this->getMock('Illuminate\Database\Eloquent\Collection', array('first'), array(array('foo')));
 		$mockItem = m::mock('StdClass');
-		$c->expects($this->once())->method('first')->will($this->returnValue($mockItem));
+		$c->expects($this->exactly(3))->method('first')->will($this->returnValue($mockItem));
 		$mockItem->shouldReceive('newQuery')->once()->andReturn($mockItem);
 		$mockItem->shouldReceive('with')->with(array('bar', 'baz'))->andReturn($mockItem);
 		$mockItem->shouldReceive('eagerLoadRelations')->once()->with(array('foo'))->andReturn(array('results'));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -660,12 +660,12 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	{
 		$model = m::mock('Illuminate\Database\Eloquent\Model[belongsTo]');
 		$model->foo_type = 'FooClass';
-		$model->shouldReceive('belongsTo')->with('FooClass', 'foo_id');
+		$model->shouldReceive('belongsTo')->with('FooClass', 'foo_id')->andReturn(new StdClass);
 		$relation = $model->morphTo('foo');
 
 		$model = m::mock('EloquentModelStub[belongsTo]');
 		$model->morph_to_stub_type = 'FooClass';
-		$model->shouldReceive('belongsTo')->with('FooClass', 'morph_to_stub_id');
+		$model->shouldReceive('belongsTo')->with('FooClass', 'morph_to_stub_id')->andReturn(new StdClass);
 		$relation = $model->morphToStub();
 	}
 


### PR DESCRIPTION
Adds support for lazy eager loading of polymorphic relationships from a collection.

For example a report may be owned by a User, or a Team so would have

```
class Report extends Eloquent {

    public function owner()
    {
        return $this->morphTo('owner');
    }

}
```

This would function correctly for a single model e.g. `Report::find(1)->owner`

However `Report::all()->owner` would almost function correctly. It would however have the quirk of
assuming all owners of the reports are the same type as the first model in the collection.
This patch fixes that by splitting each collection into it's own sub collection, loading the relationship
on that collection and the remerging the sub collections together.

This patch also adds a new `polymorph` property onto polymorphic relationships to mark them as polymorphic and
provide the required information (id column name and type column name) of the polymorphic relationships.

One test had to be altered due to this change as it was mocking the belongsTo method and causing it not to return
anything which threw an error when we tried to set a property on the returned relationship.

Another test had to be changed to account for the extra calls to ->first() on the collection.

This should fix [laravel/laravel#1681](https://github.com/laravel/laravel/issues/1681) and is similar to #3038 Although I have had reports that #3038 is outdated so I am proposing this version. Note that I have created this before I saw the mentioned pull request so it is not based on the above pull request.
