### PR TITLE
Create a composite index for morphing columns

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -668,6 +668,8 @@ class Blueprint {
 		$this->unsignedInteger("{$name}_id");
 
 		$this->string("{$name}_type");
+
+		$this->index(array("{$name}_id", "{$name}_type"));
 	}
 
 	/**


### PR DESCRIPTION
When creating morphing columns with `$table->morphs(...)`, we should also create a composite index with those columns.

I think this is a good default. If anyone doesn't want the index, they can fall back to creating those two columns separately.

---

I pulled against master since I consider this a breaking change; re-running a migration shouldn't introduce a new index.
