### PR TITLE
Fix the encrypter to actually use AES encryption by default.

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -16,21 +16,21 @@ class Encrypter {
 	 *
 	 * @var string
 	 */
-	protected $cipher = 'rijndael-256';
+	protected $cipher = MCRYPT_RIJNDAEL_128;
 
 	/**
 	 * The mode used for encryption.
 	 *
 	 * @var string
 	 */
-	protected $mode = 'cbc';
+	protected $mode = MCRYPT_MODE_CBC;
 
 	/**
 	 * The block size of the cipher.
 	 *
 	 * @var int
 	 */
-	protected $block = 32;
+	protected $block = 16;
 
 	/**
 	 * Create a new encrypter instance.
@@ -257,6 +257,7 @@ class Encrypter {
 	public function setCipher($cipher)
 	{
 		$this->cipher = $cipher;
+		$this->updateBlockSize();
 	}
 
 	/**
@@ -268,6 +269,12 @@ class Encrypter {
 	public function setMode($mode)
 	{
 		$this->mode = $mode;
+		$this->updateBlockSize();
+	}
+
+	private function updateBlockSize()
+	{
+		$this->block = mcrypt_get_iv_size($this->cipher, $this->mode);
 	}
 
 }

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -12,6 +12,14 @@ class EncrypterTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' == $e->decrypt($encrypted));
 	}
 
+	public function testEncryptionWithCustomCipher()
+	{
+		$e = $this->getEncrypter();
+		$e->setCipher(MCRYPT_RIJNDAEL_256);
+		$this->assertFalse('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' == $e->encrypt('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
+		$encrypted = $e->encrypt('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+		$this->assertTrue('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' == $e->decrypt($encrypted));
+	}
 
 	/**
 	 * @expectedException Illuminate\Encryption\DecryptException


### PR DESCRIPTION
Fix for #4027.

The encrypter class was using incorrect values for implementing AES encryption. Instead of using Rijndael with a 128 bit block size (AES), the encrypter was using a 256 bit block size. This is a common mistake - confusing the block size with the key size. This PR changes the default operation of the encrypter to use the correct cipher for AES encryption.

Note that it is still possible to decrypt data encrypted before this PR, but you must manually set `MCRYPT_RIJNDAEL_256` as the cipher.

This PR also fixes a bug whereby changing the cipher/mode would not update the internal block size used to calculate the padding length.

Regarding whether this is "important" or not, a good summary of the difference between Rijndael in 128 and 256 bit block sizes can be found in this [StackExchange answer](http://crypto.stackexchange.com/questions/6016/difference-between-rijndael-128-256-blocksize-implementations-and-impact-of):

> ...
> This means that Rijndael-128-256 will be slower than Rijndael-128-128 (AES-128), and that Rijndael-256-256 _may_ have a lower security margin that Rijndael-256-128.
> 
> **Bottom line**
> 
> Rijndael N-256 hasn't received nearly as much attention as AES, so it might have some undiscovered weaknesses.
> 
> In contrast, AES is considered secure, despite being subject to probably more cryptanalysis than any other cipher.
> 
> The 128-bit block size isn't a problem. If it ain't broken, don't fix it!

I'll submit a related documentation PR shortly.
