### PR TITLE
Eloquent Pivot - Make sure original attribute values are being set on call to setRawAttributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -49,7 +49,7 @@ class Pivot extends Model {
 		// The pivot model is a "dynamic" model since we will set the tables dynamically
 		// for the instance. This allows it work for any intermediate tables for the
 		// many to many relationship that are defined by this developer's classes.
-		$this->setRawAttributes($attributes);
+		$this->setRawAttributes($attributes, true);
 
 		$this->setTable($table);
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -24,6 +24,27 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testPropertiesUnchangedAreNotDirty()
+	{
+		$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
+		$parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
+		$pivot = new Pivot($parent, array('foo' => 'bar', 'shimy' => 'shake'), 'table', true);
+
+		$this->assertEquals(array(), $pivot->getDirty());
+	}
+
+
+	public function testPropertiesChangedAreDirty()
+	{
+		$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
+		$parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
+		$pivot = new Pivot($parent, array('foo' => 'bar', 'shimy' => 'shake'), 'table', true);
+		$pivot->shimy = 'changed';
+
+		$this->assertEquals(array('shimy' => 'changed'), $pivot->getDirty());
+	}
+
+
 	public function testTimestampPropertyIsSetIfCreatedAtInAttributes()
 	{
 		$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName,getDates]');


### PR DESCRIPTION
From: laravel/framework#4555 -- merging to 4.2 not master...
