### PR TITLE
Fix select clause on belongsToMany relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -140,6 +140,7 @@ class BelongsToMany extends Relation {
 		// First we'll add the proper select columns onto the query so it is run with
 		// the proper columns. Then, we will get the results and hydrate out pivot
 		// models with the result of those columns as a separate model relation.
+		$columns = $this->query->getQuery()->columns ? array() : $columns;
 		$select = $this->getSelectColumns($columns);
 
 		$models = $this->query->addSelect($select)->getModels();

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
@@ -26,6 +27,10 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation->getQuery()->shouldReceive('getModels')->once()->andReturn($models);
 		$relation->getQuery()->shouldReceive('eagerLoadRelations')->once()->with($models)->andReturn($models);
 		$relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function($array) { return new Collection($array); });
+
+		$baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+		$relation->getQuery()->shouldReceive('getQuery')->once()->andReturn($baseBuilder);
+
 		$results = $relation->get();
 
 		$this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $results);
@@ -67,6 +72,10 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation->getQuery()->shouldReceive('getModels')->once()->andReturn($models);
 		$relation->getQuery()->shouldReceive('eagerLoadRelations')->once()->with($models)->andReturn($models);
 		$relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function($array) { return new Collection($array); });
+
+		$baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+		$relation->getQuery()->shouldReceive('getQuery')->once()->andReturn($baseBuilder);
+
 		$results = $relation->get();
 	}
 


### PR DESCRIPTION
Tiny fix on BelongsToMany relation addressing #2679.

Let's you do this:

```
// User model, belongsToMany('Category')

$user->categories()->select('name', updated_at')->get();
// or
public function categoriesAnotherRelation()
{
  return $this->belongsToMany('Category')->select('name', 'updated_at');
}

// resulting query:
// 'SELECT name, updated_at, pivot_fields... ' 
// instead of:
// 'SELECT name, updated_at, categories.*, pivot_fields... '
```
