### PR TITLE
Add cursor mode to Paginator and DB.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -270,6 +270,26 @@ class Builder {
 	}
 
 	/**
+	 * Get a paginator in cursor mode for the "select" statement.
+	 *
+	 * @param  int    $perPage
+	 * @param  array  $columns
+	 * @return \Illuminate\Pagination\Paginator
+	 */
+	public function cursor($perPage = null, $columns = array('*'))
+	{
+		$paginator = $this->query->getConnection()->getPaginator();
+
+		$page = $paginator->getCurrentPage();
+		$perPage = $perPage ?: $this->model->getPerPage();
+
+		// Use skip method to set correct offset and take perPage + 1 items.
+		$this->query->skip(($page - 1) * $perPage)->take($perPage + 1);
+
+		return $paginator->make($this->get($columns)->all(), $perPage);
+	}
+
+	/**
 	 * Update a record in the database.
 	 *
 	 * @param  array  $values

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1509,6 +1509,26 @@ class Builder {
 	}
 
 	/**
+	 * Get a paginator in cursor mode for the "select" statement.
+	 *
+	 * @param  int    $perPage
+	 * @param  array  $columns
+	 * @return \Illuminate\Pagination\Paginator
+	 */
+	public function cursor($perPage = null, $columns = array('*'))
+	{
+		$paginator = $this->connection->getPaginator();
+
+		$page = $paginator->getCurrentPage();
+		$perPage = $perPage ?: $this->model->getPerPage();
+
+		// Use skip method to set correct offset and take perPage + 1 items.
+		$this->skip(($page - 1) * $perPage)->take($perPage + 1);
+
+		return $paginator->make($this->get($columns), $perPage);
+	}
+
+	/**
 	 * Determine if any rows exist for the current query.
 	 *
 	 * @return bool

--- a/src/Illuminate/Pagination/Environment.php
+++ b/src/Illuminate/Pagination/Environment.php
@@ -95,10 +95,10 @@ class Environment {
 	 *
 	 * @param  array  $items
 	 * @param  int    $total
-	 * @param  int    $perPage
+	 * @param  mixed  $perPage
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	public function make(array $items, $total, $perPage)
+	public function make(array $items, $total, $perPage = null)
 	{
 		$paginator = new Paginator($this, $items, $total, $perPage);
 

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -25,6 +25,13 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	protected $items;
 
 	/**
+	 * Item indicating if next page is available.
+	 *
+	 * @var array
+	 */
+	protected $cursor;
+
+	/**
 	 * The total number of items.
 	 *
 	 * @var int
@@ -86,15 +93,29 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	 * @param  \Illuminate\Pagination\Environment  $env
 	 * @param  array  $items
 	 * @param  int    $total
-	 * @param  int    $perPage
+	 * @param  mixed  $perPage
 	 * @return void
 	 */
-	public function __construct(Environment $env, array $items, $total, $perPage)
+	public function __construct(Environment $env, array $items, $total, $perPage = null)
 	{
 		$this->env = $env;
-		$this->items = $items;
-		$this->total = (int) $total;
-		$this->perPage = (int) $perPage;
+
+		// Paginator received only 3 parameters which means that it's being used
+		// in cursor mode. In this mode third argument $total is used as $perPage.
+		if (is_null($perPage))
+		{
+			$this->items = array_slice($items, 0, $perPage);
+			$this->perPage = (int) $total;
+
+			$cursor = array_slice($items, $this->perPage, 1);
+			$this->cursor = empty($cursor) ? null : $cursor[0];
+		}
+		else
+		{
+			$this->items = $items;
+			$this->total = (int) $total;
+			$this->perPage = (int) $perPage;
+		}
 	}
 
 	/**
@@ -118,9 +139,19 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	 */
 	protected function calculateCurrentAndLastPages()
 	{
-		$this->lastPage = (int) ceil($this->total / $this->perPage);
+		if (is_null($this->total))
+		{
+			$page = $this->env->getCurrentPage();
+			$this->currentPage = $this->isValidPageNumber($page) ? (int) $page : 1;
 
-		$this->currentPage = $this->calculateCurrentPage($this->lastPage);
+			$this->lastPage = is_null($this->cursor) ? $this->currentPage : $this->currentPage + 1;
+		}
+		else
+		{
+			$this->lastPage = (int) ceil($this->total / $this->perPage);
+
+			$this->currentPage = $this->calculateCurrentPage($this->lastPage);
+		}
 	}
 
 	/**
@@ -367,6 +398,16 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	public function getTotal()
 	{
 		return $this->total;
+	}
+
+	/**
+	 * Get cursor for this paginator.
+	 *
+	 * @return mixed
+	 */
+	public function getCursor()
+	{
+		return $this->cursor;
 	}
 
 	/**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -587,6 +587,24 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testCursorCorrectlyCreatesPaginatorInstance()
+	{
+		$connection = m::mock('Illuminate\Database\ConnectionInterface');
+		$grammar = m::mock('Illuminate\Database\Query\Grammars\Grammar');
+		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+		$builder = $this->getMock('Illuminate\Database\Query\Builder', array('skip', 'take', 'get'), array($connection, $grammar, $processor));
+		$paginator = m::mock('Illuminate\Pagination\Environment');
+		$paginator->shouldReceive('getCurrentPage')->once()->andReturn(1);
+		$connection->shouldReceive('getPaginator')->once()->andReturn($paginator);
+		$builder->expects($this->once())->method('skip')->with($this->equalTo(0))->will($this->returnValue($builder));
+		$builder->expects($this->once())->method('take')->with($this->equalTo(16))->will($this->returnValue($builder));
+		$builder->expects($this->once())->method('get')->with($this->equalTo(array('*')))->will($this->returnValue(array('foo')));
+		$paginator->shouldReceive('make')->once()->with(array('foo'), 15)->andReturn(array('results'));
+
+		$this->assertEquals(array('results'), $builder->cursor(15, array('*')));
+	}
+
+
 	public function testPluckMethodReturnsSingleColumn()
 	{
 		$builder = $this->getBuilder();

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -22,6 +22,18 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testPaginationContextIsSetupCorrectlyInCursorMode()
+	{
+		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('foo', 'bar', 'baz'), 2);
+		$env->shouldReceive('getCurrentPage')->once()->andReturn(1);
+		$p->setupPaginationContext();
+
+		$this->assertEquals(2, $p->getLastPage());
+		$this->assertEquals(1, $p->getCurrentPage());
+		$this->assertEquals('baz', $p->getCursor());
+	}
+
+
 	public function testPaginationContextSetsUpRangeCorrectly()
 	{
 		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('foo', 'bar', 'baz'), 3, 2);


### PR DESCRIPTION
Continuation from #2876. Added `cursor()` method to Eloquent and Fluent.
Works the same way as paginator, except that it'll create Paginator instance in cursor mode (without knowing total number of items available).

Usage with Eloquent:

``` php
// Will execute: SELECT * FROM users ORDER BY id LIMIT 0, 31;
$users = User::orderBy('id')->cursor(30);
// Paginator instance $items array will contain 30 items and one extra item would be put into $cursor.
```

And with Paginator:

``` php
// On render will return Prev link (disabled) and Next link leading to page 2.
// First argument - items array, second argument - number of items per page. Total will be set to null.
$pager = Paginator::make(['foo', 'bar', 'baz'], 2);
```

P.S.: Removed several stray spaces in tests.
