### PR TITLE
Use PHP's abstract features

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -123,10 +123,7 @@ abstract class Facade {
 	 *
 	 * @throws \RuntimeException
 	 */
-	protected static function getFacadeAccessor()
-	{
-		throw new \RuntimeException("Facade does not implement getFacadeAccessor method.");
-	}
+	abstract protected static function getFacadeAccessor();
 
 	/**
 	 * Resolve the facade root instance from the container.


### PR DESCRIPTION
I can't see why you shouldn't use the `abstract` keyword here instead of throwing an exception.

Submitted to the master branch, as it's not fully comptable with before (an error instead of an exception)
