### PR TITLE
[4.2] Route : provides HEAD when GET is set in Route::match()

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -680,6 +680,11 @@ class Route {
 	 */
 	public function methods()
 	{
+		if (in_array('GET', $this->methods) && ! in_array('HEAD', $this->methods))
+		{
+			$this->methods[] = 'HEAD';
+		}
+
 		return $this->methods;
 	}
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -142,7 +142,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	public function get($uri, $action)
 	{
-		return $this->addRoute(array('GET', 'HEAD'), $uri, $action);
+		return $this->addRoute('GET', $uri, $action);
 	}
 
 	/**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -89,6 +89,35 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testHeadDispatcher()
+	{
+		$router = $this->getRouter();
+		$router->match(['GET', 'POST'], 'foo', function () { return 'bar'; });
+
+		$response = $router->dispatch(Request::create('foo', 'OPTIONS'));
+		$this->assertEquals(200, $response->getStatusCode());
+		$this->assertEquals('GET,HEAD,POST', $response->headers->get('Allow'));
+
+		$response = $router->dispatch(Request::create('foo', 'HEAD'));
+		$this->assertEquals(200, $response->getStatusCode());
+		$this->assertEquals('', $response->getContent());
+
+		$router = $this->getRouter();
+		$router->match(['GET'], 'foo', function () { return 'bar'; });
+
+		$response = $router->dispatch(Request::create('foo', 'OPTIONS'));
+		$this->assertEquals(200, $response->getStatusCode());
+		$this->assertEquals('GET,HEAD', $response->headers->get('Allow'));
+
+		$router = $this->getRouter();
+		$router->match(['POST'], 'foo', function () { return 'bar'; });
+
+		$response = $router->dispatch(Request::create('foo', 'OPTIONS'));
+		$this->assertEquals(200, $response->getStatusCode());
+		$this->assertEquals('POST', $response->headers->get('Allow'));
+	}
+
+
 	public function testNonGreedyMatches()
 	{
 		$route = new Route('GET', 'images/{id}.{ext}', function() {});


### PR DESCRIPTION
This ensures that `HEAD` method is also taken in consideration when `GET` method is set in `Route::match()`.

This way, these two routes declarations also provide a `HEAD` method.

``` php
Route::get('foo', function() { return 'bar'; });
Route::match(['GET'], 'foo', function() { return 'bar'; });
```
