### PR TITLE
 A fix for #4498 and #4684. Eloquent model now boots all used traits, not only those declared in current class only #4877 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -302,7 +302,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	protected static function bootTraits()
 	{
-		foreach (class_uses(get_called_class()) as $trait)
+		foreach (class_uses_deep(get_called_class()) as $trait)
 		{
 			if (method_exists(get_called_class(), $method = 'boot'.class_basename($trait)))
 			{

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1105,3 +1105,48 @@ if ( ! function_exists('with'))
 		return $object;
 	}
 }
+
+if ( ! function_exists('class_uses_deep'))
+{
+	/**
+	 * Returns all traits used by a class, it's subclasses and trait of their traits
+	 *
+	 * @param string $class
+	 * @param bool   $classDeep
+	 * @param bool   $traitDeep
+	 *
+	 * @return array
+	 */
+	function class_uses_deep($class, $classDeep = true, $traitDeep = true)
+	{
+		$result        = [];
+		$searchClasses = [$class => $class] + ($classDeep ? class_parents($class) : []);
+		foreach ($searchClasses as $class)
+		{
+			$result = $result + ($traitDeep ? trait_uses_deep($class) : class_uses($class));
+		}
+
+		return $result;
+	}
+}
+
+if ( ! function_exists('trait_uses_deep'))
+{
+
+	/**
+	 * Returns all traits used by a trait and its traits
+	 *
+	 * @param $trait
+	 *
+	 * @return array
+	 */
+	function trait_uses_deep($trait)
+	{
+		$result = class_uses($trait);
+		foreach ($result as $trait)
+		{
+			$result += trait_uses_deep($trait);
+		}
+		return $result;
+	}
+}


### PR DESCRIPTION
A fix for #4498 and #4684.

As described in #4498, if you add a trait to a parent model any children models will include the properties and methods of that trait but it's boot method will not be called. This is because Eloquent only boots the traits of the model itself, not it's parent models.

This patch introduces a new helper for deep traits inspection + modifies Eloquent model to use this helper instead of class_uses()
