### PR TITLE
Make OptimizeCommand compile views

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Composer;
+use Illuminate\View\Engines\CompilerEngine;
 use ClassPreloader\Command\PreCompileCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -64,6 +65,10 @@ class OptimizeCommand extends Command {
 			$this->info('Compiling common classes');
 
 			$this->compileClasses();
+
+			$this->info('Compiling views');
+
+			$this->compileViews();
 		}
 		else
 		{
@@ -111,6 +116,32 @@ class OptimizeCommand extends Command {
 	protected function registerClassPreloaderCommand()
 	{
 		$this->getApplication()->add(new PreCompileCommand);
+	}
+
+	/**
+	 * Compile all view files.
+	 *
+	 * @return void
+	 */
+	protected function compileViews()
+	{
+		$paths = $this->laravel['view']->getFinder()
+			->getPaths();
+
+		foreach ($paths as $dir)
+		{
+			$files = $this->laravel['files']->allFiles($dir);
+
+			foreach ($files as $path)
+			{
+				$engine = $this->laravel['view']->getEngineFromPath($path);
+
+				if ($engine instanceof CompilerEngine)
+				{
+					$engine->getCompiler()->compile($path);
+				}
+			}
+		}
 	}
 
 	/**

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -247,7 +247,7 @@ class Factory {
 	 * @param  string  $path
 	 * @return \Illuminate\View\Engines\EngineInterface
 	 */
-	protected function getEngineFromPath($path)
+	public function getEngineFromPath($path)
 	{
 		$engine = $this->extensions[$this->getExtension($path)];
 


### PR DESCRIPTION
Had this idea a while ago but dismissed it, but a request from the IRC channel reminded me of it. By making the `artisan optimize` command compile existing views (assuming they can be compiled) you can bring some load off your server or at the very least ensure that the first person to hit your website won't get a much slower response than the ones after him/her.

This is obviously not an issue for 99% of the framework's users, but I thought, why not?
