### PR TITLE
Added abstract method getDefaultDriver()

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -120,6 +120,13 @@ abstract class Manager {
 	}
 
 	/**
+	 * Get the default driver name
+	 * 
+	 * @return string
+	 */
+	abstract public function getDefaultDriver();
+	
+	/**
 	 * Dynamically call the default driver instance.
 	 *
 	 * @param  string  $method


### PR DESCRIPTION
The driver() method calls getDefaultDriver(), but nothing in the class says it should be implemented.
