### PR TITLE
[4.2] Session:  Call Artisan dump-autoload after session:table

### DIFF
--- a/src/Illuminate/Session/Console/SessionTableCommand.php
+++ b/src/Illuminate/Session/Console/SessionTableCommand.php
@@ -51,6 +51,8 @@ class SessionTableCommand extends Command {
 		$this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/database.stub'));
 
 		$this->info('Migration created successfully!');
+
+		$this->call('dump-autoload');
 	}
 
 	/**


### PR DESCRIPTION
As `dump-autoload` is a post-requirement to `session:table` (https://github.com/laravel/docs/blob/1a55def4d49605ea2953796b7fef1792bc106a18/session.md#database-sessions), it can be added after `session:table` command.

Also closes https://github.com/laravel/framework/pull/4657
