### PR TITLE
Fix/dot flatten environment variable array

### DIFF
--- a/src/Illuminate/Config/FileEnvironmentVariablesLoader.php
+++ b/src/Illuminate/Config/FileEnvironmentVariablesLoader.php
@@ -46,7 +46,7 @@ class FileEnvironmentVariablesLoader implements EnvironmentVariablesLoaderInterf
 		}
 		else
 		{
-			return $this->files->getRequire($path);
+			return array_dot($this->files->getRequire($path));
 		}
 	}
 


### PR DESCRIPTION
coming from here https://github.com/laravel/framework/pull/4618

Right now `.env` files allows only single dimensional array of config variables, on adding a multidimensional array like this

``` php
return array(
    'database' => array(
        'mysql' => array(
            'host' => 'localhost',
            'user' => 'user',
            'password' => 'pass'
        ),
        'pgsql' => array(
            'host' => 'localhost',
            'user' => 'user',
            'password' => 'pass'
        )
    )
);
```

It throws error while trying to put keys and values in `$_ENV` and `$_SERVER` globals.
This patch converts array from `.env` file into a dot notation flatten array like this:

``` php
array(
    'database.mysql.host' => 'localhost',
    'database.mysql.user' => 'user',
    'database.mysql.password' => 'pass',
    'database.pgsql.host' => 'localhost',
    'database.pgsql.user' => 'user',
    'database.pgsql.password' => 'pass',    
)
```

and lets you access them via dot notations. `getenv('database.mysql.host')` and so on
