### PR TITLE
Add/fix support for distinct selects when using pagination

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1549,13 +1549,13 @@ class Builder {
 	 */
 	public function getPaginationCount()
 	{
+		// Because some database engines may throw errors if we leave the ordering
+		// statements on the query, we will "back them up" and remove them from
+		// the query. Once we have the count we will put them back onto this.
 		list($orders, $this->orders) = array($this->orders, null);
 
 		$columns = $this->columns;
 
-		// Because some database engines may throw errors if we leave the ordering
-		// statements on the query, we will "back them up" and remove them from
-		// the query. Once we have the count we will put them back onto this.
 		$total = $this->count();
 
 		$this->orders = $orders;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1556,7 +1556,17 @@ class Builder {
 
 		$columns = $this->columns;
 
-		$total = $this->count();
+		// We have to check if the value is "null" so that the count function does
+		// not attempt to count an invalid string. Checking the value is better
+		// here because the count function already has an optional parameter.
+		if ( is_null($columns))
+		{
+			$total = $this->count();
+		}
+		else
+		{
+			$total = $this->count($columns);
+		}
 
 		$this->orders = $orders;
 
@@ -1581,12 +1591,17 @@ class Builder {
 	/**
 	 * Retrieve the "count" result of the query.
 	 *
-	 * @param  string  $column
+	 * @param  string  $columns
 	 * @return int
 	 */
-	public function count($column = '*')
+	public function count($columns = '*')
 	{
-		return (int) $this->aggregate(__FUNCTION__, array($column));
+		if ( ! is_array($columns))
+		{
+			$columns = array($columns);
+		}
+
+		return (int) $this->aggregate(__FUNCTION__, $columns);
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1559,7 +1559,7 @@ class Builder {
 		// We have to check if the value is "null" so that the count function does
 		// not attempt to count an invalid string. Checking the value is better
 		// here because the count function already has an optional parameter.
-		if ( is_null($columns))
+		if (is_null($columns))
 		{
 			$total = $this->count();
 		}

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -690,6 +690,27 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testGetPaginationCountGetsResultCountWithSelectDistinct()
+	{
+		unset($_SERVER['orders']);
+		$builder = $this->getBuilder();
+		$builder->getConnection()->shouldReceive('select')->once()->with('select count(distinct "foo", "bar") as aggregate from "users"', array())->andReturn(array(array('aggregate' => 1)));
+		$builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function($query, $results)
+		{
+			$_SERVER['orders'] = $query->orders;
+			return $results;
+		});
+		$results = $builder->distinct()->select('foo', 'bar')->from('users')->orderBy('foo', 'desc')->getPaginationCount();
+
+		$this->assertNull($_SERVER['orders']);
+		unset($_SERVER['orders']);
+
+		$this->assertEquals(array('foo', 'bar'), $builder->columns);
+		$this->assertEquals(array(0 => array('column' => 'foo', 'direction' => 'desc')), $builder->orders);
+		$this->assertEquals(1, $results);
+	}
+
+
 	public function testPluckMethodReturnsSingleColumn()
 	{
 		$builder = $this->getBuilder();


### PR DESCRIPTION
This adds/fixes the ability to use `select()->distinct()->paginate()`. Previously, the count would be off because the count query disregarded `distinct()`.

Fixes #3191
