### PR TITLE
Classes bound by name into container were not receiving parameters

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -151,11 +151,11 @@ class Container implements ArrayAccess {
 	 */
 	protected function getClosure($abstract, $concrete)
 	{
-		return function($c) use ($abstract, $concrete)
+		return function($c, $parameters) use ($abstract, $concrete)
 		{
 			$method = ($abstract == $concrete) ? 'build' : 'make';
 
-			return $c->$method($concrete);
+			return $c->$method($concrete, $parameters);
 		};
 	}
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -272,7 +272,6 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($_SERVER['__test.rebind']);
 	}
 
-
 	public function testPassingSomePrimitiveParameters()
 	{
 		$container = new Container;
@@ -288,6 +287,14 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('taylor', $value->first);
 		$this->assertEquals('otwell', $value->last);
 		$this->assertInstanceOf('ContainerConcreteStub', $value->stub);
+	}
+
+	public function testCreatingBoundConcreteClassPassesParameters() {
+		$container = new Container;
+		$container->bind('TestAbstractClass', 'ContainerConstructorParameterLoggingStub');
+		$parameters = array('First', 'Second');
+		$instance = $container->make('TestAbstractClass', $parameters);
+		$this->assertEquals($parameters, $instance->receivedParameters);
 	}
 
 }
@@ -332,3 +339,13 @@ class ContainerMixedPrimitiveStub {
 		$this->first = $first;
 	}
 }
+
+class ContainerConstructorParameterLoggingStub {
+	public $receivedParameters;
+
+	public function __construct($first, $second)
+	{
+		$this->receivedParameters = func_get_args();
+	}
+}
+


### PR DESCRIPTION
This has never worked since getClosure was added, so apologies if I've misunderstood and it's deliberate. The test case in this PR shows what I'm expecting to be able to do.
