### PR TITLE
[Proposal] Added support for change column in Schema #4745 #895

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -103,9 +103,16 @@ class Blueprint {
 	 */
 	protected function addImpliedCommands()
 	{
-		if (count($this->columns) > 0 && ! $this->creating())
+		//compileAdd command to add columns
+		if (count($this->addedColumns()) > 0 && ! $this->creating())
 		{
 			array_unshift($this->commands, $this->createCommand('add'));
+		}
+
+		//compileChange command to modify columns
+		if (count($this->changedColumns()) > 0 && ! $this->creating())
+		{
+			array_unshift($this->commands, $this->createCommand('change'));
 		}
 
 		$this->addFluentIndexes();
@@ -814,7 +821,7 @@ class Blueprint {
 	}
 
 	/**
-	 * Get the columns that should be added.
+	 * Get the columns on the blueprint.
 	 *
 	 * @return array
 	 */
@@ -831,6 +838,30 @@ class Blueprint {
 	public function getCommands()
 	{
 		return $this->commands;
+	}
+
+	/**
+	 * Get the columns on the blueprint that should be added.
+	 *
+	 * @return array
+	 */
+	public function addedColumns()
+	{
+		return array_filter($this->columns, function($column) {
+			return !$column->change;
+		});
+	}
+
+	/**
+	 * Get the columns on the blueprint that should be changed.
+	 *
+	 * @return array
+	 */
+	public function changedColumns()
+	{
+		return array_filter($this->columns, function($column) {
+			return !!$column->change;
+		});
 	}
 
 }


### PR DESCRIPTION
This will allow doing the following:

```
Schema::table('tests', function($table) {
    $table->string('name')->nullable()->change();
});
```

New function `compileChange` enables changing columns in MySQL grammar. Similar implementation can be easily added to sqlite, sqlserver and postgres.
