### PR TITLE
Added colour highlights for queue work command

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -117,15 +117,13 @@ class WorkCommand extends Command {
 	 */
 	protected function writeOutput(Job $job, $failed)
 	{
-		$options = OutputInterface::OUTPUT_RAW;
-
 		if ($failed)
 		{
-			$this->output->writeln('<error>Failed:</error> '.$job->getName(), $options);
+			$this->output->writeln('<error>Failed:</error> '.$job->getName());
 		}
 		else
 		{
-			$this->output->writeln('<info>Processed:</info> '.$job->getName(), $options);
+			$this->output->writeln('<info>Processed:</info> '.$job->getName());
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue mentioned in #4793. This makes it so "Failed" and "Processed" are coloured properly in the same way that queue:listen does it. I'm not sure if using OUTPUT_RAW was wanted, but I don't think so since the <error> and <info> tags are used in the output.
