### PR TITLE
[Cache] get() return null when forgetting

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -71,7 +71,9 @@ class DatabaseStore implements StoreInterface {
 
 			if (time() >= $cache->expiration)
 			{
-				return $this->forget($key);
+				$this->forget($key);
+
+				return null;
 			}
 
 			return $this->encrypter->decrypt($cache->value);

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -63,7 +63,9 @@ class FileStore implements StoreInterface {
 		// this directory much cleaner for us as old files aren't hanging out.
 		if (time() >= $expire)
 		{
-			return $this->forget($key);
+			$this->forget($key);
+
+			return null;
 		}
 
 		return unserialize(substr($contents, 10));


### PR DESCRIPTION
`forget($key)` now returns true/false instead of void, so if `get($key)` is called and the cache is expired, true/false is returned instead of null as it should.
