### PR TITLE
add 'taxes' in irregular

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -81,6 +81,7 @@ class Pluralizer {
 		'move' => 'moves',
 		'person' => 'people',
 		'sex' => 'sexes',
+		'tax' => 'taxes',
 		'tooth' => 'teeth',
 	);
 


### PR DESCRIPTION
`Pluralizer::singular('taxes')` got `taxis`. It should be `tax`.
