### PR TITLE
Add `remember_token` method to Schema Builder

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -671,6 +671,16 @@ class Blueprint {
 
 		$this->index(array("{$name}_id", "{$name}_type"));
 	}
+	
+	/**
+	 * Add the proper column for a user `remember_token`
+	 * 
+	 * @return void
+	 */
+	public function remember_token()
+	{
+		$this->string('remember_token', 100)->nullable();
+	}
 
 	/**
 	 * Create a new drop index command on the blueprint.

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -492,6 +492,17 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table `users` add `foo` blob not null', $statements[0]);
 	}
+	
+	public function testAddingRememberToken()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->remember_token();
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` add `remember_token` varchar(100) null', $statements[0]);
+
+	}
 
 
 	protected function getConnection()


### PR DESCRIPTION
Allows for developers to simply call `$table->remember_token()` instead of `$table->string('remember_token', 100)->nullable()` while creating user tables with migrations.
