### PR TITLE
Queue: Add missing code to make it work outside of laravel

### DIFF
--- a/src/Illuminate/Queue/README.md
+++ b/src/Illuminate/Queue/README.md
@@ -17,6 +17,13 @@ $queue->addConnection([
     'queue' => 'default',
 ]);
 
+$queue->getContainer()->bind('encrypter', function() {
+	return new Illuminate\Encryption\Encrypter('foobar');
+});
+$queue->getContainer()->bind('request', function() {
+	return new Illuminate\Http\Request();
+});
+
 // Make this Capsule instance available globally via static methods... (optional)
 $queue->setAsGlobal();
 ```


### PR DESCRIPTION
The current readme presents the following error when using an iron queue with Illuminate/queue outside of Laravel

> Fatal error: Uncaught exception 'ReflectionException' with message 'Class encrypter does not exist' in /vendor/illuminate/container/Illuminate/Container/Container.php on line 485

The attached commit fixes this.
