### PR TITLE
More DRY e() helper & consistent html entities in HtmlBuilder

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -195,7 +195,7 @@ class FormBuilder {
 
 		$options = $this->html->attributes($options);
 
-		$value = e($this->formatLabel($name, $value));
+		$value = $this->html->entities($this->formatLabel($name, $value));
 
 		return '<label for="'.$name.'"'.$options.'>'.$value.'</label>';
 	}
@@ -349,7 +349,7 @@ class FormBuilder {
 		// the element. Then we'll create the final textarea elements HTML for us.
 		$options = $this->html->attributes($options);
 
-		return '<textarea'.$options.'>'.e($value).'</textarea>';
+		return '<textarea'.$options.'>'.$this->html->entities($value).'</textarea>';
 	}
 
 	/**
@@ -516,7 +516,7 @@ class FormBuilder {
 			$html[] = $this->option($display, $value, $selected);
 		}
 
-		return '<optgroup label="'.e($label).'">'.implode('', $html).'</optgroup>';
+		return '<optgroup label="'.$this->html->entities($label).'">'.implode('', $html).'</optgroup>';
 	}
 
 	/**
@@ -531,9 +531,9 @@ class FormBuilder {
 	{
 		$selected = $this->getSelectedValue($value, $selected);
 
-		$options = array('value' => e($value), 'selected' => $selected);
+		$options = array('value' => $this->html->entities($value), 'selected' => $selected);
 
-		return '<option'.$this->html->attributes($options).'>'.e($display).'</option>';
+		return '<option'.$this->html->attributes($options).'>'.$this->html->entities($display).'</option>';
 	}
 
 	/**

--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -282,7 +282,7 @@ class HtmlBuilder {
 		}
 		else
 		{
-			return '<li>'.e($value).'</li>';
+			return '<li>'.$this->entities($value).'</li>';
 		}
 	}
 
@@ -340,7 +340,7 @@ class HtmlBuilder {
 	{
 		if (is_numeric($key)) $key = $value;
 
-		if ( ! is_null($value)) return $key.'="'.e($value).'"';
+		if ( ! is_null($value)) return $key.'="'.$this->entities($value).'"';
 	}
 
 	/**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -621,7 +621,7 @@ if ( ! function_exists('e'))
 	 */
 	function e($value)
 	{
-		return htmlentities($value, ENT_QUOTES, 'UTF-8', false);
+		return app('html')->entities($value);
 	}
 }
 

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -245,7 +245,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 
 		$callback = function($matches)
 		{
-			return '<?php echo e('.$this->compileEchoDefaults($matches[1]).'); ?>';
+			return "<?php echo \$app['html']->entities(".$this->compileEchoDefaults($matches[1]).'); ?>';
 		};
 
 		return preg_replace_callback($pattern, $callback, $value);

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -83,7 +83,7 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 	public function testEchosAreCompiled()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
-		$this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{{$name}}}'));
+		$this->assertEquals("<?php echo \$app['html']->entities(\$name); ?>", $compiler->compileString('{{{$name}}}'));
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{$name}}'));
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{ $name }}'));
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{
@@ -147,7 +147,7 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
 		$compiler->setEscapedContentTags('{{', '}}');
 		$compiler->setContentTags('{{{', '}}}');
-		$this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{$name}}'));
+		$this->assertEquals("<?php echo \$app['html']->entities(\$name); ?>", $compiler->compileString('{{$name}}'));
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{{$name}}}'));
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{{ $name }}}'));
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{{
@@ -378,7 +378,7 @@ breeze
 		$compiler->setContentTags('[[', ']]');
 		$compiler->setEscapedContentTags('[[[', ']]]');
 
-		$this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('[[[ $name ]]]'));
+		$this->assertEquals("<?php echo \$app['html']->entities(\$name); ?>", $compiler->compileString('[[[ $name ]]]'));
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('[[ $name ]]'));
 		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('[[
 			$name


### PR DESCRIPTION
See Issue #4782.

The changes away from `e()` are to prevent failing tests. With `e()` depending on `app('html')`, tests for the html/form builder classes and the blade view compiler class will complain that `App::make` doesn't exist. `HtmlBuilder` and `FormBuilder` fix is easy, because `HtmlBuilder::entities()` is readily available (`FormBuilder::$html` is an instance of `HtmlBuilder`). For escapes compiled by blade, the `HtmlBuilder` can be retrieved with `$app['html']` (which required editing some tests to change expectations to not include the `e()` helper). 
