### PR TITLE
Schema migration status

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -1,0 +1,96 @@
+<?php namespace Illuminate\Database\Console\Migrations;
+
+use Illuminate\Database\Migrations\Migrator;
+use Symfony\Component\Console\Input\InputOption;
+
+class StatusCommand extends BaseCommand {
+
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'migrate:status';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Show a list of migrations up/down';
+
+	/**
+	 * The migrator instance.
+	 *
+	 * @var \Illuminate\Database\Migrations\Migrator
+	 */
+	protected $migrator;
+
+	/**
+	 * Create a new migration rollback command instance.
+	 *
+	 * @param  \Illuminate\Database\Migrations\Migrator $migrator
+	 * @return \Illuminate\Database\Console\Migrations\StatusCommand
+	 */
+	public function __construct(Migrator $migrator)
+	{
+		parent::__construct();
+
+		$this->migrator = $migrator;
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return void
+	 */
+	public function fire()
+	{
+		$this->migrator->setConnection($this->input->getOption('database'));
+
+		$this->output->writeln(" Status   Migration Name ");
+		$this->output->writeln("--------------------------------------------");
+
+		$versions = $this->migrator->getRepository()->getRan();
+		$migrationFiles = $this->migrator->getMigrationFiles($this->getMigrationPath());
+
+		foreach ($migrationFiles as $migration)
+		{
+			if (in_array($migration, $versions))
+			{
+				$status = "   <info>up</info>  ";
+				unset($versions[array_search($migration, $versions)]);
+			}
+			else
+			{
+				$status = "  <error>down</error> ";
+			}
+
+			$this->output->writeln("{$status}   <comment>{$migration}</comment>");
+		}
+
+		foreach ($versions as $missing)
+		{
+			$this->output->writeln("   <error>up</error>     {$missing} <error>*** MISSING ***</error>");
+		}
+	}
+
+	/**
+	 * Get the console command options.
+	 *
+	 * @return array
+	 */
+	protected function getOptions()
+	{
+		return array(
+			array('bench', null, InputOption::VALUE_OPTIONAL, 'The name of the workbench to migrate.', null),
+
+			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+
+			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to migration files.', null),
+
+			array('package', null, InputOption::VALUE_OPTIONAL, 'The package to migrate.', null),
+		);
+	}
+
+}

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Console\Migrations\InstallCommand;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Database\Console\Migrations\RollbackCommand;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
+use Illuminate\Database\Console\Migrations\StatusCommand;
 use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 
 class MigrationServiceProvider extends ServiceProvider {
@@ -77,7 +78,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerCommands()
 	{
-		$commands = array('Migrate', 'Rollback', 'Reset', 'Refresh', 'Install', 'Make');
+		$commands = array('Migrate', 'Rollback', 'Reset', 'Refresh', 'Install', 'Make', 'Status');
 
 		// We'll simply spin through the list of commands that are migration related
 		// and register each one of them with an application container. They will
@@ -93,7 +94,8 @@ class MigrationServiceProvider extends ServiceProvider {
 		$this->commands(
 			'command.migrate', 'command.migrate.make',
 			'command.migrate.install', 'command.migrate.rollback',
-			'command.migrate.reset', 'command.migrate.refresh'
+			'command.migrate.reset', 'command.migrate.refresh',
+            'command.migrate.status'
 		);
 	}
 
@@ -151,6 +153,14 @@ class MigrationServiceProvider extends ServiceProvider {
 		});
 	}
 
+    protected function registerStatusCommand()
+    {
+        $this->app->bindShared('command.migrate.status', function($app)
+        {
+            return new StatusCommand($app['migrator']);
+        });
+    }
+
 	/**
 	 * Register the "install" migration command.
 	 *
@@ -165,7 +175,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	}
 
 	/**
-	 * Register the "install" migration command.
+	 * Register the "make" migration command.
 	 *
 	 * @return void
 	 */
@@ -200,7 +210,8 @@ class MigrationServiceProvider extends ServiceProvider {
 			'migrator', 'migration.repository', 'command.migrate',
 			'command.migrate.rollback', 'command.migrate.reset',
 			'command.migrate.refresh', 'command.migrate.install',
-			'migration.creator', 'command.migrate.make',
+            'command.migrate.status', 'migration.creator',
+            'command.migrate.make',
 		);
 	}
 

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -95,7 +95,7 @@ class MigrationServiceProvider extends ServiceProvider {
 			'command.migrate', 'command.migrate.make',
 			'command.migrate.install', 'command.migrate.rollback',
 			'command.migrate.reset', 'command.migrate.refresh',
-            'command.migrate.status'
+			'command.migrate.status'
 		);
 	}
 
@@ -153,13 +153,13 @@ class MigrationServiceProvider extends ServiceProvider {
 		});
 	}
 
-    protected function registerStatusCommand()
-    {
-        $this->app->bindShared('command.migrate.status', function($app)
-        {
-            return new StatusCommand($app['migrator']);
-        });
-    }
+	protected function registerStatusCommand()
+	{
+		$this->app->bindShared('command.migrate.status', function($app)
+		{
+			return new StatusCommand($app['migrator']);
+		});
+	}
 
 	/**
 	 * Register the "install" migration command.
@@ -210,8 +210,8 @@ class MigrationServiceProvider extends ServiceProvider {
 			'migrator', 'migration.repository', 'command.migrate',
 			'command.migrate.rollback', 'command.migrate.reset',
 			'command.migrate.refresh', 'command.migrate.install',
-            'command.migrate.status', 'migration.creator',
-            'command.migrate.make',
+			'command.migrate.status', 'migration.creator',
+			'command.migrate.make',
 		);
 	}
 


### PR DESCRIPTION
This will allow you to run `migrate:status` and see migrations that have already migrated and those which haven't. The code is based on code from https://github.com/davedevelopment/phpmig.

```
$ artisan migrate:status

 Status   Migration Name
--------------------------------------------
   up     2014_05_12_112556_AddUsersTable
  down    2014_06_19_110125_AddGuessTable
   up     2014_06_18_220416_AddOauthTable *** MISSING ***
```
