### PR TITLE
Prepare Query Bindings for Exception

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -552,7 +552,7 @@ class Connection implements ConnectionInterface {
 		// lot more helpful to the developer instead of just the database's errors.
 		catch (\Exception $e)
 		{
-			throw new QueryException($query, $bindings, $e);
+			throw new QueryException($query, $this->prepareBindings($bindings), $e);
 		}
 
 		// Once we have run the query we will calculate the time that it took to run and


### PR DESCRIPTION
Prepare query bindings (format DateTime etc.) before passing them to Illuminate\Database\QueryException, this will prevent the "Object of class DateTime could not be converted to string" error that occurs when query errors are encountered.
