### PR TITLE
[4.1] Fixed Swiftmailer Dependency

### DIFF
--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -13,7 +13,7 @@
         "illuminate/log": "4.1.*",
         "illuminate/support": "4.1.*",
         "illuminate/view": "4.1.*",
-        "swiftmailer/swiftmailer": "4.3.*"
+        "swiftmailer/swiftmailer": "5.0.*"
     },
     "require-dev": {
         "illuminate/queue": "4.1.*",


### PR DESCRIPTION
The main composer.json specifies 5.0, but src/Illuminate/Mail/composer.json was never updated to 5.0 from 4.3.
