### PR TITLE
Prevent a fatal error if Router->current is empty

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1554,6 +1554,8 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	public function currentRouteAction()
 	{
+		if (!$this->current()) return null;
+		
 		$action = $this->current()->getAction();
 
 		return isset($action['controller']) ? $action['controller'] : null;

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1554,7 +1554,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	public function currentRouteAction()
 	{
-		if (!$this->current()) return null;
+		if (!$this->current()) return;
 		
 		$action = $this->current()->getAction();
 


### PR DESCRIPTION
Prevents a fatal error ("Call to a member function getAction() on a non-object") if currentRouteAction() is called and there is no current route.  This adds code that is similar to a check found in `currentRouteName()`.  I've run into this error when other packages try to use `currentRouteAction()` and the current request is being handled by a `before()` filter.
