### PR TITLE
Don't return underlying query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -601,7 +601,7 @@ class Builder {
 		}
 		else
 		{
-			return call_user_func_array(
+			call_user_func_array(
 				array($this->query, 'where'), array_slice(func_get_args(), 0, func_num_args())
 			);
 		}

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -383,6 +383,15 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testSimpleWhere()
+	{
+		$builder = $this->getBuilder();
+		$builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'bar');
+		$result = $builder->where('foo', '=', 'bar');
+		$this->assertEquals($result, $builder);
+	}
+
+
 	protected function mockConnectionForModel($model, $database)
 	{
 		$grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';


### PR DESCRIPTION
Should fix #3732 #3731 and other issues with models being returned as StdClass and undefined methods on query builders.
## How to fix the problem if you have this issue

The only ones who should get this error are people who are actively opting in for non-stable versions of the framework - for example by requiring  `"laravel/framework": "4.1.*"` and having `"minimum-stability": "dev"` in their composer.json. Change your minimum-stability to `"stable"` and `composer update` to fix the issue and not get experimental changes in the future.

Symptoms of this bug are:
- All your Eloquent models are suddenly StdClass objects. `Undefined method StdClass::...` errors.
- Eloquent-specific queries like `with()` no longer work, `Undefined method Illuminate\Database\Query\Builder::with` errors
