### PR TITLE
Add hidden field for checkbox

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -567,7 +567,9 @@ class FormBuilder {
 	 */
 	public function checkbox($name, $value = 1, $checked = null, $options = array())
 	{
-		return $this->checkable('checkbox', $name, $value, $checked, $options);
+		$hidden = $this->input('hidden', $name, ($value ? 0 : 1), $options);
+		$checkbox = $this->checkable('checkbox', $name, $value, $checked, $options);
+		return $hidden.$checkbox;
 	}
 
 	/**

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -298,7 +298,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form3 = $this->formBuilder->checkbox('foo', 'foobar', true);
 		$form4 = $this->formBuilder->checkbox('foo', 'foobar', false, array('class' => 'span2'));
 
-		$this->assertEquals('<input name="foo" type="hidden"><input name="foo" type="checkbox">', $form1);
+		$this->assertEquals('<input name="foo" type="checkbox">', $form1);
 		$this->assertEquals('<input name="foo" type="hidden" value="0"><input name="foo" type="checkbox" value="1">', $form2);
 		$this->assertEquals('<input name="foo" type="hidden" value="0"><input checked="checked" name="foo" type="checkbox" value="foobar">', $form3);
 		$this->assertEquals('<input class="span2" name="foo" type="hidden" value="0"<input class="span2" name="foo" type="checkbox" value="foobar">', $form4);
@@ -312,7 +312,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
 		$session->shouldReceive('getOldInput')->once()->with('check')->andReturn(null);
 		$check = $this->formBuilder->checkbox('check', 1, true);
-		$this->assertEquals('<input name="check" type="checkbox" value="1">', $check);
+		$this->assertEquals('<input name="check" type="hidden" value="0"><input name="check" type="checkbox" value="1">', $check);
 
 		$session->shouldReceive('getOldInput')->with('check.key')->andReturn('yes');
 		$check = $this->formBuilder->checkbox('check[key]', 'yes');

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -298,10 +298,10 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form3 = $this->formBuilder->checkbox('foo', 'foobar', true);
 		$form4 = $this->formBuilder->checkbox('foo', 'foobar', false, array('class' => 'span2'));
 
-		$this->assertEquals('<input name="foo" type="checkbox">', $form1);
-		$this->assertEquals('<input name="foo" type="checkbox" value="1">', $form2);
-		$this->assertEquals('<input checked="checked" name="foo" type="checkbox" value="foobar">', $form3);
-		$this->assertEquals('<input class="span2" name="foo" type="checkbox" value="foobar">', $form4);
+		$this->assertEquals('<input name="foo" type="hidden"><input name="foo" type="checkbox">', $form1);
+		$this->assertEquals('<input name="foo" type="hidden" value="0"><input name="foo" type="checkbox" value="1">', $form2);
+		$this->assertEquals('<input name="foo" type="hidden" value="0"><input checked="checked" name="foo" type="checkbox" value="foobar">', $form3);
+		$this->assertEquals('<input class="span2" name="foo" type="hidden" value="0"<input class="span2" name="foo" type="checkbox" value="foobar">', $form4);
 	}
 
 


### PR DESCRIPTION
http://nielson.io/2014/02/handling-checkbox-input-in-laravel/

> This inserts a hidden field in my form with the same name, but opposite value of the approved checkbox. Since the HTML specification says that inputs are sent to the server in the same order as they are in the form, this works flawlessly. What happens is if the checkbox is unchecked, the value approved gets submitted as false using the hidden field. But if it is checked, the checkbox's value gets submitted instead because it comes after the hidden field.
