### PR TITLE
Email config overriding issue with artisan.

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -22,10 +22,12 @@ class MailServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->registerSwiftMailer();
+		$me = $this;
 
-		$this->app->bindShared('mailer', function($app)
+		$this->app->bindShared('mailer', function($app) use($me)
 		{
+			$me->registerSwiftMailer();
+
 			// Once we have create the mailer instance, we will set a container instance
 			// on the mailer. This allows us to resolve mailer classes via containers
 			// for maximum testability on said classes instead of passing Closures.


### PR DESCRIPTION
This fixes an issue where queueing emails with overridden mail configs ( using a custom config loader ) falls back to the default config loader.

The swiftMailer registration is firing before the app is booted which makes it impossible to override its config when using artisan.

Signed-off-by: Suhayb El Wardany me@suw.me
