### PR TITLE
Allow any 'callable' action, not just anonymous functions

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -506,7 +506,7 @@ class Route {
 	{
 		return array_first($action, function($key, $value)
 		{
-			return $value instanceof Closure;
+			return is_callable($value);
 		});
 	}
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -480,7 +480,7 @@ class Route {
 		// If the action is already a Closure instance, we will just set that instance
 		// as the "uses" property, because there is nothing else we need to do when
 		// it is available. Otherwise we will need to find it in the action list.
-		if ($action instanceof Closure)
+		if (is_callable($action))
 		{
 			return array('uses' => $action);
 		}


### PR DESCRIPTION
If creating routes dynamically, like the following:

``` php
$router->getRoutes()->add(new Route(array('GET'), '/foo', array($this, 'xxx')));
```

... then the previous code will fail because `php array($this, 'xxx')` is not an instance of `Closure`, however `is_callable` will work just fine.
