### PR TITLE
[4.1] [FIX] Improved Random

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/http-kernel": "2.4.*",
         "symfony/process": "2.4.*",
         "symfony/routing": "2.4.*",
-        "symfony/security": "2.4.*",
+        "symfony/security-core": "2.4.*",
         "symfony/translation": "2.4.*"
     },
     "replace": {

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Auth;
 
+use Illuminate\Support\Str;
 use Illuminate\Cookie\CookieJar;
 use Illuminate\Events\Dispatcher;
 use Symfony\Component\HttpFoundation\Request;
@@ -545,7 +546,7 @@ class Guard {
 	 */
 	protected function refreshRememberToken(UserInterface $user)
 	{
-		$user->setRememberToken($token = str_random(60));
+		$user->setRememberToken($token = Str::random(60));
 
 		$this->provider->updateRememberToken($user, $token);
 	}

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Encryption;
 
+use Illuminate\Support\Str;
 use Symfony\Component\Security\Core\Util\StringUtils;
-use Symfony\Component\Security\Core\Util\SecureRandom;
 
 class DecryptException extends \RuntimeException {}
 
@@ -148,7 +148,7 @@ class Encrypter {
 	 */
 	protected function validMac(array $payload)
 	{
-		$bytes = with(new SecureRandom)->nextBytes(16);
+		$bytes = Str::fullRandom(16);
 
 		$calcMac = hash_hmac('sha256', $this->hash($payload['iv'], $payload['value']), $bytes, true);
 

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.1.*",
-        "symfony/security": "2.4.*"
+        "symfony/security-core": "2.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.0.*"

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Queue;
 
+use Illuminate\Support\Str;
 use Illuminate\Redis\Database;
 use Illuminate\Queue\Jobs\RedisJob;
 
@@ -219,7 +220,7 @@ class RedisQueue extends Queue implements QueueInterface {
 	 */
 	protected function getRandomId()
 	{
-		return str_random(20);
+		return Str::random(20);
 	}
 
 	/**

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Session;
 
+use Illuminate\Support\Str;
 use SessionHandlerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
@@ -156,7 +157,7 @@ class Store implements SessionInterface {
 	 */
 	protected function generateSessionId()
 	{
-		return sha1(uniqid(true).str_random(25).microtime(true));
+		return sha1(uniqid(true).Str::random(25).microtime(true));
 	}
 
 	/**
@@ -550,7 +551,7 @@ class Store implements SessionInterface {
 	 */
 	public function regenerateToken()
 	{
-		$this->put('_token', str_random(40));
+		$this->put('_token', Str::random(40));
 	}
 
 	/**

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -11,6 +11,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
+        "symfony/security-core": "2.4.*",
         "jeremeamia/superclosure": "1.0.*",
         "patchwork/utf8": "1.1.*",
         "mockery/mockery": "0.9.*",


### PR DESCRIPTION
I've added a `fullRandom` function which will attempt to generate a truly random string.

I have updated the current `random` function to use this new secure function if available, and then to fallback on `quickRandom`.

I've fixed the errors introduced by @taylorotwell in laravel 4.1.28 whenever the `validMac` function was called causing: `You need to specify a file path to store the seed`.

---

Related to #4130. Fixes #4182 and laravel/laravel#2849.
