### PR TITLE
Use after:now with date_format validator

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1258,11 +1258,6 @@ class Validator implements MessageProviderInterface {
 	{
 		$this->requireParameterCount(1, $parameters, 'before');
 
-		if ($format = $this->getDateFormat($attribute))
-		{
-			return $this->validateBeforeWithFormat($format, $value, $parameters);
-		}
-
 		if ( ! ($date = strtotime($parameters[0])))
 		{
 			return strtotime($value) < strtotime($this->getValue($parameters[0]));
@@ -1271,20 +1266,6 @@ class Validator implements MessageProviderInterface {
 		{
 			return strtotime($value) < $date;
 		}
-	}
-
-	/**
-	 * Validate the date is before a given date with a given format.
-	 *
-	 * @param  string  $format
-	 * @param  mixed   $value
-	 * @param  array   $parameters
-	 * @return bool
-	 */
-	protected function validateBeforeWithFormat($format, $value, $parameters)
-	{
-		return DateTime::createFromFormat($format, $value) <
-               DateTime::createFromFormat($format, $parameters[0]);
 	}
 
 	/**
@@ -1299,11 +1280,6 @@ class Validator implements MessageProviderInterface {
 	{
 		$this->requireParameterCount(1, $parameters, 'after');
 
-		if ($format = $this->getDateFormat($attribute))
-		{
-			return $this->validateAfterWithFormat($format, $value, $parameters);
-		}
-
 		if ( ! ($date = strtotime($parameters[0])))
 		{
 			return strtotime($value) > strtotime($this->getValue($parameters[0]));
@@ -1312,20 +1288,6 @@ class Validator implements MessageProviderInterface {
 		{
 			return strtotime($value) > $date;
 		}
-	}
-
-	/**
-	 * Validate the date is after a given date with a given format.
-	 *
-	 * @param  string  $format
-	 * @param  mixed   $value
-	 * @param  array   $parameters
-	 * @return bool
-	 */
-	protected function validateAfterWithFormat($format, $value, $parameters)
-	{
-		return DateTime::createFromFormat($format, $value) >
-               DateTime::createFromFormat($format, $parameters[0]);
 	}
 	
 	/**


### PR DESCRIPTION
Hello,

In the below, the reasons for make this pull requests:
- I cannot use `after:now` or `before:now` with `date_format:Y-m-d H:i:s`
- I think the (`after`, `before`) validator should not be related with `date_format`, because its not an inputs!
- At the same time, this code is not working: 

``` php
class TestModel extends Model
{
    public static $rules = array(
        'field' => 'required|after:' . date('Y-m-d H:i:s') . '|date_format:Y-m-d H:i:s'
    );
}
```

So, I remove the functions (validateAfterWithFormat, validateBeforeWithFormat)
and its work!

Thanks
