### PR TITLE
[Proposal] added '/' fallback for Redirect::back()

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -50,7 +50,7 @@ class Redirector {
 	 */
 	public function back($status = 302, $headers = array())
 	{
-		$back = $this->generator->getRequest()->headers->get('referer');
+		$back = $this->generator->getRequest()->headers->get('referer', '/');
 
 		return $this->createRedirect($back, $status, $headers);
 	}


### PR DESCRIPTION
Added a fallback value `/` for `Redirect::back()` 

Example scenario: 

I have a filter `flag.check` on a route `/user/{id}/edit`, in this filter I check a condition and if it fails it should `Redirect::back()->with('error', 'You do not have sufficient permissions for this task');` to where the user came from and not allow access to the edit route. However, someone may try to hit the url directly if they know RESTful (or guess) the url structure. In this case it throws a `can not redirect to empty url` error. 

With this change, if the user has typed the url into the browser it will redirect to `/` with the error message
