### PR TITLE
Fix relation name inconsistency

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -466,12 +466,14 @@ class Builder {
 	 */
 	public function getRelation($relation)
 	{
+		$relationId = camel_case($relation);
+
 		// We want to run a relationship query without any constrains so that we will
 		// not have to remove these where clauses manually which gets really hacky
 		// and is error prone while we remove the developer's own where clauses.
-		$query = Relation::noConstraints(function() use ($relation)
+		$query = Relation::noConstraints(function() use ($relationId)
 		{
-			return $this->getModel()->$relation();
+			return $this->getModel()->$relationId();
 		});
 
 		$nested = $this->nestedRelations($relation);


### PR DESCRIPTION
Consider a case when user defines a relation with complex name such as `surgeryTypes`. The attribute should be snake-cased (`surgery_types`). This works:

``` php
$obj->surgery_types->lists('id');
```

This won't work:

``` php
$obj->load('surgery_types');
```

This will work:

``` php
$obj->load('surgeryTypes');
```

But the relation result will be stored under `surgeryTypes` name rather than `surgery_types`, and when user tries to access `$obj->surgery_types`, the relation will be loaded once again.

I suggest to stick with snake-cased relation names when they are eager-loaded.
