### PR TITLE
Make exception handler comply with HttpKernelInterface

### DIFF
--- a/src/Illuminate/Exception/Handler.php
+++ b/src/Illuminate/Exception/Handler.php
@@ -102,7 +102,7 @@ class Handler {
 	 */
 	protected function registerExceptionHandler()
 	{
-		set_exception_handler(array($this, 'handleException'));
+		set_exception_handler(array($this, 'handleUncaughtException'));
 	}
 
 	/**
@@ -138,7 +138,7 @@ class Handler {
 	 * Handle an exception for the application.
 	 *
 	 * @param  \Exception  $exception
-	 * @return void
+	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
 	public function handleException($exception)
 	{
@@ -149,31 +149,24 @@ class Handler {
 		// type of exceptions to handled by a Closure giving great flexibility.
 		if ( ! is_null($response))
 		{
-			$response = $this->prepareResponse($response);
+			return $this->prepareResponse($response);
 		}
 
 		// If no response was sent by this custom exception handler, we will call the
 		// default exception displayer for the current application context and let
 		// it show the exception to the user / developer based on the situation.
-		else
-		{
-			$response = $this->displayException($exception);
-		}
-
-		return $this->sendResponse($response);
+		return $this->displayException($exception);
 	}
 
 	/**
-	 * Send the repsonse back to the client.
+	 * Handle an uncaught exception.
 	 *
-	 * @param  \Symfony\Component\HttpFoundation\Response  $response
-	 * @return mixed
+	 * @param  \Exception  $exception
+	 * @return void
 	 */
-	protected function sendResponse($response)
+	public function handleUncaughtException($exception)
 	{
-		return $this->responsePreparer->readyForResponses() && ! $this->runningInConsole()
-								? $response
-								: $response->send();
+		$this->handleException($exception)->send();
 	}
 
 	/**


### PR DESCRIPTION
Removed `Handler::sendResponse`. In the case of `Application::handle`'s try/catch block catching an exception, the Response object should be returned, not sent immediately, in order to comply to the HttpKernelInterface.

This may also fix the long standing bug where `App::after` / `App::shutdown` callbacks not firing for error responses.

Added `handleUncaughtException` which _does_ send the response, in case of uncaught exceptions (that is, exceptions that occur outside of any try/catch block such as the one found in `Application::handle`.

My use case for this is that I need to write some tests for a package that rely on the exception handler functioning properly. Currently, if an exception is caught by `Application::run` and the environment is "testing", the exception will just be re-thrown, but if I se the environment to something else, the response is sent and floods the terminal with HTML.
