### PR TITLE
[4.1] Component Composer Fixes/Improvements

### DIFF
--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -10,11 +10,11 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/encryption": "4.1.*",
-        "illuminate/support": "4.1.*",
         "symfony/http-kernel": "2.4.*",
         "symfony/http-foundation": "2.4.*"
     },
     "require-dev": {
+        "illuminate/support": "4.1.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "4.0.*"
     },

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -8,10 +8,10 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
-        "illuminate/support": "4.1.*"
+        "php": ">=5.3.0"
     },
     "require-dev": {
+        "illuminate/support": "4.1.*",
         "phpunit/phpunit": "4.0.*"
     },
     "autoload": {

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -9,10 +9,10 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.*",
         "symfony/finder": "2.4.*"
     },
     "require-dev": {
+        "illuminate/support": "4.1.*",
         "phpunit/phpunit": "4.0.*"
     },
     "autoload": {

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -9,10 +9,10 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.*",
         "ircmaxell/password-compat": "1.0.*"
     },
     "require-dev": {
+        "illuminate/support": "4.1.*",
         "phpunit/phpunit": "4.0.*"
     },
     "autoload": {

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -9,13 +9,13 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.*",
         "monolog/monolog": "1.*"
     },
     "require-dev": {
+        "illuminate/events": "4.1.*",
+        "illuminate/support": "4.1.*",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "4.0.*",
-        "illuminate/events": "4.1.*"
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -9,10 +9,10 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.*",
         "predis/predis": "0.8.*"
     },
     "require-dev": {
+        "illuminate/support": "4.1.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "4.0.*"
     },

--- a/src/Illuminate/Remote/composer.json
+++ b/src/Illuminate/Remote/composer.json
@@ -9,11 +9,14 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.*",
-        "phpseclib/phpseclib": "0.3.*"
+        "phpseclib/phpseclib": "0.3.*",
+        "illuminate/support": "4.1.*"
     },
     "require-dev": {
-        "mockery/mockery": "0.8.0"
+        "illuminate/console": "4.1.*",
+        "illuminate/filesystem": "4.1.*",
+        "mockery/mockery": "0.9.*",
+        "phpunit/phpunit": "4.0.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Workbench/composer.json
+++ b/src/Illuminate/Workbench/composer.json
@@ -9,11 +9,11 @@
     ],
     "require": {
         "illuminate/filesystem": "4.1.*",
-        "illuminate/support": "4.1.*",
         "symfony/finder": "2.4.*"
     },
     "require-dev": {
         "illuminate/console": "4.1.*",
+        "illuminate/support": "4.1.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "4.0.*"
     },


### PR DESCRIPTION
I've moved the support dependencies to require-dev if they are only used in service providers to improve usage outside of laravel. I've also added some missing dev-dependencies to the remote composer.json.
