### PR TITLE
Add a chunk method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -387,6 +387,25 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Chunk the underlying collection array.
+	 *
+	 * @param  int $size
+	 * @param  bool  $preserveKeys
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function chunk($size, $preserveKeys = false)
+	{
+		$chunks = new static;
+
+		foreach (array_chunk($this->items, $size, $preserveKeys) as $chunk)
+		{
+			$chunks->push(new static($chunk));
+		}
+
+		return $chunks;
+	}
+
+	/**
 	 * Sort through each item with a callback.
 	 *
 	 * @param  Closure  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -230,6 +230,19 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testChunk ()
+	{
+		$data = new Collection(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+		$data = $data->chunk(3);
+
+		$this->assertInstanceOf('Illuminate\Support\Collection', $data);
+		$this->assertInstanceOf('Illuminate\Support\Collection', $data[0]);
+		$this->assertEquals(4, $data->count());
+		$this->assertEquals(array(1, 2, 3), $data[0]->toArray());
+		$this->assertEquals(array(10), $data[3]->toArray());
+	}
+
+
 	public function testListsWithArrayAndObjectValues()
 	{
 		$data = new Collection(array((object) array('name' => 'taylor', 'email' => 'foo'), array('name' => 'dayle', 'email' => 'bar')));


### PR DESCRIPTION
Let's add a `chunk` method to `Collection`. We already implement most of php's array methods, so why not.

People ask about this a lot in IRC, since it's very handy when building a grid out of items:

``` html
@foreach ($products->chunk(3) as $chunk)
    <div class="row">
        @foreach ($chunk as $product)
            <div class="col-xs-4">{{ $product->name }}</div>
        @endforeach
    </div>
@endforeach
```

Note that `$chunk`s themselves are collections :)
