### PR TITLE
Removed PHP Memory Limit From Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
 
-script: phpunit -d memory_limit=1024M
+script: phpunit
 
 matrix:
   allow_failures:


### PR DESCRIPTION
It is not needed anymore. Travis upped its memory limit a while back, and when laravel moved to mockery 0.9,  the memory usage during tests was significantly decreased.
