### PR TITLE
[bug 4.1] Updated BladeCompiler to handle a statement that comes immediately follo...

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -466,7 +466,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function createMatcher($function)
 	{
-		return '/(?<!\w)(\s*)@'.$function.'(\s*\(.*\))/';
+		return '/(?<!\w)(\s*)@'.$function.'(\s*\([^@<]*\))/';
 	}
 
 	/**
@@ -477,7 +477,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function createOpenMatcher($function)
 	{
-		return '/(?<!\w)(\s*)@'.$function.'(\s*\(.*)\)/';
+		return '/(?<!\w)(\s*)@'.$function.'(\s*\([^@<]*)\)/';
 	}
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -264,6 +264,7 @@ breeze
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
 		$this->assertEquals('<?php echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@include(\'foo\')'));
 		$this->assertEquals('<?php echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@include(name(foo))'));
+		$this->assertEquals('<?php echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?> <?php if ($fooIsTrue): ?>', $compiler->compileString('@include(name(foo)) @if ($fooIsTrue)'));
 	}
 
 


### PR DESCRIPTION
When Blade compiles statements using `createMatcher` and `createOpenMatcher`, it uses the dot operator to find the expression to use in `preg_replace`. However, this causes problems when one statement immediately follows another (see `testIncludesAreCompiled` in [the BladeCompiler tests](https://github.com/tshelburne/framework/blob/ca886d4cd3f12182ba65d537ccc6b55cffc15f39/tests/View/ViewBladeCompilerTest.php#LC262)). To avoid this, I updated the regex to stop when it hits either of the '@' or '<' characters, to handle statements that have yet to be parsed, as well as those that have already been compiled. 

This isn't an issue in 4.2 and beyond, but I've run into it a couple times in my project and I can't jump to 4.2 yet.
