### PR TITLE
[Database\Capsule] Only create a "config" instance if only it not yet created.

### DIFF
--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -60,7 +60,10 @@ class Manager {
 	{
 		$this->container = $container ?: new Container;
 
-		$this->container->instance('config', new Fluent);
+		if ( ! $this->container->bound('config'))
+		{
+			$this->container->instance('config', new Fluent);
+		}
 	}
 
 	/**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (I consider it a bug, in my use case :smile:) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | None |
| License | MIT |
| Doc PR | None |

On one of the project I'm working right now, I'm using both `Config` and `Capsule` component, since I register config service location first and then capsule, all the preloaded config is destroy and the config service location is converted to instance of `Illuminate\Support\Fluent` which is not ideal in my use case.

Signed-off-by: crynobone crynobone@gmail.com
