### PR TITLE
MessageBag clear and clearKey

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -54,6 +54,22 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 	}
 
 	/**
+	 * Clear messages for a given key.
+	 *
+	 * @param  string  $key
+	 * @return \Illuminate\Support\MessageBag
+	 */
+	public function clearKey($key)
+	{
+		if ($this->has($key))
+		{
+			unset($this->messages[$key]);
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Merge a new array of messages into the bag.
 	 *
 	 * @param  \Illuminate\Support\Contracts\MessageProviderInterface|array  $messages

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -54,6 +54,18 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 	}
 
 	/**
+	 * Clear all messages.
+	 *
+	 * @return \Illuminate\Support\MessageBag
+	 */
+	public function clear()
+	{
+		$this->messages = array();
+
+		return $this;
+	}
+
+	/**
 	 * Clear messages for a given key.
 	 *
 	 * @param  string  $key

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -48,6 +48,18 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testMessagesAreCleared()
+	{
+		$container = new MessageBag;
+		$container->add('foo', 'bar');
+		$container->add('foo', 'baz');
+		$container->add('boom', 'bust');
+		$this->assertEquals(3, $container->count());
+		$container->clear();
+		$this->assertEquals(0, $container->count());
+	}
+
+
 	public function testMessagesMayBeMerged()
 	{
 		$container = new MessageBag(array('username' => array('foo')));

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -34,6 +34,20 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testKeysAreCleared()
+	{
+		$container = new MessageBag;
+		$container->add('foo', 'bar');
+		$container->add('foo', 'baz');
+		$container->add('boom', 'bust');
+		$this->assertTrue($container->has('foo'));
+		$this->assertTrue($container->has('boom'));
+		$container->clearKey('foo');
+		$this->assertFalse($container->has('foo'));
+		$this->assertTrue($container->has('boom'));
+	}
+
+
 	public function testMessagesMayBeMerged()
 	{
 		$container = new MessageBag(array('username' => array('foo')));


### PR DESCRIPTION
I may have been overlooking something, or maybe I just over engineered my application a bit, however I thought add a `clear` and `clearKey` method might be useful on the MessageBag.  I won't go into detail on my use case, but I was using a singleton instance and got into a bit of trouble.

Feel free to just shoot this down, I can just as easily add it in my extended class.
