### PR TITLE
Allow urlencoded everything in route parameters

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -20,24 +20,6 @@ class UrlGenerator {
 	protected $request;
 
 	/**
-	 * Characters that should not be URL encoded.
-	 *
-	 * @var array
-	 */
-	protected $dontEncode = array(
-		'%2F' => '/',
-		'%40' => '@',
-		'%3A' => ':',
-		'%3B' => ';',
-		'%2C' => ',',
-		'%3D' => '=',
-		'%2B' => '+',
-		'%21' => '!',
-		'%2A' => '*',
-		'%7C' => '|',
-	);
-
-	/**
 	 * Create a new URL Generator instance.
 	 *
 	 * @param  \Illuminate\Routing\RouteCollection  $routes
@@ -220,14 +202,16 @@ class UrlGenerator {
 	 */
 	protected function toRoute($route, array $parameters, $absolute)
 	{
-		$domain = $this->getRouteDomain($route, $parameters);
-
-		$uri = strtr(rawurlencode($this->trimUrl(
+	        $domain = $this->getRouteDomain($route, $parameters);
+	        $queryString = $this->getRouteQueryString($parameters);
+	        $parameters = array_map('rawurlencode', $parameters);
+	
+	        $uri = $this->trimUrl(
 			$root = $this->replaceRoot($route, $domain, $parameters),
 			$this->replaceRouteParameters($route->uri(), $parameters)
-		)), $this->dontEncode).$this->getRouteQueryString($parameters);
-
-		return $absolute ? $uri : '/'.ltrim(str_replace($root, '', $uri), '/');
+	        ).$queryString;
+	
+	        return $absolute ? $uri : '/'.ltrim(str_replace($root, '', $uri), '/');
 	}
 
 	/**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -202,16 +202,17 @@ class UrlGenerator {
 	 */
 	protected function toRoute($route, array $parameters, $absolute)
 	{
-	        $domain = $this->getRouteDomain($route, $parameters);
-	        $queryString = $this->getRouteQueryString($parameters);
-	        $parameters = array_map('rawurlencode', $parameters);
-	
-	        $uri = $this->trimUrl(
-			$root = $this->replaceRoot($route, $domain, $parameters),
-			$this->replaceRouteParameters($route->uri(), $parameters)
-	        ).$queryString;
-	
-	        return $absolute ? $uri : '/'.ltrim(str_replace($root, '', $uri), '/');
+		$domain = $this->getRouteDomain($route, $parameters);
+		// rawurlencode the parameters, the rest should be good
+		// this will allow slashes in the parameters!
+		$parameters = array_map('rawurlencode', $parameters);
+		
+		$uri = $this->trimUrl(
+				$root = $this->replaceRoot($route, $domain, $parameters),
+				$this->replaceRouteParameters($route->uri(), $parameters)
+			).$this->getRouteQueryString(array_map('rawurldecode', $parameters));;
+		
+		return $absolute ? $uri : '/'.ltrim(str_replace($root, '', $uri), '/');
 	}
 
 	/**


### PR DESCRIPTION
current implementation does not allow urlencoded slashes and more due to the encode or entire Url and then decode of certain characters.  This will allow for only the parameters to be urlencoded and allow slashes (like part numbers) into the parameters for routing. This will work very well with laravel#4297 which deals with decoding these types of urls.
