### PR TITLE
[4.2] Make Soft Delete Trait Backward Compatible

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
@@ -154,7 +154,7 @@ trait SoftDeletingTrait {
 	 */
 	public function getDeletedAtColumn()
 	{
-		return 'deleted_at';
+		return defined('static::DELETED_AT') ? static::DELETED_AT : 'deleted_at';
 	}
 
 	/**


### PR DESCRIPTION
4.0 and 4.1 allowed the column for soft deletes to be set to something other than the default "deleted_at", just as is possible for `created_at` and `deleted_at`. 4.2 breaks backward compatibility by hardcoding in the string "deleted_at" in `SoftDeletingTrait::getDeletedAtColumn()`.

This commit checks whether the old `DELETED_AT` constant is set before resorting to the default.
