### PR TITLE
Throw an exception if a package is created without setting the author's email

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
@@ -84,6 +84,7 @@ trait SoftDeletingTrait {
 		// Once we have saved the model, we will fire the "restored" event so this
 		// developer will do anything they need to after a restore operation is
 		// totally finished. Then we will return the result of the save call.
+		$this->exists = true;
 		$result = $this->save();
 
 		$this->fireModelEvent('restored', false);

--- a/src/Illuminate/Workbench/Package.php
+++ b/src/Illuminate/Workbench/Package.php
@@ -52,9 +52,15 @@ class Package {
 	 * @param  string  $author
 	 * @param  string  $email
 	 * @return void
+	 * 
+	 * @throws \UnexpectedValueException
 	 */
 	public function __construct($vendor, $name, $author, $email)
 	{
+		if (filter_var($email, FILTER_VALIDATE_EMAIL, FILTER_NULL_ON_FAILURE) === null) {
+			throw new \UnexpectedValueException("Please set the author's email for in app/config/workbench.php.");
+		}
+
 		$this->name = $name;
 		$this->email = $email;
 		$this->vendor = $vendor;


### PR DESCRIPTION
`artisan workbench {namespace/package} [--resources]` will create the files for a package even if you didn't set up the author details for workbench.
When the command try to `composer install`, composer will throw `Composer\Json\JsonValidationException`.

The context isn't very clear since one cannot find the composer exception anywhere in the code, so this should clarify the error.
