### PR TITLE
Added exception when key named "flash" is used to store flash content in to Session

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -347,6 +347,10 @@ class Store implements SessionInterface {
 	 */
 	public function flash($key, $value)
 	{
+		if ($key === 'flash') {
+			throw new \InvalidArgumentException('"flash" is a reserved key');
+		}
+
 		$this->put($key, $value);
 
 		$this->push('flash.new', $key);


### PR DESCRIPTION
I think that is good to developers to know what vars are reserved when they are storing data into session.

Also, I think that this reserved var should be documented at http://laravel.com/docs/session

Related issue #4007 
