### PR TITLE
Table prefix was added twice

### DIFF
--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -70,7 +70,7 @@ class SessionManager extends Manager {
 	{
 		$connection = $this->getDatabaseConnection();
 
-		$table = $connection->getTablePrefix().$this->app['config']['session.table'];
+		$table = $this->app['config']['session.table'];
 
 		return $this->buildSession(new DatabaseSessionHandler($connection, $table));
 	}


### PR DESCRIPTION
If a table prefix was set in the database config, this code caused the prefix to be added twice: once here and once in the call to the database engine inside `DatabaseSessionHandler`. refs #4580 on the correct branch.
