### PR TITLE
[4.2] Database\Query\Builder::groupBy() now accepts arrays as arguments

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -973,7 +973,7 @@ class Builder {
 	 */
 	public function groupBy()
 	{
-		foreach(func_get_args() AS $arg)
+		foreach(func_get_args() as $arg)
 		{
 			$this->groups = array_merge((array) $this->groups, ((is_array($arg)) ? $arg:[$arg]));
 		}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -973,7 +973,10 @@ class Builder {
 	 */
 	public function groupBy()
 	{
-		$this->groups = array_merge((array) $this->groups, func_get_args());
+		foreach(func_get_args() AS $arg)
+		{
+			$this->groups = array_merge((array) $this->groups, ((is_array($arg)) ? $arg:[$arg]));
+		}
 
 		return $this;
 	}

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -424,6 +424,10 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->groupBy('id', 'email');
 		$this->assertEquals('select * from "users" group by "id", "email"', $builder->toSql());
+
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->groupBy(['id', 'email']);
+		$this->assertEquals('select * from "users" group by "id", "email"', $builder->toSql());
 	}
 
 


### PR DESCRIPTION
This is a bug fix pull request for branch 4.2 of the same issue described in issue #4843 that was for master.
