### PR TITLE
Updated SqsQueue so it builds the QueueUrl automatically using sqs->getB...

### DIFF
--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -17,7 +17,7 @@ class SqsConnector implements ConnectorInterface {
 
 		$sqs = SqsClient::factory($sqsConfig);
 
-		return new SqsQueue($sqs, $config['queue']);
+		return new SqsQueue($sqs, $config['queue'], $config['account']);
 	}
 
 }

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -24,14 +24,14 @@ class SqsJob extends Job {
 	 *
 	 * @param  \Illuminate\Container\Container  $container
 	 * @param  \Aws\Sqs\SqsClient  $sqs
-	 * @param  string  $queue
 	 * @param  array   $job
+	 * @param  string  $queue
 	 * @return void
 	 */
 	public function __construct(Container $container,
                                 SqsClient $sqs,
-                                $queue,
-                                array $job)
+                                array $job,
+                                $queue)
 	{
 		$this->sqs = $sqs;
 		$this->job = $job;

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -13,6 +13,13 @@ class SqsQueue extends Queue implements QueueInterface {
 	protected $sqs;
 
 	/**
+	 * The account associated with the default tube
+	 *
+	 * @var string
+	 */
+	protected $account;
+
+	/**
 	 * The name of the default tube.
 	 *
 	 * @var string
@@ -24,12 +31,14 @@ class SqsQueue extends Queue implements QueueInterface {
 	 *
 	 * @param  \Aws\Sqs\SqsClient  $sqs
 	 * @param  string  $default
+	 * @param  string  $account
 	 * @return void
 	 */
-	public function __construct(SqsClient $sqs, $default)
+	public function __construct(SqsClient $sqs, $default, $account)
 	{
 		$this->sqs = $sqs;
 		$this->default = $default;
+		$this->account = $account;
 	}
 
 	/**
@@ -98,7 +107,7 @@ class SqsQueue extends Queue implements QueueInterface {
 
 		if (count($response['Messages']) > 0)
 		{
-			return new SqsJob($this->container, $this->sqs, $queue, $response['Messages'][0]);
+			return new SqsJob($this->container, $this->sqs, $response['Messages'][0], $queue);
 		}
 	}
 
@@ -110,7 +119,7 @@ class SqsQueue extends Queue implements QueueInterface {
 	 */
 	public function getQueue($queue)
 	{
-		return $queue ?: $this->default;
+		return $this->sqs->getBaseUrl() . '/' . $this->account . '/' . ($queue ?: $this->default);
 	}
 
 	/**

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Mockery as m;
+
+use Aws\Sqs\SqsClient;
+use Aws\Common\Credentials\Credentials;
+use Aws\Common\Credentials\CredentialsInterface;
+use Aws\Common\Signature\SignatureInterface;
+use Aws\Common\Signature\SignatureV4;
+
+use Guzzle\Common\Collection;
+use Guzzle\Service\Resource\Model;
+
+class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
+
+	public function setUp() {
+
+		$this->key = 'AMAZONSQSKEY';
+		$this->secret = 'AmAz0n+SqSsEcReT+aLpHaNuM3R1CsTr1nG';
+		$this->service = 'sqs';
+		$this->region = 'someregion';
+		$this->account = '1234567891011';
+		$this->queueName = 'emails';
+		$this->baseUrl = 'https://sqs.someregion.amazonaws.com';
+
+		// The Aws\Common\AbstractClient needs these three constructor parameters
+		$this->credentials = new Credentials( $this->key, $this->secret );
+		$this->signature = new SignatureV4( $this->service, $this->region );
+		$this->config = new Collection();
+
+		// This is how the modified getQueue builds the queueUrl
+		$this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
+
+		// Get a mock of the SqsClient 
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		
+		// Use Mockery to mock the IoC Container
+		$this->mockedContainer = m::mock('Illuminate\Container\Container');
+
+		$this->mockedJob = 'foo';
+		$this->mockedData = array('data');
+		$this->mockedPayload = json_encode(array('job' => $this->mockedJob, 'data' => $this->mockedData, 'attempts' => 1));
+		$this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
+		$this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
+
+		$this->mockedJobData = array('Body' => $this->mockedPayload,
+					     'MD5OfBody' => md5($this->mockedPayload),
+					     'ReceiptHandle' => $this->mockedReceiptHandle,
+					     'MessageId' => $this->mockedMessageId,
+					     'Attributes' => array('ApproximateReceiveCount' => 1));
+
+	}
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testFireProperlyCallsTheJobHandler()
+	{
+		$job = $this->getJob();
+		$job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
+		$handler->shouldReceive('fire')->once()->with($job, array('data'));
+
+		$job->fire();
+	}
+
+
+	public function testDeleteRemovesTheJobFromSqs()
+	{
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->queueName, $this->account));
+		$queue->setContainer($this->mockedContainer);
+		$job = $this->getJob();
+		$job->getSqs()->expects($this->once())->method('deleteMessage')->with(array('QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle));	
+		$job->delete();
+	}
+
+	protected function getJob()
+	{
+		return new Illuminate\Queue\Jobs\SqsJob(
+			$this->mockedContainer,
+			$this->mockedSqsClient,
+			$this->mockedJobData,
+			$this->queueUrl
+		);
+	}
+
+}

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Mockery as m;
+
+use Aws\Sqs\SqsClient;
+use Guzzle\Service\Resource\Model;
+
+class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function setUp() {
+
+		// Use Mockery to mock the SqsClient
+		$this->sqs = m::mock('Aws\Sqs\SqsClient');
+
+		$this->account = '1234567891011';
+		$this->queueName = 'emails';
+		$this->baseUrl = 'https://sqs.someregion.amazonaws.com';
+
+		// This is how the modified getQueue builds the queueUrl
+		$this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
+
+		$this->mockedJob = 'foo';
+		$this->mockedData = array('data');
+		$this->mockedPayload = json_encode(array('job' => $this->mockedJob, 'data' => $this->mockedData));
+		$this->mockedDelay = 10;
+		$this->mockedDateTime = m::mock('DateTime');
+		$this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
+		$this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
+
+		$this->mockedSendMessageResponseModel = new Model(array('Body' => $this->mockedPayload,
+						      			'MD5OfBody' => md5($this->mockedPayload),
+						      			'ReceiptHandle' => $this->mockedReceiptHandle,
+						      			'MessageId' => $this->mockedMessageId,
+						      			'Attributes' => array('ApproximateReceiveCount' => 1)));
+
+		$this->mockedReceiveMessageResponseModel = new Model(array('Messages' => array( 0 => array(
+												'Body' => $this->mockedPayload,
+						     						'MD5OfBody' => md5($this->mockedPayload),
+						      						'ReceiptHandle' => $this->mockedReceiptHandle,
+						     						'MessageId' => $this->mockedMessageId))));
+	}
+
+	public function testPopProperlyPopsJobOffOfSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('receiveMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'AttributeNames' => array('ApproximateReceiveCount')))->andReturn($this->mockedReceiveMessageResponseModel);
+		$result = $queue->pop($this->queueName);
+		$this->assertInstanceOf('Illuminate\Queue\Jobs\SqsJob', $result);
+	}
+
+	public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getSeconds', 'getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
+		$queue->expects($this->once())->method('getSeconds')->with($this->mockedDateTime)->will($this->returnValue($this->mockedDateTime));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload, 'DelaySeconds' => $this->mockedDateTime))->andReturn($this->mockedSendMessageResponseModel);
+		$id = $queue->later($this->mockedDateTime, $this->mockedJob, $this->mockedData, $this->queueName);
+		$this->assertEquals($this->mockedMessageId, $id);
+	}
+
+	public function testDelayedPushProperlyPushesJobOntoSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getSeconds', 'getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
+		$queue->expects($this->once())->method('getSeconds')->with($this->mockedDelay)->will($this->returnValue($this->mockedDelay));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload, 'DelaySeconds' => $this->mockedDelay))->andReturn($this->mockedSendMessageResponseModel);
+		$id = $queue->later($this->mockedDelay, $this->mockedJob, $this->mockedData, $this->queueName);
+		$this->assertEquals($this->mockedMessageId, $id);
+	}
+
+	public function testPushProperlyPushesJobOntoSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload))->andReturn($this->mockedSendMessageResponseModel);
+		$id = $queue->push($this->mockedJob, $this->mockedData, $this->queueName);
+		$this->assertEquals($this->mockedMessageId, $id);
+	}
+
+	public function testGetQueueCallsGetBaseUrlAndBuildsQueueUrl()
+	{
+		$queue = new Illuminate\Queue\SqsQueue($this->sqs, $this->queueName, $this->account);
+		$this->sqs->shouldReceive('getBaseUrl')->once()->andReturn($this->baseUrl);
+		$resultQueueUrl = $queue->getQueue($this->queueName);
+		$this->assertEquals($this->queueUrl, $resultQueueUrl);
+		$this->sqs->shouldReceive('getBaseUrl')->once()->andReturn('https://bar');
+		$resultQueueUrl = $queue->getQueue($this->queueName);
+		$this->assertNotEquals($this->queueUrl, $resultQueueUrl);
+	}
+}


### PR DESCRIPTION
...aseUrl along with a new 'account' variable in the sqs connection config.  Also switched order of job and queue parameters of SqsJob to be inline with the order used by the other two 3rd party queue providers.

Here's the background for why I feel like this should be a welcomed change.  When I was initially testing out the 3 main queue providers, IronMQ, Beanstalkd and Sqs, I thought it was strange that for the first two, the queue name was all that was needed to listen for and push onto the queues.  But, for Sqs, it didn't work with just the queue name (e.g. 'emails').  Instead, I had to use the entire QueueURL.  That was not only confusing initially, but I feel like it also goes against the idea of providing "a unified API across a variety of different queue services."  So, with the changes I made in this PR, all a user would have to do is add a new "account" config variable in app/config/queue.php.  For example:

``` php
                'sqs' => array(
                        'driver'  => 'sqs',
                        'account' => '1234567891011',
                        'key'     => 'AMAZONSQSKEY',
                        'secret'  => 'zBPh+8ymO9P2UwD5+eM4ISYCZm3MSU1ExNBS98Uy',
                        'queue'   => 'emails',
                        'region'  => 'us-east-1',
                ),
```

Since the SqsClient already provides a getBaseUrl() which will get the base url of the QueueUrl, I used that along with the new account config + the "queue" (i.e. Queue Name) to build the full QueueURL.  With this change, users would be able to switch between all three queue providers without having to update their calls to Queue::push or queue::listen because the API is more unified.

Update: I added the unit tests I wrote since there weren't any written for SqsQueue and SqsJob.  
