### PR TITLE
Bugfix for URL which has segment "0"

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -114,7 +114,7 @@ class Request extends SymfonyRequest {
 	{
 		$segments = explode('/', $this->path());
 
-		return array_values(array_filter($segments));
+		return array_values(array_filter($segments,function($v) {return $v!='';} ));
 	}
 
 	/**


### PR DESCRIPTION
For URL like /one/0/three, Request::segments() expected result is [one, 0, three], but there is [one, three], because array_filter without closure checks $v!=false ("0"==false), but should check for emptiness.
