### PR TITLE
MessageBag clear and clearKey 4.1

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -54,12 +54,19 @@ class Seeder {
 		{
 			$instance = $this->container->make($class);
 
-			return $instance->setContainer($this->container)->setCommand($this->command);
+			$instance->setContainer($this->container);
 		}
 		else
 		{
-			return new $class;
+			$instance = new $class;
 		}
+
+		if (isset($this->command))
+		{
+			$instance->setCommand($this->command);
+		}
+
+		return $instance;
 	}
 
 	/**

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -53,6 +53,26 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 	}
 
 	/**
+	 * Clear all messages or just messages from a key if given.
+	 *
+	 * @param  string  $key
+	 * @return \Illuminate\Support\MessageBag
+	 */
+	public function clear($key = null)
+	{
+		if (is_null($key))
+		{
+			$this->messages = array();
+		}
+		else
+		{
+			unset($this->messages[$key]);
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Merge a new array of messages into the bag.
 	 *
 	 * @param  \Illuminate\Support\Contracts\MessageProviderInterface|array  $messages

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -34,6 +34,32 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testKeysAreCleared()
+	{
+		$container = new MessageBag;
+		$container->add('foo', 'bar');
+		$container->add('foo', 'baz');
+		$container->add('boom', 'bust');
+		$this->assertTrue($container->has('foo'));
+		$this->assertTrue($container->has('boom'));
+		$container->clear('foo');
+		$this->assertFalse($container->has('foo'));
+		$this->assertTrue($container->has('boom'));
+	}
+
+
+	public function testMessagesAreCleared()
+	{
+		$container = new MessageBag;
+		$container->add('foo', 'bar');
+		$container->add('foo', 'baz');
+		$container->add('boom', 'bust');
+		$this->assertEquals(3, $container->count());
+		$container->clear();
+		$this->assertEquals(0, $container->count());
+	}
+
+
 	public function testMessagesMayBeMerged()
 	{
 		$container = new MessageBag(array('username' => array('foo')));


### PR DESCRIPTION
Originally submitted at #4014 against master, should be okay for 4.1 though.

I may have been overlooking something, or maybe I just over engineered my application a bit, however I thought add a `clear` and `clearKey` method might be useful on the MessageBag.  I won't go into detail on my use case, but I was using a singleton instance and got into a bit of trouble.

Feel free to just shoot this down, I can just as easily add it in my extended class.
