### PR TITLE
Added automatic boolean conversion when setting or fetching model attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -130,6 +130,13 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	protected $dates = array();
 
 	/**
+	 * The attributes that should be mutated to booleans.
+	 *
+	 * @var array
+	 */
+	protected $booleans = array();
+
+	/**
 	 * The relationships that should be touched on save.
 	 *
 	 * @var array
@@ -2236,6 +2243,14 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			if ($value) return $this->asDateTime($value);
 		}
 
+		// If the attribute is listed as a boolean, we will convert it to a boolean,
+		// which makes it quite easy to work with when actual boolean values are needed
+		// instead of 0 and 1.
+		elseif (in_array($key, $this->getBooleans()))
+		{
+			return $this->asBoolean($value);
+		}
+
 		return $value;
 	}
 
@@ -2328,6 +2343,14 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			}
 		}
 
+		// If the attribute is listed as a boolean, we will convert it to a boolean,
+		// which makes it quite easy to work with when actual boolean values are needed
+		// instead of 0 and 1.
+		elseif (in_array($key, $this->getBooleans()))
+		{
+			$value = (bool)$value;
+		}
+
 		$this->attributes[$key] = $value;
 	}
 
@@ -2352,6 +2375,16 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		$defaults = array(static::CREATED_AT, static::UPDATED_AT);
 
 		return array_merge($this->dates, $defaults);
+	}
+
+	/**
+	 * Get the attributes that should be converted to booleans.
+	 *
+	 * @return array
+	 */
+	public function getBooleans()
+	{
+		return $this->booleans;
 	}
 
 	/**
@@ -2434,6 +2467,17 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		}
 
 		return Carbon::instance($value);
+	}
+
+	/**
+	 * Return a value as a boolean.
+	 *
+	 * @param  mixed  $value
+	 * @return boolean
+	 */
+	protected function asBoolean($value)
+	{
+		return (bool)$value;
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -743,6 +743,40 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
 	}
 
+
+	public function testBooleansAreMutatedProperly()
+	{
+		// Check integer conversion
+		$model = new EloquentBooleanModelStub;
+		$model->completed = 0;
+		$attributes = $model->getAttributes();
+		$this->assertFalse($model->completed);
+		$this->assertFalse($attributes['completed']);
+
+		$model = new EloquentBooleanModelStub;
+		$model->completed = 1;
+		$attributes = $model->getAttributes();
+		$this->assertTrue($model->completed);
+		$this->assertTrue($attributes['completed']);
+
+		$model = new EloquentBooleanModelStub;
+		$model->invited = 0;
+		$this->assertFalse($model->invited);
+
+		$model = new EloquentBooleanModelStub;
+		$model->invited = 1;
+		$this->assertTrue($model->invited);
+
+		$model = new EloquentBooleanModelStub;
+		$model->completed = true;
+		$this->assertTrue($model->completed);
+
+		$model = new EloquentBooleanModelStub;
+		$model->invited = false;
+		$attributes = $model->getAttributes();
+		$this->assertFalse($model->invited);
+		$this->assertFalse($attributes['invited']);
+	}
 }
 
 class EloquentTestObserverStub {
@@ -875,4 +909,8 @@ class EloquentModelBootingTestStub extends Illuminate\Database\Eloquent\Model {
 	{
 		return array_key_exists(get_called_class(), static::$booted);
 	}
+}
+
+class EloquentBooleanModelStub extends EloquentModelStub {
+	protected $booleans = array('completed', 'invited');
 }


### PR DESCRIPTION
This pull request allows the user to specific automatic boolean conversion of specific fields on models, much like the existing date conversion functionality. You can do this by setting the $booleans variabled, or by overriding the getBooleans() function and returning an array.

The follow example explains the usage:

```
class TestModel extends \Eloquent {
    protected $booleans = array('completed', 'invited');
}
```

Now whenever you fetch the completed or invited value, you will get a boolean false or true value instead of the normal "0" or "1" strings.
