### PR TITLE
[Proposal] Redirect::back() fallback

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -48,9 +48,14 @@ class Redirector {
 	 * @param  array  $headers
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	public function back($status = 302, $headers = array())
+	public function back($fallback = '/', $status = 302, $headers = array())
 	{
 		$back = $this->generator->getRequest()->headers->get('referer');
+
+		if ( ! isset($back))
+		{
+			$back = $this->generator->to($fallback, array());
+		}
 
 		return $this->createRedirect($back, $status, $headers);
 	}


### PR DESCRIPTION
Added fallback argument to Redirect::back().

For when back doesn't have a referer to send user back.
- Users accessing the link from a bookmark, history or by typing the link manually do not have a referer.
- IE has also been known to remove the referer in situations revolving around javascript. Such as window.open, window.location and even setting target="_blank" in anchors or meta refresh.
- Clicking an embedded link in a chat application, PDF/Word/Excel document, will also not set a referer.
- Using AJAX, file_get_contents, fopen and other similar functions in other languages will probably not set a referer request.
- cURL, fsockopen, applications that have browser-like components might not set a referer.

(From http://stackoverflow.com/questions/5643773/http-referer-not-always-being-passed/5643868#5643868)

Related issue/request: https://github.com/laravel/framework/issues/952
