### PR TITLE
Add --coverage-text to travis output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
 
-script: phpunit -d memory_limit=1024M
+script: phpunit -d memory_limit=1024M --coverage-text
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Avoids the coverage amount being some dark secret worthy of posting on Reddit, and gives people a clear and simple goal of where they can work on PR's to "fix" the situation. Coveralls might be an interesting next step too.
