### PR TITLE
[Proposal] Support multiple paginations in 1 page

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -214,6 +214,7 @@ class Builder {
 	 *
 	 * @param  int    $perPage
 	 * @param  array  $columns
+	 * @param  string  $pageName
 	 * @return \Illuminate\Pagination\Paginator
 	 */
 	public function paginate($perPage = null, $columns = array('*'), $pageName = 'page')
@@ -238,6 +239,7 @@ class Builder {
 	 * @param  \Illuminate\Pagination\Environment  $paginator
 	 * @param  int    $perPage
 	 * @param  array  $columns
+	 * @param  string $pageName
 	 * @return \Illuminate\Pagination\Paginator
 	 */
 	protected function groupedPaginate($paginator, $perPage, $columns, $pageName)
@@ -253,6 +255,7 @@ class Builder {
 	 * @param  \Illuminate\Pagination\Environment  $paginator
 	 * @param  int    $perPage
 	 * @param  array  $columns
+	 * @param  string $pageName
 	 * @return \Illuminate\Pagination\Paginator
 	 */
 	protected function ungroupedPaginate($paginator, $perPage, $columns, $pageName)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -216,7 +216,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	public function paginate($perPage = null, $columns = array('*'))
+	public function paginate($perPage = null, $columns = array('*'), $pageName = 'page')
 	{
 		$perPage = $perPage ?: $this->model->getPerPage();
 
@@ -224,11 +224,11 @@ class Builder {
 
 		if (isset($this->query->groups))
 		{
-			return $this->groupedPaginate($paginator, $perPage, $columns);
+			return $this->groupedPaginate($paginator, $perPage, $columns, $pageName);
 		}
 		else
 		{
-			return $this->ungroupedPaginate($paginator, $perPage, $columns);
+			return $this->ungroupedPaginate($paginator, $perPage, $columns, $pageName);
 		}
 	}
 
@@ -240,11 +240,11 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	protected function groupedPaginate($paginator, $perPage, $columns)
+	protected function groupedPaginate($paginator, $perPage, $columns, $pageName)
 	{
 		$results = $this->get($columns)->all();
 
-		return $this->query->buildRawPaginator($paginator, $results, $perPage);
+		return $this->query->buildRawPaginator($paginator, $results, $perPage, $pageName);
 	}
 
 	/**
@@ -255,18 +255,18 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	protected function ungroupedPaginate($paginator, $perPage, $columns)
+	protected function ungroupedPaginate($paginator, $perPage, $columns, $pageName)
 	{
 		$total = $this->query->getPaginationCount();
 
 		// Once we have the paginator we need to set the limit and offset values for
 		// the query so we can get the properly paginated items. Once we have an
 		// array of items we can create the paginator instances for the items.
-		$page = $paginator->getCurrentPage($total);
+		$page = $paginator->getCurrentPage($pageName);
 
 		$this->query->forPage($page, $perPage);
 
-		return $paginator->make($this->get($columns)->all(), $total, $perPage);
+		return $paginator->make($this->get($columns)->all(), $total, $perPage, $pageName);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -164,14 +164,14 @@ class BelongsToMany extends Relation {
 	 * @param  array  $columns
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	public function paginate($perPage = null, $columns = array('*'))
+	public function paginate($perPage = null, $columns = array('*'), $pageName = 'page')
 	{
 		$this->query->addSelect($this->getSelectColumns($columns));
 
 		// When paginating results, we need to add the pivot columns to the query and
 		// then hydrate into the pivot objects once the results have been gathered
 		// from the database since this isn't performed by the Eloquent builder.
-		$pager = $this->query->paginate($perPage, $columns);
+		$pager = $this->query->paginate($perPage, $columns, $pageName);
 
 		$this->hydratePivotRelation($pager->getItems());
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -162,6 +162,7 @@ class BelongsToMany extends Relation {
 	 *
 	 * @param  int    $perPage
 	 * @param  array  $columns
+	 * @param  string $pageName
 	 * @return \Illuminate\Pagination\Paginator
 	 */
 	public function paginate($perPage = null, $columns = array('*'), $pageName = 'page')

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1411,17 +1411,17 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	public function paginate($perPage = 15, $columns = array('*'))
+	public function paginate($perPage = 15, $columns = array('*'), $pageName = 'page')
 	{
 		$paginator = $this->connection->getPaginator();
 
 		if (isset($this->groups))
 		{
-			return $this->groupedPaginate($paginator, $perPage, $columns);
+			return $this->groupedPaginate($paginator, $perPage, $columns, $pageName);
 		}
 		else
 		{
-			return $this->ungroupedPaginate($paginator, $perPage, $columns);
+			return $this->ungroupedPaginate($paginator, $perPage, $columns, $pageName);
 		}
 	}
 
@@ -1433,11 +1433,11 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	protected function groupedPaginate($paginator, $perPage, $columns)
+	protected function groupedPaginate($paginator, $perPage, $columns, $pageName)
 	{
 		$results = $this->get($columns);
 
-		return $this->buildRawPaginator($paginator, $results, $perPage);
+		return $this->buildRawPaginator($paginator, $results, $perPage, $pageName);
 	}
 
 	/**
@@ -1448,16 +1448,16 @@ class Builder {
 	 * @param  int    $perPage
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	public function buildRawPaginator($paginator, $results, $perPage)
+	public function buildRawPaginator($paginator, $results, $perPage, $pageName)
 	{
 		// For queries which have a group by, we will actually retrieve the entire set
 		// of rows from the table and "slice" them via PHP. This is inefficient and
 		// the developer must be aware of this behavior; however, it's an option.
-		$start = ($paginator->getCurrentPage() - 1) * $perPage;
+		$start = ($paginator->getCurrentPage($pageName) - 1) * $perPage;
 
 		$sliced = array_slice($results, $start, $perPage);
 
-		return $paginator->make($sliced, count($results), $perPage);
+		return $paginator->make($sliced, count($results), $perPage, $pageName);
 	}
 
 	/**
@@ -1468,18 +1468,18 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	protected function ungroupedPaginate($paginator, $perPage, $columns)
+	protected function ungroupedPaginate($paginator, $perPage, $columns, $pageName)
 	{
 		$total = $this->getPaginationCount();
 
 		// Once we have the total number of records to be paginated, we can grab the
 		// current page and the result array. Then we are ready to create a brand
 		// new Paginator instances for the results which will create the links.
-		$page = $paginator->getCurrentPage($total);
+		$page = $paginator->getCurrentPage($pageName);
 
 		$results = $this->forPage($page, $perPage)->get($columns);
 
-		return $paginator->make($results, $total, $perPage);
+		return $paginator->make($results, $total, $perPage, $pageName);
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1409,6 +1409,7 @@ class Builder {
 	 *
 	 * @param  int    $perPage
 	 * @param  array  $columns
+	 * @param  string $pageName
 	 * @return \Illuminate\Pagination\Paginator
 	 */
 	public function paginate($perPage = 15, $columns = array('*'), $pageName = 'page')
@@ -1431,6 +1432,7 @@ class Builder {
 	 * @param  \Illuminate\Pagination\Environment  $paginator
 	 * @param  int    $perPage
 	 * @param  array  $columns
+	 * @param  string $pageName
 	 * @return \Illuminate\Pagination\Paginator
 	 */
 	protected function groupedPaginate($paginator, $perPage, $columns, $pageName)
@@ -1446,6 +1448,7 @@ class Builder {
 	 * @param  \Illuminate\Pagination\Environment  $paginator
 	 * @param  array  $results
 	 * @param  int    $perPage
+	 * @param  string $pageName
 	 * @return \Illuminate\Pagination\Paginator
 	 */
 	public function buildRawPaginator($paginator, $results, $perPage, $pageName)
@@ -1466,6 +1469,7 @@ class Builder {
 	 * @param  \Illuminate\Pagination\Environment  $paginator
 	 * @param  int    $perPage
 	 * @param  array  $columns
+	 * @param  string $pageName
 	 * @return \Illuminate\Pagination\Paginator
 	 */
 	protected function ungroupedPaginate($paginator, $perPage, $columns, $pageName)

--- a/src/Illuminate/Pagination/Environment.php
+++ b/src/Illuminate/Pagination/Environment.php
@@ -87,6 +87,7 @@ class Environment {
 	 * @param  array  $items
 	 * @param  int    $total
 	 * @param  int    $perPage
+	 * @param  string $pageName
 	 * @return \Illuminate\Pagination\Paginator
 	 */
 	public function make(array $items, $total, $perPage, $pageName = 'page')
@@ -113,6 +114,7 @@ class Environment {
 	/**
 	 * Get the number of the current page.
 	 *
+	 * @param  string $pageName
 	 * @return int
 	 */
 	public function getCurrentPage($pageName = 'page')

--- a/src/Illuminate/Pagination/Environment.php
+++ b/src/Illuminate/Pagination/Environment.php
@@ -56,27 +56,18 @@ class Environment {
 	protected $baseUrl;
 
 	/**
-	 * The input parameter used for the current page.
-	 *
-	 * @var string
-	 */
-	protected $pageName;
-
-	/**
 	 * Create a new pagination environment.
 	 *
 	 * @param  \Symfony\Component\HttpFoundation\Request  $request
 	 * @param  \Illuminate\View\Environment  $view
 	 * @param  \Symfony\Component\Translation\TranslatorInterface  $trans
-	 * @param  string  $pageName
 	 * @return void
 	 */
-	public function __construct(Request $request, ViewEnvironment $view, TranslatorInterface $trans, $pageName = 'page')
+	public function __construct(Request $request, ViewEnvironment $view, TranslatorInterface $trans)
 	{
 		$this->view = $view;
 		$this->trans = $trans;
 		$this->request = $request;
-		$this->pageName = $pageName;
 		$this->setupPaginationEnvironment();
 	}
 
@@ -98,9 +89,9 @@ class Environment {
 	 * @param  int    $perPage
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	public function make(array $items, $total, $perPage)
+	public function make(array $items, $total, $perPage, $pageName = 'page')
 	{
-		$paginator = new Paginator($this, $items, $total, $perPage);
+		$paginator = new Paginator($this, $items, $total, $perPage, $pageName);
 
 		return $paginator->setupPaginationContext();
 	}
@@ -124,9 +115,9 @@ class Environment {
 	 *
 	 * @return int
 	 */
-	public function getCurrentPage()
+	public function getCurrentPage($pageName = 'page')
 	{
-		$page = (int) $this->currentPage ?: $this->request->query->get($this->pageName, 1);
+		$page = (int) $this->currentPage ?: $this->request->query->get($pageName, 1);
 
 		if ($page < 1 || filter_var($page, FILTER_VALIDATE_INT) === false)
 		{
@@ -166,27 +157,6 @@ class Environment {
 	public function setBaseUrl($baseUrl)
 	{
 		$this->baseUrl = $baseUrl;
-	}
-
-	/**
-	 * Set the input page parameter name used by the paginator.
-	 *
-	 * @param  string  $pageName
-	 * @return void
-	 */
-	public function setPageName($pageName)
-	{
-		$this->pageName = $pageName;
-	}
-
-	/**
-	 * Get the input page parameter name used by the paginator.
-	 *
-	 * @return string
-	 */
-	public function getPageName()
-	{
-		return $this->pageName;
 	}
 
 	/**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -338,9 +338,9 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	}
 
 	/**
-	 * Get the number of items to be displayed per page.
+	 * Get the input page parameter name used by the paginator.
 	 *
-	 * @return int
+	 * @return string
 	 */
 	public function getPageName()
 	{

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -81,20 +81,29 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	protected $fragment;
 
 	/**
+     * The input parameter used for the current page.
+     *
+     * @var string
+     */
+    protected $pageName;
+
+    /**
 	 * Create a new Paginator instance.
 	 *
 	 * @param  \Illuminate\Pagination\Environment  $env
 	 * @param  array  $items
 	 * @param  int    $total
 	 * @param  int    $perPage
+	 * @param  string $pageName
 	 * @return void
 	 */
-	public function __construct(Environment $env, array $items, $total, $perPage)
+	public function __construct(Environment $env, array $items, $total, $perPage, $pageName = 'page')
 	{
 		$this->env = $env;
 		$this->items = $items;
 		$this->total = (int) $total;
 		$this->perPage = (int) $perPage;
+        $this->pageName = $pageName;
 	}
 
 	/**
@@ -143,7 +152,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	 */
 	protected function calculateCurrentPage($lastPage)
 	{
-		$page = $this->env->getCurrentPage();
+		$page = $this->env->getCurrentPage($this->pageName);
 
 		// The page number will get validated and adjusted if it either less than one
 		// or greater than the last page available based on the count of the given
@@ -187,7 +196,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	public function getUrl($page)
 	{
 		$parameters = array(
-			$this->env->getPageName() => $page,
+			$this->pageName => $page,
 		);
 
 		// If we have any extra query string key / value pairs that need to be added
@@ -326,6 +335,16 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	public function getPerPage()
 	{
 		return $this->perPage;
+	}
+
+	/**
+	 * Get the number of items to be displayed per page.
+	 *
+	 * @return int
+	 */
+	public function getPageName()
+	{
+		return $this->pageName;
 	}
 
 	/**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -81,13 +81,13 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	protected $fragment;
 
 	/**
-     * The input parameter used for the current page.
-     *
-     * @var string
-     */
-    protected $pageName;
+	 * The input parameter used for the current page.
+	 *
+	 * @var string
+	 */
+	protected $pageName;
 
-    /**
+	/**
 	 * Create a new Paginator instance.
 	 *
 	 * @param  \Illuminate\Pagination\Environment  $env
@@ -103,7 +103,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 		$this->items = $items;
 		$this->total = (int) $total;
 		$this->perPage = (int) $perPage;
-        $this->pageName = $pageName;
+		$this->pageName = $pageName;
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -191,9 +191,28 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->getQuery()->shouldReceive('getConnection')->once()->andReturn($conn);
 		$builder->getQuery()->shouldReceive('forPage')->once()->with(1, 15);
 		$builder->shouldReceive('get')->with(array('*'))->andReturn(new Collection(array('results')));
-		$paginator->shouldReceive('make')->once()->with(array('results'), 10, 15)->andReturn(array('results'));
+		$paginator->shouldReceive('make')->once()->with(array('results'), 10, 15, 'page')->andReturn(array('results'));
 
 		$this->assertEquals(array('results'), $builder->paginate());
+	}
+
+
+	public function testPaginateMethodWithPageArgument()
+	{
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', array($this->getMockQueryBuilder()));
+        $builder->setModel($this->getMockModel());
+        $builder->getModel()->shouldReceive('getPerPage')->once()->andReturn(15);
+        $builder->getQuery()->shouldReceive('getPaginationCount')->once()->andReturn(10);
+        $conn = m::mock('stdClass');
+        $paginator = m::mock('stdClass');
+        $paginator->shouldReceive('getCurrentPage')->once()->andReturn(1);
+        $conn->shouldReceive('getPaginator')->once()->andReturn($paginator);
+        $builder->getQuery()->shouldReceive('getConnection')->once()->andReturn($conn);
+        $builder->getQuery()->shouldReceive('forPage')->once()->with(1, 15);
+        $builder->shouldReceive('get')->with(array('*'))->andReturn(new Collection(array('results')));
+		$paginator->shouldReceive('make')->once()->with(array('results'), 10, 15, 'foo')->andReturn(array('results'));
+
+		$this->assertEquals(array('results'), $builder->paginate(null, array('*'), 'foo'));
 	}
 
 
@@ -214,7 +233,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$conn->shouldReceive('getPaginator')->once()->andReturn($paginator);
 		$query->expects($this->once())->method('getConnection')->will($this->returnValue($conn));
 		$builder->expects($this->once())->method('get')->with($this->equalTo(array('*')))->will($this->returnValue(new Collection(array('foo', 'bar', 'baz'))));
-		$paginator->shouldReceive('make')->once()->with(array('baz'), 3, 2)->andReturn(array('results'));
+		$paginator->shouldReceive('make')->once()->with(array('baz'), 3, 2, 'page')->andReturn(array('results'));
 
 		$this->assertEquals(array('results'), $builder->groupBy('foo')->paginate());
 	}

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -199,17 +199,17 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 
 	public function testPaginateMethodWithPageArgument()
 	{
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', array($this->getMockQueryBuilder()));
-        $builder->setModel($this->getMockModel());
-        $builder->getModel()->shouldReceive('getPerPage')->once()->andReturn(15);
-        $builder->getQuery()->shouldReceive('getPaginationCount')->once()->andReturn(10);
-        $conn = m::mock('stdClass');
-        $paginator = m::mock('stdClass');
-        $paginator->shouldReceive('getCurrentPage')->once()->andReturn(1);
-        $conn->shouldReceive('getPaginator')->once()->andReturn($paginator);
-        $builder->getQuery()->shouldReceive('getConnection')->once()->andReturn($conn);
-        $builder->getQuery()->shouldReceive('forPage')->once()->with(1, 15);
-        $builder->shouldReceive('get')->with(array('*'))->andReturn(new Collection(array('results')));
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', array($this->getMockQueryBuilder()));
+		$builder->setModel($this->getMockModel());
+		$builder->getModel()->shouldReceive('getPerPage')->once()->andReturn(15);
+		$builder->getQuery()->shouldReceive('getPaginationCount')->once()->andReturn(10);
+		$conn = m::mock('stdClass');
+		$paginator = m::mock('stdClass');
+		$paginator->shouldReceive('getCurrentPage')->once()->andReturn(1);
+		$conn->shouldReceive('getPaginator')->once()->andReturn($paginator);
+		$builder->getQuery()->shouldReceive('getConnection')->once()->andReturn($conn);
+		$builder->getQuery()->shouldReceive('forPage')->once()->with(1, 15);
+		$builder->shouldReceive('get')->with(array('*'))->andReturn(new Collection(array('results')));
 		$paginator->shouldReceive('make')->once()->with(array('results'), 10, 15, 'foo')->andReturn(array('results'));
 
 		$this->assertEquals(array('results'), $builder->paginate(null, array('*'), 'foo'));

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -553,16 +553,16 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 
 	public function testPaginateCorrectlyCreatesPaginatorInstanceWithPageArgument()
 	{
-        $connection = m::mock('Illuminate\Database\ConnectionInterface');
-        $grammar = m::mock('Illuminate\Database\Query\Grammars\Grammar');
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
-        $builder = $this->getMock('Illuminate\Database\Query\Builder', array('getPaginationCount', 'forPage', 'get'), array($connection, $grammar, $processor));
-        $paginator = m::mock('Illuminate\Pagination\Environment');
-        $paginator->shouldReceive('getCurrentPage')->once()->andReturn(1);
-        $connection->shouldReceive('getPaginator')->once()->andReturn($paginator);
-        $builder->expects($this->once())->method('forPage')->with($this->equalTo(1), $this->equalTo(15))->will($this->returnValue($builder));
-        $builder->expects($this->once())->method('get')->with($this->equalTo(array('*')))->will($this->returnValue(array('foo')));
-        $builder->expects($this->once())->method('getPaginationCount')->will($this->returnValue(10));
+		$connection = m::mock('Illuminate\Database\ConnectionInterface');
+		$grammar = m::mock('Illuminate\Database\Query\Grammars\Grammar');
+		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+		$builder = $this->getMock('Illuminate\Database\Query\Builder', array('getPaginationCount', 'forPage', 'get'), array($connection, $grammar, $processor));
+		$paginator = m::mock('Illuminate\Pagination\Environment');
+		$paginator->shouldReceive('getCurrentPage')->once()->andReturn(1);
+		$connection->shouldReceive('getPaginator')->once()->andReturn($paginator);
+		$builder->expects($this->once())->method('forPage')->with($this->equalTo(1), $this->equalTo(15))->will($this->returnValue($builder));
+		$builder->expects($this->once())->method('get')->with($this->equalTo(array('*')))->will($this->returnValue(array('foo')));
+		$builder->expects($this->once())->method('getPaginationCount')->will($this->returnValue(10));
 		$paginator->shouldReceive('make')->once()->with(array('foo'), 10, 15, 'foo')->andReturn(array('results'));
 
 		$this->assertEquals(array('results'), $builder->paginate(15, array('*'), 'foo'));

--- a/tests/Pagination/PaginationEnvironmentTest.php
+++ b/tests/Pagination/PaginationEnvironmentTest.php
@@ -80,15 +80,6 @@ class PaginationEnvironmentTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testOverridingPageParam()
-	{
-		$env = $this->getEnvironment();
-		$this->assertEquals('page', $env->getPageName());
-		$env->setPageName('foo');
-		$this->assertEquals('foo', $env->getPageName());
-	}
-
-
 	protected function getEnvironment()
 	{
 		$request = m::mock('Illuminate\Http\Request');
@@ -96,7 +87,7 @@ class PaginationEnvironmentTest extends PHPUnit_Framework_TestCase {
 		$trans = m::mock('Symfony\Component\Translation\TranslatorInterface');
 		$view->shouldReceive('addNamespace')->once()->with('pagination', realpath(__DIR__.'/../../src/Illuminate/Pagination').'/views');
 
-		return new Environment($request, $view, $trans, 'page');
+		return new Environment($request, $view, $trans);
 	}
 
 }

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -101,7 +101,6 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 	{
 		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('foo', 'bar', 'baz'), 3, 2);
 		$env->shouldReceive('getCurrentUrl')->twice()->andReturn('http://foo.com');
-		$env->shouldReceive('getPageName')->twice()->andReturn('page');
 
 		$this->assertEquals('http://foo.com?page=1', $p->getUrl(1));
 		$p->addQuery('foo', 'bar');
@@ -137,7 +136,6 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 	{
 		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('foo', 'bar', 'baz'), 3, 2);
 		$env->shouldReceive('getCurrentUrl')->twice()->andReturn('http://foo.com');
-		$env->shouldReceive('getPageName')->twice()->andReturn('page');
 
 		$p->fragment("a-fragment");
 
@@ -153,6 +151,14 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 		$last = $p->last();
 
 		$this->assertEquals('c', $last);
+	}
+
+    public function testOverridingPageParam()
+    {
+        $p = new Paginator(m::mock('Illuminate\Pagination\Environment'), array('a', 'b', 'c'), 3, 2);
+        $this->assertEquals('page', $p->getPageName());
+        $p = new Paginator(m::mock('Illuminate\Pagination\Environment'), array('a', 'b', 'c'), 3, 2, 'foo');
+        $this->assertEquals('foo', $p->getPageName());
 	}
 
 }

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -153,12 +153,12 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('c', $last);
 	}
 
-    public function testOverridingPageParam()
-    {
-        $p = new Paginator(m::mock('Illuminate\Pagination\Environment'), array('a', 'b', 'c'), 3, 2);
-        $this->assertEquals('page', $p->getPageName());
-        $p = new Paginator(m::mock('Illuminate\Pagination\Environment'), array('a', 'b', 'c'), 3, 2, 'foo');
-        $this->assertEquals('foo', $p->getPageName());
+	public function testOverridingPageParam()
+	{
+		$p = new Paginator(m::mock('Illuminate\Pagination\Environment'), array('a', 'b', 'c'), 3, 2);
+		$this->assertEquals('page', $p->getPageName());
+		$p = new Paginator(m::mock('Illuminate\Pagination\Environment'), array('a', 'b', 'c'), 3, 2, 'foo');
+		$this->assertEquals('foo', $p->getPageName());
 	}
 
 }


### PR DESCRIPTION
The problem description: https://github.com/laravel/framework/issues/164
I sugest passing **$pageName** in **paginate()** method.

How to use:

``` php
Model1::paginate(15, array('*')); // By default 'page' will be used
Model2::paginate(15, array('*'), 'page2');
```

In views:

``` php
$model1_objects->appends('page2', Input::get('page2', 1))->links(); 
...
$model2_objects->appends('page', Input::get('page', 1))->links();
```

Using **appends()** is optional.
