### PR TITLE
Readability fixes in Router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -528,9 +528,10 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	protected function addResourceIndex($name, $base, $controller, $options)
 	{
+		$uri = $this->getResourceUri($name);
 		$action = $this->getResourceAction($name, $controller, 'index', $options);
 
-		return $this->get($this->getResourceUri($name), $action);
+		return $this->get($uri, $action);
 	}
 
 	/**
@@ -544,9 +545,10 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	protected function addResourceCreate($name, $base, $controller, $options)
 	{
+		$uri = $this->getResourceUri($name).'/create';
 		$action = $this->getResourceAction($name, $controller, 'create', $options);
 
-		return $this->get($this->getResourceUri($name).'/create', $action);
+		return $this->get($uri, $action);
 	}
 
 	/**
@@ -560,9 +562,10 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	protected function addResourceStore($name, $base, $controller, $options)
 	{
+		$uri = $this->getResourceUri($name);
 		$action = $this->getResourceAction($name, $controller, 'store', $options);
 
-		return $this->post($this->getResourceUri($name), $action);
+		return $this->post($uri, $action);
 	}
 
 	/**
@@ -577,8 +580,9 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	protected function addResourceShow($name, $base, $controller, $options)
 	{
 		$uri = $this->getResourceUri($name).'/{'.$base.'}';
+		$action = $this->getResourceAction($name, $controller, 'show', $options);
 
-		return $this->get($uri, $this->getResourceAction($name, $controller, 'show', $options));
+		return $this->get($uri, $action);
 	}
 
 	/**
@@ -593,8 +597,9 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	protected function addResourceEdit($name, $base, $controller, $options)
 	{
 		$uri = $this->getResourceUri($name).'/{'.$base.'}/edit';
+		$action = $this->getResourceAction($name, $controller, 'edit', $options);
 
-		return $this->get($uri, $this->getResourceAction($name, $controller, 'edit', $options));
+		return $this->get($uri, $action);
 	}
 
 	/**
@@ -625,8 +630,9 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	protected function addPutResourceUpdate($name, $base, $controller, $options)
 	{
 		$uri = $this->getResourceUri($name).'/{'.$base.'}';
+		$action = $this->getResourceAction($name, $controller, 'update', $options);
 
-		return $this->put($uri, $this->getResourceAction($name, $controller, 'update', $options));
+		return $this->put($uri, $action);
 	}
 
 	/**
@@ -655,9 +661,10 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	protected function addResourceDestroy($name, $base, $controller, $options)
 	{
+		$uri = $this->getResourceUri($name).'/{'.$base.'}';
 		$action = $this->getResourceAction($name, $controller, 'destroy', $options);
 
-		return $this->delete($this->getResourceUri($name).'/{'.$base.'}', $action);
+		return $this->delete($uri, $action);
 	}
 
 	/**


### PR DESCRIPTION
Resource Route creation previously had some methods written in one style and others in a different style.  This fix makes all of them one style.
