### PR TITLE
Add check for parameter count

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -870,7 +870,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateUnique($attribute, $value, $parameters)
 	{
-		$this->requireParameterCount(2, $parameters, 'unique');
+		$this->requireParameterCount(1, $parameters, 'unique');
 
 		$table = $parameters[0];
 
@@ -943,7 +943,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateExists($attribute, $value, $parameters)
 	{
-		$this->requireParameterCount(2, $parameters, 'exists');
+		$this->requireParameterCount(1, $parameters, 'exists');
 
 		$table = $parameters[0];
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1175,7 +1175,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateDateFormat($attribute, $value, $parameters)
 	{
-		$this->requireParameterCount(1, $parameters, 'date');
+		$this->requireParameterCount(1, $parameters, 'date_format');
 
 		$parsed = date_parse_from_format($parameters[0], $value);
 
@@ -2184,12 +2184,12 @@ class Validator implements MessageProviderInterface {
 	 * Require a certain number of parameters to be present.
 	 *
 	 * @param  int    $count
-	 * @param  array  $parametrers
+	 * @param  array  $parameters
 	 * @param  string $rule
 	 * @return void
 	 * @throws \InvalidArgumentException
 	 */
-	protected function requireParameterCount($count, array $parametrers, $rule)
+	protected function requireParameterCount($count, $parameters, $rule)
 	{
 		if (count($parameters) < $count)
 		{

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -560,6 +560,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateRequiredIf($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(2, $parameters, 'required_if');
+
 		if ($parameters[1] == array_get($this->data, $parameters[0]))
 		{
 			return $this->validateRequired($attribute, $value);
@@ -611,6 +613,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateSame($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(1, $parameters, 'same');
+
 		$other = array_get($this->data, $parameters[0]);
 
 		return (isset($other) && $value == $other);
@@ -626,6 +630,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateDifferent($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(1, $parameters, 'different');
+
 		$other = $parameters[0];
 
 		return isset($this->data[$other]) && $value != $this->data[$other];
@@ -693,6 +699,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateDigits($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(1, $parameters, 'digits');
+
 		return $this->validateNumeric($attribute, $value)
 			&& strlen((string) $value) == $parameters[0];
 	}
@@ -707,6 +715,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateDigitsBetween($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(2, $parameters, 'digits_between');
+
 		$length = strlen((string) $value);
 
 		return $length >= $parameters[0] && $length <= $parameters[1];
@@ -722,6 +732,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateSize($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(1, $parameters, 'size');
+
 		return $this->getSize($attribute, $value) == $parameters[0];
 	}
 
@@ -735,6 +747,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateBetween($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(2, $parameters, 'between');
+
 		$size = $this->getSize($attribute, $value);
 
 		return $size >= $parameters[0] && $size <= $parameters[1];
@@ -750,6 +764,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateMin($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(1, $parameters, 'min');
+
 		return $this->getSize($attribute, $value) >= $parameters[0];
 	}
 
@@ -763,6 +779,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateMax($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(1, $parameters, 'max');
+
 		if ($value instanceof UploadedFile && ! $value->isValid()) return false;
 
 		return $this->getSize($attribute, $value) <= $parameters[0];
@@ -852,6 +870,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateUnique($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(2, $parameters, 'unique');
+
 		$table = $parameters[0];
 
 		// The second parameter position holds the name of the column that needs to
@@ -923,6 +943,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateExists($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(2, $parameters, 'exists');
+
 		$table = $parameters[0];
 
 		// The second parameter position holds the name of the column that should be
@@ -1120,6 +1142,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateRegex($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(1, $parameters, 'regex');
+
 		return preg_match($parameters[0], $value);
 	}
 
@@ -1151,6 +1175,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateDateFormat($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(1, $parameters, 'date');
+
 		$parsed = date_parse_from_format($parameters[0], $value);
 
 		return $parsed['error_count'] === 0 && $parsed['warning_count'] === 0;
@@ -1166,6 +1192,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateBefore($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(1, $parameters, 'before');
+
 		if ( ! ($date = strtotime($parameters[0])))
 		{
 			return strtotime($value) < strtotime($this->getValue($parameters[0]));
@@ -1186,6 +1214,8 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateAfter($attribute, $value, $parameters)
 	{
+		$this->requireParameterCount(1, $parameters, 'after');
+
 		if ( ! ($date = strtotime($parameters[0])))
 		{
 			return strtotime($value) > strtotime($this->getValue($parameters[0]));
@@ -2148,6 +2178,23 @@ class Validator implements MessageProviderInterface {
 		list($class, $method) = explode('@', $callback);
 
 		return call_user_func_array(array($this->container->make($class), $method), array_slice(func_get_args(), 1));
+	}
+
+	/**
+	 * Require a certain number of parameters to be present.
+	 *
+	 * @param  int    $count
+	 * @param  array  $parametrers
+	 * @param  string $rule
+	 * @return void
+	 * @throws \InvalidArgumentException
+	 */
+	protected function requireParameterCount($count, array $parametrers, $rule)
+	{
+		if (count($parameters) < $count)
+		{
+			throw new \InvalidArgumentException("Validation rule $rule requires at least $count parameters.");
+		}
 	}
 
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -986,6 +986,17 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testExceptionThrownOnIncorrectParameterCount()
+	{
+		$trans = $this->getTranslator();
+		$v = new Validator($trans, array(), array('foo' => 'required_if:foo'));
+		$v->passes();
+	}
+
+
 	protected function getTranslator()
 	{
 		return m::mock('Symfony\Component\Translation\TranslatorInterface');


### PR DESCRIPTION
Because `undefined offset: 0` errors are butt ugly and not developer friendly.
