### PR TITLE
modify Collection sort to reset the keys when the array isn't associative

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -413,7 +413,11 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 */
 	public function sort(Closure $callback)
 	{
-		uasort($this->items, $callback);
+		if( $this->isAssociative() ) {
+			uasort($this->items, $callback);
+		} else {
+			usort($this->items, $callback);
+		}
 
 		return $this;
 	}
@@ -447,12 +451,19 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 		// Once we have sorted all of the keys in the array, we will loop through them
 		// and grab the corresponding model so we can set the underlying items list
 		// to the sorted version. Then we'll just return the collection instance.
+		$itemResults = [];
 		foreach (array_keys($results) as $key)
 		{
-			$results[$key] = $this->items[$key];
+			if( $this->isAssociative() ) {
+				// preserve both order and keys
+				$itemResults[$key] = $this->items[$key];
+			} else {
+				// preserve order, reset keys
+				$itemResults[] = $this->items[$key];
+			}
 		}
 
-		$this->items = $results;
+		$this->items = $itemResults;
 
 		return $this;
 	}
@@ -700,6 +711,17 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 		}
 
 		return $items;
+	}
+
+	/**
+	 * Returns whether the items array has associative keys. If not,
+	 * it's numeric.
+	 *
+	 * @return bool
+	 */
+	private function isAssociative()
+	{
+		return array_keys($this->items) !== range(0, count($this->items) - 1);	
 	}
 
 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -451,7 +451,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 		// Once we have sorted all of the keys in the array, we will loop through them
 		// and grab the corresponding model so we can set the underlying items list
 		// to the sorted version. Then we'll just return the collection instance.
-		$itemResults = [];
+		$itemResults = array();
 		foreach (array_keys($results) as $key)
 		{
 			if( $this->isAssociative() ) {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -195,6 +195,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		});
 
 		$this->assertEquals(range(1, 5), array_values($data->all()));
+		$this->assertEquals(range(0, 4), array_keys($data->all()));
 	}
 
 
@@ -204,11 +205,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$data = $data->sortBy(function($x) { return $x; });
 
 		$this->assertEquals(array('dayle', 'taylor'), array_values($data->all()));
+		$this->assertEquals(array(0,1), array_keys($data->all()));
 
 		$data = new Collection(array('dayle', 'taylor'));
 		$data->sortByDesc(function($x) { return $x; });
 
 		$this->assertEquals(array('taylor', 'dayle'), array_values($data->all()));
+		$this->assertEquals(array(0,1), array_keys($data->all()));
 	}
 
 
@@ -218,6 +221,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$data = $data->sortBy('name');
 
 		$this->assertEquals(array(array('name' => 'dayle'), array('name' => 'taylor')), array_values($data->all()));
+		$this->assertEquals(array(0,1), array_keys($data->all()));
 	}
 
 


### PR DESCRIPTION
In this fork I fixed (with tests) what I think might be an unintended behavior of the Collection sort methods.

In one of my controllers, I retrieved a Collection via a relationship, then returned it as JSON:

```
$model = $this->model1->find($id);
return Response::json($model->model2->toArray());
```

This returned an array:

```
[{"id":"1", …},{"id":"2", …}, …]
```

However, a problem occurred when I sorted the Collection:

```
$model = $this->model1->find($id);
return Response::json($model->model2->sortBy('fieldname')->toArray());
```

It started returning an object instead:

```
{"1":{"id":"2", …}, "0":{"id":"1", …}, …}
```

I noticed that this "object" had integer keys, but not sequential ones. When I var_dump()ed the data to find out what was different, I found out that the objects were still in a Collection, but that not only were the
objects sorted (as intended), but also the array indexes were out of order (which was unintended):

Before:

```
object(Illuminate\Database\Eloquent\Collection)#317 (1) {
  ["items":protected]=>
  array(16) {
    [0]=>
    object(…)#300 (28) {…}
    [1]=>
    object(…)#318 (28) {…}
    …
  }
}
```

After:

```
object(Illuminate\Database\Eloquent\Collection)#317 (1) {
  ["items":protected]=>
  array(16) {
    [1]=>
    object(…)#318 (28) {…}
    [0]=>
    object(…)#300 (28) {…}
    …
  }
}
```

I noted that this is the result of using associative sort methods. If that behavior is intentional even for non-associative arrays, you can ignore this pull request. But it seems like it might be unintentional, and it leads to the above unexpected behavior with Response::json().

If this behavior is unintentional, this pull request includes new assertions to catch this behavior, and changes to the Collection sort methods to adjust it. If the Collection's array is associative, the associative sorts are still used, but if it is not associative then the non-associative sorts are now used. Using this change, Response::json() still returns an array, just like when unsorted.

Let me know any thoughts, feedback, corrections. Thanks for the review! Hope this is helpful.
