### PR TITLE
Implemented "compiles" method for service providers.

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Composer;
+use Illuminate\Foundation\PackageCompiler;
 use ClassPreloader\Command\PreCompileCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -29,16 +30,25 @@ class OptimizeCommand extends Command {
 	protected $composer;
 
 	/**
+	 * The package compiler instance.
+	 * 
+	 * @var \Illuminate\Foundation\PackageCompiler
+	 */
+	protected $packages;
+
+	/**
 	 * Create a new optimize command instance.
 	 *
 	 * @param  \Illuminate\Foundation\Composer  $composer
+	 * @param  \Illuminate\Foundation\PackageCompiler  $packages
 	 * @return void
 	 */
-	public function __construct(Composer $composer)
+	public function __construct(Composer $composer, PackageCompiler $packages)
 	{
 		parent::__construct();
 
 		$this->composer = $composer;
+		$this->packages = $packages;
 	}
 
 	/**
@@ -100,7 +110,28 @@ class OptimizeCommand extends Command {
 
 		$core = require __DIR__.'/Optimize/config.php';
 
-		return array_merge($core, $this->laravel['config']['compile']);
+		$packages = $this->option('with-packages') ? $this->getPackageClassFiles() : array();
+
+		return array_merge($core, $packages, $this->laravel['config']['compile']);
+	}
+
+	/**
+	 * Get the package classes that should be combined and compiled.
+	 * 
+	 * @return array
+	 */
+	protected function getPackageClassFiles()
+	{
+		$paths = array();
+
+		foreach ($this->laravel->getLoadedProviders() as $provider => $loaded)
+		{
+			$provider = $this->laravel->getRegistered($provider);
+
+			$paths[] = $this->packages->compile($provider);
+		}
+
+		return array_flatten($paths);
 	}
 
 	/**
@@ -124,6 +155,8 @@ class OptimizeCommand extends Command {
 			array('force', null, InputOption::VALUE_NONE, 'Force the compiled class file to be written.'),
 
 			array('psr', null, InputOption::VALUE_NONE, 'Do not optimize Composer dump-autoload.'),
+
+			array('with-packages', null, InputOption::VALUE_NONE, 'Compile package class files.'),
 		);
 	}
 

--- a/src/Illuminate/Foundation/PackageCompiler.php
+++ b/src/Illuminate/Foundation/PackageCompiler.php
@@ -1,0 +1,159 @@
+<?php namespace Illuminate\Foundation;
+
+use ReflectionClass;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\ServiceProvider;
+
+class PackageCompiler {
+
+	/**
+	 * The filesystem instance.
+	 * 
+	 * @var \Illuminate\Filesystem\Filesystem
+	 */
+	protected $files;
+
+	/**
+	 * Relative path to the compiled file.
+	 * 
+	 * @var string
+	 */
+	protected $compiledRelativePath;
+
+	/**
+	 * Create a new package compiler instance.
+	 * 
+	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  string  $compiledRelativePath
+	 * @return void
+	 */
+	public function __construct(Filesystem $files, $compiledRelativePath = 'bootstrap/compiled.php')
+	{
+		$this->files = $files;
+		$this->compiledRelativePath = $compiledRelativePath;
+	}
+
+	/**
+	 * Get the files to be compiled for a package.
+	 * 
+	 * @param  \Illuminate\Support\ServiceProvider  $provider
+	 * @return array
+	 */
+	public function compile(ServiceProvider $provider)
+	{
+		if ( ! $providerRootPath = $this->getProviderRootPath($provider)) return array();
+
+		$paths = array();
+
+		foreach ($provider->compiles() as $path)
+		{
+			$paths[] = $this->getProviderPaths($providerRootPath, $path);
+		}
+
+		$paths = array_flatten($paths);
+
+		return $this->stripProviderPath($provider, $paths);
+	}
+
+	/**
+	 * Get paths that should be combined and compiled from a path.
+	 * 
+	 * @param  string  $providerRootPath
+	 * @param  string  $path
+	 * @return array
+	 */
+	protected function getProviderPaths($providerRootPath, $path)
+	{
+		$fullPath = $providerRootPath.'/'.$path;
+
+		if ($this->files->exists($fullPath))
+		{
+			return $this->getFileOrDirectoryPaths($fullPath);
+		}
+
+		if (ends_with($path, '**/*'))
+		{
+			$fullPath = substr($fullPath, 0, -4);
+
+			if ($this->files->exists($fullPath))
+			{
+				return $this->mapFilePaths($this->files->allFiles($fullPath));
+			}
+		}
+
+		if (ends_with($path, '*'))
+		{
+			$fullPath = substr($fullPath, 0, -2);
+
+			if ($this->files->exists($fullPath))
+			{
+				return $this->getFileOrDirectoryPaths($fullPath);
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Get path to a file or array of paths to files in a directory.
+	 * 
+	 * @param  string  $path
+	 * @return string|array
+	 */
+	protected function getFileOrDirectoryPaths($path)
+	{
+		return $this->files->isDirectory($path) ? $this->files->files($path) : $path;
+	}
+
+	/**
+	 * Map an array of SplFileInfo objects to file paths.
+	 * 
+	 * @param  array  $files
+	 * @return array
+	 */
+	protected function mapFilePaths($files)
+	{
+		return array_map(function($file) { return $file->getPathname(); }, $files);
+	}
+
+	/**
+	 * Get the root path to the provider.
+	 * 
+	 * @param  \Illuminate\Support\ServiceProvider  $provider
+	 * @return string|null
+	 */
+	protected function getProviderRootPath(ServiceProvider $provider)
+	{
+		$path = $this->getProviderPath($provider);
+
+		return ! ends_with($path, $this->compiledRelativePath) ? dirname($path) : null;
+	}
+
+	/**
+	 * Get the path to the provider.
+	 * 
+	 * @param  \Illuminate\Support\ServiceProvider  $provider
+	 * @return string
+	 */
+	protected function getProviderPath(ServiceProvider $provider)
+	{
+		$reflection = new ReflectionClass($provider);
+
+		return $reflection->getFileName();
+	}
+
+	/**
+	 * Strip provider path so that it's not compiled.
+	 * 
+	 * @param  \Illuminate\Support\ServiceProvider  $provider
+	 * @param  array  $paths
+	 * @return array
+	 */
+	protected function stripProviderPath(ServiceProvider $provider, array $paths)
+	{
+		$providerPath = $this->getProviderPath($provider);
+
+		return array_filter($paths, function($path) use ($providerPath) { return $path != $providerPath; });
+	}
+
+}

--- a/src/Illuminate/Foundation/Providers/OptimizeServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/OptimizeServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Foundation\PackageCompiler;
 use Illuminate\Foundation\Console\OptimizeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
 
@@ -36,7 +37,7 @@ class OptimizeServiceProvider extends ServiceProvider {
 	{
 		$this->app->bindShared('command.optimize', function($app)
 		{
-			return new OptimizeCommand($app['composer']);
+			return new OptimizeCommand($app['composer'], new PackageCompiler($app['files']));
 		});
 	}
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -180,6 +180,16 @@ abstract class ServiceProvider {
 	}
 
 	/**
+	 * Get the files to be compiled.
+	 * 
+	 * @return array
+	 */
+	public function compiles()
+	{
+		return array();
+	}
+
+	/**
 	 * Determine if the provider is deferred.
 	 *
 	 * @return bool

--- a/tests/Foundation/FoundationPackageCompilerTest.php
+++ b/tests/Foundation/FoundationPackageCompilerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+class FoundationPackageCompilerTest extends PHPUnit_Framework_TestCase {
+
+	public function setUp()
+	{
+		$this->app = new Illuminate\Foundation\Application;
+		$this->files = new Illuminate\Filesystem\Filesystem;
+	}
+
+
+	public function testAlreadyCompiledProviderReturnsEmptyArray()
+	{
+		$compiler = new Illuminate\Foundation\PackageCompiler($this->files, 'FoundationPackageCompilerTest.php');
+		$this->assertEquals(array(), $compiler->compile(new PackageCompilerServiceProviderStub($this->app)));
+	}
+
+
+	public function testCompilesAllFiles()
+	{
+		$compiler = new Illuminate\Foundation\PackageCompiler($this->files);
+		$provider = new PackageCompilerServiceProviderStub($this->app);
+		$provider->setCompiles(array('stubs/**/*'));
+
+		$expected = array(
+			__DIR__.'/stubs/Foo/Bar.php',
+			__DIR__.'/stubs/Foo/Bar/Baz.php',
+			__DIR__.'/stubs/Foo.php'
+		);
+
+		$actual = $compiler->compile($provider);
+
+		sort($expected);
+		sort($actual);
+
+		$this->assertEquals($expected, $actual);
+	}
+
+
+	public function testCompilesDirectoryRecursively()
+	{
+		$compiler = new Illuminate\Foundation\PackageCompiler($this->files);
+		$provider = new PackageCompilerServiceProviderStub($this->app);
+		$provider->setCompiles(array('stubs/Foo/**/*'));
+
+		$expected = array(
+			__DIR__.'/stubs/Foo/Bar.php',
+			__DIR__.'/stubs/Foo/Bar/Baz.php'
+		);
+
+		$actual = $compiler->compile($provider);
+
+		sort($expected);
+		sort($actual);
+
+		$this->assertEquals($expected, $actual);
+	}
+
+
+	public function testCompilesDirectory()
+	{
+		$compiler = new Illuminate\Foundation\PackageCompiler($this->files);
+		$provider = new PackageCompilerServiceProviderStub($this->app);
+		
+		$provider->setCompiles(array('stubs/Foo/*'));
+		$this->assertEquals(array(__DIR__.'/stubs/Foo/Bar.php'), $compiler->compile($provider));
+
+		$provider->setCompiles(array('stubs/Foo'));
+		$this->assertEquals(array(__DIR__.'/stubs/Foo/Bar.php'), $compiler->compile($provider));
+	}
+
+
+	public function testCompilesFiles()
+	{
+		$compiler = new Illuminate\Foundation\PackageCompiler($this->files);
+		$provider = new PackageCompilerServiceProviderStub($this->app);
+		$provider->setCompiles(array('stubs/Foo.php', 'stubs/Foo/Bar.php'));
+
+		$expected = array(
+			__DIR__.'/stubs/Foo.php',
+			__DIR__.'/stubs/Foo/Bar.php'
+		);
+
+		$actual = $compiler->compile($provider);
+
+		sort($expected);
+		sort($actual);
+
+		$this->assertEquals($expected, $actual);
+	}
+
+
+	public function testMissingFilesAreIgnored()
+	{
+		$compiler = new Illuminate\Foundation\PackageCompiler($this->files);
+		$provider = new PackageCompilerServiceProviderStub($this->app);
+
+		$provider->setCompiles(array('stubs/Bar.php'));
+		$this->assertEquals(array(), $compiler->compile($provider));
+
+		$provider->setCompiles(array('stubs/Bar/**/*'));
+		$this->assertEquals(array(), $compiler->compile($provider));
+
+		$provider->setCompiles(array('stubs/Bar/*'));
+		$this->assertEquals(array(), $compiler->compile($provider));
+	}
+
+
+	public function testServiceProviderIsIgnored()
+	{
+		$compiler = new Illuminate\Foundation\PackageCompiler($this->files);
+		$provider = new PackageCompilerServiceProviderStub($this->app);
+		$provider->setCompiles(array('FoundationPackageCompilerTest.php'));
+
+		$this->assertEquals(array(), $compiler->compile($provider));
+	}
+
+
+}
+
+
+class PackageCompilerServiceProviderStub extends Illuminate\Support\ServiceProvider {
+
+	protected $compiles = array();
+
+	public function register() {}
+
+	public function compiles()
+	{
+		return $this->compiles;
+	}
+
+	public function setCompiles(array $compiles)
+	{
+		$this->compiles = $compiles;
+	}
+
+}

--- a/tests/Foundation/stubs/Foo.php
+++ b/tests/Foundation/stubs/Foo.php
@@ -1,0 +1,3 @@
+<?php
+
+class Foo {}

--- a/tests/Foundation/stubs/Foo/Bar.php
+++ b/tests/Foundation/stubs/Foo/Bar.php
@@ -1,0 +1,3 @@
+<?php namespace Foo;
+
+class Bar {}

--- a/tests/Foundation/stubs/Foo/Bar/Baz.php
+++ b/tests/Foundation/stubs/Foo/Bar/Baz.php
@@ -1,0 +1,3 @@
+<?php namespace Foo\Bar;
+
+class Baz {}


### PR DESCRIPTION
See proposal #1916 from last year.

Decided to target `master` for this, will re-submit if you'd like it against `4.1`, just let me know.

Would also love feedback on the implementation. Cheers.

Unsure how the tests will go on other systems as well, e.g., Windows. Will try it when I get a chance.

---

Recursively compile all the packages files.

``` php
public function compiles()
{
    return array('**/*');
}
```

Compile all files in the given directory.

``` php
public function compiles()
{
    return array('Foo');

    // Or...

   return array('Foo/*');
}
```

Compile individual files.

``` php
public function compiles()
{
    return array('Foo.php');
}
```

A bit of a mixture, compile individual files and recursively compile all files in a directory.

``` php
public function compiles()
{
    return array('Foo.php', 'Foo/**/*');
}
```

All paths are relative to the service provider. It will also skip service providers that are themselves being called from `bootstrap/compiled.php`.

Service providers are stripped from the path so they are not compiled. This is to prevent breakages from packages using `$this->package()` in their `boot` method as it would bugger up all the paths.
