### PR TITLE
Unit Tests for SQS - Push support for SQS utilizing SNS - Overhaul of SubscribeCommand - Addition of UnsubscribeCommand - Move setContainer to Job base class and more

### DIFF
--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -14,7 +14,7 @@ class SqsConnector implements ConnectorInterface {
 	protected $request;
 
 	/**
-	* Create a new Iron connector instance.
+	* Create a new Sqs connector instance.
 	*
 	* @param  \Illuminate\Http\Request  $request
 	* @return void

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -17,7 +17,7 @@ class SqsConnector implements ConnectorInterface {
 
 		$sqs = SqsClient::factory($sqsConfig);
 
-		return new SqsQueue($sqs, $config['queue']);
+		return new SqsQueue($sqs, $config['queue'], $config['account']);
 	}
 
 }

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -1,8 +1,10 @@
 <?php namespace Illuminate\Queue\Connectors;
 
+use Aws\Sns\SnsClient;
 use Aws\Sqs\SqsClient;
 use Illuminate\Http\Request;
 use Illuminate\Queue\SqsQueue;
+use Log;
 
 class SqsConnector implements ConnectorInterface {
 
@@ -32,11 +34,15 @@ class SqsConnector implements ConnectorInterface {
 	 */
 	public function connect(array $config)
 	{
+		Log::info('SqsConnector connect', array('config'=>$config));
+
 		$sqsConfig = array_only($config, array('key', 'secret', 'region', 'default_cache_config'));
 
 		$sqs = SqsClient::factory($sqsConfig);
 
-		return new SqsQueue($sqs, $this->request, $config['queue'], $config['account']);
+		$sns = SnsClient::factory($sqsConfig);
+
+		return new SqsQueue($sqs, $sns, $this->request, $config['queue'], $config['account']);
 	}
 
 }

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -1,9 +1,28 @@
 <?php namespace Illuminate\Queue\Connectors;
 
 use Aws\Sqs\SqsClient;
+use Illuminate\Http\Request;
 use Illuminate\Queue\SqsQueue;
 
 class SqsConnector implements ConnectorInterface {
+
+	/**
+	* The current request instance.
+	*
+	* @var \Illuminate\Http\Request;
+	*/
+	protected $request;
+
+	/**
+	* Create a new Iron connector instance.
+	*
+	* @param  \Illuminate\Http\Request  $request
+	* @return void
+	*/
+	public function __construct(Request $request)
+	{
+		$this->request = $request;
+	}
 
 	/**
 	 * Establish a queue connection.
@@ -17,7 +36,7 @@ class SqsConnector implements ConnectorInterface {
 
 		$sqs = SqsClient::factory($sqsConfig);
 
-		return new SqsQueue($sqs, $config['queue']);
+		return new SqsQueue($sqs, $this->request, $config['queue']);
 	}
 
 }

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -4,7 +4,6 @@ use Aws\Sns\SnsClient;
 use Aws\Sqs\SqsClient;
 use Illuminate\Http\Request;
 use Illuminate\Queue\SqsQueue;
-use Log;
 
 class SqsConnector implements ConnectorInterface {
 
@@ -34,8 +33,6 @@ class SqsConnector implements ConnectorInterface {
 	 */
 	public function connect(array $config)
 	{
-		Log::info('SqsConnector connect', array('config'=>$config));
-
 		$sqsConfig = array_only($config, array('key', 'secret', 'region', 'default_cache_config'));
 
 		$sqs = SqsClient::factory($sqsConfig);

--- a/src/Illuminate/Queue/Console/SubscribeCommand.php
+++ b/src/Illuminate/Queue/Console/SubscribeCommand.php
@@ -1,8 +1,5 @@
 <?php namespace Illuminate\Queue\Console;
 
-use RuntimeException;
-use Illuminate\Queue\IronQueue;
-use Illuminate\Queue\SqsQueue;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -24,13 +21,6 @@ class SubscribeCommand extends Command {
 	protected $description = 'Subscribe a URL to an Iron.io or SQS push queue';
 
 	/**
-	 * The queue meta information
-	 *
-	 * @var object
-	 */
-	protected $meta;
-
-	/**
 	 * Execute the console command.
 	 *
 	 * @return void
@@ -40,111 +30,10 @@ class SubscribeCommand extends Command {
 	public function fire()
 	{
 		$queue = $this->laravel['queue']->connection();
-
-		if ($queue instanceof IronQueue)
-		{
-			$queue->getIron()->updateQueue($this->argument('queue'), $this->getQueueOptions());
-		} 
-		else if ($queue instanceof SqsQueue)
-		{
-			$response = $queue->getSns()->createTopic(array('Name' => $this->argument('queue')));
-
-			$response = $queue->getSns()->subscribe(array('TopicArn' => $response->get('TopicArn'), 'Protocol' => ((stripos($this->argument('url'), 'https') !== false) ? 'https' : 'http'), 'Endpoint' => $this->argument('url')));
-		} 
-		else 
-		{
-			throw new RuntimeException("The default queue must be either IronMQ or SQS.");
-		}
+		
+		$queue->subscribe($this->argument('queue'), $this->argument('url'), array_only($this->option(), array('type', 'retries', 'patience')));
 
 		$this->line('<info>Queue subscriber added:</info> <comment>'.$this->argument('url').'</comment>');
-	}
-
-	/**
-	 * Get the queue options.
-	 *
-	 * @return array
-	 */
-	protected function getQueueOptions()
-	{
-		return array(
-			'push_type' => $this->getPushType(), 'subscribers' => $this->getSubscriberList()
-		);
-	}
-
-	/**
-	 * Get the push type for the queue.
-	 *
-	 * @return string
-	 */
-	protected function getPushType()
-	{
-		if ($this->option('type')) return $this->option('type');
-
-		try
-		{
-			return $this->getQueue()->push_type;
-		}
-		catch (\Exception $e)
-		{
-			return 'multicast';
-		}
-	}
-
-	/**
-	 * Get the current subscribers for the queue.
-	 *
-	 * @return array
-	 */
-	protected function getSubscriberList()
-	{
-		$subscribers = $this->getCurrentSubscribers();
-
-		$subscribers[] = array('url' => $this->argument('url'));
-
-		return $subscribers;
-	}
-
-	/**
-	 * Get the current subscriber list.
-	 *
-	 * @return array
-	 */
-	protected function getCurrentSubscribers()
-	{
-		try
-		{
-			return $this->getQueue()->subscribers;
-		}
-		catch (\Exception $e)
-		{
-			return array();
-		}
-	}
-
-	/**
-	 * Get the queue information
-	 *
-	 * @return object
-	 */
-	protected function getQueue()
-	{
-		if (isset($this->meta)) return $this->meta;
-
-		$queue = $this->laravel['queue']->connection();
-
-		if ($queue instanceof IronQueue)
-		{
-			return $this->meta = $this->laravel['queue']->getIron()->getQueue($this->argument('queue'));
-		} 
-		else if ($queue instanceof SqsQueue)
-		{
-			return $this->meta = $this->laravel['queue']->getSqs()->getQueueAttributes(array('QueueUrl' => $this->argument('queue')));
-		} 
-		else 
-		{
-			throw new RuntimeException("The default queue must be either IronMQ or SQS.");
-		}
-	
 	}
 
 	/**
@@ -169,7 +58,11 @@ class SubscribeCommand extends Command {
 	protected function getOptions()
 	{
 		return array(
-			array('type', null, InputOption::VALUE_OPTIONAL, 'The push type for the queue.'),
+			array('type', null, InputOption::VALUE_OPTIONAL, 'The push type for the queue.', 'multicast'),
+
+			array('retries', null, InputOption::VALUE_OPTIONAL, 'Number of retries.', 3),
+
+			array('patience', null, InputOption::VALUE_OPTIONAL, 'The number of seconds to wait between retries.', '60'),
 		);
 	}
 

--- a/src/Illuminate/Queue/Console/SubscribeCommand.php
+++ b/src/Illuminate/Queue/Console/SubscribeCommand.php
@@ -6,7 +6,6 @@ use Illuminate\Queue\SqsQueue;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
-use Log;
 
 class SubscribeCommand extends Command {
 
@@ -48,15 +47,9 @@ class SubscribeCommand extends Command {
 		} 
 		else if ($queue instanceof SqsQueue)
 		{
-			Log::info('SubscribeCommand fire', array('createTopic' => $this->argument('queue')));		
-
 			$response = $queue->getSns()->createTopic(array('Name' => $this->argument('queue')));
 
-			Log::info('SubscribeCommand fire', array('response' => $response->toArray()));
-
 			$response = $queue->getSns()->subscribe(array('TopicArn' => $response->get('TopicArn'), 'Protocol' => ((stripos($this->argument('url'), 'https') !== false) ? 'https' : 'http'), 'Endpoint' => $this->argument('url')));
-
-			Log::info('SubscribeCommand fire', array('response' => $response->toArray()));
 		} 
 		else 
 		{
@@ -141,14 +134,10 @@ class SubscribeCommand extends Command {
 
 		if ($queue instanceof IronQueue)
 		{
-			Log::info('SubscribeCommand getQueue', array('queue metadata' => $this->laravel['queue']->getIron()->getQueue($this->argument('queue')))); 
-
 			return $this->meta = $this->laravel['queue']->getIron()->getQueue($this->argument('queue'));
 		} 
 		else if ($queue instanceof SqsQueue)
 		{
-			Log::info('SubscribeCommand getQueue', array('queue metadata' => $this->laravel['queue']->getSqs()->getQueueAttributes(array('QueueUrl' => $this->argument('queue'))))); 
-
 			return $this->meta = $this->laravel['queue']->getSqs()->getQueueAttributes(array('QueueUrl' => $this->argument('queue')));
 		} 
 		else 

--- a/src/Illuminate/Queue/Console/UnsubscribeCommand.php
+++ b/src/Illuminate/Queue/Console/UnsubscribeCommand.php
@@ -1,8 +1,5 @@
 <?php namespace Illuminate\Queue\Console;
 
-use RuntimeException;
-use Illuminate\Queue\IronQueue;
-use Illuminate\Queue\SqsQueue;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -24,13 +21,6 @@ class UnsubscribeCommand extends Command {
 	protected $description = 'Unsubscribe a URL from an Iron.io or SQS push queue';
 
 	/**
-	 * The queue meta information
-	 *
-	 * @var object
-	 */
-	protected $meta;
-
-	/**
 	 * Execute the console command.
 	 *
 	 * @return void
@@ -41,120 +31,9 @@ class UnsubscribeCommand extends Command {
 	{
 		$queue = $this->laravel['queue']->connection();
 
-		if ($queue instanceof IronQueue)
-		{
-			$queue->getIron()->updateQueue($this->argument('queue'), $this->getQueueOptions());
-		} 
-		else if ($queue instanceof SqsQueue)
-		{
-			$response = $queue->getSns()->listSubscriptions();
-
-			$endpoint = $this->argument('url');		
-	
-			$subscription = array_filter($response->toArray()['Subscriptions'], function($element) use ($endpoint) {
-				
-				return $element['Endpoint'] == $endpoint;
-			});
-
-			if(count($subscription)) {
-
-				$response = $queue->getSns()->unsubscribe(array('SubscriptionArn' => $subscription[0]['SubscriptionArn']));
-			}
-		} 
-		else 
-		{
-			throw new RuntimeException("The default queue must be either IronMQ or SQS.");
-		}
+		$queue->unsubscribe($this->argument('queue'), $this->argument('url'));
 
 		$this->line('<info>Queue </info><comment>'.$this->argument('queue').'</comment><info> unsubscribed from:</info> <comment>'.$this->argument('url').'</comment>');
-	}
-
-	/**
-	 * Get the queue options.
-	 *
-	 * @return array
-	 */
-	protected function getQueueOptions()
-	{
-		return array(
-			'push_type' => $this->getPushType(), 'subscribers' => $this->getSubscriberList()
-		);
-	}
-
-	/**
-	 * Get the push type for the queue.
-	 *
-	 * @return string
-	 */
-	protected function getPushType()
-	{
-		if ($this->option('type')) return $this->option('type');
-
-		try
-		{
-			return $this->getQueue()->push_type;
-		}
-		catch (\Exception $e)
-		{
-			return 'multicast';
-		}
-	}
-
-	/**
-	 * Get the current subscribers for the queue.
-	 *
-	 * @return array
-	 */
-	protected function getSubscriberList()
-	{
-		$subscribers = $this->getCurrentSubscribers();
-
-		$subscribers[] = array('url' => $this->argument('url'));
-
-		return $subscribers;
-	}
-
-	/**
-	 * Get the current subscriber list.
-	 *
-	 * @return array
-	 */
-	protected function getCurrentSubscribers()
-	{
-		try
-		{
-			return $this->getQueue()->subscribers;
-		}
-		catch (\Exception $e)
-		{
-			return array();
-		}
-	}
-
-	/**
-	 * Get the queue information
-	 *
-	 * @return object
-	 */
-	protected function getQueue()
-	{
-		if (isset($this->meta)) return $this->meta;
-
-		$queue = $this->laravel['queue']->connection();
-
-		if ($queue instanceof IronQueue)
-		{
-			return $this->meta = $this->laravel['queue']->getIron()->getQueue($this->argument('queue'));
-		} 
-		else if ($queue instanceof SqsQueue)
-		{
-			return $this->meta = $this->laravel['queue']->getSqs()->getQueueAttributes(array('QueueUrl' => $this->argument('queue')));
-		} 
-		else 
-		{
-			throw new RuntimeException("The default queue must be either IronMQ or SQS.");
-		}
-	
 	}
 
 	/**
@@ -168,18 +47,6 @@ class UnsubscribeCommand extends Command {
 			array('queue', InputArgument::REQUIRED, 'The name of Iron.io queue or SNS topic.'),
 
 			array('url', InputArgument::REQUIRED, 'The URL to be unsubscribed.'),
-		);
-	}
-
-	/**
-	 * Get the console command options.
-	 *
-	 * @return array
-	 */
-	protected function getOptions()
-	{
-		return array(
-			array('type', null, InputOption::VALUE_OPTIONAL, 'The push type for the queue.'),
 		);
 	}
 

--- a/src/Illuminate/Queue/Console/UnsubscribeCommand.php
+++ b/src/Illuminate/Queue/Console/UnsubscribeCommand.php
@@ -6,7 +6,6 @@ use Illuminate\Queue\SqsQueue;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
-use Log;
 
 class UnsubscribeCommand extends Command {
 
@@ -48,11 +47,7 @@ class UnsubscribeCommand extends Command {
 		} 
 		else if ($queue instanceof SqsQueue)
 		{
-			Log::info('UnsubscribeCommand fire', array('list' => 'subscriptions'));
-
 			$response = $queue->getSns()->listSubscriptions();
-
-			Log::info('UnsubscribeCommand fire', array('listSubscriptions' => $response->toArray()));
 
 			$endpoint = $this->argument('url');		
 	
@@ -61,13 +56,9 @@ class UnsubscribeCommand extends Command {
 				return $element['Endpoint'] == $endpoint;
 			});
 
-			Log::info('UnsubscribeCommand fire', array('subscription' => $subscription));
-	
 			if(count($subscription)) {
 
 				$response = $queue->getSns()->unsubscribe(array('SubscriptionArn' => $subscription[0]['SubscriptionArn']));
-
-				Log::info('UnsubscribeCommand fire', array('response' => $response->toArray()));
 			}
 		} 
 		else 
@@ -153,14 +144,10 @@ class UnsubscribeCommand extends Command {
 
 		if ($queue instanceof IronQueue)
 		{
-			Log::info('UnsubscribeCommand getQueue', array('queue metadata' => $this->laravel['queue']->getIron()->getQueue($this->argument('queue')))); 
-
 			return $this->meta = $this->laravel['queue']->getIron()->getQueue($this->argument('queue'));
 		} 
 		else if ($queue instanceof SqsQueue)
 		{
-			Log::info('UnsubscribeCommand getQueue', array('queue metadata' => $this->laravel['queue']->getSqs()->getQueueAttributes(array('QueueUrl' => $this->argument('queue'))))); 
-
 			return $this->meta = $this->laravel['queue']->getSqs()->getQueueAttributes(array('QueueUrl' => $this->argument('queue')));
 		} 
 		else 

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Response;
 use Illuminate\Queue\Jobs\IronJob;
 use Illuminate\Encryption\Encrypter;
 
-class IronQueue extends Queue implements QueueInterface {
+class IronQueue extends PushQueue implements QueueInterface {
 
 	/**
 	 * The IronMQ instance.
@@ -21,13 +21,6 @@ class IronQueue extends Queue implements QueueInterface {
 	 * @var \Illuminate\Encryption\Encrypter
 	 */
 	protected $crypt;
-
-	/**
-	 * The current request instance.
-	 *
-	 * @var \Illuminate\Http\Request
-	 */
-	protected $request;
 
 	/**
 	 * The name of the default tube.
@@ -242,27 +235,6 @@ class IronQueue extends Queue implements QueueInterface {
 	public function getIron()
 	{
 		return $this->iron;
-	}
-
-	/**
-	 * Get the request instance.
-	 *
-	 * @return \Symfony\Component\HttpFoundation\Request
-	 */
-	public function getRequest()
-	{
-		return $this->request;
-	}
-
-	/**
-	 * Set the request instance.
-	 *
-	 * @param  \Symfony\Component\HttpFoundation\Request  $request
-	 * @return void
-	 */
-	public function setRequest(Request $request)
-	{
-		$this->request = $request;
 	}
 
 }

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -259,4 +259,35 @@ class IronQueue extends PushQueue implements QueueInterface {
 		return $this->iron;
 	}
 
+	/**
+	 * Subscribe a queue to the endpoint url
+	 *
+	 * @param string  $queue
+	 * @param string  $endpoint
+	 * @param array   $options
+	 * @return array
+	 */
+	public function subscribe($queue, $endpoint, array $options = array())
+	{	
+		$response = $this->getIron()->addSubscriber($queue, array('url' => $endpoint));
+	
+		$response = $this->getIron()->updateQueue($queue, $options);
+
+		return $response;
+	}
+	
+	/**
+	 * Unsubscribe a queue from an endpoint url
+	 *
+	 * @param string  $queue
+	 * @param string  $url
+	 * @return array
+	 */
+	public function unsubscribe($queue, $endpoint)
+	{
+		$response = $this->getIron()->removeSubscriber($queue, array('url' => $endpoint));
+
+		return $response;
+	}
+
 }

--- a/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
+++ b/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
@@ -118,16 +118,6 @@ class BeanstalkdJob extends Job {
 	}
 
 	/**
-	 * Get the IoC container instance.
-	 *
-	 * @return \Illuminate\Container\Container
-	 */
-	public function getContainer()
-	{
-		return $this->container;
-	}
-
-	/**
 	 * Get the underlying Pheanstalk instance.
 	 *
 	 * @return Pheanstalk

--- a/src/Illuminate/Queue/Jobs/IronJob.php
+++ b/src/Illuminate/Queue/Jobs/IronJob.php
@@ -32,7 +32,6 @@ class IronJob extends Job {
 	 * @param  \Illuminate\Container\Container  $container
 	 * @param  \Illuminate\Queue\IronQueue  $iron
 	 * @param  object  $job
-	 * @param  string  $queue
 	 * @param  bool    $pushed
 	 * @return void
 	 */
@@ -127,16 +126,6 @@ class IronJob extends Job {
 	public function getJobId()
 	{
 		return $this->job->id;
-	}
-
-	/**
-	 * Get the IoC container instance.
-	 *
-	 * @return \Illuminate\Container\Container
-	 */
-	public function getContainer()
-	{
-		return $this->container;
 	}
 
 	/**

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -168,4 +168,14 @@ abstract class Job {
 		return $this->queue;
 	}
 
+	/**
+	 * Get the IoC container instance.
+	 *
+	 * @return \Illuminate\Container\Container
+	 */
+	public function getContainer()
+	{
+		return $this->container;
+	}
+
 }

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Queue\Jobs;
 
 use DateTime;
+use Log;
 
 abstract class Job {
 
@@ -89,6 +90,8 @@ abstract class Job {
 	 */
 	protected function resolveAndFire(array $payload)
 	{
+		Log::info('Job resolveAndFire', array('payload'=>$payload));
+
 		list($class, $method) = $this->parseJob($payload['job']);
 
 		$this->instance = $this->resolve($class);

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -1,7 +1,6 @@
 <?php namespace Illuminate\Queue\Jobs;
 
 use DateTime;
-use Log;
 
 abstract class Job {
 
@@ -90,8 +89,6 @@ abstract class Job {
 	 */
 	protected function resolveAndFire(array $payload)
 	{
-		Log::info('Job resolveAndFire', array('payload'=>$payload));
-
 		list($class, $method) = $this->parseJob($payload['job']);
 
 		$this->instance = $this->resolve($class);

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -102,16 +102,6 @@ class RedisJob extends Job {
 	}
 
 	/**
-	 * Get the IoC container instance.
-	 *
-	 * @return \Illuminate\Container\Container
-	 */
-	public function getContainer()
-	{
-		return $this->container;
-	}
-
-	/**
 	 * Get the underlying queue driver instance.
 	 *
 	 * @return \Illuminate\Redis\Database

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -24,14 +24,14 @@ class SqsJob extends Job {
 	 *
 	 * @param  \Illuminate\Container\Container  $container
 	 * @param  \Aws\Sqs\SqsClient  $sqs
-	 * @param  string  $queue
 	 * @param  array   $job
+	 * @param  string  $queue
 	 * @return void
 	 */
 	public function __construct(Container $container,
                                 SqsClient $sqs,
-                                $queue,
-                                array $job)
+                                array $job,
+                                $queue)
 	{
 		$this->sqs = $sqs;
 		$this->job = $job;

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -20,6 +20,13 @@ class SqsJob extends Job {
 	protected $job;
 
 	/**
+	 * Indicates if the message was a push message.
+	 *
+	 * @var bool
+	 */
+	protected $pushed = false;
+
+	/**
 	 * Create a new job instance.
 	 *
 	 * @param  \Illuminate\Container\Container  $container
@@ -31,11 +38,13 @@ class SqsJob extends Job {
 	public function __construct(Container $container,
                                 SqsClient $sqs,
                                 $queue,
-                                array $job)
+                                array $job,
+				$pushed = false)
 	{
 		$this->sqs = $sqs;
 		$this->job = $job;
 		$this->queue = $queue;
+		$this->pushed = $pushed;
 		$this->container = $container;
 	}
 
@@ -67,6 +76,8 @@ class SqsJob extends Job {
 	public function delete()
 	{
 		parent::delete();
+
+		if (isset($this->job['pushed'])) return;
 
 		$this->sqs->deleteMessage(array(
 

--- a/src/Illuminate/Queue/PushQueue.php
+++ b/src/Illuminate/Queue/PushQueue.php
@@ -1,0 +1,33 @@
+<?php namespace Illuminate\Queue;
+
+abstract class PushQueue extends Queue {
+
+	/**
+	* The current request instance.
+	*
+	* @var \Illuminate\Http\Request
+	*/
+	protected $request;
+
+	/**
+	* Get the request instance.
+	*
+	* @return \Symfony\Component\HttpFoundation\Request
+	*/
+	public function getRequest()
+	{
+		return $this->request;
+	}
+
+	/**
+	* Set the current request instance.
+	*
+	* @param  \Symfony\Component\HttpFoundation\Request  $request
+	* @return void
+	*/
+	public function setRequest(Request $request)
+	{
+		$this->request = $request;
+	}
+
+}

--- a/src/Illuminate/Queue/PushQueue.php
+++ b/src/Illuminate/Queue/PushQueue.php
@@ -1,6 +1,6 @@
 <?php namespace Illuminate\Queue;
 
-abstract class PushQueue extends Queue {
+abstract class PushQueue extends Queue implements PushQueueInterface {
 
 	/**
 	* The current request instance.

--- a/src/Illuminate/Queue/PushQueueInterface.php
+++ b/src/Illuminate/Queue/PushQueueInterface.php
@@ -3,11 +3,19 @@
 interface PushQueueInterface {
 
 	/**
+	 * Marshal a push queue request and fire the job.
+	 *
+	 * @return \Illuminate\Http\Response
+	 */
+	public function marshal();
+
+	/**
 	 * Subscribe a queue to the endpoint url
 	 *
 	 * @param string  $queue
 	 * @param string  $endpoint
 	 * @param array   $options
+	 *
 	 * @return array
 	 */
 	public function subscribe($queue, $endpoint, array $options = array());
@@ -17,6 +25,7 @@ interface PushQueueInterface {
 	 *
 	 * @param string  $queue
 	 * @param string  $endpoint
+	 *
 	 * @return array
 	 */
 	public function unsubscribe($queue, $endpoint);

--- a/src/Illuminate/Queue/PushQueueInterface.php
+++ b/src/Illuminate/Queue/PushQueueInterface.php
@@ -1,0 +1,24 @@
+<?php namespace Illuminate\Queue;
+
+interface PushQueueInterface {
+
+	/**
+	 * Subscribe a queue to the endpoint url
+	 *
+	 * @param string  $queue
+	 * @param string  $endpoint
+	 * @param array   $options
+	 * @return array
+	 */
+	public function subscribe($queue, $endpoint, array $options = array());
+
+	/**
+	 * Unsubscribe a queue from an endpoint url
+	 *
+	 * @param string  $queue
+	 * @param string  $endpoint
+	 * @return array
+	 */
+	public function unsubscribe($queue, $endpoint);
+
+}

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -4,6 +4,7 @@ use Closure;
 use DateTime;
 use Illuminate\Container\Container;
 use Illuminate\Support\SerializableClosure;
+use Illuminate\Support\Facades\Config;
 
 abstract class Queue {
 
@@ -126,6 +127,33 @@ abstract class Queue {
 	public function setContainer(Container $container)
 	{
 		$this->container = $container;
+	}
+
+	/**
+	 * The base subscribe function just throws a runtime exception to let the user know it's not supported.
+	 *  Derived classes that support push queues are required to implement an overriding subscribe function.
+	 *
+	 * @param string  $queue
+	 * @param string  $endpoint
+	 * @param array   $options
+	 * @throws \RuntimeException
+	 */
+	public function subscribe($queue, $endpoint, array $options = array())
+	{
+		throw new \RuntimeException("The default queue driver '".Config::get('queue.default')."' doesn't support the subscribe command.");	
+	}
+
+	/**
+	 * This base unsubscribe function just throws a runtime exception to let the user know it's not supported.
+	 *  Derived classes that support push queues are required to implement an overriding unsubscribe function.
+	 *
+	 * @param string  $queue
+	 * @param string  $endpoint
+	 * @throws \RuntimeException
+	 */
+	public function unsubscribe($queue, $endpoint)
+	{
+		throw new \RuntimeException("The default queue driver '".Config::get('queue.default')."' doesn't support the unsubscribe command.");
 	}
 
 }

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -21,7 +21,7 @@ abstract class Queue {
 	 */
 	public function marshal()
 	{
-		throw new \RuntimeException("Push queues only supported by Iron.");
+		throw new \RuntimeException("Push queues only supported by Iron and SQS.");
 	}
 
 	/**

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -1,7 +1,6 @@
 <?php namespace Illuminate\Queue;
 
 use Closure;
-use Log;
 
 class QueueManager {
 
@@ -62,23 +61,15 @@ class QueueManager {
 	{
 		$name = $name ?: $this->getDefaultDriver();
 
-		Log::info('QueueManager connection', array('name'=>$name));
-
 		// If the connection has not been resolved yet we will resolve it now as all
 		// of the connections are resolved when they are actually needed so we do
 		// not make any unnecessary connection to the various queue end-points.
 		if ( ! isset($this->connections[$name]))
 		{
-			Log::info('QueueManager connection calling this->resolve', array('name'=>$name));
-
 			$this->connections[$name] = $this->resolve($name);
-
-			Log::info('QueueManager connection calling setContainer', array('name'=>$name));
-
+		
 			$this->connections[$name]->setContainer($this->app);
 		}
-
-		Log::info('QueueManager connection returning this->connections[name]', array('connections-name'=>$this->connections[$name]));
 
 		return $this->connections[$name];
 	}
@@ -190,8 +181,6 @@ class QueueManager {
 	 */
 	public function __call($method, $parameters)
 	{
-		Log::info('QueueManager __call', array('method'=>$method, 'parameters'=>$parameters));
-
 		$callable = array($this->connection(), $method);
 
 		return call_user_func_array($callable, $parameters);

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Queue;
 
 use Closure;
+use Log;
 
 class QueueManager {
 
@@ -61,15 +62,23 @@ class QueueManager {
 	{
 		$name = $name ?: $this->getDefaultDriver();
 
+		Log::info('QueueManager connection', array('name'=>$name));
+
 		// If the connection has not been resolved yet we will resolve it now as all
 		// of the connections are resolved when they are actually needed so we do
 		// not make any unnecessary connection to the various queue end-points.
 		if ( ! isset($this->connections[$name]))
 		{
+			Log::info('QueueManager connection calling this->resolve', array('name'=>$name));
+
 			$this->connections[$name] = $this->resolve($name);
+
+			Log::info('QueueManager connection calling setContainer', array('name'=>$name));
 
 			$this->connections[$name]->setContainer($this->app);
 		}
+
+		Log::info('QueueManager connection returning this->connections[name]', array('connections-name'=>$this->connections[$name]));
 
 		return $this->connections[$name];
 	}
@@ -181,6 +190,8 @@ class QueueManager {
 	 */
 	public function __call($method, $parameters)
 	{
+		Log::info('QueueManager __call', array('method'=>$method, 'parameters'=>$parameters));
+
 		$callable = array($this->connection(), $method);
 
 		return call_user_func_array($callable, $parameters);

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -199,10 +199,14 @@ class QueueServiceProvider extends ServiceProvider {
 	 */
 	protected function registerSqsConnector($manager)
 	{
-		$manager->addConnector('sqs', function()
+		$app = $this->app;
+
+		$manager->addConnector('sqs', function($app)
 		{
-			return new SqsConnector;
+			return new SqsConnector($app['request']);
 		});
+
+		$this->registerRequestBinder('sqs');
 	}
 
 	/**
@@ -220,21 +224,22 @@ class QueueServiceProvider extends ServiceProvider {
 			return new IronConnector($app['encrypter'], $app['request']);
 		});
 
-		$this->registerIronRequestBinder();
+		$this->registerRequestBinder('iron');
 	}
 
 	/**
-	 * Register the request rebinding event for the Iron queue.
+	 * Register the request rebinding event for the push queue.
 	 *
+	 * @param string $driver
 	 * @return void
 	 */
-	protected function registerIronRequestBinder()
+	protected function registerRequestBinder($driver)
 	{
-		$this->app->rebinding('request', function($app, $request)
+		$this->app->rebinding('request', function($app, $request) use ($driver)
 		{
-			if ($app['queue']->connected('iron'))
+			if ($app['queue']->connected($driver))
 			{
-				$app['queue']->connection('iron')->setRequest($request);
+				$app['queue']->connection($driver)->setRequest($request);
 			}
 		});
 	}

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -201,7 +201,7 @@ class QueueServiceProvider extends ServiceProvider {
 	{
 		$app = $this->app;
 
-		$manager->addConnector('sqs', function($app)
+		$manager->addConnector('sqs', function() use ($app)
 		{
 			return new SqsConnector($app['request']);
 		});

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -13,6 +13,13 @@ class SqsQueue extends Queue implements QueueInterface {
 	protected $sqs;
 
 	/**
+	 * The account associated with the default tube
+	 *
+	 * @var string
+	 */
+	protected $account;
+
+	/**
 	 * The name of the default tube.
 	 *
 	 * @var string
@@ -24,12 +31,14 @@ class SqsQueue extends Queue implements QueueInterface {
 	 *
 	 * @param  \Aws\Sqs\SqsClient  $sqs
 	 * @param  string  $default
+	 * @param  string  $account
 	 * @return void
 	 */
-	public function __construct(SqsClient $sqs, $default)
+	public function __construct(SqsClient $sqs, $default, $account)
 	{
 		$this->sqs = $sqs;
 		$this->default = $default;
+		$this->account = $account;
 	}
 
 	/**
@@ -110,7 +119,7 @@ class SqsQueue extends Queue implements QueueInterface {
 	 */
 	public function getQueue($queue)
 	{
-		return $queue ?: $this->default;
+		return $this->sqs->getBaseUrl() . '/' . $this->account . '/' . ($queue ?: $this->default);
 	}
 
 	/**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -6,7 +6,6 @@ use Aws\Sqs\SqsClient;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Queue\Jobs\SqsJob;
-use Log;
 
 class SqsQueue extends PushQueue implements QueueInterface {
 
@@ -148,16 +147,11 @@ class SqsQueue extends PushQueue implements QueueInterface {
 	{
 		$r = $this->request;
 
-		Log::info('SqsQueue marshalPushedJob', array('request->header()'=>$r->header()));
-		Log::info('SqsQueue marshalPushedJob', array('request->json()'=>$r->json()));
-
 		$body = $r->getContent();
 
 		if($r->json('Type') == 'SubscriptionConfirmation') {
 	
 			$response = $this->getSns()->confirmSubscription(array('TopicArn' => $r->json('TopicArn'), 'Token' => $r->json('Token'), 'AuthenticateOnUnsubscribe' => 'true'));
-
-			Log::info('SqsQueue marshalPushedJob', array('response' => $response->toArray()));
 
 			$body = '{"job":"NotificationHandler@send","data":{"subscription":"confirmed"}}';
 		} 
@@ -170,12 +164,6 @@ class SqsQueue extends PushQueue implements QueueInterface {
 		{
 			throw new RuntimeException("The marshaled job must come from SQS.");	
 		}
-
-		Log::info('SqsQueue marshalPushedJob', array(	'MessageId' => $r->header('xaws-sqsd-msgid') ?: $r->header('x-amz-sns-message-id'),
-                        					'Body' => $body,
-                        					'Attributes' => array('ApproximateReceiveCount' => $r->header('X-aws-sqsd-receive-count')),
-                        					'pushed' => true,
-                					    ));
 
 		return array(
 			'MessageId' => $r->header('xaws-sqsd-msgid') ?: $r->header('x-amz-sns-message-id'),

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -98,7 +98,7 @@ class SqsQueue extends Queue implements QueueInterface {
 
 		if (count($response['Messages']) > 0)
 		{
-			return new SqsJob($this->container, $this->sqs, $queue, $response['Messages'][0]);
+			return new SqsJob($this->container, $this->sqs, $response['Messages'][0], $queue);
 		}
 	}
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -79,7 +79,7 @@ class SqsQueue extends PushQueue implements QueueInterface {
 	 */
 	public function pushRaw($payload, $queue = null, array $options = array())
 	{
-		$response = $this->sqs->sendMessage(array('QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload));
+		$response = $this->sqs->sendMessage(array('QueueUrl' => $this->getQueueUrl($queue), 'MessageBody' => $payload));
 
 		return $response->get('MessageId');
 	}
@@ -101,7 +101,7 @@ class SqsQueue extends PushQueue implements QueueInterface {
 
 		return $this->sqs->sendMessage(array(
 
-			'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload, 'DelaySeconds' => $delay,
+			'QueueUrl' => $this->getQueueUrl($queue), 'MessageBody' => $payload, 'DelaySeconds' => $delay,
 
 		))->get('MessageId');
 	}
@@ -114,10 +114,12 @@ class SqsQueue extends PushQueue implements QueueInterface {
 	 */
 	public function pop($queue = null)
 	{
-		$queue = $this->getQueue($queue);
+		$this->queue = $queue;
+
+		$queueUrl = $this->getQueueUrl($this->queue);
 
 		$response = $this->sqs->receiveMessage(
-			array('QueueUrl' => $queue, 'AttributeNames' => array('ApproximateReceiveCount'))
+			array('QueueUrl' => $queueUrl, 'AttributeNames' => array('ApproximateReceiveCount'))
 		);
 
 		if (count($response['Messages']) > 0)
@@ -174,12 +176,22 @@ class SqsQueue extends PushQueue implements QueueInterface {
 	}
 
 	/**
-	 * Get the queue or return the default.
+	 * Get the queue name
+	 *
+	 * @return string
+	 */
+	public function getQueue()
+	{
+		return $this->queue;
+	}
+
+	/**
+	 * Get the full queue url based on the one passed in or the default.
 	 *
 	 * @param  string|null  $queue
 	 * @return string
 	 */
-	public function getQueue($queue = null)
+	public function getQueueUrl($queue = null)
 	{
 		return $this->sqs->getBaseUrl() . '/' . $this->account . '/' . ($queue ?: $this->queue);
 	}

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -1,9 +1,11 @@
 <?php namespace Illuminate\Queue;
 
 use Aws\Sqs\SqsClient;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Queue\Jobs\SqsJob;
 
-class SqsQueue extends Queue implements QueueInterface {
+class SqsQueue extends PushQueue implements QueueInterface {
 
 	/**
 	 * The Amazon SQS instance.
@@ -23,12 +25,14 @@ class SqsQueue extends Queue implements QueueInterface {
 	 * Create a new Amazon SQS queue instance.
 	 *
 	 * @param  \Aws\Sqs\SqsClient  $sqs
+	 * @param  \Illuminate\Http\Request  $request
 	 * @param  string  $default
 	 * @return void
 	 */
-	public function __construct(SqsClient $sqs, $default)
+	public function __construct(SqsClient $sqs, Request $request, $default)
 	{
 		$this->sqs = $sqs;
+		$this->request = $request;
 		$this->default = $default;
 	}
 
@@ -100,6 +104,46 @@ class SqsQueue extends Queue implements QueueInterface {
 		{
 			return new SqsJob($this->container, $this->sqs, $queue, $response['Messages'][0]);
 		}
+	}
+
+	/**
+	* Marshal a push queue request and fire the job.
+	*
+	* @return \Illuminate\Http\Response
+	*/
+	public function marshal()
+	{
+		$this->createPushedSqsJob($this->marshalPushedJob())->fire();
+
+		return new Response('OK');
+	}
+
+	/**
+	* Marshal out the pushed job and payload.
+	*
+	* @return array
+	*/
+	protected function marshalPushedJob()
+	{
+		$r = $this->request;
+
+		return array(
+			'MessageId' => $r->header('X-aws-sqsd-msgid'),
+			'Body' => $r->getContent(),
+			'Attributes' => array('ApproximateReceiveCount' => $r->header('X-aws-sqsd-receive-count')),
+			'pushed' => true,
+		);
+	}
+
+	/**
+	* Create a new SqsJob for a pushed job.
+	*
+	* @param  array  $job
+	* @return \Illuminate\Queue\Jobs\SqsJob
+	*/
+	protected function createPushedSqsJob($job)
+	{
+		return new SqsJob($this->container, $this->sqs, $this, $job, true);
 	}
 
 	/**

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -228,16 +228,6 @@ class SqsQueue extends PushQueue implements QueueInterface {
 	}
 
 	/**
-	 * Get the request associated with the object
-	 *
-	 * @return \Illuminate\Http\Request
-	 */
-	public function getRequest()
-	{
-		return $this->request;
-	}
-
-	/**
 	 * Get the underlying SQS instance.
 	 *
 	 * @return \Aws\Sqs\SqsClient

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -24,18 +24,18 @@ class SqsQueue extends PushQueue implements QueueInterface {
 	protected $sns;
 
 	/**
-	 * The account associated with the default queue
-	 *
-	 * @var string
-	 */
-	protected $account;
-
-	/**
 	 * The name of the default queue.
 	 *
 	 * @var string
 	 */
 	protected $queue;
+
+	/**
+	 * The account associated with the default queue
+	 *
+	 * @var string
+	 */
+	protected $account;
 
 	/**
 	 * Create a new Amazon SQS queue instance.
@@ -124,15 +124,15 @@ class SqsQueue extends PushQueue implements QueueInterface {
 
 		if (count($response['Messages']) > 0)
 		{
-			return new SqsJob($this->container, $this, $response['Messages'][0]);
+			return $this->createSqsJob($response['Messages'][0]);
 		}
 	}
 
 	/**
-	* Marshal a push queue request and fire the job.
-	*
-	* @return \Illuminate\Http\Response
-	*/
+	 * Marshal a push queue request and fire the job.
+	 *
+	 * @return \Illuminate\Http\Response
+	 */
 	public function marshal()
 	{
 		$r = $this->request;
@@ -143,17 +143,17 @@ class SqsQueue extends PushQueue implements QueueInterface {
 		} 
 		else 
 		{
-			$this->createPushedSqsJob($this->marshalPushedJob())->fire();
+			$this->createSqsJob($this->marshalPushedJob(), $pushed = true)->fire();
 		}
 
 		return new Response('OK');
 	}
 
 	/**
-	* Marshal out the pushed job and payload.
-	*
-	* @return array
-	*/
+	 * Marshal out the pushed job and payload.
+	 *
+	 * @return array
+	 */
 	protected function marshalPushedJob()
 	{
 		$r = $this->request;
@@ -165,14 +165,15 @@ class SqsQueue extends PushQueue implements QueueInterface {
 	}
 
 	/**
-	* Create a new SqsJob for a pushed job.
-	*
-	* @param  array  $job
-	* @return \Illuminate\Queue\Jobs\SqsJob
-	*/
-	protected function createPushedSqsJob($job)
+	 * Create a new SqsJob.
+	 *
+	 * @param  array  $job
+	 * @param  bool	  $pushed 
+	 * @return \Illuminate\Queue\Jobs\SqsJob
+	 */
+	protected function createSqsJob($job, $pushed = false)
 	{
-		return new SqsJob($this->container, $this, $job, true);
+		return new SqsJob($this->container, $this, $job, $pushed);
 	}
 
 	/**

--- a/tests/Queue/QueueIronQueueTest.php
+++ b/tests/Queue/QueueIronQueueTest.php
@@ -105,4 +105,13 @@ class QueueIronQueueTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(200, $response->getStatusCode());
 	}
 
+	/**
+	 * @expectedException RuntimeException
+	 */
+	public function testPushedJobsMustComeFromIronMQ()
+	{
+		$queue = $this->getMock('Illuminate\Queue\IronQueue', array('createPushedIronJob'), array($iron = m::mock('IronMQ'), $crypt = m::mock('Illuminate\Encryption\Encrypter'), $request = m::mock('Illuminate\Http\Request'), 'default', true));
+		$request->shouldReceive('header')->once()->with('iron-message-id')->andReturn(null);
+		$response = $queue->marshal();
+	}
 }

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use Mockery as m;
+
+use Aws\Sqs\SqsClient;
+use Aws\Common\Credentials\Credentials;
+use Aws\Common\Credentials\CredentialsInterface;
+use Aws\Common\Signature\SignatureInterface;
+use Aws\Common\Signature\SignatureV4;
+
+use Guzzle\Common\Collection;
+use Guzzle\Service\Resource\Model;
+
+class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
+
+	public function setUp() {
+
+		$this->key = 'AMAZONSQSKEY';
+		$this->secret = 'AmAz0n+SqSsEcReT+aLpHaNuM3R1CsTr1nG';
+		$this->service = 'sqs';
+		$this->region = 'someregion';
+		$this->account = '1234567891011';
+		$this->queueName = 'emails';
+		$this->baseUrl = 'https://sqs.someregion.amazonaws.com';
+
+		// The Aws\Common\AbstractClient needs these three constructor parameters
+		$this->credentials = new Credentials( $this->key, $this->secret );
+		$this->signature = new SignatureV4( $this->service, $this->region );
+		$this->config = new Collection();
+
+		// This is how the modified getQueue builds the queueUrl
+		$this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
+
+		// Get a mock of the SqsClient 
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		
+		// Use Mockery to mock the IoC Container
+		$this->mockedContainer = m::mock('Illuminate\Container\Container');
+
+		$this->mockedJob = 'foo';
+		$this->mockedData = array('data');
+		$this->mockedPayload = json_encode(array('job' => $this->mockedJob, 'data' => $this->mockedData, 'attempts' => 1));
+		$this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
+		$this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
+
+		$this->mockedJobData = array('Body' => $this->mockedPayload,
+					     'MD5OfBody' => md5($this->mockedPayload),
+					     'ReceiptHandle' => $this->mockedReceiptHandle,
+					     'MessageId' => $this->mockedMessageId,
+					     'Attributes' => array('ApproximateReceiveCount' => 1));
+
+	}
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testFireProperlyCallsTheJobHandler()
+	{
+		$job = $this->getJob();
+		$job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
+		$handler->shouldReceive('fire')->once()->with($job, array('data'));
+		$job->fire();
+	}
+
+
+	public function testDeleteRemovesTheJobFromSqs()
+	{
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->queueName, $this->account));
+		$queue->setContainer($this->mockedContainer);
+		$job = $this->getJob();
+		$job->getSqs()->expects($this->once())->method('deleteMessage')->with(array('QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle));	
+		$job->delete();
+	}
+
+	protected function getJob()
+	{
+		return new Illuminate\Queue\Jobs\SqsJob(
+			$this->mockedContainer,
+			$this->mockedSqsClient,
+			$this->queueUrl,
+			$this->mockedJobData
+		);
+	}
+
+}

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -21,23 +21,20 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 		$this->region = 'someregion';
 		$this->account = '1234567891011';
 		$this->queueName = 'emails';
+		$this->pushQueueName = 'notifications';
 		$this->baseUrl = 'https://sqs.someregion.amazonaws.com';
 
-		// The Aws\Common\AbstractClient needs these three constructor parameters
 		$this->credentials = new Credentials( $this->key, $this->secret );
 		$this->signature = new SignatureV4( $this->service, $this->region );
 		$this->config = new Collection();
 
-		// This is how the modified getQueue builds the queueUrl
 		$this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
+		$this->pushQueueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->pushQueueName;
 
-		// Get a mock of the SqsClient 
 		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
 
-		// Use Mockery to mock the SnsClient
 		$this->sns = m::mock('Aws\Sns\SnsClient');
 		
-		// Use Mockery to mock the IoC Container
 		$this->mockedContainer = m::mock('Illuminate\Container\Container');
 
 		$this->mockedJob = 'foo';
@@ -46,12 +43,19 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 		$this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
 		$this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
 
+		$this->mockedTopicArn = 'arn:aws:sns:'.$this->region.':'.$this->account.':'.$this->pushQueueName;	
+
 		$this->mockedJobData = array('Body' => $this->mockedPayload,
 					     'MD5OfBody' => md5($this->mockedPayload),
 					     'ReceiptHandle' => $this->mockedReceiptHandle,
 					     'MessageId' => $this->mockedMessageId,
 					     'Attributes' => array('ApproximateReceiveCount' => 1));
 
+		$this->mockedReceiveMessageResponseModel = new Model(array('Messages' => array( 0 => array(
+												'Body' => $this->mockedPayload,
+						     						'MD5OfBody' => md5($this->mockedPayload),
+						      						'ReceiptHandle' => $this->mockedReceiptHandle,
+						     						'MessageId' => $this->mockedMessageId))));
 	}
 
 	public function tearDown()
@@ -61,7 +65,10 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 
 	public function testFireProperlyCallsTheJobHandler()
 	{
-		$job = $this->getJob();
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->sns, m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
+		$queue->setContainer($this->mockedContainer);
+		$job = $this->getJob($queue);
 		$job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
 		$handler->shouldReceive('fire')->once()->with($job, array('data'));
 		$job->fire();
@@ -69,31 +76,36 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 
 	public function testDeleteRemovesTheJobFromSqs()
 	{
-		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->sns, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('receiveMessage', 'deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->sns, $request = m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
 		$queue->setContainer($this->mockedContainer);
-		$job = $this->getJob();
-		$job->getSqs()->expects($this->once())->method('deleteMessage')->with(array('QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle));	
+		$queue->expects($this->once())->method('getQueue')->with(null)->will($this->returnValue($this->queueUrl));
+		$job = $this->getJob($queue);
+		$job->getSqsQueue()->getSqs()->expects($this->once())->method('deleteMessage')->with(array('QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle));	
 		$job->delete();
 	}
 
-	public function testDeleteNoopsOnPushedQueues()
+	public function testDeleteRemovesThePushedJobFromSqs()
 	{
-		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->sns, m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('receiveMessage', 'deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->sns, $request = m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
 		$queue->setContainer($this->mockedContainer);
-		$job = $this->getJob(true);
-		$job->getSqs()->expects($this->never())->method('deleteMessage');
+		$queue->expects($this->at(0))->method('getQueue')->with(null)->will($this->returnValue($this->queueUrl));
+		$queue->expects($this->at(1))->method('getQueue')->with($this->pushQueueName)->will($this->returnValue($this->pushQueueUrl));
+		$request->shouldReceive('header')->once()->with('x-amz-sns-topic-arn')->andReturn($this->mockedTopicArn);
+		$job = $this->getJob($queue, true);
+		$job->getSqsQueue()->getSqs()->expects($this->once())->method('receiveMessage')->with(array('QueueUrl' => $this->pushQueueUrl))->will($this->returnValue($this->mockedReceiveMessageResponseModel));	
+		$job->getSqsQueue()->getSqs()->expects($this->once())->method('deleteMessage')->with(array('QueueUrl' => $this->pushQueueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle));	
 		$job->delete();
 	}
 
-	protected function getJob($pushed = false)
+	protected function getJob($queue, $pushed = false)
 	{
 		return new Illuminate\Queue\Jobs\SqsJob(
 			$this->mockedContainer,
-			$this->mockedSqsClient,
-			($pushed ? array_merge($this->mockedJobData, array('pushed' => true)) : $this->mockedJobData),	
-			$this->queueUrl
+			$queue,
+			$this->mockedJobData,
+			$pushed
 		);
 	}
 

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -80,7 +80,7 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueueUrl'), array($this->mockedSqsClient, $this->sns, $request = m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
 		$queue->setContainer($this->mockedContainer);
 		$queue->expects($this->at(0))->method('getQueueUrl')->with(null)->will($this->returnValue($this->queueUrl));
-		$queue->expects($this->at(1))->method('getQueueUrl')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$queue->expects($this->at(1))->method('getQueueUrl')->with(null)->will($this->returnValue($this->queueUrl));
 		$job = $this->getJob($queue);
 		$job->getSqsQueue()->getSqs()->expects($this->once())->method('deleteMessage')->with(array('QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle));	
 		$job->delete();

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Mockery as m;
+
+use Aws\Sqs\SqsClient;
+use Aws\Common\Credentials\Credentials;
+use Aws\Common\Credentials\CredentialsInterface;
+use Aws\Common\Signature\SignatureInterface;
+use Aws\Common\Signature\SignatureV4;
+
+use Guzzle\Common\Collection;
+use Guzzle\Service\Resource\Model;
+
+class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
+
+	public function setUp() {
+
+		$this->key = 'AMAZONSQSKEY';
+		$this->secret = 'AmAz0n+SqSsEcReT+aLpHaNuM3R1CsTr1nG';
+		$this->service = 'sqs';
+		$this->region = 'someregion';
+		$this->account = '1234567891011';
+		$this->queueName = 'emails';
+		$this->baseUrl = 'https://sqs.someregion.amazonaws.com';
+
+		// The Aws\Common\AbstractClient needs these three constructor parameters
+		$this->credentials = new Credentials( $this->key, $this->secret );
+		$this->signature = new SignatureV4( $this->service, $this->region );
+		$this->config = new Collection();
+
+		// This is how the modified getQueue builds the queueUrl
+		$this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
+
+		// Get a mock of the SqsClient 
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		
+		// Use Mockery to mock the IoC Container
+		$this->mockedContainer = m::mock('Illuminate\Container\Container');
+
+		$this->mockedJob = 'foo';
+		$this->mockedData = array('data');
+		$this->mockedPayload = json_encode(array('job' => $this->mockedJob, 'data' => $this->mockedData, 'attempts' => 1));
+		$this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
+		$this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
+
+		$this->mockedJobData = array('Body' => $this->mockedPayload,
+					     'MD5OfBody' => md5($this->mockedPayload),
+					     'ReceiptHandle' => $this->mockedReceiptHandle,
+					     'MessageId' => $this->mockedMessageId,
+					     'Attributes' => array('ApproximateReceiveCount' => 1));
+
+	}
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testFireProperlyCallsTheJobHandler()
+	{
+		$job = $this->getJob();
+		$job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
+		$handler->shouldReceive('fire')->once()->with($job, array('data'));
+
+		$job->fire();
+	}
+
+
+	public function testDeleteRemovesTheJobFromSqs()
+	{
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->queueName, $this->account));
+		$queue->setContainer($this->mockedContainer);
+		$job = $this->getJob();
+		$job->getSqs()->expects($this->once())->method('deleteMessage')->with(array('QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle));	
+		$job->delete();
+	}
+
+	protected function getJob()
+	{
+		return new Illuminate\Queue\Jobs\SqsJob(
+			$this->mockedContainer,
+			$this->mockedSqsClient,
+			$this->queueUrl,
+			$this->mockedJobData
+		);
+	}
+
+}

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -33,6 +33,9 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 
 		// Get a mock of the SqsClient 
 		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+
+		// Use Mockery to mock the SnsClient
+		$this->sns = m::mock('Aws\Sns\SnsClient');
 		
 		// Use Mockery to mock the IoC Container
 		$this->mockedContainer = m::mock('Illuminate\Container\Container');
@@ -67,7 +70,7 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 	public function testDeleteRemovesTheJobFromSqs()
 	{
 		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->sns, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
 		$queue->setContainer($this->mockedContainer);
 		$job = $this->getJob();
 		$job->getSqs()->expects($this->once())->method('deleteMessage')->with(array('QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle));	
@@ -77,7 +80,7 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 	public function testDeleteNoopsOnPushedQueues()
 	{
 		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->sns, m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
 		$queue->setContainer($this->mockedContainer);
 		$job = $this->getJob(true);
 		$job->getSqs()->expects($this->never())->method('deleteMessage');

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use Mockery as m;
+
+use Aws\Sqs\SqsClient;
+use Aws\Common\Credentials\Credentials;
+use Aws\Common\Credentials\CredentialsInterface;
+use Aws\Common\Signature\SignatureInterface;
+use Aws\Common\Signature\SignatureV4;
+
+use Guzzle\Common\Collection;
+use Guzzle\Service\Resource\Model;
+
+class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
+
+	public function setUp() {
+
+		$this->key = 'AMAZONSQSKEY';
+		$this->secret = 'AmAz0n+SqSsEcReT+aLpHaNuM3R1CsTr1nG';
+		$this->service = 'sqs';
+		$this->region = 'someregion';
+		$this->account = '1234567891011';
+		$this->queueName = 'emails';
+		$this->baseUrl = 'https://sqs.someregion.amazonaws.com';
+
+		// The Aws\Common\AbstractClient needs these three constructor parameters
+		$this->credentials = new Credentials( $this->key, $this->secret );
+		$this->signature = new SignatureV4( $this->service, $this->region );
+		$this->config = new Collection();
+
+		// This is how the modified getQueue builds the queueUrl
+		$this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
+
+		// Get a mock of the SqsClient 
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		
+		// Use Mockery to mock the IoC Container
+		$this->mockedContainer = m::mock('Illuminate\Container\Container');
+
+		$this->mockedJob = 'foo';
+		$this->mockedData = array('data');
+		$this->mockedPayload = json_encode(array('job' => $this->mockedJob, 'data' => $this->mockedData, 'attempts' => 1));
+		$this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
+		$this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
+
+		$this->mockedJobData = array('Body' => $this->mockedPayload,
+					     'MD5OfBody' => md5($this->mockedPayload),
+					     'ReceiptHandle' => $this->mockedReceiptHandle,
+					     'MessageId' => $this->mockedMessageId,
+					     'Attributes' => array('ApproximateReceiveCount' => 1));
+
+	}
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testFireProperlyCallsTheJobHandler()
+	{
+		$job = $this->getJob();
+		$job->getContainer()->shouldReceive('make')->once()->with('foo')->andReturn($handler = m::mock('StdClass'));
+		$handler->shouldReceive('fire')->once()->with($job, array('data'));
+		$job->fire();
+	}
+
+
+	public function testDeleteRemovesTheJobFromSqs()
+	{
+		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->queueName, $this->account));
+		$queue->setContainer($this->mockedContainer);
+		$job = $this->getJob();
+		$job->getSqs()->expects($this->once())->method('deleteMessage')->with(array('QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle));	
+		$job->delete();
+	}
+
+	protected function getJob()
+	{
+		return new Illuminate\Queue\Jobs\SqsJob(
+			$this->mockedContainer,
+			$this->mockedSqsClient,
+			$this->mockedJobData,
+			$this->queueUrl
+		);
+	}
+
+}

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -69,7 +69,7 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 	public function testDeleteRemovesTheJobFromSqs()
 	{
 		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->queueName, $this->account));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
 		$queue->setContainer($this->mockedContainer);
 		$job = $this->getJob();
 		$job->getSqs()->expects($this->once())->method('deleteMessage')->with(array('QueueUrl' => $this->queueUrl, 'ReceiptHandle' => $this->mockedReceiptHandle));	

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use Mockery as m;
+
+use Aws\Sqs\SqsClient;
+use Guzzle\Service\Resource\Model;
+
+class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function setUp() {
+
+		// Use Mockery to mock the SqsClient
+		$this->sqs = m::mock('Aws\Sqs\SqsClient');
+
+		$this->account = '1234567891011';
+		$this->queueName = 'emails';
+		$this->baseUrl = 'https://sqs.someregion.amazonaws.com';
+
+		// This is how the modified getQueue builds the queueUrl
+		$this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
+
+		$this->mockedJob = 'foo';
+		$this->mockedData = array('data');
+		$this->mockedPayload = json_encode(array('job' => $this->mockedJob, 'data' => $this->mockedData));
+		$this->mockedDelay = 10;
+		$this->mockedDateTime = m::mock('DateTime');
+		$this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
+		$this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
+
+		$this->mockedSendMessageResponseModel = new Model(array('Body' => $this->mockedPayload,
+						      			'MD5OfBody' => md5($this->mockedPayload),
+						      			'ReceiptHandle' => $this->mockedReceiptHandle,
+						      			'MessageId' => $this->mockedMessageId,
+						      			'Attributes' => array('ApproximateReceiveCount' => 1)));
+
+		$this->mockedReceiveMessageResponseModel = new Model(array('Messages' => array( 0 => array(
+												'Body' => $this->mockedPayload,
+						     						'MD5OfBody' => md5($this->mockedPayload),
+						      						'ReceiptHandle' => $this->mockedReceiptHandle,
+						     						'MessageId' => $this->mockedMessageId))));
+	}
+
+	public function testPopProperlyPopsJobOffOfSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('receiveMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'AttributeNames' => array('ApproximateReceiveCount')))->andReturn($this->mockedReceiveMessageResponseModel);
+		$result = $queue->pop($this->queueName);
+		$this->assertInstanceOf('Illuminate\Queue\Jobs\SqsJob', $result);
+	}
+
+	public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getSeconds', 'getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
+		$queue->expects($this->once())->method('getSeconds')->with($this->mockedDateTime)->will($this->returnValue($this->mockedDateTime));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload, 'DelaySeconds' => $this->mockedDateTime))->andReturn($this->mockedSendMessageResponseModel);
+		$id = $queue->later($this->mockedDateTime, $this->mockedJob, $this->mockedData, $this->queueName);
+		$this->assertEquals($this->mockedMessageId, $id);
+	}
+
+	public function testDelayedPushProperlyPushesJobOntoSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getSeconds', 'getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
+		$queue->expects($this->once())->method('getSeconds')->with($this->mockedDelay)->will($this->returnValue($this->mockedDelay));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload, 'DelaySeconds' => $this->mockedDelay))->andReturn($this->mockedSendMessageResponseModel);
+		$id = $queue->later($this->mockedDelay, $this->mockedJob, $this->mockedData, $this->queueName);
+		$this->assertEquals($this->mockedMessageId, $id);
+	}
+
+	public function testPushProperlyPushesJobOntoSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload))->andReturn($this->mockedSendMessageResponseModel);
+		$id = $queue->push($this->mockedJob, $this->mockedData, $this->queueName);
+		$this->assertEquals($this->mockedMessageId, $id);
+	}
+}

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -111,8 +111,7 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 		$request->shouldReceive('json')->once()->andReturn($content = json_encode(array('foo' => 'bar')));
 		$pushedJob = array(
 			'MessageId' => 'message-id',
-			'Body' => json_encode(array('foo' => 'bar')),
-			'pushed' => true,
+			'Body' => json_encode(array('foo' => 'bar'))
 		);
 		$queue->expects($this->once())->method('createPushedSqsJob')->with($this->equalTo($pushedJob))->will($this->returnValue($mockSqsJob = m::mock('StdClass')));
 		$mockSqsJob->shouldReceive('fire')->once();

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -91,23 +91,18 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 	public function testPushedJobsCanBeMarshaled()
 	{
 		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPushedSqsJob'), array($this->sqs, $request = m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
-
 		$request->shouldReceive('header')->once()->with('X-aws-sqsd-msgid')->andReturn('message-id');
 		$request->shouldReceive('header')->once()->with('X-aws-sqsd-receive-count')->andReturn(1);
 		$request->shouldReceive('getContent')->once()->andReturn($content = json_encode(array('foo' => 'bar')));
-
 		$pushedJob = array(
 			'MessageId' => 'message-id',
 			'Body' => json_encode(array('foo' => 'bar')),
 			'Attributes' => array('ApproximateReceiveCount' => 1),
 			'pushed' => true,
 		);
-
 		$queue->expects($this->once())->method('createPushedSqsJob')->with($this->equalTo($pushedJob))->will($this->returnValue($mockSqsJob = m::mock('StdClass')));
 		$mockSqsJob->shouldReceive('fire')->once();
-
 		$response = $queue->marshal();
-
 		$this->assertInstanceOf('Illuminate\Http\Response', $response);
 		$this->assertEquals(200, $response->getStatusCode());
 	}

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Mockery as m;
+
+use Aws\Sqs\SqsClient;
+use Guzzle\Service\Resource\Model;
+
+class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function setUp() {
+
+		// Use Mockery to mock the SqsClient
+		$this->sqs = m::mock('Aws\Sqs\SqsClient');
+
+		$this->account = '1234567891011';
+		$this->queueName = 'emails';
+		$this->baseUrl = 'https://sqs.someregion.amazonaws.com';
+
+		// This is how the modified getQueue builds the queueUrl
+		$this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
+
+		$this->mockedJob = 'foo';
+		$this->mockedData = array('data');
+		$this->mockedPayload = json_encode(array('job' => $this->mockedJob, 'data' => $this->mockedData));
+		$this->mockedDelay = 10;
+		$this->mockedDateTime = m::mock('DateTime');
+		$this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
+		$this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
+
+		$this->mockedSendMessageResponseModel = new Model(array('Body' => $this->mockedPayload,
+						      			'MD5OfBody' => md5($this->mockedPayload),
+						      			'ReceiptHandle' => $this->mockedReceiptHandle,
+						      			'MessageId' => $this->mockedMessageId,
+						      			'Attributes' => array('ApproximateReceiveCount' => 1)));
+
+		$this->mockedReceiveMessageResponseModel = new Model(array('Messages' => array( 0 => array(
+												'Body' => $this->mockedPayload,
+						     						'MD5OfBody' => md5($this->mockedPayload),
+						      						'ReceiptHandle' => $this->mockedReceiptHandle,
+						     						'MessageId' => $this->mockedMessageId))));
+	}
+
+	public function testPopProperlyPopsJobOffOfSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('receiveMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'AttributeNames' => array('ApproximateReceiveCount')))->andReturn($this->mockedReceiveMessageResponseModel);
+		$result = $queue->pop($this->queueName);
+		$this->assertInstanceOf('Illuminate\Queue\Jobs\SqsJob', $result);
+	}
+
+	public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getSeconds', 'getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
+		$queue->expects($this->once())->method('getSeconds')->with($this->mockedDateTime)->will($this->returnValue($this->mockedDateTime));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload, 'DelaySeconds' => $this->mockedDateTime))->andReturn($this->mockedSendMessageResponseModel);
+		$id = $queue->later($this->mockedDateTime, $this->mockedJob, $this->mockedData, $this->queueName);
+		$this->assertEquals($this->mockedMessageId, $id);
+	}
+
+	public function testDelayedPushProperlyPushesJobOntoSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getSeconds', 'getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
+		$queue->expects($this->once())->method('getSeconds')->with($this->mockedDelay)->will($this->returnValue($this->mockedDelay));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload, 'DelaySeconds' => $this->mockedDelay))->andReturn($this->mockedSendMessageResponseModel);
+		$id = $queue->later($this->mockedDelay, $this->mockedJob, $this->mockedData, $this->queueName);
+		$this->assertEquals($this->mockedMessageId, $id);
+	}
+
+	public function testPushProperlyPushesJobOntoSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueue'), array($this->sqs, $this->queueName, $this->account));
+		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
+		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload))->andReturn($this->mockedSendMessageResponseModel);
+		$id = $queue->push($this->mockedJob, $this->mockedData, $this->queueName);
+		$this->assertEquals($this->mockedMessageId, $id);
+	}
+
+	public function testGetQueueCallsGetBaseUrlAndBuildsQueueUrl()
+	{
+		$queue = new Illuminate\Queue\SqsQueue($this->sqs, $this->queueName, $this->account);
+		$this->sqs->shouldReceive('getBaseUrl')->once()->andReturn($this->baseUrl);
+		$resultQueueUrl = $queue->getQueue($this->queueName);
+		$this->assertEquals($this->queueUrl, $resultQueueUrl);
+		$this->sqs->shouldReceive('getBaseUrl')->once()->andReturn('https://bar');
+		$resultQueueUrl = $queue->getQueue($this->queueName);
+		$this->assertNotEquals($this->queueUrl, $resultQueueUrl);
+	}
+}

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -49,22 +49,22 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 						     						'MessageId' => $this->mockedMessageId))));
 	}
 
-	public function testGetQueueCallsGetBaseUrlAndBuildsQueueUrl()
+	public function testGetQueueUrlCallsGetBaseUrlAndBuildsQueueUrl()
 	{
 		$queue = new Illuminate\Queue\SqsQueue($this->sqs, $this->sns, m::mock('Illuminate\Http\Request'), $this->queueName, $this->account);
 		$this->sqs->shouldReceive('getBaseUrl')->once()->andReturn($this->baseUrl);
-		$resultQueueUrl = $queue->getQueue($this->queueName);
+		$resultQueueUrl = $queue->getQueueUrl($this->queueName);
 		$this->assertEquals($this->queueUrl, $resultQueueUrl);
 		$this->sqs->shouldReceive('getBaseUrl')->once()->andReturn('https://bar');
-		$resultQueueUrl = $queue->getQueue($this->queueName);
+		$resultQueueUrl = $queue->getQueueUrl($this->queueName);
 		$this->assertNotEquals($this->queueUrl, $resultQueueUrl);
 	}
 
 	public function testPopProperlyPopsJobOffOfSqs()
 	{
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->sqs, $this->sns, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueueUrl'), array($this->sqs, $this->sns, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
 		$queue->setContainer(m::mock('Illuminate\Container\Container'));
-		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$queue->expects($this->once())->method('getQueueUrl')->with($this->queueName)->will($this->returnValue($this->queueUrl));
 		$this->sqs->shouldReceive('receiveMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'AttributeNames' => array('ApproximateReceiveCount')))->andReturn($this->mockedReceiveMessageResponseModel);
 		$result = $queue->pop($this->queueName);
 		$this->assertInstanceOf('Illuminate\Queue\Jobs\SqsJob', $result);
@@ -72,10 +72,10 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
 	{
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueue', 'getSeconds'), array($this->sqs, $this->sns, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueueUrl', 'getSeconds'), array($this->sqs, $this->sns, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
 		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
 		$queue->expects($this->once())->method('getSeconds')->with($this->mockedDateTime)->will($this->returnValue($this->mockedDateTime));
-		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$queue->expects($this->once())->method('getQueueUrl')->with($this->queueName)->will($this->returnValue($this->queueUrl));
 		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload, 'DelaySeconds' => $this->mockedDateTime))->andReturn($this->mockedSendMessageResponseModel);
 		$id = $queue->later($this->mockedDateTime, $this->mockedJob, $this->mockedData, $this->queueName);
 		$this->assertEquals($this->mockedMessageId, $id);
@@ -83,10 +83,10 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testDelayedPushProperlyPushesJobOntoSqs()
 	{
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueue', 'getSeconds'), array($this->sqs, $this->sns, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueueUrl', 'getSeconds'), array($this->sqs, $this->sns, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
 		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
 		$queue->expects($this->once())->method('getSeconds')->with($this->mockedDelay)->will($this->returnValue($this->mockedDelay));
-		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$queue->expects($this->once())->method('getQueueUrl')->with($this->queueName)->will($this->returnValue($this->queueUrl));
 		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload, 'DelaySeconds' => $this->mockedDelay))->andReturn($this->mockedSendMessageResponseModel);
 		$id = $queue->later($this->mockedDelay, $this->mockedJob, $this->mockedData, $this->queueName);
 		$this->assertEquals($this->mockedMessageId, $id);
@@ -94,9 +94,9 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testPushProperlyPushesJobOntoSqs()
 	{
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueue'), array($this->sqs, $this->sns, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueueUrl'), array($this->sqs, $this->sns, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
 		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
-		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+		$queue->expects($this->once())->method('getQueueUrl')->with($this->queueName)->will($this->returnValue($this->queueUrl));
 		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload))->andReturn($this->mockedSendMessageResponseModel);
 		$id = $queue->push($this->mockedJob, $this->mockedData, $this->queueName);
 		$this->assertEquals($this->mockedMessageId, $id);

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -48,7 +48,7 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetQueueCallsGetBaseUrlAndBuildsQueueUrl()
 	{
-		$queue = new Illuminate\Queue\SqsQueue($this->sqs, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName);
+		$queue = new Illuminate\Queue\SqsQueue($this->sqs, m::mock('Illuminate\Http\Request'), $this->queueName, $this->account);
 		$this->sqs->shouldReceive('getBaseUrl')->once()->andReturn($this->baseUrl);
 		$resultQueueUrl = $queue->getQueue($this->queueName);
 		$this->assertEquals($this->queueUrl, $resultQueueUrl);
@@ -69,7 +69,7 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
 	{
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->sqs, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueue', 'getSeconds'), array($this->sqs, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
 		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
 		$queue->expects($this->once())->method('getSeconds')->with($this->mockedDateTime)->will($this->returnValue($this->mockedDateTime));
 		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
@@ -80,7 +80,7 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testDelayedPushProperlyPushesJobOntoSqs()
 	{
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->sqs, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueue', 'getSeconds'), array($this->sqs, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
 		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
 		$queue->expects($this->once())->method('getSeconds')->with($this->mockedDelay)->will($this->returnValue($this->mockedDelay));
 		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
@@ -91,7 +91,7 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testPushProperlyPushesJobOntoSqs()
 	{
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->sqs, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPayload', 'getQueue'), array($this->sqs, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
 		$queue->expects($this->once())->method('createPayload')->with($this->mockedJob, $this->mockedData)->will($this->returnValue($this->mockedPayload));
 		$queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
 		$this->sqs->shouldReceive('sendMessage')->once()->with(array('QueueUrl' => $this->queueUrl, 'MessageBody' => $this->mockedPayload))->andReturn($this->mockedSendMessageResponseModel);

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -104,7 +104,7 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 	
 	public function testPushedJobsCanBeMarshaled()
 	{
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPushedSqsJob'), array($this->sqs, $this->sns, $request = m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createSqsJob'), array($this->sqs, $this->sns, $request = m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
 		$request->shouldReceive('header')->once()->with('x-amz-sns-message-type')->andReturn('Notification');
 		$request->shouldReceive('header')->once()->with('x-amz-sns-message-id')->andReturn('message-id');
 		$request->shouldReceive('header')->once()->with('x-aws-sqsd-msgid')->andReturn('message-id');
@@ -113,7 +113,7 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 			'MessageId' => 'message-id',
 			'Body' => json_encode(array('foo' => 'bar'))
 		);
-		$queue->expects($this->once())->method('createPushedSqsJob')->with($this->equalTo($pushedJob))->will($this->returnValue($mockSqsJob = m::mock('StdClass')));
+		$queue->expects($this->once())->method('createSqsJob')->with($this->equalTo($pushedJob))->will($this->returnValue($mockSqsJob = m::mock('StdClass')));
 		$mockSqsJob->shouldReceive('fire')->once();
 		$response = $queue->marshal();
 		$this->assertInstanceOf('Illuminate\Http\Response', $response);
@@ -125,7 +125,7 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testPushedJobsMustComeFromSqsOrSns()
 	{
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPushedSqsJob'), array($this->sqs, $this->sns, $request = m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createSqsJob'), array($this->sqs, $this->sns, $request = m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
 		$request->shouldReceive('header')->once()->with('x-amz-sns-message-type')->andReturn('Notification');
 		$request->shouldReceive('header')->once()->with('x-amz-sns-message-id')->andReturn(null);
 		$request->shouldReceive('header')->once()->with('x-aws-sqsd-msgid')->andReturn(null);
@@ -134,7 +134,7 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testSubscriptionConfirmationNoJob()
 	{
-		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createPushedSqsJob'), array($this->sqs, $this->sns, $request = m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createSqsJob'), array($this->sqs, $this->sns, $request = m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
 		$request->shouldReceive('header')->once()->with('x-amz-sns-message-type')->andReturn('SubscriptionConfirmation');
 		$request->shouldReceive('json')->once()->with('TopicArn')->andReturn('foo');
 		$request->shouldReceive('json')->once()->with('Token')->andReturn('bar');

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -127,7 +127,7 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 	public function testPushedJobsMustComeFromSqsOrSns()
 	{
 		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('createSqsJob'), array($this->sqs, $this->sns, $request = m::mock('Illuminate\Http\Request'), $this->queueName, $this->account));
-		$request->shouldReceive('header')->once()->with('x-amz-sns-message-type')->andReturn('Notification');
+		$request->shouldReceive('header')->once()->with('x-amz-sns-message-type')->andReturn(null);
 		$request->shouldReceive('header')->once()->with('x-amz-sns-message-id')->andReturn(null);
 		$request->shouldReceive('header')->once()->with('x-aws-sqsd-msgid')->andReturn(null);
 		$response = $queue->marshal();

--- a/tests/Queue/QueueSubscribeTest.php
+++ b/tests/Queue/QueueSubscribeTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use Mockery as m;
+
+use Guzzle\Service\Resource\Model;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class QueueSubscribeTest extends PHPUnit_Framework_TestCase {
+
+	public function setUp() {
+
+		parent::setUp();	
+
+		$this->command = new Illuminate\Queue\Console\SubscribeCommand;
+
+		$this->sns = m::mock('Aws\Sns\SnsClient');
+		$this->sqs = m::mock('Aws\Sqs\SqsClient');
+
+		$this->region = 'someregion';
+		$this->account = '1234567891011';
+		$this->queueName = 'notifications';
+		$this->topicName = 'notifications';
+		
+		$this->endpointUrl = 'http://www.somedomain.com/receive/notifications';	
+		$this->mockedTopicArn = 'arn:aws:sns:'.$this->region.':'.$this->account.':'.$this->topicName;
+		$this->mockedSubscriptionArn = $this->mockedTopicArn . ':foo';
+
+		$this->mockedCreateTopicResponseModel = new Model(array('TopicArn' => $this->mockedTopicArn));
+		$this->mockedSubscribeResponseModel = new Model(array('SubscriptionArn' => $this->mockedSubscriptionArn));
+
+		$this->app = m::mock('AppMock');
+		$this->app->shouldReceive('instance')->once()->andReturn($this->app);
+
+		Illuminate\Support\Facades\Facade::setFacadeApplication($this->app);
+		Illuminate\Support\Facades\Config::swap($this->config = m::mock('ConfigMock'));
+	}
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function testSubscribeCommandCreatesTopicAndSubscribesToSqs()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('connection'), array($this->sqs, $this->sns, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$app = $this->getQueueConfigForTest($queue, 'sqs');
+		$queue->expects($this->any())->method('connection')->will($this->returnValue($queue));
+		$this->sns->shouldReceive('createTopic')->once()->with(array('Name' => $this->queueName))->andReturn($response = $this->mockedCreateTopicResponseModel);
+		$this->sns->shouldReceive('subscribe')->once()->with(array('TopicArn' => $response->get('TopicArn'), 'Protocol' => ((stripos($this->endpointUrl, 'https') !== false) ? 'https' : 'http'), 'Endpoint' => $this->endpointUrl))->andReturn($response = $this->mockedSubscribeResponseModel);
+		$this->command->setLaravel($app);
+		$this->command->run(new ArrayInput(array('queue' => $this->queueName, 'url' => $this->endpointUrl)), new NullOutput);
+		$this->assertEquals($this->mockedSubscriptionArn, $response->get('SubscriptionArn'));
+	}
+
+	public function testSubscribeCommandCreatesTopicAndSubscribesToIron()
+	{
+		$queue = $this->getMock('Illuminate\Queue\IronQueue', array('connection'), array($iron = m::mock('IronMQ'), $crypt = m::mock('Illuminate\Encryption\Encrypter'), m::mock('Illuminate\Http\Request'), 'default', true));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$app = $this->getQueueConfigForTest($queue, 'iron');
+		$queue->expects($this->any())->method('connection')->will($this->returnValue($queue));
+		$iron->shouldReceive('addSubscriber')->once()->with($this->queueName, array('url' => $this->endpointUrl))->andReturn($response = (object) array('msg' => 'Updated'));
+		$iron->shouldReceive('updateQueue')->once()->with($this->queueName, array('type' => 'multicast', 'retries' => '3', 'patience' => '60'))->andReturn((object) array('foo' => 'bar'));
+		$this->command->setLaravel($app);
+		$this->command->run(new ArrayInput(array('queue' => $this->queueName, 'url' => $this->endpointUrl)), new NullOutput);
+		$this->assertEquals('Updated', $response->msg);
+	}
+
+	/**
+	 * @expectedException RuntimeException
+	 */
+	public function testSubscribeCommandThrowsRuntimeExceptionForBeanstalkd()
+	{
+		$queue = $this->getMock('Illuminate\Queue\BeanstalkdQueue', array('connection'), array(m::mock('Pheanstalk_Pheanstalk'), 'default'));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$this->config->shouldReceive('get')->once()->with('queue.default')->andReturn('beanstalkd');
+		$app = $this->getQueueConfigForTest($queue, 'beanstalkd');
+		$queue->app = $app;
+		$queue->expects($this->any())->method('connection')->will($this->returnValue($queue));
+		$this->command->setLaravel($app);
+		$this->command->run(new ArrayInput(array('queue' => $this->queueName, 'url' => $this->endpointUrl)), new NullOutput);
+	}
+
+	/**
+	 * @expectedException RuntimeException
+	 */
+	public function testSubscribeCommandThrowsRuntimeExceptionForRedis()
+	{
+		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('connection'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$this->config->shouldReceive('get')->once()->with('queue.default')->andReturn('redis');
+		$app = $this->getQueueConfigForTest($queue, 'redis');
+		$queue->app = $app;
+		$queue->expects($this->any())->method('connection')->will($this->returnValue($queue));
+		$this->command->setLaravel($app);
+		$this->command->run(new ArrayInput(array('queue' => $this->queueName, 'url' => $this->endpointUrl)), new NullOutput);
+	}
+
+	/**
+	 * @expectedException RuntimeException
+	 */
+	public function testSubscribeCommandThrowsRuntimeExceptionForSync()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SyncQueue', array('connection'));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$this->config->shouldReceive('get')->once()->with('queue.default')->andReturn('sync');
+		$app = $this->getQueueConfigForTest($queue, 'sync');
+		$queue->app = $app;
+		$queue->expects($this->any())->method('connection')->will($this->returnValue($queue));
+		$this->command->setLaravel($app);
+		$this->command->run(new ArrayInput(array('queue' => $this->queueName, 'url' => $this->endpointUrl)), new NullOutput);
+	}
+
+	public function getQueueConfigForTest($queue, $driver)
+	{
+		return array('config' => array('queue.default' => $driver, 'queue.connections.'.$driver => array('driver' => $driver)), 'queue' => $queue);
+	}
+}

--- a/tests/Queue/QueueUnsubscribeTest.php
+++ b/tests/Queue/QueueUnsubscribeTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use Mockery as m;
+
+use Guzzle\Service\Resource\Model;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class QueueUnsubscribeTest extends PHPUnit_Framework_TestCase {
+
+	public function setUp() {
+
+		parent::setUp();	
+
+		$this->command = new Illuminate\Queue\Console\UnsubscribeCommand;
+
+		$this->sns = m::mock('Aws\Sns\SnsClient');
+		$this->sqs = m::mock('Aws\Sqs\SqsClient');
+
+		$this->region = 'someregion';
+		$this->account = '1234567891011';
+		$this->queueName = 'notifications';
+		$this->topicName = 'notifications';
+		
+		$this->endpointUrl = 'http://www.somedomain.com/receive/notifications';	
+		$this->mockedTopicArn = 'arn:aws:sns:'.$this->region.':'.$this->account.':'.$this->topicName;
+		$this->mockedSubscriptionArn = $this->mockedTopicArn . ':foo';
+		$this->mockedRequestId = 'foo';
+
+		$this->mockedListSubscriptionsResponseModel = new Model(array('Subscriptions' => array( 0 => array('Protocol' => 'http', 'Owner' => $this->account, 'TopicArn' => $this->mockedTopicArn, 'SubscriptionArn' => $this->mockedSubscriptionArn, 'Endpoint' => $this->endpointUrl)), 'ResponseMetadata' => array('RequestId' => $this->mockedRequestId)));
+		$this->mockedUnsubscribeResponseModel = new Model(array());
+
+		$this->app = m::mock('AppMock');
+		$this->app->shouldReceive('instance')->once()->andReturn($this->app);
+
+		Illuminate\Support\Facades\Facade::setFacadeApplication($this->app);
+		Illuminate\Support\Facades\Config::swap($this->config = m::mock('ConfigMock'));
+	}
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function testUnsubscribeCommandUnsubscribesFromSnsTopic()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('connection'), array($this->sqs, $this->sns, m::mock('Illuminate\Http\Request'), $this->account, $this->queueName));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$app = $this->getQueueConfigForTest($queue, 'sqs');
+		$queue->expects($this->any())->method('connection')->will($this->returnValue($queue));	
+		$this->sns->shouldReceive('listSubscriptions')->once()->andReturn($response = $this->mockedListSubscriptionsResponseModel);
+		$this->sns->shouldReceive('unsubscribe')->once()->with(array('SubscriptionArn' => $this->mockedSubscriptionArn))->andReturn($this->mockedUnsubscribeResponseModel);
+		$this->command->setLaravel($app);
+		$this->command->run(new ArrayInput(array('queue' => $this->queueName, 'url' => $this->endpointUrl)), new NullOutput);
+	}
+
+	public function testUnsubscribeCommandUnsubscribesFromIronQueue()
+	{
+		$queue = $this->getMock('Illuminate\Queue\IronQueue', array('connection'), array($iron = m::mock('IronMQ'), $crypt = m::mock('Illuminate\Encryption\Encrypter'), m::mock('Illuminate\Http\Request'), 'default', true));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$app = $this->getQueueConfigForTest($queue, 'iron');
+		$queue->expects($this->any())->method('connection')->will($this->returnValue($queue));
+		$iron->shouldReceive('removeSubscriber')->once()->with($this->queueName, array('url' => $this->endpointUrl))->andReturn($response = (object) array('msg' => 'Updated'));
+		$this->command->setLaravel($app);
+		$this->command->run(new ArrayInput(array('queue' => $this->queueName, 'url' => $this->endpointUrl)), new NullOutput);
+		$this->assertEquals('Updated', $response->msg);
+	}
+
+	/**
+	 * @expectedException RuntimeException
+	 */
+	public function testUnsubscribeCommandThrowsRuntimeExceptionForBeanstalkd()
+	{
+		$queue = $this->getMock('Illuminate\Queue\BeanstalkdQueue', array('connection'), array(m::mock('Pheanstalk_Pheanstalk'), 'default'));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$this->config->shouldReceive('get')->once()->with('queue.default')->andReturn('beanstalkd');
+		$app = $this->getQueueConfigForTest($queue, 'beanstalkd');
+		$queue->app = $app;
+		$queue->expects($this->any())->method('connection')->will($this->returnValue($queue));
+		$this->command->setLaravel($app);
+		$this->command->run(new ArrayInput(array('queue' => $this->queueName, 'url' => $this->endpointUrl)), new NullOutput);
+	}
+
+	/**
+	 * @expectedException RuntimeException
+	 */
+	public function testUnSubscribeCommandThrowsRuntimeExceptionForRedis()
+	{
+		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('connection'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$this->config->shouldReceive('get')->once()->with('queue.default')->andReturn('redis');
+		$app = $this->getQueueConfigForTest($queue, 'redis');
+		$queue->app = $app;
+		$queue->expects($this->any())->method('connection')->will($this->returnValue($queue));
+		$this->command->setLaravel($app);
+		$this->command->run(new ArrayInput(array('queue' => $this->queueName, 'url' => $this->endpointUrl)), new NullOutput);
+	}
+
+	/**
+	 * @expectedException RuntimeException
+	 */
+	public function testUnsubscribeCommandThrowsRuntimeExceptionForSync()
+	{
+		$queue = $this->getMock('Illuminate\Queue\SyncQueue', array('connection'));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$this->config->shouldReceive('get')->once()->with('queue.default')->andReturn('sync');
+		$app = $this->getQueueConfigForTest($queue, 'sync');
+		$queue->app = $app;
+		$queue->expects($this->any())->method('connection')->will($this->returnValue($queue));
+		$this->command->setLaravel($app);
+		$this->command->run(new ArrayInput(array('queue' => $this->queueName, 'url' => $this->endpointUrl)), new NullOutput);
+	}
+
+	public function getQueueConfigForTest($queue, $driver)
+	{
+		return array('config' => array('queue.default' => $driver, 'queue.connections.'.$driver => array('driver' => $driver)), 'queue' => $queue);
+	}
+
+}


### PR DESCRIPTION
The branch probably isn't named appropriately, but the title of this PR pretty much sums up what would be included.  

This PR has grown out of a few other proposals/PRs from myself and @SammyK (#3759, #3778, #3784, #3789) so I'd like to get some more eyes on the additions/deletions/changes that are included in the 23 commits included in the branch (I know I need to squash them down to 1)..

First, a little background on this.  I started out by writing unit tests for SqsQueue and SqsJob since there were none and also made a couple other small changes. @taylorotwell wanted me to submit just 1 PR to cover those few things. Then, @SammyK proposed (and implemented) adding push support for SQS, so I wanted to get that included since there were going to be merge conflicts (so I borrowed his contribution and took care of the conflicts). I was trying to ensure @SammyK received the official and much deserved credit for the initial addition of SQS push support by making him a contributor to my fork of laravel/framework (so he can push his files in and be recorded as a contributor).  But, I haven't heard back from him since 6 days ago and I need to move on (this was a huge tangent from working on my own project that's built with Laravel).  

I'd like to make sure this is all worthy of being included in the core of the framework and make sure any issues that people see are addressed so I can get everything ready to be merged.  

It's hard to tell if I broke anything with my SubscribeCommand refactor since there weren't any unit tests and I was only using it for testing the IronMQ and SQS/SNS push queue functionality using the default queue config.  I didn't really like how it was using IronMQ's `updateQueue` function (rather than the `addSubscriber`) for subscribing (along with all the functions for gathering meta data for the queue) since that seems better suited for a new command, something like `php artisan queue:update -whatever` (via a new UpdateCommand).  However, I did make sure to call `updateQueue` after call to `addSubscriber` just in case it actually is needed (minus the subscribers part of the options parameter).  I also didn't like the checks for `if($queue instanceof IronMQ)` since it seems like (and I think I've shown) it can be better handled through polymorphism.  Additionally, I felt like the setContainer functions that were in every derived class of Job should be removed and just defined in the base class.  

There are also a bunch of unit tests I wrote, so I'd love to get some feedback from a phpunit expert.  Anyway, there are a lot of other changes to discuss and get feedback on, so please have a look.  Thanks for taking the time.
