### PR TITLE
Making it possible to SSH without SFTP access.

### DIFF
--- a/src/Illuminate/Remote/SecLibGateway.php
+++ b/src/Illuminate/Remote/SecLibGateway.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Remote;
 
+use Net_SFTP,Net_SSH2, Crypt_RSA;
 use Illuminate\Filesystem\Filesystem;
-use Net_SFTP, Crypt_RSA, System_SSH_Agent;
 
 class SecLibGateway implements GatewayInterface {
 
@@ -36,7 +36,7 @@ class SecLibGateway implements GatewayInterface {
 	/**
 	 * The SecLib connection instance.
 	 *
-	 * @var \Net_SFTP
+	 * @var \Net_SFTP or Net_SSH2
 	 */
 	protected $connection;
 
@@ -115,7 +115,7 @@ class SecLibGateway implements GatewayInterface {
 	 */
 	public function get($remote, $local)
 	{
-		$this->getConnection()->get($remote, $local);
+		$this->getConnection('Net_SFTP')->get($remote, $local);
 	}
 
 	/**
@@ -126,7 +126,7 @@ class SecLibGateway implements GatewayInterface {
 	 */
 	public function getString($remote)
 	{
-		return $this->getConnection()->get($remote);
+		return $this->getConnection('Net_SFTP')->get($remote);
 	}
 
 	/**
@@ -138,7 +138,7 @@ class SecLibGateway implements GatewayInterface {
 	 */
 	public function put($local, $remote)
 	{
-		$this->getConnection()->put($remote, $local, NET_SFTP_LOCAL_FILE);
+		$this->getConnection('Net_SFTP')->put($remote, $local, NET_SFTP_LOCAL_FILE);
 	}
 
 	/**
@@ -150,7 +150,7 @@ class SecLibGateway implements GatewayInterface {
 	 */
 	public function putString($remote, $contents)
 	{
-		$this->getConnection()->put($remote, $contents);
+		$this->getConnection('Net_SFTP')->put($remote, $contents);
 	}
 
 	/**
@@ -168,17 +168,15 @@ class SecLibGateway implements GatewayInterface {
 	/**
 	 * Get the authentication object for login.
 	 *
-	 * @return \Crypt_RSA|\System_SSH_Agent|string
+	 * @return \Crypt_RSA|string
 	 * @throws \InvalidArgumentException
 	 */
 	protected function getAuthForLogin()
 	{
-		if ($this->useAgent()) return $this->getAgent();
-
 		// If a "key" was specified in the auth credentials, we will load it into a
 		// secure RSA key instance, which will be used to connect to the servers
 		// in place of a password, and avoids the developer specifying a pass.
-		elseif ($this->hasRsaKey())
+		if ($this->hasRsaKey())
 		{
 			return $this->loadRsaKey($this->auth);
 		}
@@ -246,26 +244,6 @@ class SecLibGateway implements GatewayInterface {
 	}
 
 	/**
-	 * Determine if the SSH Agent should provide an RSA key.
-	 *
-	 * @return bool
-	 */
-	protected function useAgent()
-	{
-		return isset($this->auth['agent']) && $this->auth['agent'] === true;
-	}
-
-	/**
-	 * Get a new SSH Agent instance.
-	 *
-	 * @return \System_SSH_Agent
-	 */
-	public function getAgent()
-	{
-		return new System_SSH_Agent;
-	}
-
-	/**
 	 * Get a new RSA key instance.
 	 *
 	 * @return \Crypt_RSA
@@ -306,15 +284,17 @@ class SecLibGateway implements GatewayInterface {
 	}
 
 	/**
-	 * Get the underlying Net_SFTP connection.
+	 * Get the underlying Net_SFTP or Net_SSH2 connection,
+	 * whichever is minimal for the above function.
+	 * Once created, it will 'upgrade' itself if needed.
 	 *
-	 * @return \Net_SFTP
+	 * @return \Net_SFTP or Net_SSH2
 	 */
-	public function getConnection()
+	public function getConnection($type='Net_SSH2')
 	{
-		if ($this->connection) return $this->connection;
+		if ($this->connection &&(is_a($this->connection, 'Net_SFTP')||get_class($this->connection)==$type)) return $this->connection;
 
-		return $this->connection = new Net_SFTP($this->host, $this->port);
+		return $this->connection = new $type($this->host, $this->port);
 	}
 
 }

--- a/src/Illuminate/Remote/SecLibGateway.php
+++ b/src/Illuminate/Remote/SecLibGateway.php
@@ -244,6 +244,25 @@ class SecLibGateway implements GatewayInterface {
 
 		return $key;
 	}
+/**
+	 * Determine if the SSH Agent should provide an RSA key.
+	 *
+	 * @return bool
+	 */
+	protected function useAgent()
+	{
+		return isset($this->auth['agent']) && $this->auth['agent'] === true;
+	}
+
+	/**
+	 * Get a new SSH Agent instance.
+	 *
+	 * @return \System_SSH_Agent
+	 */
+	public function getAgent()
+	{
+		return new System_SSH_Agent;
+	}
 
 	/**
 	 * Get a new RSA key instance.


### PR DESCRIPTION
The current master implementation requires SFTP access to do a simple SSH.

My pull request creates an SSH2 connection by default, and keeps it until the first time a SFTP command is used, which destroys the SSH2 connection and creates an SFTP connection in the same variable.
