### PR TITLE
[Fix] Make Paginator::getUrl have priority over appends

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -195,7 +195,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 		// to the URL. This allows for extra information like sortings storage.
 		if (count($this->query) > 0)
 		{
-			$parameters = array_merge($parameters, $this->query);
+			$parameters = array_merge($this->query, $parameters);
 		}
 
 		$fragment = $this->buildFragment();

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -153,9 +153,17 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 		$env->shouldReceive('getCurrentUrl')->twice()->andReturn('http://foo.com');
 		$env->shouldReceive('getPageName')->twice()->andReturn('page');
 
-		$this->assertEquals('http://foo.com?page=1', $p->getUrl(1));
-		$p->addQuery('page', '2');
-		$this->assertEquals('http://foo.com?page=1', $p->getUrl(1));
+		$p->appends(array(
+			'sort' => 'asc',
+			'page' => 2,
+		));
+		$this->assertEquals('http://foo.com?sort=asc&page=1', $p->getUrl(1));
+
+		$p->appends(array(
+			'sort' => 'desc',
+			'page' => '2'
+		));
+		$this->assertEquals('http://foo.com?sort=desc&page=1', $p->getUrl(1));
 	}
 
 

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -105,7 +105,7 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals('http://foo.com?page=1', $p->getUrl(1));
 		$p->addQuery('foo', 'bar');
-		$this->assertEquals('http://foo.com?page=1&foo=bar', $p->getUrl(1));
+		$this->assertEquals('http://foo.com?foo=bar&page=1', $p->getUrl(1));
 	}
 
 
@@ -143,7 +143,19 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals('http://foo.com?page=1#a-fragment', $p->getUrl(1));
 		$p->addQuery('foo', 'bar');
-		$this->assertEquals('http://foo.com?page=1&foo=bar#a-fragment', $p->getUrl(1));
+		$this->assertEquals('http://foo.com?foo=bar&page=1#a-fragment', $p->getUrl(1));
+	}
+
+
+	public function testGetUrlHasPriorityOverAppends()
+	{
+		$p = new Paginator($env = m::mock('Illuminate\Pagination\Environment'), array('foo', 'bar', 'baz'), 3, 2);
+		$env->shouldReceive('getCurrentUrl')->twice()->andReturn('http://foo.com');
+		$env->shouldReceive('getPageName')->twice()->andReturn('page');
+
+		$this->assertEquals('http://foo.com?page=1', $p->getUrl(1));
+		$p->addQuery('page', '2');
+		$this->assertEquals('http://foo.com?page=1', $p->getUrl(1));
 	}
 
 


### PR DESCRIPTION
Currently if for some reason you append a `page` parameter to a Paginator instance, calling `getUrl` with any argument will still return that instead of the requested page :

``` php
$sortings = Input::all(); // ['sort' => 'asc', 'page' => 2]
$paginator->appends($sortings);

// Before fix
$paginator->getUrl(3) // ?sort=asc&page=2

// After fix
$paginator->getUrl(3) // ?sort=asc&page=3
```

Note: the reason `Input::except('page')` is not being used here (which would solve it) is because the name of the key is variable in this case. Still a bug nevertheless to me.
