### PR TITLE
[4.1] Eloquent Builder Collection Creation Consistency

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -77,7 +77,7 @@ class Builder {
 	 */
 	public function findMany($id, $columns = array('*'))
 	{
-		if (empty($id)) return new Collection;
+		if (empty($id)) return $this->model->newCollection();
 
 		$this->query->whereIn($this->model->getKeyName(), $id);
 


### PR DESCRIPTION
Elsewhere in this very same class (`...\Eloquent\Builder`) we are using `$this->model->newCollection()` to create a collection, yet here we were just calling `new Collection;`. For consistency, I have changed it to be the same as `$this->model->newCollection()`.
