### PR TITLE
Allow view composers as objects

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -363,6 +363,10 @@ class Factory {
 		{
 			return $this->addClassEvent($view, $callback, $prefix, $priority);
 		}
+		else
+		{
+			return $this->addObjectEvent($view, $callback, $prefix, $priority);
+		}
 	}
 
 	/**
@@ -381,6 +385,34 @@ class Factory {
 		// classes from the application IoC container then call the compose method
 		// on the instance. This allows for convenient, testable view composers.
 		$callback = $this->buildClassEventCallback($class, $prefix);
+
+		$this->addEventListener($name, $callback, $priority);
+
+		return $callback;
+	}
+
+	/**
+	 * Register a object based view composer.
+	 *
+	 * @param  string     $view
+	 * @param  \stdObject $class
+	 * @param  string     $prefix
+	 * @return \Closure
+	 */
+	protected function addObjectEvent($view, $object, $prefix, $priority = null)
+	{
+		$name = $prefix.$view;
+
+		$method = str_contains($prefix, 'composing') ? 'compose' : 'create';
+
+		// When registering a object based view "composer", we will simply call
+		// the compose method on the instance.
+		$callback = function() use ($object, $method)
+		{
+			$callable = array($object, $method);
+
+			return call_user_func_array($callable, func_get_args());
+		};
 
 		$this->addEventListener($name, $callback, $priority);
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -213,6 +213,19 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testObjectCallbacks()
+	{
+		$factory = $this->getFactory();
+		$factory->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type('Closure'));
+		$composer = m::mock('StdClass');
+		$composer->shouldReceive('compose')->once()->with('view')->andReturn('composed');
+		$callback = $factory->composer('foo', $composer);
+		$callback = $callback[0];
+
+		$this->assertEquals('composed', $callback('view'));
+	}
+
+
 	public function testCallComposerCallsProperEvent()
 	{
 		$factory = $this->getFactory();


### PR DESCRIPTION
Allow view composers and creators to be passed objects that are pre-constructed rather than only a string FQCN that the container will construct (or a closure).

My use case was that I wanted to do my own DI on a view composer class (I needed to pass in a locally-instantiated class rather than one that would be resolved out of the IoC container) and the current setup wouldn't let me.
