### PR TITLE
Enforce boolean autoIncrement

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -739,10 +739,16 @@ class Blueprint {
 	 * @param  string  $name
 	 * @param  array   $parameters
 	 * @return \Illuminate\Support\Fluent
+	 * @throws \InvalidArgumentException  If autoIncrement is not a boolean.
 	 */
 	protected function addColumn($type, $name, array $parameters = array())
 	{
 		$attributes = array_merge(compact('type', 'name'), $parameters);
+
+		if (isset($attributes['autoIncrement']) && ! is_bool($attributes['autoIncrement']))
+		{
+			throw new \InvalidArgumentException('An autoIncrement argument was given but was not boolean.');
+		}
 
 		$this->columns[] = $column = new Fluent($attributes);
 


### PR DESCRIPTION
A lot of people make the mistake of adding a second argument to the `integer()` methods, thinking it means length. I think adding this manual check could save people time troubleshooting.

This would probably break someone's 4.1 codebase (though one could argue that that would be to their benefit) so requested against master.
