### PR TITLE
Use PHP 5.4 Closures $this Where Safe To

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -458,13 +458,11 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function compileOrders(Builder $query, $orders)
 	{
-		$me = $this;
-
-		return 'order by '.implode(', ', array_map(function($order) use ($me)
+		return 'order by '.implode(', ', array_map(function($order)
 		{
 			if (isset($order['sql'])) return $order['sql'];
 
-			return $me->wrap($order['column']).' '.$order['direction'];
+			return $this->wrap($order['column']).' '.$order['direction'];
 		}
 		, $orders));
 	}

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -105,11 +105,9 @@ class Dispatcher {
 	 */
 	public function queue($event, $payload = array())
 	{
-		$me = $this;
-
-		$this->listen($event.'_queue', function() use ($me, $event, $payload)
+		$this->listen($event.'_queue', function() use ($event, $payload)
 		{
-			$me->fire($event, $payload);
+			$this->fire($event, $payload);
 		});
 	}
 

--- a/src/Illuminate/Foundation/MigrationPublisher.php
+++ b/src/Illuminate/Foundation/MigrationPublisher.php
@@ -61,11 +61,9 @@ class MigrationPublisher {
 	 */
 	protected function getFreshMigrations($source, $destination)
 	{
-		$me = $this;
-
-		return array_filter($this->getPackageMigrations($source), function($file) use ($me, $destination)
+		return array_filter($this->getPackageMigrations($source), function($file) use ($destination)
 		{
-			return ! $me->migrationExists($file, $destination);
+			return ! $this->migrationExists($file, $destination);
 		});
 	}
 

--- a/src/Illuminate/Remote/Connection.php
+++ b/src/Illuminate/Remote/Connection.php
@@ -213,9 +213,7 @@ class Connection implements ConnectionInterface {
 	{
 		if ( ! is_null($callback)) return $callback;
 
-		$me = $this;
-
-		return function($line) use ($me) { $me->display($line); };
+		return function($line) { $this->display($line); };
 	}
 
 	/**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -440,14 +440,12 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	protected function getNestedResourceUri(array $segments)
 	{
-		$me = $this;
-
 		// We will spin through the segments and create a place-holder for each of the
 		// resource segments, as well as the resource itself. Then we should get an
 		// entire string for the resource URI that contains all nested resources.
-		return implode('/', array_map(function($s) use ($me)
+		return implode('/', array_map(function($s)
 		{
-			return $s.'/{'.$me->getResourceWildcard($s).'}';
+			return $s.'/{'.$this->getResourceWildcard($s).'}';
 
 		}, $segments));
 	}

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -190,13 +190,11 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	protected function compileRegularEchos($value)
 	{
-		$me = $this;
-
 		$pattern = sprintf('/(@)?%s\s*(.+?)\s*%s/s', $this->contentTags[0], $this->contentTags[1]);
 
-		$callback = function($matches) use ($me)
+		$callback = function($matches)
 		{
-			return $matches[1] ? substr($matches[0], 1) : '<?php echo '.$me->compileEchoDefaults($matches[2]).'; ?>';
+			return $matches[1] ? substr($matches[0], 1) : '<?php echo '.$this->compileEchoDefaults($matches[2]).'; ?>';
 		};
 
 		return preg_replace_callback($pattern, $callback, $value);
@@ -210,13 +208,11 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	protected function compileEscapedEchos($value)
 	{
-		$me = $this;
-
 		$pattern = sprintf('/%s\s*(.+?)\s*%s/s', $this->escapedTags[0], $this->escapedTags[1]);
 
-		$callback = function($matches) use ($me)
+		$callback = function($matches)
 		{
-			return '<?php echo e('.$me->compileEchoDefaults($matches[1]).'); ?>';
+			return '<?php echo e('.$this->compileEchoDefaults($matches[1]).'); ?>';
 		};
 
 		return preg_replace_callback($pattern, $callback, $value);


### PR DESCRIPTION
PHP 5.4 supports $this in closures, and as laravel 4.2 is targeting it, we might as well use it, or rather, not use it, if you get what I am saying. I have got rid of some of the `$me = $this;` stuff from the closures that don't need it because we are use that $this will be the correct object.
