### PR TITLE
Add BeanstalkQueue::deleteMessage

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -107,6 +107,18 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 	}
 
 	/**
+	 * Delete a message from the Beanstalk queue.
+	 *
+	 * @param  string  $queue
+	 * @param  string  $id
+	 * @return void
+	 */
+	public function deleteMessage($queue, $id)
+	{
+		$this->pheanstalk->useTube($this->getQueue($queue))->delete($id);
+	}
+
+	/**
 	 * Get the queue or return the default.
 	 *
 	 * @param  string|null  $queue

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -50,4 +50,14 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf('Illuminate\Queue\Jobs\BeanstalkdJob', $result);
 	}
 
+	public function testDeleteProperlyRemoveJobsOffBeanstalkd()
+	{
+		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk_Pheanstalk'), 'default', 60);
+		$pheanstalk = $queue->getPheanstalk();
+		$pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
+		$pheanstalk->shouldReceive('delete')->once()->with(1);
+
+		$queue->deleteMessage('default', 1);
+	}
+
 }


### PR DESCRIPTION
Pheanstalk supports deleting jobs but the method wasn't present on the Queue instance, like it is on IronQueue per example. Added it.
