### PR TITLE
[4.2] Console : add abort function

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -332,6 +332,21 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	}
 
 	/**
+	 * Abort the command.
+	 *
+	 * @param  string|null  $string
+	 * @return void
+	 */
+	protected function abort($string = null)
+	{
+		$string = $string ? : $this->getName().' aborted !';
+
+		$this->error($string);
+
+		exit();
+	}
+
+	/**
 	 * Get the console command arguments.
 	 *
 	 * @return array


### PR DESCRIPTION
Allows to `abort` a command.
If no custom error message is set, the name of the command will be used with " aborted !"
