### PR TITLE
Moved illuminate\filesystem into require from require-dev

### DIFF
--- a/src/Illuminate/Remote/composer.json
+++ b/src/Illuminate/Remote/composer.json
@@ -9,12 +9,12 @@
     ],
     "require": {
         "php": ">=5.3.0",
+        "illuminate/filesystem": "4.1.*",
         "illuminate/support": "4.1.*",
         "phpseclib/phpseclib": "0.3.*"
     },
     "require-dev": {
         "illuminate/console": "4.1.*",
-        "illuminate/filesystem": "4.1.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "4.0.*"
     },


### PR DESCRIPTION
The Connection.php class, and subsequently the SecLibGateway.php class requires FileSystem.

https://github.com/illuminate/remote/blob/master/Connection.php#L74
https://github.com/illuminate/remote/blob/master/SecLibGateway.php#L50
