### PR TITLE
Add dot notation to input only

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -241,7 +241,15 @@ class Request extends SymfonyRequest {
 	{
 		$keys = is_array($keys) ? $keys : func_get_args();
 
-		return array_only($this->input(), $keys) + array_fill_keys($keys, null);
+		$results = array();
+		$input = $this->input();
+
+		foreach ($keys as $key)
+		{
+			array_set($results, $key, array_get($input, $key, null));
+		}
+
+		return $results;
 	}
 
 	/**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -169,6 +169,10 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$request = Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 25));
 		$this->assertEquals(array('age' => 25), $request->only('age'));
 		$this->assertEquals(array('name' => 'Taylor', 'age' => 25), $request->only('name', 'age'));
+
+		$request = Request::create('/', 'GET', array('developer' => array('name' => 'Taylor', 'age' => 25)));
+		$this->assertEquals(array('developer' => array('age' => 25)), $request->only('developer.age'));
+		$this->assertEquals(array('developer' => array('name' => 'Taylor'), 'test' => null), $request->only('developer.name', 'test'));
 	}
 
 


### PR DESCRIPTION
This pull request adds support for handling nested arrays using Input::only using dot notation. This was reported by @soxyl in #4726.

For example, if the input is ['developer' => ['age' => 25']] you can now use Input::only('developer.age') to get ['developer.age' => 25]. It used to just return null and you could get a nested input value. I believe this was inconsistent as Input::get('developer.age') would work fine and return 25. This may not be the behaviour that is wanted though as it may make more sense to return ['developer' => ['age' => 25]] instead of ['developer.age' => 25]. Open to any opinions about this.
