### PR TITLE
Download files with non-ascii characters v2

### DIFF
--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -84,14 +84,14 @@ class Response {
 	 */
 	public static function download($file, $name = null, array $headers = array(), $disposition = 'attachment')
 	{
-		$response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
+		$response = new BinaryFileResponse($file, 200, $headers, true);
 
-		if ( ! is_null($name))
+		if (is_null($name))
 		{
-			return $response->setContentDisposition($disposition, $name, Str::ascii($name));
+			$name = basename($file);
 		}
-
-		return $response;
+		
+		return $response->setContentDisposition($disposition, $name, Str::ascii($name));
 	}
 
 }


### PR DESCRIPTION
We can't set the ContentDisposition 'attachment' in the constructor.
If the filename contains non-ascii characters, the constructor will throw an exception.
In this revision, if you don't specify a name, it is taken from the filename (this is what Symphony does if you don't provide a name, but here we can convert the filename to an ascii string so it won't throw any exception).
