### PR TITLE
Add namespace to form

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -261,7 +261,7 @@ class FormBuilder {
 
 		$options = array_merge($options, $merge);
 
-		if (!is_null($this->namespace))
+		if (!is_null($this->namespace) && $options['name'] != '_token')
 		{
 			$options['name'] = $this->getNameAttribute($options['name']);
 		}


### PR DESCRIPTION
I added functionality to wrap form parameters with namespaces.

So

{{ Form::model($user, array('route' => 'admin.user.store')) }}
  {{ Form::text('email') }}
{{ Form::close() }}

will produce

<form method="POST" action="http://malkovich.local/admin/store" accept-charset="UTF-8">
  <input name="_token" type="hidden" value="3FSS3nh2AC665gR4jQr7TTUUw34P7LCofBwxIk1b"/>
  <input name="user[email]" type="text" id="email"/>
</form>


and

{{ Form::model($user, array('route' => 'admin.user.store', 'namespace' => 'xxx')) }}
  {{ Form::text('email') }}
{{ Form::close() }}

will produce

<form method="POST" action="http://malkovich.local/admin/store" accept-charset="UTF-8">
  <input name="_token" type="hidden" value="3FSS3nh2AC665gR4jQr7TTUUw34P7LCofBwxIk1b"/>
  <input name="xxx[email]" type="text" id="email"/>
</form>

.

This new functionality is also available for Form::open method.
