### PR TITLE
Use PHPUnit 4.0, And Don't Allow Travis Failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,3 @@ before_script:
   - composer install --prefer-source --no-interaction --dev
 
 script: phpunit -d memory_limit=1024M
-
-matrix:
-  allow_failures:
-    - php: 5.6
-    - php: hhvm
-  fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "iron-io/iron_mq": "1.5.*",
         "pda/pheanstalk": "2.1.*",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "classmap": [

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "illuminate/console": "4.1.*",
         "illuminate/routing": "4.1.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {"Illuminate\\Auth": ""}

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -13,7 +13,7 @@
         "nesbot/carbon": "1.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "4.0.*",
         "illuminate/database": "4.1.*",
         "illuminate/encryption": "4.1.*",
         "illuminate/filesystem": "4.1.*",

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -13,7 +13,7 @@
         "illuminate/support": "4.1.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {"Illuminate\\Config": ""}

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -11,7 +11,7 @@
         "symfony/console": "2.4.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -11,7 +11,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -22,7 +22,7 @@
         "illuminate/pagination": "4.1.*",
         "illuminate/support": "4.1.*",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -12,7 +12,7 @@
         "illuminate/support": "4.1.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Exception/composer.json
+++ b/src/Illuminate/Exception/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "monolog/monolog": "1.6.*",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -13,7 +13,7 @@
         "symfony/finder": "2.4.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -13,7 +13,7 @@
         "ircmaxell/password-compat": "1.0.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Html/composer.json
+++ b/src/Illuminate/Html/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "4.0.*",
         "illuminate/events": "4.1.*"
     },
     "autoload": {

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "illuminate/queue": "4.1.*",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -21,7 +21,7 @@
         "iron-io/iron_mq": "1.5.*",
         "pda/pheanstalk": "2.1.*",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -20,7 +20,7 @@
         "illuminate/console": "4.1.*",
         "illuminate/filesystem": "4.1.*",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "illuminate/console": "4.1.*",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -13,7 +13,7 @@
     "require-dev": {
         "patchwork/utf8": "1.1.*",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "illuminate/database": "4.1.*",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Workbench/composer.json
+++ b/src/Illuminate/Workbench/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "illuminate/console": "4.1.*",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
PHPUnit 4.0 is very stable, and will be released in 2 weeks. I have removed the travis allowed failures because at this stage everything is passing, and I am unaware of any plans to break hhvm compatibility.
