### PR TITLE
[Bug] Modified getCheckedState to handle string values correctly

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -645,6 +645,9 @@ class FormBuilder {
 
 		$posted = $this->getValueAttribute($name);
 
+		// If posted value is a string other than "0" cast to an array
+		if (is_string($posted) && (bool)$posted) $posted = [$posted];
+
 		return is_array($posted) ? in_array($value, $posted) : (bool) $posted;
 	}
 

--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -646,7 +646,7 @@ class FormBuilder {
 		$posted = $this->getValueAttribute($name);
 
 		// If posted value is a string other than "0" cast to an array
-		if (is_string($posted) && (bool)$posted) $posted = [$posted];
+		if (is_string($posted) && (bool)$posted) $posted = array($posted);
 
 		return is_array($posted) ? in_array($value, $posted) : (bool) $posted;
 	}


### PR DESCRIPTION
I currently require the use of checkboxes to set enum data on my models in a couple forms. To facilitate the request correctly, I created a macro to generate a regular Laravel Form checkbox with the checked state value as well as a hidden input with unchecked state value, both bearing the same input name property. 

Generated output would look something like this:

```
 <input id="testHidden" type="hidden" value="off" name="test">
 <input checked="checked" name="test" type="checkbox" value="on">
```

This is a requirement to properly ensure that the input from the checked/unchecked state exists in the $_POST array and updates to the model are performed correctly(Unchecked checkbox inputs by default are excluded from the $_POST and therefore cannot update an enum field). 

Using Laravel Form helpers (as well as my custom macro) to generate all the fields in my form. I bound the form data with the form model binding facade Form::model(), and all fields are populated in the general precedence order dictated by the FormBuilder class methods. 

The issue lies in the inability for FormBuilder's getCheckboxCheckedState to properly deal with string values like shown above in the sample output. It will always render the checkbox checked when being populated by the model's enum field, since any string other than "0" will always return true when cast to a boolean.
