### PR TITLE
Updated WinCache driver to use correct function for put() implementation...

### DIFF
--- a/src/Illuminate/Cache/WinCacheStore.php
+++ b/src/Illuminate/Cache/WinCacheStore.php
@@ -46,7 +46,7 @@ class WinCacheStore extends TaggableStore implements StoreInterface {
 	 */
 	public function put($key, $value, $minutes)
 	{
-		wincache_ucache_add($this->prefix.$key, $value, $minutes * 60);
+		wincache_ucache_set($this->prefix.$key, $value, $minutes * 60);
 	}
 
 	/**


### PR DESCRIPTION
WinCache driver was incorrectly using wincache_ucache_add(...) for put(...) implementation of Cache. 

Whenever a key already existed in the cache, the function threw an exception ("wincache_ucache_add(): function called with a key which already exists").

The correct function to use in this case is wincache_ucache_set(...).
