### PR TITLE
[4.2] Restore The Ability To Easily Override The Compilers

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -19,6 +19,18 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	protected $path;
 
 	/**
+	 * All of the available compiler functions.
+	 *
+	 * @var array
+	 */
+	protected $compilers = array(
+		'Extensions',
+		'Statements',
+		'Comments',
+		'Echos'
+	);
+
+	/**
 	 * Array of opening and closing tags for escaped echos.
 	 *
 	 * @var array
@@ -125,7 +137,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 
 		if ($id == T_INLINE_HTML)
 		{
-			foreach (['Extensions', 'Statements', 'Comments', 'Echos'] as $type)
+			foreach ($this->compilers as $type)
 			{
 				$content = $this->{"compile{$type}"}($content);
 			}


### PR DESCRIPTION
I accidentally removed this in https://github.com/laravel/framework/pull/3690 a while back.

---

This was brought to my attention by https://github.com/GrahamCampbell/Laravel-HTMLMin/issues/11.
