### PR TITLE
Fix type hint of UrlGenerator

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Routing;
 
 use InvalidArgumentException;
-use Symfony\Component\HttpFoundation\Request;
+use Illuminate\Http\Request;
 
 class UrlGenerator {
 
@@ -15,7 +15,7 @@ class UrlGenerator {
 	/**
 	 * The request instance.
 	 *
-	 * @var \Symfony\Component\HttpFoundation\Request
+	 * @var \Illuminate\Http\Request
 	 */
 	protected $request;
 


### PR DESCRIPTION
It is implied the UrlGenerator needs an instance of a Symfony request but that's not actually true because some methods that are called by the class (such as `$this->request->root()`) only exist on Illuminate requests.
