### PR TITLE
Use nested where for where arrays

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -385,13 +385,17 @@ class Builder {
 	{
 		// If the column is an array, we will assume it is an array of key-value pairs
 		// and can add them each as a where clause. We will maintain the boolean we
-		// received when the method was called and pass it onto the other wheres.
+		// received when the method was called and pass it into the nested where.
 		if (is_array($column))
 		{
-			foreach ($column as $innerKey => $innerValue)
+			$this->whereNested(function($query) use($column)
 			{
-				$this->where($innerKey, '=', $innerValue, $boolean);
-			}
+				foreach ($column as $key => $value)
+				{
+					$query->where($key, '=', $value);
+				}
+
+			}, $boolean);
 
 			return $this;
 		}


### PR DESCRIPTION
I think the way it is currently set up is counter intuitive. Take the following piece of code as an example:

``` php
$attributes1 = ['fname' => 'Taylor', 'lname' => 'Otwell'];
$attributes2 = ['fname' => 'Joseph', 'lname' => 'Silber'];

$users = User::where($attributes1)->orWhere($attributes2)->get();
```

With the way it is currently set up, this'll run the following query:

``` sql
select *
from `users`
where `fname` = 'Taylor' and `lname` = 'Otwell'
or `fname` = 'Joseph' or `lname` = 'Silber'
```

I think this is obviously wrong.

After the PR, the code above will run this query:

``` sql
select *
from `users`
where (`fname` = 'Taylor' and `lname` = 'Otwell')
or (`fname` = 'Joseph' and `lname` = 'Silber')
```
