### PR TITLE
[Proposal] add getters for Blade's contentTags and escapedContentTags

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -485,4 +485,24 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 		$this->setContentTags($openTag, $closeTag, true);
 	}
 
+	/**
+	 * Gets the content tags used for the compiler.
+	 *
+	 * @return string
+	 */
+	public function getContentTags()
+	{
+		return $this->contentTags;
+	}
+
+	/**
+	 * Gets the escaped content tags used for the compiler.
+	 *
+	 * @return string
+	 */
+	public function getEscapedContentTags()
+	{
+		return $this->escapedTags;
+	}
+
 }


### PR DESCRIPTION
Some people that are using Javascript front end frameworks are changing the Blade content tags using the `Blade:setContentTags('[[', ']]')` and `Blade:setEscapedContentTags('[[[', ']]]')` which sets a different set of tags for defining Blade syntax in a view.

Currently there are only setters for the `contentTags` protected properties of the `BladeCompiler` class. Therefore, it is not easily possible to retrieve these values with something like `Blade:getContentTags()` and `Blade:setEscapedContentTags()`.
