### PR TITLE
[PROPOSAL] Automatically add a default model Observer

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -284,6 +284,12 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			}
 		}
 
+		// Automatically register a model observer.
+		if (class_exists($observerClass = $class.'Observer'))
+		{
+			static::observe(new $observerClass);
+		}
+
 		static::bootTraits();
 	}
 


### PR DESCRIPTION
So that model `User` would be automatically observed by class `UserObserver`.
So no need to do `User::observe(new UserObserver());`

This could be in a trait, but this default behavior seems interesting IMO.
