### PR TITLE
[4.2] Router : add subdomain feature

### DIFF
--- a/src/Illuminate/Foundation/Console/RoutesCommand.php
+++ b/src/Illuminate/Foundation/Console/RoutesCommand.php
@@ -42,7 +42,7 @@ class RoutesCommand extends Command {
 	 * @var array
 	 */
 	protected $headers = array(
-		'Domain', 'URI', 'Name', 'Action', 'Before Filters', 'After Filters'
+		'Subomain', 'Domain', 'URI', 'Name', 'Action', 'Before Filters', 'After Filters'
 	);
 
 	/**
@@ -103,12 +103,13 @@ class RoutesCommand extends Command {
 		$uri = implode('|', $route->methods()).' '.$route->uri();
 
 		return $this->filterRoute(array(
-			'host'   => $route->domain(),
-			'uri'    => $uri,
-			'name'   => $route->getName(),
-			'action' => $route->getActionName(),
-			'before' => $this->getBeforeFilters($route),
-			'after'  => $this->getAfterFilters($route)
+			'subdomain' => $route->subdomain(),
+			'domain'    => $route->domain(),
+			'uri'       => $uri,
+			'name'      => $route->getName(),
+			'action'    => $route->getActionName(),
+			'before'    => $this->getBeforeFilters($route),
+			'after'     => $this->getAfterFilters($route)
 		));
 	}
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -720,13 +720,27 @@ class Route {
 	}
 
 	/**
+	 * Get the subdomain defined for the route.
+	 *
+	 * @return string|null
+	 */
+	public function subdomain()
+	{
+		return array_get($this->action, 'subdomain');
+	}
+
+	/**
 	 * Get the domain defined for the route.
 	 *
 	 * @return string|null
 	 */
 	public function domain()
 	{
-		return array_get($this->action, 'domain');
+		$subdomain = $this->subdomain();
+
+		$domain = array_get($this->action, 'domain');
+
+		return $subdomain ? $subdomain.'.'.$domain : $domain;
 	}
 
 	/**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -735,6 +735,8 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 
 		if (isset($new['domain'])) unset($old['domain']);
 
+		if (isset($new['domain']) || isset($new['subdomain'])) unset($old['subdomain']);
+
 		$new['where'] = array_merge(array_get($old, 'where', []), array_get($new, 'where', []));
 
 		return array_merge_recursive(array_except($old, array('namespace', 'prefix', 'where')), $new);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -19,7 +19,17 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('dayle', $router->dispatch(Request::create('http://api.dayle.baz/foo/bar', 'GET'))->getContent());
 
 		$router = $this->getRouter();
+		$route = $router->get('foo/bar', array('domain' => '{name}.bar', 'subdomain' => 'api', function($name) { return $name; }));
+		$route = $router->get('foo/bar', array('domain' => '{name}.baz', 'subdomain' => 'api', function($name) { return $name; }));
+		$this->assertEquals('taylor', $router->dispatch(Request::create('http://api.taylor.bar/foo/bar', 'GET'))->getContent());
+		$this->assertEquals('dayle', $router->dispatch(Request::create('http://api.dayle.baz/foo/bar', 'GET'))->getContent());
+
+		$router = $this->getRouter();
 		$route = $router->get('foo/{age}', array('domain' => 'api.{name}.bar', function($name, $age) { return $name.$age; }));
+		$this->assertEquals('taylor25', $router->dispatch(Request::create('http://api.taylor.bar/foo/25', 'GET'))->getContent());
+
+		$router = $this->getRouter();
+		$route = $router->get('foo/{age}', array('domain' => '{name}.bar', 'subdomain' => 'api', function($name, $age) { return $name.$age; }));
 		$this->assertEquals('taylor25', $router->dispatch(Request::create('http://api.taylor.bar/foo/25', 'GET'))->getContent());
 
 		$router = $this->getRouter();
@@ -423,6 +433,17 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 
 		$request = Request::create('http://something.bar.com/foo/bar', 'GET');
 		$route = new Route('GET', 'foo/{bar}', array('domain' => '{foo}.foo.com', function() {}));
+		$this->assertFalse($route->matches($request));
+
+		/**
+		 * Subdomain checks
+		 */
+		$request = Request::create('http://something.foo.com/foo/bar', 'GET');
+		$route = new Route('GET', 'foo/{bar}', array('domain' => 'foo.com', 'subdomain' => 'something', function() {}));
+		$this->assertTrue($route->matches($request));
+
+		$request = Request::create('http://something.bar.com/foo/bar', 'GET');
+		$route = new Route('GET', 'foo/{bar}', array('domain' => 'foo.com', 'subdomain' => 'something', function() {}));
 		$this->assertFalse($route->matches($request));
 
 		/**


### PR DESCRIPTION
Simple yet useful (IMO) : add `subdomain` feature to `Router`.
Of course, if no `domain` is set, `subdomain` becomes useless and is not taken into consideration.

The following:

``` php
Route::group(['subdomain' => 'test'], function () {
    // http://*/test
    Route::get('test', function () {
        return 'no domain';
    });
});

Route::group(['domain' => 'bar.baz'], function () {
    // http://bar.baz/
    Route::get(null, function () {
        return 'no subdomain';
    });

    // http://api.bar.baz/
    Route::get(null, ['subdomain' => 'api', 'uses' => function () {
        return 'api subdomain for bar.baz';
    }]);
});

Route::group(['domain' => 'foo.com', 'subdomain' => 'www'], function () {
    // http://api.foo.com/
    Route::get(null, ['subdomain' => 'api', 'uses' => function () {
        return 'api subdomain forced';
    }]);

    // http://baz.test/
    Route::get('override', ['domain' => 'baz.test', function () {
        return 'group domain overridden : www subdomain is not taken';
    }]);

    // http://www.foo.com/
    Route::get(null, function () {
        return 'get group domain and subdomain';
    });
});
```

will provide these routes:

``` sh
+-------------+-------------------+------+---------+----------------+---------------+
| Domain      | URI               | Name | Action  | Before Filters | After Filters |
+-------------+-------------------+------+---------+----------------+---------------+
|             | GET|HEAD test     |      | Closure |                |               |
| bar.baz     | GET|HEAD /        |      | Closure |                |               |
| api.bar.baz | GET|HEAD /        |      | Closure |                |               |
| api.foo.com | GET|HEAD /        |      | Closure |                |               |
| baz.test    | GET|HEAD override |      | Closure |                |               |
| www.foo.com | GET|HEAD /        |      | Closure |                |               |
+-------------+-------------------+------+---------+----------------+---------------+
```
