### PR TITLE
Very minor, spelling mistake in DocBlock.

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -146,7 +146,7 @@ class RouteCollection implements Countable, IteratorAggregate {
 	}
 
 	/**
-	 * Throw a methdo not allowed HTTP exception.
+	 * Throw a method not allowed HTTP exception.
 	 *
 	 * @param  string  $other
 	 * @return void


### PR DESCRIPTION
I found this very minor spelling error whilst creating unit tests for a Laravel 4 Service Provider.
