### PR TITLE
Add soft-deleting and soft-deleted events

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
@@ -61,7 +61,11 @@ trait SoftDeletingTrait {
 
 		$this->{$this->getDeletedAtColumn()} = $time = $this->freshTimestamp();
 
+		$this->fireModelEvent('softDeleting', false);
+
 		$query->update(array($this->getDeletedAtColumn() => $this->fromDateTime($time)));
+
+		$this->fireModelEvent('softDeleted', false);
 	}
 
 	/**
@@ -123,6 +127,28 @@ trait SoftDeletingTrait {
 		$column = $instance->getQualifiedDeletedAtColumn();
 
 		return $instance->newQueryWithoutScope(new SoftDeletingScope)->whereNotNull($column);
+	}
+
+	/**
+	 * Register a soft deleting model event with the dispatcher.
+	 *
+	 * @param  \Closure|string  $callback
+	 * @return void
+	 */
+	public static function softDeleting($callback)
+	{
+		static::registerModelEvent('softDeleting', $callback);
+	}
+
+	/**
+	 * Register a soft deleted model event with the dispatcher.
+	 *
+	 * @param  \Closure|string  $callback
+	 * @return void
+	 */
+	public static function softDeleted($callback)
+	{
+		static::registerModelEvent('softDeleted', $callback);
 	}
 
 	/**


### PR DESCRIPTION
As soft deleting models don't actually delete anything you have no way to hook into the removal process unless you hook into `updating` and check that `deleted_at` is being updated which is inconvenient and not really clean. This adds a dedicated event for the soft removal of a model.

I'm not sure about the convention for two-words events though, should that event be `soft-deleting` or `softDeleting` ?
