### PR TITLE
Custom Column Type in Schema Builder - centralized way to handle

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -765,7 +765,7 @@ class Connection implements ConnectionInterface {
 	/**
 	 * Get the schema grammar used by the connection.
 	 *
-	 * @return \Illuminate\Database\Query\Grammars\Grammar
+	 * @return \Illuminate\Database\Schema\Grammars\Grammar
 	 */
 	public function getSchemaGrammar()
 	{

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -385,6 +385,18 @@ class Blueprint {
 	}
 
 	/**
+	 * Create new column of custom type on the table
+	 *
+	 * @param string   $column
+	 * @param callable $callback
+	 * @return \Illuminate\Support\Fluent
+	 */
+	public function custom ($column, Closure $callback)
+	{
+		$this->addColumn('custom', $column, compact('callback'));
+	}
+
+	/**
 	 * Create a new text column on the table.
 	 *
 	 * @param  string  $column

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -387,13 +387,16 @@ class Blueprint {
 	/**
 	 * Create new column of custom type on the table
 	 *
-	 * @param string   $column
-	 * @param callable $callback
+	 * @param string $name
+	 * @param string $type
+	 *
 	 * @return \Illuminate\Support\Fluent
 	 */
-	public function custom ($column, Closure $callback)
+	public function custom($name, $type)
 	{
-		$this->addColumn('custom', $column, compact('callback'));
+		$params = func_get_args();
+		$params = array_splice($params, 2);
+		$this->addColumn('custom', $name, ['type_name' => $type, 'params' => $params]);
 	}
 
 	/**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -222,4 +222,15 @@ class Builder {
 		$this->resolver = $resolver;
 	}
 
+	/**
+	 * Function to register custom column type handlers
+	 *
+	 * @param string $name
+	 * @param array $handlers
+	 */
+	public function registerCustomType($name, array $handlers)
+	{
+		$this->grammar->registerCustomType($name, $handlers);
+	}
+
 }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -228,9 +228,9 @@ class Builder {
 	 * @param string $name
 	 * @param array $handlers
 	 */
-	public function registerCustomType($name, array $handlers)
+	public function columnType($name, array $handlers)
 	{
-		$this->grammar->registerCustomType($name, $handlers);
+		$this->grammar->columnType($name, $handlers);
 	}
 
 }

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -192,6 +192,18 @@ abstract class Grammar extends BaseGrammar {
 	}
 
 	/**
+	 * Custom column type
+	 *
+	 * @param Fluent $column
+	 *
+	 * @return mixed
+	 */
+	protected function typeCustom(Fluent $column)
+	{
+		return call_user_func($column->callback, $column);
+	}
+
+	/**
 	 * Add a prefix to an array of values.
 	 *
 	 * @param  string  $prefix

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -215,7 +215,7 @@ abstract class Grammar extends BaseGrammar {
 	 * @param string $name
 	 * @param array  $handlers
 	 */
-	public function registerCustomType($name, array $handlers)
+	public function columnType($name, array $handlers)
 	{
 		$className = get_class($this);
 		do

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -51,5 +51,19 @@ class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('users_foo_index', $commands[0]->index);
 	}
 
+	public function testCustomType ()
+	{
+		$conn      = m::mock('Illuminate\Database\Connection');
+		$grammar   = new \Illuminate\Database\Schema\Grammars\MySqlGrammar();
+		$blueprint = new Blueprint('user');
+		$blueprint->string('teststr', 200);
+		$blueprint->custom('mycolumn', function ($column)
+		{
+			return 'MY_CUSTOM_COLUMN_TYPE';
+		});
+
+		$this->assertEquals('alter table `user` add `teststr` varchar(200) not null, add `mycolumn` MY_CUSTOM_COLUMN_TYPE not null',
+			$blueprint->toSql($conn, $grammar)[0]);
+	}
 
 }

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -51,18 +51,26 @@ class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('users_foo_index', $commands[0]->index);
 	}
 
-	public function testCustomType ()
+
+	public function testCustomType()
 	{
 		$conn      = m::mock('Illuminate\Database\Connection');
 		$grammar   = new \Illuminate\Database\Schema\Grammars\MySqlGrammar();
 		$blueprint = new Blueprint('user');
 		$blueprint->string('teststr', 200);
-		$blueprint->custom('mycolumn', function ($column)
-		{
-			return 'MY_CUSTOM_COLUMN_TYPE';
-		});
+		$conn->shouldReceive('getSchemaGrammar')->andReturnValues([$grammar]);
 
-		$this->assertEquals('alter table `user` add `teststr` varchar(200) not null, add `mycolumn` MY_CUSTOM_COLUMN_TYPE not null',
+		/** @var $conn Illuminate\Database\Connection $conn */
+		$conn->getSchemaGrammar()->registerCustomType('my_custom_type', [
+			'MySql' => function ($param1, $param2)
+				{
+					return sprintf('MY_TEST_TYPE (%s, %s)', $param1, $param2);
+				}
+		]);
+
+		$blueprint->custom('my_col', 'my_custom_type', 'param1', 'param2');
+
+		$this->assertEquals('alter table `user` add `teststr` varchar(200) not null, add `my_col` MY_TEST_TYPE (param1, param2) not null',
 			$blueprint->toSql($conn, $grammar)[0]);
 	}
 

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -61,7 +61,7 @@ class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase {
 		$conn->shouldReceive('getSchemaGrammar')->andReturnValues([$grammar]);
 
 		/** @var $conn Illuminate\Database\Connection $conn */
-		$conn->getSchemaGrammar()->registerCustomType('my_custom_type', [
+		$conn->getSchemaGrammar()->columnType('my_custom_type', [
 			'MySql' => function ($param1, $param2)
 				{
 					return sprintf('MY_TEST_TYPE (%s, %s)', $param1, $param2);


### PR DESCRIPTION
This is an implementation of custom column types in Schema Builder mentioned in #3393, #678, #376.

Implementation is alternative to #4885 and provides a universal way to handle new custom types in database.

First we register column type:

``` php
Schema::registerCustomType('my_custom_type', [
    'MySql' => function ($param1, $param2) {
                    return sprintf('MY_MYSQL_TYPE (%s, %s)', $param1, $param2);
                },
    'Postgres' => function ($param1, $param2) {
                    return sprintf('MY_POSTGRES_TYPE (%s ||| %s)', $param1, $param2);
                },
        ]);
```

Keys 'MySql' and 'Postres' are the string endings of Schema grammar class names. If grammar class name ends with 'Grammar', 'Grammar' is trimmed before comparison.Grammar class hierarchy is respected.

Custom column type is then added to the table by calling blueprint's `custom()` method

``` php
        Schema::create('user', function (Blueprint $table) {
        $table->custom('my_col', 'my_custom_type', 'param1', 'param2');
        }
```

The generated SQL statement, executed against MySQL connection will look like:

``` sql
alter table `user` add `my_col` MY_MYSQL_TYPE (param1, param2) not null
```

whereas if we execute it against Postgres grammar, it will change to:

``` sql
alter table `user` add `my_col` MY_POSTGRES_TYPE (param1 ||| param2) not null
```
