### PR TITLE
Make --optimize optional for composer dump-autoload

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -50,7 +50,14 @@ class OptimizeCommand extends Command {
 	{
 		$this->info('Generating optimized class loader');
 
-		$this->composer->dumpOptimized();
+		if ($this->option('psr'))
+		{
+			$this->composer->dumpAutoloads();
+		}
+		else
+		{
+			$this->composer->dumpOptimized();
+		}
 
 		if ($this->option('force') || ! $this->laravel['config']['app.debug'])
 		{
@@ -115,6 +122,7 @@ class OptimizeCommand extends Command {
 	{
 		return array(
 			array('force', null, InputOption::VALUE_NONE, 'Force the compiled class file to be written.'),
+			array('psr', null, InputOption::VALUE_NONE, 'Do not optimize Composer dump-autoload.'),
 		);
 	}
 


### PR DESCRIPTION
As asked in https://github.com/laravel/framework/pull/3701, option is now `--psr`.
