### PR TITLE
Add Illuminate\Auth\RememberableInterface, this would reduce the need to implement "remember_token" when you don't even use it.

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -80,11 +80,11 @@ class DatabaseUserProvider implements UserProviderInterface {
 	/**
 	 * Update the "remember me" token for the given user in storage.
 	 *
-	 * @param  \Illuminate\Auth\UserInterface  $user
+	 * @param  \Illuminate\Auth\RememberableInterface   $user
 	 * @param  string  $token
 	 * @return void
 	 */
-	public function updateRememberToken(UserInterface $user, $token)
+	public function updateRememberToken(RememberableInterface $user, $token)
 	{
 		$this->conn->table($this->table)
                             ->where('id', $user->getAuthIdentifier())

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -53,20 +53,25 @@ class EloquentUserProvider implements UserProviderInterface {
 	{
 		$model = $this->createModel();
 
-		return $model->newQuery()
-                        ->where($model->getKeyName(), $identifier)
-                        ->where($model->getRememberTokenName(), $token)
-                        ->first();
+		$query = $model->newQuery()
+						->where($model->getKeyName(), $identifier);
+
+		if ($model instanceof RememberableInterface)
+		{
+			$query->where($model->getRememberTokenName(), $token);
+		}
+
+		return $query->first();
 	}
 
 	/**
 	 * Update the "remember me" token for the given user in storage.
 	 *
-	 * @param  \Illuminate\Auth\UserInterface  $user
+	 * @param  \Illuminate\Auth\RememberableInterface   $user
 	 * @param  string  $token
 	 * @return void
 	 */
-	public function updateRememberToken(UserInterface $user, $token)
+	public function updateRememberToken(RememberableInterface $user, $token)
 	{
 		$user->setAttribute($user->getRememberTokenName(), $token);
 

--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -1,6 +1,6 @@
 <?php namespace Illuminate\Auth;
 
-class GenericUser implements UserInterface {
+class GenericUser implements UserInterface, RememberableInterface {
 
 	/**
 	 * All of the user's attributes.

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -553,10 +553,10 @@ class Guard {
 	/**
 	 * Create a new remember token for the user if one doens't already exist.
 	 *
-	 * @param  \Illuminate\Auth\UserInterface  $user
+	 * @param  \Illuminate\Auth\RememberableInterface   $user
 	 * @return void
 	 */
-	protected function createRememberTokenIfDoesntExist(UserInterface $user)
+	protected function createRememberTokenIfDoesntExist(RememberableInterface $user)
 	{
 		if (is_null($user->getRememberToken()))
 		{

--- a/src/Illuminate/Auth/RememberableInterface.php
+++ b/src/Illuminate/Auth/RememberableInterface.php
@@ -1,0 +1,27 @@
+<?php namespace Illuminate\Auth;
+
+interface RememberableInterface {
+
+	/**
+	 * Get the token value for the "remember me" session.
+	 *
+	 * @return string
+	 */
+	public function getRememberToken();
+
+	/**
+	 * Set the token value for the "remember me" session.
+	 *
+	 * @param  string  $value
+	 * @return void
+	 */
+	public function setRememberToken($value);
+
+	/**
+	 * Get the column name for the "remember me" token.
+	 *
+	 * @return string
+	 */
+	public function getRememberTokenName();
+
+}

--- a/src/Illuminate/Auth/UserInterface.php
+++ b/src/Illuminate/Auth/UserInterface.php
@@ -16,26 +16,4 @@ interface UserInterface {
 	 */
 	public function getAuthPassword();
 
-	/**
-	 * Get the token value for the "remember me" session.
-	 *
-	 * @return string
-	 */
-	public function getRememberToken();
-
-	/**
-	 * Set the token value for the "remember me" session.
-	 *
-	 * @param  string  $value
-	 * @return void
-	 */
-	public function setRememberToken($value);
-
-	/**
-	 * Get the column name for the "remember me" token.
-	 *
-	 * @return string
-	 */
-	public function getRememberTokenName();
-
 }

--- a/src/Illuminate/Auth/UserProviderInterface.php
+++ b/src/Illuminate/Auth/UserProviderInterface.php
@@ -22,11 +22,11 @@ interface UserProviderInterface {
 	/**
 	 * Update the "remember me" token for the given user in storage.
 	 *
-	 * @param  \Illuminate\Auth\UserInterface  $user
+	 * @param  \Illuminate\Auth\RememberableInterface   $user
 	 * @param  string  $token
 	 * @return void
 	 */
-	public function updateRememberToken(UserInterface $user, $token);
+	public function updateRememberToken(RememberableInterface $user, $token);
 
 	/**
 	 * Retrieve a user by the given credentials.

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -164,7 +164,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		list($session, $provider, $request, $cookie) = $this->getMocks();
 		$mock = $this->getMock('Illuminate\Auth\Guard', array('getName', 'getRecallerName'), array($provider, $session, $request));
 		$mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
-		$user = m::mock('Illuminate\Auth\UserInterface');
+		$user = m::mock('Illuminate\Auth\UserInterface', 'Illuminate\Auth\RememberableInterface');
 		$user->shouldReceive('setRememberToken')->once();
 		$mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
 		$mock->expects($this->once())->method('getRecallerName')->will($this->returnValue('bar'));
@@ -186,7 +186,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		$mock = $this->getMock('Illuminate\Auth\Guard', array('clearUserDataFromStorage'), array($provider, $session, $request));
 		$mock->expects($this->once())->method('clearUserDataFromStorage');
 		$mock->setDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
-		$user = m::mock('Illuminate\Auth\UserInterface');
+		$user = m::mock('Illuminate\Auth\UserInterface', 'Illuminate\Auth\RememberableInterface');
 		$user->shouldReceive('setRememberToken')->once();
 		$provider->shouldReceive('updateRememberToken')->once();
 		$mock->setUser($user);
@@ -205,7 +205,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		$cookie->shouldReceive('queue')->once()->with($foreverCookie);
 		$guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
 		$session->shouldReceive('migrate')->once();
-		$user = m::mock('Illuminate\Auth\UserInterface');
+		$user = m::mock('Illuminate\Auth\UserInterface', 'Illuminate\Auth\RememberableInterface');
 		$user->shouldReceive('getAuthIdentifier')->andReturn('foo');
 		$user->shouldReceive('getRememberToken')->andReturn('recaller');
 		$user->shouldReceive('setRememberToken')->never();
@@ -224,7 +224,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		$cookie->shouldReceive('queue')->once()->with($foreverCookie);
 		$guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
 		$session->shouldReceive('migrate')->once();
-		$user = m::mock('Illuminate\Auth\UserInterface');
+		$user = m::mock('Illuminate\Auth\UserInterface', 'Illuminate\Auth\RememberableInterface');
 		$user->shouldReceive('getAuthIdentifier')->andReturn('foo');
 		$user->shouldReceive('getRememberToken')->andReturn(null);
 		$user->shouldReceive('setRememberToken')->once();


### PR DESCRIPTION
As discuss on IRC. This just an idea to reduce breaking upgrade when for people that doesn't use remember me option.

Signed-off-by: crynobone crynobone@gmail.com
