### PR TITLE
[Fix] BelongsToMany: sync return value is forced to int

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -586,7 +586,7 @@ class BelongsToMany extends Relation {
 		{
 			$this->detach($detach);
 
-			$changes['detached'] = (array) array_map('intval', $detach);
+			$changes['detached'] = (array) $detach;
 		}
 
 		// Now we are finally ready to attach the new records. Note that we'll disable
@@ -648,7 +648,7 @@ class BelongsToMany extends Relation {
 			{
 				$this->attach($id, $attributes, $touch);
 
-				$changes['attached'][] = (int) $id;
+				$changes['attached'][] = $id;
 			}
 
 			// Now we'll try to update an existing pivot record with the attributes that were
@@ -658,7 +658,7 @@ class BelongsToMany extends Relation {
 			{
 				if ($this->updateExistingPivot($id, $attributes, $touch))
 				{
-					$changes['updated'][] = (int) $id;
+					$changes['updated'][] = $id;
 				}
 			}
 		}


### PR DESCRIPTION
Removes the array map intval and int typecasting which breaks the return value of `sync()` when  models with string based keys are used.
