### PR TITLE
Make html escaping of form lables optional.

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -191,15 +191,19 @@ class FormBuilder {
 	 * @param  string  $name
 	 * @param  string  $value
 	 * @param  array   $options
+	 * @param  bool    $escape
 	 * @return string
 	 */
-	public function label($name, $value = null, $options = array())
+	public function label($name, $value = null, $options = array(), $escape = true)
 	{
 		$this->labels[] = $name;
 
 		$options = $this->html->attributes($options);
 
-		$value = e($this->formatLabel($name, $value));
+		if ($escape || $value === null)
+		{
+			$value = e($this->formatLabel($name, $value));
+		}
 
 		return '<label for="'.$name.'"'.$options.'>'.$value.'</label>';
 	}

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -56,9 +56,15 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$form1 = $this->formBuilder->label('foo', 'Foobar');
 		$form2 = $this->formBuilder->label('foo', 'Foobar', array('class' => 'control-label'));
+		$form3 = $this->formBuilder->label('foo', 'Foobar <em>emphasis</em>');
+		$form4 = $this->formBuilder->label('foo', 'Foobar <em>emphasis</em>', null, false);
+		$form5 = $this->formBuilder->label('foo', 'Foobar <em>emphasis</em>', array('class' => 'control-label'), false);
 
 		$this->assertEquals('<label for="foo">Foobar</label>', $form1);
 		$this->assertEquals('<label for="foo" class="control-label">Foobar</label>', $form2);
+		$this->assertEquals('<label for="foo">Foobar &lt;em&gt;emphasis&lt;/em&gt;</label>', $form3);
+		$this->assertEquals('<label for="foo">Foobar <em>emphasis</em></label>', $form4);
+		$this->assertEquals('<label for="foo" class="control-label">Foobar <em>emphasis</em></label>', $form5);
 	}
 
 


### PR DESCRIPTION
HTML5 labels can contain phrasing content.

Eg: `<label>Name <em>required</em></label>`

Passing 'false' as 4th argument to Illuminate\Html\label skips html escaping
of (optional) label content value.
