### PR TITLE
[Proposal] Eloquent save() should return false if nothing was saved

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1415,9 +1415,14 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			$this->setKeysForSaveQuery($query)->update($dirty);
 
 			$this->fireModelEvent('updated', false);
+
+			// Return true to indicate that a save operation did occur
+			return true;
 		}
 
-		return true;
+		// Return false to indicate that a save operation did not occur, relations should
+		// not be touched, and the 'saved' event should not be fired.
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
If no save operation occurred when calling save() on a model, because attributes are not dirty, we should return false in performUpdate() and the originating save() call. This way relationships won't be touched (since we haven't touched ourselves), and the 'saved' event won't be fired.

The touching of the relationships aspect here, seems to be a bug in my opinion. If you load a model instance from an existing record, and set attributes on the instance which are the same values as the original, a save() call on the instance results in the record _not_ being updated. However, if you happen to have a $touches property set on the model, those relationships will be touched, wether or not the originating model was actually updated. This is out of line with what the documentation currently says about using the $touches attribute; which states that the relationship(s) specified will only be updated if the originating model instance is updated.

Merging into 'master', in case this change affects the way people rely on the current behavior and output of the save() function, and/or the triggering of the 'saved' event.
