### PR TITLE
Add ability to set pivot filters on save

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -135,7 +135,7 @@ class BelongsToMany extends Relation {
 	 */
 	protected function generateFilters()
 	{
-		$filters = [];
+		$filters = array();
 		foreach ($this->pivotFilters as $column => $value)
 		{
 			if (is_callable($value)) {
@@ -161,7 +161,7 @@ class BelongsToMany extends Relation {
 	{
 		$this->setFilter($column, $value);
 		$this->wherePivot($column, $value);
-		$this->withPivot([$column]);
+		$this->withPivot(array($column));
 
 		return $this;
 	}

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -43,6 +43,13 @@ class BelongsToMany extends Relation {
 	protected $pivotColumns = array();
 
 	/**
+	 * Pivot Columns to be set when creating a new link
+	 *
+	 * @var array
+	 */
+	protected $pivotFilters = array();
+
+	/**
 	 * Create a new has many relationship instance.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -99,6 +106,64 @@ class BelongsToMany extends Relation {
 	public function orWherePivot($column, $operator = null, $value = null)
 	{
 		return $this->wherePivot($column, $operator, $value, 'or');
+	}
+
+
+	/**
+	 * Create a new filter to set when creating a link
+	 *
+	 * @param closure|array|string $column
+	 * @param closure|string|null $value
+	 * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+	 */
+	public function setFilter($column, $value = null)
+	{
+		if (is_array($column)){
+			$this->pivotFilters = array_merge($this->pivotFilters,$column);
+		} elseif (is_callable($column)) {
+			$this->pivotFilters[] = $column;
+		} else {
+			$this->pivotFilters[ $column ] = $value;
+		}
+		return $this;
+	}
+
+	/**
+	 * Run any closures and return an array of column=>value
+	 *
+	 * @return array
+	 */
+	protected function generateFilters()
+	{
+		$filters = [];
+		foreach ($this->pivotFilters as $column => $value)
+		{
+			if (is_callable($value)) {
+				$result = call_user_func($value, $this);
+				if (is_array($result)) {
+					$filters = array_merge($filters, $result);
+				} else {
+					$filters[$column] = $result;
+				}
+			} else {
+				$filters[$column] = $value;
+			}
+		}
+		return $filters;
+	}
+
+	/**
+	 * @param string $column
+	 * @param string|null $value
+	 * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+	 */
+	public function filter($column, $value = null)
+	{
+		$this->setFilter($column, $value);
+		$this->wherePivot($column, $value);
+		$this->withPivot([$column]);
+
+		return $this;
 	}
 
 	/**
@@ -487,6 +552,8 @@ class BelongsToMany extends Relation {
 	public function save(Model $model, array $joining = array(), $touch = true)
 	{
 		$model->save(array('touch' => false));
+
+		$joining = array_merge($joining, $this->generateFilters());
 
 		$this->attach($model->getKey(), $joining, $touch);
 


### PR DESCRIPTION
This adds the ability to setup "filters" in your model, and save those column/value pairs when links are created.

I am working on a Legacy system, that has filters set in the pivot table (Job description), and I had to filter by them, as well as create links with them.

We also have a very complicated way of working with id's, as we do not have AI fields.

This is how I ended up using it in my model...

``` php
<?php

class Employer extends Eloquent
{
    public function developers()
    {
        return $this->belongsToManyEmployees('DEVELOPERS');
    }

    public function secretaries()
    {
        return $this->belongsToManyEmployees('SECRETARY');
    }

    public function managers()
    {
        return $this->belongsToManyEmployees('MANAGER');
    }

    public function drivers()
    {
        return $this->belongsToManyEmployees('DRIVER');
    }

    protected function belongsToManyEmployees($job)
    {
        return $this->belongsToMany('Employee')
            ->filter('job', $job)
            ->setFilter(function($pivot) {
                $branch_id = $pivot->getParent()->branch_id;
                $max = DB::table($pivot->getTable())->
                    where('branch_id', $branch_id)->
                    first([DB::raw('MAX(`link_id`) as max')]);

                $result['branch_id'] = $branch_id;
                $result['link_id'] = $max ? $max->max+1 : 1;
                return $result;
            });
    }
}
```

Outside of the model, you can now use:

```
$employer->developers()->save($employee);
```

This will set the `job` field to DEVELOPER as well as set the branch_id and link_id fields.
