### PR TITLE
Allow attributesToArray handle instances of ArrayableInterface

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2139,9 +2139,11 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		{
 			if ( ! array_key_exists($key, $attributes)) continue;
 
-			$attributes[$key] = $this->mutateAttribute(
+			$value = $this->mutateAttribute(
 				$key, $attributes[$key]
 			);
+			
+			$attributes[$key] = $value instanceof ArrayableInterface ? $value->toArray() : $value;
 		}
 
 		// Here we will grab all of the appended, calculated attributes to this model
@@ -2149,7 +2151,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// when we need to array or JSON the model for convenience to the coder.
 		foreach ($this->appends as $key)
 		{
-			$attributes[$key] = $this->mutateAttribute($key, null);
+			$value = $this->mutateAttribute($key, null);
+			$attributes[$key] = $value instanceof ArrayableInterface ? $value->toArray() : $value;
 		}
 
 		return $attributes;


### PR DESCRIPTION
Ran into a stackoverflow question where the problem was that `attributesToArray` wasn't able to handle instances of ArrayableInterface properly. So added handling for that in the model
