### PR TITLE
Allow Table Prefixes in Query Builder `lists()` Method.

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1460,13 +1460,14 @@ class Builder {
 	 */
 	public function lists($column, $key = null)
 	{
-		$columns = $this->getListSelect($column, $key);
+		$select = is_null($key) ? array($column) : array($column, $key);
 
 		// First we will just get all of the column values for the record result set
 		// then we can associate those values with the column if it was specified
 		// otherwise we can just give these values back without a specific key.
-		$results = new Collection($this->get($columns));
+		$results = new Collection($this->get($select));
 
+		$columns = $this->removeTablePrefixes($select);
 		$values = $results->fetch($columns[0])->all();
 
 		// If a key was specified and we have results, we will go ahead and combine
@@ -1474,7 +1475,7 @@ class Builder {
 		// be accessed by the key of the rows instead of simply being numeric.
 		if ( ! is_null($key) && count($results) > 0)
 		{
-			$keys = $results->fetch($key)->all();
+			$keys = $results->fetch($columns[1])->all();
 
 			return array_combine($keys, $values);
 		}
@@ -1483,22 +1484,21 @@ class Builder {
 	}
 
 	/**
-	 * Get the columns that should be used in a list array.
+	 * Get the columns that should be used in a list array without their prefixes (if any).
 	 *
-	 * @param  string  $column
-	 * @param  string  $key
+	 * @param  array  $select
 	 * @return array
 	 */
-	protected function getListSelect($column, $key)
+	protected function removeTablePrefixes($select)
 	{
-		$select = is_null($key) ? array($column) : array($column, $key);
-
-		// If the selected column contains a "dot", we will remove it so that the list
+		// If the selected fields contain a "dot", we will remove it so that the list
 		// operation can run normally. Specifying the table is not needed, since we
 		// really want the names of the columns as it is in this resulting array.
-		if (($dot = strpos($select[0], '.')) !== false)
-		{
-			$select[0] = substr($select[0], $dot + 1);
+		foreach($select as &$field) {
+			if (($dot = strpos($field, '.')) !== false)
+			{
+				$field = substr($field, $dot + 1);
+			}
 		}
 
 		return $select;


### PR DESCRIPTION
Currently, table prefixes on column names are removed when calling `lists()`. Thus when joining two tables which share column names, e.g., `id`, one cannot specify which `id` to select while using `lists()` without also including a `select()`. See the discussion at #1069, for example. This PR aims to fix that.
#### The Problem

Assume a table `house` with columns `id`, `owner_id`, and `name`. Assume a second table `owner` with columns `id` and `name`. The following query is an intuitive use of `lists`, but in Laravel 4.2 and earlier will cause MySQL to complain about ambiguous columns.

``` php
DB::table('house')->join('owner', 'owner_id', '=', 'owner.id')->lists('house.id');
```

A more useful version getting a key/val of house ID/owner name likewise fails:

``` php
DB::table('house')->join('owner', 'owner_id', '=', 'owner.id')->lists('house.id', 'owner.name');
```
#### The Hack

The current solution as described by @guilex is to include a separate `select()`, as so:

``` php
DB::table('house')->join('owner', 'owner_id', '=', 'owner.id')
    ->select('house.id', 'owner.name')
    ->lists('id', 'name');
```

It's not the end of the world, but it's somewhat annoying and certainly not intuitive.
#### The Solution

The only reason the table prefix is removed is so that Laravel can access the correct keys in the resulting collection after the query is made. What I've done in this PR is basically just remove the table prefixes after making the query instead of before, so that both Laravel and the DB know which columns you're referring to. I've also made it handle `$column` and `$key` identically so that table prefixes can be used on either. Since the job of `Builder::getListSelect()` changed to be only removing the prefixes, I took the liberty of changing its name to `removeTablePrefixes`. It wasn't used by any other methods, so that shouldn't cause any trouble.
