### PR TITLE
Date attributes retrieved from Model::attributesToArray() was not converted to Carbon instances according to Model::getDates()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2088,13 +2088,27 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// We want to spin through all the mutated attributes for this model and call
 		// the mutator for the attribute. We cache off every mutated attributes so
 		// we don't have to constantly check on attributes that actually change.
-		foreach ($this->getMutatedAttributes() as $key)
+		$mutated = $this->getMutatedAttributes();
+		foreach ($mutated as $key)
 		{
 			if ( ! array_key_exists($key, $attributes)) continue;
 
 			$attributes[$key] = $this->mutateAttribute(
 				$key, $attributes[$key]
 			);
+		}
+
+		// If the attribute is listed as a date, we will convert it to a DateTime
+		// instance on retrieval, which makes it quite convenient to work with
+		// date fields without having to create a mutator for each property
+		$dates = array_diff(
+			array_intersect($this->getDates(), array_keys($attributes)),
+			$mutated
+		);
+		foreach($dates as $key) {
+			if (isset($attributes[$key])) {
+				$attributes[$key] = $this->asDateTime($attributes[$key]);
+			}
 		}
 
 		// Here we will grab all of the appended, calculated attributes to this model
@@ -2712,7 +2726,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		if (isset(static::$mutatorCache[$class]))
 		{
-			return static::$mutatorCache[get_class($this)];
+			return static::$mutatorCache[$class];
 		}
 
 		return array();


### PR DESCRIPTION
Bugfix with forgotten date converting in Model::attributesToArray() and + minor improvement in Model::getMutatedAttributes() logic
