### PR TITLE
[Proposal] Add an assertion that checks whether a view lacks a given variable. (Was against master branch)

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -221,7 +221,10 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	{
 		$response = $this->client->getResponse()->original;
 
-		$this->assertInstanceOf('Illuminate\View\View', $response, 'The response was not a view.');
+		if ( ! $response instanceof View)
+		{
+			return $this->assertTrue(false, 'The response was not a view.');
+		}
 
 		$this->assertArrayNotHasKey($key, $response->getData());
 	}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -212,6 +212,21 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Assert that the response view does not have a given piece of bound data.
+	 *
+	 * @param  string  $key
+	 * @return void
+	 */
+	public function assertViewMissing($key)
+	{
+		$response = $this->client->getResponse()->original;
+
+		$this->assertInstanceOf('Illuminate\View\View', $response, 'The response was not a view.');
+
+		$this->assertArrayNotHasKey($key, $response->getData());
+	}
+
+	/**
 	 * Assert whether the client was redirected to a given URI.
 	 *
 	 * @param  string  $uri


### PR DESCRIPTION
I am writing a RESTful API, in which I have groups that entities are attached to. These groups are themselves attached to a parent company, which the admin user is also attached to. So no need to specify the parent company. But I also have a super admin, who can move a group to another parent company.

This assertion allows me to check that the parent companies list is not sent to the view when the user is not super admin level. I have written it for myself, but I imagine there are other situations when it would be useful, so I propose to include it into the framework.
