### PR TITLE
Undefined function "starts_with" in Illuminate/Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -476,7 +476,7 @@ class Container implements ArrayAccess {
 	 */
 	protected function missingLeadingSlash($abstract)
 	{
-		return is_string($abstract) && ! starts_with($abstract, '\\');
+		return is_string($abstract) && strpos($abstract, '\\') !== 0;
 	}
 
 	/**


### PR DESCRIPTION
A change was pushed a few days ago into the Container library that used the starts_with() function. This is fine in the Laravel framework since that function is defined in the Support library but if you're only using the illuminate/container package without any other Laravel packages then you will get an error since the Support is not listed as a dependency.

What's the best solution? Make illuminate/support a dependency of illuminate/container or change the code to not use that function?
