### PR TITLE
[Bug] Request::segment returns incorrect value when path contains an empty segment

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -94,7 +94,7 @@ class Request extends SymfonyRequest {
 	{
 		$segments = explode('/', trim($this->getPathInfo(), '/'));
 
-		$segments = array_filter($segments, function($v) { return $v != ''; });
+		$segments = array_values(array_filter($segments));
 
 		return array_get($segments, $index - 1, $default);
 	}

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -42,16 +42,24 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testSegmentMethod()
+	/**
+	 * @dataProvider segmentProvider
+	 */
+	public function testSegmentMethod($path, $segment, $expected)
 	{
-		$request = Request::create('', 'GET');
-		$this->assertEquals('default', $request->segment(1, 'default'));
-
-		$request = Request::create('foo/bar', 'GET');
-		$this->assertEquals('foo', $request->segment(1, 'default'));
-		$this->assertEquals('bar', $request->segment(2, 'default'));
+		$request = Request::create($path, 'GET');
+		$this->assertEquals($expected, $request->segment($segment, 'default'));
 	}
 
+	public function segmentProvider()
+	{
+		return array(
+			array('', 1, 'default'),
+			array('foo/bar//baz', '1', 'foo'),
+			array('foo/bar//baz', '2', 'bar'),
+			array('foo/bar//baz', '3', 'baz')
+		);
+	}
 
 	public function testSegmentsMethod()
 	{


### PR DESCRIPTION
The `Request::segment` method uses `array_filter` to remove empty segments from the `$segments` array, however `array_filter` also preserves the keys of the filtered array. This change uses `array_values` to rekey the filtered array.

Also, this change removes the closure used to filter the array as it wasn't providing anything useful since, by default, `array_filter` removes "falsey" values.
### Current Behaviour

``` php
$request  = Request::create('foo//bar', 'GET');
$segment = $request->segment(2, 'oops'); // $segment is 'oops'
```
### Corrected Behaviour

``` php
$request  = Request::create('foo//bar', 'GET');
$segment = $request->segment(2, 'oops'); // $segment is 'bar'
```
