### PR TITLE
Bugfix for nested route groups using namespaces

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -735,14 +735,16 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	protected static function formatUsesPrefix($new, $old)
 	{
-		if (isset($new['namespace']))
+		if (isset($new['namespace']) && isset($old['namespace']))
 		{
 			return trim(array_get($old, 'namespace'), '\\').'\\'.trim($new['namespace'], '\\');
 		}
-		else
+		elseif (isset($new['namespace']))
 		{
-			return array_get($old, 'namespace');
+			return trim($new['namespace'], '\\');
 		}
+
+		return array_get($old, 'namespace');
 	}
 
 	/**
@@ -758,10 +760,8 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		{
 			return trim(array_get($old, 'prefix'), '/').'/'.trim($new['prefix'], '/');
 		}
-		else
-		{
-			return array_get($old, 'prefix');
-		}
+
+		return array_get($old, 'prefix');
 	}
 
 	/**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -608,6 +608,20 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$action = $routes[0]->getAction();
 
 		$this->assertEquals('Namespace\\Nested\\Controller', $action['controller']);
+
+
+		$router = $this->getRouter();
+		$router->group(array('prefix' => 'baz'), function() use ($router)
+		{
+			$router->group(array('namespace' => 'Namespace'), function() use ($router)
+			{
+				$router->get('foo/bar', 'Controller');
+			});
+		});
+		$routes = $router->getRoutes()->getRoutes();
+		$action = $routes[0]->getAction();
+
+		$this->assertEquals('Namespace\\Controller', $action['controller']);
 	}
 
 


### PR DESCRIPTION
When using nested route groups where only a child group is adding a namespace, the entry in the router action list will have a prepended `\` which breaks action route lookups.
