### PR TITLE
Performance improvements of relation name detection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -848,21 +848,28 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	protected function getRelationCaller($relation)
 	{
-		$self = __FUNCTION__;
-
 		$class = $this;
-
 		$limit = 2;
 
 		while ($class = get_parent_class($class)) $limit++;
 
-		$caller = array_first(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $limit),
-			function($key, $trace) use ($self, $relation)
-		{
-			$caller = $trace['function'];
+		$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $limit);
 
-			return ($caller != $self && $caller != $relation);
-		});
+		if ($limit == 3)
+		{
+			$caller = last($backtrace);
+		}
+		else
+		{
+			$self = __FUNCTION__;
+
+			$caller = array_first($backtrace, function($key, $trace) use ($self, $relation)
+			{
+				$caller = $trace['function'];
+
+				return ($caller != $self && $caller != $relation);
+			});
+		}
 
 		return ! is_null($caller) ? $caller['function'] : null;
 	}

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -26,7 +26,7 @@ class BelongsTo extends Relation {
 	 *
 	 * @var string
 	 */
-	protected $relation;
+	protected $relationName;
 
 	/**
 	 * Create a new belongs to relationship instance.
@@ -38,10 +38,10 @@ class BelongsTo extends Relation {
 	 * @param  string  $relation
 	 * @return void
 	 */
-	public function __construct(Builder $query, Model $parent, $foreignKey, $otherKey, $relation)
+	public function __construct(Builder $query, Model $parent, $foreignKey, $otherKey, $relationName)
 	{
 		$this->otherKey = $otherKey;
-		$this->relation = $relation;
+		$this->relationName = $relationName;
 		$this->foreignKey = $foreignKey;
 
 		parent::__construct($query, $parent);
@@ -204,7 +204,7 @@ class BelongsTo extends Relation {
 	{
 		$this->parent->setAttribute($this->foreignKey, $model->getAttribute($this->otherKey));
 
-		return $this->parent->setRelation($this->relation, $model);
+		return $this->parent->setRelation($this->relationName, $model);
 	}
 
 	/**
@@ -258,6 +258,16 @@ class BelongsTo extends Relation {
 	public function getQualifiedOtherKeyName()
 	{
 		return $this->related->getTable().'.'.$this->otherKey;
+	}
+
+	/**
+	 * Get the relationship name for the relationship.
+	 *
+	 * @return string
+	 */
+	public function getRelationName()
+	{
+		return $this->relationName;
 	}
 
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -692,6 +692,29 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRelationNameDetection()
+	{
+		$model = new EloquentModelRelationNameStub;
+		$this->addMockConnection($model);
+
+		$relation = $model->belongsToManyStub();
+		$this->assertEquals('belongsToManyStub', $relation->getRelationName());
+
+		$relation = $model->morphToManyStub();
+		$this->assertEquals('morphToManyStub', $relation->getRelationName());
+
+		$relation = $model->morphedByManyStub();
+		$this->assertEquals('morphedByManyStub', $relation->getRelationName());
+
+		$relation = $model->belongsToStub();
+		$this->assertEquals('belongsToStub', $relation->getRelationName());
+
+		$model->morph_to_stub_type = 'EloquentModelSaveStub';
+		$relation = $model->morphToStub();
+		$this->assertEquals('morphToStub', $relation->getRelationName());
+	}
+
+
 	public function testModelsAssumeTheirName()
 	{
 		$model = new EloquentModelWithoutTableStub;
@@ -832,6 +855,52 @@ class EloquentDateModelStub extends EloquentModelStub {
 	public function getDates()
 	{
 		return array('created_at', 'updated_at');
+	}
+}
+
+class EloquentModelOverridingStub extends Illuminate\Database\Eloquent\Model {
+	public function belongsToMany($related, $table = null, $foreignKey = null, $otherKey = null, $relation = null)
+	{
+		return parent::belongsToMany($related, $table, $foreignKey, $otherKey, $relation);
+	}
+	public function morphToMany($related, $name, $table = null, $foreignKey = null, $otherKey = null, $relation = null, $inverse = false)
+	{
+		return parent::morphToMany($related, $name, $table, $foreignKey, $otherKey, $relation, $inverse);
+	}
+	public function morphedByMany($related, $name, $table = null, $foreignKey = null, $otherKey = null, $relation = null)
+	{
+		return parent::morphedByMany($related, $name, $table, $foreignKey, $otherKey, $relation);
+	}
+	public function belongsTo($related, $foreignKey = null, $otherKey = null, $relation = null)
+	{
+		return parent::belongsTo($related, $foreignKey, $otherKey, $relation);
+	}
+	public function morphTo($name = null, $type = null, $id = null)
+	{
+		return parent::morphTo($name, $type, $id);
+	}
+}
+
+class EloquentModelRelationNameStub extends EloquentModelOverridingStub {
+	public function belongsToManyStub()
+	{
+		return $this->belongsToMany('EloquentModelSaveStub');
+	}
+	public function morphToManyStub()
+	{
+		return $this->morphToMany('EloquentModelSaveStub', 'foo');
+	}
+	public function morphedByManyStub()
+	{
+		return $this->morphedByMany('EloquentModelSaveStub', 'foo');
+	}
+	public function belongsToStub()
+	{
+		return $this->belongsTo('EloquentModelSaveStub');
+	}
+	public function morphToStub()
+	{
+		return $this->morphTo();
 	}
 }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -646,6 +646,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->addMockConnection($model);
 		$relation = $model->belongsToStub();
 		$this->assertEquals('belongs_to_stub_id', $relation->getForeignKey());
+		$this->assertEquals('belongsToStub', $relation->getRelationName());
 		$this->assertTrue($relation->getParent() === $model);
 		$this->assertTrue($relation->getQuery()->getModel() instanceof EloquentModelSaveStub);
 
@@ -660,12 +661,12 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	{
 		$model = m::mock('Illuminate\Database\Eloquent\Model[belongsTo]');
 		$model->foo_type = 'FooClass';
-		$model->shouldReceive('belongsTo')->with('FooClass', 'foo_id');
+		$model->shouldReceive('belongsTo')->with('FooClass', 'foo_id', null, 'foo');
 		$relation = $model->morphTo('foo');
 
 		$model = m::mock('EloquentModelStub[belongsTo]');
 		$model->morph_to_stub_type = 'FooClass';
-		$model->shouldReceive('belongsTo')->with('FooClass', 'morph_to_stub_id');
+		$model->shouldReceive('belongsTo')->with('FooClass', 'morph_to_stub_id', null, 'morphToStub');
 		$relation = $model->morphToStub();
 	}
 


### PR DESCRIPTION
PR for proposal https://github.com/laravel/framework/issues/3567.
- refactored `getBelongsToManyCaller()` to `getRelationCaller()` using `DEBUG_BACKTRACE_IGNORE_ARGS` option and new `$limit` parameter to limit the number of stack frames returned.
- use new method for detection of relation name 
- added `$relation` parameter to `morphToMany` and `morphedByMany` methods so it is possible to explicitly pass a relation name
- added `getRelationName()` method to `BelongsTo` and rename property to `$relationName` for consistency with `BelongsToMany`
- fixed tests for `morphTo` and added test for relation name of `belongsTo` relationship

Kind regards, Ruby.
