### PR TITLE
Docblock Fixes

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -66,9 +66,9 @@ class Repository implements ArrayAccess {
 	/**
 	 * Store an item in the cache.
 	 *
-	 * @param  string              $key
-	 * @param  mixed               $value
-	 * @param  Carbon|Datetime|int $minutes
+	 * @param  string         $key
+	 * @param  mixed          $value
+	 * @param  \DateTime|int  $minutes
 	 * @return void
 	 */
 	public function put($key, $value, $minutes)
@@ -81,9 +81,9 @@ class Repository implements ArrayAccess {
 	/**
 	 * Store an item in the cache if the key does not exist.
 	 *
-	 * @param  string              $key
-	 * @param  mixed               $value
-	 * @param  Carbon|Datetime|int $minutes
+	 * @param  string         $key
+	 * @param  mixed          $value
+	 * @param  \DateTime|int  $minutes
 	 * @return bool
 	 */
 	public function add($key, $value, $minutes)
@@ -99,9 +99,9 @@ class Repository implements ArrayAccess {
 	/**
 	 * Get an item from the cache, or store the default value.
 	 *
-	 * @param  string              $key
-	 * @param  Carbon|Datetime|int $minutes
-	 * @param  Closure             $callback
+	 * @param  string         $key
+	 * @param  \DateTime|int  $minutes
+	 * @param  Closure        $callback
 	 * @return mixed
 	 */
 	public function remember($key, $minutes, Closure $callback)
@@ -232,7 +232,7 @@ class Repository implements ArrayAccess {
 	/**
 	 * Calculate the number of minutes with the given duration.
 	 *
-	 * @param  Carbon|DateTime|int  $duration
+	 * @param  \DateTime|int  $duration
 	 * @return int
 	 */
 	protected function getMinutes($duration)

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -72,9 +72,9 @@ class TaggedCache implements StoreInterface {
 	/**
 	 * Store an item in the cache if the key does not exist.
 	 *
-	 * @param  string  $key
-	 * @param  mixed  $value
-	 * @param  Carbon|Datetime|int $minutes
+	 * @param  string         $key
+	 * @param  mixed          $value
+	 * @param  \DateTime|int  $minutes
 	 * @return bool
 	 */
 	public function add($key, $value, $minutes)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1102,8 +1102,8 @@ class Builder {
 	/**
 	 * Indicate that the query results should be cached.
 	 *
-	 * @param  \Carbon\Carbon|\Datetime|int  $minutes
-	 * @param  string  $key
+	 * @param  \DateTime|int  $minutes
+	 * @param  string         $key
 	 * @return \Illuminate\Database\Query\Builder|static
 	 */
 	public function remember($minutes, $key = null)

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -24,7 +24,7 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 	 * Create a new Beanstalkd queue instance.
 	 *
 	 * @param  Pheanstalk  $pheanstalk
-	 * @param  string  $default
+	 * @param  string      $default
 	 * @return void
 	 */
 	public function __construct(Pheanstalk $pheanstalk, $default)
@@ -63,9 +63,9 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 	 * Push a new job onto the queue after a delay.
 	 *
 	 * @param  \DateTime|int  $delay
-	 * @param  string  $job
-	 * @param  mixed  $data
-	 * @param  string  $queue
+	 * @param  string         $job
+	 * @param  mixed          $data
+	 * @param  string         $queue
 	 * @return mixed
 	 */
 	public function later($delay, $job, $data = '', $queue = null)

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -103,6 +103,7 @@ class Manager {
      * @param  string  $job
      * @param  mixed   $data
      * @param  string  $queue
+     * @param  string  $connection
      * @return mixed
      */
     public static function push($job, $data = '', $queue = null, $connection = null)
@@ -113,9 +114,10 @@ class Manager {
     /**
      * Push a new an array of jobs onto the queue.
      *
-     * @param  array  $jobs
-     * @param  mixed  $data
+     * @param  array   $jobs
+     * @param  mixed   $data
      * @param  string  $queue
+     * @param  string  $connection
      * @return mixed
      */
     public static function bulk($jobs, $data = '', $queue = null, $connection = null)
@@ -127,9 +129,10 @@ class Manager {
      * Push a new job onto the queue after a delay.
      *
      * @param  \DateTime|int  $delay
-     * @param  string  $job
-     * @param  mixed  $data
-     * @param  string  $queue
+     * @param  string         $job
+     * @param  mixed          $data
+     * @param  string         $queue
+     * @param  string         $connection
      * @return mixed
      */
     public static function later($delay, $job, $data = '', $queue = null, $connection = null)

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -86,7 +86,7 @@ class IronQueue extends Queue implements QueueInterface {
 	 *
 	 * @param  string  $payload
 	 * @param  string  $queue
-	 * @param  int  $delay
+	 * @param  int     $delay
 	 * @return mixed
 	 */
 	public function recreate($payload, $queue = null, $delay)
@@ -100,9 +100,9 @@ class IronQueue extends Queue implements QueueInterface {
 	 * Push a new job onto the queue after a delay.
 	 *
 	 * @param  \DateTime|int  $delay
-	 * @param  string  $job
-	 * @param  mixed  $data
-	 * @param  string  $queue
+	 * @param  string         $job
+	 * @param  mixed          $data
+	 * @param  string         $queue
 	 * @return mixed
 	 */
 	public function later($delay, $job, $data = '', $queue = null)

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -27,8 +27,8 @@ abstract class Queue {
 	/**
 	 * Push a new an array of jobs onto the queue.
 	 *
-	 * @param  array  $jobs
-	 * @param  mixed  $data
+	 * @param  array   $jobs
+	 * @param  mixed   $data
 	 * @param  string  $queue
 	 * @return mixed
 	 */
@@ -64,7 +64,7 @@ abstract class Queue {
 	 * Create a payload string for the given Closure job.
 	 *
 	 * @param  \Closure  $job
-	 * @param  mixed  $data
+	 * @param  mixed     $data
 	 * @return string
 	 */
 	protected function createClosurePayload($job, $data)

--- a/src/Illuminate/Queue/QueueInterface.php
+++ b/src/Illuminate/Queue/QueueInterface.php
@@ -26,9 +26,9 @@ interface QueueInterface {
 	 * Push a new job onto the queue after a delay.
 	 *
 	 * @param  \DateTime|int  $delay
-	 * @param  string  $job
-	 * @param  mixed  $data
-	 * @param  string  $queue
+	 * @param  string         $job
+	 * @param  mixed          $data
+	 * @param  string         $queue
 	 * @return mixed
 	 */
 	public function later($delay, $job, $data = '', $queue = null);

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -71,9 +71,9 @@ class RedisQueue extends Queue implements QueueInterface {
 	 * Push a new job onto the queue after a delay.
 	 *
 	 * @param  \DateTime|int  $delay
-	 * @param  string  $job
-	 * @param  mixed  $data
-	 * @param  string  $queue
+	 * @param  string         $job
+	 * @param  mixed          $data
+	 * @param  string         $queue
 	 * @return void
 	 */
 	public function later($delay, $job, $data = '', $queue = null)
@@ -89,7 +89,7 @@ class RedisQueue extends Queue implements QueueInterface {
 	 * @param  string  $queue
 	 * @param  string  $payload
 	 * @param  string  $delay
-	 * @param  int  $attempts
+	 * @param  int     $attempts
 	 * @return void
 	 */
 	public function release($queue, $payload, $delay, $attempts)
@@ -169,7 +169,7 @@ class RedisQueue extends Queue implements QueueInterface {
 	 * Get the delayed jobs that are ready.
 	 *
 	 * @param  string  $queue
-	 * @param  int  $time
+	 * @param  int     $time
 	 * @return array
 	 */
 	protected function getExpiredJobs($queue, $time)
@@ -181,7 +181,7 @@ class RedisQueue extends Queue implements QueueInterface {
 	 * Remove the delayed jobs that are ready for processing.
 	 *
 	 * @param  string  $queue
-	 * @param  int  $time
+	 * @param  int     $time
 	 * @return void
 	 */
 	protected function removeExpiredJobs($queue, $time)

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -64,9 +64,9 @@ class SqsQueue extends Queue implements QueueInterface {
 	 * Push a new job onto the queue after a delay.
 	 *
 	 * @param  \DateTime|int  $delay
-	 * @param  string  $job
-	 * @param  mixed  $data
-	 * @param  string  $queue
+	 * @param  string         $job
+	 * @param  mixed          $data
+	 * @param  string         $queue
 	 * @return mixed
 	 */
 	public function later($delay, $job, $data = '', $queue = null)

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -34,9 +34,9 @@ class SyncQueue extends Queue implements QueueInterface {
 	 * Push a new job onto the queue after a delay.
 	 *
 	 * @param  \DateTime|int  $delay
-	 * @param  string  $job
-	 * @param  mixed  $data
-	 * @param  string  $queue
+	 * @param  string         $job
+	 * @param  mixed          $data
+	 * @param  string         $queue
 	 * @return mixed
 	 */
 	public function later($delay, $job, $data = '', $queue = null)
@@ -56,7 +56,7 @@ class SyncQueue extends Queue implements QueueInterface {
 	 * Resolve a Sync job instance.
 	 *
 	 * @param  string  $job
-	 * @param  string  $data
+	 * @param  mixed   $data
 	 * @return \Illuminate\Queue\Jobs\SyncJob
 	 */
 	protected function resolveJob($job, $data)


### PR DESCRIPTION
The class is called `DateTime`, not `Datetime`. I have fixed this mistake in the doc blocks. I have also fixed a load more docblock mistakes.
