### PR TITLE
Throw an exception if a package is created without setting the author's email

### DIFF
--- a/src/Illuminate/Workbench/Package.php
+++ b/src/Illuminate/Workbench/Package.php
@@ -52,10 +52,16 @@ class Package {
 	 * @param  string  $author
 	 * @param  string  $email
 	 * @return void
+ 	 * 
+ 	 * @throws \UnexpectedValueException
 	 */
 	public function __construct($vendor, $name, $author, $email)
 	{
-		$this->name = $name;
+		if (filter_var($email, FILTER_VALIDATE_EMAIL, FILTER_NULL_ON_FAILURE) === null) {
+			throw new \UnexpectedValueException("Please set the author's email for in app/config/workbench.php.");
+		}
+
+ 		$this->name = $name;
 		$this->email = $email;
 		$this->vendor = $vendor;
 		$this->author = $author;


### PR DESCRIPTION
`artisan workbench {namespace/package}` will create the files for a package even if you didn't set up the configuration for workbench.

When the command try to `composer install`, composer will throw `Composer\Json\JsonValidationException`.

The context isn't very clear since one cannot find the exception anywhere in the code, so this should clarify the error.
