### PR TITLE
Adding `$table->rememberToken()` method to schema builder

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -672,6 +672,11 @@ class Blueprint {
 		$this->index(array("{$name}_id", "{$name}_type"));
 	}
 
+	public function rememberToken()
+	{
+	  $this->string('remember_token', 100)->nullable();
+	}
+
 	/**
 	 * Create a new drop index command on the blueprint.
 	 *

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -672,6 +672,11 @@ class Blueprint {
 		$this->index(array("{$name}_id", "{$name}_type"));
 	}
 
+	/**
+	 * Adds `remember_token` column to the table.
+	 * 
+	 * @return void
+	 */
 	public function rememberToken()
 	{
 	  $this->string('remember_token', 100)->nullable();

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -482,6 +482,15 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('alter table `users` add `created_at` timestamp default 0 not null, add `updated_at` timestamp default 0 not null', $statements[0]);
 	}
 
+	public function testAddingRememberToken()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->rememberToken();
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` add `remember_token` varchar(100) null', $statements[0]);
+	}
 
 	public function testAddingBinary()
 	{

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -379,6 +379,16 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($expected, $statements);
 	}
 
+	public function testAddingRememberToken()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->rememberToken();
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table "users" add column "remember_token" varchar null', $statements[0]);
+	}
+
 
 	public function testAddingBinary()
 	{

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -403,6 +403,16 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('alter table "users" add "created_at" datetime not null, "updated_at" datetime not null', $statements[0]);
 	}
 
+	public function testAddingRememberToken()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->rememberToken();
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table "users" add "remember_token" nvarchar(100) null', $statements[0]);
+	}
+
 
 	public function testAddingBinary()
 	{


### PR DESCRIPTION
Includes tests

Signed-off-by: Adam Engebretson adam@enge.me
