### PR TITLE
Updated SqlServer grammar date format.

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -216,7 +216,7 @@ class SqlServerGrammar extends Grammar {
 	 */
 	public function getDateFormat()
 	{
-		return 'Y-m-d H:i:s.000';
+		return 'Y-m-d H:i:s.u';
 	}
 
 }


### PR DESCRIPTION
Previous format (`Y-m-d H:i:s.000`) caused 'The format separator does not match' error when a DateTime string with non-zero millisecond value was supplied.

Note that although `u` in the format stands for microseconds rather than milliseconds, it does not make any difference as Carbon does not support fraction of a second anyway.

Fixes #2591 #2235.
