### PR TITLE
Changing ->timestamps() to use DATETIME.

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -632,9 +632,9 @@ class Blueprint {
 	 */
 	public function timestamps()
 	{
-		$this->timestamp('created_at');
+		$this->dateTime('created_at');
 
-		$this->timestamp('updated_at');
+		$this->dateTime('updated_at');
 	}
 
 	/**


### PR DESCRIPTION
This has roots in the 2038 problem. MySQL TIMESTAMP columns do not
have the ability to store a date greater than the year 2038. MySQL
DATETIME has no issue on 64-bit platoforms, but it does have the
same issue on 32-bit platforms. Assuming most people will be using
64-bit servers, this change will prevent a huge number of people
running into this issue at all.
