### PR TITLE
[Proposal] Make Dependency Injection work for Laravel Facades

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -188,58 +188,58 @@ abstract class Facade {
 		static::$app = $app;
 	}
 
-	 /**
-     * static calls handling.
-     *
-     * @param  string $method
-     * @param  array  $args
-     * @return mixed
-     */
-    public static function __callStatic($method, $args)
-    {
-        return static::callMethod($method, $args);
-    }
+	/**
+	 * static calls handling.
+	 *
+	 * @param  string $method
+	 * @param  array  $args
+	 * @return mixed
+	 */
+	public static function __callStatic($method, $args)
+	{
+		return static::callMethod($method, $args);
+	}
 
-    /**
-     * None static calls, such as Facade Instance through DI.
-     * @param  string $method
-     * @param  array  $args
-     * @return mixed
-     */
-    public function __call($method, $args)
-    {
-       return static::callMethod($method, $args);
-    }
+	/**
+	 * None static calls, such as Facade Instance through DI.
+	 * @param  string $method
+	 * @param  array  $args
+	 * @return mixed
+	 */
+	public function __call($method, $args)
+	{
+	   return static::callMethod($method, $args);
+	}
 
-    /**
-     * Access the object methods.
-     * @param  string $method
-     * @param  array  $args
-     * @return mixed
-     */
-    private static function callMethod($method, $args)
-    {
-        $instance = static::resolveFacadeInstance(static::getFacadeAccessor());
+	/**
+	 * Access the object methods.
+	 * @param  string $method
+	 * @param  array  $args
+	 * @return mixed
+	 */
+	private static function callMethod($method, $args)
+	{
+		$instance = static::resolveFacadeInstance(static::getFacadeAccessor());
 
-        switch (count($args)) {
-            case 0:
-                return $instance->$method();
+		switch (count($args)) {
+			case 0:
+				return $instance->$method();
 
-            case 1:
-                return $instance->$method($args[0]);
+			case 1:
+				return $instance->$method($args[0]);
 
-            case 2:
-                return $instance->$method($args[0], $args[1]);
+			case 2:
+				return $instance->$method($args[0], $args[1]);
 
-            case 3:
-                return $instance->$method($args[0], $args[1], $args[2]);
+			case 3:
+				return $instance->$method($args[0], $args[1], $args[2]);
 
-            case 4:
-                return $instance->$method($args[0], $args[1], $args[2], $args[3]);
+			case 4:
+				return $instance->$method($args[0], $args[1], $args[2], $args[3]);
 
-            default:
-                return call_user_func_array(array($instance, $method), $args);
-        }
-    }
+			default:
+				return call_user_func_array(array($instance, $method), $args);
+		}
+	}
 
 }

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -188,37 +188,58 @@ abstract class Facade {
 		static::$app = $app;
 	}
 
-	/**
-	 * Handle dynamic, static calls to the object.
-	 *
-	 * @param  string  $method
-	 * @param  array   $args
-	 * @return mixed
-	 */
-	public static function __callStatic($method, $args)
-	{
-		$instance = static::getFacadeRoot();
+	 /**
+     * static calls handling.
+     *
+     * @param  string $method
+     * @param  array  $args
+     * @return mixed
+     */
+    public static function __callStatic($method, $args)
+    {
+        return static::callMethod($method, $args);
+    }
 
-		switch (count($args))
-		{
-			case 0:
-				return $instance->$method();
+    /**
+     * None static calls, such as Facade Instance through DI.
+     * @param  string $method
+     * @param  array  $args
+     * @return mixed
+     */
+    public function __call($method, $args)
+    {
+       return static::callMethod($method, $args);
+    }
 
-			case 1:
-				return $instance->$method($args[0]);
+    /**
+     * Access the object methods.
+     * @param  string $method
+     * @param  array  $args
+     * @return mixed
+     */
+    private static function callMethod($method, $args)
+    {
+        $instance = static::resolveFacadeInstance(static::getFacadeAccessor());
 
-			case 2:
-				return $instance->$method($args[0], $args[1]);
+        switch (count($args)) {
+            case 0:
+                return $instance->$method();
 
-			case 3:
-				return $instance->$method($args[0], $args[1], $args[2]);
+            case 1:
+                return $instance->$method($args[0]);
 
-			case 4:
-				return $instance->$method($args[0], $args[1], $args[2], $args[3]);
+            case 2:
+                return $instance->$method($args[0], $args[1]);
 
-			default:
-				return call_user_func_array(array($instance, $method), $args);
-		}
-	}
+            case 3:
+                return $instance->$method($args[0], $args[1], $args[2]);
+
+            case 4:
+                return $instance->$method($args[0], $args[1], $args[2], $args[3]);
+
+            default:
+                return call_user_func_array(array($instance, $method), $args);
+        }
+    }
 
 }

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -191,8 +191,8 @@ abstract class Facade {
 	/**
 	 * static calls handling.
 	 *
-	 * @param  string $method
-	 * @param  array  $args
+	 * @param  string  $method
+	 * @param  array   $args
 	 * @return mixed
 	 */
 	public static function __callStatic($method, $args)
@@ -202,8 +202,8 @@ abstract class Facade {
 
 	/**
 	 * None static calls, such as Facade Instance through DI.
-	 * @param  string $method
-	 * @param  array  $args
+	 * @param  string  $method
+	 * @param  array   $args
 	 * @return mixed
 	 */
 	public function __call($method, $args)
@@ -213,8 +213,8 @@ abstract class Facade {
 
 	/**
 	 * Access the object methods.
-	 * @param  string $method
-	 * @param  array  $args
+	 * @param  string  $method
+	 * @param  array   $args
 	 * @return mixed
 	 */
 	private static function callMethod($method, $args)

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -208,7 +208,7 @@ abstract class Facade {
 	 */
 	public function __call($method, $args)
 	{
-	   return static::callMethod($method, $args);
+		return static::callMethod($method, $args);
 	}
 
 	/**


### PR DESCRIPTION
I felt this might be handy incases where we wanted to get an instance of the facade into laravel dependency injection instead of type hinting to the actual class. Not sure how useful this would be though. 

for example if I needed Event Dispatcher, I can type hint to Illuminate\Support\Facades\Event instead of Illuminate\Events\Dispatcher.
