### PR TITLE
Messed up Mailer (Introduced by 4.1 -> 4.2)

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -127,7 +127,7 @@ class Mailer {
 	 * @param  string|array  $view
 	 * @param  array  $data
 	 * @param  Closure|string  $callback
-	 * @return int
+	 * @return void
 	 */
 	public function send($view, array $data, $callback)
 	{
@@ -147,7 +147,7 @@ class Mailer {
 
 		$message = $message->getSwiftMessage();
 
-		return $this->sendSwiftMessage($message);
+		$this->sendSwiftMessage($message);
 	}
 
 	/**


### PR DESCRIPTION
In 4.1 it was possible returning a count of sent emails from Mail::send().
In 4.2 you'll always get null returned. 
(`Mail::send()` is now returning the `void` method `sendSwiftMessage()`)

> `sendSwiftMessage()` was returning a count of sent emails in 4.1

If that was intended the send method needs an update which I'm providing with this pull request.
Anyways I hope it was not and the `send()` method will return the count of sent emails again in future. (Was using this feature and liked it alot)

**EDIT**
This Pull Request is just fixing a wrong PHPDoc block for `Mail::send()`. Please don't get confused by my writing above :-)
