### PR TITLE
[Request] HasManyThrought can't work in both ways

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -86,8 +86,8 @@ class HasManyThrough extends Relation {
 	{
         $query = $query ?: $this->query;
 
-        $foreignKey = $this->related->getQualifiedKeyName();
-        $primaryKey = $this->parent->getTable() .'.-'. $this->secondKey;
+        $foreignKey = $this->related->getTable() . '.' . $this->related->getKeyName();
+        $primaryKey = $this->parent->getTable() .'.'. $this->secondKey;
 
         $query->join($this->parent->getTable(), $primaryKey, '=', $foreignKey);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -84,12 +84,13 @@ class HasManyThrough extends Relation {
 	 */
 	protected function setJoin(Builder $query = null)
 	{
-		$query = $query ?: $this->query;
+        $query = $query ?: $this->query;
 
-		$foreignKey = $this->related->getTable().'.'.$this->secondKey;
+        $foreignKey = $this->related->getQualifiedKeyName();
+        $primaryKey = $this->parent->getTable() .'.-'. $this->secondKey;
 
-		$query->join($this->parent->getTable(), $this->getQualifiedParentKeyName(), '=', $foreignKey);
-	}
+        $query->join($this->parent->getTable(), $primaryKey, '=', $foreignKey);
+    }
 
 	/**
 	 * Set the constraints for an eager load of the relation.

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -246,4 +246,21 @@ class HasManyThrough extends Relation {
 		return $this->farParent->getQualifiedKeyName();
 	}
 
+    /**
+     * Attach a related model
+     *
+     * @param Model $model
+     * @return Model
+     */
+    public function save(Model $model) {
+        $firstKey = $this->firstKey;
+        $secondKey = $this->secondKey;
+
+        $this->parent->$firstKey = $this->farParent->getKey();
+        $this->parent->$secondKey = $model->getKey();
+
+        $this->parent->save();
+
+        return $this->parent;
+    }
 }


### PR DESCRIPTION
fix #3785 

Here was a proposal  - https://github.com/laravel/framework/issues/3052

 taylorotwell says to use the same relationship both ways.

But design of HasManyThrough() do not allow that.

Here is an example:

Admins table: 
| `Id` | `Name` |

Model:

```
class Admins extends Model {
   protected $primaryKey = 'Id';
   public function permission() {
        return $this->hasManyThrough('Permissions','AdminsToPermissions','AdminsId','Id');
    }
}
```

AdminsToPermission table:

| `AdminsId` | `PermissionsId` |

Model (for a better readability in SQL i set PK to AdminsToPermissionsKey)

```
class AdminsToPermissions extends Model {
   public $primaryKey = 'AdminsToPermissionsKey';
}
```

Permissions table:

| `Id` | `Permission` |

Model:

```
class Permissions extends Model {
   protected $primaryKey = 'Id';
   public function admins() {
        return $this->hasManyThrough('Admins','AdminsToPermissions','PermissionsId','Id');
    }
}
```

SQL query when i call $admin->permission

```
SELECT
    `Permissions`.*, `AdminsToPermissions`.`AdminsId`
FROM
    `Permissions`
INNER JOIN `AdminsToPermissions` ON `AdminsToPermissions`.`AdminsToPermissionsKey` = `Permissions`.`Id`
WHERE
    `AdminsToPermissions`.`AdminsId` = 1
)
```

Here is a mistake - AdminsToPermissionsKey used in joins, so that can't be switched when using $permission->admins, because its generate next query

```
SELECT
    `Admins`.*, `AdminsToPermissions`.`PermissionsId`
FROM
    `Admins`
INNER JOIN `AdminsToPermissions` ON `AdminsToPermissions`.`AdminsToPermissionsKey` = `Admins`.`Id`
WHERE
    `AdminsToPermissions`.`PermissionsId` = 1
)
```

Workaround is to create PermissionsToAdmins model, but its just workaround.

My opition that best way was to use $firstkey and $secondkey in joins, and for finder use keys from parent model.

Current usage query:

```
SELECT
    `Admins`.*, `AdminsToPermissions`.`FirstKey`
FROM
    `Admins`
INNER JOIN `AdminsToPermissions` ON `AdminsToPermissions`.`AdminsToPermissionsKey` = `Admins`.`SecondKey`
WHERE
    `AdminsToPermissions`.`FirstKey` = 1
)
```

Best usage query:

```
SELECT
    `Admins`.*, `AdminsToPermissions`.`FirstKey`
FROM
    `Admins`
INNER JOIN `AdminsToPermissions` ON `AdminsToPermissions`.`SecondKey` = `Admins`.`AdminsModelKey`
WHERE
    `AdminsToPermission`.`FirstKey` = 1
)
```

But it breaks backward complability.
So second way maybe to create belongsToThrough method.
