### PR TITLE
[4.1] FormBuilder::checkbox can't be checked without session

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -639,7 +639,7 @@ class FormBuilder {
 	 */
 	protected function getCheckboxCheckedState($name, $value, $checked)
 	{
-		if ( ! $this->oldInputIsEmpty() && is_null($this->old($name))) return false;
+		if (isset($this->session) && ! $this->oldInputIsEmpty() && is_null($this->old($name))) return false;
 
 		if ($this->missingOldAndModel($name)) return $checked;
 

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -327,7 +327,17 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<input name="multicheck[]" type="checkbox" value="2">', $check2);
 		$this->assertEquals('<input checked="checked" name="multicheck[]" type="checkbox" value="3">', $check3);
 	}
+	
+	
+	public function testFormCheckboxWithoutSession()
+	{
+	    $form1 = $this->formBuilder->checkbox('foo');
+	    $form2 = $this->formBuilder->checkbox('foo', 'foobar', true);
 
+	    $this->assertEquals('<input name="foo" type="checkbox" value="1">', $form1);
+	    $this->assertEquals('<input checked="checked" name="foo" type="checkbox" value="foobar">', $form2);
+	}
+	
 
 	public function testFormRadio()
 	{


### PR DESCRIPTION
If the value of `$this->session` within FormBuilder is null, it’s not possible to set a checkbox to checked.

I created an issue here: https://github.com/illuminate/html/issues/6
