### PR TITLE
[4.2] Model : firstByAttributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -578,10 +578,9 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Get the first model for the given attributes.
 	 *
 	 * @param  array  $attributes
-	 * @param  bool   $fail
 	 * @return \Illuminate\Database\Eloquent\Model|null
 	 */
-	public static function firstByAttributes($attributes, $fail = false)
+	public static function firstByAttributes($attributes)
 	{
 		$query = static::query();
 
@@ -589,8 +588,6 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		{
 			$query->where($key, $value);
 		}
-
-		if ($fail) return $query->firstOrFail();
 
 		return $query->first() ?: null;
 	}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -578,9 +578,10 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Get the first model for the given attributes.
 	 *
 	 * @param  array  $attributes
+	 * @param  bool   $fail
 	 * @return \Illuminate\Database\Eloquent\Model|null
 	 */
-	protected static function firstByAttributes($attributes)
+	public static function firstByAttributes($attributes, $fail = false)
 	{
 		$query = static::query();
 
@@ -588,6 +589,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		{
 			$query->where($key, $value);
 		}
+
+		if ($fail) return $query->firstOrFail();
 
 		return $query->first() ?: null;
 	}


### PR DESCRIPTION
Set `firstByAttributes` as public so it can be used outside the `Model` class.

Also add `$fail` flag (default to `false`) : if no instance of the model is found, a `ModelNotFoundException` will be thrown.
