### PR TITLE
Fix nested arrays getting split when using numeric keys

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -287,7 +287,57 @@ if ( ! function_exists('array_where'))
 	 */
 	function array_where($array, Closure $callback)
 	{
-		return Arr::where($array, $callback);
+		$filtered = array();
+
+		foreach ($array as $key => $value)
+		{
+			if (call_user_func($callback, $key, $value)) $filtered[$key] = $value;
+		}
+
+		return $filtered;
+	}
+}
+
+if ( ! function_exists('is_assoc'))
+{
+	/**
+	 * Determine if the given array is associative.
+	 *
+	 * @param  array  $array
+	 * @return bool
+	 */
+	function is_assoc($array)
+	{
+		return (bool) count(array_filter(array_keys($array), 'is_string'));
+	}
+}
+
+if ( ! function_exists('asset'))
+{
+	/**
+	 * Generate an asset path for the application.
+	 *
+	 * @param  string  $path
+	 * @param  bool    $secure
+	 * @return string
+	 */
+	function asset($path, $secure = null)
+	{
+		return app('url')->asset($path, $secure);
+	}
+}
+
+if ( ! function_exists('base_path'))
+{
+	/**
+	 * Get the path to the base of the install.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	function base_path($path = '')
+	{
+		return app()->make('path.base').($path ? '/'.$path : $path);
 	}
 }
 
@@ -592,7 +642,7 @@ if ( ! function_exists('str_limit'))
 	 */
 	function str_limit($value, $limit = 100, $end = '...')
 	{
-		return Str::limit($value, $limit, $end);
+		return Illuminate\Support\Str::limit($value, $limit, $end);
 	}
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -287,14 +287,7 @@ if ( ! function_exists('array_where'))
 	 */
 	function array_where($array, Closure $callback)
 	{
-		$filtered = array();
-
-		foreach ($array as $key => $value)
-		{
-			if (call_user_func($callback, $key, $value)) $filtered[$key] = $value;
-		}
-
-		return $filtered;
+		return Arr::where($array, $callback);
 	}
 }
 
@@ -309,35 +302,6 @@ if ( ! function_exists('is_assoc'))
 	function is_assoc($array)
 	{
 		return (bool) count(array_filter(array_keys($array), 'is_string'));
-	}
-}
-
-if ( ! function_exists('asset'))
-{
-	/**
-	 * Generate an asset path for the application.
-	 *
-	 * @param  string  $path
-	 * @param  bool    $secure
-	 * @return string
-	 */
-	function asset($path, $secure = null)
-	{
-		return app('url')->asset($path, $secure);
-	}
-}
-
-if ( ! function_exists('base_path'))
-{
-	/**
-	 * Get the path to the base of the install.
-	 *
-	 * @param  string  $path
-	 * @return string
-	 */
-	function base_path($path = '')
-	{
-		return app()->make('path.base').($path ? '/'.$path : $path);
 	}
 }
 
@@ -642,7 +606,7 @@ if ( ! function_exists('str_limit'))
 	 */
 	function str_limit($value, $limit = 100, $end = '...')
 	{
-		return Illuminate\Support\Str::limit($value, $limit, $end);
+		return Str::limit($value, $limit, $end);
 	}
 }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -252,11 +252,15 @@ class Validator implements ValidatorContract {
 			throw new \InvalidArgumentException('Attribute for each() must be an array.');
 		}
 
+		$keyed = is_assoc($rules);
+
 		foreach ($data as $dataKey => $dataValue)
 		{
-			foreach ($rules as $ruleValue)
+			foreach ($rules as $ruleKey => $ruleValue)
 			{
-				$this->mergeRules("$attribute.$dataKey", $ruleValue);
+				$nestedAttribute = ($keyed) ? "$attribute.$dataKey.$ruleKey" : "$attribute.$dataKey";
+
+				$this->mergeRules($nestedAttribute, $ruleValue);
 			}
 		}
 	}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -254,29 +254,11 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		array_values(array_sort($array, function($v) { return $v['name']; })));
 	}
 
-
-	public function testClassUsesRecursiveShouldReturnTraitsOnParentClasses()
+	public function testIsAssoc()
 	{
-		$this->assertEquals([
-			'SupportTestTraitOne' => 'SupportTestTraitOne',
-			'SupportTestTraitTwo' => 'SupportTestTraitTwo',
-		],
-		class_uses_recursive('SupportTestClassTwo'));
-	}
-
-
-	public function testArrayAdd()
-	{
-		$this->assertEquals(array('surname' => 'Mövsümov'), array_add(array(), 'surname', 'Mövsümov'));
-		$this->assertEquals(array('developer' => array('name' => 'Ferid')), array_add(array(), 'developer.name', 'Ferid'));
-	}
-
-
-	public function testArrayPull()
-	{
-		$developer = array('firstname' => 'Ferid', 'surname' => 'Mövsümov');
-		$this->assertEquals('Mövsümov', array_pull($developer, 'surname'));
-		$this->assertEquals(array('firstname' => 'Ferid'), $developer);
+		$this->assertTrue(is_assoc(array('foo' => 'bar')));
+		$this->assertFalse(is_assoc(array('0' => 'bar')));
+		$this->assertFalse(is_assoc(array('bar')));
 	}
 
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -254,6 +254,32 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		array_values(array_sort($array, function($v) { return $v['name']; })));
 	}
 
+
+	public function testClassUsesRecursiveShouldReturnTraitsOnParentClasses()
+	{
+		$this->assertEquals([
+			'SupportTestTraitOne' => 'SupportTestTraitOne',
+			'SupportTestTraitTwo' => 'SupportTestTraitTwo',
+		],
+		class_uses_recursive('SupportTestClassTwo'));
+	}
+
+
+	public function testArrayAdd()
+	{
+		$this->assertEquals(array('surname' => 'Mövsümov'), array_add(array(), 'surname', 'Mövsümov'));
+		$this->assertEquals(array('developer' => array('name' => 'Ferid')), array_add(array(), 'developer.name', 'Ferid'));
+	}
+
+
+	public function testArrayPull()
+	{
+		$developer = array('firstname' => 'Ferid', 'surname' => 'Mövsümov');
+		$this->assertEquals('Mövsümov', array_pull($developer, 'surname'));
+		$this->assertEquals(array('firstname' => 'Ferid'), $developer);
+	}
+
+
 	public function testIsAssoc()
 	{
 		$this->assertTrue(is_assoc(array('foo' => 'bar')));

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1338,11 +1338,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$data = ['foo' => [5, 10, 15]];
 
 		$v = new Validator($trans, $data, ['foo' => 'Array']);
-		$v->each('foo', ['field' => 'numeric|min:6|max:14']);
+		$v->each('foo', ['numeric|min:6|max:14']);
 		$this->assertFalse($v->passes());
 
 		$v = new Validator($trans, $data, ['foo' => 'Array']);
-		$v->each('foo', ['field' => 'numeric|min:4|max:16']);
+		$v->each('foo', ['numeric|min:4|max:16']);
 		$this->assertTrue($v->passes());
 	}
 
@@ -1365,6 +1365,21 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, ['foo' => 'string'], ['foo' => 'numeric']);
 		$v->each('foo', ['min:7|max:13']);
 		$this->assertFalse($v->passes());
+	}
+
+
+	public function testValidateEachWithKeyedNestedData()
+	{
+		$trans = $this->getRealTranslator();
+		$data = ['foo' => [['field' => 5], ['field' => 10], ['field' => 15]]];
+
+		$v = new Validator($trans, $data, ['foo' => 'Array']);
+		$v->each('foo', ['field' => 'numeric|min:6|max:14']);
+		$this->assertFalse($v->passes());
+
+		$v = new Validator($trans, $data, ['foo' => 'Array']);
+		$v->each('foo', ['field' => 'numeric|min:4|max:16']);
+		$this->assertTrue($v->passes());
 	}
 
 


### PR DESCRIPTION
This expands on #2680 specifically @asiral's [comment](https://github.com/laravel/framework/pull/2680#issuecomment-33502878) to join nested arrays that are numerically keyed.
