### PR TITLE
Stashing limit/offset clause before performing total pagination count

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1550,15 +1550,20 @@ class Builder {
 	public function getPaginationCount()
 	{
 		list($orders, $this->orders) = array($this->orders, null);
+		list($offset, $this->offset) = array($this->offset, null);
+		list($limit, $this->limit) = array($this->limit, null);
 
 		$columns = $this->columns;
 
-		// Because some database engines may throw errors if we leave the ordering
-		// statements on the query, we will "back them up" and remove them from
-		// the query. Once we have the count we will put them back onto this.
+		// Because some database engines may throw errors, or return incorrect
+		// results, if we leave the ordering, limit, and/or offset statements on
+		// the query, we will "back them up" and remove them from the query.
+		// Once we have the count we will put them back onto this.
 		$total = $this->count();
 
 		$this->orders = $orders;
+		$this->offset = $offset;
+		$this->limit = $limit;
 
 		// Once the query is run we need to put the old select columns back on the
 		// instance so that the select query will run properly. Otherwise, they


### PR DESCRIPTION
Some database engines return zero, when using the count aggregate on a query with limit and offset. Just followed the same pattern for stashing the 'orders' clause before performing a count on the query, and adding back to the query when done.
