### PR TITLE
[CACHE] Move Cache::has to drivers

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -30,6 +30,17 @@ class ApcStore extends TaggableStore implements StoreInterface {
 	}
 
 	/**
+	 * Determine if an item exists in the cache.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		return $this->apc->has($this->prefix.$key);
+	}
+
+	/**
 	 * Retrieve an item from the cache by key.
 	 *
 	 * @param  string  $key

--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -20,6 +20,17 @@ class ApcWrapper {
 	}
 
 	/**
+	 * Determine if an item exists in the cache.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		return $this->apcu ? apcu_exists($key) : apc_exists($key);
+	}
+
+	/**
 	 * Get an item from the cache.
 	 *
 	 * @param  string  $key

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -10,6 +10,17 @@ class ArrayStore extends TaggableStore implements StoreInterface {
 	protected $storage = array();
 
 	/**
+	 * Determine if an item exists in the cache.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		return array_key_exists($key, $this->storage);
+	}
+
+	/**
 	 * Retrieve an item from the cache by key.
 	 *
 	 * @param  string  $key

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -51,6 +51,38 @@ class DatabaseStore implements StoreInterface {
 	}
 
 	/**
+	 * Determine if an item exists in the cache.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		$prefixed = $this->prefix.$key;
+
+		$cache = $this->table()->where('key', '=', $prefixed)->first();
+
+		if (is_null($cache))
+		{
+			return false;
+		}
+
+		// If we have a cache record we will check the expiration time against current
+		// time on the system and see if the record has expired. If it has, we will
+		// remove the records from the database table so it isn't returned again.
+		if (is_array($cache)) $cache = (object)$cache;
+
+		if (time() >= $cache->expiration)
+		{
+			$this->forget($key);
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Retrieve an item from the cache by key.
 	 *
 	 * @param  string  $key

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -32,6 +32,19 @@ class MemcachedStore extends TaggableStore implements StoreInterface {
 	}
 
 	/**
+	 * Determine if an item exists in the cache.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		$value = $this->memcached->get($this->prefix.$key);
+
+		return $this->memcached->getResultCode() == 0;
+	}
+
+	/**
 	 * Retrieve an item from the cache by key.
 	 *
 	 * @param  string  $key

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -41,6 +41,17 @@ class RedisStore extends TaggableStore implements StoreInterface {
 	}
 
 	/**
+	 * Determine if an item exists in the cache.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		return $this->connection()->exists($this->prefix.$key);
+	}
+
+	/**
 	 * Retrieve an item from the cache by key.
 	 *
 	 * @param  string  $key

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -44,7 +44,7 @@ class Repository implements ArrayAccess {
 	 */
 	public function has($key)
 	{
-		return ! is_null($this->get($key));
+		return $this->store->has($key);
 	}
 
 	/**

--- a/src/Illuminate/Cache/StoreInterface.php
+++ b/src/Illuminate/Cache/StoreInterface.php
@@ -3,6 +3,14 @@
 interface StoreInterface {
 
 	/**
+	 * Determine if an item exists in the cache.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function has($key);
+
+	/**
 	 * Retrieve an item from the cache by key.
 	 *
 	 * @param  string  $key

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -39,7 +39,7 @@ class TaggedCache implements StoreInterface {
 	 */
 	public function has($key)
 	{
-		return ! is_null($this->get($key));
+		return $this->store->has($key);
 	}
 
 	/**

--- a/src/Illuminate/Cache/WinCacheStore.php
+++ b/src/Illuminate/Cache/WinCacheStore.php
@@ -21,6 +21,17 @@ class WinCacheStore extends TaggableStore implements StoreInterface {
 	}
 
 	/**
+	 * Determine if an item exists in the cache.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		return wincache_ucache_exists($this->prefix.$key);
+	}
+
+	/**
 	 * Retrieve an item from the cache by key.
 	 *
 	 * @param  string  $key

--- a/src/Illuminate/Cache/XCacheStore.php
+++ b/src/Illuminate/Cache/XCacheStore.php
@@ -21,6 +21,17 @@ class XCacheStore extends TaggableStore implements StoreInterface {
 	}
 
 	/**
+	 * Determine if an item exists in the cache.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		return xcache_isset($this->prefix.$key);
+	}
+
+	/**
 	 * Retrieve an item from the cache by key.
 	 *
 	 * @param  string  $key

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -39,8 +39,8 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase {
 	public function testHasMethod()
 	{
 		$repo = $this->getRepository();
-		$repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn(null);
-		$repo->getStore()->shouldReceive('get')->once()->with('bar')->andReturn('bar');
+		$repo->getStore()->shouldReceive('has')->once()->with('foo')->andReturn(false);
+		$repo->getStore()->shouldReceive('has')->once()->with('bar')->andReturn(true);
 
 		$this->assertTrue($repo->has('bar'));
 		$this->assertFalse($repo->has('foo'));


### PR DESCRIPTION
Move Cache::has function to drivers.
So that drivers as `apc` and `redis` can now use specific `*exists` function.
