### PR TITLE
Update MySqlConnector.php to support Sphinx

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -26,7 +26,7 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 		// is set on the server but needs to be set here on this client objects.
 		$charset = $config['charset'];
 
-		$names = "set names '$charset' collate '$collation'";
+		$names = "set names '$charset'".($collation!==null ? " collate '$collation'" : null);
 
 		$connection->prepare($names)->execute();
 


### PR DESCRIPTION
Sphinx is one of the 4 main search engines PHP has documented and provides classes for.

http://www.php.net/manual/en/refs.search.php

Sphinx uses the mysql protocol as an interface.  The problem is when passing collate the connection to sphinx fails.  The patch will not include collate in the connection if in the config file its set to null.

Thank you

(Original Ticket #3519)
