### PR TITLE
Fix premature instantiation of extended bindings and extending of deferred services

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -81,6 +81,17 @@ class Container implements ArrayAccess {
 	}
 
 	/**
+	 * Determine if the given abstract type has been resolved.
+	 *
+	 * @param  string $abstract
+	 * @return bool
+	 */
+	public function resolved($abstract)
+	{
+		return isset($this->resolved[$abstract]) || isset($this->instances[$abstract]);
+	}
+
+	/**
 	 * Determine if a given string is an alias.
 	 *
 	 * @param  string  $name
@@ -129,14 +140,12 @@ class Container implements ArrayAccess {
 			$concrete = $this->getClosure($abstract, $concrete);
 		}
 
-		$bound = $this->bound($abstract);
-
 		$this->bindings[$abstract] = compact('concrete', 'shared');
 
-		// If the abstract type was already bound in this container, we will fire the
+		// If the abstract type was already resolved in this container, we will fire the
 		// rebound listener so that any objects which have already gotten resolved
 		// can have their copy of the object updated via the listener callbacks.
-		if ($bound)
+		if ($this->resolved($abstract))
 		{
 			$this->rebound($abstract);
 		}
@@ -405,8 +414,6 @@ class Container implements ArrayAccess {
 	{
 		$abstract = $this->getAlias($abstract);
 
-		$this->resolved[$abstract] = true;
-
 		// If an instance of the type is currently being managed as a singleton we'll
 		// just return an existing instance instead of instantiating new instances
 		// so the developer can keep using the same objects instance every time.
@@ -438,6 +445,8 @@ class Container implements ArrayAccess {
 		}
 
 		$this->fireResolvingCallbacks($abstract, $object);
+
+		$this->resolved[$abstract] = true;
 
 		return $object;
 	}

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -464,6 +464,42 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	}
 
 	/**
+	 * Determine if the given abstract type has been bound.
+	 *
+	 * (Overriding Container::bound)
+	 *
+	 * @param  string  $abstract
+	 * @return bool
+	 */
+	public function bound($abstract)
+	{
+		return isset($this->deferredServices[$abstract]) || parent::bound($abstract);
+	}
+
+	/**
+	 * "Extend" an abstract type in the container.
+	 *
+	 * (Overriding Container::extend)
+	 *
+	 * @param  string   $abstract
+	 * @param  Closure  $closure
+	 * @return void
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	public function extend($abstract, Closure $closure)
+	{
+		$abstract = $this->getAlias($abstract);
+
+		if (isset($this->deferredServices[$abstract]))
+		{
+			$this->loadDeferredProvider($abstract);
+		}
+
+		return parent::extend($abstract, $closure);
+	}
+
+	/**
 	 * Register a "before" application filter.
 	 *
 	 * @param  Closure|string  $callback

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -203,6 +203,17 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testExtendIsLazyInitialized()
+	{
+		$container = new Container;
+		$container->bind('ContainerLazyExtendStub');
+		$container->extend('ContainerLazyExtendStub', function($obj, $container) { $obj->init(); return $obj; });
+		$this->assertEquals(false, ContainerLazyExtendStub::$initialized);
+		$container->make('ContainerLazyExtendStub');
+		$this->assertEquals(true, ContainerLazyExtendStub::$initialized);
+	}
+
+
 	public function testParametersCanBePassedThroughToClosure()
 	{
 		$container = new Container;
@@ -370,3 +381,7 @@ class ContainerConstructorParameterLoggingStub {
 	}
 }
 
+class ContainerLazyExtendStub {
+	public static $initialized = false;
+	public function init() { static::$initialized = true; }
+}

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -37,6 +37,84 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue(in_array($class, $app->getLoadedProviders()));
 	}
 
+
+	public function testDeferredServicesMarkedAsBound()
+	{
+		$app = new Application;
+		$app->setDeferredServices(array('foo' => 'ApplicationDeferredServiceProviderStub'));
+		$this->assertTrue($app->bound('foo'));
+		$this->assertEquals('foo', $app->make('foo'));
+	}
+
+
+	public function testDeferredServicesAreSharedProperly()
+	{
+		$app = new Application;
+		$app->setDeferredServices(array('foo' => 'ApplicationDeferredSharedServiceProviderStub'));
+		$this->assertTrue($app->bound('foo'));
+		$one = $app->make('foo'); $two = $app->make('foo');
+		$this->assertInstanceOf('StdClass', $one);
+		$this->assertInstanceOf('StdClass', $two);
+		$this->assertSame($one, $two);
+	}
+
+
+	public function testDeferredServicesCanBeExtended()
+	{
+		$app = new Application;
+		$app->setDeferredServices(array('foo' => 'ApplicationDeferredServiceProviderStub'));
+		$app->extend('foo', function($instance, $container) { return $instance.'bar'; });
+		$this->assertEquals('foobar', $app->make('foo'));
+	}
+
+
+	public function testDeferredServiceProviderIsRegisteredOnlyOnce()
+	{
+		$app = new Application;
+		$app->setDeferredServices(array('foo' => 'ApplicationDeferredServiceProviderCountStub'));
+		$obj = $app->make('foo');
+		$this->assertInstanceOf('StdClass', $obj);
+		$this->assertSame($obj, $app->make('foo'));
+		$this->assertEquals(1, ApplicationDeferredServiceProviderCountStub::$count);
+	}
+
+
+	public function testDeferredServicesAreLazilyInitialized()
+	{
+		ApplicationDeferredServiceProviderStub::$initialized = false;
+		$app = new Application;
+		$app->setDeferredServices(array('foo' => 'ApplicationDeferredServiceProviderStub'));
+		$this->assertTrue($app->bound('foo'));
+		$this->assertFalse(ApplicationDeferredServiceProviderStub::$initialized);
+		$app->extend('foo', function($instance, $container) { return $instance.'bar'; });
+		$this->assertTrue(ApplicationDeferredServiceProviderStub::$initialized);
+		$this->assertEquals('foobar', $app->make('foo'));
+		$this->assertTrue(ApplicationDeferredServiceProviderStub::$initialized);
+	}
+
+
+	public function testDeferredServicesCanRegisterFactories()
+	{
+		$app = new Application;
+		$app->setDeferredServices(array('foo' => 'ApplicationFactoryProviderStub'));
+		$this->assertTrue($app->bound('foo'));
+		$this->assertEquals(1, $app->make('foo'));
+		$this->assertEquals(2, $app->make('foo'));
+		$this->assertEquals(3, $app->make('foo'));
+	}
+
+
+	public function testSingleProviderCanProvideMultipleDeferredServices()
+	{
+		$app = new Application;
+		$app->setDeferredServices(array(
+			'foo' => 'ApplicationMultiProviderStub',
+			'bar' => 'ApplicationMultiProviderStub',
+		));
+		$this->assertEquals('foo', $app->make('foo'));
+		$this->assertEquals('foobar', $app->make('bar'));
+	}
+
 }
 
 class ApplicationCustomExceptionHandlerStub extends Illuminate\Foundation\Application {
@@ -56,4 +134,54 @@ class ApplicationKernelExceptionHandlerStub extends Illuminate\Foundation\Applic
 
 	protected function setExceptionHandler(Closure $handler) { return $handler; }
 
+}
+
+class ApplicationDeferredSharedServiceProviderStub extends Illuminate\Support\ServiceProvider {
+	protected $defer = true;
+	public function register()
+	{
+		$this->app->bindShared('foo', function() {
+			return new StdClass;
+		});
+	}
+}
+
+class ApplicationDeferredServiceProviderCountStub extends Illuminate\Support\ServiceProvider {
+	public static $count = 0;
+	protected $defer = true;
+	public function register()
+	{
+		static::$count++;
+		$this->app['foo'] = new StdClass;
+	}
+}
+
+class ApplicationDeferredServiceProviderStub extends Illuminate\Support\ServiceProvider {
+	public static $initialized = false;
+	protected $defer = true;
+	public function register()
+	{
+		static::$initialized = true;
+		$this->app['foo'] = 'foo';
+	}
+}
+
+class ApplicationFactoryProviderStub extends Illuminate\Support\ServiceProvider {
+	protected $defer = true;
+	public function register()
+	{
+		$this->app->bind('foo', function() {
+			static $count = 0;
+			return ++$count;
+		});
+	}
+}
+
+class ApplicationMultiProviderStub extends Illuminate\Support\ServiceProvider {
+	protected $defer = true;
+	public function register()
+	{
+		$this->app->bindShared('foo', function() { return 'foo'; });
+		$this->app->bindShared('bar', function($app) { return $app['foo'].'bar'; });
+	}
 }


### PR DESCRIPTION
See https://github.com/laravel/framework/pull/3790. Re-done for 4.2.

> If you app->extend an object after it's been bound but before it's been resolved, it will be initialized right away. See the unit test for an example. The solution is pretty simple, just check if an object has actually been resolved rather than if it's bound.
> 
> A related issue that can also be solved as a part of this is that you can't extend deferred services. This has also been fixed.

Split tests into its own commit. All the source changes are backwards compatible with existing tests.
