### PR TITLE
Added array_undot function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -164,6 +164,27 @@ if ( ! function_exists('array_dot'))
 	}
 }
 
+if ( ! function_exists('array_undot'))
+{
+	/**
+	 * Expand an array with dotted keys into a multi-dimensional associative array.
+	 *
+	 * @param  array   $array
+	 * @return array
+	 */
+	function array_undot($array)
+	{
+		$results = array();
+
+		foreach ($array as $key => $value)
+		{
+			array_set($results, $key, value($value));
+		}
+
+		return $results;
+	}
+}
+
 if ( ! function_exists('array_except'))
 {
 	/**

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -18,6 +18,13 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testArrayUndot()
+	{
+		$array = array_undot(array('developer.name' => 'taylor', 'developer.age' => 25, 'developer.address.number' => 123, 'developer.address.street' => 'Fake St', 'language' => 'php', 'closure' => function() { return 'closure'; }));
+		$this->assertEquals($array, array('developer' => array('name' => 'taylor', 'age' => 25, 'address' => array('number' => 123, 'street' => 'Fake St')), 'language' => 'php', 'closure' => 'closure'));
+	}
+
+
 	public function testArrayGet()
 	{
 		$array = array('names' => array('developer' => 'taylor'));


### PR DESCRIPTION
This function converts an array with dotted keys to an associative array. Not sure if it's the best name, but hopefully some of you find the helper useful in some way.

Example:

```
$array = array('developer.name' => 'John Smith', 'developer.age' => 25, 'developer.address.number' => 123, 'developer.address.street' => 'Fake St');
$undottedArray = array_undot($array);
// $undottedArray is now array('developer' => array('name' => 'John Smith', 'age' => 25, 'address' => array('number' => 123, 'street' => 'Fake St')))
```
