### PR TITLE
Fixed issue using whereHas with HasManyThrough Relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Collection;
 
 class HasManyThrough extends Relation {
@@ -71,9 +72,15 @@ class HasManyThrough extends Relation {
 	 */
 	public function getRelationCountQuery(Builder $query, Builder $parent)
 	{
+		$parentTable = $this->parent->getTable();
+
 		$this->setJoin($query);
 
-		return parent::getRelationCountQuery($query, $parent);
+		$query->select(new Expression('count(*)'));
+
+		$key = $this->wrap($parentTable.'.'.$this->farParent->getForeignKey());
+
+		return $query->where($this->getHasCompareKey(), '=', new Expression($key));
 	}
 
 	/**


### PR DESCRIPTION
Fixes issue #3560

This PR fixed my issue, however I'm worried line 81 might cause issues if the parent key doesn't follow conventions. Any comments?

```
$key = $this->wrap($parentTable.'.'.$this->farParent->getForeignKey());
```
