### PR TITLE
Fix: Some request path segment is missing.

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -114,7 +114,7 @@ class Request extends SymfonyRequest {
 	{
 		$segments = explode('/', $this->path());
 
-		return array_values(array_filter($segments));
+		return array_values($segments);
 	}
 
 	/**


### PR DESCRIPTION
Some request path segment is missing when that segment is 0.

Example url: `http://test.loc/collections/best-seller/0/83`
When I call `print_r(Request::segments());`

I get this result.

```
array(3) [
    string (11) "collections"
    string (11) "best-seller"
    string (2) "83"
]
```

It happen because `array_filer()` remove 0 from array.
