### PR TITLE
[Proposal] A new blade statement: stack

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -474,6 +474,39 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	}
 
 	/**
+	 * Compile the stack statements into the content
+	 *
+	 * @param  string $expression
+	 * @return string
+	 */
+	protected function compileStack($expression)
+	{
+		return "<?php echo \$__env->stackContent{$expression}; ?>";
+	}
+
+	/**
+	 * Compile the push statements into valid PHP
+	 *
+	 * @param $expression
+	 * @return string
+	 */
+	protected function compilePush($expression)
+	{
+		return "<?php echo \$__env->startPush{$expression}; ?>";
+	}
+
+	/**
+	 * Compile the endpush statements into valid PHP
+	 *
+	 * @param $expression
+	 * @return string
+	 */
+	protected function compileEndpush($expression)
+	{
+		return "<?php echo \$__env->endPush{$expression}; ?>";
+	}
+
+	/**
 	 * Register a custom Blade compiler.
 	 *
 	 * @param  Closure  $compiler

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -152,6 +152,25 @@ test';
 		$this->assertEquals($expected, $compiler->compileString($string));
 	}
 
+	public function testPushIsCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$string = '@push(\'foo\')
+test
+@endpush';
+		$expected = '<?php echo $__env->startPush(\'foo\'); ?>
+test
+<?php echo $__env->endPush; ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
+
+	public function testStackIsCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$string = '@stack(\'foo\')';;
+		$expected = '<?php echo $__env->stackContent(\'foo\'); ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
 
 	public function testCommentsAreCompiled()
 	{

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -256,6 +256,26 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('hi there', $factory->yieldContent('foo'));
 	}
 
+	public function testSingleStackPush()
+	{
+		$factory = $this->getFactory();
+		$factory->startPush('foo');
+		echo 'hi';
+		$factory->endPush();
+		$this->assertEquals('hi', $factory->stackContent('foo'));
+	}
+
+	public function testMultipleStackPush()
+	{
+		$factory = $this->getFactory();
+		$factory->startPush('foo');
+		echo 'hi';
+		$factory->endPush();
+		$factory->startPush('foo');
+		echo ', Hello!';
+		$factory->endPush();
+		$this->assertEquals('hi, Hello!', $factory->stackContent('foo'));
+	}
 
 	public function testSessionAppending()
 	{


### PR DESCRIPTION
`@stack` statement provides easy way to `@push` contents into a container from multiple locations.
# Example use-case

 The most beneficial use-case would be to push javascript code into the before `</body>` javascripts. An example:

**layout.blade.php**

```
<html>
    <body>
        @include('something')
        @include('someone')
        <script type="text/javascript" src="jquery.js"></script>
        @stack('scripts')
    </body>
</html>
```

**something.blade.php:**

```
// Only this page needs helloWorld() function so defining this function here makes sense
<a href="javascript:helloWorld()">Hello!</a>
@push('scripts')
    <script type="text/javascript">
        function helloWorld() {
            alert('Hello!');
        }
    </script>
@endpush
```

**someone.blade.php**

```
// this page has a datepicker so jquery.datepicker.js should be included
<div id="datepicker"></div>
@push('scripts')
    <script type="text/javascript" src="jquery.datepicker.js">
    <script type="text/javascript">
         $('#datepicker').datepicker();
    </script>
@endpush
```

The resulting content for `@stack('scripts')` would be:

```
<script type="text/javascript">
    function helloWorld() {
        alert('Hello!');
    }
</script>
<script type="text/javascript" src="jquery.datepicker.js">
<script type="text/javascript">
    $('#datepicker').datepicker();
</script>
```
