### PR TITLE
Garbage collector not delete old sessions

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -101,7 +101,7 @@ class DatabaseSessionHandler implements \SessionHandlerInterface, ExistenceAware
 	 */
 	public function gc($lifetime)
 	{
-		$this->getQuery()->where('last_activity', '<=', $lifetime)->delete();
+		$this->getQuery()->where('last_activity', '<=', time() - $lifetime)->delete();
 	}
 
 	/**


### PR DESCRIPTION
$lifetime is second, but timestamp required to SQL. 
(sorry my bad english)
