### PR TITLE
Check path in method hasFile.

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -297,7 +297,7 @@ class Request extends SymfonyRequest {
 	{
 		if (is_array($file = $this->file($key))) $file = head($file);
 
-		return $file instanceof \SplFileInfo;
+		return ($file instanceof \SplFileInfo && $file->getPath() != '');
 	}
 
 	/**


### PR DESCRIPTION
This pull-request solves a problem encountered when uploading a "corrupt" file like one of the files you can found at <a href="http://www.thinkbroadband.com/download.html">ThinkBroad</a>.

Any of these files is considered empty in the validation (I am checking that a image is uploaded), therefore these pass validation. However, in the controller, when I try to save the image I check if Input has the file and this returned true.

This commit solves this problem. Previously a corrupt file passed the validation because is considered empty and is not required, but was not considered empty by the method Input::hasFile().
