### PR TITLE
Add Validator::each for validation of arrays

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -202,6 +202,34 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
+	 * Define a set of rules that apply to each element in an array attribute.
+	 *
+	 * @param  string  $attribute
+	 * @param  string|array  $rules
+	 * @return void
+	 */
+	public function each($attribute, $rules)
+	{
+		$data = array_get($this->data, $attribute);
+
+		if ( ! is_array($data))
+		{
+			if ($this->hasRule($attribute, 'Array')) return;
+
+			throw new \InvalidArgumentException('Attribute for each() must be an array.');
+		}
+
+		foreach ($data as $dataKey => $dataValue)
+		{
+			foreach ($rules as $ruleKey => $ruleValue)
+			{
+				$key = "$attribute.$dataKey.$ruleKey";
+				$this->mergeRules($key, $ruleValue);
+			}
+		}
+	}
+
+	/**
 	 * Merge additional rules into a given attribute.
 	 *
 	 * @param  string  $attribute
@@ -1786,6 +1814,11 @@ class Validator implements MessageProviderInterface {
 	protected function getRule($attribute, $rules)
 	{
 		$rules = (array) $rules;
+
+		if ( ! array_key_exists($attribute, $this->rules))
+		{
+			return;
+		}
 
 		foreach ($this->rules[$attribute] as $rule)
 		{

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1056,6 +1056,42 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testValidateEach()
+	{
+		$trans = $this->getRealTranslator();
+		$data = ['foo' => [['field' => 5], ['field' => 10], ['field' => 15]]];
+
+		$v = new Validator($trans, $data, ['foo' => 'array']);
+		$v->each('foo', ['field' => 'numeric|min:6|max:14']);
+		$this->assertFalse($v->passes());
+
+		$v = new Validator($trans, $data, ['foo' => 'array']);
+		$v->each('foo', ['field' => 'numeric|min:4|max:16']);
+		$this->assertTrue($v->passes());
+	}
+
+
+	public function testValidateEachWithNonArrayWithArrayRule()
+	{
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, ['foo' => 'string'], ['foo' => 'array']);
+		$v->each('foo', ['field' => 'min:7|max:13']);
+		$this->assertFalse($v->passes());
+	}
+
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testValidateEachWithNonArrayWithoutArrayRule()
+	{
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, ['foo' => 'string'], ['foo' => 'numeric']);
+		$v->each('foo', ['field' => 'min:7|max:13']);
+		$this->assertFalse($v->passes());
+	}
+
+
 	protected function getTranslator()
 	{
 		return m::mock('Symfony\Component\Translation\TranslatorInterface');


### PR DESCRIPTION
Sometimes you have an array of data and you want to validate all of them equally. This feature makes that easy.

Had to fix a somewhat unrelated bug with `getRule` to make it work.
