### PR TITLE
Automatically add hidden input fields alongside checkboxes

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -565,9 +565,31 @@ class FormBuilder {
 	 * @param  array   $options
 	 * @return string
 	 */
-	public function checkbox($name, $value = 1, $checked = null, $options = array())
+	public function checkbox($name, $value = 1, $checked = null, $options = array(), $uncheckedValue = 0)
 	{
-		return $this->checkable('checkbox', $name, $value, $checked, $options);
+		$hidden = $this->hiddenFieldForCheckbox($name, $uncheckedValue, $options);
+		$checkbox = $this->checkable('checkbox', $name, $value, $checked, $options);;
+		return $hidden . $checkbox;
+	}
+
+	/**
+	 * Create a hidden field for a checkbox input field.
+	 *
+	 * @param  string  $name
+	 * @param  mixed   $uncheckedValue
+	 * @param  array   $options
+	 * @return string
+	 */
+	protected function hiddenFieldForCheckbox($name, $uncheckedValue, $options)
+	{
+		$hidden = '';
+		if (!is_null($uncheckedValue) && $uncheckedValue !== false) {
+			$this->skipValueTypes[] = 'hidden';
+			$hidden = $this->hidden($name, $uncheckedValue, array_only($options, array('disabled', 'form')));
+			$this->skipValueTypes = array_diff($this->skipValueTypes, array('hidden'));
+		}
+
+		return $hidden;
 	}
 
 	/**

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -297,11 +297,15 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$form2 = $this->formBuilder->checkbox('foo');
 		$form3 = $this->formBuilder->checkbox('foo', 'foobar', true);
 		$form4 = $this->formBuilder->checkbox('foo', 'foobar', false, array('class' => 'span2'));
+		$form5 = $this->formBuilder->checkbox('foo', 'foobar', false, array(), 'no');
+		$form6 = $this->formBuilder->checkbox('foo', 'foobar', false, array(), false);
 
 		$this->assertEquals('<input name="foo" type="checkbox">', $form1);
-		$this->assertEquals('<input name="foo" type="checkbox" value="1">', $form2);
-		$this->assertEquals('<input checked="checked" name="foo" type="checkbox" value="foobar">', $form3);
-		$this->assertEquals('<input class="span2" name="foo" type="checkbox" value="foobar">', $form4);
+		$this->assertEquals('<input name="foo" type="hidden" value="0"><input name="foo" type="checkbox" value="1">', $form2);
+		$this->assertEquals('<input name="foo" type="hidden" value="0"><input checked="checked" name="foo" type="checkbox" value="foobar">', $form3);
+		$this->assertEquals('<input name="foo" type="hidden" value="0"><input class="span2" name="foo" type="checkbox" value="foobar">', $form4);
+		$this->assertEquals('<input name="foo" type="hidden" value="no"><input name="foo" type="checkbox" value="foobar">', $form5);
+		$this->assertEquals('<input name="foo" type="checkbox" value="foobar">', $form6);
 	}
 
 
@@ -312,20 +316,20 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
 		$session->shouldReceive('getOldInput')->once()->with('check')->andReturn(null);
 		$check = $this->formBuilder->checkbox('check', 1, true);
-		$this->assertEquals('<input name="check" type="checkbox" value="1">', $check);
+		$this->assertEquals('<input name="check" type="hidden" value="0"><input name="check" type="checkbox" value="1">', $check);
 
 		$session->shouldReceive('getOldInput')->with('check.key')->andReturn('yes');
 		$check = $this->formBuilder->checkbox('check[key]', 'yes');
-		$this->assertEquals('<input checked="checked" name="check[key]" type="checkbox" value="yes">', $check);
+		$this->assertEquals('<input name="check[key]" type="hidden" value="0"><input checked="checked" name="check[key]" type="checkbox" value="yes">', $check);
 
 		$session->shouldReceive('getOldInput')->with('multicheck')->andReturn(array(1, 3));
 		$check1 = $this->formBuilder->checkbox('multicheck[]', 1);
 		$check2 = $this->formBuilder->checkbox('multicheck[]', 2, true);
 		$check3 = $this->formBuilder->checkbox('multicheck[]', 3);
 
-		$this->assertEquals('<input checked="checked" name="multicheck[]" type="checkbox" value="1">', $check1);
-		$this->assertEquals('<input name="multicheck[]" type="checkbox" value="2">', $check2);
-		$this->assertEquals('<input checked="checked" name="multicheck[]" type="checkbox" value="3">', $check3);
+		$this->assertEquals('<input name="multicheck[]" type="hidden" value="0"><input checked="checked" name="multicheck[]" type="checkbox" value="1">', $check1);
+		$this->assertEquals('<input name="multicheck[]" type="hidden" value="0"><input name="multicheck[]" type="checkbox" value="2">', $check2);
+		$this->assertEquals('<input name="multicheck[]" type="hidden" value="0"><input checked="checked" name="multicheck[]" type="checkbox" value="3">', $check3);
 	}
 
 


### PR DESCRIPTION
Same as pull request at #3572 but moved to master because of @taylorotwell's suggestion.

This request automatically adds a hidden input field alongside checkboxes to make saving of unchecked checkboxes easier on the server side. This idea is used extensively in other frameworks like Ruby on Rails, and seems to help simplify form creation.

I added the $uncheckedValue parameter to the end of the method signature, but because this is in master we may be able to move it next to the value field to keep $options at the end like in all the other methods. I'm open to suggestions about this and any others things.
