### PR TITLE
[Bug] Unable to limit and order unions

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -935,7 +935,14 @@ class Builder {
 	{
 		$direction = strtolower($direction) == 'asc' ? 'asc' : 'desc';
 
-		$this->orders[] = compact('column', 'direction');
+		if ($this->unions)
+		{
+			$this->unionOrders[] = compact('column', 'direction');
+		}
+		else
+		{
+			$this->orders[] = compact('column', 'direction');
+		}
 
 		return $this;
 	}
@@ -1012,7 +1019,16 @@ class Builder {
 	 */
 	public function limit($value)
 	{
-		if ($value > 0) $this->limit = $value;
+		if ($value <= 0) return $this;
+
+		if ($this->unions)
+		{
+			$this->limitUnion = $value;
+		}
+		else
+		{
+			$this->limit = $value;
+		}
 
 		return $this;
 	}
@@ -1068,35 +1084,6 @@ class Builder {
 	public function unionAll($query)
 	{
 		return $this->union($query, true);
-	}
-
-	/**
-	 * Set the "limit" value of the union query.
-	 *
-	 * @param  int  $value
-	 * @return \Illuminate\Database\Query\Builder|static
-	 */
-	public function limitUnion($value)
-	{
-		if ($value > 0) $this->unionLimit = $value;
-
-		return $this;
-	}
-	
-	/**
-	 * Add an "order by" clause to the union query.
-	 *
-	 * @param  string  $column
-	 * @param  string  $direction
-	 * @return \Illuminate\Database\Query\Builder|static
-	 */
-	public function orderUnionBy($column, $direction = 'asc')
-	{
-		$direction = strtolower($direction) == 'asc' ? 'asc' : 'desc';
-
-		$this->unionOrders[] = compact('column', 'direction');
-
-		return $this;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1023,7 +1023,7 @@ class Builder {
 
 		if ($this->unions)
 		{
-			$this->limitUnion = $value;
+			$this->unionLimit = $value;
 		}
 		else
 		{

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -121,6 +121,20 @@ class Builder {
 	public $unions;
 
 	/**
+	 * The maximum number of union records to return.
+	 *
+	 * @var int
+	 */
+	public $unionLimit;
+	
+	/**
+	 * The orderings for the union query.
+	 *
+	 * @var array
+	 */
+	public $unionOrders;
+
+	/**
 	 * Indicates whether row locking is being used.
 	 *
 	 * @var string|bool
@@ -1054,6 +1068,35 @@ class Builder {
 	public function unionAll($query)
 	{
 		return $this->union($query, true);
+	}
+
+	/**
+	 * Set the "limit" value of the union query.
+	 *
+	 * @param  int  $value
+	 * @return \Illuminate\Database\Query\Builder|static
+	 */
+	public function limitUnion($value)
+	{
+		if ($value > 0) $this->unionLimit = $value;
+
+		return $this;
+	}
+	
+	/**
+	 * Add an "order by" clause to the union query.
+	 *
+	 * @param  string  $column
+	 * @param  string  $direction
+	 * @return \Illuminate\Database\Query\Builder|static
+	 */
+	public function orderUnionBy($column, $direction = 'asc')
+	{
+		$direction = strtolower($direction) == 'asc' ? 'asc' : 'desc';
+
+		$this->unionOrders[] = compact('column', 'direction');
+
+		return $this;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -508,6 +508,16 @@ class Grammar extends BaseGrammar {
 			$sql .= $this->compileUnion($union);
 		}
 
+		if (isset($query->unionOrders))
+		{
+			$sql .= ' '.$this->compileOrders($query, $query->unionOrders);
+		}
+
+		if (isset($query->unionLimit))
+		{
+			$sql .= ' '.$this->compileLimit($query, $query->unionLimit);
+		}
+
 		return ltrim($sql);
 	}
 


### PR DESCRIPTION
Refs https://github.com/laravel/framework/pull/3901
Fixes https://github.com/laravel/laravel/issues/2664

---

There is no streamlined method to to sort or limit a union query. Eg:

```
$query1->union($query2)->orderBy('foo'); 
```

This sorts $query1, not the union.

**Desired SQL:**

`(query 1 sql) union (query 2 sql) order by foo`

**Actual SQL:**

`(query 1 sql order by foo) union (query 2 sql)`

**Current solution (which is pretty bad):**

```
$result = DB::select(DB::raw($query1->toSql() . ' ORDER BY foo'), $query1->getBindings());
```

**Proposed solution**:

Syntax has not changed, logic has been improved.
- If `limit()` or `orderBy()` is called _after_ a `union()`, it will affect the union query, not the calling query. To constrain the query, it must be done before `union()` is called. Eg:

```
$query1->orderBy('foo')->union($query2)->orderBy('bar'); 
```

Resulting SQL:

`(query 1 sql order by foo) union (query 2 sql) order by bar`

Note:

To `limit` or `orderBy` the calling query, it should come before the `union`.

No documentation change is required, this is an implied expectation.

Cheers
