### PR TITLE
throw DecryptException on decrypt error (consistency fix)

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -109,7 +109,12 @@ class Encrypter {
 	 */
 	protected function mcryptDecrypt($value, $iv)
 	{
-		return mcrypt_decrypt($this->cipher, $this->key, $value, $this->mode, $iv);
+		try {
+			return mcrypt_decrypt($this->cipher, $this->key, $value, $this->mode, $iv);
+		}
+		catch (\Exception $e) {
+			throw new DecryptException($e->getMessage());
+		}
 	}
 
 	/**


### PR DESCRIPTION
Currently, switching my 4.1 install to 4.2 causes a _Warning: mcrypt_decrypt(): The IV parameter must be as long as the blocksize_ error

The error relates to decrypting cookie information, and there is a try/catch block that looks for a DecryptException to get around this, but an ErrorException is thrown when this error occurs.

This update forces the Encrypter to throw a DecryptException, which can then be caught and allow users to view the 4.2 based application without errors (and without cookies, so they'll have to log in again)
