### PR TITLE
Add TTR to Beanstalkd...

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -21,16 +21,24 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 	protected $default;
 
 	/**
+	 * The timeout for workers
+	 *
+	 * @var int
+	 */
+	protected $ttr;
+
+	/**
 	 * Create a new Beanstalkd queue instance.
 	 *
 	 * @param  Pheanstalk  $pheanstalk
 	 * @param  string  $default
 	 * @return void
 	 */
-	public function __construct(Pheanstalk $pheanstalk, $default)
+	public function __construct(Pheanstalk $pheanstalk, $default, $ttr)
 	{
-		$this->default = $default;
+		$this->default    = $default;
 		$this->pheanstalk = $pheanstalk;
+		$this->ttr        = $ttr;
 	}
 
 	/**
@@ -56,7 +64,7 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 	 */
 	public function pushRaw($payload, $queue = null, array $options = array())
 	{
-		return $this->pheanstalk->useTube($this->getQueue($queue))->put($payload);
+		return $this->pheanstalk->useTube($this->getQueue($queue))->put($payload, Pheanstalk::DEFAULT_PRIORITY, PheanstalkInterface::DEFAULT_DELAY, $this->ttr);
 	}
 
 	/**

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -64,7 +64,7 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 	 */
 	public function pushRaw($payload, $queue = null, array $options = array())
 	{
-		return $this->pheanstalk->useTube($this->getQueue($queue))->put($payload, Pheanstalk::DEFAULT_PRIORITY, PheanstalkInterface::DEFAULT_DELAY, $this->ttr);
+		return $this->pheanstalk->useTube($this->getQueue($queue))->put($payload, Pheanstalk::DEFAULT_PRIORITY, Pheanstalk::DEFAULT_DELAY, $this->ttr);
 	}
 
 	/**

--- a/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
+++ b/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
@@ -15,7 +15,9 @@ class BeanstalkdConnector implements ConnectorInterface {
 	{
 		$pheanstalk = new Pheanstalk($config['host']);
 
-		return new BeanstalkdQueue($pheanstalk, $config['queue']);
+		$config['ttr'] = isset($config['ttr']) ? $config['ttr'] : Pheanstalk::DEFAULT_TTR;
+
+		return new BeanstalkdQueue($pheanstalk, $config['queue'], $config['ttr']);
 	}
 
 }

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -12,7 +12,7 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testPushProperlyPushesJobOntoBeanstalkd()
 	{
-		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk_Pheanstalk'), 'default');
+		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk_Pheanstalk'), 'default', 60);
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('useTube')->once()->with('stack')->andReturn($pheanstalk);
 		$pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
@@ -25,7 +25,7 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testDelayedPushProperlyPushesJobOntoBeanstalkd()
 	{
-		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk_Pheanstalk'), 'default');
+		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk_Pheanstalk'), 'default', 60);
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('useTube')->once()->with('stack')->andReturn($pheanstalk);
 		$pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
@@ -38,7 +38,7 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testPopProperlyPopsJobOffOfBeanstalkd()
 	{
-		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk_Pheanstalk'), 'default');
+		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk_Pheanstalk'), 'default', 60);
 		$queue->setContainer(m::mock('Illuminate\Container\Container'));
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('watchOnly')->once()->with('default')->andReturn($pheanstalk);


### PR DESCRIPTION
This fixes #3443 and #3480.

Maybe a better way would be to optionally include the TTR (time to run) parameter with every call to push() instead of including it in the constructor though? I wasn't sure, so this solution is exactly as it was described in the previously mentioned issue (the constructor way).
