### PR TITLE
Attribute names snake-cased by default to make cleaner error messages

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1437,7 +1437,7 @@ class Validator implements MessageProviderInterface {
 		// used as default versions of the attribute's displayable names.
 		else
 		{
-			return str_replace('_', ' ', $attribute);
+			return str_replace('_', ' ', snake_case($attribute));
 		}
 	}
 


### PR DESCRIPTION
Current, attributes with snake_cased names (e.g. foo_bar) are presented as 'foo bar', whereas camelCased names (fooBar) are untouched.

This update ensures uniformity of error messages, regardless of naming styling
