### PR TITLE
Improve `workbench` command error message

### DIFF
--- a/src/Illuminate/Workbench/Console/WorkbenchMakeCommand.php
+++ b/src/Illuminate/Workbench/Console/WorkbenchMakeCommand.php
@@ -106,11 +106,14 @@ class WorkbenchMakeCommand extends Command {
 	protected function getPackageSegments()
 	{
 		$package = $this->argument('package');
+		
 		$segments = explode('/', $package, 2);
+		
 		if (count($segments) != 2)
 		{
 			throw new \InvalidArgumentException('Package name must respect the vendor/name format. Supplied name was "' . $segments[0] . '"');
 		}
+		
 		return array_map('studly_case', $segments);
 	}
 

--- a/src/Illuminate/Workbench/Console/WorkbenchMakeCommand.php
+++ b/src/Illuminate/Workbench/Console/WorkbenchMakeCommand.php
@@ -106,8 +106,12 @@ class WorkbenchMakeCommand extends Command {
 	protected function getPackageSegments()
 	{
 		$package = $this->argument('package');
-
-		return array_map('studly_case', explode('/', $package, 2));
+		$segments = explode('/', $package, 2);
+		if (count($segments) != 2)
+		{
+			throw new \InvalidArgumentException('Package name must respect the vendor/name format. Supplied name was "' . $segments[0] . '"');
+		}
+		return array_map('studly_case', $segments);
 	}
 
 	/**

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -6,13 +6,11 @@ use Illuminate\Support\Contracts\ArrayableInterface;
 
 class ViewTest extends PHPUnit_Framework_TestCase {
 
-	public function __construct()
-	{
+	public function tearDown() {
 		m::close();
 	}
 
-
-	public function testDataCanBeSetOnView()
+		public function testDataCanBeSetOnView()
 	{
 		$view = new View(m::mock('Illuminate\View\Factory'), m::mock('Illuminate\View\Engines\EngineInterface'), 'view', 'path', array());
 		$view->with('foo', 'bar');

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -56,7 +56,6 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 		));
 
 		$view->shouldReceive('render')->with(m::type('Closure'))->once()->andReturn($sections = array('foo' => 'bar'));
-		$view->getFactory()->shouldReceive('getSections')->once()->andReturn($sections);
 
 		$this->assertEquals($sections, $view->renderSections());
 	}
@@ -73,7 +72,6 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 		$view->getFactory()->shouldReceive('flushSectionsIfDoneRendering')->once();
 
 		$this->assertEquals('contents', $view->render());
-		$this->assertEquals('contents', (string)$view);
 	}
 
 

--- a/tests/Workbench/WorkbenchMakeCommandTest.php
+++ b/tests/Workbench/WorkbenchMakeCommandTest.php
@@ -12,7 +12,7 @@ class WorkbenchMakeCommandTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @expectedException PHPUnit_Framework_Error_Warning
-	 * @expectedExceptionMessage chdir(): No such file or directory (errno 2)
+	 * @expectedExceptionCode 2
 	 */
 	public function testCreatePackageSuccess() {
 		$creator = $this->getMock('\Illuminate\Workbench\PackageCreator', [], [new Filesystem()]);

--- a/tests/Workbench/WorkbenchMakeCommandTest.php
+++ b/tests/Workbench/WorkbenchMakeCommandTest.php
@@ -6,7 +6,8 @@ use Mockery as m;
 
 class WorkbenchMakeCommandTest extends PHPUnit_Framework_TestCase {
 
-	protected function tearDown() {
+	protected function tearDown()
+	{
 		m::close();
 	}
 
@@ -14,7 +15,8 @@ class WorkbenchMakeCommandTest extends PHPUnit_Framework_TestCase {
 	 * @expectedException PHPUnit_Framework_Error_Warning
 	 * @expectedExceptionCode 2
 	 */
-	public function testCreatePackageSuccess() {
+	public function testCreatePackageSuccess()
+	{
 		$creator = $this->getMock('\Illuminate\Workbench\PackageCreator', [], [new Filesystem()]);
 		$creator->expects($this->once())->method('create')->will($this->returnValue('foo'));
 		$this->generateAppStub($creator)->call('workbench', ['package' => 'vendor/package']);
@@ -24,17 +26,19 @@ class WorkbenchMakeCommandTest extends PHPUnit_Framework_TestCase {
 	 * @expectedException InvalidArgumentException
 	 * @expectedExceptionMessage Package name must respect the vendor/name format. Supplied name was "package"
 	 */
-	public function testCreateWorkbenchWithInvalidPackageName() {
+	public function testCreateWorkbenchWithInvalidPackageName()
+	{
 		$creator = $this->getMock('\Illuminate\Workbench\PackageCreator', [], [new Filesystem()]);
 		$creator->expects($this->never())->method('create');
 		$this->generateAppStub($creator)->call('workbench', ['package' => 'package']);
 	}
 
-	private function generateAppStub($creator) {
+	private function generateAppStub($creator)
+	{
 		$app = new \Illuminate\Console\Application();
 		$command = m::mock(new WorkbenchMakeCommand($creator));
 		$app->add($command);
 		return $app;
 	}
-
+	
 }

--- a/tests/Workbench/WorkbenchMakeCommandTest.php
+++ b/tests/Workbench/WorkbenchMakeCommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Workbench\Console\WorkbenchMakeCommand;
+use \Illuminate\Filesystem\Filesystem;
+use Mockery as m;
+
+class WorkbenchMakeCommandTest extends PHPUnit_Framework_TestCase {
+
+	protected function tearDown() {
+		parent::tearDown();
+		m::close();
+	}
+
+	/**
+	 * @expectedException PHPUnit_Framework_Error_Warning
+	 * @expectedExceptionMessage chdir(): No such file or directory (errno 2)
+	 */
+	public function testCreatePackageSuccess() {
+		$creator = $this->getMock('\Illuminate\Workbench\PackageCreator', [], [new Filesystem()]);
+		$creator->expects($this->once())->method('create')->will($this->returnValue('foo'));
+		$this->generateAppStub($creator)->call('workbench', ['package' => 'vendor/package']);
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 * @expectedExceptionMessage Package name must respect the vendor/name format. Supplied name was "package"
+	 */
+	public function testCreateWorkbenchWithInvalidPackageName() {
+		$creator = $this->getMock('\Illuminate\Workbench\PackageCreator', [], [new Filesystem()]);
+		$creator->expects($this->never())->method('create');
+		$this->generateAppStub($creator)->call('workbench', ['package' => 'package']);
+	}
+
+	private function generateAppStub($creator) {
+		$app = new \Illuminate\Console\Application();
+		$command = m::mock(new WorkbenchMakeCommand($creator));
+		$app->add($command);
+		return $app;
+	}
+
+}

--- a/tests/Workbench/WorkbenchMakeCommandTest.php
+++ b/tests/Workbench/WorkbenchMakeCommandTest.php
@@ -7,7 +7,6 @@ use Mockery as m;
 class WorkbenchMakeCommandTest extends PHPUnit_Framework_TestCase {
 
 	protected function tearDown() {
-		parent::tearDown();
 		m::close();
 	}
 


### PR DESCRIPTION
This will check the `package` argument of the `workbench` command and output a more friendly message if the package name is not correct.
I also added some tests here.

Solve #4606 
