### PR TITLE
Add where constraint support to Route::group()

### DIFF
--- a/src/Illuminate/Routing/RouteGroupStack.php
+++ b/src/Illuminate/Routing/RouteGroupStack.php
@@ -1,0 +1,79 @@
+<?php namespace Illuminate\Routing;
+
+use Closure;
+
+class RouteGroupStack extends Route {
+
+	/**
+	 * The attributes assigned to the route group stack.
+	 *
+	 * @var array
+	 */
+	protected $attributes;
+
+
+	/**
+	 * The Closure containing routing instructions.
+	 *
+	 * @var callable
+	 */
+	protected $callback;
+
+	/**
+	 * The routes contained within this route group stack.
+	 *
+	 * @var RouteCollection
+	 */
+	protected $routes;
+
+	/**
+	 * Create a new RouteGroupStack instance.
+	 *
+	 * @param array $attributes
+	 * @param callable $callback
+	 */
+	public function __construct(array $attributes, Closure $callback)
+	{
+		$this->attributes = $attributes;
+		$this->callback = $callback;
+		$this->routes = new RouteCollection;
+	}
+
+	/**
+	 * Get the attributes of the stack.
+	 *
+	 * @return array
+	 */
+	public function getAttributes()
+	{
+		return $this->attributes;
+	}
+
+	/**
+	 * Add a route to the stack.
+	 *
+	 * @param \Illuminate\Routing\Route $route
+	 * @return void
+	 */
+	public function add(Route $route)
+	{
+		$this->routes->add($route);
+	}
+
+	/**
+	 * Set a regular expression requirement to the routes contained within this stack.
+	 *
+	 * @param array|string $name
+	 * @param null $expression
+	 * @return void
+	 */
+	public function where($name, $expression = null)
+	{
+		foreach ($this->routes as $route)
+		{
+			$route->where($name, $expression);
+		}
+		return $this;
+	}
+
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -97,7 +97,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	protected $patterns = array();
 
 	/**
-	 * The route group attribute stack.
+	 * The route group stack.
 	 *
 	 * @var array
 	 */
@@ -485,7 +485,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		// the resource action. Otherwise we'll just use an empty string for here.
 		$prefix = isset($options['as']) ? $options['as'].'.' : '';
 
-		if (count($this->groupStack) == 0)
+		if (count($this->groupStack) === 0)
 		{
 			return $prefix.$resource.'.'.$method;
 		}
@@ -671,30 +671,29 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	public function group(array $attributes, Closure $callback)
 	{
-		$this->updateGroupStack($attributes);
+		$this->groupStack[] = new RouteGroupStack($this->mergeGroupAttributes($attributes), $callback);
 
 		// Once we have updated the group stack, we will execute the user Closure and
 		// merge in the groups attributes when the route is created. After we have
 		// run the callback, we will pop the attributes off of this group stack.
 		call_user_func($callback, $this);
 
-		array_pop($this->groupStack);
+		return array_pop($this->groupStack);
 	}
 
 	/**
-	 * Update the group stack with the given attributes.
+	 * Merge the group stack attributes.
 	 *
-	 * @param  array  $attributes
-	 * @return void
+	 * @param array $attributes
+	 * @return array
 	 */
-	protected function updateGroupStack(array $attributes)
+	protected function mergeGroupAttributes(array $attributes)
 	{
 		if (count($this->groupStack) > 0)
 		{
-			$attributes = $this->mergeGroup($attributes, last($this->groupStack));
+			return $this->mergeGroup($attributes, last($this->groupStack)->getAttributes());
 		}
-
-		$this->groupStack[] = $attributes;
+		return $attributes;
 	}
 
 	/**
@@ -705,7 +704,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	public function mergeWithLastGroup($new)
 	{
-		return $this->mergeGroup($new, last($this->groupStack));
+		return $this->mergeGroup($new, last($this->groupStack)->getAttributes());
 	}
 
 	/**
@@ -773,7 +772,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	{
 		if (count($this->groupStack) > 0)
 		{
-			return array_get(last($this->groupStack), 'prefix', '');
+			return array_get(last($this->groupStack)->getAttributes(), 'prefix', '');
 		}
 
 		return '';
@@ -789,7 +788,12 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	protected function addRoute($methods, $uri, $action)
 	{
-		return $this->routes->add($this->createRoute($methods, $uri, $action));
+		$newRoute = $this->createRoute($methods, $uri, $action);
+		foreach ($this->groupStack as $groupStack)
+		{
+			$groupStack->add($newRoute);
+		}
+		return $this->routes->add($newRoute);
 	}
 
 	/**
@@ -943,7 +947,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	protected function prependGroupUses($uses)
 	{
-		$group = last($this->groupStack);
+		$group = last($this->groupStack)->getAttributes();
 
 		return isset($group['namespace']) ? $group['namespace'].'\\'.$uses : $uses;
 	}
@@ -1601,6 +1605,8 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 * Get the response for a given request.
 	 *
 	 * @param  \Symfony\Component\HttpFoundation\Request  $request
+	 * @param int $type
+	 * @param bool $catch
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
 	public function handle(SymfonyRequest $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -562,6 +562,31 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo', $routes[0]->getPrefix());
 	}
 
+	public function testRouteGroupWhere()
+	{
+		$router = $this->getRouter();
+		$router->group(array('prefix' => '{foo}'), function() use ($router)
+		{
+			$router->get('bar', function() { return 'hello'; });
+			$router->group(array('prefix' => '{bar}'), function() use ($router)
+			{
+				$router->get('{baz}', function() { return 'hello'; });
+			})->where('bar', '[0-9]+');
+		})->where('foo', '(bar|baz)')->where('baz', '[a-z]+');
+
+		$request1 = Request::create('bar/bar', 'GET');
+		$router->getRoutes()->match($request1);
+
+		$request2 = Request::create('baz/3/bar', 'GET');
+		$router->getRoutes()->match($request2);
+
+		$routes = $router->getRoutes();
+		$routes = $routes->getRoutes();
+
+		$this->assertEquals('#^/(?P<foo>(bar|baz))/bar$#s', $routes[0]->getCompiled()->getRegex());
+		$this->assertEquals('#^/(?P<foo>(bar|baz))/(?P<bar>[0-9]+)/(?P<baz>[a-z]+)$#s', $routes[1]->getCompiled()->getRegex());
+	}
+
 
 	public function testMergingControllerUses()
 	{


### PR DESCRIPTION
Hi,

It would be useful if we could call 

``` php
Route::group(['prefix' => '{var}'], ...)->where('var', '[0-9]+');
```

to constraint the prefix value itself (or possibly any other variable declared in a route within the group) much like it is currently possible to do on the `Route` object.

My current use case is the following:

``` php
Route::filter('set-language', function($route, $request) {
    $language = $route->parameters('language', 'fr');
    App::setLocale($language);
});

Route::group(['prefix' => '{language}', 'before' => 'set-language'], function() {
[...]
})->where('language', '(fr|en)');
```

Thanks!
