### PR TITLE
[Proposal] [WIP] Customizable publish paths

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -37,6 +37,13 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	protected $booted = false;
 
 	/**
+	 * Packages registered with the application.
+	 *
+	 * @var array
+	 */
+	protected $packages = [];
+
+	/**
 	 * The array of booting callbacks.
 	 *
 	 * @var array
@@ -1052,6 +1059,22 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 		$this['translator']->setLocale($locale);
 
 		$this['events']->fire('locale.changed', array($locale));
+	}
+
+	public function registerPackage($package, array $paths)
+	{
+		$this->packages[$package] = $paths;
+	}
+
+	public function getPackage($package)
+	{
+		return array_key_exists($package, $this->packages) ?
+			$this->packages[$package] : null;
+	}
+
+	public function getPackages()
+	{
+		return $this->packages;
 	}
 
 	/**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -109,6 +109,13 @@ abstract class ServiceProvider {
 			$this->app['view']->addNamespace($namespace, $view);
 		}
 
+		$asset = isset($paths['asset']) ? $paths['asset'] : $path.'/public';
+
+		if ($this->app['files']->isDirectory($asset))
+		{
+			$paths['asset'] = $asset;
+		}
+
 		$this->app->registerPackage($package, $paths);
 	}
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -58,22 +58,33 @@ abstract class ServiceProvider {
 		// In this method we will register the configuration package for the package
 		// so that the configuration options cleanly cascade into the application
 		// folder to make the developers lives much easier in maintaining them.
-		$path = $path ?: $this->guessPackagePath();
+		if (is_array($path))
+		{
+			$paths = $path;
+			$path = $this->guessPackagePath();
+		}
+		else
+		{
+			$path = $path ?: $this->guessPackagePath();
+			$paths = [];
+		}
 
-		$config = $path.'/config';
+		$config = isset($paths['config']) ? $paths['config'] : $path.'/config';
 
 		if ($this->app['files']->isDirectory($config))
 		{
+			$paths['config'] = $config;
 			$this->app['config']->package($package, $config, $namespace);
 		}
 
 		// Next we will check for any "language" components. If language files exist
 		// we will register them with this given package's namespace so that they
 		// may be accessed using the translation facilities of the application.
-		$lang = $path.'/lang';
+		$lang = isset($paths['lang']) ? $paths['lang'] : $path.'/lang';
 
 		if ($this->app['files']->isDirectory($lang))
 		{
+			$paths['lang'] = $lang;
 			$this->app['translator']->addNamespace($namespace, $lang);
 		}
 
@@ -90,12 +101,15 @@ abstract class ServiceProvider {
 		// Finally we will register the view namespace so that we can access each of
 		// the views available in this package. We use a standard convention when
 		// registering the paths to every package's views and other components.
-		$view = $path.'/views';
+		$view = isset($paths['view']) ? $paths['view'] : $path.'/view';
 
 		if ($this->app['files']->isDirectory($view))
 		{
+			$paths['view'] = $view;
 			$this->app['view']->addNamespace($namespace, $view);
 		}
+
+		$this->app->registerPackage($package, $paths);
 	}
 
 	/**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -116,6 +116,13 @@ abstract class ServiceProvider {
 			$paths['asset'] = $asset;
 		}
 
+		$migrations = isset($paths['migrations']) ? $paths['migrations'] : $path.'/migrations';
+
+		if ($this->app['files']->isDirectory($migrations))
+		{
+			$paths['migrations'] = $migrations;
+		}
+
 		$this->app->registerPackage($package, $paths);
 	}
 


### PR DESCRIPTION
Related: #4013

Currently, the various publish commands assume in a very rigid fashion that config files reside within "/src/config", view files inside "/src/views" and so on (relative to the package root). This is not very flexible, especially with PSR-4 autoloading becoming more popular.

Here's one idea on how to handle it - keep an array of registered package paths on the Application class, let service providers add to that array and then somehow pass those on to every Publisher and/or PublishCommand class.

Thoughts?
