### PR TITLE
[BugFix] Artisan URL Generation

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -849,6 +849,8 @@ class Application extends Container implements HttpKernelInterface, ResponsePrep
 		$parameters = array($url, 'GET', array(), array(), array(), $_SERVER);
 
 		$this->instance('request', static::onRequest('create', $parameters));
+		
+		$this->request->setBaseUrlForConsoleEnvironment();
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -31,6 +31,17 @@ class Request extends SymfonyRequest {
 	}
 
 	/**
+	 * Set the base URL for the application, particulary when using artisan.
+	 *
+	 * @return void
+	 */
+	public function setBaseUrlForConsoleEnvironment()
+	{
+		$this->baseUrl = $this->getRequestUri();
+	}
+
+
+	/**
 	 * Get the root URL for the application.
 	 *
 	 * @return string

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -40,7 +40,6 @@ class Request extends SymfonyRequest {
 		$this->baseUrl = $this->getRequestUri();
 	}
 
-
 	/**
 	 * Get the root URL for the application.
 	 *


### PR DESCRIPTION
URLs are merely pointing to the host name in artisan even if the Request is pointing to a subdirectory, when the app running in a subdirectory.

`prepareBaseUrl()` found in `Symfony\Component\HttpFoundation\Request` does not account for console run scripts such as artisan when determining the current baseURL. 

This causes `root()` found in `Illuminate\Http\Request` to return `$this->getSchemeAndHttpHost()` and `$this->getBaseUrl() = ''`

What this means is that something like `http://hostname` will be returned for an app running under `http://hostname/subdir`. My solution sets the base URL to be equal to artisans current request URI. 

As a result, `root()` found in `Illuminate\Http\Request` will return the same string as what `URL::current()` supplies when using artisan.
