### PR TITLE
Fix the error of page break which passing array include $pageName key.

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -195,7 +195,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 		// to the URL. This allows for extra information like sortings storage.
 		if (count($this->query) > 0)
 		{
-			$parameters = array_merge($parameters, $this->query);
+			$parameters = array_merge($this->query, $parameters);
 		}
 
 		$fragment = $this->buildFragment();


### PR DESCRIPTION
Fix the error of page break which passing an array include $pageName query to appends() method.

Steps to Reproduce：
1. pageName:'page'
3. view: `{{$items->appends(Request::all())->links();}}`,the current url is: `'http://host/query?page=1&something=hello'`
4. all links of paginator are 'http://host/query?page=1&something=hello'.
