### PR TITLE
Allow pgsql enum fields /w reserved words as names

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -393,7 +393,7 @@ class PostgresGrammar extends Grammar {
 	{
 		$allowed = array_map(function($a) { return "'".$a."'"; }, $column->allowed);
 
-		return "varchar(255) check ({$column->name} in (".implode(', ', $allowed)."))";
+		return "varchar(255) check (\"{$column->name}\" in (".implode(', ', $allowed)."))";
 	}
 
 	/**

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -355,7 +355,7 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table "users" add column "foo" varchar(255) check (foo in (\'bar\', \'baz\')) not null', $statements[0]);
+		$this->assertEquals('alter table "users" add column "foo" varchar(255) check ("foo" in (\'bar\', \'baz\')) not null', $statements[0]);
 	}
 
 


### PR DESCRIPTION
Rebase of #3653

An enum with a name like `unique` would cause an SQL syntax error, so just wrapped that sucker up in double-quotes to make it work.
