### PR TITLE
[DATABASE] Add untouchables property to Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -67,6 +67,13 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	public $timestamps = true;
 
 	/**
+	 * The model's attributes for which timestamps are not updated.
+	 *
+	 * @var array
+	 */
+	public $untouchables = array();
+
+	/**
 	 * The model's attributes.
 	 *
 	 * @var array
@@ -1402,7 +1409,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			// First we need to create a fresh query instance and touch the creation and
 			// update timestamp on the model which are maintained by us for developer
 			// convenience. Then we will just continue saving the model instances.
-			if ($this->timestamps)
+			if ($this->timestamps && count(array_diff(array_keys($dirty), $this->untouchables)) > 0)
 			{
 				$this->updateTimestamps();
 			}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -222,6 +222,66 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($model->save());
 	}
 
+	public function testUpdateProcessWithTimestampsWithoutUntouchables()
+	{
+		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps', 'fireModelEvent'));
+		$model->timestamps = true;
+		$model->untouchables = array();
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('where')->once()->with('id', '=', 1);
+		$query->shouldReceive('update')->once()->with(array('name' => 'taylor', 'logged_at' => '2014-05-09 23:59:59'));
+		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('updateTimestamps');
+		$model->expects($this->any())->method('fireModelEvent')->will($this->returnValue(true));
+
+		$model->id = 1;
+		$model->syncOriginal();
+		$model->name = 'taylor';
+		$model->logged_at = '2014-05-09 23:59:59';
+		$model->exists = true;
+		$this->assertTrue($model->save());
+	}
+
+	public function testUpdateProcessWithTimestampsWithSomeUntouchables()
+	{
+		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps', 'fireModelEvent'));
+		$model->timestamps = true;
+		$model->untouchables = array('logged_at');
+		$model->logged_at = '2012-01-01 00:00:00';
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('where')->once()->with('id', '=', 1);
+		$query->shouldReceive('update')->once()->with(array('name' => 'taylor', 'logged_at' => '2014-05-09 23:59:59'));
+		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('updateTimestamps');
+		$model->expects($this->any())->method('fireModelEvent')->will($this->returnValue(true));
+
+		$model->id = 1;
+		$model->syncOriginal();
+		$model->name = 'taylor';
+		$model->logged_at = '2014-05-09 23:59:59';
+		$model->exists = true;
+		$this->assertTrue($model->save());
+	}
+
+	public function testUpdateProcessWithTimestampsWithOnlyUntouchables()
+	{
+		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps', 'fireModelEvent'));
+		$model->timestamps = true;
+		$model->untouchables = array('logged_at');
+		$model->logged_at = '2012-01-01 00:00:00';
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('where')->once()->with('id', '=', 1);
+		$query->shouldReceive('update')->once()->with(array('logged_at' => '2014-05-09 23:59:59'));
+		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->never())->method('updateTimestamps');
+		$model->expects($this->any())->method('fireModelEvent')->will($this->returnValue(true));
+
+		$model->id = 1;
+		$model->syncOriginal();
+		$model->logged_at = '2014-05-09 23:59:59';
+		$model->exists = true;
+		$this->assertTrue($model->save());
+	}
 
 	public function testUpdateUsesOldPrimaryKey()
 	{


### PR DESCRIPTION
Allow a model to skip timestamps update if the updated attributes are set as _untouchables_.

**Use case:**
Let's say you have a `user` table, with a `logged_at` column. Your `User` model has `timestamps` enabled : each time a user login you want to track his last connection date. The drawback of that is that the `updated_at` column will also be updated, and it does not really reflects the last time a user has _really_ updated his profile.

**Solution:**
Add `logged_at` to the `untouchables` array. This way, if `timestamps` is enabled, and if the only attributes that you change are referenced as `untouchables`, the model will be saved (hopefully) but the `updated_at` attribute will remain the same.
