### PR TITLE
Add default to array_pull (to match array_get)

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -376,11 +376,12 @@ if ( ! function_exists('array_pull'))
 	 *
 	 * @param  array   $array
 	 * @param  string  $key
+	 * @param  mixed   $default
 	 * @return mixed
 	 */
-	function array_pull(&$array, $key)
+	function array_pull(&$array, $key, $default = null)
 	{
-		$value = array_get($array, $key);
+		$value = array_get($array, $key, $default);
 
 		array_forget($array, $key);
 


### PR DESCRIPTION
Since `array_pull` is just a wrapper around `array_get` and `array_forget`, it'd be nice to be able to provide a default value. That way it can be used in the same exact way as array_get.
