### PR TITLE
Table prefix was missing in BelongsToMany@getRelationCountQueryForSelfJoin

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -267,7 +267,9 @@ class BelongsToMany extends Relation {
 	{
 		$query->select(new \Illuminate\Database\Query\Expression('count(*)'));
 
-		$query->from($this->table.' as '.$hash = $this->getRelationCountHash());
+		$tablePrefix = $this->query->getQuery()->getConnection()->getTablePrefix();
+
+		$query->from($this->table.' as '.$tablePrefix.$hash = $this->getRelationCountHash());
 
 		$key = $this->wrap($this->getQualifiedParentKeyName());
 


### PR DESCRIPTION
Table prefix was missing in the SQL query generated by Eloquent ORM, as discussed here : https://github.com/laravel/laravel/issues/2672
