### PR TITLE
[Bug] Fix many to many polymorphic pivot updates

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -5,6 +5,13 @@ use Illuminate\Database\Eloquent\Builder;
 class MorphPivot extends Pivot {
 
 	/**
+	 * The type of the polymorphic relation.
+	 *
+	 * @var string
+	 */
+	protected $morphType;
+
+	/**
 	 * Set the keys for a save update query.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $query


### PR DESCRIPTION
`$morphType` set by `setMorphType` is being included in queries from x->pivot->save() and the like. As the object is being added as a public data member on an object with an empty original, it is treated as an attribute and added as a column to the queries. As this column doesn't exist, the query will be erroneous. Adding it as a protected data member hides it from being added as an attribute.

https://github.com/laravel/framework/issues/3693

This still does not resolve the defect that all columns are being submitted because the pivot object has an empty original, but at least that doesn't generate errors.
