### PR TITLE
Fix table command

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -273,7 +273,9 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	{
 		$table = new Table($this->output);
 
-		$table->setHeaders($headers)->setRows($rows)->setStyle($style)->render();
+		$table->setHeaders($headers)->setRows($rows)->setStyle($style);
+		
+		$table->render();
 	}
 
 	/**


### PR DESCRIPTION
This was broken because setStyle() now returns null, according to:

https://github.com/symfony/Console/commit/c4f8f7a1cccc76c429ca505da9e99ce64a5ea051#diff-f79bdf7a3f5bde84727730f0a23964d8L122
