### PR TITLE
Adds two helper methods for generating HTML links based on a condition.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -651,6 +651,48 @@ if ( ! function_exists('link_to'))
 	}
 }
 
+if ( ! function_exists('link_to_if'))
+{
+    /**
+     * Generate a HTML link if the condition returns true.
+     *
+     * @param  bool    $condition
+     * @param  string  $url
+     * @param  string  $title
+     * @param  array   $attributes
+     * @param  bool    $secure
+     * @return string
+     */
+    function link_to_if($condition, $url, $title = null, $attributes = array(), $secure = null)
+    {
+        if ($condition)
+            return app('html')->link($url, $title, $attributes, $secure);
+
+        return null;
+    }
+}
+
+if ( ! function_exists('link_to_unless'))
+{
+    /**
+     * Generate a HTML link unless the condition returns true.
+     *
+     * @param  bool    $condition
+     * @param  string  $url
+     * @param  string  $title
+     * @param  array   $attributes
+     * @param  bool    $secure
+     * @return string
+     */
+    function link_to_unless($condition, $url, $title = null, $attributes = array(), $secure = null)
+    {
+        if ( ! $condition)
+            return app('html')->link($url, $title, $attributes, $secure);
+
+        return null;
+    }
+}
+
 if ( ! function_exists('last'))
 {
 	/**


### PR DESCRIPTION
This is an implementation of the Ruby URL helpers documented at:
- **link_to_if** http://apidock.com/rails/ActionView/Helpers/UrlHelper/link_to_if
- **link_to_unless** http://apidock.com/rails/ActionView/Helpers/UrlHelper/link_to_unless

If I need to submit tests along with this, please let me know.  I noticed the [link_to](https://github.com/laravel/framework/blob/master/src/Illuminate/Support/helpers.php#L637) helper did not have tests and I assume that is because it requires the framework to be booted.  I am happy to attempt the process of writing tests for link_to\* helpers!

Thanks!
