### PR TITLE
Support languages like Hebrew

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -121,7 +121,7 @@ class Request extends SymfonyRequest {
 	{
 		foreach (func_get_args() as $pattern)
 		{
-			if (str_is($pattern, $this->path()))
+			if (str_is(urldecode($pattern), urldecode($this->path())))
 			{
 				return true;
 			}


### PR DESCRIPTION
Without urldecode() the compare look like this:
$pattern = 'אודות'
$this->path = '%d7%90%d7%95%d7%93%d7%95%d7%aa'
So it will always fail.
With urldecode() it look like this:
$pattern = 'אודות'
$this->path = 'אודות'
As it should be :)
