### PR TITLE
Replace the hardcoded /meta path with the manifest path from config

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -839,7 +839,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	 */
 	public function isDownForMaintenance()
 	{
-		return file_exists($this['path.storage'].'/meta/down');
+		return file_exists($this['config']['app.manifest'].'/down');
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
+++ b/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
@@ -30,7 +30,7 @@ class ClearCompiledCommand extends Command {
 			@unlink($path);
 		}
 
-		if (file_exists($path = $this->laravel['path.storage'].'/meta/services.json'))
+		if (file_exists($path = $this->laravel['config']['app.manifest'].'/services.json'))
 		{
 			@unlink($path);
 		}

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -25,7 +25,7 @@ class DownCommand extends Command {
 	 */
 	public function fire()
 	{
-		touch($this->laravel['path.storage'].'/meta/down');
+		touch($this->laravel['config']['app.manifest'].'/down');
 
 		$this->comment('Application is now in maintenance mode.');
 	}

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -25,7 +25,7 @@ class UpCommand extends Command {
 	 */
 	public function fire()
 	{
-		@unlink($this->laravel['path.storage'].'/meta/down');
+		@unlink($this->laravel['config']['app.manifest'].'/down');
 
 		$this->info('Application is now live.');
 	}


### PR DESCRIPTION
If the manifest folder /meta is physically renamed and its path changed accordingly in config/app.php, `isDownForMaintenance` is not working as expected, and the following commands are failing : 
- `artisan up`
- `artisan down`
- `artisan clear`

This commit should fix that.
