### PR TITLE
WIP - [4.2] View : provides dotted notation

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -34,9 +34,9 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 * Echos matching patterns.
 	 */
 	const ECHO_REGULAR_DEFAULT = '/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s';
-	const ECHO_DOTTED          = '/^(?=\$)(.+?)\.(.+?)$/s';
-	const ECHO_DOTTED_DEFAULT  = '/^(?=\$)(.+?)\.(.+?)(?:\s+or\s+)(.+?)$/s';
-
+	const ECHO_DOTTED          = '/^(?=\$)(.+?)\.([^\$]+?)$/s';
+	const ECHO_DOTTED_DEFAULT  = '/^(?=\$)(.+?)\.([^\$]+?)(?:\s+or\s+)(.+?)$/s';
+	
 	/**
 	 * Array of opening and closing tags for escaped echos.
 	 *

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -31,6 +31,13 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	);
 
 	/**
+	 * Echos matching patterns.
+	 */
+	const ECHO_REGULAR_DEFAULT = '/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s';
+	const ECHO_DOTTED          = '/^(?=\$)(.+?)\.(.+?)$/s';
+	const ECHO_DOTTED_DEFAULT  = '/^(?=\$)(.+?)\.(.+?)(?:\s+or\s+)(.+?)$/s';
+
+	/**
 	 * Array of opening and closing tags for escaped echos.
 	 *
 	 * @var array
@@ -252,6 +259,28 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	}
 
 	/**
+	 * Compile the values for the dotted echo statement.
+	 *
+	 * @param  string $value
+	 * @return string
+	 */
+	public function compileDottedEchos($value)
+	{
+		return preg_replace(static::ECHO_DOTTED, 'data_get($1, "$2")', $value);
+	}
+
+	/**
+	 * Compile the default values for the dotted echo statement.
+	 *
+	 * @param  string $value
+	 * @return string
+	 */
+	public function compileDottedEchoDefaults($value)
+	{
+		return preg_replace(static::ECHO_DOTTED_DEFAULT, 'data_get($1, "$2", $3)', $value);
+	}
+
+	/**
 	 * Compile the default values for the echo statement.
 	 *
 	 * @param  string  $value
@@ -259,7 +288,17 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function compileEchoDefaults($value)
 	{
-		return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s', 'isset($1) ? $1 : $2', $value);
+		if (preg_match(static::ECHO_DOTTED_DEFAULT, $value) == 1)
+		{
+			return $this->compileDottedEchoDefaults($value);
+		}
+
+		if (preg_match(static::ECHO_DOTTED, $value) == 1)
+		{
+			return $this->compileDottedEchos($value);
+		}
+
+		return preg_replace(static::ECHO_REGULAR_DEFAULT, 'isset($1) ? $1 : $2', $value);
 	}
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -128,6 +128,54 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDottedEchosAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$this->assertEquals('<?php echo e(data_get($user, "name")); ?>', $compiler->compileString('{{{$user.name}}}'));
+		$this->assertEquals('<?php echo data_get($user, "name"); ?>', $compiler->compileString('{{$user.name}}'));
+		$this->assertEquals('<?php echo data_get($user, "name"); ?>', $compiler->compileString('{{ $user.name }}'));
+		$this->assertEquals('<?php echo data_get($user, "name"); ?>', $compiler->compileString('{{
+			$user.name
+		}}'));
+
+		$this->assertEquals('<?php echo data_get($user, "name", "foo"); ?>', $compiler->compileString('{{ $user.name or "foo" }}'));
+		$this->assertEquals('<?php echo data_get($user, "name", "foo"); ?>', $compiler->compileString('{{$user.name or "foo"}}'));
+		$this->assertEquals('<?php echo data_get($user, "name", "foo"); ?>', $compiler->compileString('{{
+			$user.name or "foo"
+		}}'));
+
+		$this->assertEquals('<?php echo data_get($user, "name", \'foo\'); ?>', $compiler->compileString('{{ $user.name or \'foo\' }}'));
+		$this->assertEquals('<?php echo data_get($user, "name", \'foo\'); ?>', $compiler->compileString('{{$user.name or \'foo\'}}'));
+		$this->assertEquals('<?php echo data_get($user, "name", \'foo\'); ?>', $compiler->compileString('{{
+			$user.name or \'foo\'
+		}}'));
+
+		$this->assertEquals('<?php echo data_get($user, "age", 90); ?>', $compiler->compileString('{{ $user.age or 90 }}'));
+		$this->assertEquals('<?php echo data_get($user, "age", 90); ?>', $compiler->compileString('{{$user.age or 90}}'));
+		$this->assertEquals('<?php echo data_get($user, "age", 90); ?>', $compiler->compileString('{{
+			$user.age or 90
+		}}'));
+
+		$this->assertEquals('<?php echo data_get($user, "country.currency", "USD"); ?>', $compiler->compileString('{{ $user.country.currency or "USD" }}'));
+		$this->assertEquals('<?php echo data_get($user, "country.currency", "USD"); ?>', $compiler->compileString('{{ $user.country.currency or "USD" }}'));
+		$this->assertEquals('<?php echo data_get($user, "country.currency", "USD"); ?>', $compiler->compileString('{{
+			$user.country.currency or "USD"
+		}}'));
+
+		$this->assertEquals('<?php echo data_get($user, "country.currency", \'USD\'); ?>', $compiler->compileString('{{ $user.country.currency or \'USD\' }}'));
+		$this->assertEquals('<?php echo data_get($user, "country.currency", \'USD\'); ?>', $compiler->compileString('{{$user.country.currency or \'USD\'}}'));
+		$this->assertEquals('<?php echo data_get($user, "country.currency", \'USD\'); ?>', $compiler->compileString('{{
+			$user.country.currency or \'USD\'
+		}}'));
+
+		$this->assertEquals('<?php echo data_get($user, "birthday.month", 12); ?>', $compiler->compileString('{{ $user.birthday.month or 12 }}'));
+		$this->assertEquals('<?php echo data_get($user, "birthday.month", 12); ?>', $compiler->compileString('{{$user.birthday.month or 12}}'));
+		$this->assertEquals('<?php echo data_get($user, "birthday.month", 12); ?>', $compiler->compileString('{{
+			$user.birthday.month or 12
+		}}'));
+	}
+
+
 	public function testEscapedWithAtEchosAreCompiled()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
@@ -142,6 +190,20 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testEscapedWithAtDottedEchosAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$this->assertEquals('{{$user.name}}', $compiler->compileString('@{{$user.name}}'));
+		$this->assertEquals('{{ $user.name }}', $compiler->compileString('@{{ $user.name }}'));
+		$this->assertEquals('{{
+			$user.name
+		}}',
+			$compiler->compileString('@{{
+			$user.name
+		}}'));
+	}
+
+
 	public function testReversedEchosAreCompiled()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
@@ -152,6 +214,20 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{{ $name }}}'));
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{{
 			$name
+		}}}'));
+	}
+
+
+	public function testReversedDottedEchosAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$compiler->setEscapedContentTags('{{', '}}');
+		$compiler->setContentTags('{{{', '}}}');
+		$this->assertEquals('<?php echo e(data_get($user, "name")); ?>', $compiler->compileString('{{$user.name}}'));
+		$this->assertEquals('<?php echo data_get($user, "name"); ?>', $compiler->compileString('{{{$user.name}}}'));
+		$this->assertEquals('<?php echo data_get($user, "name"); ?>', $compiler->compileString('{{{ $user.name }}}'));
+		$this->assertEquals('<?php echo data_get($user, "name"); ?>', $compiler->compileString('{{{
+			$user.name
 		}}}'));
 	}
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -138,6 +138,14 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 			$user.name
 		}}'));
 
+		// ensure concatenated strings are not interpreted as dotted variables
+		$this->assertEquals('<?php echo e($user.$name); ?>', $compiler->compileString('{{{$user.$name}}}'));
+		$this->assertEquals('<?php echo $user.$name; ?>', $compiler->compileString('{{$user.$name}}'));
+		$this->assertEquals('<?php echo $user.$name; ?>', $compiler->compileString('{{ $user.$name }}'));
+		$this->assertEquals('<?php echo $user.$name; ?>', $compiler->compileString('{{
+			$user.$name
+		}}'));
+
 		$this->assertEquals('<?php echo data_get($user, "name", "foo"); ?>', $compiler->compileString('{{ $user.name or "foo" }}'));
 		$this->assertEquals('<?php echo data_get($user, "name", "foo"); ?>', $compiler->compileString('{{$user.name or "foo"}}'));
 		$this->assertEquals('<?php echo data_get($user, "name", "foo"); ?>', $compiler->compileString('{{


### PR DESCRIPTION
This PR provides dotted notation for Blade engine.
The following notation would be permitted:

``` php
{{ $user.name }} // => {{ $user['name'] }}
{{ $user.name or "Taylor" }} // => {{ $user['name'] or "Taylor" }}
{{ $user.birthday.year or 1990 }} // => {{ $user['birthday']['date'] or 1990 }}
```

This works exactly the same if `$user`is an object:

``` php
{{ $user.name }} // => {{ $user->name }}
{{ $user.name or "Taylor" }} // => {{ $user->name or "Taylor" }}
{{ $user.birthday.year or 1990 }} // => {{ $user->birthday->date or 1990 }}
```

Of course the array value or the object attribute can either be a value or an object:

``` php
{{ $user.birthday.year or 1990 }} 
// => {{ $user->birthday->date or 1990 }}
// => {{ $user['birthday']['date'] or 1990 }}
// => {{ $user->birthday['date'] or 1990 }}
// => {{ $user['birthday']->date or 1990 }}
```

When using default notation with `{{ $user.name }}`, if `name` attribute or value does not exist, `null` will be returned.
