### PR TITLE
Filesystem mode

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -291,7 +291,7 @@ class Filesystem {
 	 * @param  bool    $force
 	 * @return bool
 	 */
-	public function makeDirectory($path, $mode = 0777, $recursive = false, $force = false)
+	public function makeDirectory($path, $mode = 0755, $recursive = false, $force = false)
 	{
 		if ($force)
 		{


### PR DESCRIPTION
We could go back and forth about security practices and bring Github down.  However, would it be more sane to change the default mode for for new directories to 755?

Yes, this may be one of those "let's help the newcomers" of a PR, but I think it would save most of us a couple keystrokes.  Hopefully I'm not alone in that I rarely ever need to create new directories writable by users other than the one executing the PHP.
