### PR TITLE
[4.2] Travis Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,9 @@ php:
   - 5.5
   - 5.6
   - hhvm
-  - hhvm-nightly
 
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --prefer-source --no-interaction --dev
 
 script: vendor/bin/phpunit --verbose
-
-matrix:
-  allow_failures:
-    - php: 5.6
-    - php: hhvm
-    - php: hhvm-nightly
-  fast_finish: true


### PR DESCRIPTION
All Laravel's tests are passing on hhvm now, and php 5.6 is reaching a point of a stable api, so why not take them out of allow failures. I have also removed hhvm-nightly since it's a bit pointless because the original reason for adding it was to get the latest hhvm codebase to workaround any hhvm bugs, but currently, the bleeding edge hhvm doesn't even work with composer, so there's no point in trying to run Laravel's tests on it.
