### PR TITLE
migrate:refresh command now properly passes force option to reset and migrate

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -32,13 +32,14 @@ class RefreshCommand extends Command {
 		if ( ! $this->confirmToProceed()) return;
 
 		$database = $this->input->getOption('database');
+		$force = $this->input->getOption('force');
 
-		$this->call('migrate:reset', array('--database' => $database));
+		$this->call('migrate:reset', array('--database' => $database, '--force' => $force));
 
 		// The refresh command is essentially just a brief aggregate of a few other of
 		// the migration commands and just provides a convenient wrapper to execute
 		// them in succession. We'll also see if we need to re-seed the database.
-		$this->call('migrate', array('--database' => $database));
+		$this->call('migrate', array('--database' => $database, '--force' => $force));
 
 		if ($this->needsSeeding())
 		{


### PR DESCRIPTION
This should fix the issue mentioned by @AndreiLunga in #4611. The migrate:refresh command calls a few other commands to carry out its task, but it doesn't pass the --force option along to them like I think it should. I'm sure there are some other options that should be passed, but this was the most obvious one.
