### PR TITLE
updated the regex of 'alpha*' validation rules, to support languages with modifiers.

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1107,7 +1107,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateAlphaDash($attribute, $value)
 	{
-		return preg_match('/^[\pL\pM_-]+$/u', $value);
+		return preg_match('/^[\pL\pM\pN_-]+$/u', $value);
 	}
 
 	/**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1083,7 +1083,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateAlpha($attribute, $value)
 	{
-		return preg_match('/^\pL+$/u', $value);
+		return preg_match('/^[\pL\pM]+$/u', $value);
 	}
 
 	/**
@@ -1095,7 +1095,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateAlphaNum($attribute, $value)
 	{
-		return preg_match('/^[\pL\pN]+$/u', $value);
+		return preg_match('/^[\pL\pM\pN]+$/u', $value);
 	}
 
 	/**
@@ -1107,7 +1107,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateAlphaDash($attribute, $value)
 	{
-		return preg_match('/^[\pL\pN_-]+$/u', $value);
+		return preg_match('/^[\pL\pM\pN_-]+$/u', $value);
 	}
 
 	/**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1107,7 +1107,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateAlphaDash($attribute, $value)
 	{
-		return preg_match('/^[\pL\pM\pN_-]+$/u', $value);
+		return preg_match('/^[\pL\pM_-]+$/u', $value);
 	}
 
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -857,13 +857,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('x' => 'http://g232oogle.com'), array('x' => 'AlphaNum'));
 		$this->assertFalse($v->passes());
 		
-		$v = new Validator($trans, array('x' => '१२३'), array('x' => 'Alpha'));//numbers in Hindi
+		$v = new Validator($trans, array('x' => '१२३'), array('x' => 'AlphaNum'));//numbers in Hindi
 		$this->assertTrue($v->passes());
 		
 		$v = new Validator($trans, array('x' => '٧٨٩'), array('x' => 'AlphaNum'));//eastern arabic numerals
 		$this->assertTrue($v->passes());
 		
-		$v = new Validator($trans, array('x' => 'नमस्कार'), array('x' => 'Alpha'));
+		$v = new Validator($trans, array('x' => 'नमस्कार'), array('x' => 'AlphaNum'));
 		$this->assertFalse($v->passes());
 	}
 
@@ -877,10 +877,10 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('x' => 'http://-g232oogle.com'), array('x' => 'AlphaDash'));
 		$this->assertFalse($v->passes());
 		
-		$v = new Validator($trans, array('x' => 'नमस्कार-_'), array('x' => 'Alpha'));
+		$v = new Validator($trans, array('x' => 'नमस्कार-_'), array('x' => 'AlphaDash'));
 		$this->assertTrue($v->passes());
 		
-		$v = new Validator($trans, array('x' => '٧٨٩'), array('x' => 'AlphaNum'));//eastern arabic numerals
+		$v = new Validator($trans, array('x' => '٧٨٩'), array('x' => 'AlphaDash'));//eastern arabic numerals
 		$this->assertFalse($v->passes());
 		
 	}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -823,6 +823,28 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v = new Validator($trans, array('x' => 'http://google.com'), array('x' => 'Alpha'));
 		$this->assertFalse($v->passes());
+		
+		$v = new Validator($trans, array('x' => 'ユニコードを基盤技術と'), array('x' => 'Alpha'));
+		$this->assertTrue($v->passes());
+		
+		$v = new Validator($trans, array('x' => 'ユニコード を基盤技術と'), array('x' => 'Alpha'));
+		$this->assertFalse($v->passes());
+		
+		$v = new Validator($trans, array('x' => 'नमस्कार'), array('x' => 'Alpha'));
+		$this->assertTrue($v->passes());
+		
+		$v = new Validator($trans, array('x' => 'आपका स्वागत है'), array('x' => 'Alpha'));
+		$this->assertFalse($v->passes());
+		
+		$v = new Validator($trans, array('x' => 'Continuación'), array('x' => 'Alpha'));
+		$this->assertTrue($v->passes());
+		
+		$v = new Validator($trans, array('x' => 'ofreció su dimisión'), array('x' => 'Alpha'));
+		$this->assertFalse($v->passes());
+		
+		$v = new Validator($trans, array('x' => '❤'), array('x' => 'Alpha'));
+		$this->assertFalse($v->passes());
+		
 	}
 
 
@@ -833,6 +855,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 
 		$v = new Validator($trans, array('x' => 'http://g232oogle.com'), array('x' => 'AlphaNum'));
+		$this->assertFalse($v->passes());
+		
+		$v = new Validator($trans, array('x' => '१२३'), array('x' => 'Alpha'));//numbers in Hindi
+		$this->assertTrue($v->passes());
+		
+		$v = new Validator($trans, array('x' => '٧٨٩'), array('x' => 'AlphaNum'));//eastern arabic numerals
+		$this->assertTrue($v->passes());
+		
+		$v = new Validator($trans, array('x' => 'नमस्कार'), array('x' => 'Alpha'));
 		$this->assertFalse($v->passes());
 	}
 
@@ -845,6 +876,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v = new Validator($trans, array('x' => 'http://-g232oogle.com'), array('x' => 'AlphaDash'));
 		$this->assertFalse($v->passes());
+		
+		$v = new Validator($trans, array('x' => 'नमस्कार-_'), array('x' => 'Alpha'));
+		$this->assertTrue($v->passes());
+		
+		$v = new Validator($trans, array('x' => '٧٨٩'), array('x' => 'AlphaNum'));//eastern arabic numerals
+		$this->assertFalse($v->passes());
+		
 	}
 
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -864,7 +864,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 		
 		$v = new Validator($trans, array('x' => 'नमस्कार'), array('x' => 'AlphaNum'));
-		$this->assertFalse($v->passes());
+		$this->assertTrue($v->passes());
 	}
 
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -881,7 +881,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 		
 		$v = new Validator($trans, array('x' => '٧٨٩'), array('x' => 'AlphaDash'));//eastern arabic numerals
-		$this->assertFalse($v->passes());
+		$this->assertTrue($v->passes());
 		
 	}
 


### PR DESCRIPTION
Regex for alphabets was '/^\pL+$/u', which would match almost all 'letters'.
There are some languages in which a 'modifier' is also applicable to the letter, 
adding another '/pM' takes care of this.
