### PR TITLE
Fix nested arrays when using numeric keys

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -214,7 +214,7 @@ class Request extends SymfonyRequest {
 	 */
 	public function all()
 	{
-		return array_merge_recursive($this->input(), $this->files->all());
+		return array_replace_recursive($this->input(), $this->files->all());
 	}
 
 	/**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -325,6 +325,14 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAllInputReturnsNestedInputAndFilesWithNumericKeys()
+	{
+		$file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', null, array(__FILE__, 'photo.jpg'));
+		$request = Request::create('/?boom=breeze', 'GET', array('foo' => array(array('bar' => 'baz'))), array(), array('foo' => array(array('photo' => $file))));
+		$this->assertEquals(array('foo' => array(array('bar' => 'baz', 'photo' => $file)), 'boom' => 'breeze'), $request->all());
+	}
+
+
 	public function testOldMethodCallsSession()
 	{
 		$request = Request::create('/', 'GET');


### PR DESCRIPTION
> This expands on #2680 specifically @asiral's comment to join nested arrays that are numerically keyed.

Originally opened as #4590 re-PRed against 4.1 as requested by @GrahamCampbell
