### PR TITLE
Fix for bug in IronMQ integration

### DIFF
--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -126,13 +126,12 @@ class IronQueue extends Queue implements QueueInterface {
 
 		$job = $this->iron->getMessage($queue);
 
-		$job->queue = $queue;
-		
 		// If we were able to pop a message off of the queue, we will need to decrypt
 		// the message body, as all Iron.io messages are encrypted, since the push
 		// queues will be a security hazard to unsuspecting developers using it.
 		if ( ! is_null($job))
 		{
+			$job->queue = $queue;
 			$job->body = $this->crypt->decrypt($job->body);
 
 			return new IronJob($this->container, $this, $job);

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -126,6 +126,8 @@ class IronQueue extends Queue implements QueueInterface {
 
 		$job = $this->iron->getMessage($queue);
 
+		$job->queue = $queue;
+		
 		// If we were able to pop a message off of the queue, we will need to decrypt
 		// the message body, as all Iron.io messages are encrypted, since the push
 		// queues will be a security hazard to unsuspecting developers using it.

--- a/src/Illuminate/Queue/Jobs/IronJob.php
+++ b/src/Illuminate/Queue/Jobs/IronJob.php
@@ -166,7 +166,7 @@ class IronJob extends Job {
 	 */
 	public function getQueue()
 	{
-		return array_get(json_decode($this->job->body, true), 'queue');
+		return $this->job->queue;
 	}
 
 }

--- a/src/Illuminate/Queue/Jobs/IronJob.php
+++ b/src/Illuminate/Queue/Jobs/IronJob.php
@@ -166,7 +166,7 @@ class IronJob extends Job {
 	 */
 	public function getQueue()
 	{
-		return (isset($this->job->queue)) ? $this->job->queue : array_get(json_decode($this->job->body, true), 'queue');
+		return $this->job->queue;
 	}
 
 }

--- a/src/Illuminate/Queue/Jobs/IronJob.php
+++ b/src/Illuminate/Queue/Jobs/IronJob.php
@@ -166,7 +166,7 @@ class IronJob extends Job {
 	 */
 	public function getQueue()
 	{
-		return $this->job->queue;
+		return (isset($this->job->queue)) ? $this->job->queue : array_get(json_decode($this->job->body, true), 'queue');
 	}
 
 }

--- a/tests/Queue/QueueIronJobTest.php
+++ b/tests/Queue/QueueIronJobTest.php
@@ -34,7 +34,7 @@ class QueueIronJobTest extends PHPUnit_Framework_TestCase {
 		$job = new Illuminate\Queue\Jobs\IronJob(
 			m::mock('Illuminate\Container\Container'),
 			m::mock('Illuminate\Queue\IronQueue'),
-			(object) array('id' => 1, 'body' => json_encode(array('job' => 'foo', 'data' => array('data'))), 'timeout' => 60, 'pushed' => true),
+			(object) array('id' => 1, 'queue' => 'default', 'body' => json_encode(array('job' => 'foo', 'data' => array('data'))), 'timeout' => 60, 'pushed' => true),
 			'default'
 		);
 		$job->getIron()->shouldReceive('deleteMessage')->never();
@@ -47,7 +47,7 @@ class QueueIronJobTest extends PHPUnit_Framework_TestCase {
 	{
 		$job = $this->getJob();
 		$job->getIron()->shouldReceive('deleteMessage')->once();
-		$job->getIron()->shouldReceive('recreate')->once()->with(json_encode(array('job' => 'foo', 'data' => array('data'), 'attempts' => 2, 'queue' => 'default')), 'default', 5);
+		$job->getIron()->shouldReceive('recreate')->once()->with(json_encode(array('job' => 'foo', 'data' => array('data'), 'attempts' => 2)), 'default', 5);
 
 		$job->release(5);
 	}
@@ -58,7 +58,7 @@ class QueueIronJobTest extends PHPUnit_Framework_TestCase {
 		return new Illuminate\Queue\Jobs\IronJob(
 			m::mock('Illuminate\Container\Container'),
 			m::mock('Illuminate\Queue\IronQueue'),
-			(object) array('id' => 1, 'body' => json_encode(array('job' => 'foo', 'data' => array('data'), 'attempts' => 1, 'queue' => 'default')), 'timeout' => 60)
+			(object) array('id' => 1, 'queue' => 'default', 'body' => json_encode(array('job' => 'foo', 'data' => array('data'), 'attempts' => 1)), 'timeout' => 60)
 		);
 	}
 


### PR DESCRIPTION
The current getQueue function doesn't return the queue name when new messages are pulled from IronMQ.

```
public function getQueue()
{
    return array_get(json_decode($this->job->body, true), 'queue');
}
```

I'm not sure if this was caused by an API change by Iron.io or a change to the IronMQ repo but the queue name is no longer attached to the job->body. These changes push the queue name onto the job once it's returned from IronMQ which is then passed on to the IronJob class.
