### PR TITLE
[Bugfix] Allow passing delays as DateTime Objects to the Redis Queue Driver.

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -80,6 +80,8 @@ class RedisQueue extends Queue implements QueueInterface {
 	{
 		$payload = $this->createPayload($job, $data);
 
+		$delay = $this->getSeconds($delay);
+
 		$this->redis->zadd($this->getQueue($queue).':delayed', $this->getTime() + $delay, $payload);
 	}
 

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -22,8 +22,9 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testDelayedPushProperlyPushesJobOntoRedis()
 	{
-		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime', 'getRandomId'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
+		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getSeconds', 'getTime', 'getRandomId'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
 		$queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
+		$queue->expects($this->once())->method('getSeconds')->with(1)->will($this->returnValue(1));
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
 
 		$redis->shouldReceive('zadd')->once()->with(
@@ -33,6 +34,24 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 		);
 
 		$queue->later(1, 'foo', array('data'));
+	}
+
+
+	public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis()
+	{
+		$date = m::mock('DateTime');
+		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getSeconds', 'getTime', 'getRandomId'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
+		$queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
+		$queue->expects($this->once())->method('getSeconds')->with($date)->will($this->returnValue(1));
+		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
+
+		$redis->shouldReceive('zadd')->once()->with(
+			'queues:default:delayed',
+			2,
+			json_encode(array('job' => 'foo', 'data' => array('data'), 'id' => 'foo', 'attempts' => 1))
+		);
+
+		$queue->later($date, 'foo', array('data'));
 	}
 
 


### PR DESCRIPTION
This is a documented feature, but currently unsupported by the Redis Queue Driver.
