### PR TITLE
Replace DateTime with Carbon, add setTestNow

### DIFF
--- a/phpunit.php
+++ b/phpunit.php
@@ -26,3 +26,5 @@ require __DIR__.'/vendor/autoload.php';
 */
 
 date_default_timezone_set('UTC');
+
+Carbon\Carbon::setTestNow(Carbon\Carbon::now());

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -1,6 +1,6 @@
 <?php namespace Illuminate\Queue\Failed;
 
-use DateTime;
+use Carbon\Carbon;
 use Illuminate\Database\ConnectionResolverInterface;
 
 class DatabaseFailedJobProvider implements FailedJobProviderInterface {
@@ -51,7 +51,7 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface {
 	 */
 	public function log($connection, $queue, $payload)
 	{
-		$failed_at = new DateTime;
+		$failed_at = Carbon::now();
 
 		$this->getTable()->insert(compact('connection', 'queue', 'payload', 'failed_at'));
 	}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -249,8 +249,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	public function testTimestampsAreReturnedAsObjectsOnCreate()
 	{
 		$timestamps = array(
-			'created_at' => new DateTime,
-			'updated_at' => new DateTime
+			'created_at' => Carbon\Carbon::now(),
+			'updated_at' => Carbon\Carbon::now()
 		);
 		$model = new EloquentDateModelStub;
 		Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
@@ -266,8 +266,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	public function testDateTimeAttributesReturnNullIfSetToNull()
 	{
 		$timestamps = array(
-			'created_at' => new DateTime,
-			'updated_at' => new DateTime
+			'created_at' => Carbon\Carbon::now(),
+			'updated_at' => Carbon\Carbon::now()
 		);
 		$model = new EloquentDateModelStub;
 		Illuminate\Database\Eloquent\Model::setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
@@ -372,7 +372,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->setSoftDeleting(true);
 		$query = m::mock('stdClass');
 		$query->shouldReceive('where')->once()->with('id', 1)->andReturn($query);
-		$query->shouldReceive('update')->once()->with(array('deleted_at' => $model->fromDateTime(new DateTime)));
+		$query->shouldReceive('update')->once()->with(array('deleted_at' => $model->fromDateTime(Carbon\Carbon::now())));
 		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
 		$model->expects($this->once())->method('touchOwners');
 		$model->exists = true;

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -21,8 +21,8 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
 		$relation = new HasOne($builder, $parent, 'foreign_key', 'id');
 		$related->shouldReceive('getTable')->andReturn('table');
 		$related->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-		$related->shouldReceive('freshTimestampString')->andReturn(new DateTime);
-		$builder->shouldReceive('update')->once()->with(array('updated_at' => new DateTime));
+		$related->shouldReceive('freshTimestampString')->andReturn(Carbon\Carbon::now());
+		$builder->shouldReceive('update')->once()->with(array('updated_at' => Carbon\Carbon::now()));
 
 		$relation->touch();
 	}


### PR DESCRIPTION
Carbon has a `setTestNow` method that ensures that all `Carbon::now()` and similar calls return the same timestamps. Prevents false negatives in unit tests that might occur if you're comparing two "new DateTime" instances but one was created at 16:00:00.999 while the other was created at 16:00:01.000.
