### PR TITLE
Handle non-string messages in Log::method() calls

### DIFF
--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -234,6 +234,10 @@ class Writer {
 	 */
 	public function __call($method, $parameters)
 	{
+		if (isset($parameters[0]) && in_array(gettype($parameters[0]), ['object', 'array', 'resource'])) {
+			$parameters[0] = print_r($parameters[0], true);
+		}
+		
 		if (in_array($method, $this->levels))
 		{
 			call_user_func_array(array($this, 'fireLogEvent'), array_merge(array($method), $parameters));


### PR DESCRIPTION
Passing a more complex variable like an object or array to one of the Log calls spits out an error exception. This patch converts these messages into a `print_r` representation. This would allow the following:

```
$variable = new stdClass;
$variable->attribute = 'hello world';
Log::info($variable);
```
