### PR TITLE
Redis: use setex instead of set and expires

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -66,9 +66,7 @@ class RedisStore extends TaggableStore implements StoreInterface {
 	{
 		$value = is_numeric($value) ? $value : serialize($value);
 
-		$this->connection()->set($this->prefix.$key, $value);
-
-		$this->connection()->expire($this->prefix.$key, $minutes * 60);
+		$this->connection()->setex($this->prefix.$key, $minutes * 60, $value);
 	}
 
 	/**


### PR DESCRIPTION
Use Redis `setex` command instead of `set` then `expires`.
See: http://redis.io/commands/SETEX
One command instead of two. Can't hurt
