### PR TITLE
Add custom create and edit url segments on resource routes

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -545,8 +545,9 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	protected function addResourceCreate($name, $base, $controller, $options)
 	{
 		$action = $this->getResourceAction($name, $controller, 'create', $options);
+		$segment = '/'.(isset($options['create']) ? $options['create'] : 'create');
 
-		return $this->get($this->getResourceUri($name).'/create', $action);
+		return $this->get($this->getResourceUri($name).$segment, $action);
 	}
 
 	/**
@@ -592,7 +593,8 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	protected function addResourceEdit($name, $base, $controller, $options)
 	{
-		$uri = $this->getResourceUri($name).'/{'.$base.'}/edit';
+		$segment = isset($options['edit']) ? $options['edit'] : 'edit';
+		$uri = $this->getResourceUri($name).'/{'.$base.'}/'.$segment;
 
 		return $this->get($uri, $this->getResourceAction($name, $controller, 'edit', $options));
 	}

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -651,6 +651,14 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals('foo-bars/{foo_bars}', $routes[0]->getUri());
 		$this->assertEquals('prefix.foo-bars.show', $routes[0]->getName());
+
+		$router = $this->getRouter();
+		$router->resource('foo', 'FooController', array('create' => 'make', 'edit' => 'change'));
+		$routes = $router->getRoutes();
+		$routes = $routes->getRoutes();
+
+		$this->assertEquals('foo/make', $routes[1]->getUri());
+		$this->assertEquals('foo/{foo}/change', $routes[4]->getUri());
 	}
 
 


### PR DESCRIPTION
This feature allows you to easily change the endpoints when using resource controllers from things like `resource/create` and `resource/1/edit` to `resource/make` and `resource/1/change` respectively. This is similar to something done in Rails as shown here: http://guides.rubyonrails.org/routing.html#overriding-the-new-and-edit-segments.

To use this feature, in your resource route definition you can do the following: 

```
Route::resource('foo', 'FooController', array('create' => 'make', 'edit' => 'change'));
```

I'm open to any recommendations of now to improve this, or if anyone will actually find it useful.
