### PR TITLE
add displayabled values support

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -83,6 +83,13 @@ class Validator implements MessageProviderInterface {
 	protected $customAttributes = array();
 
 	/**
+	 * The array of custom displayabled values.
+	 *
+	 * @var array
+	 */
+	protected $customValues = array();
+
+	/**
 	 * All of the custom validator extensions.
 	 *
 	 * @var array
@@ -1491,6 +1498,35 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
+	 * Get the displayable name of the value.
+	 *
+	 * @param  string $attribute
+	 * @param  mixed  $value
+	 * @return string
+	 */
+	public function getDisplayableValue($attribute, $value)
+	{
+		if (isset($this->customValues[$attribute][$value]))
+		{
+			return $this->customValues[$attribute][$value];
+		}
+
+		$key = "validation.values.{$attribute}.{$value}";
+
+		// We allow for the developer to specify language lines for each of the
+		// values allowing for more displayable counterparts of each of
+		// the attribute's value. This provides the ability for simple formats.
+		if (($line = $this->translator->trans($key)) !== $key)
+		{
+			return $line;
+		}
+		else
+		{
+			return $value;
+		}
+	}
+
+	/**
 	 * Replace all place-holders for the between rule.
 	 *
 	 * @param  string  $message
@@ -1585,6 +1621,10 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function replaceIn($message, $attribute, $rule, $parameters)
 	{
+		foreach ($parameters as &$parameter) {
+			$parameter = $this->getDisplayableValue($attribute, $parameter);
+		}
+
 		return str_replace(':values', implode(', ', $parameters), $message);
 	}
 
@@ -1599,6 +1639,10 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function replaceNotIn($message, $attribute, $rule, $parameters)
 	{
+		foreach ($parameters as &$parameter) {
+			$parameter = $this->getDisplayableValue($attribute, $parameter);
+		}
+
 		return str_replace(':values', implode(', ', $parameters), $message);
 	}
 
@@ -1675,6 +1719,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function replaceRequiredIf($message, $attribute, $rule, $parameters)
 	{
+		$parameters[1] = $this->getDisplayableValue($parameters[0], $parameters[1]);
 		$parameters[0] = $this->getAttribute($parameters[0]);
 
 		return str_replace(array(':other', ':value'), $parameters, $message);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -115,6 +115,28 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('Name is required!', $v->messages()->first('name'));
 	}
 
+	public function testDisplayableValuesAreReplaced()
+	{
+		//required_if:foo,bar
+		$trans = $this->getRealTranslator();
+		$trans->addResource('array', array('validation.required_if' => 'The :attribute field is required when :other is :value.'), 'en', 'messages');
+		$trans->addResource('array', array('validation.values.color.1' => 'red'), 'en', 'messages');
+		$v = new Validator($trans, array('color' => '1', 'bar' => ''), array('bar' => 'RequiredIf:color,1'));
+		$this->assertFalse($v->passes());
+		$v->messages()->setFormat(':message');
+		$this->assertEquals('The bar field is required when color is red.', $v->messages()->first('bar'));
+
+		//in:foo,bar,...
+		$trans = $this->getRealTranslator();
+		$trans->addResource('array', array('validation.in' => ':attribute must be included in :values.'), 'en', 'messages');
+		$trans->addResource('array', array('validation.values.type.5' => 'Short'), 'en', 'messages');
+		$trans->addResource('array', array('validation.values.type.300' => 'Long'), 'en', 'messages');
+		$v = new Validator($trans, array('type' => '4'), array('type' => 'in:5,300'));
+		$this->assertFalse($v->passes());
+		$v->messages()->setFormat(':message');
+		$this->assertEquals('type must be included in Short, Long.', $v->messages()->first('type'));
+
+	}
 
 	public function testCustomValidationLinesAreRespected()
 	{


### PR DESCRIPTION
some times we need custom displayable values, especially when using multi-byte encoded text scenes. for example:

HTML:

``` html
<label>banner type</label>
<select name="content_type" >
    <option value="1" data-type="image">Image</option>
    <option value="3" data-type="video">video</option>
    <option value="4" data-type="web">Web</option>
</select>
...
<div>
    <label>banner image</label>
    <input type="url" name="image" value="" placeholder="the url of banner image.">
</div>
<div>
    <label>banner video</label>
    <input type="url" name="video" value="" placeholder="the url of banner video.">
</div>
...
```

Rule:

``` php
    ...
    $rules = array(
              'content_type' => 'required|in:1,3,4',
              'image'        => 'required_if:content_type,1',
              'video'        => 'required_if:content_type,3',
             ),
    ...
```

app/lang/en/validation.php:

``` php
    ...
    'attributes' => array(
                     'content_type' => 'banner type',
                     'image'        => 'banner image url',
                     'video'        => 'banner video url',
                    ),
    ...
```

Request:

``` php
array(
 'content_type' => 1,
 'image'        => '',
);
```

Errors:

> The banner image url field is required when content type is 1. 

Difficult for users to understand what the number `1` is 

We expect that this:

> The banner image url field is required when banner type is Image.

Now we can add the `values` ​field to the `app/lang/en/validation.php` to achieve it：

``` php
    ...
    'values' => array(
                 'content_type' => array(
                                    '1' => 'Image',
                                    '3' => 'Video',
                                    '4' => 'Web'
                                   ),
                ),
    ...
```

Thanks!
