### PR TITLE
[Bug] Fix "processInsertGetId" in a read/write connection:

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -275,7 +275,11 @@ class Connection implements ConnectionInterface {
 			// For select statements, we'll simply execute the query and return an array
 			// of the database result set. Each element in the array will be a single
 			// row from the database table, and will either be an array or objects.
-			$statement = $me->getReadPdo()->prepare($query);
+			if (starts_with($query, "insert")) {
+				$statement = $me->getPdo()->prepare($query);
+			} else {
+				$statement = $me->getReadPdo()->prepare($query);
+			}
 
 			$statement->execute($me->prepareBindings($bindings));
 


### PR DESCRIPTION
When Laravel call the "processInsertGetId" method a select method is executed but this method execute an INSERT and SELECT at the same time, which make that the query fails in the cases when the 'read' machine can only execute SELECT statements. I posted a question in SO with a little more information http://stackoverflow.com/questions/24499839/cannot-execute-insert-in-a-read-only-transaction-laravel-read-write

There must be a more elegant solution, but I hope Taylor that you can merge this simple solution because I need this:+1: 
