### PR TITLE
IronQueue now respects ssl_verifypeer settings to disable SSL check

### DIFF
--- a/src/Illuminate/Queue/Connectors/IronConnector.php
+++ b/src/Illuminate/Queue/Connectors/IronConnector.php
@@ -46,7 +46,13 @@ class IronConnector implements ConnectorInterface {
 
 		if (isset($config['host'])) $ironConfig['host'] = $config['host'];
 
-		return new IronQueue(new IronMQ($ironConfig), $this->crypt, $this->request, $config['queue']);
+		$iron = new IronMQ($ironConfig);
+
+		if (isset($config['ssl_verifypeer'])) {
+			$iron->ssl_verifypeer = $config['ssl_verifypeer'];
+		}
+
+		return new IronQueue($iron, $this->crypt, $this->request, $config['queue']);
 	}
 
 }


### PR DESCRIPTION
Iron-IO fails on some setups due to SSL verification checks. According to their documentation, one of the ways to work around this issue is to set ssl_verifypeer = false.

This update allows for that change to be made from the laravel configuration
