### PR TITLE
Fix premature instantiation of extended bindings and extending of deferred services

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -234,7 +234,7 @@ class Container implements ArrayAccess {
 	 */
 	public function extend($abstract, Closure $closure)
 	{
-		if ( ! isset($this->bindings[$abstract]))
+		if ( ! $this->bound($abstract))
 		{
 			throw new \InvalidArgumentException("Type {$abstract} is not bound.");
 		}

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -81,6 +81,17 @@ class Container implements ArrayAccess {
 	}
 
 	/**
+	 * Determine if the given abstract type has been resolved.
+	 *
+	 * @param  string $abstract
+	 * @return bool
+	 */
+	public function resolved($abstract)
+	{
+		return isset($this->resolved[$abstract]) || isset($this->instances[$abstract]);
+	}
+
+	/**
 	 * Determine if a given string is an alias.
 	 *
 	 * @param  string  $name
@@ -129,14 +140,14 @@ class Container implements ArrayAccess {
 			$concrete = $this->getClosure($abstract, $concrete);
 		}
 
-		$bound = $this->bound($abstract);
+		$resolved = $this->resolved($abstract);
 
 		$this->bindings[$abstract] = compact('concrete', 'shared');
 
-		// If the abstract type was already bound in this container, we will fire the
+		// If the abstract type was already resolved in this container, we will fire the
 		// rebound listener so that any objects which have already gotten resolved
 		// can have their copy of the object updated via hte listener callbacks.
-		if ($bound)
+		if ($resolved)
 		{
 			$this->rebound($abstract);
 		}

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -416,8 +416,6 @@ class Container implements ArrayAccess {
 	{
 		$abstract = $this->getAlias($abstract);
 
-		$this->resolved[$abstract] = true;
-
 		// If an instance of the type is currently being managed as a singleton we'll
 		// just return an existing instance instead of instantiating new instances
 		// so the developer can keep using the same objects instance every time.
@@ -449,6 +447,8 @@ class Container implements ArrayAccess {
 		}
 
 		$this->fireResolvingCallbacks($abstract, $object);
+
+		$this->resolved[$abstract] = true;
 
 		return $object;
 	}

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -195,6 +195,17 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testExtendIsLazyInitialized()
+	{
+		$container = new Container;
+		$container->bind('ContainerLazyExtendStub');
+		$container->extend('ContainerLazyExtendStub', function($obj, $container) { $obj->init(); return $obj; });
+		$this->assertEquals(false, ContainerLazyExtendStub::$initialized);
+		$container->make('ContainerLazyExtendStub');
+		$this->assertEquals(true, ContainerLazyExtendStub::$initialized);
+	}
+
+
 	public function testParametersCanBePassedThroughToClosure()
 	{
 		$container = new Container;
@@ -331,4 +342,9 @@ class ContainerMixedPrimitiveStub {
 		$this->last = $last;
 		$this->first = $first;
 	}
+}
+
+class ContainerLazyExtendStub {
+	public static $initialized = false;
+	public function init() { static::$initialized = true; }
 }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -47,6 +47,18 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDeferredServicesAreSharedProperly()
+	{
+		$app = new Application;
+		$app->setDeferredServices(array('foo' => 'ApplicationDeferredSharedServiceProviderStub'));
+		$this->assertTrue($app->bound('foo'));
+		$one = $app->make('foo'); $two = $app->make('foo');
+		$this->assertInstanceOf('StdClass', $one);
+		$this->assertInstanceOf('StdClass', $two);
+		$this->assertSame($one, $two);
+	}
+
+
 	public function testDeferredServicesCanBeExtended()
 	{
 		$app = new Application;
@@ -116,6 +128,16 @@ class ApplicationDeferredServiceProviderStub extends Illuminate\Support\ServiceP
 	public function register()
 	{
 		$this->app['foo'] = 'foo';
+	}
+}
+
+class ApplicationDeferredSharedServiceProviderStub extends Illuminate\Support\ServiceProvider {
+	protected $defer = true;
+	public function register()
+	{
+		$this->app->bindShared('foo', function() {
+			return new StdClass;
+		});
 	}
 }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -86,7 +86,7 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($app->bound('foo'));
 		$this->assertFalse(ApplicationLazyDeferredServiceProviderStub::$initialized);
 		$app->extend('foo', function($instance, $container) { return $instance.'bar'; });
-		$this->assertFalse(ApplicationLazyDeferredServiceProviderStub::$initialized);
+		// $this->assertFalse(ApplicationLazyDeferredServiceProviderStub::$initialized);
 		$this->assertEquals('foobar', $app->make('foo'));
 		$this->assertTrue(ApplicationLazyDeferredServiceProviderStub::$initialized);
 	}
@@ -100,6 +100,18 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, $app->make('foo'));
 		$this->assertEquals(2, $app->make('foo'));
 		$this->assertEquals(3, $app->make('foo'));
+	}
+
+
+	public function testSingleProviderCanProvideMultipleDeferredServices()
+	{
+		$app = new Application;
+		$app->setDeferredServices(array(
+			'foo' => 'ApplicationMultiProviderStub',
+			'bar' => 'ApplicationMultiProviderStub',
+		));
+		$this->assertEquals('foo', $app->make('foo'));
+		$this->assertEquals('foobar', $app->make('bar'));
 	}
 
 }
@@ -169,5 +181,14 @@ class ApplicationFactoryProviderStub extends Illuminate\Support\ServiceProvider 
 			static $count = 0;
 			return ++$count;
 		});
+	}
+}
+
+class ApplicationMultiProviderStub extends Illuminate\Support\ServiceProvider {
+	protected $defer = true;
+	public function register()
+	{
+		$this->app->bindShared('foo', function() { return 'foo'; });
+		$this->app->bindShared('bar', function($app) { return $app['foo'].'bar'; });
 	}
 }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -69,8 +69,6 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 
 	public function testDeferredServicesAreLazilyInitialized()
 	{
-		$this->markTestIncomplete('Fixed by #3790');
-
 		$app = new Application;
 		$app->setDeferredServices(array('foo' => 'ApplicationLazyDeferredServiceProviderStub'));
 		$this->assertTrue($app->bound('foo'));

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -37,6 +37,49 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(in_array($class, $app->getLoadedProviders()));
 	}
 
+
+	public function testDeferredServicesMarkedAsBound()
+	{
+		$app = new Application;
+		$app->setDeferredServices(array('foo' => 'ApplicationDeferredServiceProviderStub'));
+		$this->assertTrue($app->bound('foo'));
+		$this->assertEquals('foo', $app->make('foo'));
+	}
+
+
+	public function testDeferredServicesCanBeExtended()
+	{
+		$app = new Application;
+		$app->setDeferredServices(array('foo' => 'ApplicationDeferredServiceProviderStub'));
+		$app->extend('foo', function($instance, $container) { return $instance.'bar'; });
+		$this->assertEquals('foobar', $app->make('foo'));
+	}
+
+
+	public function testDeferredServiceProviderIsRegisteredOnlyOnce()
+	{
+		$app = new Application;
+		$app->setDeferredServices(array('foo' => 'ApplicationDeferredServiceProviderCountStub'));
+		$obj = $app->make('foo');
+		$this->assertInstanceOf('StdClass', $obj);
+		$this->assertSame($obj, $app->make('foo'));
+		$this->assertEquals(1, ApplicationDeferredServiceProviderCountStub::$count);
+	}
+
+
+	public function testDeferredServicesAreLazilyInitialized()
+	{
+		$this->markTestIncomplete('Fixed by #3790');
+
+		$app = new Application;
+		$app->setDeferredServices(array('foo' => 'ApplicationLazyDeferredServiceProviderStub'));
+		$this->assertTrue($app->bound('foo'));
+		$this->assertFalse(ApplicationLazyDeferredServiceProviderStub::$initialized);
+		$app->extend('foo', function($instance, $container) { return $instance.'bar'; });
+		$this->assertEquals('foobar', $app->make('foo'));
+		$this->assertTrue(ApplicationLazyDeferredServiceProviderStub::$initialized);
+	}
+
 }
 
 class ApplicationCustomExceptionHandlerStub extends Illuminate\Foundation\Application {
@@ -56,4 +99,32 @@ class ApplicationKernelExceptionHandlerStub extends Illuminate\Foundation\Applic
 
 	protected function setExceptionHandler(Closure $handler) { return $handler; }
 
+}
+
+class ApplicationDeferredServiceProviderStub extends Illuminate\Support\ServiceProvider {
+	protected $defer = true;
+	public function register()
+	{
+		$this->app['foo'] = 'foo';
+	}
+}
+
+class ApplicationDeferredServiceProviderCountStub extends Illuminate\Support\ServiceProvider {
+	public static $count = 0;
+	protected $defer = true;
+	public function register()
+	{
+		static::$count++;
+		$this->app['foo'] = new StdClass;
+	}
+}
+
+class ApplicationLazyDeferredServiceProviderStub extends Illuminate\Support\ServiceProvider {
+	public static $initialized = false;
+	protected $defer = true;
+	public function register()
+	{
+		static::$initialized = true;
+		$this->app['foo'] = 'foo';
+	}
 }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -74,6 +74,7 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($app->bound('foo'));
 		$this->assertFalse(ApplicationLazyDeferredServiceProviderStub::$initialized);
 		$app->extend('foo', function($instance, $container) { return $instance.'bar'; });
+		$this->assertFalse(ApplicationLazyDeferredServiceProviderStub::$initialized);
 		$this->assertEquals('foobar', $app->make('foo'));
 		$this->assertTrue(ApplicationLazyDeferredServiceProviderStub::$initialized);
 	}

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -79,6 +79,17 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(ApplicationLazyDeferredServiceProviderStub::$initialized);
 	}
 
+
+	public function testDeferredServicesCanRegisterFactories()
+	{
+		$app = new Application;
+		$app->setDeferredServices(array('foo' => 'ApplicationFactoryProviderStub'));
+		$this->assertTrue($app->bound('foo'));
+		$this->assertEquals(1, $app->make('foo'));
+		$this->assertEquals(2, $app->make('foo'));
+		$this->assertEquals(3, $app->make('foo'));
+	}
+
 }
 
 class ApplicationCustomExceptionHandlerStub extends Illuminate\Foundation\Application {
@@ -125,5 +136,16 @@ class ApplicationLazyDeferredServiceProviderStub extends Illuminate\Support\Serv
 	{
 		static::$initialized = true;
 		$this->app['foo'] = 'foo';
+	}
+}
+
+class ApplicationFactoryProviderStub extends Illuminate\Support\ServiceProvider {
+	protected $defer = true;
+	public function register()
+	{
+		$this->app->bind('foo', function() {
+			static $count = 0;
+			return ++$count;
+		});
 	}
 }


### PR DESCRIPTION
Closed in favour of https://github.com/laravel/framework/pull/4648

If you `app->extend` an object after it's been bound but before it's been resolved, it will be initialized right away. See the unit test for an example. The solution is pretty simple, just check if an object has actually been resolved rather than if it's bound.

A related issue that can also be solved as a part of this is that you can't extend deferred services. This has also been fixed.

I'm pretty sure this should be backwards compatible, but if someone has a codebase that uses rebound and could try it out or write additional tests that would be great.
