### PR TITLE
Remove find, findOrFail from model, delegate to query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -77,7 +77,7 @@ class Builder {
 	 */
 	public function findMany($id, $columns = array('*'))
 	{
-		if (empty($id)) return new Collection;
+		if (empty($id)) return $this->model->newCollection();
 
 		$this->query->whereIn($this->model->getKeyName(), $id);
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -77,6 +77,8 @@ class Builder {
 	 */
 	public function findMany($id, $columns = array('*'))
 	{
+		if (empty($id)) return new Collection;
+
 		$this->query->whereIn($this->model->getKeyName(), $id);
 
 		return $this->get($columns);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -505,22 +505,6 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
-	 * Find a model by its primary key.
-	 *
-	 * @param  mixed  $id
-	 * @param  array  $columns
-	 * @return \Illuminate\Database\Eloquent\Model|Collection|static
-	 */
-	public static function find($id, $columns = array('*'))
-	{
-		if (is_array($id) && empty($id)) return new Collection;
-
-		$instance = new static;
-
-		return $instance->newQuery()->find($id, $columns);
-	}
-
-	/**
 	 * Find a model by its primary key or return new static.
 	 *
 	 * @param  mixed  $id
@@ -532,22 +516,6 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		if ( ! is_null($model = static::find($id, $columns))) return $model;
 
 		return new static($columns);
-	}
-
-	/**
-	 * Find a model by its primary key or throw an exception.
-	 *
-	 * @param  mixed  $id
-	 * @param  array  $columns
-	 * @return \Illuminate\Database\Eloquent\Model|Collection|static
-	 *
-	 * @throws ModelNotFoundException
-	 */
-	public static function findOrFail($id, $columns = array('*'))
-	{
-		if ( ! is_null($model = static::find($id, $columns))) return $model;
-
-		throw with(new ModelNotFoundException)->setModel(get_called_class());
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -72,7 +72,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testFindOrFailMethodThrowsModelNotFoundException()
 	{
-		$result = EloquentModelFindNotFoundStub::findOrFail(1);
+		$result = EloquentModelFindOrFailStub::findOrFail(1);
 	}
 
 
@@ -847,16 +847,16 @@ class EloquentModelFindStub extends Illuminate\Database\Eloquent\Model {
 	public function newQuery($excludeDeleted = true)
 	{
 		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
-		$mock->shouldReceive('find')->once()->with(1, array('*'))->andReturn('foo');
+		$mock->shouldReceive('find')->once()->with(1)->andReturn('foo');
 		return $mock;
 	}
 }
 
-class EloquentModelFindNotFoundStub extends Illuminate\Database\Eloquent\Model {
+class EloquentModelFindOrFailStub extends Illuminate\Database\Eloquent\Model {
 	public function newQuery($excludeDeleted = true)
 	{
 		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
-		$mock->shouldReceive('find')->once()->with(1, array('*'))->andReturn(null);
+		$mock->shouldReceive('findOrFail')->once()->with(1)->andThrow('Illuminate\Database\Eloquent\ModelNotFoundException');
 		return $mock;
 	}
 }
@@ -876,7 +876,7 @@ class EloquentModelFindManyStub extends Illuminate\Database\Eloquent\Model {
 	public function newQuery($excludeDeleted = true)
 	{
 		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
-		$mock->shouldReceive('find')->once()->with(array(1, 2), array('*'))->andReturn('foo');
+		$mock->shouldReceive('find')->once()->with(array(1, 2))->andReturn('foo');
 		return $mock;
 	}
 }


### PR DESCRIPTION
See #3682

Realisticly the tests for `Model::find/findOrFail` should be removed, but I left them in for the sake of ensuring that the static method calls still work.
