### PR TITLE
Fix Request::segments() ignores segment "/0"

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -114,7 +114,7 @@ class Request extends SymfonyRequest {
 	{
 		$segments = explode('/', $this->path());
 
-		return array_values(array_filter($segments));
+		return array_values(array_filter($segments, function($v) {return $v!='';} ));
 	}
 
 	/**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -78,7 +78,8 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		return array(
 			array('', array()),
 			array('foo/bar', array('foo', 'bar')),
-			array('foo/bar//baz', array('foo', 'bar', 'baz'))
+			array('foo/bar//baz', array('foo', 'bar', 'baz')),
+			array('foo/0/bar', array('foo', '0', 'bar'))
 		);
 	}
 


### PR DESCRIPTION
For url like "/one/0/three", Request::segments() expected result is [one, 0, three], but there it returns  [one,three]. This happens because array_filter without closure checks $v!=false, but should check for emptiness in this case.
