### PR TITLE
[4.2] Forward Thinking For Composer

### DIFF
--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -23,9 +23,10 @@
         "illuminate/routing": "4.2.*"
     },
     "autoload": {
-        "psr-0": {"Illuminate\\Auth": ""}
+        "psr-4": {
+            "Illuminate\\Auth\\": ""
+        }
     },
-    "target-dir": "Illuminate/Auth",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -19,9 +19,10 @@
         "illuminate/redis": "4.2.*"
     },
     "autoload": {
-        "psr-0": {"Illuminate\\Cache": ""}
+        "psr-4": {
+            "Illuminate\\Cache\\": ""
+        }
     },
-    "target-dir": "Illuminate/Cache",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -13,9 +13,10 @@
         "illuminate/support": "4.2.*"
     },
     "autoload": {
-        "psr-0": {"Illuminate\\Config": ""}
+        "psr-4": {
+            "Illuminate\\Config\\": ""
+        }
     },
-    "target-dir": "Illuminate/Config",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -12,11 +12,10 @@
         "symfony/console": "2.5.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Console": ""
+        "psr-4": {
+            "Illuminate\\Console\\": ""
         }
     },
-    "target-dir": "Illuminate/Console",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -11,11 +11,10 @@
         "php": ">=5.4.0"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Container": ""
+        "psr-4": {
+            "Illuminate\\Container\\": ""
         }
     },
-    "target-dir": "Illuminate/Container",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -15,11 +15,10 @@
         "symfony/http-foundation": "2.5.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Cookie": ""
+        "psr-4": {
+            "Illuminate\\Cookie\\": ""
         }
     },
-    "target-dir": "Illuminate/Cookie",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -23,11 +23,10 @@
         "illuminate/support": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Database": ""
+        "psr-4": {
+            "Illuminate\\Database\\": ""
         }
     },
-    "target-dir": "Illuminate/Database",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -13,11 +13,10 @@
         "symfony/security-core": "2.5.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Encryption": ""
+        "psr-4": {
+            "Illuminate\\Encryption\\": ""
         }
     },
-    "target-dir": "Illuminate/Encryption",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -13,11 +13,10 @@
         "illuminate/support": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Events": ""
+        "psr-4": {
+            "Illuminate\\Events\\": ""
         }
     },
-    "target-dir": "Illuminate/Events",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Exception/composer.json
+++ b/src/Illuminate/Exception/composer.json
@@ -18,11 +18,10 @@
         "monolog/monolog": "~1.6"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Exception": ""
+        "psr-4": {
+            "Illuminate\\Exception\\": ""
         }
     },
-    "target-dir": "Illuminate/Exception",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -13,11 +13,10 @@
         "symfony/finder": "2.5.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Filesystem": ""
+        "psr-4": {
+            "Illuminate\\Filesystem\\": ""
         }
     },
-    "target-dir": "Illuminate/Filesystem",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -13,11 +13,10 @@
         "ircmaxell/password-compat": "~1.0"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Hashing": ""
+        "psr-4": {
+            "Illuminate\\Hashing\\": ""
         }
     },
-    "target-dir": "Illuminate/Hashing",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Html/composer.json
+++ b/src/Illuminate/Html/composer.json
@@ -14,11 +14,10 @@
         "illuminate/support": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Html": ""
+        "psr-4": {
+            "Illuminate\\Html\\": ""
         }
     },
-    "target-dir": "Illuminate/Html",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -15,11 +15,10 @@
         "symfony/http-kernel": "2.5.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Http": ""
+        "psr-4": {
+            "Illuminate\\Http\\": ""
         }
     },
-    "target-dir": "Illuminate/Http",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -16,11 +16,10 @@
         "illuminate/events": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Log": ""
+        "psr-4": {
+            "Illuminate\\Log\\": ""
         }
     },
-    "target-dir": "Illuminate/Log",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -19,11 +19,10 @@
         "illuminate/queue": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Mail": ""
+        "psr-4": {
+            "Illuminate\\Mail\\": ""
         }
     },
-    "target-dir": "Illuminate/Mail",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -16,11 +16,10 @@
         "symfony/translation": "2.5.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Pagination": ""
+        "psr-4": {
+            "Illuminate\\Pagination\\": ""
         }
     },
-    "target-dir": "Illuminate/Pagination",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -22,14 +22,13 @@
         "pda/pheanstalk": "~2.1"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Queue": ""
+        "psr-4": {
+            "Illuminate\\Queuing\\": ""
         },
         "classmap": [
             "IlluminateQueueClosure.php"
         ]
     },
-    "target-dir": "Illuminate/Queue",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -13,11 +13,10 @@
         "predis/predis": "0.8.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Redis": ""
+        "psr-4": {
+            "Illuminate\\Redis\\": ""
         }
     },
-    "target-dir": "Illuminate/Redis",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Remote/composer.json
+++ b/src/Illuminate/Remote/composer.json
@@ -17,11 +17,10 @@
         "illuminate/console": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Remote": ""
+        "psr-4": {
+            "Illuminate\\Remote\\": ""
         }
     },
-    "target-dir": "Illuminate/Remote",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -22,11 +22,10 @@
         "illuminate/filesystem": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Routing": ""
+        "psr-4": {
+            "Illuminate\\Routing\\": ""
         }
     },
-    "target-dir": "Illuminate/Routing",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -21,11 +21,10 @@
         "illuminate/console": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Session": ""
+        "psr-4": {
+            "Illuminate\\Session\\": ""
         }
     },
-    "target-dir": "Illuminate/Session",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -15,14 +15,13 @@
         "patchwork/utf8": "1.1.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Support": ""
+        "psr-4": {
+            "Illuminate\\Support\\": ""
         },
         "files": [
-            "Illuminate/Support/helpers.php"
+            "helpers.php"
         ]
     },
-    "target-dir": "Illuminate/Support",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -14,11 +14,10 @@
         "symfony/translation": "2.5.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Translation": ""
+        "psr-4": {
+            "Illuminate\\Translation\\": ""
         }
     },
-    "target-dir": "Illuminate/Translation",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -18,11 +18,10 @@
         "illuminate/database": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Validation": ""
+        "psr-4": {
+            "Illuminate\\Validation\\": ""
         }
     },
-    "target-dir": "Illuminate/Validation",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -15,11 +15,10 @@
         "illuminate/support": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\View": ""
+        "psr-4": {
+            "Illuminate\\View\\": ""
         }
     },
-    "target-dir": "Illuminate/View",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"

--- a/src/Illuminate/Workbench/composer.json
+++ b/src/Illuminate/Workbench/composer.json
@@ -17,11 +17,10 @@
         "illuminate/console": "4.2.*"
     },
     "autoload": {
-        "psr-0": {
-            "Illuminate\\Workbench": ""
+        "psr-4": {
+            "Illuminate\\Workbench\\": ""
         }
     },
-    "target-dir": "Illuminate/Workbench",
     "extra": {
         "branch-alias": {
             "dev-master": "4.2-dev"


### PR DESCRIPTION
All this `"target-dir"` stuff is deprecated in composer. We better migrate over to the better way of doing it.
