### PR TITLE
Make MacroableTrait handle non-static calls

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -256,18 +256,13 @@ class Repository implements ArrayAccess {
 	 */
 	public function __call($method, $parameters)
 	{
-		try
+		if (isset(static::$macros[$method]))
 		{
-			return $this->macroCall($method, $parameters);
+			return call_user_func_array(static::$macros[$method], $parameters);
 		}
-		catch (\BadMethodCallException $e)
+		else
 		{
-			if (is_callable(array($this->store, $method)))
-			{
-				return call_user_func_array(array($this->store, $method), $parameters);
-			}
-
-			throw $e;
+			return call_user_func_array(array($this->store, $method), $parameters);
 		}
 	}
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -256,9 +256,9 @@ class Repository implements ArrayAccess {
 	 */
 	public function __call($method, $parameters)
 	{
-		if (isset(static::$macros[$method]))
+		if (static::hasMacro($method))
 		{
-			return call_user_func_array(static::$macros[$method], $parameters);
+			return $this->macroCall($method, $parameters);
 		}
 		else
 		{

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -7,6 +7,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Traits\MacroableTrait;
 
 class Repository implements ArrayAccess {
+
 	use MacroableTrait {
 		__call as macroCall;
 	}
@@ -255,13 +256,19 @@ class Repository implements ArrayAccess {
 	 */
 	public function __call($method, $parameters)
 	{
-		try {
+		try
+		{
 			return $this->macroCall($method, $parameters);
-		} catch (\BadMethodCallException $e) {
-			if (is_callable(array($this->store, $method))) {
+		}
+		catch (\BadMethodCallException $e)
+		{
+			if (is_callable(array($this->store, $method)))
+			{
 				return call_user_func_array(array($this->store, $method), $parameters);
 			}
+
 			throw $e;
 		}
 	}
+
 }

--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -2,8 +2,11 @@
 
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Session\Store as Session;
+use Illuminate\Support\Traits\MacroableTrait;
 
 class FormBuilder {
+
+	use MacroableTrait;
 
 	/**
 	 * The HTML builder instance.
@@ -46,13 +49,6 @@ class FormBuilder {
 	 * @var array
 	 */
 	protected $labels = array();
-
-	/**
-	 * The registered form builder macros.
-	 *
-	 * @var array
-	 */
-	protected $macros = array();
 
 	/**
 	 * The reserved form open attributes.
@@ -731,18 +727,6 @@ class FormBuilder {
 	}
 
 	/**
-	 * Register a custom form macro.
-	 *
-	 * @param  string    $name
-	 * @param  callable  $macro
-	 * @return void
-	 */
-	public function macro($name, $macro)
-	{
-		$this->macros[$name] = $macro;
-	}
-
-	/**
 	 * Parse the form action method.
 	 *
 	 * @param  string  $method
@@ -982,25 +966,6 @@ class FormBuilder {
 		$this->session = $session;
 
 		return $this;
-	}
-
-	/**
-	 * Dynamically handle calls to the form builder.
-	 *
-	 * @param  string  $method
-	 * @param  array   $parameters
-	 * @return mixed
-	 *
-	 * @throws \BadMethodCallException
-	 */
-	public function __call($method, $parameters)
-	{
-		if (isset($this->macros[$method]))
-		{
-			return call_user_func_array($this->macros[$method], $parameters);
-		}
-
-		throw new \BadMethodCallException("Method {$method} does not exist.");
 	}
 
 }

--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -1,8 +1,11 @@
 <?php namespace Illuminate\Html;
 
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Traits\MacroableTrait;
 
 class HtmlBuilder {
+
+	use MacroableTrait;
 
 	/**
 	 * The URL generator instance.
@@ -10,13 +13,6 @@ class HtmlBuilder {
 	 * @var \Illuminate\Routing\UrlGenerator
 	 */
 	protected $url;
-
-	/**
-	 * The registered html macros.
-	 *
-	 * @var array
-	 */
-	protected $macros;
 
 	/**
 	 * Create a new HTML builder instance.
@@ -27,18 +23,6 @@ class HtmlBuilder {
 	public function __construct(UrlGenerator $url = null)
 	{
 		$this->url = $url;
-	}
-
-	/**
-	 * Register a custom HTML macro.
-	 *
-	 * @param  string    $name
-	 * @param  callable  $macro
-	 * @return void
-	 */
-	public function macro($name, $macro)
-	{
-		$this->macros[$name] = $macro;
 	}
 
 	/**
@@ -387,25 +371,6 @@ class HtmlBuilder {
 		}
 
 		return $safe;
-	}
-
-	/**
-	 * Dynamically handle calls to the html class.
-	 *
-	 * @param  string  $method
-	 * @param  array   $parameters
-	 * @return mixed
-	 *
-	 * @throws \BadMethodCallException
-	 */
-	public function __call($method, $parameters)
-	{
-		if (isset($this->macros[$method]))
-		{
-			return call_user_func_array($this->macros[$method], $parameters);
-		}
-
-		throw new \BadMethodCallException("Method {$method} does not exist.");
 	}
 
 }

--- a/src/Illuminate/Support/Traits/MacroableTrait.php
+++ b/src/Illuminate/Support/Traits/MacroableTrait.php
@@ -22,6 +22,17 @@ trait MacroableTrait {
 	}
 
 	/**
+	 * Checks if macro is registered
+	 *
+	 * @param  string    $name
+	 * @return boolean
+	 */
+	public static function hasMacro($name)
+	{
+		return isset(static::$macros[$name]);
+	}
+
+	/**
 	 * Dynamically handle calls to the class.
 	 *
 	 * @param  string  $method
@@ -32,7 +43,7 @@ trait MacroableTrait {
 	 */
 	public static function __callStatic($method, $parameters)
 	{
-		if (isset(static::$macros[$method]))
+		if (static::hasMacro($method))
 		{
 			return call_user_func_array(static::$macros[$method], $parameters);
 		}

--- a/src/Illuminate/Support/Traits/MacroableTrait.php
+++ b/src/Illuminate/Support/Traits/MacroableTrait.php
@@ -40,4 +40,18 @@ trait MacroableTrait {
 		throw new \BadMethodCallException("Method {$method} does not exist.");
 	}
 
+	/**
+	 * Dynamically handle calls to the form builder.
+	 *
+	 * @param  string  $method
+	 * @param  array   $parameters
+	 * @return mixed
+	 *
+	 * @throws \BadMethodCallException
+	 */
+	public function __call($method, $parameters)
+	{
+		return static::__callStatic($method, $parameters);
+	}
+
 }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -76,6 +76,14 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRegisterMacroWithNonStaticCall()
+	{
+		$repo = $this->getRepository();
+		$repo::macro(__CLASS__, function() { return 'Taylor'; });
+		$this->assertEquals($repo->{__CLASS__}(), 'Taylor');
+	}
+
+
 	protected function getRepository()
 	{
 		return new Illuminate\Cache\Repository(m::mock('Illuminate\Cache\StoreInterface'));

--- a/tests/Support/SupportMacroTraitTest.php
+++ b/tests/Support/SupportMacroTraitTest.php
@@ -26,4 +26,11 @@ class SupportMacroTraitTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals('Taylor', $macroTrait::{__CLASS__}());
 	}
 
+	public function testResgisterMacroAndCallWithoutStatic()
+	{
+		$macroTrait = $this->macroTrait;
+		$macroTrait::macro(__CLASS__, function() { return 'Taylor'; });
+		$this->assertEquals('Taylor', $macroTrait->{__CLASS__}());
+	}
+
 }


### PR DESCRIPTION
This will make MacroableTrait able to cover Cache\Repository, HtmlBuilder and FormBuilder.

Question is if there's a problem not being able to have the same macro method on different instances?
Atleast not when defining them all early in the cycle.
