### PR TITLE
[Bug] Minor bug in MySQLGrammar logic

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -79,12 +79,12 @@ class MySqlGrammar extends Grammar {
 	{
 		$sql = parent::compileUpdate($query, $values);
 
-		if (isset($query->orders))
+		if (!empty($query->orders))
 		{
 			$sql .= ' '.$this->compileOrders($query, $query->orders);
 		}
 
-		if (isset($query->limit))
+		if (!empty($query->limit))
 		{
 			$sql .= ' '.$this->compileLimit($query, $query->limit);
 		}

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -79,12 +79,12 @@ class MySqlGrammar extends Grammar {
 	{
 		$sql = parent::compileUpdate($query, $values);
 
-		if (!empty($query->orders))
+		if ( ! empty($query->orders))
 		{
 			$sql .= ' '.$this->compileOrders($query, $query->orders);
 		}
 
-		if (!empty($query->limit))
+		if ( ! empty($query->limit))
 		{
 			$sql .= ' '.$this->compileLimit($query, $query->limit);
 		}


### PR DESCRIPTION
For your consideration, this global scope applies a default sort order:

``` php
<?php namespace October\Rain\Database;

use Illuminate\Database\Eloquent\Builder as BuilderBase;
use Illuminate\Database\Eloquent\ScopeInterface;

class NestedTreeScope implements ScopeInterface
{
    public function apply(BuilderBase $builder)
    {
        $model = $builder->getModel();
        $builder->orderBy('left_column');
    }

    public function remove(BuilderBase $builder)
    {
        $column = 'left_column';
        $query = $builder->getQuery();

        foreach ((array) $query->orders as $key => $order) {

            if (!$this->isNestedTreeConstraint($order, $column))
                continue;

            unset($query->orders[$key]);
            $query->orders = array_values($query->orders);
        }
    }

    protected function isNestedTreeConstraint(array $order, $column)
    {
        return $order['column'] == $column;
    }
}
```

This class is modelled after `SoftDeletingScope` and will **unset()** the `$orders` property of the query builder. This leaves an empty array.

Currently the logic checks using **isset()** on the property, which allows an empty array to pass through, resulting in a fragmented SQL statement.

```
update `table` set `title` = 'foobar' where `id` = 1 order by
```

I _could_ update the scope to check if the array is empty and set it to `null`, but I believe this should be the frameworks responsibility to weed out these instances, hence is a bug in the logic.

Cheers
