### PR TITLE
[Feature] Auto HTTP OPTIONS response

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -120,7 +120,9 @@ class RouteCollection implements Countable, IteratorAggregate {
 	 */
 	public function match(Request $request)
 	{
-		$routes = $this->get($request->getMethod());
+		$method = $request->getMethod();
+
+		$routes = $this->get($method);
 
 		// First, we will see if we can find a matching route for this current request
 		// method. If we can, great, we can just return it so that it can be called
@@ -133,37 +135,56 @@ class RouteCollection implements Countable, IteratorAggregate {
 		}
 
 		// If no route was found, we will check if a matching is route is specified on
-		// another HTTP verb. If it is we will need to throw a MethodNotAllowed and
-		// inform the user agent of which HTTP verb it should use for this route.
-		$this->checkForAlternateVerbs($request);
+		// another HTTP verb.
+		$alternativeVerbs = $this->checkForAlternateVerbs($method, $request->path());
+
+		// If we have some verbs, then we might need to complain. First though, 
+		// if this is an OPTIONS call we can programatically offer some useful 
+		// information.
+		if ($alternativeVerbs)
+		{
+			if ($method === 'OPTIONS')
+			{
+				// @TODO Make this talk to the actual Symfony/Laravel response somehow
+				header('Allow: '.implode(',', $alternativeVerbs));
+				exit;
+			}
+
+			// We know that some other route exists for this uri, but we do not 
+			// know how well it is implemented. Really we don't care, just complain
+			// and die.
+			else
+			{
+				$this->methodNotAllowed($method);
+			}
+		}
 
 		throw new NotFoundHttpException;
 	}
 
 	/**
-	 * Determine if any routes match on another HTTP verb.
+	 * Determine if any routes match this URI using another HTTP verb.
 	 *
-	 * @param  \Illuminate\Http\Request  $request
-	 * @return void
+	 * @param  string  $method
+	 * @param  string  $uri
+	 * @return array
 	 */
-	protected function checkForAlternateVerbs($request)
+	protected function checkForAlternateVerbs($method, $uri)
 	{
-		$others = array_diff(Router::$verbs, array($request->getMethod()));
-
-		// Here we will spin through all verbs except for the current request verb and
-		// check to see if any routes respond to them. If they do, we will return a
-		// proper error response with the correct headers on the response string.
-		foreach ($others as $other)
+		$matchingMethods = array();
+		foreach ($this->actionList as $route)
 		{
-			if ( ! is_null($this->check($this->get($other), $request)))
+			if ($route->uri() == $uri)
 			{
-				$this->methodNotAllowed($other);
+				$matchingMethods = array_merge($matchingMethods, $route->getMethods());
 			}
-		}
+		};
+
+		return array_unique(array_diff($matchingMethods, array($method)));
 	}
 
 	/**
-	 * Throw a methdo not allowed HTTP exception.
+	 * Throw a method not allowed HTTP exception.
 	 *
 	 * @param  string  $other
 	 * @return void


### PR DESCRIPTION
If the OPTIONS verb is not implemented manually through the router (quite likely) then Laravel should respond with the routes that are available. It does this by looking at the action list and listing a unique set of verbs. 

For example, if I set:

``` php
Route::get('/places', 'PlaceController@index');
Route::post('/places', 'PlaceController@create');
```

... then I would expect to see the header:

> Allow: GET,HEAD,POST

Now, two things. 

1.) This might not be the fastest approach, but I did not want to add a huge amount of pre-population of new arrays just for this feature, as that would muddy what is actually happening somewhat.

2.) Obviously `exit;` is a bad idea. I have no idea how to bubble this header back up from the method in which I have set it, to somewhere where the actual response is available. @taylorotwell hopefully you can gimme some advice on that? 

Everything else works as expected. :) 
