### PR TITLE
Pivot updates recorded only if something updated

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -649,9 +649,10 @@ class BelongsToMany extends Relation {
 			}
 			elseif (count($attributes) > 0)
 			{
-				$this->updateExistingPivot($id, $attributes, $touch);
-
-				$changes['updated'][] = (int) $id;
+				if ($this->updateExistingPivot($id, $attributes, $touch))
+				{
+					$changes['updated'][] = (int) $id;
+				}
 			}
 		}
 		return $changes;
@@ -672,9 +673,11 @@ class BelongsToMany extends Relation {
 			$attributes = $this->setTimestampsOnAttach($attributes, true);
 		}
 
-		$this->newPivotStatementForId($id)->update($attributes);
+		$updated = $this->newPivotStatementForId($id)->update($attributes);
 
 		if ($touch) $this->touchIfTouching();
+
+		return $updated;
 	}
 
 	/**


### PR DESCRIPTION
The sync() method currently returns ids for all attached models when an update is made if they have attributes to update also - regardless of whether an update actually took place.

This fix ensures that only those pivot records that actually got updated are returned, as not to include false positives.
