### PR TITLE
[4.2] Added FilesystemInterface

### DIFF
--- a/src/Illuminate/Auth/Console/RemindersControllerCommand.php
+++ b/src/Illuminate/Auth/Console/RemindersControllerCommand.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Auth\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class RemindersControllerCommand extends Command {
 
@@ -22,17 +22,17 @@ class RemindersControllerCommand extends Command {
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
 	/**
 	 * Create a new reminder table command instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files)
+	public function __construct(FilesystemInterface $files)
 	{
 		parent::__construct();
 

--- a/src/Illuminate/Auth/Console/RemindersTableCommand.php
+++ b/src/Illuminate/Auth/Console/RemindersTableCommand.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Auth\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class RemindersTableCommand extends Command {
 
@@ -22,17 +22,17 @@ class RemindersTableCommand extends Command {
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
 	/**
 	 * Create a new reminder table command instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files)
+	public function __construct(FilesystemInterface $files)
 	{
 		parent::__construct();
 

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Cache\CacheManager;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class ClearCommand extends Command {
 
@@ -30,7 +30,7 @@ class ClearCommand extends Command {
 	/**
 	 * The file system instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -38,10 +38,10 @@ class ClearCommand extends Command {
 	 * Create a new cache clear command instance.
 	 *
 	 * @param  \Illuminate\Cache\CacheManager  $cache
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public function __construct(CacheManager $cache, Filesystem $files)
+	public function __construct(CacheManager $cache, FilesystemInterface $files)
 	{
 		parent::__construct();
 
@@ -59,7 +59,7 @@ class ClearCommand extends Command {
 		$this->cache->flush();
 
 		$this->files->delete($this->laravel['config']['app.manifest'].'/services.json');
-		
+
 		$this->laravel['events']->fire('cache:cleared');
 
 		$this->info('Application cache cleared!');

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\Cache;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class FileStore implements StoreInterface {
 
 	/**
 	 * The Illuminate Filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -21,11 +21,11 @@ class FileStore implements StoreInterface {
 	/**
 	 * Create a new file cache store instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @param  string  $directory
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $directory)
+	public function __construct(FilesystemInterface $files, $directory)
 	{
 		$this->files = $files;
 		$this->directory = $directory;
@@ -202,7 +202,7 @@ class FileStore implements StoreInterface {
 	/**
 	 * Get the Filesystem instance.
 	 *
-	 * @return \Illuminate\Filesystem\Filesystem
+	 * @return \Illuminate\Filesystem\FilesystemInterface
 	 */
 	public function getFilesystem()
 	{

--- a/src/Illuminate/Config/FileEnvironmentVariablesLoader.php
+++ b/src/Illuminate/Config/FileEnvironmentVariablesLoader.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\Config;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class FileEnvironmentVariablesLoader implements EnvironmentVariablesLoaderInterface {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -21,10 +21,10 @@ class FileEnvironmentVariablesLoader implements EnvironmentVariablesLoaderInterf
 	/**
 	 * Create a new file environment loader instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $path = null)
+	public function __construct(FilesystemInterface $files, $path = null)
 	{
 		$this->files = $files;
 		$this->path = $path ?: base_path();

--- a/src/Illuminate/Config/FileLoader.php
+++ b/src/Illuminate/Config/FileLoader.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\Config;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class FileLoader implements LoaderInterface {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -35,11 +35,11 @@ class FileLoader implements LoaderInterface {
 	/**
 	 * Create a new file configuration loader.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @param  string  $defaultPath
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $defaultPath)
+	public function __construct(FilesystemInterface $files, $defaultPath)
 	{
 		$this->files = $files;
 		$this->defaultPath = $defaultPath;
@@ -245,7 +245,7 @@ class FileLoader implements LoaderInterface {
 	/**
 	 * Get the Filesystem instance.
 	 *
-	 * @return \Illuminate\Filesystem\Filesystem
+	 * @return \Illuminate\Filesystem\FilesystemInterface
 	 */
 	public function getFilesystem()
 	{

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -1,14 +1,14 @@
 <?php namespace Illuminate\Database\Migrations;
 
 use Closure;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class MigrationCreator {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -22,10 +22,10 @@ class MigrationCreator {
 	/**
 	 * Create a new migration creator instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files)
+	public function __construct(FilesystemInterface $files)
 	{
 		$this->files = $files;
 	}
@@ -161,7 +161,7 @@ class MigrationCreator {
 	/**
 	 * Get the filesystem instance.
 	 *
-	 * @return \Illuminate\Filesystem\Filesystem
+	 * @return \Illuminate\Filesystem\FilesystemInterface
 	 */
 	public function getFilesystem()
 	{

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -1,6 +1,6 @@
 <?php namespace Illuminate\Database\Migrations;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 class Migrator {
@@ -15,7 +15,7 @@ class Migrator {
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -45,12 +45,12 @@ class Migrator {
 	 *
 	 * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
 	 * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
 	public function __construct(MigrationRepositoryInterface $repository,
 								Resolver $resolver,
-                                Filesystem $files)
+                                FilesystemInterface $files)
 	{
 		$this->files = $files;
 		$this->resolver = $resolver;
@@ -369,7 +369,7 @@ class Migrator {
 	/**
 	 * Get the file system instance.
 	 *
-	 * @return \Illuminate\Filesystem\Filesystem
+	 * @return \Illuminate\Filesystem\FilesystemInterface
 	 */
 	public function getFilesystem()
 	{

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -5,7 +5,7 @@ use Symfony\Component\Finder\Finder;
 
 class FileNotFoundException extends \Exception {}
 
-class Filesystem {
+class Filesystem implements FilesystemInterface {
 
 	/**
 	 * Determine if a file exists.
@@ -199,7 +199,7 @@ class Filesystem {
 	}
 
 	/**
-	 * Determine if the given path is writable.
+	 * Determine if the given path is writeable.
 	 *
 	 * @param  string  $path
 	 * @return bool

--- a/src/Illuminate/Filesystem/FilesystemInterface.php
+++ b/src/Illuminate/Filesystem/FilesystemInterface.php
@@ -1,0 +1,223 @@
+<?php namespace Illuminate\Filesystem;
+
+interface FilesystemInterface {
+
+	/**
+	 * Determine if a file exists.
+	 *
+	 * @param  string  $path
+	 * @return bool
+	 */
+	public function exists($path);
+
+	/**
+	 * Get the contents of a file.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 *
+	 * @throws FileNotFoundException
+	 */
+	public function get($path);
+
+	/**
+	 * Get the returned value of a file.
+	 *
+	 * @param  string  $path
+	 * @return mixed
+	 *
+	 * @throws FileNotFoundException
+	 */
+	public function getRequire($path);
+
+	/**
+	 * Require the given file once.
+	 *
+	 * @param  string  $file
+	 * @return mixed
+	 */
+	public function requireOnce($file);
+
+	/**
+	 * Write the contents of a file.
+	 *
+	 * @param  string  $path
+	 * @param  string  $contents
+	 * @return int
+	 */
+	public function put($path, $contents);
+
+	/**
+	 * Prepend to a file.
+	 *
+	 * @param  string  $path
+	 * @param  string  $data
+	 * @return int
+	 */
+	public function prepend($path, $data);
+
+	/**
+	 * Append to a file.
+	 *
+	 * @param  string  $path
+	 * @param  string  $data
+	 * @return int
+	 */
+	public function append($path, $data);
+
+	/**
+	 * Delete the file at a given path.
+	 *
+	 * @param  string|array  $paths
+	 * @return bool
+	 */
+	public function delete($paths);
+
+	/**
+	 * Move a file to a new location.
+	 *
+	 * @param  string  $path
+	 * @param  string  $target
+	 * @return bool
+	 */
+	public function move($path, $target);
+
+	/**
+	 * Copy a file to a new location.
+	 *
+	 * @param  string  $path
+	 * @param  string  $target
+	 * @return bool
+	 */
+	public function copy($path, $target);
+
+	/**
+	 * Extract the file extension from a file path.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public function extension($path);
+
+	/**
+	 * Get the file type of a given file.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public function type($path);
+
+	/**
+	 * Get the file size of a given file.
+	 *
+	 * @param  string  $path
+	 * @return int
+	 */
+	public function size($path);
+
+	/**
+	 * Get the file's last modification time.
+	 *
+	 * @param  string  $path
+	 * @return int
+	 */
+	public function lastModified($path);
+
+	/**
+	 * Determine if the given path is a directory.
+	 *
+	 * @param  string  $directory
+	 * @return bool
+	 */
+	public function isDirectory($directory);
+
+	/**
+	 * Determine if the given path is writeable.
+	 *
+	 * @param  string  $path
+	 * @return bool
+	 */
+	public function isWritable($path);
+
+	/**
+	 * Determine if the given path is a file.
+	 *
+	 * @param  string  $file
+	 * @return bool
+	 */
+	public function isFile($file);
+
+	/**
+	 * Find path names matching a given pattern.
+	 *
+	 * @param  string  $pattern
+	 * @param  int     $flags
+	 * @return array
+	 */
+	public function glob($pattern, $flags = 0);
+
+	/**
+	 * Get an array of all files in a directory.
+	 *
+	 * @param  string  $directory
+	 * @return array
+	 */
+	public function files($directory);
+
+	/**
+	 * Get all of the files from the given directory (recursive).
+	 *
+	 * @param  string  $directory
+	 * @return array
+	 */
+	public function allFiles($directory);
+
+	/**
+	 * Get all of the directories within a given directory.
+	 *
+	 * @param  string  $directory
+	 * @return array
+	 */
+	public function directories($directory);
+
+	/**
+	 * Create a directory.
+	 *
+	 * @param  string  $path
+	 * @param  int     $mode
+	 * @param  bool    $recursive
+	 * @param  bool    $force
+	 * @return bool
+	 */
+	public function makeDirectory($path, $mode = 0755, $recursive = false, $force = false);
+
+	/**
+	 * Copy a directory from one location to another.
+	 *
+	 * @param  string  $directory
+	 * @param  string  $destination
+	 * @param  int     $options
+	 * @return bool
+	 */
+	public function copyDirectory($directory, $destination, $options = null);
+
+	/**
+	 * Recursively delete a directory.
+	 *
+	 * The directory itself may be optionally preserved.
+	 *
+	 * @param  string  $directory
+	 * @param  bool    $preserve
+	 * @return bool
+	 */
+	public function deleteDirectory($directory, $preserve = false);
+
+	/**
+	 * Empty the specified directory of all files and folders.
+	 *
+	 * @param  string  $directory
+	 * @return bool
+	 */
+	public function cleanDirectory($directory);
+
+}

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1074,7 +1074,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 			'encrypter'      => 'Illuminate\Encryption\Encrypter',
 			'db'             => 'Illuminate\Database\DatabaseManager',
 			'events'         => 'Illuminate\Events\Dispatcher',
-			'files'          => 'Illuminate\Filesystem\Filesystem',
+			'files'          => 'Illuminate\Filesystem\FilesystemInterface',
 			'form'           => 'Illuminate\Html\FormBuilder',
 			'hash'           => 'Illuminate\Hashing\HasherInterface',
 			'html'           => 'Illuminate\Html\HtmlBuilder',

--- a/src/Illuminate/Foundation/AssetPublisher.php
+++ b/src/Illuminate/Foundation/AssetPublisher.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\Foundation;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class AssetPublisher {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -28,11 +28,11 @@ class AssetPublisher {
 	/**
 	 * Create a new asset publisher instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @param  string  $publishPath
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $publishPath)
+	public function __construct(FilesystemInterface $files, $publishPath)
 	{
 		$this->files = $files;
 		$this->publishPath = $publishPath;

--- a/src/Illuminate/Foundation/Composer.php
+++ b/src/Illuminate/Foundation/Composer.php
@@ -1,14 +1,14 @@
 <?php namespace Illuminate\Foundation;
 
-use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class Composer {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -22,11 +22,11 @@ class Composer {
 	/**
 	 * Create a new Composer manager instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @param  string  $workingPath
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $workingPath = null)
+	public function __construct(FilesystemInterface $files, $workingPath = null)
 	{
 		$this->files = $files;
 		$this->workingPath = $workingPath;

--- a/src/Illuminate/Foundation/ConfigPublisher.php
+++ b/src/Illuminate/Foundation/ConfigPublisher.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\Foundation;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class ConfigPublisher {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -28,11 +28,11 @@ class ConfigPublisher {
 	/**
 	 * Create a new configuration publisher instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @param  string  $publishPath
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $publishPath)
+	public function __construct(FilesystemInterface $files, $publishPath)
 	{
 		$this->files = $files;
 		$this->publishPath = $publishPath;

--- a/src/Illuminate/Foundation/Console/CommandMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CommandMakeCommand.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -24,10 +24,10 @@ class CommandMakeCommand extends Command {
 	/**
 	 * Create a new command creator command.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files)
+	public function __construct(FilesystemInterface $files)
 	{
 		parent::__construct();
 

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class KeyGenerateCommand extends Command {
 
@@ -23,10 +23,10 @@ class KeyGenerateCommand extends Command {
 	/**
 	 * Create a new key generator command.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files)
+	public function __construct(FilesystemInterface $files)
 	{
 		parent::__construct();
 

--- a/src/Illuminate/Foundation/Console/Optimize/config.php
+++ b/src/Illuminate/Foundation/Console/Optimize/config.php
@@ -40,6 +40,7 @@ return array_map('realpath', array(
     $basePath.'/vendor/laravel/framework/src/Illuminate/Config/EnvironmentVariablesLoaderInterface.php',
     $basePath.'/vendor/laravel/framework/src/Illuminate/Config/FileEnvironmentVariablesLoader.php',
     $basePath.'/vendor/laravel/framework/src/Illuminate/Config/EnvironmentVariables.php',
+    $basePath.'/vendor/laravel/framework/src/Illuminate/Filesystem/FilesystemInterface.php',
     $basePath.'/vendor/laravel/framework/src/Illuminate/Filesystem/Filesystem.php',
     $basePath.'/vendor/laravel/framework/src/Illuminate/Foundation/AliasLoader.php',
     $basePath.'/vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php',

--- a/src/Illuminate/Foundation/MigrationPublisher.php
+++ b/src/Illuminate/Foundation/MigrationPublisher.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Foundation;
 
 use Carbon\Carbon;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class MigrationPublisher {
 
@@ -15,10 +15,10 @@ class MigrationPublisher {
 	/**
 	 * Create a new migration publisher instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files)
+	public function __construct(FilesystemInterface $files)
 	{
 		$this->files = $files;
 	}

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\Foundation;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class ProviderRepository {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -28,11 +28,11 @@ class ProviderRepository {
 	/**
 	 * Create a new service repository instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @param  string  $manifestPath
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $manifestPath)
+	public function __construct(FilesystemInterface $files, $manifestPath)
 	{
 		$this->files = $files;
 		$this->manifestPath = $manifestPath;
@@ -221,7 +221,7 @@ class ProviderRepository {
 	/**
 	 * Get the filesystem instance.
 	 *
-	 * @return \Illuminate\Filesystem\Filesystem
+	 * @return \Illuminate\Filesystem\FilesystemInterface
 	 */
 	public function getFilesystem()
 	{

--- a/src/Illuminate/Foundation/ViewPublisher.php
+++ b/src/Illuminate/Foundation/ViewPublisher.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\Foundation;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class ViewPublisher {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -28,11 +28,11 @@ class ViewPublisher {
 	/**
 	 * Create a new view publisher instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @param  string  $publishPath
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $publishPath)
+	public function __construct(FilesystemInterface $files, $publishPath)
 	{
 		$this->files = $files;
 		$this->publishPath = $publishPath;

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class FailedTableCommand extends Command {
 
@@ -22,17 +22,17 @@ class FailedTableCommand extends Command {
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
 	/**
 	 * Create a new session table command instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files)
+	public function __construct(FilesystemInterface $files)
 	{
 		parent::__construct();
 

--- a/src/Illuminate/Remote/SecLibGateway.php
+++ b/src/Illuminate/Remote/SecLibGateway.php
@@ -1,6 +1,6 @@
 <?php namespace Illuminate\Remote;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 use Net_SFTP, Crypt_RSA, System_SSH_Agent;
 
 class SecLibGateway implements GatewayInterface {
@@ -29,7 +29,7 @@ class SecLibGateway implements GatewayInterface {
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -47,7 +47,7 @@ class SecLibGateway implements GatewayInterface {
 	 * @param  array   $auth
 	 * @return void
 	 */
-	public function __construct($host, array $auth, Filesystem $files)
+	public function __construct($host, array $auth, FilesystemInterface $files)
 	{
 		$this->auth = $auth;
 		$this->files = $files;

--- a/src/Illuminate/Routing/Generators/ControllerGenerator.php
+++ b/src/Illuminate/Routing/Generators/ControllerGenerator.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\Routing\Generators;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class ControllerGenerator {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -29,10 +29,10 @@ class ControllerGenerator {
 	/**
 	 * Create a new controller generator instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files)
+	public function __construct(FilesystemInterface $files)
 	{
 		$this->files = $files;
 	}

--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Session\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class SessionTableCommand extends Command {
 
@@ -22,17 +22,17 @@ class SessionTableCommand extends Command {
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
 	/**
 	 * Create a new session table command instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files)
+	public function __construct(FilesystemInterface $files)
 	{
 		parent::__construct();
 

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -1,14 +1,14 @@
 <?php namespace Illuminate\Session;
 
 use Symfony\Component\Finder\Finder;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class FileSessionHandler implements \SessionHandlerInterface {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -22,11 +22,11 @@ class FileSessionHandler implements \SessionHandlerInterface {
 	/**
 	 * Create a new file driven handler instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @param  string  $path
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $path)
+	public function __construct(FilesystemInterface $files, $path)
 	{
 		$this->path = $path;
 		$this->files = $files;

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Support\Facades;
 
 /**
- * @see \Illuminate\Filesystem\Filesystem
+ * @see \Illuminate\Filesystem\FilesystemInterface
  */
 class File extends Facade {
 

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\Translation;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class FileLoader implements LoaderInterface {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -28,11 +28,11 @@ class FileLoader implements LoaderInterface {
 	/**
 	 * Create a new file loader instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @param  string  $path
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $path)
+	public function __construct(FilesystemInterface $files, $path)
 	{
 		$this->path = $path;
 		$this->files = $files;

--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\View\Compilers;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 abstract class Compiler {
 
 	/**
 	 * The Filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -21,11 +21,11 @@ abstract class Compiler {
 	/**
 	 * Create a new compiler instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @param  string  $cachePath
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $cachePath)
+	public function __construct(FilesystemInterface $files, $cachePath)
 	{
 		$this->files = $files;
 		$this->cachePath = $cachePath;

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\View;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class FileViewFinder implements ViewFinderInterface {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -49,12 +49,12 @@ class FileViewFinder implements ViewFinderInterface {
 	/**
 	 * Create a new file view loader instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @param  array  $paths
 	 * @param  array  $extensions
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, array $paths, array $extensions = null)
+	public function __construct(FilesystemInterface $files, array $paths, array $extensions = null)
 	{
 		$this->files = $files;
 		$this->paths = $paths;
@@ -240,7 +240,7 @@ class FileViewFinder implements ViewFinderInterface {
 	/**
 	 * Get the filesystem instance.
 	 *
-	 * @return \Illuminate\Filesystem\Filesystem
+	 * @return \Illuminate\Filesystem\FilesystemInterface
 	 */
 	public function getFilesystem()
 	{

--- a/src/Illuminate/Workbench/PackageCreator.php
+++ b/src/Illuminate/Workbench/PackageCreator.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\Workbench;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class PackageCreator {
 
 	/**
 	 * The filesystem instance.
 	 *
-	 * @var \Illuminate\Filesystem\Filesystem
+	 * @var \Illuminate\Filesystem\FilesystemInterface
 	 */
 	protected $files;
 
@@ -38,10 +38,10 @@ class PackageCreator {
 	/**
 	 * Create a new package creator instance.
 	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files)
+	public function __construct(FilesystemInterface $files)
 	{
 		$this->files = $files;
 	}

--- a/src/Illuminate/Workbench/Starter.php
+++ b/src/Illuminate/Workbench/Starter.php
@@ -2,6 +2,7 @@
 
 use Symfony\Component\Finder\Finder;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FilesystemInterface;
 
 class Starter {
 
@@ -10,10 +11,10 @@ class Starter {
 	 *
 	 * @param  string  $path
 	 * @param  \Symfony\Component\Finder\Finder  $finder
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Filesystem\FilesystemInterface  $files
 	 * @return void
 	 */
-	public static function start($path, Finder $finder = null, Filesystem $files = null)
+	public static function start($path, Finder $finder = null, FilesystemInterface $files = null)
 	{
 		$finder = $finder ?: new Finder;
 


### PR DESCRIPTION
I was trying to write another class with the same public interface as `Filesystem`, but the only way for me to inject it into any laravel classes was for me to extend the class `Filesystem`, then override every single method. That seems a bit hacky to me. Surely the proper way to do it would be to have a `FilesystemInterface`. I can't be the only one wanting to use a remote filesystem where by I wanted my own implementation to talk to it.
