### PR TITLE
[Proposal] add findOrNew eloquent method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -521,6 +521,20 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
+	 * Find a model by its primary key or return new static.
+	 *
+	 * @param  mixed  $id
+	 * @param  array  $columns
+	 * @return \Illuminate\Database\Eloquent\Model|Collection|static
+	 */
+	public static function findOrNew($id, $columns = array('*'))
+	{
+		if ( ! is_null($model = static::find($id, $columns))) return $model;
+
+		return new static($columns);
+	}
+
+	/**
 	 * Find a model by its primary key or throw an exception.
 	 *
 	 * @param  mixed  $id

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -23,6 +23,37 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('baz', $result);
 	}
 
+	public function testFindOrNewMethodModelFound()
+	{
+		$model = $this->getMockModel();
+		$model->shouldReceive('findOrNew')->once()->andReturn('baz');
+
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', array($this->getMockQueryBuilder()));
+		$builder->setModel($model);
+		$builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'bar');
+		$builder->shouldReceive('first')->with(array('column'))->andReturn('baz');
+
+		$expected = $model->findOrNew('bar', array('column'));
+		$result = $builder->find('bar', array('column'));
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testFindOrNewMethodModelNotFound()
+	{
+		$model = $this->getMockModel();
+		$model->shouldReceive('findOrNew')->once()->andReturn(m::mock('Illuminate\Database\Eloquent\Model'));
+
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', array($this->getMockQueryBuilder()));
+		$builder->setModel($model);
+		$builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'bar');
+		$builder->shouldReceive('first')->with(array('column'))->andReturn(null);
+
+		$result = $model->findOrNew('bar', array('column'));
+		$findResult = $builder->find('bar', array('column'));
+		$this->assertNull($findResult);
+		$this->assertInstanceOf('Illuminate\Database\Eloquent\Model', $result);
+	}
+
 	/**
 	 * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
 	 */


### PR DESCRIPTION
**_Use Case:**_
When using one form for both edit and new record. I usually load a record via primary key. Hence, I usually load my model like below and pass it to view to fill-up the fields via `Form::model()`:

``` php
public function getForm($id=0)
{
    $user = User::find($id);
    if (!$user)
        $user = new User;

    $this->layout->content = View::make('users.form', compact('user'));
}
```

Using `findOrNew` method, we can simplify the code above and ensures that we have a real object passed to view to prevent error referencing to non-object when we used some model methods inside the view:

``` php
public function getForm($id=0)
{
    $user = User::findOrNew($id);
    $this->layout->content = View::make('users.form', compact('user'));
}
```

It can also be used on saving a record. If a record was found, it will update the record. If not, then it will create a new record (assuming all validations passed). Making it simple to update/insert a record.

``` php
public function postForm($id=0)
{
    $user = User::findOrNew($id);
    $data = Input::all();

    if (!$user->validate($data)) {
        return Redirect::back()->withInput()->withErrors($user->errors);
    }

    $user->fill($data);
    $user->save();
    return Redirect::to('/')->with('message','Record successfully saved!');
}
```

I am also aware that we can use `firstOrNew` for this but the difference is using `findOrNew` will find the record via primary key while `firstOrNew` uses the attributes.

Counter part `firstOrNew` implementation. But then again, you have to specify an array with primary key on it.

``` php
public function getForm($id=0)
{
    $user = User::firstOrNew(array('id'=>$id));
    $this->layout->content = View::make('users.form', compact('user'));
}
```
