### PR TITLE
Potential improvement on PHPunit error handling

### DIFF
--- a/phpunit.php
+++ b/phpunit.php
@@ -1,5 +1,14 @@
 <?php
 
+error_reporting(E_ALL);
+
+set_error_handler(function($no, $str, $file, $line, $context) {
+	// allow user-suppressed errors to pass
+	if (error_reporting() === 0) return;
+	echo "PHP error no. $no - $str" . PHP_EOL . "In $file on line $line" . PHP_EOL;
+	exit(1);
+});
+
 /*
 |--------------------------------------------------------------------------
 | Register The Composer Auto Loader


### PR DESCRIPTION
In the wake of #3673 I messed around a bit. PHPUnit will not catch all errors that occur during code execution for whatever reason.

By setting error_reporting to E_ALL we ensure that people who don't have it set to that in their php.ini still get the error output. I think the default config for CLI is E_ALL & ~E_DEPRECATED & ~E_STRICT which means some errors are suppressed by default.

By adding a custom error handler we can print the error and then exit with a status code of 1, telling Travis CI that the build failed.

The check for `error_reporting() === 0` allows user-suppressed errors using `@` to pass - these are not present in Laravel code as far as I know, but some other libraries use them.

Hopefully this ensures that code-level errors are caught more reliably in the future.
