### PR TITLE
[4.2] Cache: use available getPrefix() function instead of $this->prefix

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -37,7 +37,7 @@ class ApcStore extends TaggableStore implements StoreInterface {
 	 */
 	public function get($key)
 	{
-		$value = $this->apc->get($this->prefix.$key);
+		$value = $this->apc->get($this->getPrefix().$key);
 
 		if ($value !== false)
 		{
@@ -55,7 +55,7 @@ class ApcStore extends TaggableStore implements StoreInterface {
 	 */
 	public function put($key, $value, $minutes)
 	{
-		$this->apc->put($this->prefix.$key, $value, $minutes * 60);
+		$this->apc->put($this->getPrefix().$key, $value, $minutes * 60);
 	}
 
 	/**
@@ -67,7 +67,7 @@ class ApcStore extends TaggableStore implements StoreInterface {
 	 */
 	public function increment($key, $value = 1)
 	{
-		return $this->apc->increment($this->prefix.$key, $value);
+		return $this->apc->increment($this->getPrefix().$key, $value);
 	}
 
 	/**
@@ -79,7 +79,7 @@ class ApcStore extends TaggableStore implements StoreInterface {
 	 */
 	public function decrement($key, $value = 1)
 	{
-		return $this->apc->decrement($this->prefix.$key, $value);
+		return $this->apc->decrement($this->getPrefix().$key, $value);
 	}
 
 	/**
@@ -102,7 +102,7 @@ class ApcStore extends TaggableStore implements StoreInterface {
 	 */
 	public function forget($key)
 	{
-		$this->apc->delete($this->prefix.$key);
+		$this->apc->delete($this->getPrefix().$key);
 	}
 
 	/**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -58,7 +58,7 @@ class DatabaseStore implements StoreInterface {
 	 */
 	public function get($key)
 	{
-		$prefixed = $this->prefix.$key;
+		$prefixed = $this->getPrefix().$key;
 
 		$cache = $this->table()->where('key', '=', $prefixed)->first();
 
@@ -90,7 +90,7 @@ class DatabaseStore implements StoreInterface {
 	 */
 	public function put($key, $value, $minutes)
 	{
-		$key = $this->prefix.$key;
+		$key = $this->getPrefix().$key;
 
 		// All of the cached values in the database are encrypted in case this is used
 		// as a session data store by the consumer. We'll also calculate the expire
@@ -167,7 +167,7 @@ class DatabaseStore implements StoreInterface {
 	 */
 	public function forget($key)
 	{
-		$this->table()->where('key', '=', $this->prefix.$key)->delete();
+		$this->table()->where('key', '=', $this->getPrefix().$key)->delete();
 	}
 
 	/**

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -39,7 +39,7 @@ class MemcachedStore extends TaggableStore implements StoreInterface {
 	 */
 	public function get($key)
 	{
-		$value = $this->memcached->get($this->prefix.$key);
+		$value = $this->memcached->get($this->getPrefix().$key);
 
 		if ($this->memcached->getResultCode() == 0)
 		{
@@ -57,7 +57,7 @@ class MemcachedStore extends TaggableStore implements StoreInterface {
 	 */
 	public function put($key, $value, $minutes)
 	{
-		$this->memcached->set($this->prefix.$key, $value, $minutes * 60);
+		$this->memcached->set($this->getPrefix().$key, $value, $minutes * 60);
 	}
 
 	/**
@@ -69,7 +69,7 @@ class MemcachedStore extends TaggableStore implements StoreInterface {
 	 */
 	public function increment($key, $value = 1)
 	{
-		return $this->memcached->increment($this->prefix.$key, $value);
+		return $this->memcached->increment($this->getPrefix().$key, $value);
 	}
 
 	/**
@@ -81,7 +81,7 @@ class MemcachedStore extends TaggableStore implements StoreInterface {
 	 */
 	public function decrement($key, $value = 1)
 	{
-		return $this->memcached->decrement($this->prefix.$key, $value);
+		return $this->memcached->decrement($this->getPrefix().$key, $value);
 	}
 
 	/**
@@ -104,7 +104,7 @@ class MemcachedStore extends TaggableStore implements StoreInterface {
 	 */
 	public function forget($key)
 	{
-		$this->memcached->delete($this->prefix.$key);
+		$this->memcached->delete($this->getPrefix().$key);
 	}
 
 	/**

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -48,7 +48,7 @@ class RedisStore extends TaggableStore implements StoreInterface {
 	 */
 	public function get($key)
 	{
-		if ( ! is_null($value = $this->connection()->get($this->prefix.$key)))
+		if ( ! is_null($value = $this->connection()->get($this->getPrefix().$key)))
 		{
 			return is_numeric($value) ? $value : unserialize($value);
 		}
@@ -66,7 +66,7 @@ class RedisStore extends TaggableStore implements StoreInterface {
 	{
 		$value = is_numeric($value) ? $value : serialize($value);
 
-		$this->connection()->setex($this->prefix.$key, $minutes * 60, $value);
+		$this->connection()->setex($this->getPrefix().$key, $minutes * 60, $value);
 	}
 
 	/**
@@ -78,7 +78,7 @@ class RedisStore extends TaggableStore implements StoreInterface {
 	 */
 	public function increment($key, $value = 1)
 	{
-		return $this->connection()->incrby($this->prefix.$key, $value);
+		return $this->connection()->incrby($this->getPrefix().$key, $value);
 	}
 
 	/**
@@ -90,7 +90,7 @@ class RedisStore extends TaggableStore implements StoreInterface {
 	 */
 	public function decrement($key, $value = 1)
 	{
-		return $this->connection()->decrby($this->prefix.$key, $value);
+		return $this->connection()->decrby($this->getPrefix().$key, $value);
 	}
 
 	/**
@@ -104,7 +104,7 @@ class RedisStore extends TaggableStore implements StoreInterface {
 	{
 		$value = is_numeric($value) ? $value : serialize($value);
 
-		$this->connection()->set($this->prefix.$key, $value);
+		$this->connection()->set($this->getPrefix().$key, $value);
 	}
 
 	/**
@@ -115,7 +115,7 @@ class RedisStore extends TaggableStore implements StoreInterface {
 	 */
 	public function forget($key)
 	{
-		$this->connection()->del($this->prefix.$key);
+		$this->connection()->del($this->getPrefix().$key);
 	}
 
 	/**

--- a/src/Illuminate/Cache/WinCacheStore.php
+++ b/src/Illuminate/Cache/WinCacheStore.php
@@ -28,7 +28,7 @@ class WinCacheStore extends TaggableStore implements StoreInterface {
 	 */
 	public function get($key)
 	{
-		$value = wincache_ucache_get($this->prefix.$key);
+		$value = wincache_ucache_get($this->getPrefix().$key);
 
 		if ($value !== false)
 		{
@@ -46,7 +46,7 @@ class WinCacheStore extends TaggableStore implements StoreInterface {
 	 */
 	public function put($key, $value, $minutes)
 	{
-		wincache_ucache_set($this->prefix.$key, $value, $minutes * 60);
+		wincache_ucache_set($this->getPrefix().$key, $value, $minutes * 60);
 	}
 
 	/**
@@ -58,7 +58,7 @@ class WinCacheStore extends TaggableStore implements StoreInterface {
 	 */
 	public function increment($key, $value = 1)
 	{
-		return wincache_ucache_inc($this->prefix.$key, $value);
+		return wincache_ucache_inc($this->getPrefix().$key, $value);
 	}
 
 	/**
@@ -70,7 +70,7 @@ class WinCacheStore extends TaggableStore implements StoreInterface {
 	 */
 	public function decrement($key, $value = 1)
 	{
-		return wincache_ucache_dec($this->prefix.$key, $value);
+		return wincache_ucache_dec($this->getPrefix().$key, $value);
 	}
 
 	/**
@@ -93,7 +93,7 @@ class WinCacheStore extends TaggableStore implements StoreInterface {
 	 */
 	public function forget($key)
 	{
-		wincache_ucache_delete($this->prefix.$key);
+		wincache_ucache_delete($this->getPrefix().$key);
 	}
 
 	/**

--- a/src/Illuminate/Cache/XCacheStore.php
+++ b/src/Illuminate/Cache/XCacheStore.php
@@ -28,7 +28,7 @@ class XCacheStore extends TaggableStore implements StoreInterface {
 	 */
 	public function get($key)
 	{
-		$value = xcache_get($this->prefix.$key);
+		$value = xcache_get($this->getPrefix().$key);
 
 		if (isset($value))
 		{
@@ -46,7 +46,7 @@ class XCacheStore extends TaggableStore implements StoreInterface {
 	 */
 	public function put($key, $value, $minutes)
 	{
-		xcache_set($this->prefix.$key, $value, $minutes * 60);
+		xcache_set($this->getPrefix().$key, $value, $minutes * 60);
 	}
 
 	/**
@@ -58,7 +58,7 @@ class XCacheStore extends TaggableStore implements StoreInterface {
 	 */
 	public function increment($key, $value = 1)
 	{
-		return xcache_inc($this->prefix.$key, $value);
+		return xcache_inc($this->getPrefix().$key, $value);
 	}
 
 	/**
@@ -70,7 +70,7 @@ class XCacheStore extends TaggableStore implements StoreInterface {
 	 */
 	public function decrement($key, $value = 1)
 	{
-		return xcache_dec($this->prefix.$key, $value);
+		return xcache_dec($this->getPrefix().$key, $value);
 	}
 
 	/**
@@ -93,7 +93,7 @@ class XCacheStore extends TaggableStore implements StoreInterface {
 	 */
 	public function forget($key)
 	{
-		xcache_unset($this->prefix.$key);
+		xcache_unset($this->getPrefix().$key);
 	}
 
 	/**


### PR DESCRIPTION
Function `getPrefix()` is available and can be used to determine the prefixed key, instead of prepending `$this->prefix`.
