### PR TITLE
Allow urlencoded characters in route parameters

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -34,24 +34,6 @@ class UrlGenerator {
 	protected $forceSchema;
 
 	/**
-	 * Characters that should not be URL encoded.
-	 *
-	 * @var array
-	 */
-	protected $dontEncode = array(
-		'%2F' => '/',
-		'%40' => '@',
-		'%3A' => ':',
-		'%3B' => ';',
-		'%2C' => ',',
-		'%3D' => '=',
-		'%2B' => '+',
-		'%21' => '!',
-		'%2A' => '*',
-		'%7C' => '|',
-	);
-
-	/**
 	 * Create a new URL Generator instance.
 	 *
 	 * @param  \Illuminate\Routing\RouteCollection  $routes
@@ -246,12 +228,13 @@ class UrlGenerator {
 	protected function toRoute($route, array $parameters, $absolute)
 	{
 		$domain = $this->getRouteDomain($route, $parameters);
-
-		$uri = strtr(rawurlencode($this->trimUrl(
-			$root = $this->replaceRoot($route, $domain, $parameters),
-			$this->replaceRouteParameters($route->uri(), $parameters)
-		)), $this->dontEncode).$this->getRouteQueryString($parameters);
-
+		$parameters = array_map('rawurlencode', $parameters);
+		
+		$uri = $this->trimUrl(
+				$root = $this->replaceRoot($route, $domain, $parameters),
+				$this->replaceRouteParameters($route->uri(), $parameters)
+			).$this->getRouteQueryString(array_map('rawurldecode', $parameters));;
+		
 		return $absolute ? $uri : '/'.ltrim(str_replace($root, '', $uri), '/');
 	}
 


### PR DESCRIPTION
current implementation does not allow urlencoded slashes and more due to the encode of the entire Url and then decode of certain characters. This implementation will allow for only the parameters to be rawurlencoded and allow slashes (like part numbers) into the parameters for better routing. This will work very well with laravel#4297 which deals with decoding these urls.
