### PR TITLE
Improve formatting of mail logging

### DIFF
--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -2,6 +2,7 @@
 
 use Swift_Transport;
 use Swift_Mime_Message;
+use Swift_Mime_MimeEntity;
 use Psr\Log\LoggerInterface;
 use Swift_Events_EventListener;
 
@@ -54,7 +55,24 @@ class LogTransport implements Swift_Transport {
 	 */
 	public function send(Swift_Mime_Message $message, &$failedRecipients = null)
 	{
-		$this->logger->debug((string) $message);
+		$this->logger->debug($this->getMimeEntityString($message));
+	}
+
+	/**
+	 * Get a loggable string out of a Swiftmailer entity.
+	 *
+	 * @param  \Swift_Mime_MimeEntity $entity
+	 * @return string
+	 */
+	protected function getMimeEntityString(Swift_Mime_MimeEntity $entity)
+	{
+		$string = (string) $entity->getHeaders().PHP_EOL.$entity->getBody();
+		
+		foreach ($entity->getChildren() as $children) {
+			$string .= PHP_EOL.PHP_EOL.$this->getMimeEntityString($entity);
+		}
+
+		return $string;
 	}
 
 	/**


### PR DESCRIPTION
Casting the message to a string means the mail is logged with each line broken at 78 characters, with a `=` showing where the linebreaks happen. I assume this is how emails are formatted when sent to a mail server, but clearly for logging purposes it's no good. Unfortunately there is no way to cast to a string without this behaviour, so we have to do it manually.
