### PR TITLE
Update create.stub to use dropIfExists

### DIFF
--- a/src/Illuminate/Database/Migrations/stubs/create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/create.stub
@@ -26,7 +26,7 @@ class {{class}} extends Migration {
 	 */
 	public function down()
 	{
-		Schema::drop('{{table}}');
+		Schema::dropIfExists('{{table}}');
 	}
 
 }


### PR DESCRIPTION
Using dropIfExists will allow migrations (reset/refresh) to continue without error if the database table was dropped from an external source (phpMyAdmin, mySQL client etc).
