### PR TITLE
[4.1] Minor Composer Tweak

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpseclib/phpseclib": "0.3.*",
         "predis/predis": "0.8.*",
         "stack/builder": "1.0.*",
-        "swiftmailer/swiftmailer": "~5.0",
+        "swiftmailer/swiftmailer": "5.*",
         "symfony/browser-kit": "2.4.*",
         "symfony/console": "2.4.*",
         "symfony/css-selector": "2.4.*",

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -13,7 +13,7 @@
         "illuminate/log": "4.1.*",
         "illuminate/support": "4.1.*",
         "illuminate/view": "4.1.*",
-        "swiftmailer/swiftmailer": "~5.0"
+        "swiftmailer/swiftmailer": "5.*"
     },
     "require-dev": {
         "illuminate/queue": "4.1.*",


### PR DESCRIPTION
Let's make the swiftmailer version constraint consistent with the way we are requiring other stuff in laravel 4.1. The `~5.0` notation is what we are using in 4.2, and `5.*` matches how we are requiring stuff in 4.1.

---

NB: For merging into 4.2, we should keep what 4.2 has, and discard the changes on the 4.1 branch.
