### PR TITLE
Added abstract method getDefaultDriver()

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -119,6 +119,14 @@ abstract class Manager {
 		return $this->drivers;
 	}
 
+
+	/**
+	 * Get the default driver name
+	 * 
+	 * @return string
+	 */
+	abstract public function getDefaultDriver();
+	
 	/**
 	 * Dynamically call the default driver instance.
 	 *


### PR DESCRIPTION
The driver() method calls getDefaultDriver(), but nothing in the class says it should be implemented.
Fixed the typo that was causing build to fail.
