### PR TITLE
Allows for route group name nesting with 'as'

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -760,7 +760,13 @@ class Route {
 	 */
 	public function getName()
 	{
-		return array_get($this->action, 'as');
+		$names = array_get($this->action, 'as');
+		if(is_array($names)) {
+			$names = array_map(function($name) { return trim($name, ". \t\n\r\0\x0B"); }, $names);
+			return implode('.', $names);
+		} else {
+			return $names;
+		}
 	}
 
 	/**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -83,7 +83,7 @@ class RouteCollection implements Countable, IteratorAggregate {
 
 		if (isset($action['as']))
 		{
-			$this->nameList[$action['as']] = $route;
+			$this->addToNameList($action, $route);
 		}
 
 		// When the route is routing to a controller we will also store the action that
@@ -107,6 +107,40 @@ class RouteCollection implements Countable, IteratorAggregate {
 		if ( ! isset($this->actionList[$action['controller']]))
 		{
 			$this->actionList[$action['controller']] = $route;
+		}
+	}
+
+	/**
+	 * Add a route to the named route dictionary.
+	 *
+	 * @param  array  $action
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @return void
+	 */
+	protected function addToNameList($action, $route)
+	{
+		$name = $this->getNameForRoute($action);
+
+		if ( ! isset($this->nameList[$name]))
+		{
+			$this->nameList[$name] = $route;
+		}
+	}
+
+	/**
+	 * Parses name for nested route names.
+	 *
+	 * @param  array  $action
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @return void
+	 */
+	protected function getNameForRoute($action)
+	{
+		if(is_array($action['as'])) {
+			$names = array_map(function($name) { return trim($name, ". \t\n\r\0\x0B"); }, $action['as']);
+			return implode('.', $names);
+		} else {
+			return $action['as'];
 		}
 	}
 

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -119,28 +119,11 @@ class RouteCollection implements Countable, IteratorAggregate {
 	 */
 	protected function addToNameList($action, $route)
 	{
-		$name = $this->getNameForRoute($action);
+		$name = $route->getName();
 
 		if ( ! isset($this->nameList[$name]))
 		{
 			$this->nameList[$name] = $route;
-		}
-	}
-
-	/**
-	 * Parses name for nested route names.
-	 *
-	 * @param  array  $action
-	 * @param  \Illuminate\Routing\Route  $route
-	 * @return void
-	 */
-	protected function getNameForRoute($action)
-	{
-		if(is_array($action['as'])) {
-			$names = array_map(function($name) { return trim($name, ". \t\n\r\0\x0B"); }, $action['as']);
-			return implode('.', $names);
-		} else {
-			return $action['as'];
 		}
 	}
 


### PR DESCRIPTION
Currently if you try to nest routes within a group route with the `as` name set, then it will throw an error.

This allows for nesting with route naming by prefixing route names with `prefix.`.
