### PR TITLE
[4.2] Smarter before/after rules with date_format

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1166,6 +1166,13 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateBefore($attribute, $value, $parameters)
 	{
+		if ($format = $this->getDateFormat($attribute))
+		{
+			$date = DateTime::createFromFormat($format, $value);
+			$before = DateTime::createFromFormat($format, $parameters[0]);
+			return $date < $before;
+		}
+
 		if ( ! ($date = strtotime($parameters[0])))
 		{
 			return strtotime($value) < strtotime($this->getValue($parameters[0]));
@@ -1186,6 +1193,13 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateAfter($attribute, $value, $parameters)
 	{
+		if ($format = $this->getDateFormat($attribute))
+		{
+			$date = DateTime::createFromFormat($format, $value);
+			$after = DateTime::createFromFormat($format, $parameters[0]);
+			return $date > $after;
+		}
+
 		if ( ! ($date = strtotime($parameters[0])))
 		{
 			return strtotime($value) > strtotime($this->getValue($parameters[0]));
@@ -1193,6 +1207,22 @@ class Validator implements MessageProviderInterface {
 		else
 		{
 			return strtotime($value) > $date;
+		}
+	}
+
+	/**
+	 * Get the date format for an attribute if it has one.
+	 *
+	 * @param  string $attribute
+	 * @return string|null
+	 */
+	protected function getDateFormat($attribute)
+	{
+		if ($result = $this->hasRule($attribute, 'DateFormat'))
+		{
+			list($rule, $params) = $result;
+			$format = $params[0];
+			return $format;
 		}
 	}
 
@@ -1682,7 +1712,7 @@ class Validator implements MessageProviderInterface {
 		{
 			list($rule, $parameters) = $this->parseRule($rule);
 
-			if (in_array($rule, $rules)) return true;
+			if (in_array($rule, $rules)) return [$rule, $parameters];
 		}
 
 		return false;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1711,7 +1711,7 @@ class Validator implements MessageProviderInterface {
 	 *
 	 * @param  string  $attribute
 	 * @param  string|array  $rules
-	 * @return bool
+	 * @return array|null
 	 */
 	protected function getRule($attribute, $rules)
 	{

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1218,7 +1218,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function getDateFormat($attribute)
 	{
-		if ($result = $this->hasRule($attribute, 'DateFormat'))
+		if ($result = $this->getRule($attribute, 'DateFormat'))
 		{
 			list($rule, $params) = $result;
 			$format = $params[0];
@@ -1698,24 +1698,31 @@ class Validator implements MessageProviderInterface {
 	 * Determine if the given attribute has a rule in the given set.
 	 *
 	 * @param  string  $attribute
-	 * @param  array   $rules
+	 * @param  string|array  $rules
 	 * @return bool
 	 */
 	protected function hasRule($attribute, $rules)
 	{
+		return ! is_null($this->getRule($attribute, $rules));
+	}
+
+	/**
+	 * Get a rule and its parameters for a given attribute.
+	 *
+	 * @param  string  $attribute
+	 * @param  string|array  $rules
+	 * @return bool
+	 */
+	protected function getRule($attribute, $rules)
+	{
 		$rules = (array) $rules;
 
-		// To determine if the attribute has a rule in the ruleset, we will spin
-		// through each of the rules assigned to the attribute and parse them
-		// all, then check to see if the parsed rules exists in the arrays.
 		foreach ($this->rules[$attribute] as $rule)
 		{
 			list($rule, $parameters) = $this->parseRule($rule);
 
 			if (in_array($rule, $rules)) return [$rule, $parameters];
 		}
-
-		return false;
 	}
 
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -902,6 +902,19 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testBeforeAndAfterWithFormat()
+	{
+		date_default_timezone_set('UTC');
+		$trans = $this->getRealTranslator();
+
+		$v = new Validator($trans, array('x' => '02/04/2012'), array('x' => 'After:03/03/2012|Before:01/05/2012'));
+		$this->assertTrue($v->fails());
+
+		$v = new Validator($trans, array('x' => '02/04/2012'), array('x' => 'date_format:d/m/Y|After:03/03/2012|Before:01/05/2012'));
+		$this->assertTrue($v->passes());
+	}
+
+
 	public function testSometimesAddingRules()
 	{
 		$trans = $this->getRealTranslator();


### PR DESCRIPTION
See #3603 - basically this makes the before/after rules smarter by taking into account the corresponding date_format rule if it is passed.

This is a potentially backwards breaking change, so I targetted master instead of 4.1.
