### PR TITLE
[Refactor] Small changes to Http\Request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -92,11 +92,7 @@ class Request extends SymfonyRequest {
 	 */
 	public function segment($index, $default = null)
 	{
-		$segments = explode('/', trim($this->getPathInfo(), '/'));
-
-		$segments = array_values(array_filter($segments));
-
-		return array_get($segments, $index - 1, $default);
+		return array_get($this->segments(), $index - 1, $default);
 	}
 
 	/**
@@ -106,9 +102,9 @@ class Request extends SymfonyRequest {
 	 */
 	public function segments()
 	{
-		$path = $this->path();
+		$segments = explode('/', $this->path());
 
-		return $path == '/' ? array() : explode('/', $path);
+		return array_values(array_filter($segments));
 	}
 
 	/**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -61,15 +61,26 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testSegmentsMethod()
+	/**
+	 * @dataProvider segmentsProvider
+	 */
+	public function testSegmentsMethod($path, $expected)
 	{
-		$request = Request::create('', 'GET');
-		$this->assertEquals(array(), $request->segments());
+		$request = Request::create($path, 'GET');
+		$this->assertEquals($expected, $request->segments());
 
 		$request = Request::create('foo/bar', 'GET');
 		$this->assertEquals(array('foo', 'bar'), $request->segments());
 	}
 
+	public function segmentsProvider()
+	{
+		return array(
+			array('', array()),
+			array('foo/bar', array('foo', 'bar')),
+			array('foo/bar//baz', array('foo', 'bar', 'baz'))
+		);
+	}
 
 	public function testUrlMethod()
 	{


### PR DESCRIPTION
### In This PR
- improve consistency between `segment` and `segments` method
  - the `segment` method has been DRY'd out so that it uses the `segments` method, this improves consistency between the methods and makes the expected return values from each method more reliable  
- add braces around control structures containing a single line as their body
  - this is required by [PSR 2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#5-control-structures) and stops me from bitting my nails
