### PR TITLE
Array forget many

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -256,7 +256,7 @@ class Request extends SymfonyRequest {
 
 		$results = $this->input();
 
-		foreach ($keys as $key) array_forget($results, $key);
+		array_forget($results, $keys);
 
 		return $results;
 	}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -266,29 +266,30 @@ if ( ! function_exists('array_flatten'))
 if ( ! function_exists('array_forget'))
 {
 	/**
-	 * Remove an array item from a given array using "dot" notation.
+	 * Remove one or many array items from a given array using "dot" notation.
 	 *
-	 * @param  array   $array
-	 * @param  string  $key
+	 * @param  array        $array
+	 * @param  array|string $keys
 	 * @return void
 	 */
-	function array_forget(&$array, $key)
+	function array_forget(&$array, $keys)
 	{
-		$keys = explode('.', $key);
-
-		while (count($keys) > 1)
+		foreach ((array) $keys as $key)
 		{
-			$key = array_shift($keys);
+			$parts = explode('.', $key);
 
-			if ( ! isset($array[$key]) || ! is_array($array[$key]))
+			while (count($parts) > 1)
 			{
-				return;
+				$part = array_shift($parts);
+
+				if (isset($array[$part]) && is_array($array[$part]))
+				{
+					$array =& $array[$part];
+				}
 			}
 
-			$array =& $array[$key];
+			unset($array[array_shift($parts)]);
 		}
-
-		unset($array[array_shift($keys)]);
 	}
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -41,6 +41,12 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		array_forget($array, 'names.developer');
 		$this->assertFalse(isset($array['names']['developer']));
 		$this->assertTrue(isset($array['names']['otherDeveloper']));
+
+		$array = ['names' => ['developer' => 'taylor', 'otherDeveloper' => 'dayle', 'thirdDeveloper' => 'Lucas']];
+		array_forget($array, ['names.developer', 'names.otherDeveloper']);
+		$this->assertFalse(isset($array['names']['developer']));
+		$this->assertFalse(isset($array['names']['otherDeveloper']));
+		$this->assertTrue(isset($array['names']['thirdDeveloper']));
 	}
 
 


### PR DESCRIPTION
Allows `array_forget` to unset or many keys:

``` php
array_forget($array, 'foo.bar');
// the following is now also possible:
array_forget($array, ['foo.bar', 'laravel.framework']);
```
