### PR TITLE
Support of workbench packages in migration:publish

### DIFF
--- a/src/Illuminate/Foundation/Console/MigratePublishCommand.php
+++ b/src/Illuminate/Foundation/Console/MigratePublishCommand.php
@@ -37,21 +37,26 @@ class MigratePublishCommand extends Command {
 	}
 
 	/**
-	 * Get the path to the source files (Including vendor and workbench)
+	 * Get the path to the source files, including vendor and workbench.
 	 *
 	 * @return string
 	 */
 	protected function getSourcePath()
 	{
 		$workbench = $this->laravel['path.base'].'/workbench';
-		if (file_exists($workbench)) {
+		
+		if (file_exists($workbench)) 
+		{
 			$path = $workbench.'/'.$this->argument('package').'/src/migrations';
-			if (file_exists($path)) {
+			
+			if (file_exists($path)) 
+			{
 				return $path;
 			}
 		}
 
 		$vendor = $this->laravel['path.base'].'/vendor';
+		
 		return $vendor.'/'.$this->argument('package').'/src/migrations';
 	}
 

--- a/src/Illuminate/Foundation/Console/MigratePublishCommand.php
+++ b/src/Illuminate/Foundation/Console/MigratePublishCommand.php
@@ -37,14 +37,21 @@ class MigratePublishCommand extends Command {
 	}
 
 	/**
-	 * Get the path to the source files.
+	 * Get the path to the source files (Including vendor and workbench)
 	 *
 	 * @return string
 	 */
 	protected function getSourcePath()
 	{
-		$vendor = $this->laravel['path.base'].'/vendor';
+		$workbench = $this->laravel['path.base'].'/workbench';
+		if (file_exists($workbench)) {
+			$path = $workbench.'/'.$this->argument('package').'/src/migrations';
+			if (file_exists($path)) {
+				return $path;
+			}
+		}
 
+		$vendor = $this->laravel['path.base'].'/vendor';
 		return $vendor.'/'.$this->argument('package').'/src/migrations';
 	}
 


### PR DESCRIPTION
Just encountered an issue where publishing migrations from a package inside workbench folder isn't working (No migration found)

migration:publish now support publishing migrations from packages inside the workbench folder.
