### PR TITLE
Replace hard coded references to php with PHP_BINARY

### DIFF
--- a/src/Illuminate/Foundation/Composer.php
+++ b/src/Illuminate/Foundation/Composer.php
@@ -66,7 +66,7 @@ class Composer {
 	{
 		if ($this->files->exists($this->workingPath.'/composer.phar'))
 		{
-			return 'php composer.phar';
+			return '"'.PHP_BINARY.'" composer.phar';
 		}
 
 		return 'composer';

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -38,7 +38,7 @@ class Listener {
 	 *
 	 * @var string
 	 */
-	protected $workerCommand = 'php artisan queue:work %s --queue="%s" --delay=%s --memory=%s --sleep=%s --tries=%s';
+	protected $workerCommand = '"'.PHP_BINARY.'" artisan queue:work %s --queue="%s" --delay=%s --memory=%s --sleep=%s --tries=%s';
 
 	/**
 	 * The output handler callback.

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -38,7 +38,7 @@ class Listener {
 	 *
 	 * @var string
 	 */
-	protected $workerCommand = '"'.PHP_BINARY.'" artisan queue:work %s --queue="%s" --delay=%s --memory=%s --sleep=%s --tries=%s';
+	protected $workerCommand;
 
 	/**
 	 * The output handler callback.
@@ -56,6 +56,7 @@ class Listener {
 	public function __construct($commandPath)
 	{
 		$this->commandPath = $commandPath;
+		$this->workerCommand =  '"'.PHP_BINARY.'" artisan queue:work %s --queue="%s" --delay=%s --memory=%s --sleep=%s --tries=%s';
 	}
 
 	/**

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -16,7 +16,7 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase {
 		$files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
 		$process = m::mock('stdClass');
 		$composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
-		$process->shouldReceive('setCommandLine')->once()->with('php composer.phar dump-autoload');
+		$process->shouldReceive('setCommandLine')->once()->with('"'.PHP_BINARY.'" composer.phar dump-autoload');
 		$process->shouldReceive('run')->once();
 
 		$composer->dumpAutoloads();

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -41,7 +41,7 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf('Symfony\Component\Process\Process', $process);
 		$this->assertEquals(__DIR__, $process->getWorkingDirectory());
 		$this->assertEquals(3, $process->getTimeout());
-		$this->assertEquals('php artisan queue:work connection --queue="queue" --delay=1 --memory=2 --sleep=3 --tries=0', $process->getCommandLine());
+		$this->assertEquals('"'.PHP_BINARY.'" artisan queue:work connection --queue="queue" --delay=1 --memory=2 --sleep=3 --tries=0', $process->getCommandLine());
 	}
 
 }


### PR DESCRIPTION
With Laravel 4.2 requiring PHP 5.4+ we can use PHP_BINARY when launching new processes instead of the hard coded "php"
