### PR TITLE
Abolish Model::firstByAttributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -534,7 +534,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public static function firstOrCreate(array $attributes)
 	{
-		if ( ! is_null($instance = static::firstByAttributes($attributes)))
+		if ( ! is_null($instance = static::where($attributes)->first()))
 		{
 			return $instance;
 		}
@@ -550,7 +550,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public static function firstOrNew(array $attributes)
 	{
-		if ( ! is_null($instance = static::firstByAttributes($attributes)))
+		if ( ! is_null($instance = static::where($attributes)->first()))
 		{
 			return $instance;
 		}
@@ -582,14 +582,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	protected static function firstByAttributes($attributes)
 	{
-		$query = static::query();
-
-		foreach ($attributes as $key => $value)
-		{
-			$query->where($key, $value);
-		}
-
-		return $query->first() ?: null;
+		return static::where($attributes)->first();
 	}
 
 	/**
@@ -1441,7 +1434,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 				$this->fireModelEvent('updated', false);
 			}
-			
+
 			return true;
 		}
 


### PR DESCRIPTION
Since we now support [array wheres](https://github.com/laravel/framework/commit/87b267a232983abdac7c23c2dc6b1b270dd24b8a), there's no reason for the `firstByAttributes` method anymore. It always was kind of a mouthful, and not even clearer nor shorter:

``` php
Model::firstByAttributes($attributes);
Model::where($attributes)->first();
```

We might even be able to get rid of the `firstByAttributes` method completely, since it was never a `public` method; I'm not sure about the policy regarding `protected` methods, since people might be using it from within one of their models.

I left it in there for now, but if you think we can get rid of it...
