### PR TITLE
Fixes #2768: singular for criteria is criterion (in laravel/laravel)

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -73,7 +73,7 @@ class Pluralizer {
 	 */
 	public static $irregular = array(
 		'child' => 'children',
-        'criterion' => 'criteria',
+		'criterion' => 'criteria',
 		'foot' => 'feet',
 		'freshman' => 'freshmen',
 		'goose' => 'geese',

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -73,6 +73,7 @@ class Pluralizer {
 	 */
 	public static $irregular = array(
 		'child' => 'children',
+        'criterion' => 'criteria',
 		'foot' => 'feet',
 		'freshman' => 'freshmen',
 		'goose' => 'geese',

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -10,6 +10,7 @@ class SupportPluralizerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('child', str_singular('children'));
 		$this->assertEquals('test', str_singular('tests'));
 		$this->assertEquals('deer', str_singular('deer'));
+		$this->assertEquals('criterion', str_singular('criteria'));
 	}
 
 	public function testCaseSensitiveUsage()
@@ -27,6 +28,8 @@ class SupportPluralizerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('TEST', str_singular('TESTS'));
 		$this->assertEquals('Deer', str_singular('Deer'));
 		$this->assertEquals('DEER', str_singular('DEER'));
+		$this->assertEquals('Criterion', str_singular('Criteria'));
+		$this->assertEquals('CRITERION', str_singular('CRITERIA'));
 	}
 
 }


### PR DESCRIPTION
This fixes #2768 in laravel/laravel so that the singular for criteria will be criterion

Let me know if I should do things differently in regards to pull requests, not really familiar with them but thought I'd give it a go with my favourite framework :)
