### PR TITLE
Added removeBeforeFilter and removeAfterFilter controller methods.

### DIFF
--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -133,6 +133,51 @@ abstract class Controller {
 	}
 
 	/**
+	 * Remove the given named controller before filter.
+	 *
+	 * @param  string  $filter
+	 * @param  array  $options
+	 * @return void
+	 */
+	public function removeBeforeFilter($filter)
+	{
+		$this->beforeFilters = $this->removeFilter($filter, $this->getBeforeFilters());
+	}
+
+	/**
+	 * Remove the given named controller after filter.
+	 *
+	 * @param  string  $filter
+	 * @param  array  $options
+	 * @return void
+	 */
+	public function removeAfterFilter($filter)
+	{
+		$this->afterFilters = $this->removeFilter($filter, $this->getAfterFilters());
+	}
+
+	/**
+	 * Remove the given controller filter from the provided filter array.
+	 *
+	 * @param  string  $filter
+	 * @param  array  $activeFilters
+	 * @return array
+	 */
+	protected function removeFilter($filter, $activeFilters)
+	{
+		$newFilters = array();
+		foreach ($activeFilters as $activeFilter)
+		{
+			if ($activeFilter['original'] !== $filter)
+			{
+				$newFilters[] = $activeFilter;
+			}
+		}
+
+		return $newFilters;
+	}
+
+	/**
 	 * Get the registered "before" filters.
 	 *
 	 * @return array

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -145,6 +145,33 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($_SERVER['__test.after.filter']);
 
 		/**
+		 * Test filter removal.
+		 */
+		$router = $this->getRouter();
+		$router->filter('removeBefore', function() {
+			$_SERVER['__test.before.removeBeforeFilter'] = true;
+		});
+		$router->get('removeBefore', 'RouteTestControllerDispatchStub@removeBefore');
+		$this->assertEquals('removeBefore', $router->dispatch(Request::create('removeBefore', 'GET'))->getContent());
+		$this->assertTrue(!isset($_SERVER['__test.after.removeBeforeFilter']) || is_null(isset($_SERVER['__test.after.removeBeforeFilter'])));
+
+		$router = $this->getRouter();
+		$router->filter('removeAfter', function() {
+			$_SERVER['__test.after.removeAfterFilter'] = true;
+		});
+		$router->get('removeAfter', 'RouteTestControllerDispatchStub@removeAfter');
+		$this->assertEquals('removeAfter', $router->dispatch(Request::create('removeAfter', 'GET'))->getContent());
+		$this->assertTrue(!isset($_SERVER['__test.after.removeAfterFilter']) || is_null(isset($_SERVER['__test.after.removeAfterFilter'])));
+
+		$router = $this->getRouter();
+		$router->get('rb', 'RouteTestControllerDispatchStub@rb');
+		$this->assertEquals('rb', $router->dispatch(Request::create('rb', 'GET'))->getContent());
+
+		$router = $this->getRouter();
+		$router->get('ra', 'RouteTestControllerDispatchStub@ra');
+		$this->assertEquals('ra', $router->dispatch(Request::create('ra', 'GET'))->getContent());
+
+		/**
 		 * Test filters disabled...
 		 */
 		$router = $this->getRouter();
@@ -692,7 +719,16 @@ class RouteTestControllerDispatchStub extends Illuminate\Routing\Controller {
 	{
 		$this->beforeFilter('foo', array('only' => 'bar'));
 		$this->beforeFilter('@filter', array('only' => 'baz'));
+		$this->beforeFilter('removeBefore', array('only' => 'removeBefore'));
+		$this->beforeFilter('@rbFilter', array('only' => 'rb'));
 		$this->afterFilter('qux', array('only' => 'qux'));
+		$this->afterFilter('removeAfter', array('only' => 'removeAfter'));
+		$this->afterFilter('@raFilter', array('only' => 'ra'));
+
+		$this->removeBeforeFilter('removeBefore');
+		$this->removeBeforeFilter('@rbFilter');
+		$this->removeAfterFilter('removeAfter');
+		$this->removeAfterFilter('@raFilter');
 	}
 	public function foo()
 	{
@@ -713,6 +749,30 @@ class RouteTestControllerDispatchStub extends Illuminate\Routing\Controller {
 	public function qux()
 	{
 		return 'qux';
+	}
+	public function rb()
+	{
+		return 'rb';
+	}
+	public function ra()
+	{
+		return 'ra';
+	}
+	public function removeBefore()
+	{
+		return 'removeBefore';
+	}
+	public function removeAfter()
+	{
+		return 'removeAfter';
+	}
+	public function rbFilter()
+	{
+		return 'rbFilter';
+	}
+	public function raFilter()
+	{
+		return 'raFilter';
 	}
 }
 


### PR DESCRIPTION
This adds the ability to remove before and after controller filters if they are identifiable by a string. This is useful if you have a base controller that adds a before or after filter, but some of its children shouldn't use that filter.

I'm open to any suggestions about how to improve this or any added functionality. I added it to 4.1 because it should be completely non-breaking since it uses all new functions. I also ran the tests in RoutingRouteTest.php which is where I added my new tests, and it was green.

Say you had a BaseController that all controllers extended, and also a ConfigurationsController. You want CSRF protection on all posts, except for those in ConfigurationsController. You can just do something like this:

```
class BaseController extends Controller {
    public function __construct()
    {
        $this->beforeFilter('csrf', array('on' => ['post', 'put', 'patch', 'delete']));
    }
}

class ConfigurationsController extends Controller {
    function __construct()
    {
        parent::__construct();
        $this->removeBeforeFilter('csrf');
    }
}
```
