### PR TITLE
Fixed before/after + date_format rules inconsistencies

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1283,8 +1283,12 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateBeforeWithFormat($format, $value, $parameters)
 	{
-		return DateTime::createFromFormat($format, $value) <
-               DateTime::createFromFormat($format, $parameters[0]);
+		$param = $this->getValue($parameters[0]) ?: $parameters[0];
+		$date_value = DateTime::createFromFormat($format, $value);
+		$date_param = DateTime::createFromFormat($format, $param)
+			?: new DateTime($param);
+
+		return ($date_value && $date_param) && ($date_value < $date_param);
 	}
 
 	/**
@@ -1324,8 +1328,12 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function validateAfterWithFormat($format, $value, $parameters)
 	{
-		return DateTime::createFromFormat($format, $value) >
-               DateTime::createFromFormat($format, $parameters[0]);
+		$param = $this->getValue($parameters[0]) ?: $parameters[0];
+		$date_value = DateTime::createFromFormat($format, $value);
+		$date_param = DateTime::createFromFormat($format, $param)
+			?: new DateTime($param);
+
+		return ($date_value && $date_param) && ($date_value > $date_param);
 	}
 	
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1066,12 +1066,53 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	{
 		date_default_timezone_set('UTC');
 		$trans = $this->getRealTranslator();
-
-		$v = new Validator($trans, array('x' => '02/04/2012'), array('x' => 'After:03/03/2012|Before:01/05/2012'));
+		$v = new Validator($trans, array('x' => '31/12/2000'), array('x' => 'before:31/02/2012'));
 		$this->assertTrue($v->fails());
 
-		$v = new Validator($trans, array('x' => '02/04/2012'), array('x' => 'date_format:d/m/Y|After:03/03/2012|Before:01/05/2012'));
+		$v = new Validator($trans, array('x' => '31/12/2000'), array('x' => 'date_format:d/m/Y|before:31/12/2012'));
 		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('x' => '31/12/2012'), array('x' => 'after:31/12/2000'));
+		$this->assertTrue($v->fails());
+
+		$v = new Validator($trans, array('x' => '31/12/2012'), array('x' => 'date_format:d/m/Y|after:31/12/2000'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('start' => '31/12/2012', 'ends' => '31/12/2013'), array('start' => 'after:01/01/2000', 'ends' => 'after:start'));
+		$this->assertTrue($v->fails());
+
+		$v = new Validator($trans, array('start' => '31/12/2012', 'ends' => '31/12/2013'), array('start' => 'date_format:d/m/Y|after:31/12/2000', 'ends' => 'date_format:d/m/Y|after:start'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('start' => '31/12/2012', 'ends' => '31/12/2000'), array('start' => 'after:31/12/2000', 'ends' => 'after:start'));
+		$this->assertTrue($v->fails());
+
+		$v = new Validator($trans, array('start' => '31/12/2012', 'ends' => '31/12/2000'), array('start' => 'date_format:d/m/Y|after:31/12/2000', 'ends' => 'date_format:d/m/Y|after:start'));
+		$this->assertTrue($v->fails());
+
+		$v = new Validator($trans, array('start' => '31/12/2012', 'ends' => '31/12/2013'), array('start' => 'before:ends', 'ends' => 'after:start'));
+		$this->assertTrue($v->fails());
+
+		$v = new Validator($trans, array('start' => '31/12/2012', 'ends' => '31/12/2013'), array('start' => 'date_format:d/m/Y|before:ends', 'ends' => 'date_format:d/m/Y|after:start'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('start' => '31/12/2012', 'ends' => '31/12/2000'), array('start' => 'before:ends', 'ends' => 'after:start'));
+		$this->assertTrue($v->fails());
+
+		$v = new Validator($trans, array('start' => '31/12/2012', 'ends' => '31/12/2000'), array('start' => 'date_format:d/m/Y|before:ends', 'ends' => 'date_format:d/m/Y|after:start'));
+		$this->assertTrue($v->fails());
+
+		$v = new Validator($trans, array('x' => date('d/m/Y')), array('x' => 'date_format:d/m/Y|after:yesterday|before:tomorrow'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('x' => date('d/m/Y')), array('x' => 'date_format:d/m/Y|after:tomorrow|before:yesterday'));
+		$this->assertTrue($v->fails());
+
+		$v = new Validator($trans, array('x' => date('Y-m-d')), array('x' => 'after:yesterday|before:tomorrow'));
+		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, array('x' => date('Y-m-d')), array('x' => 'after:tomorrow|before:yesterday'));
+		$this->assertTrue($v->fails());
 	}
 
 


### PR DESCRIPTION
This fixes PR #3607 to provide missing functionalities described on PR #1824 and PR #4699 and line up `before`/`after` rules to work smoothly with and without a `date_format` rule.

I also rewrote `testBeforeAndAfterWithFormat()` tests to better detect inconsistencies.
