### PR TITLE
Makes Schema::getColumnListing('table_name') work irrespective of the PDO fetch mode

### DIFF
--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -10,7 +10,7 @@ class MySqlProcessor extends Processor {
 	 */
 	public function processColumnListing($results)
 	{
-		return array_map(function($r) { return $r->column_name; }, $results);
+		return array_map(function($r) { return data_get($r, 'column_name'); }, $results);
 	}
 
 }

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -34,7 +34,7 @@ class PostgresProcessor extends Processor {
 	 */
 	public function processColumnListing($results)
 	{
-		return array_values(array_map(function($r) { return $r->column_name; }, $results));
+		return array_values(array_map(function($r) { return data_get($r, 'column_name'); }, $results));
 	}
 
 }

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -10,7 +10,7 @@ class SQLiteProcessor extends Processor {
 	 */
 	public function processColumnListing($results)
 	{
-		return array_values(array_map(function($r) { return $r->name; }, $results));
+		return array_values(array_map(function($r) { data_get($r, 'column_name'); }, $results));
 	}
 
 }

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -30,7 +30,7 @@ class SqlServerProcessor extends Processor {
 	 */
 	public function processColumnListing($results)
 	{
-		return array_values(array_map(function($r) { return $r->name; }, $results));
+		return array_values(array_map(function($r) { return data_get($r, 'column_name'); }, $results));
 	}
 
 }


### PR DESCRIPTION
When PDO fetch mode is set to return an array, Laravel currently fails with the following error

```
Notice: Trying to get property of non-object in Illuminate/Database/Query/Processors/MySqlProcessor.php on line 13
```

This pull request checks for type and gets the column names accordingly!

Closes #4727
