### PR TITLE
array_fetch work with array of objects using magic __get (Eloquent models)

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -246,6 +246,28 @@ class Connection implements ConnectionInterface {
 	}
 
 	/**
+	 * Run a select statement and return the first column as an array
+	 *
+	 * @param  string  $query
+	 * @param  array   $bindings
+	 * @return array
+	 */
+	public function selectColumn($query, $bindings = array())
+	{
+		// get the fetch mode so we can set it back after we are done
+		$mode = $this->getFetchMode();
+
+		// Set the fetch mode to column and fetch the results
+		$this->setFetchMode(\PDO::FETCH_COLUMN);
+		$results = $this->select($query, $bindings);
+
+		// reset the fetch mode
+		$this->setFetchMode($mode);
+
+		return $results;
+	}
+
+	/**
 	 * Run a select statement and return a single result.
 	 *
 	 * @param  string  $query

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -191,9 +191,15 @@ if ( ! function_exists('array_fetch'))
 
 			foreach ($array as $value)
 			{
-				$value = (array) $value;
-
-				$results[] = $value[$segment];
+				if (is_object($value))
+				{
+					$results[] = $value->{$segment};
+				}
+				else
+				{
+					$value = (array) $value;
+					$results[] = $value[$segment];
+				}
 			}
 
 			$array = array_values($results);


### PR DESCRIPTION
I ran into this need when I eager loaded relations 2 levels deep and then wanted to use fetch on the collection or array_fetch() to retrieve a list of the 2nd level models.
Ex: (simplified)
$answers = Answer::with('question.user')->get();

I want to get an array or collection of users from the $answers collection.
1. I tried the fetch method on the collection but it does not give me what I need because it coverts the Collection toArray() before running the fetch and therefore not returning an array of models intact.
$answers->fetch('question.user');
1. I tried array_fetch($answers, 'question.user') but that didn't work because array_fetch casts the values to arrays even if they are objects which are array accessible.
2. I am not exactly sure why the cast exists, unless as a way to make it work for many objects

This seemed like something that would be of use to others and myself. Fixing it to work with the array_fetch helper (2) seemed the least likely to break for others. I added an is_object check which I thought would be non-breaking in all but the rare circumstance someone was counting on an object being cast to an array and accessing private/protected properties with the odd \* and class name prefixes.
- If this is implemented I wonder if the toArray() conversion in the fetch() Collection method would no longer be needed, which would allow both methods to work.
