### PR TITLE
Make registerSwiftMailer public

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -63,7 +63,7 @@ class MailServiceProvider extends ServiceProvider {
 	 *
 	 * @return void
 	 */
-	protected function registerSwiftMailer()
+	public function registerSwiftMailer()
 	{
 		$config = $this->app['config']['mail'];
 


### PR DESCRIPTION
http://laravel.io/forum/04-04-2014-fatalerrorexception-within-mailserviceprovider
#4029 broke 5.3 compatibility. This fixes it.
