### PR TITLE
Add UTF-8 as the second argument to the mb_strlen() functions.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -105,7 +105,7 @@ class Str {
 	 */
 	public static function length($value)
 	{
-		return mb_strlen($value);
+		return mb_strlen($value, 'UTF-8');
 	}
 
 	/**
@@ -118,7 +118,7 @@ class Str {
 	 */
 	public static function limit($value, $limit = 100, $end = '...')
 	{
-		if (mb_strlen($value) <= $limit) return $value;
+		if (mb_strlen($value, 'UTF-8') <= $limit) return $value;
 
 		return rtrim(mb_substr($value, 0, $limit, 'UTF-8')).$end;
 	}


### PR DESCRIPTION
Str::length works fine in a laravel app but, when including illuminate/support in a custom app it returns the real value \* 2. (tested with greek chars)
