### PR TITLE
Use input() to get page number

### DIFF
--- a/src/Illuminate/Pagination/Environment.php
+++ b/src/Illuminate/Pagination/Environment.php
@@ -126,7 +126,7 @@ class Environment {
 	 */
 	public function getCurrentPage()
 	{
-		$page = (int) $this->currentPage ?: $this->request->query->get($this->pageName, 1);
+		$page = (int) $this->currentPage ?: $this->request->input($this->pageName, 1);
 
 		if ($page < 1 || filter_var($page, FILTER_VALIDATE_INT) === false)
 		{


### PR DESCRIPTION
Restricting page numbers to `$request->query->get()` makes it very hard to make api end points which can accept a big amount of filters via an HTTP request because there are several different limitations on how a GET request can function. Allowing current-page to be accessible via `$request->input()` makes it very easy to just send the page number along with a big post-data of all the filters.
