### PR TITLE
[illuminate\support] Move stuff from require-dev to require

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -8,11 +8,11 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "jeremeamia/superclosure": "1.0.*",
+        "patchwork/utf8": "1.1.*"
     },
     "require-dev": {
-        "jeremeamia/superclosure": "1.0.*",
-        "patchwork/utf8": "1.1.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "3.7.*"
     },


### PR DESCRIPTION
Tried to use Str::slug in a package that requires illuminate\support and got a fatal error of class Patchwork\Utf8 not existing. Why were these moved to require-dev?
