### PR TITLE
Docblock fixes

### DIFF
--- a/src/Illuminate/Auth/Console/RemindersControllerCommand.php
+++ b/src/Illuminate/Auth/Console/RemindersControllerCommand.php
@@ -30,7 +30,6 @@ class RemindersControllerCommand extends Command {
 	 * Create a new reminder table command instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(Filesystem $files)
 	{

--- a/src/Illuminate/Auth/Console/RemindersTableCommand.php
+++ b/src/Illuminate/Auth/Console/RemindersTableCommand.php
@@ -30,7 +30,6 @@ class RemindersTableCommand extends Command {
 	 * Create a new reminder table command instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(Filesystem $files)
 	{

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -32,7 +32,6 @@ class DatabaseUserProvider implements UserProviderInterface {
 	 * @param  \Illuminate\Database\Connection  $conn
 	 * @param  \Illuminate\Hashing\HasherInterface  $hasher
 	 * @param  string  $table
-	 * @return void
 	 */
 	public function __construct(Connection $conn, HasherInterface $hasher, $table)
 	{

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -23,7 +23,6 @@ class EloquentUserProvider implements UserProviderInterface {
 	 *
 	 * @param  \Illuminate\Hashing\HasherInterface  $hasher
 	 * @param  string  $model
-	 * @return void
 	 */
 	public function __construct(HasherInterface $hasher, $model)
 	{

--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -13,7 +13,6 @@ class GenericUser implements UserInterface {
 	 * Create a new generic User object.
 	 *
 	 * @param  array  $attributes
-	 * @return void
 	 */
 	public function __construct(array $attributes)
 	{

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -76,7 +76,6 @@ class Guard {
 	 *
 	 * @param  \Illuminate\Auth\UserProviderInterface  $provider
 	 * @param  \Illuminate\Session\Store  $session
-	 * @return void
 	 */
 	public function __construct(UserProviderInterface $provider,
 								SessionStore $session,

--- a/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
+++ b/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
@@ -40,7 +40,6 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	 * @param  string  $table
 	 * @param  string  $hashKey
 	 * @param  int  $expires
-	 * @return void
 	 */
 	public function __construct(Connection $connection, $table, $hashKey, $expires = 60)
 	{

--- a/src/Illuminate/Auth/Reminders/PasswordBroker.php
+++ b/src/Illuminate/Auth/Reminders/PasswordBroker.php
@@ -83,7 +83,6 @@ class PasswordBroker {
 	 * @param  \Illuminate\Auth\UserProviderInterface  $users
 	 * @param  \Illuminate\Mail\Mailer  $mailer
 	 * @param  string  $reminderView
-	 * @return void
 	 */
 	public function __construct(ReminderRepositoryInterface $reminders,
                                 UserProviderInterface $users,

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -21,7 +21,6 @@ class ApcStore extends TaggableStore implements StoreInterface {
 	 *
 	 * @param  \Illuminate\Cache\ApcWrapper  $apc
 	 * @param  string  $prefix
-	 * @return void
 	 */
 	public function __construct(ApcWrapper $apc, $prefix = '')
 	{

--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -12,7 +12,6 @@ class ApcWrapper {
 	/**
 	 * Create a new APC wrapper instance.
 	 *
-	 * @return void
 	 */
 	public function __construct()
 	{

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -41,7 +41,7 @@ class ArrayStore extends TaggableStore implements StoreInterface {
 	 *
 	 * @param  string  $key
 	 * @param  mixed   $value
-	 * @return void
+	 * @return mixed
 	 */
 	public function increment($key, $value = 1)
 	{
@@ -55,7 +55,7 @@ class ArrayStore extends TaggableStore implements StoreInterface {
 	 *
 	 * @param  string  $key
 	 * @param  mixed   $value
-	 * @return void
+	 * @return mixed
 	 */
 	public function decrement($key, $value = 1)
 	{

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -39,7 +39,6 @@ class ClearCommand extends Command {
 	 *
 	 * @param  \Illuminate\Cache\CacheManager  $cache
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(CacheManager $cache, Filesystem $files)
 	{
@@ -59,7 +58,7 @@ class ClearCommand extends Command {
 		$this->cache->flush();
 
 		$this->files->delete($this->laravel['config']['app.manifest'].'/services.json');
-		
+
 		$this->laravel['events']->fire('cache:cleared');
 
 		$this->info('Application cache cleared!');

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -40,7 +40,6 @@ class DatabaseStore implements StoreInterface {
 	 * @param  \Illuminate\Encryption\Encrypter  $encrypter
 	 * @param  string  $table
 	 * @param  string  $prefix
-	 * @return void
 	 */
 	public function __construct(Connection $connection, Encrypter $encrypter, $table, $prefix = '')
 	{

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -23,7 +23,6 @@ class FileStore implements StoreInterface {
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  string  $directory
-	 * @return void
 	 */
 	public function __construct(Filesystem $files, $directory)
 	{

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -23,7 +23,6 @@ class MemcachedStore extends TaggableStore implements StoreInterface {
 	 *
 	 * @param  \Memcached  $memcached
 	 * @param  string     $prefix
-	 * @return void
 	 */
 	public function __construct(Memcached $memcached, $prefix = '')
 	{

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -31,7 +31,6 @@ class RedisStore extends TaggableStore implements StoreInterface {
 	 * @param  \Illuminate\Redis\Database  $redis
 	 * @param  string  $prefix
 	 * @param  string  $connection
-	 * @return void
 	 */
 	public function __construct(Redis $redis, $prefix = '', $connection = 'default')
 	{

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -21,7 +21,6 @@ class TagSet {
 	 *
 	 * @param  \Illuminate\Cache\StoreInterface  $store
 	 * @param  array  $names
-	 * @return void
 	 */
 	public function __construct(StoreInterface $store, array $names = array())
 	{

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -23,7 +23,6 @@ class TaggedCache implements StoreInterface {
 	 *
 	 * @param  \Illuminate\Cache\StoreInterface  $store
 	 * @param  \Illuminate\Cache\TagSet  $tags
-	 * @return void
 	 */
 	public function __construct(StoreInterface $store, TagSet $tags)
 	{

--- a/src/Illuminate/Cache/WinCacheStore.php
+++ b/src/Illuminate/Cache/WinCacheStore.php
@@ -13,7 +13,6 @@ class WinCacheStore extends TaggableStore implements StoreInterface {
 	 * Create a new WinCache store.
 	 *
 	 * @param  string     $prefix
-	 * @return void
 	 */
 	public function __construct($prefix = '')
 	{

--- a/src/Illuminate/Cache/XCacheStore.php
+++ b/src/Illuminate/Cache/XCacheStore.php
@@ -13,7 +13,6 @@ class XCacheStore extends TaggableStore implements StoreInterface {
 	 * Create a new WinCache store.
 	 *
 	 * @param  string     $prefix
-	 * @return void
 	 */
 	public function __construct($prefix = '')
 	{

--- a/src/Illuminate/Config/EnvironmentVariables.php
+++ b/src/Illuminate/Config/EnvironmentVariables.php
@@ -18,7 +18,6 @@ class EnvironmentVariables {
 	 * The server environment instance.
 	 *
 	 * @param  \Illuminate\Config\EnvironmentLoaderInterface  $loader
-	 * @return void
 	 */
 	public function __construct(EnvironmentVariablesLoaderInterface $loader)
 	{

--- a/src/Illuminate/Config/EnvironmentVariables.php
+++ b/src/Illuminate/Config/EnvironmentVariables.php
@@ -10,14 +10,14 @@ class EnvironmentVariables {
 	/**
 	 * The environment loader implementation.
 	 *
-	 * @var \Illuminate\Config\EnvironmentLoaderInterface  $loader
+	 * @var \Illuminate\Config\EnvironmentVariablesLoaderInterface  $loader
 	 */
 	protected $loader;
 
 	/**
 	 * The server environment instance.
 	 *
-	 * @param  \Illuminate\Config\EnvironmentLoaderInterface  $loader
+	 * @param  \Illuminate\Config\EnvironmentVariablesLoaderInterface  $loader
 	 */
 	public function __construct(EnvironmentVariablesLoaderInterface $loader)
 	{

--- a/src/Illuminate/Config/FileEnvironmentVariablesLoader.php
+++ b/src/Illuminate/Config/FileEnvironmentVariablesLoader.php
@@ -22,7 +22,6 @@ class FileEnvironmentVariablesLoader implements EnvironmentVariablesLoaderInterf
 	 * Create a new file environment loader instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(Filesystem $files, $path = null)
 	{

--- a/src/Illuminate/Config/FileLoader.php
+++ b/src/Illuminate/Config/FileLoader.php
@@ -37,7 +37,6 @@ class FileLoader implements LoaderInterface {
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  string  $defaultPath
-	 * @return void
 	 */
 	public function __construct(Filesystem $files, $defaultPath)
 	{

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -46,7 +46,6 @@ class Repository extends NamespacedItemResolver implements ArrayAccess {
 	 *
 	 * @param  \Illuminate\Config\LoaderInterface  $loader
 	 * @param  string  $environment
-	 * @return void
 	 */
 	public function __construct(LoaderInterface $loader, $environment)
 	{

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -45,7 +45,6 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	/**
 	 * Create a new console command instance.
 	 *
-	 * @return void
 	 */
 	public function __construct()
 	{

--- a/src/Illuminate/Cookie/Guard.php
+++ b/src/Illuminate/Cookie/Guard.php
@@ -28,7 +28,6 @@ class Guard implements HttpKernelInterface {
 	 *
 	 * @param  \Symfony\Component\HttpKernel\HttpKernelInterface  $app
 	 * @param  \Illuminate\Encryption\Encrypter  $encrypter
-	 * @return void
 	 */
 	public function __construct(HttpKernelInterface $app, Encrypter $encrypter)
 	{

--- a/src/Illuminate/Cookie/Queue.php
+++ b/src/Illuminate/Cookie/Queue.php
@@ -24,7 +24,6 @@ class Queue implements HttpKernelInterface {
 	 *
 	 * @param  \Symfony\Component\HttpKernel\HttpKernelInterface  $app
 	 * @param  \Illuminate\Cookie\CookieJar  $cookies
-	 * @return void
 	 */
 	public function __construct(HttpKernelInterface $app, CookieJar $cookies)
 	{

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -24,10 +24,10 @@ class Manager {
 	 * @var \Illuminate\Database\DatabaseManager
 	 */
 	protected $manager;
-	
+
 	/**
 	 * The container instance.
-	 * 
+	 *
 	 * @var \Illuminate\Container\Container
 	 */
 	protected $container;
@@ -36,7 +36,6 @@ class Manager {
 	 * Create a new database capsule manager.
 	 *
 	 * @param  \Illuminate\Container\Container|null  $container
-	 * @return void
 	 */
 	public function __construct(Container $container = null)
 	{

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -127,7 +127,6 @@ class Connection implements ConnectionInterface {
 	 * @param  string  $database
 	 * @param  string  $tablePrefix
 	 * @param  array   $config
-	 * @return void
 	 */
 	public function __construct(PDO $pdo, $database = '', $tablePrefix = '', array $config = array())
 	{

--- a/src/Illuminate/Database/ConnectionResolver.php
+++ b/src/Illuminate/Database/ConnectionResolver.php
@@ -20,7 +20,6 @@ class ConnectionResolver implements ConnectionResolverInterface {
 	 * Create a new connection resolver instance.
 	 *
 	 * @param  array  $connections
-	 * @return void
 	 */
 	public function __construct(array $connections = array())
 	{

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -20,7 +20,6 @@ class ConnectionFactory {
 	 * Create a new connection factory instance.
 	 *
 	 * @param  \Illuminate\Container\Container  $container
-	 * @return void
 	 */
 	public function __construct(Container $container)
 	{

--- a/src/Illuminate/Database/Console/Migrations/InstallCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/InstallCommand.php
@@ -31,7 +31,6 @@ class InstallCommand extends Command {
 	 * Create a new migration install command instance.
 	 *
 	 * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
-	 * @return void
 	 */
 	public function __construct(MigrationRepositoryInterface $repository)
 	{

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -39,7 +39,6 @@ class MigrateCommand extends BaseCommand {
 	 *
 	 * @param  \Illuminate\Database\Migrations\Migrator  $migrator
 	 * @param  string  $packagePath
-	 * @return void
 	 */
 	public function __construct(Migrator $migrator, $packagePath)
 	{

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -39,7 +39,6 @@ class MigrateMakeCommand extends BaseCommand {
 	 *
 	 * @param  \Illuminate\Database\Migrations\MigrationCreator  $creator
 	 * @param  string  $packagePath
-	 * @return void
 	 */
 	public function __construct(MigrationCreator $creator, $packagePath)
 	{

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -34,7 +34,6 @@ class ResetCommand extends Command {
 	 * Create a new migration rollback command instance.
 	 *
 	 * @param  \Illuminate\Database\Migrations\Migrator  $migrator
-	 * @return void
 	 */
 	public function __construct(Migrator $migrator)
 	{

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -34,7 +34,6 @@ class RollbackCommand extends Command {
 	 * Create a new migration rollback command instance.
 	 *
 	 * @param  \Illuminate\Database\Migrations\Migrator  $migrator
-	 * @return void
 	 */
 	public function __construct(Migrator $migrator)
 	{

--- a/src/Illuminate/Database/Console/SeedCommand.php
+++ b/src/Illuminate/Database/Console/SeedCommand.php
@@ -31,7 +31,6 @@ class SeedCommand extends Command {
 	 * Create a new database seed command instance.
 	 *
 	 * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
-	 * @return void
 	 */
 	public function __construct(Resolver $resolver)
 	{

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -37,7 +37,6 @@ class DatabaseManager implements ConnectionResolverInterface {
 	 *
 	 * @param  \Illuminate\Foundation\Application  $app
 	 * @param  \Illuminate\Database\Connectors\ConnectionFactory  $factory
-	 * @return void
 	 */
 	public function __construct($app, ConnectionFactory $factory)
 	{

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -56,7 +56,6 @@ class Builder {
 	 * Create a new Eloquent query builder instance.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
-	 * @return void
 	 */
 	public function __construct(QueryBuilder $query)
 	{

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1062,6 +1062,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Delete the model from the database.
 	 *
 	 * @return bool|null
+	 *
+	 * @throws \Exception
 	 */
 	public function delete()
 	{

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -231,7 +231,6 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Create a new Eloquent model instance.
 	 *
 	 * @param  array  $attributes
-	 * @return void
 	 */
 	public function __construct(array $attributes = array())
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -36,7 +36,6 @@ class BelongsTo extends Relation {
 	 * @param  string  $foreignKey
 	 * @param  string  $otherKey
 	 * @param  string  $relation
-	 * @return void
 	 */
 	public function __construct(Builder $query, Model $parent, $foreignKey, $otherKey, $relation)
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -51,7 +51,6 @@ class BelongsToMany extends Relation {
 	 * @param  string  $foreignKey
 	 * @param  string  $otherKey
 	 * @param  string  $relationName
-	 * @return void
 	 */
 	public function __construct(Builder $query, Model $parent, $table, $foreignKey, $otherKey, $relationName = null)
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -35,7 +35,6 @@ class HasManyThrough extends Relation {
 	 * @param  \Illuminate\Database\Eloquent\Model  $parent
 	 * @param  string  $firstKey
 	 * @param  string  $secondKey
-	 * @return void
 	 */
 	public function __construct(Builder $query, Model $farParent, Model $parent, $firstKey, $secondKey)
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -26,7 +26,6 @@ abstract class HasOneOrMany extends Relation {
 	 * @param  \Illuminate\Database\Eloquent\Builder  $query
 	 * @param  \Illuminate\Database\Eloquent\Model  $parent
 	 * @param  string  $foreignKey
-	 * @return void
 	 */
 	public function __construct(Builder $query, Model $parent, $foreignKey, $localKey)
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -27,7 +27,6 @@ abstract class MorphOneOrMany extends HasOneOrMany {
 	 * @param  string  $type
 	 * @param  string  $id
 	 * @param  string  $localKey
-	 * @return void
 	 */
 	public function __construct(Builder $query, Model $parent, $type, $id, $localKey)
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -37,7 +37,6 @@ class MorphTo extends BelongsTo {
 	 * @param  string  $otherKey
 	 * @param  string  $type
 	 * @param  string  $relation
-	 * @return void
 	 */
 	public function __construct(Builder $query, Model $parent, $foreignKey, $otherKey, $type, $relation)
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -39,7 +39,6 @@ class MorphToMany extends BelongsToMany {
 	 * @param  string  $otherKey
 	 * @param  string  $relationName
 	 * @param  bool  $inverse
-	 * @return void
 	 */
 	public function __construct(Builder $query, Model $parent, $name, $table, $foreignKey, $otherKey, $relationName = null, $inverse = false)
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -40,7 +40,6 @@ class Pivot extends Model {
 	 * @param  array   $attributes
 	 * @param  string  $table
 	 * @param  bool    $exists
-	 * @return void
 	 */
 	public function __construct(Model $parent, $attributes, $table, $exists = false)
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -41,7 +41,6 @@ abstract class Relation {
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $query
 	 * @param  \Illuminate\Database\Eloquent\Model  $parent
-	 * @return void
 	 */
 	public function __construct(Builder $query, Model $parent)
 	{

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -30,7 +30,6 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 	 *
 	 * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
 	 * @param  string  $table
-	 * @return void
 	 */
 	public function __construct(Resolver $resolver, $table)
 	{

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -23,7 +23,6 @@ class MigrationCreator {
 	 * Create a new migration creator instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(Filesystem $files)
 	{

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -46,7 +46,6 @@ class Migrator {
 	 * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
 	 * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(MigrationRepositoryInterface $repository,
 								Resolver $resolver,

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1918,6 +1918,8 @@ class Builder {
 	 * @param  array   $bindings
 	 * @param  string  $type
 	 * @return \Illuminate\Database\Query\Builder
+	 *
+	 * @throws \InvalidArgumentException
 	 */
 	public function setBindings(array $bindings, $type = 'where')
 	{
@@ -1937,6 +1939,8 @@ class Builder {
 	 * @param  mixed   $value
 	 * @param  string  $type
 	 * @return \Illuminate\Database\Query\Builder
+	 *
+	 * @throws \InvalidArgumentException
 	 */
 	public function addBinding($value, $type = 'where')
 	{

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -178,7 +178,6 @@ class Builder {
 	 * @param  \Illuminate\Database\ConnectionInterface  $connection
 	 * @param  \Illuminate\Database\Query\Grammars\Grammar  $grammar
 	 * @param  \Illuminate\Database\Query\Processors\Processor  $processor
-	 * @return void
 	 */
 	public function __construct(ConnectionInterface $connection,
                                 Grammar $grammar,

--- a/src/Illuminate/Database/Query/Expression.php
+++ b/src/Illuminate/Database/Query/Expression.php
@@ -13,7 +13,6 @@ class Expression {
 	 * Create a new raw query expression.
 	 *
 	 * @param  mixed  $value
-	 * @return void
 	 */
 	public function __construct($value)
 	{

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -36,7 +36,6 @@ class JoinClause {
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  string  $type
 	 * @param  string  $table
-	 * @return void
 	 */
 	public function __construct(Builder $query, $type, $table)
 	{

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -24,7 +24,6 @@ class QueryException extends PDOException {
 	 * @param  string  $sql
 	 * @param  array  $bindings
 	 * @param  \Exception $previous
-	 * @return void
 	 */
 	public function __construct($sql, array $bindings, $previous)
 	{

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -40,7 +40,6 @@ class Blueprint {
 	 *
 	 * @param  string   $table
 	 * @param  Closure  $callback
-	 * @return void
 	 */
 	public function __construct($table, Closure $callback = null)
 	{

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -30,7 +30,6 @@ class Builder {
 	 * Create a new database Schema manager.
 	 *
 	 * @param  \Illuminate\Database\Connection  $connection
-	 * @return void
 	 */
 	public function __construct(Connection $connection)
 	{

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -39,7 +39,6 @@ class Encrypter {
 	 * Create a new encrypter instance.
 	 *
 	 * @param  string  $key
-	 * @return void
 	 */
 	public function __construct($key)
 	{

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -43,7 +43,6 @@ class Dispatcher {
 	 * Create a new event dispatcher instance.
 	 *
 	 * @param  \Illuminate\Container\Container  $container
-	 * @return void
 	 */
 	public function __construct(Container $container = null)
 	{

--- a/src/Illuminate/Exception/Handler.php
+++ b/src/Illuminate/Exception/Handler.php
@@ -57,7 +57,6 @@ class Handler {
 	 * @param  \Illuminate\Support\Contracts\ResponsePreparerInterface  $responsePreparer
 	 * @param  \Illuminate\Exception\ExceptionDisplayerInterface  $plainDisplayer
 	 * @param  \Illuminate\Exception\ExceptionDisplayerInterface  $debugDisplayer
-	 * @return void
 	 */
 	public function __construct(ResponsePreparerInterface $responsePreparer,
                                 ExceptionDisplayerInterface $plainDisplayer,

--- a/src/Illuminate/Exception/SymfonyDisplayer.php
+++ b/src/Illuminate/Exception/SymfonyDisplayer.php
@@ -16,7 +16,6 @@ class SymfonyDisplayer implements ExceptionDisplayerInterface {
 	 * Create a new Symfony exception displayer.
 	 *
 	 * @param  \Symfony\Component\Debug\ExceptionHandler  $symfony
-	 * @return void
 	 */
 	public function __construct(ExceptionHandler $symfony)
 	{

--- a/src/Illuminate/Exception/WhoopsDisplayer.php
+++ b/src/Illuminate/Exception/WhoopsDisplayer.php
@@ -26,7 +26,6 @@ class WhoopsDisplayer implements ExceptionDisplayerInterface {
 	 *
 	 * @param  \Whoops\Run  $whoops
 	 * @param  bool  $runningInConsole
-	 * @return void
 	 */
 	public function __construct(Run $whoops, $runningInConsole)
 	{

--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -27,7 +27,6 @@ class AliasLoader {
 	 * Create a new class alias loader instance.
 	 *
 	 * @param  array  $aliases
-	 * @return void
 	 */
 	public function __construct(array $aliases = array())
 	{

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -103,7 +103,6 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	 * Create a new Illuminate application instance.
 	 *
 	 * @param  \Illuminate\Http\Request
-	 * @return void
 	 */
 	public function __construct(Request $request = null)
 	{

--- a/src/Illuminate/Foundation/Artisan.php
+++ b/src/Illuminate/Foundation/Artisan.php
@@ -22,7 +22,6 @@ class Artisan {
 	 * Create a new Artisan command runner instance.
 	 *
 	 * @param  \Illuminate\Foundation\Application  $app
-	 * @return void
 	 */
 	public function __construct(Application $app)
 	{

--- a/src/Illuminate/Foundation/AssetPublisher.php
+++ b/src/Illuminate/Foundation/AssetPublisher.php
@@ -30,7 +30,6 @@ class AssetPublisher {
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  string  $publishPath
-	 * @return void
 	 */
 	public function __construct(Filesystem $files, $publishPath)
 	{

--- a/src/Illuminate/Foundation/Composer.php
+++ b/src/Illuminate/Foundation/Composer.php
@@ -24,7 +24,6 @@ class Composer {
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  string  $workingPath
-	 * @return void
 	 */
 	public function __construct(Filesystem $files, $workingPath = null)
 	{

--- a/src/Illuminate/Foundation/ConfigPublisher.php
+++ b/src/Illuminate/Foundation/ConfigPublisher.php
@@ -30,7 +30,6 @@ class ConfigPublisher {
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  string  $publishPath
-	 * @return void
 	 */
 	public function __construct(Filesystem $files, $publishPath)
 	{

--- a/src/Illuminate/Foundation/Console/AssetPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/AssetPublishCommand.php
@@ -33,7 +33,6 @@ class AssetPublishCommand extends Command {
 	 * Create a new asset publish command instance.
 	 *
 	 * @param  \Illuminate\Foundation\AssetPublisher  $assets
-	 * @return void
 	 */
 	public function __construct(AssetPublisher $assets)
 	{

--- a/src/Illuminate/Foundation/Console/AutoloadCommand.php
+++ b/src/Illuminate/Foundation/Console/AutoloadCommand.php
@@ -31,7 +31,6 @@ class AutoloadCommand extends Command {
 	 * Create a new optimize command instance.
 	 *
 	 * @param  \Illuminate\Foundation\Composer  $composer
-	 * @return void
 	 */
 	public function __construct(Composer $composer)
 	{

--- a/src/Illuminate/Foundation/Console/CommandMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CommandMakeCommand.php
@@ -25,7 +25,6 @@ class CommandMakeCommand extends Command {
 	 * Create a new command creator command.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(Filesystem $files)
 	{

--- a/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
@@ -32,7 +32,6 @@ class ConfigPublishCommand extends Command {
 	 * Create a new configuration publish command instance.
 	 *
 	 * @param  \Illuminate\Foundation\ConfigPublisher  $config
-	 * @return void
 	 */
 	public function __construct(ConfigPublisher $config)
 	{

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -24,7 +24,6 @@ class KeyGenerateCommand extends Command {
 	 * Create a new key generator command.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(Filesystem $files)
 	{

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -32,7 +32,6 @@ class OptimizeCommand extends Command {
 	 * Create a new optimize command instance.
 	 *
 	 * @param  \Illuminate\Foundation\Composer  $composer
-	 * @return void
 	 */
 	public function __construct(Composer $composer)
 	{

--- a/src/Illuminate/Foundation/Console/RoutesCommand.php
+++ b/src/Illuminate/Foundation/Console/RoutesCommand.php
@@ -56,7 +56,6 @@ class RoutesCommand extends Command {
 	 * Create a new route command instance.
 	 *
 	 * @param  \Illuminate\Routing\Router  $router
-	 * @return void
 	 */
 	public function __construct(Router $router)
 	{

--- a/src/Illuminate/Foundation/Console/ViewPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewPublishCommand.php
@@ -32,7 +32,6 @@ class ViewPublishCommand extends Command {
 	 * Create a new view publish command instance.
 	 *
 	 * @param  \Illuminate\Foundation\ViewPublisher  $view
-	 * @return void
 	 */
 	public function __construct(ViewPublisher $view)
 	{

--- a/src/Illuminate/Foundation/Console/stubs/command.stub
+++ b/src/Illuminate/Foundation/Console/stubs/command.stub
@@ -23,7 +23,6 @@ class {{class}} extends Command {
 	/**
 	 * Create a new command instance.
 	 *
-	 * @return void
 	 */
 	public function __construct()
 	{

--- a/src/Illuminate/Foundation/MigrationPublisher.php
+++ b/src/Illuminate/Foundation/MigrationPublisher.php
@@ -16,7 +16,6 @@ class MigrationPublisher {
 	 * Create a new migration publisher instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(Filesystem $files)
 	{

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -30,7 +30,6 @@ class ProviderRepository {
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  string  $manifestPath
-	 * @return void
 	 */
 	public function __construct(Filesystem $files, $manifestPath)
 	{

--- a/src/Illuminate/Foundation/ViewPublisher.php
+++ b/src/Illuminate/Foundation/ViewPublisher.php
@@ -30,7 +30,6 @@ class ViewPublisher {
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  string  $publishPath
-	 * @return void
 	 */
 	public function __construct(Filesystem $files, $publishPath)
 	{

--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -77,7 +77,6 @@ class FormBuilder {
 	 * @param  \Illuminate\Routing\UrlGenerator  $url
 	 * @param  \Illuminate\Html\HtmlBuilder  $html
 	 * @param  string  $csrfToken
-	 * @return void
 	 */
 	public function __construct(HtmlBuilder $html, UrlGenerator $url, $csrfToken)
 	{

--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -18,7 +18,6 @@ class HtmlBuilder {
 	 * Create a new HTML builder instance.
 	 *
 	 * @param  \Illuminate\Routing\UrlGenerator  $url
-	 * @return void
 	 */
 	public function __construct(UrlGenerator $url = null)
 	{

--- a/src/Illuminate/Http/FrameGuard.php
+++ b/src/Illuminate/Http/FrameGuard.php
@@ -16,7 +16,6 @@ class FrameGuard implements HttpKernelInterface {
 	 * Create a new FrameGuard instance.
 	 *
 	 * @param  \Symfony\Component\HttpKernel\HttpKernelInterface  $app
-	 * @return void
 	 */
 	public function __construct(HttpKernelInterface $app)
 	{

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -46,7 +46,6 @@ class Writer {
 	 *
 	 * @param  \Monolog\Logger  $monolog
 	 * @param  \Illuminate\Events\Dispatcher  $dispatcher
-	 * @return void
 	 */
 	public function __construct(MonologLogger $monolog, Dispatcher $dispatcher = null)
 	{

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -87,7 +87,6 @@ class Mailer {
 	 *
 	 * @param  \Illuminate\View\Factory  $views
 	 * @param  \Swift_Mailer  $swift
-	 * @return void
 	 */
 	public function __construct(Factory $views, Swift_Mailer $swift, Dispatcher $events = null)
 	{

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -16,7 +16,6 @@ class Message {
 	 * Create a new message instance.
 	 *
 	 * @param  \Swift_Message  $swift
-	 * @return void
 	 */
 	public function __construct($swift)
 	{

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -18,7 +18,6 @@ class LogTransport implements Swift_Transport {
 	 * Create a new Mandrill transport instance.
 	 *
 	 * @param  string  $key
-	 * @return void
 	 */
 	public function __construct(LoggerInterface $logger)
 	{

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -33,7 +33,6 @@ class MailgunTransport implements Swift_Transport {
 	 *
 	 * @param  string  $key
 	 * @param  string  $domain
-	 * @return void
 	 */
 	public function __construct($key, $domain)
 	{

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -17,7 +17,6 @@ class MandrillTransport implements Swift_Transport {
 	 * Create a new Mandrill transport instance.
 	 *
 	 * @param  string  $key
-	 * @return void
 	 */
 	public function __construct($key)
 	{

--- a/src/Illuminate/Pagination/Factory.php
+++ b/src/Illuminate/Pagination/Factory.php
@@ -69,7 +69,6 @@ class Factory {
 	 * @param  \Illuminate\View\Factory  $view
 	 * @param  \Symfony\Component\Translation\TranslatorInterface  $trans
 	 * @param  string  $pageName
-	 * @return void
 	 */
 	public function __construct(Request $request, ViewFactory $view, TranslatorInterface $trans, $pageName = 'page')
 	{

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -94,7 +94,6 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	 * @param  array  $items
 	 * @param  int    $total
 	 * @param  mixed  $perPage
-	 * @return void
 	 */
 	public function __construct(Factory $factory, array $items, $total, $perPage = null)
 	{

--- a/src/Illuminate/Pagination/Presenter.php
+++ b/src/Illuminate/Pagination/Presenter.php
@@ -27,7 +27,6 @@ abstract class Presenter {
 	 * Create a new Presenter instance.
 	 *
 	 * @param  \Illuminate\Pagination\Paginator  $paginator
-	 * @return void
 	 */
 	public function __construct(Paginator $paginator)
 	{

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -33,7 +33,6 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 	 * @param  Pheanstalk  $pheanstalk
 	 * @param  string  $default
 	 * @param  int  $timeToRun
-	 * @return void
 	 */
 	public function __construct(Pheanstalk $pheanstalk, $default, $timeToRun)
 	{

--- a/src/Illuminate/Queue/Connectors/IronConnector.php
+++ b/src/Illuminate/Queue/Connectors/IronConnector.php
@@ -26,7 +26,6 @@ class IronConnector implements ConnectorInterface {
 	 *
 	 * @param  \Illuminate\Encryption\Encrypter  $crypt
 	 * @param  \Illuminate\Http\Request  $request
-	 * @return void
 	 */
 	public function __construct(Encrypter $crypt, Request $request)
 	{

--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -24,7 +24,6 @@ class RedisConnector implements ConnectorInterface {
 	 *
 	 * @param  \Illuminate\Redis\Database  $redis
 	 * @param  string|null  $connection
-	 * @return void
 	 */
 	public function __construct(Database $redis, $connection = null)
 	{

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -30,7 +30,6 @@ class FailedTableCommand extends Command {
 	 * Create a new session table command instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(Filesystem $files)
 	{

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -32,7 +32,6 @@ class ListenCommand extends Command {
 	 * Create a new queue listen command.
 	 *
 	 * @param  \Illuminate\Queue\Listener  $listener
-	 * @return void
 	 */
 	public function __construct(Listener $listener)
 	{

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -34,7 +34,6 @@ class WorkCommand extends Command {
 	 * Create a new queue listen command.
 	 *
 	 * @param  \Illuminate\Queue\Worker  $worker
-	 * @return void
 	 */
 	public function __construct(Worker $worker)
 	{

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -32,7 +32,6 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface {
 	 * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
 	 * @param  string  $database
 	 * @param  string  $table
-	 * @return void
 	 */
 	public function __construct(ConnectionResolverInterface $resolver, $database, $table)
 	{

--- a/src/Illuminate/Queue/IlluminateQueueClosure.php
+++ b/src/Illuminate/Queue/IlluminateQueueClosure.php
@@ -15,7 +15,6 @@ class IlluminateQueueClosure {
 	 * Create a new queued Closure job.
 	 *
 	 * @param  \Illuminate\Encryption\Encrypter  $crypt
-	 * @return void
 	 */
 	public function __construct(Encrypter $crypt)
 	{

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -42,7 +42,6 @@ class IronQueue extends Queue implements QueueInterface {
 	 * @param  \Illuminate\Http\Request  $request
 	 * @param  string  $default
 	 * @param  bool  $shouldEncrypt
-	 * @return void
 	 */
 	public function __construct(IronMQ $iron, Request $request, $default, $shouldEncrypt = false)
 	{

--- a/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
+++ b/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
@@ -27,7 +27,6 @@ class BeanstalkdJob extends Job {
 	 * @param  Pheanstalk  $pheanstalk
 	 * @param  Pheanstalk_Job  $job
 	 * @param  string  $queue
-	 * @return void
 	 */
 	public function __construct(Container $container,
                                 Pheanstalk $pheanstalk,

--- a/src/Illuminate/Queue/Jobs/IronJob.php
+++ b/src/Illuminate/Queue/Jobs/IronJob.php
@@ -34,7 +34,6 @@ class IronJob extends Job {
 	 * @param  object  $job
 	 * @param  string  $queue
 	 * @param  bool    $pushed
-	 * @return void
 	 */
 	public function __construct(Container $container,
                                 IronQueue $iron,

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -26,7 +26,6 @@ class RedisJob extends Job {
 	 * @param  \Illuminate\Queue\RedisQueue  $redis
 	 * @param  string  $job
 	 * @param  string  $queue
-	 * @return void
 	 */
 	public function __construct(Container $container, RedisQueue $redis, $job, $queue)
 	{

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -26,7 +26,6 @@ class SqsJob extends Job {
 	 * @param  \Aws\Sqs\SqsClient  $sqs
 	 * @param  string  $queue
 	 * @param  array   $job
-	 * @return void
 	 */
 	public function __construct(Container $container,
                                 SqsClient $sqs,

--- a/src/Illuminate/Queue/Jobs/SyncJob.php
+++ b/src/Illuminate/Queue/Jobs/SyncJob.php
@@ -25,7 +25,6 @@ class SyncJob extends Job {
 	 * @param  \Illuminate\Container\Container  $container
 	 * @param  string  $job
 	 * @param  string  $data
-	 * @return void
 	 */
 	public function __construct(Container $container, $job, $data = '')
 	{

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -51,7 +51,6 @@ class Listener {
 	 * Create a new queue listener.
 	 *
 	 * @param  string  $commandPath
-	 * @return void
 	 */
 	public function __construct($commandPath)
 	{

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -22,7 +22,6 @@ class QueueManager {
 	 * Create a new queue manager instance.
 	 *
 	 * @param  \Illuminate\Foundation\Application  $app
-	 * @return void
 	 */
 	public function __construct($app)
 	{

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -32,7 +32,6 @@ class RedisQueue extends Queue implements QueueInterface {
 	 * @param  \Illuminate\Redis\Database  $redis
 	 * @param  string  $default
 	 * @param  string  $connection
-	 * @return void
 	 */
 	public function __construct(Database $redis, $default = 'default', $connection = null)
 	{

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -24,7 +24,6 @@ class SqsQueue extends Queue implements QueueInterface {
 	 *
 	 * @param  \Aws\Sqs\SqsClient  $sqs
 	 * @param  string  $default
-	 * @return void
 	 */
 	public function __construct(SqsClient $sqs, $default)
 	{

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -33,7 +33,6 @@ class Worker {
 	 * @param  \Illuminate\Queue\QueueManager  $manager
 	 * @param  \Illuminate\Queue\Failed\FailedJobProviderInterface  $failer
 	 * @param  \Illuminate\Events\Dispatcher  $events
-	 * @return void
 	 */
 	public function __construct(QueueManager $manager,
                                 FailedJobProviderInterface $failer = null,

--- a/src/Illuminate/Redis/Database.php
+++ b/src/Illuminate/Redis/Database.php
@@ -15,7 +15,6 @@ class Database {
 	 * Create a new Redis connection instance.
 	 *
 	 * @param  array  $servers
-	 * @return void
 	 */
 	public function __construct(array $servers = array())
 	{

--- a/src/Illuminate/Remote/MultiConnection.php
+++ b/src/Illuminate/Remote/MultiConnection.php
@@ -15,7 +15,6 @@ class MultiConnection implements ConnectionInterface {
 	 * The array of connections.
 	 *
 	 * @param  array  $connections
-	 * @return void
 	 */
 	public function __construct(array $connections)
 	{

--- a/src/Illuminate/Remote/RemoteManager.php
+++ b/src/Illuminate/Remote/RemoteManager.php
@@ -16,7 +16,6 @@ class RemoteManager {
 	 * Create a new remote manager instance.
 	 *
 	 * @param  \Illuminate\Foundation\Application  $app
-	 * @return void
 	 */
 	public function __construct($app)
 	{

--- a/src/Illuminate/Remote/SecLibGateway.php
+++ b/src/Illuminate/Remote/SecLibGateway.php
@@ -45,7 +45,6 @@ class SecLibGateway implements GatewayInterface {
 	 *
 	 * @param  string  $host
 	 * @param  array   $auth
-	 * @return void
 	 */
 	public function __construct($host, array $auth, Filesystem $files)
 	{

--- a/src/Illuminate/Routing/Console/MakeControllerCommand.php
+++ b/src/Illuminate/Routing/Console/MakeControllerCommand.php
@@ -40,7 +40,6 @@ class MakeControllerCommand extends Command {
 	 *
 	 * @param  \Illuminate\Routing\Generators\ControllerGenerator  $generator
 	 * @param  string  $path
-	 * @return void
 	 */
 	public function __construct(ControllerGenerator $generator, $path)
 	{

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -25,7 +25,6 @@ class ControllerDispatcher {
 	 *
 	 * @param  \Illuminate\Routing\RouteFiltererInterface  $filterer
 	 * @param  \Illuminate\Container\Container  $container
-	 * @return void
 	 */
 	public function __construct(RouteFiltererInterface $filterer,
 								Container $container = null)

--- a/src/Illuminate/Routing/Generators/ControllerGenerator.php
+++ b/src/Illuminate/Routing/Generators/ControllerGenerator.php
@@ -30,7 +30,6 @@ class ControllerGenerator {
 	 * Create a new controller generator instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(Filesystem $files)
 	{

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -23,7 +23,6 @@ class Redirector {
 	 * Create a new Redirector instance.
 	 *
 	 * @param  \Illuminate\Routing\UrlGenerator  $generator
-	 * @return void
 	 */
 	public function __construct(UrlGenerator $generator)
 	{

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -79,7 +79,6 @@ class Route {
 	 * @param  array   $methods
 	 * @param  string  $uri
 	 * @param  \Closure|array  $action
-	 * @return void
 	 */
 	public function __construct($methods, $uri, $action)
 	{

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -122,7 +122,6 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 *
 	 * @param  \Illuminate\Events\Dispatcher  $events
 	 * @param  \Illuminate\Container\Container  $container
-	 * @return void
 	 */
 	public function __construct(Dispatcher $events, Container $container = null)
 	{

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -42,7 +42,6 @@ class UrlGenerator {
 	 *
 	 * @param  \Illuminate\Routing\RouteCollection  $routes
 	 * @param  \Symfony\Component\HttpFoundation\Request   $request
-	 * @return void
 	 */
 	public function __construct(RouteCollection $routes, Request $request)
 	{

--- a/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -23,7 +23,6 @@ class CacheBasedSessionHandler implements \SessionHandlerInterface {
 	 *
 	 * @param  \Illuminate\Cache\Repository  $cache
 	 * @param  int  $minutes
-	 * @return void
 	 */
 	public function __construct(Repository $cache, $minutes)
 	{

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -30,7 +30,6 @@ class SessionTableCommand extends Command {
 	 * Create a new session table command instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(Filesystem $files)
 	{

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -24,7 +24,6 @@ class CookieSessionHandler implements \SessionHandlerInterface {
 	 *
 	 * @param  \Illuminate\Cookie\CookieJar  $cookie
 	 * @param  int  $minutes
-	 * @return void
 	 */
 	public function __construct(CookieJar $cookie, $minutes)
 	{

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -24,7 +24,6 @@ class FileSessionHandler implements \SessionHandlerInterface {
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  string  $path
-	 * @return void
 	 */
 	public function __construct(Filesystem $files, $path)
 	{

--- a/src/Illuminate/Session/Middleware.php
+++ b/src/Illuminate/Session/Middleware.php
@@ -36,7 +36,6 @@ class Middleware implements HttpKernelInterface {
 	 * @param  \Symfony\Component\HttpKernel\HttpKernelInterface  $app
 	 * @param  \Illuminate\Session\SessionManager  $manager
 	 * @param  \Closure|null  $reject
-	 * @return void
 	 */
 	public function __construct(HttpKernelInterface $app, SessionManager $manager, Closure $reject = null)
 	{

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -69,7 +69,6 @@ class Store implements SessionInterface {
 	 * @param  string  $name
 	 * @param  \SessionHandlerInterface  $handler
 	 * @param  string|null $id
-	 * @return void
 	 */
 	public function __construct($name, SessionHandlerInterface $handler, $id = null)
 	{

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -23,7 +23,6 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Create a new collection.
 	 *
 	 * @param  array  $items
-	 * @return void
 	 */
 	public function __construct(array $items = array())
 	{

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -18,7 +18,6 @@ class Fluent implements ArrayAccess, ArrayableInterface, JsonableInterface, Json
 	 * Create a new fluent container instance.
 	 *
 	 * @param  array  $attributes
-	 * @return void
 	 */
 	public function __construct($attributes = array())
 	{

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -29,7 +29,6 @@ abstract class Manager {
 	 * Create a new manager instance.
 	 *
 	 * @param  \Illuminate\Foundation\Application  $app
-	 * @return void
 	 */
 	public function __construct($app)
 	{

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -26,7 +26,6 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 	 * Create a new message bag instance.
 	 *
 	 * @param  array  $messages
-	 * @return void
 	 */
 	public function __construct(array $messages = array())
 	{

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -22,7 +22,6 @@ abstract class ServiceProvider {
 	 * Create a new service provider instance.
 	 *
 	 * @param  \Illuminate\Foundation\Application  $app
-	 * @return void
 	 */
 	public function __construct($app)
 	{

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -30,7 +30,6 @@ class FileLoader implements LoaderInterface {
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  string  $path
-	 * @return void
 	 */
 	public function __construct(Filesystem $files, $path)
 	{

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -40,7 +40,6 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	 *
 	 * @param  \Illuminate\Translation\LoaderInterface  $loader
 	 * @param  string  $locale
-	 * @return void
 	 */
 	public function __construct(LoaderInterface $loader, $locale)
 	{

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -22,7 +22,6 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface {
 	 * Create a new database presence verifier.
 	 *
 	 * @param  \Illuminate\Database\ConnectionResolverInterface  $db
-	 * @return void
 	 */
 	public function __construct(ConnectionResolverInterface $db)
 	{

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -67,7 +67,6 @@ class Factory {
 	 *
 	 * @param  \Symfony\Component\Translation\TranslatorInterface  $translator
 	 * @param  \Illuminate\Container\Container  $container
-	 * @return void
 	 */
 	public function __construct(TranslatorInterface $translator, Container $container = null)
 	{

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -127,7 +127,6 @@ class Validator implements MessageProviderInterface {
 	 * @param  array  $rules
 	 * @param  array  $messages
 	 * @param  array  $customAttributes
-	 * @return void
 	 */
 	public function __construct(TranslatorInterface $translator, array $data, array $rules, array $messages = array(), array $customAttributes = array())
 	{

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -206,6 +206,8 @@ class Validator implements MessageProviderInterface {
 	 * @param  string  $attribute
 	 * @param  string|array  $rules
 	 * @return void
+	 *
+	 * @throws \InvalidArgumentException
 	 */
 	public function each($attribute, $rules)
 	{

--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -23,7 +23,6 @@ abstract class Compiler {
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  string  $cachePath
-	 * @return void
 	 */
 	public function __construct(Filesystem $files, $cachePath)
 	{

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -22,7 +22,6 @@ class CompilerEngine extends PhpEngine {
 	 * Create a new Blade view engine instance.
 	 *
 	 * @param  \Illuminate\View\Compilers\CompilerInterface  $compiler
-	 * @return void
 	 */
 	public function __construct(CompilerInterface $compiler)
 	{

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -91,7 +91,6 @@ class Factory {
 	 * @param  \Illuminate\View\Engines\EngineResolver  $engines
 	 * @param  \Illuminate\View\ViewFinderInterface  $finder
 	 * @param  \Illuminate\Events\Dispatcher  $events
-	 * @return void
 	 */
 	public function __construct(EngineResolver $engines, ViewFinderInterface $finder, Dispatcher $events)
 	{

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -52,7 +52,6 @@ class FileViewFinder implements ViewFinderInterface {
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  array  $paths
 	 * @param  array  $extensions
-	 * @return void
 	 */
 	public function __construct(Filesystem $files, array $paths, array $extensions = null)
 	{

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -53,7 +53,6 @@ class View implements ArrayAccess, Renderable {
 	 * @param  string  $view
 	 * @param  string  $path
 	 * @param  array   $data
-	 * @return void
 	 */
 	public function __construct(Factory $factory, EngineInterface $engine, $view, $path, $data = array())
 	{

--- a/src/Illuminate/Workbench/Console/WorkbenchMakeCommand.php
+++ b/src/Illuminate/Workbench/Console/WorkbenchMakeCommand.php
@@ -33,7 +33,6 @@ class WorkbenchMakeCommand extends Command {
 	 * Create a new make workbench command instance.
 	 *
 	 * @param  \Illuminate\Workbench\PackageCreator  $creator
-	 * @return void
 	 */
 	public function __construct(PackageCreator $creator)
 	{

--- a/src/Illuminate/Workbench/Package.php
+++ b/src/Illuminate/Workbench/Package.php
@@ -51,7 +51,6 @@ class Package {
 	 * @param  string  $name
 	 * @param  string  $author
 	 * @param  string  $email
-	 * @return void
 	 */
 	public function __construct($vendor, $name, $author, $email)
 	{

--- a/src/Illuminate/Workbench/PackageCreator.php
+++ b/src/Illuminate/Workbench/PackageCreator.php
@@ -39,7 +39,6 @@ class PackageCreator {
 	 * Create a new package creator instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @return void
 	 */
 	public function __construct(Filesystem $files)
 	{


### PR DESCRIPTION
- Removed unwanted @return void from __construct DocBlock
- Improved DocBlocks for @return, @throws and Namespace casting

Note: __construct always return void and no need to add doc statement for same. IDEs like PHPStorm give error on return statement on __construct and fails on code inspection.

![screenshot 2014-04-30 09 11 44](https://cloud.githubusercontent.com/assets/371606/2837469/52c074e0-d019-11e3-97d6-8177ae43e6e0.png)
