### PR TITLE
Support mixed target data in data_get

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -557,23 +557,38 @@ if ( ! function_exists('data_get'))
 	 * @param  string  $key
 	 * @param  mixed   $default
 	 * @return mixed
-	 *
-	 * @throws \InvalidArgumentException
 	 */
 	function data_get($target, $key, $default = null)
 	{
-		if (is_array($target))
+		if (is_null($key)) return $target;
+
+		foreach (explode('.', $key) as $segment)
 		{
-			return array_get($target, $key, $default);
+			if (is_array($target))
+			{
+				if ( ! array_key_exists($segment, $target))
+				{
+					return value($default);
+				}
+
+				$target = $target[$segment];
+			}
+			elseif (is_object($target))
+			{
+				if ( ! isset($target->{$segment}))
+				{
+					return value($default);
+				}
+
+				$target = $target->{$segment};
+			}
+			else
+			{
+				return value($default);
+			}
 		}
-		elseif (is_object($target))
-		{
-			return object_get($target, $key, $default);
-		}
-		else
-		{
-			throw new \InvalidArgumentException("Array or object must be passed to data_get.");
-		}
+
+		return $target;
 	}
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -207,6 +207,17 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('Taylor', object_get($class, 'name.first'));
 	}
 
+	public function testDataGet()
+	{
+		$object = (object) array('users' => array('name' => array('Taylor', 'Otwell')));
+		$array = array((object) array('users' => array((object) array('name' => 'Taylor'))));
+
+		$this->assertEquals('Taylor', data_get($object, 'users.name.0'));
+		$this->assertEquals('Taylor', data_get($array, '0.users.0.name'));
+		$this->assertNull(data_get($array, '0.users.3'));
+		$this->assertEquals('Not found', data_get($array, '0.users.3', 'Not found'));
+		$this->assertEquals('Not found', data_get($array, '0.users.3', function (){ return 'Not found'; }));
+	}
 
 	public function testArraySort()
 	{


### PR DESCRIPTION
This will allow `data_get` to go many levels deep into an object/array, supporting objects/arrays interchangeably all the way down the tree:

```
$object = new stdClass;
$object->framework = ['name' => 'Laravel'];
$framework = data_get($object, 'framework.name');
```
