### PR TITLE
Update replacerRequiredIf for multiple values

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1709,9 +1709,9 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function replaceRequiredIf($message, $attribute, $rule, $parameters)
 	{
-		$parameters[0] = $this->getAttribute($parameters[0]);
+		$other = $this->getAttribute($parameters[0]);
 
-		return str_replace(array(':other', ':value'), $parameters, $message);
+		return str_replace(array(':other', ':value'), array($other, implode(' / ', array_slice($parameters,1))), $message);
 	}
 
 	/**


### PR DESCRIPTION
This brings the replacer in line with the rule as modified in commit 4bc806c6fc5759d5f7227c3aa632af82282a6fa5 to accept multiple values. Now the replacer will print those multiple values to the corresponding error message.

`:value` is being used as though it were the plural `:values`. To correct this would mean updating the default language lines and causing some backwards compatibility friction.
