### PR TITLE
Return trashed models with morphTo() if told so on non-eager queries (fixes #4870)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -161,10 +161,7 @@ class MorphTo extends BelongsTo {
 
 		$query = $instance->newQuery();
 
-		if ($this->withTrashed && $query->getMacro('withTrashed') !== null)
-		{
-			$query = $query->withTrashed();
-		}
+		$query = $this->useWithTrashed($query);
 
 		return $query->whereIn($key, $this->gatherKeysByType($type)->all())->get();
 	}
@@ -216,7 +213,24 @@ class MorphTo extends BelongsTo {
 	{
 		$this->withTrashed = true;
 
+		$this->query = $this->useWithTrashed($this->query);
+
 		return $this;
+	}
+
+	/**
+	 * Return trashed models with query if told so
+	 *
+	 * @param  \Illuminate\Database\Eloquent\Builder  $query
+	 * @return \Illuminate\Database\Eloquent\Builder
+	 */
+	protected function useWithTrashed(Builder $query)
+	{
+		if ($this->withTrashed && $query->getMacro('withTrashed') !== null)
+		{
+			return $query->withTrashed();
+		}
+		return $query;
 	}
 
 }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -57,8 +57,8 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 
 		$relation->addEagerConstraints(array($one, $two, $three));
 
-		$relation->shouldReceive('createModelByType')->once()->with('morph_type_1')->andReturn($firstQuery = m::mock('StdClass'));
-		$relation->shouldReceive('createModelByType')->once()->with('morph_type_2')->andReturn($secondQuery = m::mock('StdClass'));
+		$relation->shouldReceive('createModelByType')->once()->with('morph_type_1')->andReturn($firstQuery = m::mock('Illuminate\Database\Eloquent\Builder'));
+		$relation->shouldReceive('createModelByType')->once()->with('morph_type_2')->andReturn($secondQuery = m::mock('Illuminate\Database\Eloquent\Builder'));
 		$firstQuery->shouldReceive('getKeyName')->andReturn('id');
 		$secondQuery->shouldReceive('getKeyName')->andReturn('id');
 
@@ -80,6 +80,17 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 		$relation->getEager();
 	}
 
+	public function testModelsWithSoftDeleteAreProperlyPulled()
+	{
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+
+		$relation = $this->getRelation(null, $builder);
+
+		$builder->shouldReceive('getMacro')->once()->with('withTrashed')->andReturn(function() { return true; });
+		$builder->shouldReceive('withTrashed')->once();
+
+		$relation->withTrashed();
+	}
 
 	public function testAssociateMethodSetsForeignKeyAndTypeOnModel()
 	{
@@ -111,9 +122,9 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function getRelation($parent = null)
+	public function getRelation($parent = null, $builder = null)
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = $builder ?: m::mock('Illuminate\Database\Eloquent\Builder');
 		$builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
 		$related = m::mock('Illuminate\Database\Eloquent\Model');
 		$related->shouldReceive('getKeyName')->andReturn('id');


### PR DESCRIPTION
This fixes #4870 bug, when `morphTo()->withTrashed()` has no effect when querying polymorphic associations non-eagerly. With tests and everything.
