### PR TITLE
Fix Container extend/instance problem

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -239,9 +239,18 @@ class Container implements ArrayAccess {
 			throw new \InvalidArgumentException("Type {$abstract} is not bound.");
 		}
 
-		$extender = $this->getExtender($abstract, $closure);
+		if (isset($this->instances[$abstract]))
+		{
+			$this->instances[$abstract] = $closure($this->instances[$abstract], $this);
 
-		$this->bind($abstract, $extender, $this->isShared($abstract));
+			$this->rebound($abstract);
+		}
+		else
+		{
+			$extender = $this->getExtender($abstract, $closure);
+
+			$this->bind($abstract, $extender, $this->isShared($abstract));
+		}
 	}
 
 	/**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -183,6 +183,18 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testExtendInstancesArePreserved()
+	{
+		$container = new Container;
+		$container->bind('foo', function() { $obj = new StdClass; $obj->foo = 'bar'; return $obj; });
+		$obj = new StdClass; $obj->foo = 'foo';
+		$container->instance('foo', $obj);
+		$container->extend('foo', function($obj, $container) { $obj->bar = 'baz'; return $obj; });
+		$container->extend('foo', function($obj, $container) { $obj->baz = 'foo'; return $obj; });
+		$this->assertEquals('foo', $container->make('foo')->foo);
+	}
+
+
 	public function testParametersCanBePassedThroughToClosure()
 	{
 		$container = new Container;


### PR DESCRIPTION
I ran into this problem when I was mocking a service in a unit test and then a deferred provider that called `Container::extend` on my service was invoked after the application was loaded.

Basically, if you do `Container::instance(..)` before the `Container::extend(...)` calls, the parameter passed to the `extend()` closure will contain the old instance - the one defined via `Container::bind`, not the one defined via `Container::instance`.
