### PR TITLE
Add LIMIT and ORDER BY to MySQL query grammer for deletes

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -99,4 +99,21 @@ class MySqlGrammar extends Grammar {
 		return rtrim($sql);
 	}
 
+	/**
+	 * Compile a delete statement into SQL.
+	 *
+	 * @param  \Illuminate\Database\Query\Builder  $query
+	 * @return string
+	 */
+	public function compileDelete(Builder $query)
+	{
+		$table = $this->wrapTable($query->from);
+
+		$where = is_array($query->wheres) ? $this->compileWheres($query) : '';
+		$orderBy = is_array($query->orders) ? $this->compileOrders($query, $query->orders) : '';
+		$limit = $query->limit ? $this->compileLimit($query, $query->limit) : '';
+
+		return trim("delete from $table ".implode(' ', array_filter(array($where, $orderBy, $limit))));
+	}
+
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -858,6 +858,17 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "id" = ?', array(1))->andReturn(1);
 		$result = $builder->from('users')->delete(1);
 		$this->assertEquals(1, $result);
+
+		// Test mySQL specific grammar.
+		$builder = $this->getMySqlBuilder();
+		$builder->getConnection()->shouldReceive('delete')->once()->with('delete from `users` where `email` = ? order by `title` desc limit 3', array('foo'))->andReturn(1);
+		$result = $builder->from('users')->where('email', '=', 'foo')->orderBy('title', 'desc')->limit(3)->delete();
+		$this->assertEquals(1, $result);
+
+		$builder = $this->getMySqlBuilder();
+		$mysql = new Illuminate\Database\Query\Grammars\MySqlGrammar;
+		$builder->from('users')->orderBy('title', 'asc')->limit(3);
+		$this->assertEquals('delete from `users` order by `title` asc limit 3', $mysql->compileDelete($builder));
 	}
 
 


### PR DESCRIPTION
This addition adds LIMIT and ORDER BY to SQL generated when doing a delete when using MySQL. This is valid according to https://dev.mysql.com/doc/refman/5.0/en/delete.html. This is in reference to my origin issue report at #4040.

I submitted a pull request into master, since it changes a bit how queries are done. It shouldn't cause any issues, and should be backwards compatible, but better safe than sorry I guess. If it should go in 4.1 just let me know and I'll make another request for that.

An example of what this would help accomplish is say you have a Post model and you want to delete the 5 oldest posts:  `Post::orderBy('created_at', 'asc')->limit(5)->delete()`

**Note: I accidently deleted my forked repository so I recreated this pull request as I wasn't sure how that would effect the old one at #4106. Apologies.**
