### PR TITLE
Bugfix: domain routing for subfolder

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -44,9 +44,9 @@ class Request extends SymfonyRequest {
 	 *
 	 * @return string
 	 */
-	public function root()
+	public function root($domain = null)
 	{
-		return rtrim($this->getSchemeAndHttpHost().$this->getBaseUrl(), '/');
+		return rtrim(($domain?:$this->getSchemeAndHttpHost()).$this->getBaseUrl(), '/');
 	}
 
 	/**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -439,7 +439,7 @@ class UrlGenerator {
 	 */
 	protected function getRootUrl($scheme, $root = null)
 	{
-		$root = $root ?: $this->request->root();
+		$root = $this->request->root($root);
 
 		$start = starts_with($root, 'http://') ? 'http://' : 'https://';
 


### PR DESCRIPTION
Previously, if laravel was installed to a subfolder, when attempting
to generate a route url for a route associated with a domain, the
subfolder is not included. This corrects that problem.

For more details, see request #3911
