### PR TITLE
Added pull method to Collection class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -307,6 +307,18 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Get an value from the collection, and remove it.
+	 *
+	 * @param  string  $key
+	 * @param  mixed   $default
+	 * @return mixed
+	 */
+	public function pull($key, $default = null)
+	{
+		return array_pull($this->items, $key, $default);
+	}
+
+	/**
 	 * Push an item onto the end of the collection.
 	 *
 	 * @param  mixed  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -381,6 +381,20 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(2, 1), $c->lists('id'));
 	}
 
+
+	public function testPullReturnsAndRemovesInCollection()
+	{
+		$c = new Collection(array('foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 'bazValue'));
+		$item = $c->pull('foo');
+		$nonexistentItem = $c->pull('foobar');
+		$nonexistentItemDefaultValue = $c->pull('foobar', 'missing');
+
+		$this->assertEquals('fooValue', $item);
+		$this->assertEquals(null, $nonexistentItem);
+		$this->assertEquals('missing', $nonexistentItemDefaultValue);
+		$this->assertEquals(array('bar' => 'barValue', 'baz' => 'bazValue'), $c->toArray());
+	}
+
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
Added a pull method to the Collection class that, when given a key, returns the value from the collection and removed it. This works much like the pull method in the cache repository does.

Based on the proposal by @luukholleman at #4450.
