### PR TITLE
Update MorphToMany.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -45,7 +45,7 @@ class MorphToMany extends BelongsToMany {
 	{
 		$this->inverse = $inverse;
 		$this->morphType = $name.'_type';
-		$this->morphClass = $inverse ? get_class($query->getModel()) : get_class($parent);
+		$this->morphClass = $inverse ? get_class($query->getModel()) : str_replace('\\','-',  get_class($parent) );
 
 		parent::__construct($query, $parent, $table, $foreignKey, $otherKey, $relationName);
 	}
@@ -59,7 +59,7 @@ class MorphToMany extends BelongsToMany {
 	{
 		parent::setWhere();
 
-		$this->query->where($this->table.'.'.$this->morphType, str_replace('\\','-', $this->morphClass ));
+		$this->query->where($this->table.'.'.$this->morphType, $this->morphClass);
 
 		return $this;
 	}

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -59,7 +59,7 @@ class MorphToMany extends BelongsToMany {
 	{
 		parent::setWhere();
 
-		$this->query->where($this->table.'.'.$this->morphType, $this->morphClass);
+		$this->query->where($this->table.'.'.$this->morphType, str_replace('\\','-', $this->morphClass ));
 
 		return $this;
 	}


### PR DESCRIPTION
Changes the morphType value saved to the database so that it does not include slashes "\" when using a full namespace like, ie $this->has_many('Wpb\AdminModule\Models\RMMatrix'... for some reason when using mysql it now always returns a empty array if there are any slashes in a query value. Replacing the "\" in the db stored value allows the full namespace to be used... more details are at https://github.com/laravel/framework/issues/4006#issuecomment-42623621
