### PR TITLE
Added a patterns method to the router that takes an array of patterns

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1216,6 +1216,20 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	}
 
 	/**
+	 * Set a group of global where patterns on all routes
+	 *
+	 * @param  array  $patterns
+	 * @return void
+	 */
+	public function patterns($patterns)
+	{
+		foreach ($patterns as $key => $pattern)
+		{
+			$this->pattern($key, $pattern);
+		}
+	}
+
+	/**
 	 * Call the given filter with the request and response.
 	 *
 	 * @param  string  $filter
@@ -1642,4 +1656,11 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		return $this->dispatch(Request::createFromBase($request));
 	}
 
+	/**
+	 * Get the global where patterns associated with this Router
+	 * @return array
+	 */
+	public function getPatterns() {
+		return $this->patterns;
+	}
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -722,6 +722,18 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRouterPatternSetting()
+	{
+		$router = $this->getRouter();
+		$router->pattern('test', 'pattern');
+		$this->assertEquals(array('test' => 'pattern'), $router->getPatterns());
+
+		$router = $this->getRouter();
+		$router->patterns(array('test' => 'pattern', 'test2' => 'pattern2'));
+		$this->assertEquals(array('test' => 'pattern', 'test2' => 'pattern2'), $router->getPatterns());
+	}
+
+
 	protected function getRouter()
 	{
 		return new Router(new Illuminate\Events\Dispatcher);


### PR DESCRIPTION
Based on the request by @ksdev-pl at #4744.

Instead of having to write Route::pattern() over and over again, you can now write Route::pattern() and pass it an array to do it more compactly. I added the patterns function instead of allowing pattern to accept an array, but I can change it if you believe it makes more sense just to have the one method.

```
Route::pattern('age', '[0-9]+');
Route::pattern('year', '[0-9]+');
```

Can now be written as 

```
Route::patterns(['age' => '[0-9]+', 'year' => '[0-9]+']);
```
