### PR TITLE
[4.2] Implement view name aliases

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -44,6 +44,13 @@ class Factory {
 	protected $shared = array();
 
 	/**
+	 * Array of registered view name aliases.
+	 *
+	 * @var array
+	 */
+	protected $aliases = array();
+
+	/**
 	 * All of the registered view names.
 	 *
 	 * @var array
@@ -103,6 +110,18 @@ class Factory {
 	}
 
 	/**
+	 * Add an alias for a view.
+	 *
+	 * @param  string $view  The real view name
+	 * @param  string $alias
+	 * @return void
+	 */
+	public function alias($view, $alias)
+	{
+		$this->aliases[$alias] = $view;
+	}
+
+	/**
 	 * Get the evaluated view contents for the given view.
 	 *
 	 * @param  string  $view
@@ -112,6 +131,8 @@ class Factory {
 	 */
 	public function make($view, $data = array(), $mergeData = array())
 	{
+		if (isset($this->aliases[$view])) $view = $this->aliases[$view];
+
 		$path = $this->finder->find($view);
 
 		$data = array_merge($mergeData, $this->parseData($data));

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -332,6 +332,20 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testMakeWithAlias()
+	{
+		$factory = $this->getFactory();
+		$factory->alias('real', 'alias');
+		$factory->getFinder()->shouldReceive('find')->once()->with('real')->andReturn('path.php');
+		$factory->getEngineResolver()->shouldReceive('resolve')->once()->with('php')->andReturn(m::mock('Illuminate\View\Engines\EngineInterface'));
+		$factory->getDispatcher()->shouldReceive('fire');
+
+		$view = $factory->make('alias');
+
+		$this->assertEquals('real', $view->getName());
+	}
+
+
 	protected function getFactory()
 	{
 		return new Factory(


### PR DESCRIPTION
Not sure what branch this should target. Is there a feature freeze on 4.2? I assume not since there's never been one. Feature should be self-descriptive.

I looked at the `names` array and `View::of` but it seemed rather strange. I would want to be able to call `View::make('name')` and for it to work both if there's an alias registered _and_ if the template file name.php actually exists.
