### PR TITLE
Add Rackspace Queue functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
         "aws/aws-sdk-php": "2.5.*",
         "iron-io/iron_mq": "1.5.*",
         "pda/pheanstalk": "2.1.*",
+        "rackspace/php-opencloud": "1.9.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "4.0.*"
     },

--- a/src/Illuminate/Queue/Connectors/RackspaceConnector.php
+++ b/src/Illuminate/Queue/Connectors/RackspaceConnector.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Illuminate\Queue\Connectors;
+
+use Illuminate\Queue\RackspaceQueue;
+use OpenCloud\Rackspace;
+use OpenCloud\Queues\Service;
+
+class RackspaceConnector implements ConnectorInterface {
+
+	/**
+	 * @var \OpenCloud\Rackspace
+	 */
+	protected $connection = null;
+
+	/**
+	 * @var \OpenCloud\Queues\Service
+	 */
+	protected $service = null;
+
+	/**
+	 * Establish a queue connection.
+	 *
+	 * @param  array $config
+	 * @return \Illuminate\Queue\QueueInterface
+	 */
+	public function connect(array $config)
+	{
+		switch ($config['endpoint'])
+		{
+			case 'US':
+				$endpoint = Rackspace::US_IDENTITY_ENDPOINT;
+				break;
+			case 'UK':
+			default:
+				$endpoint = Rackspace::UK_IDENTITY_ENDPOINT;
+		}
+
+		if ($this->connection == null)
+		{
+			$this->connection = new Rackspace(
+				$endpoint,
+				array(
+					'username' => $config['username'],
+					'apiKey' => $config['apiKey']
+				)
+			);
+		}
+
+		if ($this->service === null)
+		{
+			$this->service = $this->connection->queuesService(
+				Service::DEFAULT_NAME,
+				$config['region'],
+				$config['urlType']
+			);
+		}
+
+		$this->service->setClientId();
+
+		return new RackspaceQueue($this->service, $config['queue']);
+	}
+
+}

--- a/src/Illuminate/Queue/Jobs/RackspaceJob.php
+++ b/src/Illuminate/Queue/Jobs/RackspaceJob.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Illuminate\Queue\Jobs;
+
+use Illuminate\Container\Container;
+use OpenCloud\Queues\Resource\Queue as OpenCloudQueue;
+use OpenCloud\Queues\Resource\Message;
+
+class RackspaceJob extends Job {
+	/**
+	 * The Rackspace OpenCloud Queue instance.
+	 *
+	 * @var OpenCloudQueue
+	 */
+	protected $openCloudQueue;
+
+	/**
+	 * The message instance.
+	 *
+	 * @var Message
+	 */
+	protected $message;
+
+	public function __construct(Container $container, OpenCloudQueue $openCloudQueue, $queue, Message $message)
+	{
+		$this->openCloudQueue = $openCloudQueue;
+		$this->message = $message;
+		$this->queue = $queue;
+		$this->container = $container;
+	}
+
+	/**
+	 * Fire the job.
+	 *
+	 * @return void
+	 */
+	public function fire()
+	{
+		$this->resolveAndFire(json_decode($this->getRawBody(), true));
+	}
+
+	/**
+	 * Release the job back into the queue.
+	 *
+	 * @param  int $delay
+	 * @return void
+	 */
+	public function release($delay = 0)
+	{
+		$this->message->delete($this->message->getClaimIdFromHref());
+	}
+
+	/**
+	 * Get the number of times the job has been attempted.
+	 *
+	 * @throws \RuntimeException
+	 */
+	public function attempts()
+	{
+		throw new \RuntimeException('RackspaceJob::attempts() is unsupported');
+	}
+
+	/**
+	 * Get the raw body string for the job.
+	 *
+	 * @return string
+	 */
+	public function getRawBody()
+	{
+		return $this->message->getBody();
+	}
+
+	/**
+	 * Delete the job from the queue.
+	 *
+	 * @return void
+	 */
+	public function delete()
+	{
+		parent::delete();
+
+		$this->openCloudQueue->deleteMessages(array($this->message->getId()));
+	}
+
+
+	/**
+	 * Get the job identifier.
+	 *
+	 * @return string
+	 */
+	public function getJobId()
+	{
+		return $this->message->getId();
+	}
+
+}

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Queue\Console\SubscribeCommand;
 use Illuminate\Queue\Connectors\SyncConnector;
 use Illuminate\Queue\Connectors\IronConnector;
 use Illuminate\Queue\Connectors\RedisConnector;
+use Illuminate\Queue\Connectors\RackspaceConnector;
 use Illuminate\Queue\Connectors\BeanstalkdConnector;
 use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 
@@ -143,7 +144,7 @@ class QueueServiceProvider extends ServiceProvider {
 	 */
 	public function registerConnectors($manager)
 	{
-		foreach (array('Sync', 'Beanstalkd', 'Redis', 'Sqs', 'Iron') as $connector)
+		foreach (array('Sync', 'Beanstalkd', 'Redis', 'Sqs', 'Iron', 'Rackspace') as $connector)
 		{
 			$this->{"register{$connector}Connector"}($manager);
 		}
@@ -240,6 +241,20 @@ class QueueServiceProvider extends ServiceProvider {
 			}
 		});
 	}
+
+    /**
+     * Register the Rackspace queue connector.
+     *
+     * @param  \Illuminate\Queue\QueueManager  $manager
+     * @return void
+     */
+    protected function registerRackspaceConnector($manager)
+    {
+        $manager->addConnector('rackspace', function()
+        {
+            return new RackspaceConnector();
+        });
+    }
 
 	/**
 	 * Register the failed job services.

--- a/src/Illuminate/Queue/RackspaceQueue.php
+++ b/src/Illuminate/Queue/RackspaceQueue.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use OpenCloud\Common\Constants\Datetime;
+use OpenCloud\Queues\Service as OpenCloudService;
+use OpenCloud\Queues\Resource\Queue as OpenCloudQueue;
+use Illuminate\Queue\Jobs\RackspaceJob;
+
+class RackspaceQueue extends Queue implements QueueInterface {
+
+	/**
+	 * The Rackspace OpenCloud Message Service instance.
+	 *
+	 * @var OpenCloudService
+	 */
+	protected $openCloudService;
+
+	/**
+	 * The Rackspace OpenCloud Queue instance
+	 *
+	 * @var OpenCloudQueue
+	 */
+	protected $queue;
+
+	/**
+	 * The name of the default tube.
+	 *
+	 * @var string
+	 */
+	protected $default;
+
+	public function  __construct(OpenCloudService $openCloudService, $default)
+	{
+		$this->openCloudService = $openCloudService;
+		$this->default = $default;
+		$this->queue = $openCloudService->createQueue($default);
+	}
+
+	/**
+	 * Push a new job onto the queue.
+	 *
+	 * @param  string $job
+	 * @param  mixed $data
+	 * @param  string $queue
+	 * @return mixed
+	 */
+	public function push($job, $data = '', $queue = null)
+	{
+		return $this->pushRaw($this->createPayload($job, $data), $queue);
+	}
+
+	/**
+	 * Push a raw payload onto the queue.
+	 *
+	 * @param  string $payload
+	 * @param  string $queue
+	 * @param  array $options
+	 * @return mixed
+	 */
+	public function pushRaw($payload, $queue = null, array $options = array())
+	{
+		$ttl = array_key_exists('ttl', $options) ? $options['ttl'] : Datetime::DAY * 2;
+
+		return $this->queue->createMessage(array(
+				'body' => $payload,
+				'ttl'  => $ttl
+			)
+		);
+	}
+
+	/**
+	 * Push a new job onto the queue after a delay.
+	 *
+	 * @throws \RuntimeException
+	 */
+	public function later($delay, $job, $data = '', $queue = null)
+	{
+		throw new \RuntimeException('RackspaceQueue::later() method is not supported');
+	}
+
+	/**
+	 * Pop the next job off of the queue.
+	 *
+	 * @param  string $queue
+	 * @return RackspaceJob
+	 */
+	public function pop($queue = null)
+	{
+		$queue = $this->getQueue($queue);
+
+		/**
+		 * @var \OpenCloud\Common\Collection\PaginatedIterator $response
+		 */
+		$response = $this->queue->claimMessages(array(
+			'limit' => 1,
+			'grace' => 5 * Datetime::MINUTE,
+			'ttl'   => 5 * Datetime::MINUTE
+		));
+
+		if ($response and $response->valid())
+		{
+			$message = $response->current();
+
+			return new RackspaceJob($this->container, $this->queue, $queue, $message);
+		}
+	}
+
+	/**
+	 * Get the queue or return the default.
+	 *
+	 * @param  string|null  $queue
+	 * @return string
+	 */
+	public function getQueue($queue)
+	{
+		return $queue ?: $this->default;
+	}
+
+	/**
+	 * Get the underlying OpenCloud Queue instance.
+	 *
+	 * @return OpenCloudQueue
+	 */
+	public function getOpenCloudQueue()
+	{
+		return $this->queue;
+	}
+
+}

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -20,6 +20,7 @@
         "aws/aws-sdk-php": "2.5.*",
         "iron-io/iron_mq": "1.5.*",
         "pda/pheanstalk": "2.1.*",
+        "rackspace/php-opencloud": "1.9.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "4.0.*"
     },


### PR DESCRIPTION
I've created the classes to integrate RackSpace Queue functionality, implementing the PHP OpenCloud SDK (https://github.com/rackspace/php-opencloud).

This snippet is all that needs to be added inside 'connections' in app/config/queues.php.

```
'rackspace' => array(
            'driver'    => 'rackspace',
            'username'  => 'your-username',
            'apiKey'    => 'your-api-key',
            'endpoint'  => 'UK',  // supported options: UK or US
            'region'    => 'your-region',  // eg. LON, DFW, ORD
            'urlType'   => 'publicURL', // valid options: publicURL or internalUrl
            'queue'     => 'your-queue-name'
        ),
```

Let me know if I need to create a pull request on laravel/laravel to add the above into in app/config/queues.php.
