### PR TITLE
Remove unneeded calls to with

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -829,7 +829,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			$instance = new $class;
 
 			return new MorphTo(
-				with($instance)->newQuery(), $this, $id, $instance->getKeyName(), $type, $name
+				$instance->newQuery(), $this, $id, $instance->getKeyName(), $type, $name
 			);
 		}
 	}
@@ -870,7 +870,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		$secondKey = $secondKey ?: $through->getForeignKey();
 
-		return new HasManyThrough(with(new $related)->newQuery(), $this, $through, $firstKey, $secondKey);
+		return new HasManyThrough((new $related)->newQuery(), $this, $through, $firstKey, $secondKey);
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/TailCommand.php
+++ b/src/Illuminate/Foundation/Console/TailCommand.php
@@ -71,7 +71,7 @@ class TailCommand extends Command {
 
 		$lines = $this->option('lines');
 
-		with(new Process('tail -f -n '.$lines.' '.escapeshellarg($path)))->setTimeout(null)->run(function($type, $line) use ($output)
+		(new Process('tail -f -n '.$lines.' '.escapeshellarg($path)))->setTimeout(null)->run(function($type, $line) use ($output)
 		{
 			$output->write($line);
 		});

--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -46,7 +46,7 @@ class TinkerCommand extends Command {
 	{
 		$this->setupBorisErrorHandling();
 
-		with(new \Boris\Boris('> '))->start();
+		(new \Boris\Boris('> '))->start();
 	}
 
 	/**


### PR DESCRIPTION
Since we're now only supporting PHP 5.4+, there's no need for these calls to `with`.
