### PR TITLE
[4.2] [BUG?] Added support for nested ternary statement in BladeCompiler.

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -247,7 +247,16 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function compileEchoDefaults($value)
 	{
-		return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s', 'isset($1) ? $1 : $2', $value);
+		// eliminate spaces after open parenthesises / before close parenthesises
+		$value = preg_replace('/(?|(?:(\()\s+)|(?:\s+(\))))/', '$1', $value);
+
+		do
+		{
+			$value = preg_replace('/^([^"\']*)\s*(\()?(?=\$)(.+?)(?:\s+or\s+)(.+?)(\))?([^"\']*)$/s', '$1$2isset($3) ? $3 : $4$5$6', $value, -1, $count);
+		}
+		while ($count > 0);
+
+		return $value;
 	}
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -125,6 +125,16 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<?php echo myfunc(\'foo or bar\'); ?>', $compiler->compileString('{{ myfunc(\'foo or bar\') }}'));
 		$this->assertEquals('<?php echo myfunc("foo or bar"); ?>', $compiler->compileString('{{ myfunc("foo or bar") }}'));
 		$this->assertEquals('<?php echo myfunc("$name or \'foo\'"); ?>', $compiler->compileString('{{ myfunc("$name or \'foo\'") }}'));
+
+		$this->assertEquals('<?php echo (isset($name) ? $name : \'foo\'); ?>', $compiler->compileString('{{ ($name or \'foo\') }}'));
+		$this->assertEquals('<?php echo (isset($name) ? $name : \'foo\'); ?>', $compiler->compileString('{{ ( $name or \'foo\' ) }}'));
+		$this->assertEquals('<?php echo isset($bar) ? $bar : (isset($name) ? $name : \'foo\'); ?>', $compiler->compileString('{{ isset($bar) ? $bar : ($name or \'foo\') }}'));
+		$this->assertEquals('<?php echo isset($bar) ? $bar : (isset($name) ? $name : \'foo\'); ?>', $compiler->compileString('{{ isset($bar) ? $bar : ( $name or \'foo\' ) }}'));
+		$this->assertEquals('<?php echo isset($bar) ? $bar : isset($name) ? $name : \'foo\'; ?>', $compiler->compileString('{{ $bar or $name or \'foo\' }}'));
+		$this->assertEquals('<?php echo isset($bar) ? $bar : (isset($name) ? $name : \'foo\'); ?>', $compiler->compileString('{{ $bar or ($name or \'foo\') }}'));
+		$this->assertEquals('<?php echo isset($bar) ? $bar : (isset($name) ? $name : \'foo\'); ?>', $compiler->compileString('{{ $bar or ( $name or \'foo\' ) }}'));
+		$this->assertEquals('<?php echo isset($hello) ? $hello : (isset($bar) ? $bar : (isset($name) ? $name : \'foo\')); ?>', $compiler->compileString('{{ $hello or ($bar or ($name or \'foo\')) }}'));
+		$this->assertEquals('<?php echo isset($hello) ? $hello : (isset($bar) ? $bar : (isset($name) ? $name : \'foo\')); ?>', $compiler->compileString('{{ $hello or ( $bar or ( $name or \'foo\' ) ) }}'));
 	}
 
 


### PR DESCRIPTION
As suggested by @GrahamCampbell in #4431, this pull request is now made to the 4.2 branch because the BladeCompiler has been updated.

There are occasions where nested ternary statements are useful. Before this commit, the following line did not produce expected results:

```
{{ $foo or ($bar or 'foobar') }}
```

Which would have been compiled to:

``` php
<?php echo isset($foo) ? $foo : ($bar or 'foobar'); ?>
```

This PR fixed the problem and the BladeCompiler now parses the nested statement and compiled it to:

``` php
<?php echo isset($foo) ? $foo : (isset($bar) ? $bar : 'foobar'); ?>
```
