### PR TITLE
[4.2] Model : take booleans in consideration in originalIsNumericallyEquivalent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2692,7 +2692,9 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		$original = $this->original[$key];
 
-		return is_numeric($current) && is_numeric($original) && strcmp((string) $current, (string) $original) === 0;
+		return (is_numeric($current) || is_bool($current))
+			&& (is_numeric($original) || is_bool($original))
+			&& $current + 0 == $original + 0;
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -38,6 +38,34 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($model->isDirty('foo'));
 	}
 
+	
+	public function testDirtyEquivalentAttributes()
+	{
+		$model = new EloquentModelStub(array('foo' => '1'));
+		$model->syncOriginal();
+
+		$model->foo = 1;
+		$this->assertFalse($model->isDirty('foo'));
+		$model->foo = 1.0;
+		$this->assertFalse($model->isDirty('foo'));
+		$model->foo = '1.0';
+		$this->assertFalse($model->isDirty('foo'));
+		$model->foo = true;
+		$this->assertFalse($model->isDirty('foo'));
+
+		$model = new EloquentModelStub(array('foo' => '0'));
+		$model->syncOriginal();
+
+		$model->foo = 0;
+		$this->assertFalse($model->isDirty('foo'));
+		$model->foo = 0.0;
+		$this->assertFalse($model->isDirty('foo'));
+		$model->foo = '0.0';
+		$this->assertFalse($model->isDirty('foo'));
+		$model->foo = false;
+		$this->assertFalse($model->isDirty('foo'));
+	}
+
 
 	public function testCalculatedAttributes()
 	{


### PR DESCRIPTION
Take boolean in consideration in originalIsNumericallyEquivalent() and tries to solve https://github.com/laravel/framework/issues/4675

So that booleans can also be equivalent:

``` php
true
1.0
1
'1'
'1.000'
// are equivalent and...

false
0.0
0
'0'
'0.000'
// are also equivalent
```
