### PR TITLE
Adding sqs unit tests to the 4.1.x branch

### DIFF
--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use Mockery as m;
+
+use Aws\Sqs\SqsClient;
+use Aws\Common\Credentials\Credentials;
+use Aws\Common\Credentials\CredentialsInterface;
+use Aws\Common\Signature\SignatureInterface;
+use Aws\Common\Signature\SignatureV4;
+
+use Guzzle\Common\Collection;
+use Guzzle\Service\Resource\Model;
+
+class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
+
+	public function setUp() {
+
+		$this->key = 'AMAZONSQSKEY';
+		$this->secret = 'AmAz0n+SqSsEcReT+aLpHaNuM3R1CsTr1nG';
+		$this->service = 'sqs';
+		$this->region = 'someregion';
+		$this->account = '1234567891011';
+		$this->queueName = 'emails';
+		$this->baseUrl = 'https://sqs.someregion.amazonaws.com';
+
+		// The Aws\Common\AbstractClient needs these three constructor parameters
+		$this->credentials = new Credentials( $this->key, $this->secret );
+		$this->signature = new SignatureV4( $this->service, $this->region );
+		$this->config = new Collection();
+
+		// This is how the modified getQueue builds the queueUrl
+		$this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
+
+		// Get a mock of the SqsClient 
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		
+		// Use Mockery to mock the IoC Container
+		$this->mockedContainer = m::mock('Illuminate\Container\Container');
+
+		$this->mockedJob = 'foo';
+		$this->mockedData = array('data');
+		$this->mockedPayload = json_encode(array('job' => $this->mockedJob, 'data' => $this->mockedData, 'attempts' => 1));
+		$this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
+		$this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
+
+		$this->mockedJobData = array('Body' => $this->mockedPayload,
+					     'MD5OfBody' => md5($this->mockedPayload),
+					     'ReceiptHandle' => $this->mockedReceiptHandle,
+					     'MessageId' => $this->mockedMessageId,
+					     'Attributes' => array('ApproximateReceiveCount' => 1));
+
+	}
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testFireProperlyCallsTheJobHandler()
+	{
+		$job = $this->getJob();
+		$job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
+		$handler->shouldReceive('fire')->once()->with($job, array('data'));
+		$job->fire();
+	}
+
+
+	public function testDeleteRemovesTheJobFromSqs()
+	{
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->queueName, $this->account));
+		$queue->setContainer($this->mockedContainer);
+		$job = $this->getJob();
+		$job->getSqs()->expects($this->once())->method('deleteMessage')->with(array('QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle));	
+		$job->delete();
+	}
+
+	protected function getJob()
+	{
+		return new Illuminate\Queue\Jobs\SqsJob(
+			$this->mockedContainer,
+			$this->mockedSqsClient,
+			$this->queueUrl,
+			$this->mockedJobData
+		);
+	}
+
+}

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use Mockery as m;
+
+use Aws\Sqs\SqsClient;
+use Guzzle\Service\Resource\Model;
+
+class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function setUp() {
+
+		// Use Mockery to mock the SqsClient
+		$this->sqs = m::mock('Aws\Sqs\SqsClient');
+
+		$this->account = '1234567891011';
+		$this->queueName = 'emails';
+		$this->baseUrl = 'https://sqs.someregion.amazonaws.com';
+
+		// This is how the modified getQueue builds the queueUrl
+		$this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
+
+		$this->mockedJob = 'foo';
+		$this->mockedData = array('data');
+		$this->mockedPayload = json_encode(array('job' => $this->mockedJob, 'data' => $this->mockedData));
+		$this->mockedDelay = 10;
+		$this->mockedDateTime = m::mock('DateTime');
+		$this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
+		$this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
+
+		$this->mockedSendMessageResponseModel = new Model(array('Body' => $this->mockedPayload,
+						      			'MD5OfBody' => md5($this->mockedPayload),
+						      			'ReceiptHandle' => $this->mockedReceiptHandle,
+						      			'MessageId' => $this->mockedMessageId,
+						      			'Attributes' => array('ApproximateReceiveCount' => 1)));
+
+		$this->mockedReceiveMessageResponseModel = new Model(array('Messages' => array( 0 => array(
+												'Body' => $this->mockedPayload,
+						     						'MD5OfBody' => md5($this->mockedPayload),
+						      						'ReceiptHandle' => $this->mockedReceiptHandle,
+						     						'MessageId' => $this->mockedMessageId))));
+	}
+
+	public function testPopProperlyPopsJobOffOfSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('receiveMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'AttributeNames' => array('ApproximateReceiveCount')))->andReturn($this->mockedReceiveMessageResponseModel);
+		$result = $queue->pop($this->queueName);
+		$this->assertInstanceOf('Illuminate\Queue\Jobs\SqsJob', $result);
+	}
+
+	public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getSeconds', 'getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
+		$queue->expects($this->once())->method('getSeconds')->with($this->mockedDateTime)->will($this->returnValue($this->mockedDateTime));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload, 'DelaySeconds' => $this->mockedDateTime))->andReturn($this->mockedSendMessageResponseModel);
+		$id = $queue->later($this->mockedDateTime, $this->mockedJob, $this->mockedData, $this->queueName);
+		$this->assertEquals($this->mockedMessageId, $id);
+	}
+
+	public function testDelayedPushProperlyPushesJobOntoSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getSeconds', 'getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
+		$queue->expects($this->once())->method('getSeconds')->with($this->mockedDelay)->will($this->returnValue($this->mockedDelay));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload, 'DelaySeconds' => $this->mockedDelay))->andReturn($this->mockedSendMessageResponseModel);
+		$id = $queue->later($this->mockedDelay, $this->mockedJob, $this->mockedData, $this->queueName);
+		$this->assertEquals($this->mockedMessageId, $id);
+	}
+
+	public function testPushProperlyPushesJobOntoSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload))->andReturn($this->mockedSendMessageResponseModel);
+		$id = $queue->push($this->mockedJob, $this->mockedData, $this->queueName);
+		$this->assertEquals($this->mockedMessageId, $id);
+	}
+}


### PR DESCRIPTION
As pointed out in #3776, there aren't any unit tests for SQS.  This PR adds what (based on the tests for IronMQ and Beanstalkd) appeared to be the standard unit tests for a queue driver to the 4.1.x branch.    
