### PR TITLE
Fix `count` method return value. #4.0

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1308,7 +1308,7 @@ class Builder {
 	 */
 	public function count($column = '*')
 	{
-		return $this->aggregate(__FUNCTION__, array($column));
+		return (int)$this->aggregate(__FUNCTION__, array($column));
 	}
 
 	/**


### PR DESCRIPTION
Hi there, I have very simple query

``` php
dd($this->borrowings()->count());
```

**Actual output**

```
string(1) "1"
```

**Expected output**

```
int(1)
```

Happens on 4.1.x, but probably on 4.x versions as well.  
Since this, we cannot relly on `===` comparsion operator, which result into `false` all the time.  
Is this behaviour by design, or just a flaw?
