### PR TITLE
Implemented dot notation for array_pluck and Collection->lists

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -348,7 +348,7 @@ if ( ! function_exists('array_pluck'))
 
 		foreach ($array as $item)
 		{
-			$itemValue = is_object($item) ? object_get($item, $value) : array_get($item, $value);
+			$itemValue = data_get($item, $value);
 
 			// If the key is "null", we will just append the value to the array and keep
 			// looping. Otherwise we will key the array using the value of the key we
@@ -359,7 +359,7 @@ if ( ! function_exists('array_pluck'))
 			}
 			else
 			{
-				$itemKey = is_object($item) ? object_get($item, $key) : array_get($item, $key);
+				$itemKey = data_get($item, $value);
 
 				$results[$itemKey] = $itemValue;
 			}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -359,7 +359,7 @@ if ( ! function_exists('array_pluck'))
 			}
 			else
 			{
-				$itemKey = data_get($item, $value);
+				$itemKey = data_get($item, $key);
 
 				$results[$itemKey] = $itemValue;
 			}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -348,7 +348,7 @@ if ( ! function_exists('array_pluck'))
 
 		foreach ($array as $item)
 		{
-			$itemValue = is_object($item) ? $item->{$value} : $item[$value];
+			$itemValue = is_object($item) ? object_get($item, $value) : array_get($item, $value);
 
 			// If the key is "null", we will just append the value to the array and keep
 			// looping. Otherwise we will key the array using the value of the key we
@@ -359,7 +359,7 @@ if ( ! function_exists('array_pluck'))
 			}
 			else
 			{
-				$itemKey = is_object($item) ? $item->{$key} : $item[$key];
+				$itemKey = is_object($item) ? object_get($item, $key) : array_get($item, $key);
 
 				$results[$itemKey] = $itemValue;
 			}
@@ -732,7 +732,9 @@ if ( ! function_exists('object_get'))
 
 		foreach (explode('.', $key) as $segment)
 		{
-			if ( ! is_object($object) || ! isset($object->{$segment}))
+			$accessor = 'get'.lcfirst($segment).'Attribute';
+
+			if (( ! is_object($object) || ! isset($object->{$segment})) && ! method_exists($object, $accessor))
 			{
 				return value($default);
 			}

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -325,6 +325,28 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('foo', 'bar'), $data->lists('some'));
 	}
 
+
+	public function testGetListValueWithAccessorsAndDot()
+	{
+		$model = new TestAccessorEloquentTestStub(array(
+			'some' => (object)array(
+				'name' => 'taylor',
+				'age' => 25
+			)
+		));
+
+		$modelTwo = new TestAccessorEloquentTestStub(array(
+			'some' => (object)array(
+				'name' => 'dayle',
+				'age' => 20
+			)
+		));
+
+		$data = new Collection(array($model, $modelTwo));
+
+		$this->assertEquals(array('taylor' => 25, 'dayle' => 20), $data->lists('some.age', 'some.name'));
+	}
+
 	public function testTransform()
 	{
 		$data = new Collection(array('taylor', 'colin', 'shawn'));

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -51,6 +51,55 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), array_pluck($array, 'email', 'name'));
 	}
 
+	public function testArrayPluckDotWithArray()
+	{
+		$array = array(
+			array(
+				'info' => array(
+					'name' => 'taylor'
+				),
+				'contact' => array(
+					'email' => 'foo'
+				)
+			),
+			array(
+				'info' => array(
+					'name' => 'dayle'
+				),
+				'contact' => array(
+					'email' => 'bar'
+				)
+			),
+		);
+
+		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), array_pluck($array, 'contact.email', 'info.name'));
+	}
+
+
+	public function testArrayPluckDotWithObject()
+	{
+		$array = (object)array(
+			(object)array(
+				'info' => (object)array(
+						'name' => 'taylor'
+					),
+				'contact' => (object)array(
+						'email' => 'foo'
+					)
+			),
+			(object)array(
+				'info' => (object)array(
+						'name' => 'dayle'
+					),
+				'contact' => (object)array(
+						'email' => 'bar'
+					)
+			),
+		);
+
+		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), array_pluck($array, 'contact.email', 'info.name'));
+	}
+
 
 	public function testArrayExcept()
 	{


### PR DESCRIPTION
Added dot notation to array_pluck which will make code like this working:

```
$collection->lists('some.age', 'some.name')

array_pluck($array, 'contact.email', 'info.name')
```

It will also handle accessors properly.
