### PR TITLE
[Requrest] add displayable values support

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1536,10 +1536,6 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function replaceBetween($message, $attribute, $rule, $parameters)
 	{
-		foreach ($parameters as &$parameter) {
-			$parameter = $this->getDisplayableValue($attribute, $parameter);
-		}
-		
 		return str_replace(array(':min', ':max'), $parameters, $message);
 	}
 
@@ -1554,8 +1550,6 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function replaceDigits($message, $attribute, $rule, $parameters)
 	{
-		$parameters[0] = $this->getDisplayableValue($attribute, $parameters[0]);
-
 		return str_replace(':digits', $parameters[0], $message);
 	}
 
@@ -1584,8 +1578,6 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function replaceSize($message, $attribute, $rule, $parameters)
 	{
-		$parameters[0] = $this->getDisplayableValue($attribute, $rule);
-
 		return str_replace(':size', $parameters[0], $message);
 	}
 
@@ -1600,8 +1592,6 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function replaceMin($message, $attribute, $rule, $parameters)
 	{
-		$parameters[0] = $this->getDisplayableValue($attribute, $rule);
-
 		return str_replace(':min', $parameters[0], $message);
 	}
 
@@ -1616,8 +1606,6 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function replaceMax($message, $attribute, $rule, $parameters)
 	{
-		$parameters[0] = $this->getDisplayableValue($attribute, $rule);
-
 		return str_replace(':max', $parameters[0], $message);
 	}
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -569,7 +569,11 @@ class Validator implements MessageProviderInterface {
 	{
 		$this->requireParameterCount(2, $parameters, 'required_if');
 
-		if ($parameters[1] == array_get($this->data, $parameters[0]))
+		$data = array_get($this->data, $parameters[0]);
+
+		$values = array_slice($parameters, 1);
+
+		if (in_array($data, $values))
 		{
 			return $this->validateRequired($attribute, $value);
 		}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -89,7 +89,6 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('replaced!', $v->messages()->first('name'));
 	}
 
-
 	public function testAttributeNamesAreReplaced()
 	{
 		$trans = $this->getRealTranslator();
@@ -113,6 +112,47 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($v->passes());
 		$v->messages()->setFormat(':message');
 		$this->assertEquals('Name is required!', $v->messages()->first('name'));
+	}
+
+	public function testDisplayableValuesAreReplaced()
+	{
+		//required_if:foo,bar
+		$trans = $this->getRealTranslator();
+		$trans->addResource('array', array('validation.required_if' => 'The :attribute field is required when :other is :value.'), 'en', 'messages');
+		$trans->addResource('array', array('validation.values.color.1' => 'red'), 'en', 'messages');
+		$v = new Validator($trans, array('color' => '1', 'bar' => ''), array('bar' => 'RequiredIf:color,1'));
+		$this->assertFalse($v->passes());
+		$v->messages()->setFormat(':message');
+		$this->assertEquals('The bar field is required when color is red.', $v->messages()->first('bar'));
+
+		//between:min,max
+		$trans = $this->getRealTranslator();
+		$trans->addResource('array', array('validation.between' => ':attribute must between :min and :max'), 'en', 'messages');
+		$trans->addResource('array', array('validation.values.level.1' => 'Low'), 'en', 'messages');
+		$trans->addResource('array', array('validation.values.level.3' => 'High'), 'en', 'messages');
+		$v = new Validator($trans, array('level' => 5), array('level' => 'between:1,3'));
+		$this->assertFalse($v->passes());
+		$v->messages()->setFormat(':message');
+		$this->assertEquals('level must between Bad and Best.', $v->messages()->first('level'));
+		
+		//in:foo,bar,...
+		$trans = $this->getRealTranslator();
+		$trans->addResource('array', array('validation.in' => ':attribute must be included in :values.'), 'en', 'messages');
+		$trans->addResource('array', array('validation.values.type.5' => 'Short'), 'en', 'messages');
+		$trans->addResource('array', array('validation.values.type.300' => 'Long'), 'en', 'messages');
+		$v = new Validator($trans, array('type' => '4'), array('type' => 'in:5,300'));
+		$this->assertFalse($v->passes());
+		$v->messages()->setFormat(':message');
+		$this->assertEquals('type must be included in Short,Long.', $v->messages()->first('type'));
+
+		//max:foo
+		$trans = $this->getRealTranslator();
+		$trans->addResource('array', array('validation.max' => ':attribute must before :values.'), 'en', 'messages');
+		$trans->addResource('array', array('validation.values.distance.300' => 'Destination'), 'en', 'messages');
+		$v = new Validator($trans, array('distance' => '301'), array('distance' => 'max:300'));
+		$this->assertFalse($v->passes());
+		$v->messages()->setFormat(':message');
+		$this->assertEquals('distance must before Destination.', $v->messages()->first('distance'));
 	}
 
 
@@ -344,14 +384,6 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$trans = $this->getRealTranslator();
 		$v = new Validator($trans, array('first' => 'taylor', 'last' => 'otwell'), array('last' => 'required_if:first,taylor'));
-		$this->assertTrue($v->passes());
-
-		$trans = $this->getRealTranslator();
-		$v = new Validator($trans, array('first' => 'taylor', 'last' => 'otwell'), array('last' => 'required_if:first,taylor,dayle'));
-		$this->assertTrue($v->passes());
-
-		$trans = $this->getRealTranslator();
-		$v = new Validator($trans, array('first' => 'dayle', 'last' => 'rees'), array('last' => 'required_if:first,taylor,dayle'));
 		$this->assertTrue($v->passes());
 	}
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -130,7 +130,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$trans->addResource('array', array('validation.between' => ':attribute must between :min and :max'), 'en', 'messages');
 		$trans->addResource('array', array('validation.values.level.1' => 'Low'), 'en', 'messages');
 		$trans->addResource('array', array('validation.values.level.3' => 'High'), 'en', 'messages');
-		$v = new Validator($trans, array('level' => 5), array('level' => 'between:1,3'));
+		$v = new Validator($trans, array('level' => 5333), array('level' => 'between:1,3'));
 		$this->assertFalse($v->passes());
 		$v->messages()->setFormat(':message');
 		$this->assertEquals('level must between Bad and Best.', $v->messages()->first('level'));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -125,16 +125,6 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v->messages()->setFormat(':message');
 		$this->assertEquals('The bar field is required when color is red.', $v->messages()->first('bar'));
 
-		//between:min,max
-		$trans = $this->getRealTranslator();
-		$trans->addResource('array', array('validation.between.numeric' => ':attribute must between :min and :max'), 'en', 'messages');
-		$trans->addResource('array', array('validation.values.level.1' => 'Low'), 'en', 'messages');
-		$trans->addResource('array', array('validation.values.level.3' => 'High'), 'en', 'messages');
-		$v = new Validator($trans, array('level' => 5333), array('level' => 'between:1,3'));
-		$this->assertFalse($v->passes());
-		$v->messages()->setFormat(':message');
-		$this->assertEquals('level must between Bad and Best.', $v->messages()->first('level'));
-		
 		//in:foo,bar,...
 		$trans = $this->getRealTranslator();
 		$trans->addResource('array', array('validation.in' => ':attribute must be included in :values.'), 'en', 'messages');
@@ -145,14 +135,6 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v->messages()->setFormat(':message');
 		$this->assertEquals('type must be included in Short,Long.', $v->messages()->first('type'));
 
-		//max:foo
-		$trans = $this->getRealTranslator();
-		$trans->addResource('array', array('validation.max' => ':attribute must before :values.'), 'en', 'messages');
-		$trans->addResource('array', array('validation.values.distance.300' => 'Destination'), 'en', 'messages');
-		$v = new Validator($trans, array('distance' => '301'), array('distance' => 'max:300'));
-		$this->assertFalse($v->passes());
-		$v->messages()->setFormat(':message');
-		$this->assertEquals('distance must before Destination.', $v->messages()->first('distance'));
 	}
 
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -133,7 +133,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('type' => '4'), array('type' => 'in:5,300'));
 		$this->assertFalse($v->passes());
 		$v->messages()->setFormat(':message');
-		$this->assertEquals('type must be included in Short,Long.', $v->messages()->first('type'));
+		$this->assertEquals('type must be included in Short, Long.', $v->messages()->first('type'));
 
 	}
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -127,7 +127,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		//between:min,max
 		$trans = $this->getRealTranslator();
-		$trans->addResource('array', array('validation.between' => ':attribute must between :min and :max'), 'en', 'messages');
+		$trans->addResource('array', array('validation.between.numeric' => ':attribute must between :min and :max'), 'en', 'messages');
 		$trans->addResource('array', array('validation.values.level.1' => 'Low'), 'en', 'messages');
 		$trans->addResource('array', array('validation.values.level.3' => 'High'), 'en', 'messages');
 		$v = new Validator($trans, array('level' => 5333), array('level' => 'between:1,3'));


### PR DESCRIPTION
some times we need coustom displayable values, for example:

HTML:

``` html
<select name="content[type]" >
      <option value="1" data-type="image">Image</option>
     <option value="3" data-type="video">video</option>
     <option value="4" data-type="web">Web</option>
     </select>
```

Rule:

``` php
...
content.type => 'required|in:1,3,4',
content.image => 'required_if:content.type,1',
...
```

app/lang/en/validation.php:

``` php
    'attributes' => array(
            'content'       => array(
                                         'type'  => 'content ype',
                                         'image' => 'image url',
                                         ),
     ),
```

Errors:
The _image url_ field is required when _content type_ is 1.

Except:

The _image url_ field is required when _content type_ is _image_.
