### PR TITLE
Fix routes.php including for PHP Unit testing

### DIFF
--- a/src/Illuminate/Foundation/start.php
+++ b/src/Illuminate/Foundation/start.php
@@ -236,7 +236,7 @@ $app->booted(function() use ($app, $env)
 
 	$path = $app['path'].'/start/global.php';
 
-	if (file_exists($path)) require $path;
+	if (file_exists($path)) require_once $path;
 
 	/*
 	|--------------------------------------------------------------------------
@@ -251,7 +251,7 @@ $app->booted(function() use ($app, $env)
 
 	$path = $app['path']."/start/{$env}.php";
 
-	if (file_exists($path)) require $path;
+	if (file_exists($path)) require_once $path;
 	
 	/*
 	|--------------------------------------------------------------------------
@@ -266,6 +266,6 @@ $app->booted(function() use ($app, $env)
 
 	$routes = $app['path'].'/routes.php';
 
-	if (file_exists($routes)) require $routes;
+	if (file_exists($routes)) require_once $routes;
 
 });


### PR DESCRIPTION
Running tests with PHPUnit having the 'require' instead of the 'require_once' causes to include multiple times routes.php and the global/local bootstrap files, generating errors if there are functions declared in it (Cannot redeclare..)
