### PR TITLE
Remove composer.lock from generated .gitignore file.

### DIFF
--- a/src/Illuminate/Workbench/stubs/gitignore.txt
+++ b/src/Illuminate/Workbench/stubs/gitignore.txt
@@ -1,4 +1,3 @@
 /vendor
 composer.phar
-composer.lock
 .DS_Store


### PR DESCRIPTION
composer.lock shouldn't be ignored in version control as it ensures everyone has the same versions of composer packages.
