### PR TITLE
Add DB::getConnectionDriverName() from DatabaseManager.

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -189,6 +189,19 @@ class DatabaseManager implements ConnectionResolverInterface {
 	}
 
 	/**
+	 * Get the driver name for a connection.
+	 *
+	 * @param  string|null  $name
+	 * @return string
+	 */
+	public function getConnectionDriverName($name = null)
+	{
+		$config = $this->getConfig($name);
+
+		return $config['driver'];
+	}
+
+	/**
 	 * Get the default connection name.
 	 *
 	 * @return string


### PR DESCRIPTION
This change should allow the following:

``` php
Schema::create('users', function ($table) {
    $table->increments('id');

    // some fields.

    if (DB::getConnectionDriverName() === 'mysql') {
        $table->engine = 'innodb';
    }
});
```

Signed-off-by: crynobone crynobone@gmail.com
