### PR TITLE
Fix date parsing format for PostgreSQL since Laravel 4.1.30

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -172,5 +172,15 @@ class PostgresGrammar extends Grammar {
 	{
 		return array('truncate '.$this->wrapTable($query->from).' restart identity' => array());
 	}
+	
+	/**
+	 * Get the format for database stored dates.
+	 *
+	 * @return string
+	 */
+	public function getDateFormat()
+	{
+		return 'Y-m-d H:i:s.u';
+	}
 
 }


### PR DESCRIPTION
Otherwise this exception is thrown:

```
exception 'InvalidArgumentException' with message 'Trailing data' in C:\my_laravel_application\vendor\nesbot\carbon\src\Carbon\Carbon.php:358
```
