### PR TITLE
Add $options array to Queue::push for Iron.io jobs.

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -39,11 +39,12 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed   $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function push($job, $data = '', $queue = null)
+	public function push($job, $data = '', $queue = null, array $options = array())
 	{
-		return $this->pushRaw($this->createPayload($job, $data), $queue);
+		return $this->pushRaw($this->createPayload($job, $data), $queue, $options);
 	}
 
 	/**
@@ -66,9 +67,10 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed  $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function later($delay, $job, $data = '', $queue = null)
+	public function later($delay, $job, $data = '', $queue = null, array $options = array())
 	{
 		$payload = $this->createPayload($job, $data);
 

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -102,7 +102,7 @@ class IronQueue extends Queue implements QueueInterface {
 	 */
 	public function recreate($payload, $queue = null, $delay, array $options = array())
 	{
-		$options[] = array('delay' => $this->getSeconds($delay));
+		$options['delay'] = $this->getSeconds($delay);
 
 		return $this->pushRaw($payload, $queue, $options);
 	}

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -68,11 +68,12 @@ class IronQueue extends Queue implements QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed   $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function push($job, $data = '', $queue = null)
+	public function push($job, $data = '', $queue = null, array $options = array())
 	{
-		return $this->pushRaw($this->createPayload($job, $data, $queue), $queue);
+		return $this->pushRaw($this->createPayload($job, $data, $queue), $queue, $options);
 	}
 
 	/**
@@ -96,11 +97,12 @@ class IronQueue extends Queue implements QueueInterface {
 	 * @param  string  $payload
 	 * @param  string  $queue
 	 * @param  int  $delay
+	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function recreate($payload, $queue = null, $delay)
+	public function recreate($payload, $queue = null, $delay, array $options = array())
 	{
-		$options = array('delay' => $this->getSeconds($delay));
+		$options[] = array('delay' => $this->getSeconds($delay));
 
 		return $this->pushRaw($payload, $queue, $options);
 	}
@@ -112,15 +114,16 @@ class IronQueue extends Queue implements QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed  $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function later($delay, $job, $data = '', $queue = null)
+	public function later($delay, $job, $data = '', $queue = null, array $options = array())
 	{
 		$delay = $this->getSeconds($delay);
 
 		$payload = $this->createPayload($job, $data, $queue);
 
-		return $this->pushRaw($payload, $this->getQueue($queue), compact('delay'));
+		return $this->pushRaw($payload, $this->getQueue($queue), compact('delay'), $options);
 	}
 
 	/**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -30,13 +30,14 @@ abstract class Queue {
 	 * @param  array  $jobs
 	 * @param  mixed  $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function bulk($jobs, $data = '', $queue = null)
+	public function bulk($jobs, $data = '', $queue = null, array $options = array())
 	{
 		foreach ((array) $jobs as $job)
 		{
-			$this->push($job, $data, $queue);
+			$this->push($job, $data, $queue, $options);
 		}
 	}
 

--- a/src/Illuminate/Queue/QueueInterface.php
+++ b/src/Illuminate/Queue/QueueInterface.php
@@ -8,9 +8,10 @@ interface QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed   $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function push($job, $data = '', $queue = null);
+	public function push($job, $data = '', $queue = null, array $options = array());
 
 	/**
 	 * Push a raw payload onto the queue.
@@ -29,9 +30,10 @@ interface QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed  $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function later($delay, $job, $data = '', $queue = null);
+	public function later($delay, $job, $data = '', $queue = null, array $options = array());
 
 	/**
 	 * Pop the next job off of the queue.

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -47,11 +47,12 @@ class RedisQueue extends Queue implements QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed   $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return void
 	 */
-	public function push($job, $data = '', $queue = null)
+	public function push($job, $data = '', $queue = null, array $options = array())
 	{
-		return $this->pushRaw($this->createPayload($job, $data), $queue);
+		return $this->pushRaw($this->createPayload($job, $data), $queue, $options);
 	}
 
 	/**
@@ -74,9 +75,10 @@ class RedisQueue extends Queue implements QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed  $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return void
 	 */
-	public function later($delay, $job, $data = '', $queue = null)
+	public function later($delay, $job, $data = '', $queue = null, array $options = array())
 	{
 		$payload = $this->createPayload($job, $data);
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -38,11 +38,12 @@ class SqsQueue extends Queue implements QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed   $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function push($job, $data = '', $queue = null)
+	public function push($job, $data = '', $queue = null, array $options = array())
 	{
-		return $this->pushRaw($this->createPayload($job, $data), $queue);
+		return $this->pushRaw($this->createPayload($job, $data), $queue, $options);
 	}
 
 	/**
@@ -67,9 +68,10 @@ class SqsQueue extends Queue implements QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed  $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function later($delay, $job, $data = '', $queue = null)
+	public function later($delay, $job, $data = '', $queue = null, array $options = array())
 	{
 		$payload = $this->createPayload($job, $data);
 

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -8,9 +8,10 @@ class SyncQueue extends Queue implements QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed   $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function push($job, $data = '', $queue = null)
+	public function push($job, $data = '', $queue = null, array $options = array())
 	{
 		$this->resolveJob($job, $data)->fire();
 
@@ -37,11 +38,12 @@ class SyncQueue extends Queue implements QueueInterface {
 	 * @param  string  $job
 	 * @param  mixed  $data
 	 * @param  string  $queue
+	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function later($delay, $job, $data = '', $queue = null)
+	public function later($delay, $job, $data = '', $queue = null, array $options = array())
 	{
-		return $this->push($job, $data, $queue);
+		return $this->push($job, $data, $queue, $options);
 	}
 
 	/**


### PR DESCRIPTION
Allows for params to be passed in such as 'timeout' and 'expires_in'.  The 'timeout' option fixes an issue for jobs running longer than the default 60 seconds. They timeout and get submitted again, which causes multiple jobs to run.
