### PR TITLE
More Composer Fixes

### DIFF
--- a/src/Illuminate/Exception/composer.json
+++ b/src/Illuminate/Exception/composer.json
@@ -15,7 +15,7 @@
         "symfony/http-kernel": "2.4.*"
     },
     "require-dev": {
-        "monolog/monolog": "1.6.*",
+        "monolog/monolog": "1.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "3.7.*"
     },

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.1.*",
-        "monolog/monolog": "1.6.*"
+        "monolog/monolog": "1.*"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.1.*",
-        "predis/predis": "0.*"
+        "predis/predis": "0.8.*"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -11,6 +11,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
+        "jeremeamia/superclosure": "1.0.*",
         "patchwork/utf8": "1.1.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
The version constraint for monolog in the main composer.json is `1.*`, but this never got updated in the separate components' composer.json files. The same goes for predis. The version constraint was changed to `0.8.*`, but this never got updated in the redis component composer.json. Also, the superclosure dependency was missing from require-dev for the support component composer.json.
