### PR TITLE
Many colors in one console output line

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -282,9 +282,9 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * @param  string  $string
 	 * @return void
 	 */
-	public function info($string)
+	public function info($string, $newLine = true)
 	{
-		$this->output->writeln("<info>$string</info>");
+		$this->output->write("<info>$string</info>", $newLine);
 	}
 
 	/**
@@ -304,9 +304,9 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * @param  string  $string
 	 * @return void
 	 */
-	public function comment($string)
+	public function comment($string, $newLine = true)
 	{
-		$this->output->writeln("<comment>$string</comment>");
+		$this->output->write("<comment>$string</comment>", $newLine);
 	}
 
 	/**
@@ -315,9 +315,9 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * @param  string  $string
 	 * @return void
 	 */
-	public function question($string)
+	public function question($string, $newLine = true)
 	{
-		$this->output->writeln("<question>$string</question>");
+		$this->output->write("<question>$string</question>", $newLine);
 	}
 
 	/**
@@ -326,9 +326,9 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * @param  string  $string
 	 * @return void
 	 */
-	public function error($string)
+	public function error($string, $newLine = true)
 	{
-		$this->output->writeln("<error>$string</error>");
+		$this->output->write("<error>$string</error>", $newLine);
 	}
 
 	/**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -280,6 +280,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * Write a string as information output.
 	 *
 	 * @param  string  $string
+	 * @param  bool    $newLine
 	 * @return void
 	 */
 	public function info($string, $newLine = true)
@@ -302,6 +303,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * Write a string as comment output.
 	 *
 	 * @param  string  $string
+	 * @param  bool    $newLine
 	 * @return void
 	 */
 	public function comment($string, $newLine = true)
@@ -313,6 +315,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * Write a string as question output.
 	 *
 	 * @param  string  $string
+	 * @param  bool    $newLine
 	 * @return void
 	 */
 	public function question($string, $newLine = true)
@@ -324,6 +327,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * Write a string as error output.
 	 *
 	 * @param  string  $string
+	 * @param  bool    $newLine
 	 * @return void
 	 */
 	public function error($string, $newLine = true)


### PR DESCRIPTION
Add optional parameters in output helper (with style) in order to not add new line. By default a new line is added.

EDIT:

This PR change Console/Command.php in order to allow many call of helpers info, comment or error ans display all in one line.
