### PR TITLE
Fix associate on MorphTo relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -178,4 +178,19 @@ class MorphTo extends BelongsTo {
 		return $this->dictionary;
 	}
 
+	/**
+	 * Associate the model instance to the given parent.
+	 *
+	 * @param  \Illuminate\Database\Eloquent\Model  $model
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function associate(Model $model)
+	{
+		$this->parent->setAttribute($this->foreignKey, $model->getKey());
+		
+		$this->parent->setAttribute($this->morphType, get_class($model));
+
+		return $this->parent->setRelation($this->relation, $model);
+	}
+
 }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -78,6 +78,36 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAssociateMethodSetsForeignKeyAndTypeOnModel()
+	{
+		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+		
+		$relation = $this->getRelationAssociate($parent);
+		
+		$associate = m::mock('Illuminate\Database\Eloquent\Model');
+		$associate->shouldReceive('getKey')->once()->andReturn(1);
+		
+		$parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
+		$parent->shouldReceive('setAttribute')->once()->with('morph_type', get_class($associate));
+		$parent->shouldReceive('setRelation')->once()->with('relation', $associate);
+
+		$relation->associate($associate);
+	}
+
+
+	protected function getRelationAssociate($parent)
+	{
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
+		$related = m::mock('Illuminate\Database\Eloquent\Model');
+		$related->shouldReceive('getKey')->andReturn(1);
+		$related->shouldReceive('getTable')->andReturn('relation');
+		$builder->shouldReceive('getModel')->andReturn($related);
+		return new MorphTo($builder, $parent, 'foreign_key', 'id', 'morph_type', 'relation');
+	}
+
+
 	public function getRelation($parent = null)
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');


### PR DESCRIPTION
This fix overrides associate method and allows you to use the method on morphTo relation fixing both issues described below.

Issue 1: Currently morphTo uses associate inherited from belongsTo which is not working at all for non-existing model:

```
$tag = new Tag;
$tag->taggable()->associate(Post::first());
// Fatal error - loop because of 'null' in this code on Model.php:

// If the type value is null it is probably safe to assume we're eager loading
// the relationship. When that is the case we will pass in a dummy query as
// there are multiple types in the morph and we can't use single queries.
if (is_null($class = $this->$type))
{
    return new MorphTo(
        $this->newQuery(), $this, $id, null, $type, $name
    );
}
```

Issue 2: Using associate on existing model doesn't update morph_type value:

```
$tag = new Tag(['body'=>'whatever']);
Post::first()->tags()->save($tag);

$tag->taggable_id; // 1
$tag->taggable_type; //  'Post'

$tag->taggable()->associate(Category::find(5));

$tag->taggable_id; // 5
$tag->taggable_type; // 'Post'     *no update here*
```
