### PR TITLE
[4.2] Enable easier usage of error_log in Log\Writer

### DIFF
--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -5,6 +5,7 @@ use Illuminate\Events\Dispatcher;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger as MonologLogger;
 use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\RotatingFileHandler;
 use Illuminate\Support\Contracts\JsonableInterface;
 use Illuminate\Support\Contracts\ArrayableInterface;
@@ -88,7 +89,7 @@ class Writer {
 
 		$this->monolog->pushHandler($handler = new StreamHandler($path, $level));
 
-		$handler->setFormatter(new LineFormatter(null, null, true));
+		$handler->setFormatter($this->getDefaultFormatter());
 	}
 
 	/**
@@ -105,7 +106,33 @@ class Writer {
 
 		$this->monolog->pushHandler($handler = new RotatingFileHandler($path, $days, $level));
 
-		$handler->setFormatter(new LineFormatter(null, null, true));
+		$handler->setFormatter($this->getDefaultFormatter());
+	}
+
+	/**
+	 * Register an error_log handler.
+	 *
+	 * @param  integer $messageType
+	 * @param  string  $level
+	 * @return void
+	 */
+	public function useErrorLog($level = 'debug', $messageType = ErrorLogHandler::OPERATING_SYSTEM)
+	{
+		$level = $this->parseLevel($level);
+
+		$this->monolog->pushHandler($handler = new ErrorLogHandler($messageType, $level));
+
+		$handler->setFormatter($this->getDefaultFormatter());
+	}
+
+	/**
+	 * Get a defaut Monolog formatter instance.
+	 *
+	 * @return \Monolog\Formatters\LineFormatter
+	 */
+	protected function getDefaultFormatter()
+	{
+		return new LineFormatter(null, null, true);
 	}
 
 	/**

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -27,6 +27,14 @@ class LogWriterTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testErrorLogHandlerCanBeAdded()
+	{
+		$writer = new Writer($monolog = m::mock('Monolog\Logger'));
+		$monolog->shouldReceive('pushHandler')->once()->with(m::type('Monolog\Handler\ErrorLogHandler'));
+		$writer->useErrorLog();
+	}
+
+
 	public function testMagicMethodsPassErrorAdditionsToMonolog()
 	{
 		$writer = new Writer($monolog = m::mock('Monolog\Logger'));


### PR DESCRIPTION
In many setups you want to use the centralized `error_log` function in PHP to log errors and the like, so I added a quick helper method to do this.

The `$messageType` parameter corresponds to $message_type as found in the `error_log` documentation on php.net. The default behaviour is to use the default OS log, but there is an option to use the SAPI log which will, for example, let Apache2 decide where errors should be logged. This may be a more sensible default and a more recommended setup, but I figured sticking with default PHP and Monolog behaviour was best.

Also refactored the `new LineFormatter` into its own method as it was being re-used in several methods.
