### PR TITLE
Added @{{{ handling

### DIFF
--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -139,6 +139,15 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$compiler->compileString('@{{
 			$name
 		}}'));
+
+		$this->assertEquals('{{{$name}}}', $compiler->compileString('@{{{$name}}}'));
+		$this->assertEquals('{{{ $name }}}', $compiler->compileString('@{{{ $name }}}'));
+		$this->assertEquals('{{{
+			$name
+		}}}',
+		$compiler->compileString('@{{{
+			$name
+		}}}'));
 	}
 
 


### PR DESCRIPTION
Adding support for @{{{ so it is handled in the same way as @{{. This was a quick addition, and there is probably a cleaner/much better way to do this. Just added it because it was reported in #4062. 

It passed all tests locally, so it doesn't seem to cause any issues. Added to master anyway just in case some issues arise.
