### PR TITLE
Add keyBy method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -206,6 +206,26 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Key an associative array by a field.
+	 *
+	 * @param  string  $keyBy
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function keyBy($keyBy)
+	{
+		$results = [];
+
+		foreach ($this->items as $item)
+		{
+			$key = data_get($item, $keyBy);
+
+			$results[$key] = $item;
+		}
+
+		return new static($results);
+	}
+
+	/**
 	 * Determine if an item exists in the collection by key.
 	 *
 	 * @param  mixed  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -368,6 +368,14 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testKeyByAttribute()
+	{
+		$data = new Collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);
+		$result = $data->keyBy('rating');
+		$this->assertEquals([1 => ['rating' => 1, 'name' => '1'], 2 => ['rating' => 2, 'name' => '2'], 3 => ['rating' => 3, 'name' => '3']], $result->all());
+	}
+
+
 	public function testGettingSumFromCollection()
 	{
 		$c = new Collection(array((object) array('foo' => 50), (object) array('foo' => 50)));


### PR DESCRIPTION
Adds a new `keyBy` method to `Illuminate\Support\Collection`, so that you can do something like this:

``` php
$roles = Role::all()->keyBy('name');
```

which would result in an array similar to this:

```
[
    'admin'  => ...model...,
    'editor' => ...model...,
    'user'   => ...model...,
]
```

For reference, [see this question on StackOverflow](http://stackoverflow.com/questions/24130507/eloquent-column-list-by-key-with-array-as-values).
