### PR TITLE
[4.1] Fix json_decode in JsonResponse for PHP 5.3

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -6,6 +6,13 @@ use Illuminate\Support\Contracts\JsonableInterface;
 class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {
 
 	/**
+	 * The json encoding options.
+	 *
+	 * @var int
+	 */
+	protected $jsonOptions;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param  mixed  $data

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -6,13 +6,6 @@ use Illuminate\Support\Contracts\JsonableInterface;
 class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {
 
 	/**
-	 * The json encoding options.
-	 *
-	 * @var int
-	 */
-	protected $jsonOptions;
-
-	/**
 	 * Constructor.
 	 *
 	 * @param  mixed  $data
@@ -32,14 +25,11 @@ class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {
 	 *
 	 * @param  bool $assoc
 	 * @param  int  $depth
-	 * @param  int  $options
 	 * @return mixed
 	 */
-	public function getData($assoc = false, $depth = 512, $options = null)
+	public function getData($assoc = false, $depth = 512)
 	{
-		$options = $options ?: $this->jsonOptions;
-
-		return json_decode($this->data, $assoc, $depth, $options);
+		return json_decode($this->data, $assoc, $depth);
 	}
 
 	/**

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -1,0 +1,13 @@
+<?php
+
+class HttpJsonResponseTest extends PHPUnit_Framework_TestCase {
+
+	public function testSetAndRetrieveData()
+	{
+		$response = new Illuminate\Http\JsonResponse(array('foo' => 'bar'));
+		$data = $response->getData();
+		$this->assertInstanceOf('StdClass', $data);
+		$this->assertEquals('bar', $data->foo);
+	}
+
+}


### PR DESCRIPTION
Urgent bugfix, problem introduced in https://github.com/laravel/framework/commit/417f539803ce96eeab7b420d8b03f04959a603e9 - PR: #3660

PHP 5.3 does not allow 4 parameters for json_decode, and results in a fatal error.

I left the options flag in for the json_encode bit but feel that this might come off as inconsistent behaviour - allowing options on encoding but not decoding.

See differences in behaviour here: http://3v4l.org/cmPYS

This is why people need to write unit tests with their pull requests.
