### PR TITLE
Fix for MessageBag::count()

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -257,7 +257,7 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 	 */
 	public function count()
 	{
-		return count($this->messages);
+		return count($this->messages, COUNT_RECURSIVE) - count($this->messages);
 	}
 
 	/**

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -131,4 +131,17 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('{"foo":["bar"],"boom":["baz"]}', $container->toJson());
 	}
 
+
+	public function testCountReturnsCorrectValue()
+	{
+		$container = new MessageBag;
+		$this->assertEquals(0, $container->count());
+
+		$container->add('foo', 'bar');
+		$container->add('foo', 'baz');
+		$container->add('boom', 'baz');
+
+		$this->assertEquals(3, $container->count());
+	}
+
 }


### PR DESCRIPTION
The count-method now works for more than one message per key.
