### PR TITLE
[Proposal] SASL authentication in MemcachedConnector

### DIFF
--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -28,8 +28,7 @@ class CacheServiceProvider extends ServiceProvider {
 			return $app['cache']->driver();
 		});
 
-		$app = $this->app;
-		$this->app->bindShared('memcached.connector', function() use ($app)
+		$this->app->bindShared('memcached.connector', function($app)
 		{
 			return new MemcachedConnector($app);
 		});

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -28,9 +28,10 @@ class CacheServiceProvider extends ServiceProvider {
 			return $app['cache']->driver();
 		});
 
-		$this->app->bindShared('memcached.connector', function()
+		$app = $this->app;
+		$this->app->bindShared('memcached.connector', function() use ($app)
 		{
-			return new MemcachedConnector;
+			return new MemcachedConnector($app);
 		});
 
 		$this->registerCommands();

--- a/src/Illuminate/Cache/MemcachedConnector.php
+++ b/src/Illuminate/Cache/MemcachedConnector.php
@@ -5,6 +5,24 @@ use Memcached;
 class MemcachedConnector {
 
 	/**
+	 * The application instance.
+	 *
+	 * @var \Illuminate\Foundation\Application
+	 */
+	protected $app;
+
+	/**
+	 * Create a memcached connector instance.
+	 *
+	 * @param  \Illuminate\Foundation\Application  $app
+	 * @return void
+	 */
+	public function __construct($app)
+	{
+		$this->app = $app;
+	}
+
+	/**
 	 * Create a new Memcached connection.
 	 *
 	 * @param array  $servers
@@ -15,6 +33,18 @@ class MemcachedConnector {
 	public function connect(array $servers)
 	{
 		$memcached = $this->getMemcached();
+
+		if (!empty($this->app['config']['cache.memcached_options'])) {
+			$memcached->setOptions($this->app['config']['cache.memcached_options']);
+		}
+
+		if (!empty($this->app['config']['cache.memcached_sasl.username'])
+			&& !empty($this->app['config']['cache.memcached_sasl.password'])) {
+			$memcached->setSaslAuthData(
+				$this->app['config']['cache.memcached_sasl.username'],
+				$this->app['config']['cache.memcached_sasl.password']
+			);
+		}
 
 		// For each server in the array, we'll just extract the configuration and add
 		// the server to the Memcached connection. Once we have added all of these
@@ -43,5 +73,4 @@ class MemcachedConnector {
 	{
 		return new Memcached;
 	}
-
 }

--- a/src/Illuminate/Cache/MemcachedConnector.php
+++ b/src/Illuminate/Cache/MemcachedConnector.php
@@ -73,4 +73,5 @@ class MemcachedConnector {
 	{
 		return new Memcached;
 	}
+
 }

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -3,6 +3,18 @@
 use Mockery as m;
 
 class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase {
+	/**
+	 * app mock
+	 * @var array
+	 */
+	protected $app;
+
+
+	public function setUp()
+	{
+		$this->app = [];
+	}
+
 
 	public function tearDown()
 	{
@@ -12,10 +24,12 @@ class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase {
 
 	public function testServersAreAddedCorrectly()
 	{
-		$connector = $this->getMock('Illuminate\Cache\MemcachedConnector', array('getMemcached'));
+		$connector = $this->getMock('Illuminate\Cache\MemcachedConnector', array('getMemcached'), array($this->app));
 		$memcached = m::mock('stdClass');
 		$memcached->shouldReceive('addServer')->once()->with('localhost', 11211, 100);
 		$memcached->shouldReceive('getVersion')->once()->andReturn(true);
+		$memcached->shouldReceive('setOptions')->never();
+		$memcached->shouldReceive('setSaslAuthData')->never();
 		$connector->expects($this->once())->method('getMemcached')->will($this->returnValue($memcached));
 		$result = $connector->connect(array(array('host' => 'localhost', 'port' => 11211, 'weight' => 100)));
 
@@ -28,7 +42,7 @@ class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testExceptionThrownOnBadConnection()
 	{
-		$connector = $this->getMock('Illuminate\Cache\MemcachedConnector', array('getMemcached'));
+		$connector = $this->getMock('Illuminate\Cache\MemcachedConnector', array('getMemcached'), array($this->app));
 		$memcached = m::mock('stdClass');
 		$memcached->shouldReceive('addServer')->once()->with('localhost', 11211, 100);
 		$memcached->shouldReceive('getVersion')->once()->andReturn(false);
@@ -36,4 +50,48 @@ class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase {
 		$result = $connector->connect(array(array('host' => 'localhost', 'port' => 11211, 'weight' => 100)));
 	}
 
+	/**
+	 *
+	 */
+	public function testSetOptionToMemcached()
+	{
+		$app = [
+			'config' => [
+				'cache.memcached_options' => [
+					Memcached::OPT_BINARY_PROTOCOL => true,
+				],
+			],
+		];
+
+		$connector = $this->getMock('Illuminate\Cache\MemcachedConnector', array('getMemcached'), array($app));
+		$memcached = m::mock('stdClass');
+		$memcached->shouldReceive('addServer')->once()->with('localhost', 11211, 100);
+		$memcached->shouldReceive('getVersion')->once()->andReturn(true);
+		$memcached->shouldReceive('setOptions')->once();
+		$memcached->shouldReceive('setSaslAuthData')->never();
+		$connector->expects($this->once())->method('getMemcached')->will($this->returnValue($memcached));
+		$result = $connector->connect(array(array('host' => 'localhost', 'port' => 11211, 'weight' => 100)));
+	}
+
+	/**
+	 *
+	 */
+	public function testSetAuthDataToMemcached()
+	{
+		$app = [
+			'config' => [
+				'cache.memcached_sasl.username' => 'user',
+				'cache.memcached_sasl.password' => 'pass',
+			],
+		];
+
+		$connector = $this->getMock('Illuminate\Cache\MemcachedConnector', array('getMemcached'), array($app));
+		$memcached = m::mock('stdClass');
+		$memcached->shouldReceive('addServer')->once()->with('localhost', 11211, 100);
+		$memcached->shouldReceive('getVersion')->once()->andReturn(true);
+		$memcached->shouldReceive('setOptions')->never();
+		$memcached->shouldReceive('setSaslAuthData')->once()->with('user', 'pass');
+		$connector->expects($this->once())->method('getMemcached')->will($this->returnValue($memcached));
+		$result = $connector->connect(array(array('host' => 'localhost', 'port' => 11211, 'weight' => 100)));
+	}
 }

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -1,4 +1,9 @@
 <?php
+if (!class_exists('Memcached')) {
+	class Memcached {
+		const OPT_BINARY_PROTOCOL = 18;
+	}
+}
 
 use Mockery as m;
 
@@ -67,7 +72,7 @@ class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase {
 		$memcached = m::mock('stdClass');
 		$memcached->shouldReceive('addServer')->once()->with('localhost', 11211, 100);
 		$memcached->shouldReceive('getVersion')->once()->andReturn(true);
-		$memcached->shouldReceive('setOptions')->once();
+		$memcached->shouldReceive('setOptions')->once()->with([Memcached::OPT_BINARY_PROTOCOL => true]);
 		$memcached->shouldReceive('setSaslAuthData')->never();
 		$connector->expects($this->once())->method('getMemcached')->will($this->returnValue($memcached));
 		$result = $connector->connect(array(array('host' => 'localhost', 'port' => 11211, 'weight' => 100)));


### PR DESCRIPTION
This PR added SASL authentication support in MemcachedConnector.

I deployed Laravel application on Heroku. This application use Memcachier for session stored. (Memcachier is a memcached service.)

Memcachier is authenticated with SASL, but Laravel's MemcachedConnector don't support SASL Auth.

I made this PR.
## Usage

You add memcached options and sasl auth data in `cache.php`.

`memcached_options` key is memcached options.These are set by `Memcached#setOptions()`

`memcached_sasl` key is memcached sasl auth data.This section has two keys.`username` is a sasl username and `password` is a sasl password.

ex) `app/config/cache.php`

``` php
return [
    'driver' => 'memcached',
    'memcached' => [
        ['host' => 'memcached_host', 'port' => 11211, 'weight' => 100],
    ],
    'memcached_options' => [
        Memcached::OPT_BINARY_PROTOCOL => true,
    ],
    'memcached_sasl' => [
        'username' => 'sasl_user',
        'password' => 'sasl_pass',
    ],
];
```
