### PR TITLE
Fix attribute access when mixing mutators and cases

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2279,7 +2279,9 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	protected function getAttributeFromArray($key)
 	{
-		if (array_key_exists($key, $this->attributes))
+		if (array_key_exists($key, $this->attributes) ||
+			array_key_exists($key = snake_case($key), $this->attributes) ||
+			array_key_exists($key = camel_case($key), $this->attributes))
 		{
 			return $this->attributes[$key];
 		}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -29,6 +29,21 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAttributeAnyCaseAccess()
+	{
+		$model = new EloquentModelStub;
+
+		$model->anyCase = 'foo';
+		$this->assertArrayHasKey('any_case', $model->getAttributes());
+		$this->assertEquals('foo', $model->any_case);
+		$this->assertEquals('foo', $model->anyCase);
+
+		$model->any_case = 'bar';
+		$this->assertEquals('bar', $model->any_case);
+		$this->assertEquals('bar', $model->anyCase);
+	}
+
+
 	public function testCalculatedAttributes()
 	{
 		$model = new EloquentModelStub;
@@ -706,7 +721,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	{
 		$class = new EloquentModelStub;
 
-		$this->assertEquals(array('list_items', 'password', 'appendable'), $class->getMutatedAttributes());
+		$this->assertEquals(array('any_case', 'list_items', 'password', 'appendable'), $class->getMutatedAttributes());
 	}
 
 
@@ -782,6 +797,14 @@ class EloquentTestObserverStub {
 class EloquentModelStub extends Illuminate\Database\Eloquent\Model {
 	protected $table = 'stub';
 	protected $guarded = array();
+	public function getAnyCaseAttribute($value)
+	{
+		return $value;
+	}
+	public function setAnyCaseAttribute($value)
+	{
+		$this->attributes['any_case'] = $value;
+	}
 	public function getListItemsAttribute($value)
 	{
 		return json_decode($value, true);


### PR DESCRIPTION
Related to https://github.com/laravel/framework/issues/316

I found a bug when mixing mutators and cases. If the key's case in the attributes array  differ from the one used to access the model's attribute (e.g `$model->myAttribute`), the key will not be found.

Below the test that checks it with the corresponding model :

``` php
public function testAttributeAnyCaseAccess()
{
    $model = new MyModel;

    $model->anyCase = 'foo';
    $this->assertArrayHasKey('any_case', $model->getAttributes());
    $this->assertEquals('foo', $model->any_case);
    $this->assertEquals('foo', $model->anyCase);

    $model->any_case = 'bar';
    $this->assertEquals('bar', $model->any_case);
    $this->assertEquals('bar', $model->anyCase);
}

class MyModel extends Eloquent {
    protected $table = 'test_model';

    public function getAnyCaseAttribute($value)
    {
        return $value;
    }

    public function setAnyCaseAttribute($value)
    {
        $this->attributes['any_case'] = $value;
    }
}
```

Which fails at the third assert.

```
Failed asserting that null matches expected 'foo'.

app/tests/ExampleTest.php:12
```

This commit adds a simple fix to this issue, 
