### PR TITLE
Return true only if an update is written back to the database

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1440,9 +1440,9 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 				$this->setKeysForSaveQuery($query)->update($dirty);
 
 				$this->fireModelEvent('updated', false);
+
+				return true;
 			}
-			
-			return true;
 		}
 
 		return false;


### PR DESCRIPTION
The present implementation will return true if there were fields changed on the model, but some observers changed the values before before being written to the database.

This implementation ensures that TRUE is only returned when a change has actually taken place
