### PR TITLE
[4.2] Migrate To URLify

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "jeremeamia/superclosure": "~1.0",
         "monolog/monolog": "~1.6",
         "nesbot/carbon": "~1.0",
-        "patchwork/utf8": "1.1.*",
+        "jbroadway/urlify": "~1.0",
         "phpseclib/phpseclib": "0.3.*",
         "predis/predis": "0.8.*",
         "stack/builder": "~1.0",

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -10,11 +10,12 @@ class Str {
 	 * Transliterate a UTF-8 value to ASCII.
 	 *
 	 * @param  string  $value
+	 * @param  string  $lang
 	 * @return string
 	 */
-	public static function ascii($value)
+	public static function ascii($value, $lang = '')
 	{
-		return \Patchwork\Utf8::toAscii($value);
+		return \URLify::downcode($value, $lang = '');
 	}
 
 	/**
@@ -255,11 +256,12 @@ class Str {
 	 *
 	 * @param  string  $title
 	 * @param  string  $separator
+	 * @param  string  $lang
 	 * @return string
 	 */
-	public static function slug($title, $separator = '-')
+	public static function slug($title, $separator = '-', $lang = '')
 	{
-		$title = static::ascii($title);
+		$title = static::ascii($title, $lang);
 
 		// Convert all dashes/undescores into separator
 		$flip = $separator == '-' ? '_' : '-';

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -12,7 +12,7 @@
     },
     "require-dev": {
         "jeremeamia/superclosure": "~1.0",
-        "patchwork/utf8": "1.1.*",
+        "jbroadway/urlify": "~1.0",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "4.0.*"
     },


### PR DESCRIPTION
In #3643, you said you wanted to move to a smaller library for generating urls, and you mentioned urlify as a possibility. I've written an implementation here.

I've updated the asci function on the string class for urlify, ~~and in the air of simplicity, I have changed the slug method to use urlifiy's slugging method. I can revert this if you'd prefer to keep your own slugging method. If we do use it, we'd need to document that BC breakage~~.

---

Related to #3643 and #4204.
