### PR TITLE
Make the Console\Command and Console\Migrations\BaseCommand abstract

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-class Command extends \Symfony\Component\Console\Command\Command {
+abstract class Command extends \Symfony\Component\Console\Command\Command {
 
 	/**
 	 * The Laravel application instance.
@@ -382,4 +382,5 @@ class Command extends \Symfony\Component\Console\Command\Command {
 		$this->laravel = $laravel;
 	}
 
+	abstract public function fire();
 }

--- a/src/Illuminate/Database/Console/Migrations/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/BaseCommand.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Console\Command;
 
-class BaseCommand extends Command {
+abstract class BaseCommand extends Command {
 
 	/**
 	 * Get the path to the migration directory.


### PR DESCRIPTION
Following up on [Should \Illuminate\Console\Command.php be Declared `abstract`?](https://github.com/laravel/framework/issues/4273), this PR makes `Illuminate\Console\Command` and `Illuminate\Database\Console\Migrations\BaseCommand` abstract classes.

This time targeting the 4.2 branch (re: @taylorotwell's [comment on PR4372](https://github.com/laravel/framework/pull/4372#issuecomment-44036072))
