### PR TITLE
Minor Composer Tweak

### DIFF
--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -11,7 +11,7 @@
         "php": ">=5.4.0",
         "illuminate/encryption": "4.2.*",
         "illuminate/support": "4.2.*",
-        "symfony/http-kernel": "2.4.x",
+        "symfony/http-kernel": "2.4.*",
         "symfony/http-foundation": "2.4.*"
     },
     "require-dev": {

--- a/src/Illuminate/Exception/composer.json
+++ b/src/Illuminate/Exception/composer.json
@@ -11,7 +11,7 @@
         "php": ">=5.4.0",
         "filp/whoops": "1.0.10",
         "illuminate/support": "4.2.*",
-        "symfony/http-foundation": "2.4.x",
+        "symfony/http-foundation": "2.4.*",
         "symfony/http-kernel": "2.4.*"
     },
     "require-dev": {


### PR DESCRIPTION
Renamed "2.4.x" to "2.4.*". This change was made on 4.1, but was incorrectly merged into 4.2.
