### PR TITLE
Make RedisQueue::migrateExpiredJobs atomic (fixes #4912)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "nesbot/carbon": "~1.0",
         "patchwork/utf8": "1.1.*",
         "phpseclib/phpseclib": "0.3.*",
-        "predis/predis": "0.8.*",
+        "predis/predis": "~0.8.5",
         "stack/builder": "~1.0",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/browser-kit": "2.5.*",


### PR DESCRIPTION
This PR fixes [#4912](https://github.com/laravel/framework/issues/4912) by making `RedisQueue::migrateExpiredJobs` atomic. I also had to bump the predis version since `transaction()` has been introduced in `v0.8.5` and the previous `multiExec()` stuff is deprecated.

As expected, this PR breaks `QueueRedisQueueTest::testMigrateExpiredJobs`. I tried - and failed - to update it, since I have no idea how to use Mockery to test methods with callable parameters.

@taylorotwell Thoughts?
