### PR TITLE
[4.2] Mail : add isPretending()

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -413,6 +413,16 @@ class Mailer {
 	}
 
 	/**
+	 * Check if the mailer is pretending to send messages.
+	 *
+	 * @return bool
+	 */
+	public function isPretending()
+	{
+		return $this->pretending;
+	}
+
+	/**
 	 * Get the view factory instance.
 	 *
 	 * @return \Illuminate\View\Factory


### PR DESCRIPTION
We cannot know if the mailer is "really" pretending by relying on the `pretend` value in the mail config.
Because at anytime, `Mail::pretend()`can also be used.

`isPretending()` allows to access this information
