### PR TITLE
assert redirect to relative uri

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -242,7 +242,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 		$this->assertInstanceOf('Illuminate\Http\RedirectResponse', $response);
 
-		$this->assertEquals($this->app['url']->to($uri), $response->headers->get('Location'));
+		$this->assertEquals($uri, $response->headers->get('Location'));
 
 		$this->assertSessionHasAll($with);
 	}


### PR DESCRIPTION
If you generate the url in the assertion it prevents asserting to relative urls, since it will get the HTTP_SERVER information to create a full url (localhost set in symfony's component I believe).  So if you have Redirect::to('/location') in a controller and then assertRedirectTo('/location') it will fail because the assertion will actually create http://localhost/location.  I think it would be better to pass the plain given uri because theres an app instance available in the test so you could create this behavior if you really wanted to.  This is just first glance so maybe theres a specific reason for this I'm missing.  All tests still pass.
