### PR TITLE
first column modifier so columns can be added first in the table

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -18,7 +18,7 @@ class MySqlGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $modifiers = array('Unsigned', 'Nullable', 'Default', 'Increment', 'After');
+	protected $modifiers = array('Unsigned', 'Nullable', 'Default', 'Increment', 'After', 'First');
 
 	/**
 	 * The possible column serials
@@ -571,6 +571,21 @@ class MySqlGrammar extends Grammar {
 		if ( ! is_null($column->after))
 		{
 			return ' after '.$this->wrap($column->after);
+		}
+	}
+
+	/**
+	 * Get the SQL for an "first" column modifier.
+	 *
+	 * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+	 * @param  \Illuminate\Support\Fluent  $column
+	 * @return string|null
+	 */
+	protected function modifyFirst(Blueprint $blueprint, Fluent $column)
+	{
+		if ( ! is_null($column->first))
+		{
+			return ' first';
 		}
 	}
 


### PR DESCRIPTION
The After modifier currently exists in the MySQL grammer to add a column after another column but I didn't see a way to add a column and make it first. This adds support for the First modifier, which goes along with After as seen in the MySQL documentation.

http://dev.mysql.com/doc/refman/5.1/en/alter-table.html
