### PR TITLE
[4.2] Collection : Add set() function to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -457,6 +457,21 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Set an item in the collection by key if it does not exist.
+	 *
+	 * @param  mixed  $key
+	 * @param  mixed  $value
+	 * @return void
+	 */
+	public function set($key, $value)
+	{
+		if ( ! $this->has($key))
+		{
+			$this->put($key, $value);
+		}
+	}
+
+	/**
 	 * Get and remove the first item from the collection.
 	 *
 	 * @return mixed|null

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -404,6 +404,25 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testPut()
+	{
+		$c = new Collection();
+		$c->put('foo', 'bar');
+		$this->assertTrue($c->has('foo'));
+		$this->assertEquals('bar', $c->get('foo'));
+	}
+
+
+	public function testSet()
+	{
+		$c = new Collection();
+		$c->put('foo', 'bar');
+		$c->set('foo', 'baz');
+		$this->assertTrue($c->has('foo'));
+		$this->assertEquals('bar', $c->get('foo'));
+	}
+
+
 	public function testPullRetrievesItemFromCollection()
 	{
 		$c = new Collection(array('foo', 'bar'));


### PR DESCRIPTION
Add `set()`function to collection.
`set()` is the equivalent of `put()` but it does not overwrite the value if the key already exists.

(Also added a test for `put()`)
