### PR TITLE
DI via constructor for Migration classes

### DIFF
--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -66,7 +66,7 @@ class MigrationServiceProvider extends ServiceProvider {
 		{
 			$repository = $app['migration.repository'];
 
-			return new Migrator($repository, $app['db'], $app['files']);
+			return new Migrator($app, $repository, $app['db'], $app['files']);
 		});
 	}
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -48,10 +48,11 @@ class Migrator {
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @return void
 	 */
-	public function __construct(MigrationRepositoryInterface $repository,
-								Resolver $resolver,
-                                Filesystem $files)
-	{
+	public function __construct(
+		MigrationRepositoryInterface $repository,
+		Resolver $resolver,
+		Filesystem $files
+	) {
 		$this->files = $files;
 		$this->resolver = $resolver;
 		$this->repository = $repository;

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -1,15 +1,23 @@
 <?php namespace Illuminate\Database\Migrations;
 
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
 
 class Migrator {
 
 	/**
-	 * The migration repository implementation.
-	 *
-	 * @var \Illuminate\Database\Migrations\MigrationRepositoryInterface
-	 */
+	* The application container.
+	*
+	* @var \Illuminate\Foundation\Application
+	*/
+	protected $app;
+
+	/**
+	* The migration repository implementation.
+	*
+	* @var \Illuminate\Database\Migrations\MigrationRepositoryInterface
+	*/
 	protected $repository;
 
 	/**
@@ -49,10 +57,12 @@ class Migrator {
 	 * @return void
 	 */
 	public function __construct(
+		Application $app,
 		MigrationRepositoryInterface $repository,
 		Resolver $resolver,
 		Filesystem $files
 	) {
+		$this->app = $app;
 		$this->files = $files;
 		$this->resolver = $resolver;
 		$this->repository = $repository;
@@ -295,7 +305,7 @@ class Migrator {
 
 		$class = studly_case($file);
 
-		return new $class;
+		return $this->app->make($class);
 	}
 
 	/**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -7,17 +7,17 @@ use Illuminate\Container\Container;
 class Migrator {
 
 	/**
-	* The application container.
-	*
-	* @var \Illuminate\Container\Container
-	*/
+	 * The application container.
+	 *
+	 * @var \Illuminate\Container\Container
+	 */
 	protected $app;
 
 	/**
-	* The migration repository implementation.
-	*
-	* @var \Illuminate\Database\Migrations\MigrationRepositoryInterface
-	*/
+	 * The migration repository implementation.
+	 *
+	 * @var \Illuminate\Database\Migrations\MigrationRepositoryInterface
+	 */
 	protected $repository;
 
 	/**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -2,14 +2,14 @@
 
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Foundation\Application;
+use Illuminate\Container\Container;
 
 class Migrator {
 
 	/**
-	* The application instance.
+	* The application container.
 	*
-	* @var \Illuminate\Foundation\Application
+	* @var \Illuminate\Container\Container
 	*/
 	protected $app;
 
@@ -51,13 +51,14 @@ class Migrator {
 	/**
 	 * Create a new migrator instance.
 	 *
+	 * @param  \Illuminate\Container\Container  $app
 	 * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
 	 * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @return void
 	 */
 	public function __construct(
-		Application $app,
+		Container $app,
 		MigrationRepositoryInterface $repository,
 		Resolver $resolver,
 		Filesystem $files

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\Application;
 class Migrator {
 
 	/**
-	* The application container.
+	* The application instance.
 	*
 	* @var \Illuminate\Foundation\Application
 	*/

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -57,12 +57,11 @@ class Migrator {
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @return void
 	 */
-	public function __construct(
-		Container $app,
-		MigrationRepositoryInterface $repository,
-		Resolver $resolver,
-		Filesystem $files
-	) {
+	public function __construct(Container $app,
+								MigrationRepositoryInterface $repository,
+								Resolver $resolver,
+								Filesystem $files)
+	{
 		$this->app = $app;
 		$this->files = $files;
 		$this->resolver = $resolver;

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -13,7 +13,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	public function testMigrationAreRunUpWhenOutstandingMigrationsExist()
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
-			m::mock('Illuminate\Foundation\Application'),
+			m::mock('Illuminate\Container\Container'),
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
@@ -48,7 +48,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	public function testUpMigrationCanBePretended()
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
-			m::mock('Illuminate\Foundation\Application'),
+			m::mock('Illuminate\Container\Container'),
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
@@ -97,7 +97,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	public function testNothingIsDoneWhenNoMigrationsAreOutstanding()
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
-			m::mock('Illuminate\Foundation\Application'),
+			m::mock('Illuminate\Container\Container'),
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
@@ -117,7 +117,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	public function testLastBatchOfMigrationsCanBeRolledBack()
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
-			m::mock('Illuminate\Foundation\Application'),
+			m::mock('Illuminate\Container\Container'),
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
@@ -146,7 +146,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	public function testRollbackMigrationsCanBePretended()
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
-			m::mock('Illuminate\Foundation\Application'),
+			m::mock('Illuminate\Container\Container'),
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
@@ -187,7 +187,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	public function testNothingIsRolledBackWhenNothingInRepository()
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
-			m::mock('Illuminate\Foundation\Application'),
+			m::mock('Illuminate\Container\Container'),
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -13,6 +13,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	public function testMigrationAreRunUpWhenOutstandingMigrationsExist()
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
+			m::mock('Illuminate\Foundation\Application'),
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
@@ -47,6 +48,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	public function testUpMigrationCanBePretended()
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
+			m::mock('Illuminate\Foundation\Application'),
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
@@ -95,6 +97,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	public function testNothingIsDoneWhenNoMigrationsAreOutstanding()
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
+			m::mock('Illuminate\Foundation\Application'),
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
@@ -114,6 +117,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	public function testLastBatchOfMigrationsCanBeRolledBack()
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
+			m::mock('Illuminate\Foundation\Application'),
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
@@ -142,6 +146,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	public function testRollbackMigrationsCanBePretended()
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
+			m::mock('Illuminate\Foundation\Application'),
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
@@ -182,6 +187,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	public function testNothingIsRolledBackWhenNothingInRepository()
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
+			m::mock('Illuminate\Foundation\Application'),
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),


### PR DESCRIPTION
```
vagrant@precise64:/vagrant$ php artisan tinker
[1] > require_once('app/database/migrations/2014_03_03_163401_refactor_token_table.php');
[2] > App::make('RefactorTokenTable');
// object(RefactorTokenTable)(
// 
// )
[3] >
```

https://github.com/laravel/framework/blob/4.1/src/Illuminate/Database/Migrations/Migrator.php#L291-L297

It is perfectly doable to apply constructor injection.
