### PR TITLE
Eased merging of two MessageBag instances

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -55,11 +55,22 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 	/**
 	 * Merge a new array of messages into the bag.
 	 *
-	 * @param  array  $messages
+	 * @param  \Illuminate\Support\Contracts\MessageProviderInterface|array  $messages
 	 * @return \Illuminate\Support\MessageBag
 	 */
-	public function merge(array $messages)
+	public function merge($messages)
 	{
+		if ($messages instanceof MessageProviderInterface) {
+			$messages = $messages->getMessageBag()->getMessages();
+		}
+
+		if ( ! is_array($messages))
+		{
+			$class = get_class($this);
+			$type = is_object($messages) ? get_class($messages) : gettype($messages);
+			throw new \InvalidArgumentException("Argument 1 to $class::merge() must be of type Illuminate\Support\Contracts\MessageProviderInterface or array, $type given");
+		}
+
 		$this->messages = array_merge_recursive($this->messages, $messages);
 
 		return $this;

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -60,7 +60,8 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 	 */
 	public function merge($messages)
 	{
-		if ($messages instanceof MessageProviderInterface) {
+		if ($messages instanceof MessageProviderInterface)
+		{
 			$messages = $messages->getMessageBag()->getMessages();
 		}
 

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -42,6 +42,25 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testMessageBagsCanBeMerged()
+	{
+		$container = new MessageBag(array('foo' => array('bar')));
+		$otherContainer = new MessageBag(array('foo' => array('baz'), 'bar' => array('foo')));
+		$container->merge($otherContainer);
+		$this->assertEquals(array('foo' => array('bar', 'baz'), 'bar' => array('foo')), $container->getMessages());
+	}
+
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testExceptionThrownOnInvalidMergeArgument()
+	{
+		$container = new MessageBag(array('foo' => array('bar')));
+		$container->merge('foo');
+	}
+
+
 	public function testGetReturnsArrayOfMessagesByKey()
 	{
 		$container = new MessageBag;


### PR DESCRIPTION
This allows you to call `$messageBag->merge($otherMessageBag)` or `$messageBag->merge($validator)`. Useful when working with more than one set of validator instances at the same time, for example.

Currently you have to do `$messageBag->merge($otherMessageBag->getMessages())` or `$messageBag->merge($validator->getMessageBag()->getMessages())`
