### PR TITLE
[4.1] Small Random Improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/http-kernel": "2.4.*",
         "symfony/process": "2.4.*",
         "symfony/routing": "2.4.*",
-        "symfony/security": "2.4.*",
+        "symfony/security-core": "2.4.*",
         "symfony/translation": "2.4.*"
     },
     "replace": {

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Auth;
 
+use Illuminate\Support\Str;
 use Illuminate\Cookie\CookieJar;
 use Illuminate\Events\Dispatcher;
 use Symfony\Component\HttpFoundation\Request;
@@ -545,7 +546,7 @@ class Guard {
 	 */
 	protected function refreshRememberToken(UserInterface $user)
 	{
-		$user->setRememberToken($token = str_random(60));
+		$user->setRememberToken($token = Str::random(60));
 
 		$this->provider->updateRememberToken($user, $token);
 	}

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -15,6 +15,13 @@ class Encrypter {
 	protected $key;
 
 	/**
+	 * The encryption seed path for symfony.
+	 *
+	 * @var string
+	 */
+	protected $seed;
+
+	/**
 	 * The algorithm used for encryption.
 	 *
 	 * @var string
@@ -41,9 +48,10 @@ class Encrypter {
 	 * @param  string  $key
 	 * @return void
 	 */
-	public function __construct($key)
+	public function __construct($key, $seed)
 	{
 		$this->key = $key;
+		$this->seed = $seed;
 	}
 
 	/**
@@ -148,7 +156,7 @@ class Encrypter {
 	 */
 	protected function validMac(array $payload)
 	{
-		$bytes = with(new SecureRandom)->nextBytes(16);
+		$bytes = with(new SecureRandom($this->seed)->nextBytes(16);
 
 		$calcMac = hash_hmac('sha256', $this->hash($payload['iv'], $payload['value']), $bytes, true);
 

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -13,7 +13,7 @@ class EncryptionServiceProvider extends ServiceProvider {
 	{
 		$this->app->bindShared('encrypter', function($app)
 		{
-			return new Encrypter($app['config']['app.key']);
+			return new Encrypter($app['config']['app.key'], $app['path.storage'].'/meta/seed.json');
 		});
 	}
 

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.1.*",
-        "symfony/security": "2.4.*"
+        "symfony/security-core": "2.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.0.*"

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Queue;
 
+use Illuminate\Support\Str;
 use Illuminate\Redis\Database;
 use Illuminate\Queue\Jobs\RedisJob;
 
@@ -219,7 +220,7 @@ class RedisQueue extends Queue implements QueueInterface {
 	 */
 	protected function getRandomId()
 	{
-		return str_random(20);
+		return Str::random(20);
 	}
 
 	/**

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Session;
 
+use Illuminate\Support\Str;
 use SessionHandlerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
@@ -156,7 +157,7 @@ class Store implements SessionInterface {
 	 */
 	protected function generateSessionId()
 	{
-		return sha1(uniqid(true).str_random(25).microtime(true));
+		return sha1(uniqid(true).Str::random(25).microtime(true));
 	}
 
 	/**
@@ -550,7 +551,7 @@ class Store implements SessionInterface {
 	 */
 	public function regenerateToken()
 	{
-		$this->put('_token', str_random(40));
+		$this->put('_token', Str::random(40));
 	}
 
 	/**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -181,9 +181,9 @@ class Str {
 	}
 
 	/**
-	 * Generate a more truly "random" alpha-numeric string.
+	 * Generate a truly "random" alpha-numeric string.
 	 *
-	 * @param  int     $length
+	 * @param  int  $length
 	 * @return string
 	 *
 	 * @throws \RuntimeException
@@ -206,11 +206,11 @@ class Str {
 	}
 
 	/**
-	 * Generate a "random" alpha-numeric string.
+	 * Quickly generate a "random" alpha-numeric string.
 	 *
 	 * Should not be considered sufficient for cryptography, etc.
 	 *
-	 * @param  int     $length
+	 * @param  int  $length
 	 * @return string
 	 */
 	public static function quickRandom($length = 16)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -945,12 +945,12 @@ if ( ! function_exists('str_plural'))
 if ( ! function_exists('str_random'))
 {
 	/**
-	 * Generate a "random" alpha-numeric string.
+	 * Generate a truly "random" alpha-numeric string.
 	 *
-	 * Should not be considered sufficient for cryptography, etc.
-	 *
-	 * @param  int     $length
+	 * @param  int  $length
 	 * @return string
+	 *
+	 * @throws \RuntimeException
 	 */
 	function str_random($length = 16)
 	{

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -109,4 +109,13 @@ class SupportStrTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(Str::is('*/foo', 'blah/baz/foo'));
 	}
 
+
+	public function testRandom()
+	{
+		$this->assertEquals(1, strlen(Str::random(1)));
+		$this->assertEquals(16, strlen(Str::random(16)));
+		$this->assertEquals(64, strlen(Str::random(64)));
+		$this->assertTrue(ctype_alnum(Str::random(64)));
+	}
+
 }


### PR DESCRIPTION
**This change does not alter the random algorithms in any way unlike #4186.**

I've fixed the errors introduced in laravel 4.1.28 whenever the `validMac` function was called on `Illuminate\Encryption\Encrypter` causing: `You need to specify a file path to store the seed`.

I've changed the function calls to the random method to always call the string class on suggestion by @barryvdh to ensure we are definitely calling the correct random methods.

I've improved the symfony security dependency so we only require what we actually need and added a few tests to check the generated strings are ok too.

---

Replaces #4175 and #4186. Related to #4130. Fixes #4182 and laravel/laravel#2849.
