### PR TITLE
Use data_get in Collection::valueRetriever

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -561,7 +561,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	{
 		return function($item) use ($value)
 		{
-			return is_object($item) ? $item->{$value} : array_get($item, $value);
+			return data_get($item, $value);
 		};
 	}
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -358,17 +358,27 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testGettingSumFromCollection()
 	{
-			$c = new Collection(array((object) array('foo' => 50), (object) array('foo' => 50)));
-			$this->assertEquals(100, $c->sum('foo'));
+		$c = new Collection(array((object) array('foo' => 50), (object) array('foo' => 50)));
+		$this->assertEquals(100, $c->sum('foo'));
 
-			$c = new Collection(array((object) array('foo' => 50), (object) array('foo' => 50)));
-			$this->assertEquals(100, $c->sum(function($i) { return $i->foo; }));
+		$c = new Collection(array((object) array('foo' => 50), (object) array('foo' => 50)));
+		$this->assertEquals(100, $c->sum(function($i) { return $i->foo; }));
 	}
 
 	public function testGettingSumFromEmptyCollection()
 	{
-			$c = new Collection();
-			$this->assertEquals(0, $c->sum('foo'));
+		$c = new Collection();
+		$this->assertEquals(0, $c->sum('foo'));
+	}
+
+	public function testValueRetrieverAcceptsDotNotation()
+	{
+		$c = new Collection(array(
+			(object) array('id' => 1, 'foo' => array('bar' => 'B')), (object) array('id' => 2, 'foo' => array('bar' => 'A'))
+		));
+
+		$c = $c->sortBy('foo.bar');
+		$this->assertEquals(array(2, 1), $c->lists('id'));
 	}
 
 }


### PR DESCRIPTION
Now that this function exists it's best to use it in `Collection::valueRetriever` instead of doing `$item->$value` as this allows dot notation for objects in addition of arrays.

You can now do like `$conversations->sortBy('user.name')` (and everywhere else where valueRetriever is used).

(Also fixed the indentation of the two methods above)
