### PR TITLE
[Bug] urlencoded slashes in routing parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ matrix:
     - php: 5.6
     - php: hhvm
   fast_finish: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,3 @@ matrix:
     - php: 5.6
     - php: hhvm
   fast_finish: true
-

--- a/src/Illuminate/Routing/Matching/UriValidator.php
+++ b/src/Illuminate/Routing/Matching/UriValidator.php
@@ -14,9 +14,9 @@ class UriValidator implements ValidatorInterface {
 	 */
 	public function matches(Route $route, Request $request)
 	{
-		$path = $request->path() == '/' ? '/' : '/'.$request->path();
-
-		return preg_match($route->getCompiled()->getRegex(), rawurldecode($path));
+	        $path = $request->path() == '/' ? '/' : '/'.$request->path();
+	        
+	        return preg_match($route->getCompiled()->getRegex(), $path);
 	}
 
 }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -417,9 +417,9 @@ class Route {
 	 */
 	protected function bindPathParameters(Request $request)
 	{
-		preg_match($this->compiled->getRegex(), '/'.$request->decodedPath(), $matches);
-
-		return $matches;
+	        preg_match($this->compiled->getRegex(), '/'.$request->path(), $matches);
+	        
+	        return array_map('rawurldecode', $matches);
 	}
 
 	/**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -20,24 +20,6 @@ class UrlGenerator {
 	protected $request;
 
 	/**
-	 * Characters that should not be URL encoded.
-	 *
-	 * @var array
-	 */
-	protected $dontEncode = array(
-		'%2F' => '/',
-		'%40' => '@',
-		'%3A' => ':',
-		'%3B' => ';',
-		'%2C' => ',',
-		'%3D' => '=',
-		'%2B' => '+',
-		'%21' => '!',
-		'%2A' => '*',
-		'%7C' => '|',
-	);
-
-	/**
 	 * Create a new URL Generator instance.
 	 *
 	 * @param  \Illuminate\Routing\RouteCollection  $routes
@@ -221,13 +203,44 @@ class UrlGenerator {
 	protected function toRoute($route, array $parameters, $absolute)
 	{
 		$domain = $this->getRouteDomain($route, $parameters);
-
-		$uri = strtr(rawurlencode($this->trimUrl(
-			$root = $this->replaceRoot($route, $domain, $parameters),
-			$this->replaceRouteParameters($route->uri(), $parameters)
-		)), $this->dontEncode).$this->getRouteQueryString($parameters);
-
+		$parameters = array_map(array($this,'encode'), $parameters);
+		
+		$uri = $this->trimUrl(
+				$root = $this->replaceRoot($route, $domain, $parameters),
+				$this->replaceRouteParameters($route->uri(), $parameters)
+			).$this->getRouteQueryString(array_map(array($this,'decode'), $parameters));
+		
 		return $absolute ? $uri : '/'.ltrim(str_replace($root, '', $uri), '/');
+	}
+
+	/**
+	* encode callback
+	* don't decode multi-dimensional arrays, they are query string params
+	*
+	* @param $param
+	* @return string
+	*/
+	function encode($param){
+		if(!is_array($param)){
+			return rawurlencode($param);
+		}
+		
+		return $param;
+	}
+	
+	/**
+	* decode callback
+	* don't decode multi-dimensional arrays, they are query string params
+	* 
+	* @param $param
+	* @return string
+	*/
+	function decode(&$param){
+		if(!is_array($param) && !is_object($param)){
+			return rawurldecode($param);
+		}
+		
+		return $param;
 	}
 
 	/**


### PR DESCRIPTION
# Routing

Current routes do not allow for urlencoded slashes in the paths. This is problematic when trying to create ecommerce solutions with partnumbers in the routes since many part numbers have slashes in them.  There are also quite a few manufacturers with slashes in their names and or brands.  This commit provides the functionality to allow an uri to have encoded slashes, and other characters, in the [routes](http://laravel.com/docs/routing) and also to [create routes with those parameters](http://laravel.com/docs/routing#route-parameters). An example url may be...

https://stage.test.com/part/Cisco%20Systems%2C%20Inc/CISCO2851-SRST%2FK9

thank you!
