### PR TITLE
Add posibility to provide an array of paramaters to the colsure in Cache::remember

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -104,7 +104,7 @@ class Repository implements ArrayAccess {
 	 * @param  Closure  $callback
 	 * @return mixed
 	 */
-	public function remember($key, $minutes, Closure $callback)
+	public function remember($key, $minutes, Closure $callback, array $arguments = array())
 	{
 		// If the item exists in the cache we will just return this immediately
 		// otherwise we will execute the given Closure and cache the result
@@ -114,7 +114,9 @@ class Repository implements ArrayAccess {
 			return $value;
 		}
 
-		$this->put($key, $value = $callback(), $minutes);
+        $value = call_user_func_array($callback, $arguments);
+
+		$this->put($key, $value, $minutes);
 
 		return $value;
 	}


### PR DESCRIPTION
Occasionally you might have some paramaters that you want to accept through the closure in Cache::remember();

```
$task = Cache::remember('task', 120, function($var)
{
    return $var;
}, ['foo']);
```

This enhancement creates the ability to easily provide an array of arguments that you wanna send to the closure in order to get the correct data, or whatever you might wanna do.

```
Cache::remember($key, $minutes, Closure $closure, array $arguments = array());
```
