### PR TITLE
Made getKeys return a unique array of keys.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -171,11 +171,11 @@ abstract class Relation {
 	 */
 	protected function getKeys(array $models, $key = null)
 	{
-		return array_values(array_map(function($value) use ($key)
+		return array_unique(array_values(array_map(function($value) use ($key)
 		{
 			return $key ? $value->getAttribute($key) : $value->getKey();
 
-		}, $models));
+		}, $models)));
 	}
 
 	/**


### PR DESCRIPTION
This was causing applications to crash if there was somehow thousands of keys, but where most the same.

Caused the program to error with a status code of 100. With no errors at all.

This is hard to replicate, but with eager loading and belongsToMany relations, this bug was happening.

[EDIT] I've done a little more searching and this was causing PHP to crash causing a Apache "Segmentation fault (11)" and killing off a child.
