### PR TITLE
Proposal for mutating data when updating using Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -275,8 +275,13 @@ class Builder {
 	 * @param  array  $values
 	 * @return int
 	 */
-	public function update(array $values)
+	public function update(array $values, $fill = true)
 	{
+		if ($fill)
+		{
+			$values = $this->model->fill($values)->toArray();
+		}
+		
 		return $this->query->update($this->addUpdatedAtColumn($values));
 	}
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1237,7 +1237,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	{
 		if ( ! $this->exists)
 		{
-			return $this->newQuery()->update($attributes);
+			return $this->newQuery()->update($attributes, false);
 		}
 
 		return $this->fill($attributes)->save();
@@ -1353,7 +1353,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			// models are updated, giving them a chance to do any special processing.
 			$dirty = $this->getDirty();
 
-			$this->setKeysForSaveQuery($query)->update($dirty);
+			$this->setKeysForSaveQuery($query)->update($dirty, false);
 
 			$this->fireModelEvent('updated', false);
 		}


### PR DESCRIPTION
There is a issue when updating a table calling the method update of Eloquent/Builder instead of the Eloquent/Model method. That is, using your example:

<pre>
$affectedRows = User::where('votes', '>', 100)->update(array('status' => 2));
</pre>


If we have the following mutator:

<pre>
public function setStatusAttribute($value)
{
    $this->attributes['status'] = $value;
    if ($value == 2)
    {
        $this->attributes['message'] = 'You're good!'
    }
    else
    {
       $this->attributes['message'] = 'You're almost not voted!'
    }
}
</pre>


This mutator is not called when updating the model as I have just indicate. Actually, the update must be done  getting the collection of users and iterating through them to get each model and update it individually. This produces more connections to the database.

The proposal is not debugged, but shows the issue found.
