### PR TITLE
[bugfix] Database\Query\Builder::groupBy() now accepts arrays as arguments

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -168,7 +168,7 @@ class HasManyThrough extends Relation {
 	{
 		$dictionary = array();
 
-		$foreign = $this->farParent->getForeignKey();
+		$foreign = $this->firstKey;
 
 		// First we will create a dictionary of models keyed by the foreign key of the
 		// relationship as this will allow us to quickly access all of the related

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -973,7 +973,7 @@ class Builder {
 	 */
 	public function groupBy()
 	{
-		foreach(func_get_args() AS $arg)
+		foreach(func_get_args() as $arg)
 		{
 			$this->groups = array_merge((array) $this->groups, ((is_array($arg)) ? $arg:[$arg]));
 		}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -383,6 +383,20 @@ class Builder {
 	 */
 	public function where($column, $operator = null, $value = null, $boolean = 'and')
 	{
+		// If the column is an array, we will assume it is an array of key-value pairs
+		// and can add them each as a where clause. We will maintain the boolean we
+		// received when the method was called and pass it onto the other wheres.
+		if (is_array($column))
+		{
+			foreach ($column as $innerKey => $innerValue)
+			{
+				$this->where($innerKey, '=', $innerValue, $boolean);
+			}
+		}
+
+		// Here we will make some assumptions about the operator. If only 2 values are
+		// passed to the method, we will assume that the operator is an equals sign
+		// and keep going. Otherwise, we'll require the operator to be passed in.
 		if (func_num_args() == 2)
 		{
 			list($value, $operator) = array($operator, '=');

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -392,6 +392,8 @@ class Builder {
 			{
 				$this->where($innerKey, '=', $innerValue, $boolean);
 			}
+
+			return $this;
 		}
 
 		// Here we will make some assumptions about the operator. If only 2 values are

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -973,7 +973,10 @@ class Builder {
 	 */
 	public function groupBy()
 	{
-		$this->groups = array_merge((array) $this->groups, func_get_args());
+		foreach(func_get_args() AS $arg)
+		{
+			$this->groups = array_merge((array) $this->groups, ((is_array($arg)) ? $arg:[$arg]));
+		}
 
 		return $this;
 	}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -999,7 +999,10 @@ class Builder {
 	 */
 	public function groupBy()
 	{
-		$this->groups = array_merge((array) $this->groups, func_get_args());
+		foreach(func_get_args() AS $arg)
+		{
+			$this->groups = array_merge((array) $this->groups, ((is_array($arg)) ? $arg:[$arg]));
+		}
 
 		return $this;
 	}

--- a/src/Illuminate/Foundation/Console/AutoloadCommand.php
+++ b/src/Illuminate/Foundation/Console/AutoloadCommand.php
@@ -85,7 +85,7 @@ class AutoloadCommand extends Command {
 
 		if ( ! is_dir($workbench)) return array();
 
-		return Finder::create()->files()->in($workbench)->name('composer.json')->depth('< 3');
+		return Finder::create()->files()->followLinks()->in($workbench)->name('composer.json')->depth('< 3');
 	}
 
 }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -241,7 +241,7 @@ class Request extends SymfonyRequest {
 	{
 		$keys = is_array($keys) ? $keys : func_get_args();
 
-		return array_only($this->input(), $keys) + array_fill_keys($keys, null);
+		return array_only($this->all(), $keys) + array_fill_keys($keys, null);
 	}
 
 	/**
@@ -254,7 +254,7 @@ class Request extends SymfonyRequest {
 	{
 		$keys = is_array($keys) ? $keys : func_get_args();
 
-		$results = $this->input();
+		$results = $this->all();
 
 		foreach ($keys as $key) array_forget($results, $key);
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -177,7 +177,7 @@ class Request extends SymfonyRequest {
 	}
 
 	/**
-	 * Determine if the request contains a non-emtpy value for an input item.
+	 * Determine if the request contains a non-empty value for an input item.
 	 *
 	 * @param  string|array  $key
 	 * @return bool

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -241,7 +241,15 @@ class Request extends SymfonyRequest {
 	{
 		$keys = is_array($keys) ? $keys : func_get_args();
 
-		return array_only($this->input(), $keys) + array_fill_keys($keys, null);
+		$results = array();
+		$input = $this->input();
+
+		foreach ($keys as $key)
+		{
+			array_set($results, $key, array_get($input, $key, null));
+		}
+
+		return $results;
 	}
 
 	/**

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -131,7 +131,7 @@ class MailServiceProvider extends ServiceProvider {
 			extract($config);
 
 			// The Swift SMTP transport instance will allow us to use any SMTP backend
-			// for delivering mail such as Sendgrid, Amazon SMS, or a custom server
+			// for delivering mail such as Sendgrid, Amazon SES, or a custom server
 			// a developer has available. We will just pass this configured host.
 			$transport = SmtpTransport::newInstance($host, $port);
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1216,6 +1216,20 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	}
 
 	/**
+	 * Set a group of global where patterns on all routes
+	 *
+	 * @param  array  $patterns
+	 * @return void
+	 */
+	public function patterns($patterns)
+	{
+		foreach ($patterns as $key => $pattern)
+		{
+			$this->pattern($key, $pattern);
+		}
+	}
+
+	/**
 	 * Call the given filter with the request and response.
 	 *
 	 * @param  string  $filter
@@ -1642,4 +1656,11 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		return $this->dispatch(Request::createFromBase($request));
 	}
 
+	/**
+	 * Get the global where patterns associated with this Router
+	 * @return array
+	 */
+	public function getPatterns() {
+		return $this->patterns;
+	}
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1646,6 +1646,16 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	}
 
 	/**
+	 * Get the global "where" patterns.
+	 *
+	 * @return array
+	 */
+	public function getPatterns()
+	{
+		return $this->patterns;
+	}
+
+	/**
 	 * Get the response for a given request.
 	 *
 	 * @param  \Symfony\Component\HttpFoundation\Request  $request
@@ -1656,11 +1666,4 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		return $this->dispatch(Request::createFromBase($request));
 	}
 
-	/**
-	 * Get the global where patterns associated with this Router
-	 * @return array
-	 */
-	public function getPatterns() {
-		return $this->patterns;
-	}
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -424,6 +424,10 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->groupBy('id', 'email');
 		$this->assertEquals('select * from "users" group by "id", "email"', $builder->toSql());
+
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->groupBy(['id', 'email']);
+		$this->assertEquals('select * from "users" group by "id", "email"', $builder->toSql());
 	}
 
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -169,6 +169,10 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$request = Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 25));
 		$this->assertEquals(array('age' => 25), $request->only('age'));
 		$this->assertEquals(array('name' => 'Taylor', 'age' => 25), $request->only('name', 'age'));
+
+		$request = Request::create('/', 'GET', array('developer' => array('name' => 'Taylor', 'age' => 25)));
+		$this->assertEquals(array('developer' => array('age' => 25)), $request->only('developer.age'));
+		$this->assertEquals(array('developer' => array('name' => 'Taylor'), 'test' => null), $request->only('developer.name', 'test'));
 	}
 
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -722,6 +722,18 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRouterPatternSetting()
+	{
+		$router = $this->getRouter();
+		$router->pattern('test', 'pattern');
+		$this->assertEquals(array('test' => 'pattern'), $router->getPatterns());
+
+		$router = $this->getRouter();
+		$router->patterns(array('test' => 'pattern', 'test2' => 'pattern2'));
+		$this->assertEquals(array('test' => 'pattern', 'test2' => 'pattern2'), $router->getPatterns());
+	}
+
+
 	protected function getRouter()
 	{
 		return new Router(new Illuminate\Events\Dispatcher);


### PR DESCRIPTION
I'm not actually sure whether this is a bug or a new feature. I am presuming this is a bug-fix only because the comment above the function definition for Database\Query\Builder::groupBy() says that the $columns parameter is "dynamic". I'm presuming that means it is of dynamic individual argument type (assuming array or string) and dynamic length of arguments. See [this stack overflow post for a full description of the issue](http://stackoverflow.com/questions/23185432/group-by-multiple-columns-in-laravel/24415397#24415397) for more detail.

In any case, if Database\Query\Builder::groupBy() could accept arrays as is proposed in this "fix", it would resolve some confusion. As it is now, tracing the bug that results when trying to pass an array to groupBy() is extremely difficult.

The alternate solution would be to change the comment above groupBy() to more accurately state that the $columns parameter is only "dynamic" in the sense that it can accept N number of string arguments.
