### PR TITLE
[Bug] DatabasePresenceVerifier not working for booleans in the additional conditions #3927

### DIFF
--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -88,11 +88,11 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface {
 	 */
 	protected function addWhere($query, $key, $extraValue)
 	{
-		if ($extraValue == 'NULL')
+		if ($extraValue === 'NULL')
 		{
 			$query->whereNull($key);
 		}
-		elseif ($extraValue == 'NOT_NULL')
+		elseif ($extraValue === 'NOT_NULL')
 		{
 			$query->whereNotNull($key);
 		}

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -17,10 +17,11 @@ class ValidationDatabasePresenceVerifierTest extends PHPUnit_Framework_TestCase 
 		$db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock('StdClass'));
 		$conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock('StdClass'));
 		$builder->shouldReceive('where')->with('column', '=', 'value')->andReturn($builder);
-		$extra = array('foo' => 'NULL', 'bar' => 'NOT_NULL', 'baz' => 'taylor');
+		$extra = array('foo' => 'NULL', 'bar' => 'NOT_NULL', 'baz' => 'taylor', 'faz' => true);
 		$builder->shouldReceive('whereNull')->with('foo');
 		$builder->shouldReceive('whereNotNull')->with('bar');
 		$builder->shouldReceive('where')->with('baz', 'taylor');
+        $builder->shouldReceive('where')->with('faz', true);
 		$builder->shouldReceive('count')->once()->andReturn(100);
 
 		$this->assertEquals(100, $verifier->getCount('table', 'column', 'value', null, null, $extra));


### PR DESCRIPTION
Change comparison operator from 'Equal' to 'Identical' when comparing value to 'NULL'/'NOT_NULL', so a comparison with a boolean value returns correct result.
