### PR TITLE
Allow logging email subject and email body when setting email pretending mode to true

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -29,7 +29,7 @@ class MailServiceProvider extends ServiceProvider {
 			// Once we have create the mailer instance, we will set a container instance
 			// on the mailer. This allows us to resolve mailer classes via containers
 			// for maximum testability on said classes instead of passing Closures.
-			$mailer = new Mailer($app['view'], $app['swift.mailer']);
+			$mailer = new Mailer($app['view'], $app['swift.mailer'], $app['events']);
 
 			$mailer->setLogger($app['log'])->setQueue($app['queue']);
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -59,6 +59,13 @@ class Mailer {
 	 * @var array
 	 */
 	protected $failedRecipients = array();
+	
+	/**
+	 * Array of parsed views containing html and text view name.
+	 *
+	 * @var array
+	 */
+	protected $parsedViews = array();
 
 	/**
 	 * Create a new Mailer instance.
@@ -111,7 +118,7 @@ class Mailer {
 		// First we need to parse the view, which could either be a string or an array
 		// containing both an HTML and plain text versions of the view which should
 		// be used when sending an e-mail. We will extract both of them out here.
-		list($view, $plain) = $this->parseView($view);
+		list($view, $plain) = $this->parsedViews = $this->parseView($view);
 
 		$data['message'] = $message = $this->createMessage();
 
@@ -316,8 +323,9 @@ class Mailer {
 	protected function logMessage($message)
 	{
 		$emails = implode(', ', array_keys((array) $message->getTo()));
+		$views = implode(', ', $this->parsedViews);
 
-		$this->logger->info("Pretending to mail message to: {$emails} [Subject: {$message->getSubject()}] [Body: {$message->getBody()}]");
+		$this->logger->info("Pretending to mail message to: {$emails} [Subject: {$message->getSubject()}] [Use view: {$views}]");
 	}
 
 	/**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -8,6 +8,7 @@ use Illuminate\View\Factory;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Container\Container;
 use Illuminate\Support\SerializableClosure;
+use Illuminate\Events\Dispatcher;
 
 class Mailer {
 
@@ -66,6 +67,13 @@ class Mailer {
 	 * @var array
 	 */
 	protected $parsedViews = array();
+	
+	/**
+	 * The event dispatcher instance.
+	 *
+	 * @var \Illuminate\Events\Dispatcher
+	 */
+	protected $events;
 
 	/**
 	 * Create a new Mailer instance.
@@ -74,10 +82,11 @@ class Mailer {
 	 * @param  \Swift_Mailer  $swift
 	 * @return void
 	 */
-	public function __construct(Factory $views, Swift_Mailer $swift)
+	public function __construct(Factory $views, Swift_Mailer $swift, Dispatcher $events = null)
 	{
 		$this->views = $views;
 		$this->swift = $swift;
+		$this->events = $events;
 	}
 
 	/**
@@ -302,6 +311,10 @@ class Mailer {
 	 */
 	protected function sendSwiftMessage($message)
 	{
+		if ($this->events)
+		{
+			$this->events->fire('mailer.sending', array($message));
+		}
 		if ( ! $this->pretending)
 		{
 			return $this->swift->send($message, $this->failedRecipients);

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -317,7 +317,7 @@ class Mailer {
 	{
 		$emails = implode(', ', array_keys((array) $message->getTo()));
 
-		$this->logger->info("Pretending to mail message to: {$emails}");
+		$this->logger->info("Pretending to mail message to: {$emails} [Subject: {$message->getSubject()}] [Body: {$message->getBody()}]");
 	}
 
 	/**

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -140,11 +140,10 @@ class MailMailerTest extends PHPUnit_Framework_TestCase {
 		$mailer->setSwiftMailer(m::mock('StdClass'));
 		$message->shouldReceive('getTo')->once()->andReturn(array('taylor@userscape.com' => 'Taylor'));
 		$message->shouldReceive('getSubject')->once()->andReturn('Lorem Ipsum');
-		$message->shouldReceive('getBody')->once()->andReturn('Lorem ipsum dolor sit amet');
 		$message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
 		$mailer->getSwiftMailer()->shouldReceive('send')->never();
 		$logger = m::mock('Illuminate\Log\Writer');
-		$logger->shouldReceive('info')->once()->with('Pretending to mail message to: taylor@userscape.com [Subject: Lorem Ipsum] [Body: Lorem ipsum dolor sit amet]');
+		$logger->shouldReceive('info')->once()->with('Pretending to mail message to: taylor@userscape.com [Subject: Lorem Ipsum] [Use view: foo, ]');
 		$mailer->setLogger($logger);
 		$mailer->pretend();
 

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -139,10 +139,12 @@ class MailMailerTest extends PHPUnit_Framework_TestCase {
 		$message->shouldReceive('setFrom')->never();
 		$mailer->setSwiftMailer(m::mock('StdClass'));
 		$message->shouldReceive('getTo')->once()->andReturn(array('taylor@userscape.com' => 'Taylor'));
+		$message->shouldReceive('getSubject')->once()->andReturn('Lorem Ipsum');
+		$message->shouldReceive('getBody')->once()->andReturn('Lorem ipsum dolor sit amet');
 		$message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
 		$mailer->getSwiftMailer()->shouldReceive('send')->never();
 		$logger = m::mock('Illuminate\Log\Writer');
-		$logger->shouldReceive('info')->once()->with('Pretending to mail message to: taylor@userscape.com');
+		$logger->shouldReceive('info')->once()->with('Pretending to mail message to: taylor@userscape.com [Subject: Lorem Ipsum] [Body: Lorem ipsum dolor sit amet]');
 		$mailer->setLogger($logger);
 		$mailer->pretend();
 


### PR DESCRIPTION
In development environment, when the email pretending mode is set to true, the current version only log the email receivers. In some cases, developer cannot view the content of emails that they send.
