### PR TITLE
Fix Translator::get() when parseLocale() returns empty array

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -89,7 +89,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 		// If the line doesn't exist, we will return back the key which was requested as
 		// that will be quick to spot in the UI if language keys are wrong or missing
 		// from the application's language files. Otherwise we can return the line.
-		if (is_null($line)) return $key;
+		if ( ! isset($line) || is_null($line)) return $key;
 
 		return $line;
 	}


### PR DESCRIPTION
If `$this->parseLocale($locale)` returns empty array, `$line` will be undefined:

```
ErrorException
Undefined variable: line
```
