### PR TITLE
Fix loose matching when validating route schemes.

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -687,7 +687,7 @@ class Route {
 	 */
 	public function httpOnly()
 	{
-		return in_array('http', $this->action);
+		return in_array('http', $this->action, true);
 	}
 
 	/**
@@ -707,7 +707,7 @@ class Route {
 	 */
 	public function secure()
 	{
-		return in_array('https', $this->action);
+		return in_array('https', $this->action, true);
 	}
 
 	/**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -387,6 +387,10 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$route = new Route('GET', 'foo/{bar}', array('https', function() {}));
 		$this->assertTrue($route->matches($request));
 
+		$request = Request::create('https://foo.com/foo/bar', 'GET');
+		$route = new Route('GET', 'foo/{bar}', array('https', 'baz' => true, function() {}));
+		$this->assertTrue($route->matches($request));
+
 		$request = Request::create('http://foo.com/foo/bar', 'GET');
 		$route = new Route('GET', 'foo/{bar}', array('https', function() {}));
 		$this->assertFalse($route->matches($request));
@@ -400,6 +404,10 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 
 		$request = Request::create('http://foo.com/foo/bar', 'GET');
 		$route = new Route('GET', 'foo/{bar}', array('http', function() {}));
+		$this->assertTrue($route->matches($request));
+
+		$request = Request::create('http://foo.com/foo/bar', 'GET');
+		$route = new Route('GET', 'foo/{bar}', array('baz' => true, function() {}));
 		$this->assertTrue($route->matches($request));
 	}
 


### PR DESCRIPTION
This is a fix for loose matching when validating route schemes. This is fairly edge case but it's still worth fixing none the less. The tests demonstrate what's happening.

`in_array` is renowned for being a pain.
- http://www.sitepoint.com/3-strange-php-facts-you-may-not-know/ (The Mystery of Value Appearance)
- http://stackoverflow.com/questions/2739441/odd-behaviour-with-phps-in-array-function
