### PR TITLE
Fix handling of internal requests

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -958,6 +958,10 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	{
 		$this->currentRequest = $request;
 
+		$app = app();
+		$mainRequest = $app['request'];
+		$app['request'] = $request;
+
 		// If no response was returned from the before filter, we will call the proper
 		// route instance to get the response. If no route is found a response will
 		// still get returned based on why no routes were found for this request.
@@ -967,6 +971,8 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		{
 			$response = $this->dispatchToRoute($request);
 		}
+
+		$app['request'] = $mainRequest;
 
 		$response = $this->prepareResponse($request, $response);
 


### PR DESCRIPTION
When I want to call a route from another route, I do:

```
Route::get('test', function() {
    $request = Request::create('/api-uri', 'GET', ['param1' => 'value1']);

    return Route::dispatch($request)->getContent();
});
```

In doing this, a new Request is created (with Symfony as UserAgent) but if I use the Input facade in my controller, the Request accessed by the `get` method is the main request, the one pointing to the `/test`URI.
So I think that the `dispatch` function on the Router should store the main Request, change the request on the app container to the new one, call the Controller method, and then put back the original request.
