### PR TITLE
fire an event on cache clear

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -60,7 +60,7 @@ class ClearCommand extends Command {
 
 		$this->files->delete($this->laravel['config']['app.manifest'].'/services.json');
 		
-		$this->laravel['events']->fire('cache:clear');
+		$this->laravel['events']->fire('cache:cleared');
 
 		$this->info('Application cache cleared!');
 	}

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -59,6 +59,8 @@ class ClearCommand extends Command {
 		$this->cache->flush();
 
 		$this->files->delete($this->laravel['config']['app.manifest'].'/services.json');
+		
+		$this->laravel['events']->fire('cache:clear');
 
 		$this->info('Application cache cleared!');
 	}


### PR DESCRIPTION
In some situations, users may store certain cache-style data in a more custom manner than the Cache functions permit. For example, we store most cache data in Redis, but have a few larger cacheable items (rendered, minified CSS) that would incur high levels of unnecessary network traffic from the Redis server if stored there. For these larger items, we manually store to the db and/or the filesystem.

Adding a `cache:clear` event to `php artisan cache:clear` allows for a cache clearing to be hooked into via an event for additional custom processing.
