### PR TITLE
Downgrade symfony/http-foundation to temporarily fix session persistence issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/debug": "2.5.*",
         "symfony/dom-crawler": "2.5.*",
         "symfony/finder": "2.5.*",
-        "symfony/http-foundation": "2.5.*",
+        "symfony/http-foundation": "2.4.*@stable",
         "symfony/http-kernel": "2.5.*",
         "symfony/process": "2.5.*",
         "symfony/routing": "2.5.*",


### PR DESCRIPTION
This is a temporary fix for https://github.com/laravel/framework/issues/4441 to fix newly introduced session persistence issues when using a composer minimum-stability of dev.

Currently, any new Laravel project cloned from the `dev` branch will be unable to persist sessions in the database due to the reasons outlined in https://github.com/laravel/framework/issues/4441.
