### PR TITLE
Add Session\Store::regenerateToken method

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -86,7 +86,7 @@ class Store implements SessionInterface {
 	{
 		$this->loadSession();
 
-		if ( ! $this->has('_token')) $this->put('_token', str_random(40));
+		if ( ! $this->has('_token')) $this->regenerateToken();
 
 		return $this->started = true;
 	}
@@ -541,6 +541,16 @@ class Store implements SessionInterface {
 	public function getToken()
 	{
 		return $this->token();
+	}
+
+	/**
+	 * Regenerate the CSRF token value.
+	 *
+	 * @return void
+	 */
+	public function regenerateToken()
+	{
+		$this->put('_token', str_random(40));
 	}
 
 	/**

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -246,6 +246,15 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRegenerateToken()
+	{
+		$session = $this->getSession();
+		$token = $session->getToken();
+		$session->regenerateToken();
+		$this->assertNotEquals($token, $session->getToken());
+	}
+
+
 	public function testName()
 	{
 		$session = $this->getSession();


### PR DESCRIPTION
For people who want to manually regenerate the session token but keep behaviour consistent with the framework, or overwrite the way tokens are generated perhaps.
