### PR TITLE
Cast resource route options to array

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -402,11 +402,11 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	{
 		if (isset($options['only']))
 		{
-			return array_intersect($defaults, $options['only']);
+			return array_intersect($defaults, (array) $options['only']);
 		}
 		elseif (isset($options['except']))
 		{
-			return array_diff($defaults, $options['except']);
+			return array_diff($defaults, (array) $options['except']);
 		}
 
 		return $defaults;


### PR DESCRIPTION
Small change but this prevents `Route::resource('users', 'UsersController', ['only' => 'show']);` from crashing the app when typed instead of `Route::resource('users', 'UsersController', ['only' => ['show']]);`. One less nested array never hurt readability. 
