### PR TITLE
Fix for bug in Url generation for HTTPS routes

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -355,7 +355,7 @@ class UrlGenerator {
 	}
 
 	/**
-	 * Get the domain and schee for the route.
+	 * Get the domain and scheme for the route.
 	 *
 	 * @param  \Illuminate\Routing\Route  $route
 	 * @return string

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -373,7 +373,8 @@ class UrlGenerator {
 	 */
 	protected function addPortToDomain($domain)
 	{
-		if ($this->request->getPort() == '80')
+		if ((starts_with($domain, 'http://') && $this->request->getPort() == '80') 
+			|| (starts_with($domain, 'https://') && $this->request->getPort() == '443'))
 		{
 			return $domain;
 		}

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -175,6 +175,23 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testHttpsRoutesWithDomains()
+	{
+		$url = new UrlGenerator(
+			$routes = new Illuminate\Routing\RouteCollection,
+			$request = Illuminate\Http\Request::create('https://foo.com/')
+		);
+
+		/**
+		 * When on HTTPS, no need to specify 443
+		 */
+		$route = new Illuminate\Routing\Route(array('GET'), 'foo/bar', array('as' => 'baz', 'domain' => 'sub.foo.com'));
+		$routes->add($route);
+
+		$this->assertEquals('https://sub.foo.com/foo/bar', $url->route('baz'));
+	}
+
+
 	public function testUrlGenerationForControllers()
 	{
 		$url = new UrlGenerator(

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -16,7 +16,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('https://www.foo.com/foo/bar/baz/boom', $url->to('foo/bar', array('baz', 'boom'), true));
 
 		/**
-		 * Test HTTPS request URL geneation...
+		 * Test HTTPS request URL generation...
 		 */
 		$url = new UrlGenerator(
 			$routes = new Illuminate\Routing\RouteCollection,


### PR DESCRIPTION
I've added the corresponding test.

Without the proposed fix, the URL that gets generated is `https://sub.foo.com:443/foo/bar` (notice the superfluous `443`)
