### PR TITLE
Fix very minor docblock spelling issue

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -177,7 +177,7 @@ class Request extends SymfonyRequest {
 	}
 
 	/**
-	 * Determine if the request contains a non-emtpy value for an input item.
+	 * Determine if the request contains a non-empty value for an input item.
 	 *
 	 * @param  string|array  $key
 	 * @return bool


### PR DESCRIPTION
`emtpy` => `empty`
