### PR TITLE
[Issue 4315] updated limit to accept 0 or greater values

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1065,7 +1065,7 @@ class Builder {
 	 */
 	public function limit($value)
 	{
-		if ($value > 0) $this->limit = $value;
+		if ($value >= 0) $this->limit = $value;
 
 		return $this;
 	}


### PR DESCRIPTION
limit(0) return all rows which isn't intuitive. limit($value) method will now accept 0 or greater values. this allows limit(0) to return zero rows. negative values are still not allowed.

please see: https://github.com/laravel/framework/issues/4315
