### PR TITLE
Updated date validator for Relative Date formats.

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1136,9 +1136,7 @@ class Validator implements MessageProviderInterface {
 
 		if (strtotime($value) === false) return false;
 
-		$date = date_parse($value);
-
-		return checkdate($date['month'], $date['day'], $date['year']);
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Date validator is warning when using date relative, but `strtotime` isn't false. `date_parse` can't parse relative date. So it will help that remove `date_parse` line for return true when date relative using.
