### PR TITLE
use ConfirmableTrait in db:seed

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -82,7 +82,8 @@ class MigrateCommand extends BaseCommand {
 		// a migration and a seed at the same time, as it is only this command.
 		if ($this->input->getOption('seed'))
 		{
-			$this->call('db:seed');
+			$options = array('--force' => true);
+			$this->call('db:seed', $options);
 		}
 	}
 

--- a/src/Illuminate/Database/Console/SeedCommand.php
+++ b/src/Illuminate/Database/Console/SeedCommand.php
@@ -1,10 +1,13 @@
 <?php namespace Illuminate\Database\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Symfony\Component\Console\Input\InputOption;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 class SeedCommand extends Command {
+
+	use ConfirmableTrait;
 
 	/**
 	 * The console command name.
@@ -47,6 +50,8 @@ class SeedCommand extends Command {
 	 */
 	public function fire()
 	{
+		if ( ! $this->confirmToProceed()) return;
+		
 		$this->resolver->setDefaultConnection($this->getDatabase());
 
 		$this->getSeeder()->run();
@@ -87,6 +92,8 @@ class SeedCommand extends Command {
 			array('class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'DatabaseSeeder'),
 
 			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'),
+			
+			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
 		);
 	}
 


### PR DESCRIPTION
Just like the migrations, confirm before running in production.
Also added a --force flag for seeding in migration, to prevent double confirms.
(Redo of #4391 for correct branch)
