### PR TITLE
[4.2] Add fromJson method on Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -46,6 +46,28 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Create a new collection instance from a JSON string if the value isn't one already.
+	 *
+	 * @param string $string
+	 * @param bool   $strict
+	 * @return \Illuminate\Support\Collection
+	 * @throws \InvalidArgumentException
+	 */
+	public static function fromJson($string, $strict = false)
+	{
+		$items = @json_decode($string, true);
+
+		if (json_last_error())
+		{
+			if ($strict) throw new \InvalidArgumentException('Argument must be a valid JSON string.');
+
+			$items = [];
+		}
+
+		return static::make($items);
+	}
+
+	/**
 	 * Get all of the items in the collection.
 	 *
 	 * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -301,6 +301,25 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('foo'), $collection->all());
 	}
 
+	public function testFromJsonMethod()
+	{
+		$collection = Collection::fromJson('["foo"]');
+		$this->assertEquals(array('foo'), $collection->all());
+	}
+
+	public function testFromJsonNotStrictMethod()
+	{
+		$collection = Collection::fromJson('invalid_json_string', false);
+		$this->assertEquals(array(), $collection->all());
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testFromJsonWithStrictMethod()
+	{
+		$collection = Collection::fromJson('invalid_json_string', true);
+	}
 
 	public function testSplice()
 	{


### PR DESCRIPTION
Allows to make a collection from a JSON string.
When `$strict` argument is set to `false` and the JSON string is not valid, the collection will be filled with an empty array.

Closes #4537
