### PR TITLE
Allow multiple parameters for required_if

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -562,7 +562,10 @@ class Validator implements MessageProviderInterface {
 	{
 		$this->requireParameterCount(2, $parameters, 'required_if');
 
-		if ($parameters[1] == array_get($this->data, $parameters[0]))
+		$data = array_get($this->data, $parameters[0]);
+		$values = array_slice($parameters, 1);
+
+		if (in_array($data, $values))
 		{
 			return $this->validateRequired($attribute, $value);
 		}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -345,6 +345,14 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$trans = $this->getRealTranslator();
 		$v = new Validator($trans, array('first' => 'taylor', 'last' => 'otwell'), array('last' => 'required_if:first,taylor'));
 		$this->assertTrue($v->passes());
+
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('first' => 'taylor', 'last' => 'otwell'), array('last' => 'required_if:first,taylor,dayle'));
+		$this->assertTrue($v->passes());
+
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('first' => 'dayle', 'last' => 'rees'), array('last' => 'required_if:first,taylor,dayle'));
+		$this->assertTrue($v->passes());
 	}
 
 


### PR DESCRIPTION
Additional parameters will make it check if any of them are present in the conditional field. I.e. required_if:field,foo,bar will make the field required if "field" is either "foo" or "bar".
