### PR TITLE
[Bug Fix] BelongsToMany::sync, don't touch, unless something was updated.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -596,7 +596,11 @@ class BelongsToMany extends Relation {
 			$changes, $this->attachNew($records, $current, false)
 		);
 
-		$this->touchIfTouching();
+		// Only going to touch if something was attached or updated
+		if (count($changes['attached']) || count($changes['updated']))
+		{
+			$this->touchIfTouching();
+		}
 
 		return $changes;
 	}


### PR DESCRIPTION
Fix an issue where a call to sync() on the belongs to many relationship _always_ touches the parent and related objects, event if nothing is being added or updated on the pivot table.
