### PR TITLE
laravel/framework also replaces illuminate/remote

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         "illuminate/pagination": "self.version",
         "illuminate/queue": "self.version",
         "illuminate/redis": "self.version",
+        "illuminate/remote": "self.version",
         "illuminate/routing": "self.version",
         "illuminate/session": "self.version",
         "illuminate/support": "self.version",


### PR DESCRIPTION
Not sure it this is done for a reason, but now requiring illuminate/remote, will load the package on its own, but this is already in laravel/framework.
Pulled against 4.1 is this could be considered a bug fix.
