### PR TITLE
Bugfix/route resource prefixing

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1551,7 +1551,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 * @param  dynamic  string
 	 * @return bool
 	 */
-	public function isAction()
+	public function uses()
 	{
 		foreach (func_get_args() as $pattern)
 		{

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -483,7 +483,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		// the resource action. Otherwise we'll just use an empty string for here.
 		$prefix = isset($options['as']) ? $options['as'].'.' : '';
 
-		if (count($this->groupStack) == 0)
+		if ($prefix || count($this->groupStack) == 0)
 		{
 			return $prefix.$resource.'.'.$method;
 		}

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -6,28 +6,6 @@
 class Route extends Facade {
 
 	/**
-	 * Determine if the current route matches a given name.
-	 *
-	 * @param  string  $name
-	 * @return bool
-	 */
-	public static function is($name)
-	{
-		return static::$app['router']->currentRouteNamed($name);
-	}
-
-	/**
-	 * Determine if the current route uses a given controller action.
-	 *
-	 * @param  string  $action
-	 * @return bool
-	 */
-	public static function uses($action)
-	{
-		return static::$app['router']->currentRouteUses($action);
-	}
-
-	/**
 	 * Get the registered name of the component.
 	 *
 	 * @return string

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -55,6 +55,8 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('fred25', $router->dispatch(Request::create('fred', 'GET'))->getContent());
 		$this->assertEquals('fred30', $router->dispatch(Request::create('fred/30', 'GET'))->getContent());
 		$this->assertTrue($router->currentRouteNamed('foo'));
+		$this->assertTrue($router->is('foo'));
+		$this->assertFalse($router->is('bar'));
 
 		$router = $this->getRouter();
 		$router->get('foo/bar', function() { return 'hello'; });
@@ -188,6 +190,8 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('baz', $router->dispatch(Request::create('bar', 'GET'))->getContent());
 
 		$this->assertTrue($router->currentRouteUses('RouteTestControllerDispatchStub@bar'));
+		$this->assertTrue($router->uses('RouteTestControllerDispatchStub@bar'));
+		$this->assertFalse($router->uses('RouteTestControllerDispatchStub@baz'));
 	}
 
 


### PR DESCRIPTION
Here's an example routing situation:

``` php
Route::group(['prefix' => 'admin'], function()
{
    Route::model('post', '\Package\Model\Post');
    Route::resource('post', '\Package\PostController', ['as'=>'package']);
});
```

And currently, here are the resulting routes from `artisan routes`:

```
+--------+---------------------------------+----------------------------+---------------------------------+
| Domain | URI                             | Name                       | Action                          |
+--------+---------------------------------+----------------------------+---------------------------------+
|        | GET|HEAD admin/post             | package.admin.post.index   | \Package\PostController@index   |
|        | GET|HEAD admin/post/create      | package.admin.post.create  | \Package\PostController@create  |
|        | POST admin/post                 | package.admin.post.store   | \Package\PostController@store   |
|        | GET|HEAD admin/post/{post}      | package.admin.post.show    | \Package\PostController@show    |
|        | GET|HEAD admin/post/{post}/edit | package.admin.post.edit    | \Package\PostController@edit    |
|        | PUT admin/post/{post}           | package.admin.post.update  | \Package\PostController@update  |
|        | PATCH admin/post/{post}         |                            | \Package\PostController@update  |
|        | DELETE admin/post/{post}        | package.admin.post.destroy | \Package\PostController@destroy |
+--------+---------------------------------+----------------------------+---------------------------------+
```

With this patch, if you set the `as` option on the Route::resource() call, it will assume that that string is what you want to prefix your route names with, and not any of the route group names that are currently being added.  This would solve several other issues (e.g. #1616) and updates the way #3000 solved it.

While there might be some BC issues, I don't see them as truly major.  If you are passing 'as' to your Route::resource(), then I don't think you'd be expecting any prefixes anyway.

In my case, this is for a package that supplies routes where the group `prefix` is configurable.  And yes, I could use action based routing (as has always been suggested), but I think this fixes a general issue where routes aren't being named in a predictable way when you think they should be. :)

Another solution would be to allow something like a `no_group_prefix` option to be passed, in which case my code would change from:

``` diff
-       if ($prefix || count($this->groupStack) == 0)
+       if (isset($options['no_group_prefix']) || count($this->groupStack) == 0)
```
