### PR TITLE
Fix artisan route to show multiple route verbs

### DIFF
--- a/src/Illuminate/Foundation/Console/RoutesCommand.php
+++ b/src/Illuminate/Foundation/Console/RoutesCommand.php
@@ -109,7 +109,12 @@ class RoutesCommand extends Command {
 	 */
 	protected function getRouteInformation(Route $route)
 	{
-		$uri = head($route->methods()).' '.$route->uri();
+		// $uri = head($route->methods()).' '.$route->uri();
+
+		// deal with Route::match() multiple verbs to single method
+		$methods = $route->methods();
+		if (end($methods) == 'HEAD') array_pop($methods);
+		$uri = implode('|',$methods).' '.$route->uri();
 
 		return $this->filterRoute(array(
 			'host'   => $route->domain(),


### PR DESCRIPTION
"artisan route" only shows a single verb per route method. This is misleading when routes are defined with multiple verbs to a single method/endpoint, for example with Route::match().

Fixed by imploding the methods array for the command output and removing HEAD where necessary.

nb. not tested exhaustively but works with a combination of resource, controller and closure routes. I'm uncertain about cases where this approach might skew artisan route output, and have not tested with filters.
