### PR TITLE
Fix fatal error on TestCase::assertViewHas

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -173,20 +173,20 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	{
 		if (is_array($key)) return $this->assertViewHasAll($key);
 
-		$response = $this->client->getResponse()->original;
+		$response = $this->client->getResponse();
 
-		if ( ! $response instanceof View)
+		if ( ! isset($response->original) || ! $response->original instanceof View)
 		{
 			return $this->assertTrue(false, 'The response was not a view.');
 		}
 
 		if (is_null($value))
 		{
-			$this->assertArrayHasKey($key, $response->getData());
+			$this->assertArrayHasKey($key, $response->original->getData());
 		}
 		else
 		{
-			$this->assertEquals($value, $response->$key);
+			$this->assertEquals($value, $response->original->$key);
 		}
 	}
 
@@ -219,14 +219,14 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	 */
 	public function assertViewMissing($key)
 	{
-		$response = $this->client->getResponse()->original;
+		$response = $this->client->getResponse();
 
-		if ( ! $response instanceof View)
+		if ( ! isset($response->original) || ! $response->original instanceof View)
 		{
 			return $this->assertTrue(false, 'The response was not a view.');
 		}
 
-		$this->assertArrayNotHasKey($key, $response->getData());
+		$this->assertArrayNotHasKey($key, $response->original->getData());
 	}
 
 	/**


### PR DESCRIPTION
Fix fatal error on TestCase::assertViewHas when response is a Json- or RedirectResponse, as the `$original` property is not available.
