### PR TITLE
pass partial params when resolving dependencies via reflection through Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -509,10 +509,12 @@ class Container implements ArrayAccess {
 		// Once we have all the constructor's parameters we can create each of the
 		// dependency instances and then use the reflection instances to make a
 		// new instance of this class, injecting the created dependencies in.
-		$deps = array_merge($parameters, $this->getDependencies(
+		// Merge arrays with + then sort, to retain the keys.
+		$deps = $parameters + $this->getDependencies(
 			array_diff_key($classes, $parameters)
-		));
+		);
 
+		ksort($deps);
 		return $reflector->newInstanceArgs($deps);
 	}
 
@@ -526,7 +528,7 @@ class Container implements ArrayAccess {
 	{
 		$dependencies = array();
 
-		foreach ($parameters as $parameter)
+		foreach ($parameters as $key => $parameter)
 		{
 			$dependency = $parameter->getClass();
 
@@ -535,11 +537,11 @@ class Container implements ArrayAccess {
 			// we'll just bomb out with an error since we have no-where to go.
 			if (is_null($dependency))
 			{
-				$dependencies[] = $this->resolveNonClass($parameter);
+				$dependencies[$key] = $this->resolveNonClass($parameter);
 			}
 			else
 			{
-				$dependencies[] = $this->resolveClass($parameter);
+				$dependencies[$key] = $this->resolveClass($parameter);
 			}
 		}
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -215,6 +215,21 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('taylor', $instance->default);
 	}
 
+	public function testResolutionOfPassedParameterWithoutClosure()
+	{
+		$container = new Container;
+		$instance = $container->make('ContainerPartialReflectionStub', array(1 => 'foo'));
+		$this->assertInstanceOf('ContainerConcreteStub', $instance->stub);
+		$this->assertEquals('foo', $instance->param);
+	}
+
+	public function testResolutionOfPassedParameterWithoutClosureReverse()
+	{
+		$container = new Container;
+		$instance = $container->make('ContainerPartialReflectionStubReverse', array('foo'));
+		$this->assertInstanceOf('ContainerConcreteStub', $instance->stub);
+		$this->assertEquals('foo', $instance->param);
+	}
 
 	public function testResolvingCallbacksAreCalledForSpecificAbstracts()
 	{
@@ -302,5 +317,23 @@ class ContainerDefaultValueStub {
 	{
 		$this->stub = $stub;
 		$this->default = $default;
+	}
+}
+
+class ContainerPartialReflectionStub {
+	public $stub; public $param;
+	public function __construct(ContainerConcreteStub $stub, $param)
+	{
+		$this->stub = $stub;
+		$this->param = $param;
+	}
+}
+
+class ContainerPartialReflectionStubReverse {
+	public $stub; public $param;
+	public function __construct($param, ContainerConcreteStub $stub)
+	{
+		$this->stub = $stub;
+		$this->param = $param;
 	}
 }


### PR DESCRIPTION
If all of a classes dependencies can be deduced from the constructor via reflection, you can resolve the class through the container without ever binding a closure. But sometimes you have a constructor with parameters that might look like this:

```
__construct(Foo\Bar $foobar, $firstname, $lastname, Foo\Bat $foobat)
```

(more parameters than would be wise, and poorly ordered, for the sake of the example)
To resolve this dependency and pass the names in via the container, you'd have to define a closure, and you'd have to specify Foo\Bar and Foo\Bat in the closure--you can't just rely on the Container's use of reflection (as far as I can tell, anyway). 

This patch enhances Container to allow some dependencies to be passed into `$container->make()`, while others are resolved by reflection.

To make an object from a class 'Baz' with the constructor above, while passing the values in, you would use the following syntax:

```
$container->make('Baz', array(1=>'Daniel', 2=>'Karp'));
```

(the keys are 1 and 2 because those are the positions of the firstname and lastname parameters, starting counting from 0.)
Container will now respect the keys in the parameters array, and resolve the parameters in positions not passed in the parameters array by reflection.

I'm believe this is a non-breaking enhancement--it certainly passes all of the tests. But if there is interest in the feature, but concern about whether it would break anything, I can resubmit it to the master branch instead.

Sorry for the pull request without a proposal--I wanted to see if it would work before proposing anything, and it was done before I knew it.
