### PR TITLE
[4.2] Increased length of Redis Queue random id to 32 chars

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -219,7 +219,7 @@ class RedisQueue extends Queue implements QueueInterface {
 	 */
 	protected function getRandomId()
 	{
-		return str_random(20);
+		return str_random(32);
 	}
 
 	/**


### PR DESCRIPTION
This small fix will increase the entropy of the randomly generated ID for Redis Queue as described in #4492.
