### PR TITLE
update to pheanstalk 3.0.0 (PSR-4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
     "require-dev": {
         "aws/aws-sdk-php": "~2.6",
         "iron-io/iron_mq": "~1.5",
-        "pda/pheanstalk": "~2.1",
+        "pda/pheanstalk": "~3.0",
         "mockery/mockery": "~0.9",
         "phpunit/phpunit": "~4.0"
     },

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Queue;
 
-use Pheanstalk\Job as PheanstalkJob;
 use Pheanstalk\Pheanstalk;
+use Pheanstalk\Job as PheanstalkJob;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
 
 class BeanstalkdQueue extends Queue implements QueueInterface {

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Queue;
 
-use Pheanstalk\Job as Pheanstalk_Job;
-use Pheanstalk\Pheanstalk as Pheanstalk;
+use Pheanstalk\Job as PheanstalkJob;
+use Pheanstalk\Pheanstalk;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
 
 class BeanstalkdQueue extends Queue implements QueueInterface {
@@ -100,7 +100,7 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 
 		$job = $this->pheanstalk->watchOnly($queue)->reserve(0);
 
-		if ($job instanceof Pheanstalk_Job)
+		if ($job instanceof PheanstalkJob)
 		{
 			return new BeanstalkdJob($this->container, $this->pheanstalk, $job, $queue);
 		}

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Queue;
 
-use Pheanstalk_Job;
-use Pheanstalk_Pheanstalk as Pheanstalk;
+use Pheanstalk\Job as Pheanstalk_Job;
+use Pheanstalk\Pheanstalk as Pheanstalk;
 use Illuminate\Queue\Jobs\BeanstalkdJob;
 
 class BeanstalkdQueue extends Queue implements QueueInterface {

--- a/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
+++ b/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Queue\Connectors;
 
 use Illuminate\Queue\BeanstalkdQueue;
-use Pheanstalk_Pheanstalk as Pheanstalk;
+use Pheanstalk\Pheanstalk as Pheanstalk;
 
 class BeanstalkdConnector implements ConnectorInterface {
 

--- a/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
+++ b/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Queue\Connectors;
 
 use Illuminate\Queue\BeanstalkdQueue;
-use Pheanstalk\Pheanstalk as Pheanstalk;
+use Pheanstalk\Pheanstalk;
 
 class BeanstalkdConnector implements ConnectorInterface {
 

--- a/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
+++ b/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
@@ -1,8 +1,8 @@
 <?php namespace Illuminate\Queue\Jobs;
 
-use Pheanstalk_Job;
 use Illuminate\Container\Container;
-use Pheanstalk_Pheanstalk as Pheanstalk;
+use Pheanstalk\Job as Pheanstalk_Job;
+use Pheanstalk\Pheanstalk as Pheanstalk;
 
 class BeanstalkdJob extends Job {
 

--- a/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
+++ b/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
@@ -1,8 +1,8 @@
 <?php namespace Illuminate\Queue\Jobs;
 
 use Illuminate\Container\Container;
-use Pheanstalk\Job as Pheanstalk_Job;
-use Pheanstalk\Pheanstalk as Pheanstalk;
+use Pheanstalk\Job as PheanstalkJob;
+use Pheanstalk\Pheanstalk;
 
 class BeanstalkdJob extends Job {
 
@@ -16,7 +16,7 @@ class BeanstalkdJob extends Job {
 	/**
 	 * The Pheanstalk job instance.
 	 *
-	 * @var Pheanstalk_Job
+	 * @var PheanstalkJob
 	 */
 	protected $job;
 
@@ -25,13 +25,13 @@ class BeanstalkdJob extends Job {
 	 *
 	 * @param  \Illuminate\Container\Container  $container
 	 * @param  Pheanstalk  $pheanstalk
-	 * @param  Pheanstalk_Job  $job
+	 * @param  PheanstalkJob  $job
 	 * @param  string  $queue
 	 * @return void
 	 */
 	public function __construct(Container $container,
                                 Pheanstalk $pheanstalk,
-                                Pheanstalk_Job $job,
+                                PheanstalkJob $job,
                                 $queue)
 	{
 		$this->job = $job;
@@ -140,7 +140,7 @@ class BeanstalkdJob extends Job {
 	/**
 	 * Get the underlying Pheanstalk job.
 	 *
-	 * @return Pheanstalk_Job
+	 * @return PheanstalkJob
 	 */
 	public function getPheanstalkJob()
 	{

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -33,7 +33,7 @@ class QueueBeanstalkdJobTest extends PHPUnit_Framework_TestCase {
 	public function testReleaseProperlyReleasesJobOntoBeanstalkd()
 	{
 		$job = $this->getJob();
-		$job->getPheanstalk()->shouldReceive('release')->once()->with($job->getPheanstalkJob(), Pheanstalk_Pheanstalk::DEFAULT_PRIORITY, 0);
+		$job->getPheanstalk()->shouldReceive('release')->once()->with($job->getPheanstalkJob(), Pheanstalk\Pheanstalk::DEFAULT_PRIORITY, 0);
 
 		$job->release();
 	}
@@ -52,8 +52,8 @@ class QueueBeanstalkdJobTest extends PHPUnit_Framework_TestCase {
 	{
 		return new Illuminate\Queue\Jobs\BeanstalkdJob(
 			m::mock('Illuminate\Container\Container'),
-			m::mock('Pheanstalk_Pheanstalk'),
-			m::mock('Pheanstalk_Job'),
+			m::mock('Pheanstalk\Pheanstalk'),
+			m::mock('Pheanstalk\Job'),
 			'default'
 		);
 	}

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -12,7 +12,7 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testPushProperlyPushesJobOntoBeanstalkd()
 	{
-		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk_Pheanstalk'), 'default', 60);
+		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('useTube')->once()->with('stack')->andReturn($pheanstalk);
 		$pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
@@ -25,11 +25,11 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testDelayedPushProperlyPushesJobOntoBeanstalkd()
 	{
-		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk_Pheanstalk'), 'default', 60);
+		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('useTube')->once()->with('stack')->andReturn($pheanstalk);
 		$pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
-		$pheanstalk->shouldReceive('put')->twice()->with(json_encode(array('job' => 'foo', 'data' => array('data'))), Pheanstalk_Pheanstalk::DEFAULT_PRIORITY, 5, Pheanstalk_Pheanstalk::DEFAULT_TTR);
+		$pheanstalk->shouldReceive('put')->twice()->with(json_encode(array('job' => 'foo', 'data' => array('data'))), Pheanstalk\Pheanstalk::DEFAULT_PRIORITY, 5, Pheanstalk\Pheanstalk::DEFAULT_TTR);
 
 		$queue->later(5, 'foo', array('data'), 'stack');
 		$queue->later(5, 'foo', array('data'));
@@ -38,11 +38,11 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testPopProperlyPopsJobOffOfBeanstalkd()
 	{
-		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk_Pheanstalk'), 'default', 60);
+		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
 		$queue->setContainer(m::mock('Illuminate\Container\Container'));
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('watchOnly')->once()->with('default')->andReturn($pheanstalk);
-		$job = m::mock('Pheanstalk_Job');
+		$job = m::mock('Pheanstalk\Job');
 		$pheanstalk->shouldReceive('reserve')->once()->andReturn($job);
 
 		$result = $queue->pop();
@@ -53,7 +53,7 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testDeleteProperlyRemoveJobsOffBeanstalkd()
 	{
-		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk_Pheanstalk'), 'default', 60);
+		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
 		$pheanstalk->shouldReceive('delete')->once()->with(1);


### PR DESCRIPTION
Pheanstalk recently had a v3.0.0 release, which makes it PSR-4 compliant. This pull request makes Laravel compatible with Pheanstalk v3.0.0.
