### PR TITLE
Allow Input::exists to be passed an array

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -164,21 +164,16 @@ class Request extends SymfonyRequest {
 	 */
 	public function exists($key)
 	{
+		$keys = is_array($key) ? $key : func_get_args();
+
 		$input = $this->all();
 
-		if (count(func_get_args()) > 1)
+		foreach ($keys as $value)
 		{
-			foreach (func_get_args() as $value)
-			{
-				if ( ! array_key_exists($value, $input)) return false;
-			}
+			if ( ! array_key_exists($value, $input)) return false;
+		}
 
-			return true;
-		}
-		else
-		{
-			return array_key_exists($key, $input);
-		}
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
It's already in the docblock, so why not?
