### PR TITLE
Fixed SupportCollectionTest->testValueRetrieverAcceptsDotNotation().

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -374,7 +374,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	public function testValueRetrieverAcceptsDotNotation()
 	{
 		$c = new Collection(array(
-			(object) array('id' => 1, 'foo' => array('bar' => 'B')), (object) array('id' => 2, 'foo' => array('bar' => 'A'))
+			(object) array('id' => 1, 'foo' => (object) array('bar' => 'B')), (object) array('id' => 2, 'foo' => (object) array('bar' => 'A'))
 		));
 
 		$c = $c->sortBy('foo.bar');


### PR DESCRIPTION
Collection's valueRetriever() dot notation does not work when mixing objects with arrays. In the broken test both values returned by valueRetriever() are equal to NULL, so the sort()'s result is not well defined. PHP seems to get the order "right", while HHVM doesn't (they probably have different sort() implementations).
