### PR TITLE
Added conditional to buildDictionary foreach loop

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -68,7 +68,8 @@ class MorphTo extends BelongsTo {
 	{
 		foreach ($models as $model)
 		{
-			if ( $model->{$this->morphType} ) {
+			if ($model->{$this->morphType}) 
+			{
 				$this->dictionary[$model->{$this->morphType}][$model->{$this->foreignKey}][] = $model;
 			}
 		}

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -68,7 +68,9 @@ class MorphTo extends BelongsTo {
 	{
 		foreach ($models as $model)
 		{
-			$this->dictionary[$model->{$this->morphType}][$model->{$this->foreignKey}][] = $model;
+			if ( $model->{$this->morphType} ) {
+				$this->dictionary[$model->{$this->morphType}][$model->{$this->foreignKey}][] = $model;
+			}
 		}
 	}
 


### PR DESCRIPTION
Thanks for implementing polymorphic eager loading!

Came across an issue where the morphType field in the database was null and caused `Class '' not found` from `createModelByType` function.

Added conditional to `buildDictionary` method to fix situations where morphType is null
