### PR TITLE
Enabled logging of cc and bcc in pretend mail mode

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -315,7 +315,11 @@ class Mailer {
 	 */
 	protected function logMessage($message)
 	{
-		$emails = implode(', ', array_keys((array) $message->getTo()));
+		$emails = implode(', ', array_merge(
+			array_keys((array) $message->getTo()),
+			array_keys((array) $message->getCc()),
+			array_keys((array) $message->getBcc())
+		));
 
 		$this->logger->info("Pretending to mail message to: {$emails}");
 	}


### PR DESCRIPTION
When pretend mode is enabled in the mail config, cc and bcc addresses
are now logged.

This gives are true picture of what is actually being sent when pretend mode is off.
