### PR TITLE
Fixed sockets not working in Laravel

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -55,17 +55,18 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 		// need to establish the PDO connections and return them back for use.
 		extract($config);
 
-		$dsn = "mysql:host={$host};dbname={$database}";
-
-		if (isset($config['port']))
+		$dsn = "mysql:dbname={$database}";
+		
+		if (isset($config['unix_socket'])) 
 		{
-			$dsn .= ";port={$port}";
-		}
-
-		// Sometimes the developer may specify the specific UNIX socket that should
-		// be used. If that is the case we will add that option to the string we
-		// have created so that it gets utilized while the connection is made.
-		if (isset($config['unix_socket']))
+			$dsn .= ";host={$host}";
+	
+			if (isset($config['port']))
+			{
+				$dsn .= ";port={$port}";
+			}
+		} 
+		else 
 		{
 			$dsn .= ";unix_socket={$config['unix_socket']}";
 		}

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -18,6 +18,13 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 		$options = $this->getOptions($config);
 
 		$connection = $this->createConnection($dsn, $config, $options);
+		
+		// We need to explicitly exec the 'use' mysql command in case the 
+		// unix_socket option is used in the dsn.
+		if (isset($config['unix_socket']))
+		{
+			$connection->exec("use {$config['database']};");
+		}
 
 		$collation = $config['collation'];
 
@@ -55,11 +62,11 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 		// need to establish the PDO connections and return them back for use.
 		extract($config);
 
-		$dsn = "mysql:dbname={$database}";
+		$dsn = "mysql:";
 		
 		if (!isset($config['unix_socket'])) 
 		{
-			$dsn .= ";host={$host}";
+			$dsn .= "host={$host}";
 	
 			if (isset($config['port']))
 			{
@@ -68,8 +75,10 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 		} 
 		else 
 		{
-			$dsn .= ";unix_socket={$config['unix_socket']}";
+			$dsn .= "unix_socket={$config['unix_socket']}";
 		}
+		
+		$dsn .= ";dbname={$database}";
 
 		return $dsn;
 	}

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -57,7 +57,7 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 
 		$dsn = "mysql:dbname={$database}";
 		
-		if (isset($config['unix_socket'])) 
+		if (!isset($config['unix_socket'])) 
 		{
 			$dsn .= ";host={$host}";
 	

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -29,7 +29,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(array('options')))->will($this->returnValue($connection));
 		$connection->shouldReceive('prepare')->once()->with('set names \'utf8\' collate \'utf8_unicode_ci\'')->andReturn($connection);
 		$connection->shouldReceive('execute')->once();
-		$connection->shouldReceive('exec')->zeroOrMoreTimes()
+		$connection->shouldReceive('exec')->zeroOrMoreTimes();
 		$result = $connector->connect($config);
 
 		$this->assertTrue($result === $connection);

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -29,6 +29,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(array('options')))->will($this->returnValue($connection));
 		$connection->shouldReceive('prepare')->once()->with('set names \'utf8\' collate \'utf8_unicode_ci\'')->andReturn($connection);
 		$connection->shouldReceive('execute')->once();
+		$connection->shouldReceive('exec')->zeroOrMoreTimes()
 		$result = $connector->connect($config);
 
 		$this->assertTrue($result === $connection);

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -38,9 +38,9 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 	public function mySqlConnectProvider()
 	{
 		return array(
-			array('mysql:dbname=bar;host=foo', array('host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
-			array('mysql:dbname=bar;host=foo;port=111', array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
-			array('mysql:dbname=bar;unix_socket=baz', array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
+			array('mysql:host=foo;dbname=bar', array('host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
+			array('mysql:host=foo;port=111;dbname=bar', array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
+			array('mysql:unix_socket=baz;dbname=bar', array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
 		);
 	}
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -38,9 +38,9 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 	public function mySqlConnectProvider()
 	{
 		return array(
-			array('mysql:host=foo;dbname=bar', array('host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
-			array('mysql:host=foo;dbname=bar;port=111', array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
-			array('mysql:host=foo;dbname=bar;port=111;unix_socket=baz', array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
+			array('mysql:dbname=bar;host=foo', array('host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
+			array('mysql:dbname=bar;host=foo;port=111', array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
+			array('mysql:dbname=bar;unix_socket=baz', array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8')),
 		);
 	}
 


### PR DESCRIPTION
It wasn't a hard fix to do. As explained here (http://php.net/manual/en/ref.pdo-mysql.connection.php), you can either use Host and Port or Unix Sockets. This is especially useful for Google App Engine users since they have to use sockets.
