### PR TITLE
[Bug Fix] $touch should be true by default in updateExistingPivot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -673,7 +673,7 @@ class BelongsToMany extends Relation {
 	 * @param  bool   $touch
 	 * @return void
 	 */
-	public function updateExistingPivot($id, array $attributes, $touch)
+	public function updateExistingPivot($id, array $attributes, $touch = true)
 	{
 		if (in_array($this->updatedAt(), $this->pivotColumns))
 		{


### PR DESCRIPTION
Needed to be consistent with the other methods where $touch is already true by default, and also with the docs: http://laravel.com/docs/eloquent#working-with-pivot-tables
