### PR TITLE
Blade matchers need parenthetical awareness.

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -585,6 +585,70 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	}
 
 	/**
+	 *  Generate a regular expression matching a single or double quoted
+	 *  string for inclusion in a larger regular expression.
+	 *  
+	 *  CONSUMES ONE MATCHING GROUP
+	 *  
+	 *  @param int $nextGroup The number which will be assigned to the next
+	 *      capturing group in the regular expression.
+	 *  @param boolean singleLine Wether the larger regex will be compiled 
+	 *      with the 's' flag.  Defaults to false.
+	 *  @return string
+	 */
+	private function stringRegex($nextGroup, $singleLine = false) 
+	{
+		return $singleLine ?
+			'([\'"])(?:\\\\\\'.$nextGroup.'|(?!\\'.$nextGroup.').)*\\'.$nextGroup
+			:
+			'([\'"])(?:\\\\\\'.$nextGroup.'|(?!\\'.$nextGroup.')(?:.|'."\n".'))*\\'.$nextGroup
+			;
+	}
+
+	/**
+	 *  Generate a regular expression matching a Heredoc or a Nowdoc for 
+	 *  inclusion in a larger regular expression.
+	 *  
+	 *  CONSUMES TWO MATCHING GROUPS
+	 *  
+	 *  @param int $nextGroup The number which will be assigned to the next
+	 *      capturing group in the regular expression.
+	 *  @param boolean singleLine Wether the larger regex will be compiled 
+	 *      with the 's' flag.  Defaults to false.
+	 *  @return string
+	 */
+	private function hereNowDocRegex($nextGroup, $singleLine = false) 
+	{
+		return '<<<(["\']?)([a-zA-Z_]\w*)\\'.$nextGroup.PHP_EOL //Opening Identifier
+			.'(?>' .($singleLine?'.':'[\s\S]').'*?'.PHP_EOL.')?' //Closing Identifier
+			.'\\' . ($nextGroup + 1) . ';?'.PHP_EOL;  
+	}
+
+	/**
+	 *  Generate a regular expression matching a properly nested set of parentheses.
+	 *  Currently accounts for single and double quoted strings, as well as Heredocs
+	 *  and nowdocs.
+	 *  
+	 *  CONSUMES FOUR MATCHING GROUPS
+	 *  
+	 *  @param int $nextGroup The number which will be assigned to the next
+	 *      capturing group in the regular expression.
+	 *  @param boolean singleLine Wether the larger regex will be compiled 
+	 *      with the 's' flag.  Defaults to false.
+	 *  @return string
+	 */
+	private function parenRegex($nextGroup, $singleLine) 
+	{
+		return '(\((?:'
+			.$this->hereNowDocRegex($nextGroup+1, $singleLine) //Match the heredoc first, as it is complicated, but clearly marked.
+			.'|' //OR
+			.'(?>[^()"\']+)'///Any String of non paren/quote characters.
+			.'|' //OR
+			.$this->stringRegex($nextGroup + 3,$singleLine)
+			.'|(?'.$nextGroup.'))*\))';
+	}
+
+	/**
 	 * Get the regular expression for a generic Blade function.
 	 *
 	 * @param  string  $function
@@ -592,7 +656,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function createMatcher($function)
 	{
-		return '/(?<!\w)(\s*)@'.$function.'(\s*\(.*\))/';
+		return '/(?<!\w)(\s*)@'.preg_quote($function).'(\s*'.$this->parenRegex(3, true).')/s';
 	}
 
 	/**
@@ -603,7 +667,16 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function createOpenMatcher($function)
 	{
-		return '/(?<!\w)(\s*)@'.$function.'(\s*\(.*)\)/';
+		return '/(?<!\w)(\s*)@'
+			.preg_quote($function)
+			.'(\s*(?:\((?:'
+			.$this->hereNowDocRegex(3,true)  //Match the heredoc first, as it is complicated, but clearly marked.
+			.'|' //Or
+			.'(?>[^()"\']+)' //Any non-paren, non-string character.
+			.'|' //Or
+			.$this->stringRegex(5,true)
+			.'|' //OR
+			.$this->parenRegex(6, true).')*))\)/s';
 	}
 
 	/**
@@ -614,7 +687,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function createPlainMatcher($function)
 	{
-		return '/(?<!\w)(\s*)@'.$function.'(\s*)/';
+		return '/(?<!\w)(\s*)@'.preg_quote($function).'(\s*)/';
 	}
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -5,6 +5,7 @@ use Illuminate\View\Compilers\BladeCompiler;
 
 class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 
+
 	public function tearDown()
 	{
 		m::close();
@@ -405,6 +406,120 @@ breeze
 	protected function getFiles()
 	{
 		return m::mock('Illuminate\Filesystem\Filesystem');
+	}
+
+
+	/**
+	 *  @dataProvider matcherCases
+	 */
+	public function testMatcher($str, $succeed)
+	{
+		$compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+		$fauxCall = "some text @function($str) some other text with Parentheses()";
+		preg_match($compiler->createMatcher('function'), $fauxCall, $matches);
+		if ($succeed) {
+			$this->assertEquals("($str)", $matches[2]);
+		} else {
+			$this->assertNotEquals("($str)", isset($matches[2])?$matches[2]:null);
+		}
+	}
+
+
+	/**
+	 *  @dataProvider matcherCases
+	 */
+	public function testOpenMatcher($str, $succeed) 
+	{
+		$compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+		$fauxCall = "some text @function($str) some other text with Parentheses()";
+		preg_match($compiler->createOpenMatcher('function'), $fauxCall, $matches);
+		if ($succeed) {
+			$this->assertEquals("($str", isset($matches[2])?$matches[2]:null);
+		} else {
+			$this->assertNotEquals("($str", isset($matches[2])?$matches[2]:null);
+		}
+	}
+
+
+	public function matcherCases() 
+	{
+		return [
+			/**
+			 *  Cases which should match correctly.
+			 */
+			['', true] //Empty
+			, ['     ', true] //WhiteSpace
+			, ['$var', true] //variable
+			, ['$var->prop', true] //Property
+			, ['$var->method()', true]//<Method
+			, ['$arg, $list', true] //Arg list
+			, ['$multiline
+				, $arg
+				, $list', true] //Multiline Arg list
+			, ['"string"', true] //doubleQuoted String
+			, ["'string'", true] //Single Quoted String
+			, ['"String
+				Multiline"', true] //Multiline String
+			, ['"String \" with escape"', true] //Escaped Quotes
+			, ['"String with false paren)"', true]  //Parentheses within string
+			, ['((()(()(()))))', true] //Arbitrarily nested parentheses
+			, ['(-b + sqrt(($b*$b) - (4* $a * $c))) / (2*$a)', true] //Quadratic Equations.
+			, ['<<<Heredoc
+Heredoc
+',true] //empty HereDoc
+			, ['<<<Heredoc
+Huzzah, some data!
+Heredoc
+',true] //non-empty HereDoc
+			, ['<<<"Heredoc"
+Huzzah, some data!
+Heredoc
+',true] //Quoted HereDoc
+			, ['<<<"Heredoc"
+Huzzah, some data!
+Heredoc;
+',true] //Semicolon terminated Heredoc.
+			, ["<<<'Nowdoc'
+Huzzah, some data!
+Nowdoc;
+",true] //Semicolon terminated Nowdoc.
+			, ["<<<'Nowdoc'
+Unmatchable quote: '
+Nowdoc;
+",true] //Nowdoc with unmatchable Quote.
+			, ["<<<'Nowdoc'
+Unmatchable paren: (
+Nowdoc;
+",true] //Nowdoc with unmatchable open Parenthesis.
+			, ["<<<'Nowdoc'
+Early closing paren: )
+Nowdoc;
+",true] //Nowdoc with early closing parenthesis..
+			/**
+			 *  Cases which should fail.
+			 */
+			, [')', false] //Premature closure
+			, ['(', false]//unclosed Open
+			, ['())((()())()', false] //Improperly nested parentheses
+			, ['"', false] //Unterminated Strings
+			, ["'", false] //Unterminated Strings
+			, ["<<<'Nowdoc'
+Nowdoc;
+Early closing paren: )
+Nowdoc;
+",false] //Nowdoc followed by premature closure, and succeeding re-use of Identifier.
+			, ["<<<'Nowdoc'
+Nowdoc;
+Unmatchable quote: '
+Nowdoc;
+",false] //Nowdoc followed by unmatchable quote, and succeeding re-use of Identifier.
+			, ["<<<'Nowdoc'
+Nowdoc;
+Unmatchable paren: (
+Nowdoc;
+",false] //Nowdoc followed by unmatchable open parenthesis, and succeeding re-use of Identifier.
+		];
+
 	}
 
 }


### PR DESCRIPTION
Reopening: https://github.com/laravel/framework/pull/4693

> Blade matchers need parenthetical depth awareness - greedy matching with .\* leads to unwanted matches.
> 
> IE:
> 
> ```
> @extension($arg, $otherArg, ")", )         ng-src="getSource(someVar);"
> ```
> 
> Fails to match what is logically the extension - it matches 
> 
> ```
> ($arg, $otherArg, ")", )         ng-src="getSource(someVar)
> ```
> 
> Which causes view failure.
> 
> See: http://ideone.com/YmVtpK
> 
> For proof of concept.

RE Comment left on the previous request:

> You've made a syntax error there (missing semicolon). Also, you should really add some tests for this to make sure we don't break this later by mistake.

Yeah that's what happens when you make the edits on a local environment, then fork and try to back pull using the Git editor.

I've fixed it and added 34 tests (all of which pass, currently).
