### PR TITLE
Flagged exists as true when restoring the model

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
@@ -84,6 +84,7 @@ trait SoftDeletingTrait {
 		// Once we have saved the model, we will fire the "restored" event so this
 		// developer will do anything they need to after a restore operation is
 		// totally finished. Then we will return the result of the save call.
+		$this->exists = true;
 		$result = $this->save();
 
 		$this->fireModelEvent('restored', false);


### PR DESCRIPTION
`save()` will run `performInsert()` when exists is false.
This ensure that `performUpdate()` is called instead.
