### PR TITLE
Translation params for missing keys

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -89,7 +89,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 		// If the line doesn't exist, we will return back the key which was requested as
 		// that will be quick to spot in the UI if language keys are wrong or missing
 		// from the application's language files. Otherwise we can return the line.
-		if ( ! isset($line)) return $key;
+		if ( ! isset($line)) return $this->parameterizeKey($key, $replace);
 
 		return $line;
 	}
@@ -149,6 +149,25 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 		{
 			return mb_strlen($r) * -1;
 		});
+	}
+
+	/**
+	 * Return the key (with parameters) as a fallback message.
+	 *
+	 * @param  string  $key
+	 * @param  array  $parameters
+	 * @return string
+	 */
+	protected function parameterizeKey($key, $parameters)
+	{
+		if (empty($parameters)) return $key;
+
+		array_walk($parameters, function(&$value, $key) {
+			$value = "$key:$value";
+		});
+		$parameters = implode(',', $parameters);
+
+		return "$key ($parameters)";
 	}
 
 	/**

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -49,6 +49,18 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testGetMethodReturnsKeyForMissingItems()
+	{
+		$t = $this->getMock('Illuminate\Translation\Translator', null, array($this->getLoader(), 'en'));
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(null);
+		$this->assertEquals('foo', $t->get('foo'));
+
+		// Parameters should also be included in the returned key
+		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', '*')->andReturn(null);
+		$this->assertEquals('bar (key1:value1,key2:value2)', $t->get('bar', array('key1' => 'value1', 'key2' => 'value2')));
+	}
+
+
 	public function testChoiceMethodProperlyLoadsAndRetrievesItem()
 	{
 		$t = $this->getMock('Illuminate\Translation\Translator', array('get'), array($this->getLoader(), 'en'));


### PR DESCRIPTION
PR for #4515.

Missing translation with parameters will look like this: `some.missing.key (arg1:val1,arg2:val2)`.
