### PR TITLE
Custom Column Type in Schema Builder implementation

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -385,6 +385,18 @@ class Blueprint {
 	}
 
 	/**
+	 * Create new column of custom type on the table
+	 *
+	 * @param string   $column
+	 * @param callable $callback
+	 * @return \Illuminate\Support\Fluent
+	 */
+	public function custom($column, Closure $callback)
+	{
+		$this->addColumn('custom', $column, compact('callback'));
+	}
+
+	/**
 	 * Create a new text column on the table.
 	 *
 	 * @param  string  $column

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -192,6 +192,18 @@ abstract class Grammar extends BaseGrammar {
 	}
 
 	/**
+	 * Custom column type
+	 *
+	 * @param Fluent $column
+	 *
+	 * @return mixed
+	 */
+	protected function typeCustom(Fluent $column)
+	{
+		return call_user_func($column->callback, $column);
+	}
+
+	/**
 	 * Add a prefix to an array of values.
 	 *
 	 * @param  string  $prefix

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -52,4 +52,19 @@ class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testCustomType()
+	{
+		$conn      = m::mock('Illuminate\Database\Connection');
+		$grammar   = new \Illuminate\Database\Schema\Grammars\MySqlGrammar();
+		$blueprint = new Blueprint('user');
+		$blueprint->string('teststr', 200);
+		$blueprint->custom('mycolumn', function ($column)
+		{
+			return 'MY_CUSTOM_COLUMN_TYPE';
+		});
+
+		$this->assertEquals('alter table `user` add `teststr` varchar(200) not null, add `mycolumn` MY_CUSTOM_COLUMN_TYPE not null',
+			$blueprint->toSql($conn, $grammar)[0]);
+	}
+
 }


### PR DESCRIPTION
This is an implementation of custom column types in Schema Builder mentioned in #3393, #678, #376.

Custom column type is added to the table by calling blueprint's `custom()` method which receives closure.

$blueprint->custom('mycolumn', function ($column)

``` php
        Schema::create('user', function (Blueprint $table) {
        $table->custom('mycolumn', function ($column)
        {
            return 'MY_CUSTOM_COLUMN_TYPE';
        });
```

The generated SQL statement will look like

``` sql
alter table `user` add `mycolumn` MY_CUSTOM_COLUMN_TYPE not null
```

And implementation is very simple and requires very small changes in the code. Test included. PR sent to master since this is a new feature. Though it is a non-breaking and may be it could be included in 4.x?
