### PR TITLE
Array walk fixes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -584,7 +584,7 @@ class BelongsToMany extends Relation {
 		{
 			$this->detach($detach);
 
-			$changes['detached'] = (array) array_walk($detach, 'intval');
+			$changes['detached'] = (array) array_walk($detach, function(&$n) { $n = intval($n); });
 		}
 
 		// Now we are finally ready to attach the new records. Note that we'll disable

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -547,7 +547,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	{
 		if ($this->booted) return;
 
-		array_walk($this->serviceProviders, function($p) { $p->boot(); });
+		array_walk($this->serviceProviders, function(&$p) { $p->boot(); });
 
 		$this->bootApplication();
 	}


### PR DESCRIPTION
I've had a think since yesterday, and the current usage of array_walk is still incorrect.
#### What You Have Now

What this does is execute the intval function with 2 arguments: the value, and the key. This means we are setting the intval base to each array key each time. This is not the desired behaviour, and I am surprised this hasn't caused issues for people already! Currently we have is:

```
array_walk($detach, 'intval');
```

 So the code you currently have basicly does this:

```
array_walk($detach, function(&$value, $key) { $value = intval($value, $key); });
```
#### My Proposed Fix

What would be better would be to make sure we are not setting the base by mistake:

```
array_walk($detach, function(&$n) { $n = intval($n); });
```
#### PHP Documentation

You can refer to the php [intval docs](http://uk3.php.net/intval) and [array_walk docs](http://uk3.php.net/array_walk) for more information.

---

Related to #3726 and https://github.com/facebook/hhvm/issues/1935.
