### PR TITLE
Fixed Cache Tag Tests On Windows

### DIFF
--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -78,7 +78,7 @@ class TagSet {
 	 */
 	public function resetTag($name)
 	{
-		$this->store->forever($this->tagKey($name), $id = uniqid());
+		$this->store->forever($this->tagKey($name), $id = str_replace('.', '', uniqid('', true)));
 
 		return $id;
 	}


### PR DESCRIPTION
**The Problem**
On windows, calls to the uniqid function without additional entropy enabled, in the same millisecond, resulted in an identical uid being produced. This meant cache flushes on the array cache driver were failing if we were to create and flush the cache in the same millisecond, because the new uid generated was the same as the original uid, so when we thought we were invalidating the cache by generating a new uid, we were actually just setting the new uid identical to the old one.

**The Solution**
I've enabled more randomness on the uniqid function, and i've stripped out the dot it generates to avoid confusion with laravel's array dot syntax. This means we can be sure the uniqid function is actually producing a truly unique id.
