### PR TITLE
[4.2] File Store Increment/Decrement

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -200,7 +200,7 @@ class FileStore implements StoreInterface {
 	{
 		$value = $this->get($key);
 
-		$int = ! $value ? $value : 0;
+		$int = $value ? $value : 0;
 
 		return (int) $int;
 	}

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -109,13 +109,15 @@ class FileStore implements StoreInterface {
 	 *
 	 * @param  string  $key
 	 * @param  mixed   $value
-	 * @return void
-	 *
-	 * @throws \LogicException
+	 * @return int
 	 */
 	public function increment($key, $value = 1)
 	{
-		throw new \LogicException("Increment operations not supported by this driver.");
+		$int = $this->getInt($key) + $value;
+
+		$this->put($key, $int, 0);
+
+		return $int;
 	}
 
 	/**
@@ -123,13 +125,15 @@ class FileStore implements StoreInterface {
 	 *
 	 * @param  string  $key
 	 * @param  mixed   $value
-	 * @return void
-	 *
-	 * @throws \LogicException
+	 * @return int
 	 */
 	public function decrement($key, $value = 1)
 	{
-		throw new \LogicException("Decrement operations not supported by this driver.");
+		$int = $this->getInt($key) - $value;
+
+		$this->put($key, $int, 0);
+
+		return $int;
 	}
 
 	/**
@@ -184,6 +188,21 @@ class FileStore implements StoreInterface {
 		$parts = array_slice(str_split($hash = md5($key), 2), 0, 2);
 
 		return $this->directory.'/'.join('/', $parts).'/'.$hash;
+	}
+
+	/**
+	 * Get the integer value for given cache key.
+	 *
+	 * @param  string  $key
+	 * @return int
+	 */
+	protected function getInt($key)
+	{
+		$value = $this->get($key);
+
+		$int = ! $value ? $value : 0;
+
+		return (int) $int;
 	}
 
 	/**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -113,7 +113,7 @@ class FileStore implements StoreInterface {
 	 */
 	public function increment($key, $value = 1)
 	{
-		$int = $this->getInt($key) + $value;
+		$int = ((int) $this->get($key)) + $value;
 
 		$this->put($key, $int, 0);
 
@@ -129,7 +129,7 @@ class FileStore implements StoreInterface {
 	 */
 	public function decrement($key, $value = 1)
 	{
-		$int = $this->getInt($key) - $value;
+		$int = ((int) $this->get($key)) - $value;
 
 		$this->put($key, $int, 0);
 
@@ -188,21 +188,6 @@ class FileStore implements StoreInterface {
 		$parts = array_slice(str_split($hash = md5($key), 2), 0, 2);
 
 		return $this->directory.'/'.join('/', $parts).'/'.$hash;
-	}
-
-	/**
-	 * Get the integer value for given cache key.
-	 *
-	 * @param  string  $key
-	 * @return int
-	 */
-	protected function getInt($key)
-	{
-		$value = $this->get($key);
-
-		$int = $value ? $value : 0;
-
-		return (int) $int;
 	}
 
 	/**


### PR DESCRIPTION
This behaves in the same way that other cache drivers do. If the cache key doesn't exist, it will update it from 0, setting the expiry time long in the future or "forever". The only inconsistency here is that it will also ignore the expiry time if it was previously set. I assume this problem was the reason this functionality was not originally implemented. Surely an implementation despite this floor is better than no implementation?
