### PR TITLE
Make Model::hydrate's first argument mandatory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -405,7 +405,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * @param  string  $connection
 	 * @return \Illuminate\Database\Eloquent\Collection
 	 */
-	public static function hydrate(array $items = array(), $connection = null)
+	public static function hydrate(array $items, $connection = null)
 	{
 		$collection = with($instance = new static)->newCollection();
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -893,7 +893,7 @@ class EloquentModelDestroyStub extends Illuminate\Database\Eloquent\Model {
 }
 
 class EloquentModelHydrateRawStub extends Illuminate\Database\Eloquent\Model {
-	public static function hydrate(array $items = array(), $connection = null) { return 'hydrated'; }
+	public static function hydrate(array $items, $connection = null) { return 'hydrated'; }
 	public function getConnection()
 	{
 		$mock = m::mock('Illuminate\Database\Connection');


### PR DESCRIPTION
It makes no sense to call `Model::hydrate()` with no arguments.
