### PR TITLE
[5.0] Migrate To Stringy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",
         "nesbot/carbon": "~1.0",
-        "patchwork/utf8": "~1.1",
+        "danielstjules/stringy": "~1.5",
         "predis/predis": "~1.0",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/console": "2.6.*",

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": ">=5.4.0",
         "ext-openssl": "*",
         "ext-mcrypt": "*",
+        "ext-mbstring": "*",
         "classpreloader/classpreloader": "~1.0.2",
         "d11wtq/boris": "~1.0",
         "doctrine/annotations": "~1.0",

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Support;
 
-use Patchwork\Utf8;
 use RuntimeException;
+use Stringy\StaticStringy;
 use Illuminate\Support\Traits\Macroable;
 
 class Str {
@@ -37,7 +37,7 @@ class Str {
 	 */
 	public static function ascii($value)
 	{
-		return Utf8::toAscii($value);
+		return StaticStringy::toAscii($value);
 	}
 
 	/**

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.4.0",
         "illuminate/contracts": "5.0.*",
         "doctrine/inflector": "~1.0",
-        "patchwork/utf8": "~1.1"
+        "danielstjules/stringy": "~1.5"
     },
     "require-dev": {
         "jeremeamia/superclosure": "~1.0.1"

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-mbstring": "*",
         "illuminate/contracts": "5.0.*",
         "doctrine/inflector": "~1.0",
         "danielstjules/stringy": "~1.5"


### PR DESCRIPTION
#### This is #4204 retargeted at Laravel ~~4.3~~ 5.0.

In #3643, you said you wanted to move to a smaller library for generating urls, and there was significant interest in moving to Stringy in #3748. I've written an implementation here.

---

Related to #3748, #3643 and #4204.
