### PR TITLE
[4.2] Collection : add keys() function that returns the keys of the items

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -242,6 +242,16 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Get the keys of the collection items.
+	 *
+	 * @return array
+	 */
+	public function keys()
+	{
+		return array_keys($this->items);
+	}
+
+	/**
 	* Get the last item from the collection.
 	*
 	* @return mixed|null

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -431,6 +431,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(['foo', 'bar'], $c->reject(function($v) { return $v == 'baz'; })->values()->all());
 	}
 
+
+	public function testKeys()
+	{
+		$c = new Collection(array('name' => 'taylor', 'framework' => 'laravel'));
+		$this->assertEquals(array('name', 'framework'), $c->keys());
+	}
+
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
Add `keys()` function to collection. To return the keys of the Collection items as an array.
