### PR TITLE
[CACHE] Ensure forget functions properly return success (or failure)

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -98,11 +98,11 @@ class ApcStore extends TaggableStore implements StoreInterface {
 	 * Remove an item from the cache.
 	 *
 	 * @param  string  $key
-	 * @return array|bool
+	 * @return bool
 	 */
 	public function forget($key)
 	{
-		$this->apc->delete($this->prefix.$key);
+		return $this->apc->delete($this->prefix.$key);
 	}
 
 	/**

--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -71,7 +71,7 @@ class ApcWrapper {
 	 * Remove an item from the cache.
 	 *
 	 * @param  string  $key
-	 * @return array|bool
+	 * @return bool
 	 */
 	public function delete($key)
 	{

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -80,11 +80,13 @@ class ArrayStore extends TaggableStore implements StoreInterface {
 	 * Remove an item from the cache.
 	 *
 	 * @param  string  $key
-	 * @return void
+	 * @return bool
 	 */
 	public function forget($key)
 	{
 		unset($this->storage[$key]);
+
+		return true;
 	}
 
 	/**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -161,11 +161,11 @@ class DatabaseStore implements StoreInterface {
 	 * Remove an item from the cache.
 	 *
 	 * @param  string  $key
-	 * @return void
+	 * @return bool
 	 */
 	public function forget($key)
 	{
-		$this->table()->where('key', '=', $this->prefix.$key)->delete();
+		return (bool) $this->table()->where('key', '=', $this->prefix.$key)->delete();
 	}
 
 	/**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -165,7 +165,9 @@ class DatabaseStore implements StoreInterface {
 	 */
 	public function forget($key)
 	{
-		return (bool) $this->table()->where('key', '=', $this->prefix.$key)->delete();
+		$this->table()->where('key', '=', $this->prefix.$key)->delete();
+		
+		return true;
 	}
 
 	/**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -148,7 +148,7 @@ class FileStore implements StoreInterface {
 	 * Remove an item from the cache.
 	 *
 	 * @param  string  $key
-	 * @return void
+	 * @return bool
 	 */
 	public function forget($key)
 	{
@@ -156,8 +156,10 @@ class FileStore implements StoreInterface {
 
 		if ($this->files->exists($file))
 		{
-			$this->files->delete($file);
+			return $this->files->delete($file);
 		}
+
+		return false;
 	}
 
 	/**

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -100,11 +100,11 @@ class MemcachedStore extends TaggableStore implements StoreInterface {
 	 * Remove an item from the cache.
 	 *
 	 * @param  string  $key
-	 * @return void
+	 * @return bool
 	 */
 	public function forget($key)
 	{
-		$this->memcached->delete($this->prefix.$key);
+		return $this->memcached->delete($this->prefix.$key);
 	}
 
 	/**

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -111,11 +111,11 @@ class RedisStore extends TaggableStore implements StoreInterface {
 	 * Remove an item from the cache.
 	 *
 	 * @param  string  $key
-	 * @return void
+	 * @return bool
 	 */
 	public function forget($key)
 	{
-		$this->connection()->del($this->prefix.$key);
+		return (bool) $this->connection()->del($this->prefix.$key);
 	}
 
 	/**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -48,6 +48,17 @@ class Repository implements ArrayAccess {
 	}
 
 	/**
+	 * Remove an item from the cache.
+	 *
+	 * @param  string $key
+	 * @return bool
+	 */
+	public function forget($key)
+	{
+		return $this->store->forget($key);
+	}
+
+	/**
 	 * Retrieve an item from the cache by key.
 	 *
 	 * @param  string  $key

--- a/src/Illuminate/Cache/StoreInterface.php
+++ b/src/Illuminate/Cache/StoreInterface.php
@@ -51,7 +51,7 @@ interface StoreInterface {
 	 * Remove an item from the cache.
 	 *
 	 * @param  string  $key
-	 * @return void
+	 * @return bool
 	 */
 	public function forget($key);
 

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -127,11 +127,11 @@ class TaggedCache implements StoreInterface {
 	 * Remove an item from the cache.
 	 *
 	 * @param  string  $key
-	 * @return void
+	 * @return bool
 	 */
 	public function forget($key)
 	{
-		$this->store->forget($this->taggedItemKey($key));
+		return $this->store->forget($this->taggedItemKey($key));
 	}
 
 	/**

--- a/src/Illuminate/Cache/WinCacheStore.php
+++ b/src/Illuminate/Cache/WinCacheStore.php
@@ -89,11 +89,11 @@ class WinCacheStore extends TaggableStore implements StoreInterface {
 	 * Remove an item from the cache.
 	 *
 	 * @param  string  $key
-	 * @return void
+	 * @return bool
 	 */
 	public function forget($key)
 	{
-		wincache_ucache_delete($this->prefix.$key);
+		return wincache_ucache_delete($this->prefix.$key);
 	}
 
 	/**

--- a/src/Illuminate/Cache/XCacheStore.php
+++ b/src/Illuminate/Cache/XCacheStore.php
@@ -89,11 +89,11 @@ class XCacheStore extends TaggableStore implements StoreInterface {
 	 * Remove an item from the cache.
 	 *
 	 * @param  string  $key
-	 * @return void
+	 * @return bool
 	 */
 	public function forget($key)
 	{
-		xcache_unset($this->prefix.$key);
+		return xcache_unset($this->prefix.$key);
 	}
 
 	/**


### PR DESCRIPTION
Ensure cache forget functions properly return success (or failure) as a boolean

Note for `apc_delete` and `apcu_delete` :
it is true that these functions can also return an array. But when only one key is passed (which is the case here), it returns a boolean
