### PR TITLE
[PROPOSAL] Helpers : array_elevate

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -159,6 +159,39 @@ if ( ! function_exists('array_dot'))
 	}
 }
 
+if ( ! function_exists('array_expand'))
+{
+	/**
+	 * Expand a flattened array with dots to a multi-dimensional associative array.
+	 *
+	 * @param  array   $array
+	 * @param  string  $prepend
+	 * @return array
+	 */
+	function array_expand($array, $prepend = '')
+	{
+		$results = array();
+
+		if ($prepend) $prepend .= '.';
+
+		foreach ($array as $key => $value)
+		{
+			if ($prepend)
+			{
+				$pos = strpos($key, $prepend);
+				if ($pos === 0)
+				{
+					$key = substr($key, strlen($prepend));
+				}
+			}
+
+			array_set($results, $key, $value);
+		}
+
+		return $results;
+	}
+}
+
 if ( ! function_exists('array_except'))
 {
 	/**

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -17,6 +17,17 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($array, array('name' => 'taylor', 'languages.php' => true));
 	}
 
+	public function testArrayExpand()
+	{
+		$array = array_expand(array('name' => 'taylor', 'languages.php' => true));
+		$this->assertEquals($array, array('name' => 'taylor', 'languages' => array('php' => true)));
+
+		$array = array_expand(array('foo.name' => 'taylor', 'foo.languages.php' => true), 'foo');
+		$this->assertEquals($array, array('name' => 'taylor', 'languages' => array('php' => true)));
+
+		$array = array_expand(array('foo.name' => 'taylor', 'foo.languages.php' => true), 'bar');
+		$this->assertEquals($array, array('foo' => array('name' => 'taylor', 'languages' => array('php' => true))));
+	}
 
 	public function testArrayGet()
 	{


### PR DESCRIPTION
`array_elevate` is the opposite function for `array_dot`. It allows to convert a dotted array to an associative multidimensional array.

`array_elevate` has been chosen in lack of a better name. Feel free to give a better name suggestion
