### PR TITLE
Add onRaw support

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -175,11 +175,11 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function compileJoinConstraint(array $clause)
 	{
-        // compile raw join constraints
-        if (array_key_exists('sql', $clause))
-        {
-            return $clause['sql'];
-        }
+		// compile raw join constraints
+		if (array_key_exists('sql', $clause))
+		{
+			return $clause['sql'];
+		}
 
 		$first = $this->wrap($clause['first']);
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -175,6 +175,12 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function compileJoinConstraint(array $clause)
 	{
+        // compile raw join constraints
+        if (array_key_exists('sql', $clause))
+        {
+            return $clause['sql'];
+        }
+
 		$first = $this->wrap($clause['first']);
 
 		$second = $clause['where'] ? '?' : $this->wrap($clause['second']);

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -116,4 +116,28 @@ class JoinClause {
 		$this->clauses[] = compact('sql');
 		return $this;
 	}
+
+	/**
+	 * Add an "or on raw" clause to the join.
+	 *
+	 * @param string $sql
+	 * @return @return \Illuminate\Database\Query\JoinClause
+	 */
+	public function orOnRaw($sql)
+	{
+		$this->clauses[] = array('sql'=>"or $sql");
+		return $this;
+	}
+
+	/**
+	 * Add an "and on raw" clause to the join.
+	 *
+	 * @param string $sql
+	 * @return @return \Illuminate\Database\Query\JoinClause
+	 */
+	public function andOnRaw($sql)
+	{
+		$this->clauses[] = array('sql'=>"and $sql");
+		return $this;
+	}
 }

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -105,15 +105,15 @@ class JoinClause {
 		return $this->on($first, $operator, $second, 'or', true);
 	}
 
-    /**
-     * Add a raw on clause to the query.
-     *
-     * @param  string  $sql
-     * @return @return \Illuminate\Database\Query\JoinClause
-     */
-    public function onRaw($sql)
-    {
-        $this->clauses[] = compact('sql');
-        return $this;
-    }
+	/**
+	 * Add a raw on clause to the query.
+	 *
+	 * @param  string  $sql
+	 * @return @return \Illuminate\Database\Query\JoinClause
+	 */
+	public function onRaw($sql)
+	{
+		$this->clauses[] = compact('sql');
+		return $this;
+	}
 }

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -105,4 +105,15 @@ class JoinClause {
 		return $this->on($first, $operator, $second, 'or', true);
 	}
 
+    /**
+     * Add a raw on clause to the query.
+     *
+     * @param  string  $sql
+     * @return @return \Illuminate\Database\Query\JoinClause
+     */
+    public function onRaw($sql)
+    {
+        $this->clauses[] = compact('sql');
+        return $this;
+    }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -439,7 +439,6 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('bar', 'foo'), $builder->getBindings());
 	}
 
-
 	public function testComplexJoin()
 	{
 		$builder = $this->getBuilder();
@@ -456,6 +455,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		});
 		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = ? or "users"."name" = ?', $builder->toSql());
 		$this->assertEquals(array('foo', 'bar'), $builder->getBindings());
+
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('posts')->join('tags', function($j){
+			$j->onRaw('FIND_IN_SET(tag_id, tags)')->andOnRaw('user_id = 2');
+		});
+		$this->assertEquals('select * from "posts" inner join "tags" on FIND_IN_SET(tag_id, tags) and user_id = 2', $builder->toSql());
 	}
 
 


### PR DESCRIPTION
`onRaw` would be useful like `whereRaw` in many cases while using db function on `on` clause.

``` php
Post::with('user')
    ->join('posttags', function($join){
        $join->onRaw("FIND_IN_SET(tag_id, tags)");  // just an example
    });
```
