### PR TITLE
4.1 Why are protected next methods ?

### DIFF
--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -81,6 +81,7 @@ class Factory {
 	 * @param  array  $data
 	 * @param  array  $rules
 	 * @param  array  $messages
+	 * @param  array  $customAttributes
 	 * @return \Illuminate\Validation\Validator
 	 */
 	public function make(array $data, array $rules, array $messages = array(), array $customAttributes = array())
@@ -114,7 +115,7 @@ class Factory {
 	 * @param  \Illuminate\Validation\Validator  $validator
 	 * @return void
 	 */
-	protected function addExtensions($validator)
+	protected function addExtensions(Validator $validator)
 	{
 		$validator->addExtensions($this->extensions);
 
@@ -136,9 +137,10 @@ class Factory {
 	 * @param  array  $data
 	 * @param  array  $rules
 	 * @param  array  $messages
+	 * @param  array  $customAttributes
 	 * @return \Illuminate\Validation\Validator
 	 */
-	protected function resolve($data, $rules, $messages, $customAttributes)
+	protected function resolve(array $data, array $rules, array $messages, array $customAttributes)
 	{
 		if (is_null($this->resolver))
 		{

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -126,10 +126,10 @@ class Validator implements MessageProviderInterface {
 	 * @param  array  $data
 	 * @param  array  $rules
 	 * @param  array  $messages
-	 * @param  array $customAttributes
+	 * @param  array  $customAttributes
 	 * @return void
 	 */
-	public function __construct(TranslatorInterface $translator, $data, $rules, $messages = array(), $customAttributes = array())
+	public function __construct(TranslatorInterface $translator, array $data, array $rules, array $messages = array(), array $customAttributes = array())
 	{
 		$this->translator = $translator;
 		$this->customMessages = $messages;


### PR DESCRIPTION
In  \Illuminate\Database\Eloquent\Model

protected function getDateFormat()
protected function asDateTime($value)

I think better make its public, i need for them. Thanks.
