### PR TITLE
Add Boolean Validation 

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -695,6 +695,20 @@ class Validator implements MessageProviderInterface {
 		return ($this->validateRequired($attribute, $value) && in_array($value, $acceptable, true));
 	}
 
+    /**
+     * Validate that an attribute is a boolean.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    protected function validateBoolean($attribute, $value)
+    {
+        $acceptable = array(true, false, 0, 1, '0', '1');
+
+        return in_array($value, $acceptable, true);
+    }
+
 	/**
 	 * Validate that an attribute is an array.
 	 *

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -460,6 +460,44 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+    public function testValidateBoolean()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, array('foo' => 'no'), array('foo' => 'Boolean'));
+        $this->assertFalse($v->passes());
+        
+        $v = new Validator($trans, array('foo' => 'yes'), array('foo' => 'Boolean'));
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, array('foo' => 'false'), array('foo' => 'Boolean'));
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, array('foo' => 'true'), array('foo' => 'Boolean'));
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, array(), array('foo' => 'Boolean'));
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, array('foo' => false), array('foo' => 'Boolean'));
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, array('foo' => true), array('foo' => 'Boolean'));
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, array('foo' => '1'), array('foo' => 'Boolean'));
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, array('foo' => 1), array('foo' => 'Boolean'));
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, array('foo' => '0'), array('foo' => 'Boolean'));
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, array('foo' => 0), array('foo' => 'Boolean'));
+        $this->assertTrue($v->passes());
+    }
+
+
 	public function testValidateNumeric()
 	{
 		$trans = $this->getRealTranslator();


### PR DESCRIPTION
As approved in https://github.com/laravel/framework/issues/4411

Couple of small things;
- Does not enforce 'required' (like accepted does) - do you think it should?
- Does not accept "true" or "false" strings - as they are strings not actually a boolean able to be cast correctly.
