### PR TITLE
[bugfix] Fixes a bug introduced by #4773

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1414,7 +1414,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Perform a model update operation.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $query
-	 * @return bool
+	 * @return bool|null
 	 */
 	protected function performUpdate(Builder $query)
 	{
@@ -1449,11 +1449,9 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 				$this->fireModelEvent('updated', false);
 			}
-			
+
 			return true;
 		}
-
-		return false;
 	}
 
 	/**


### PR DESCRIPTION
#4773 introduced an issue by returning false if the model is clean, which makes it difficult to distinguish between a cancelled update vs a clean model with nothing changed.

This change doesn't affect the parent touching bug that was fixed by the PR mentioned above.
