### PR TITLE
4.2

### DIFF
--- a/src/Illuminate/Pagination/BootstrapPresenter.php
+++ b/src/Illuminate/Pagination/BootstrapPresenter.php
@@ -8,7 +8,7 @@ class BootstrapPresenter extends Presenter {
 	 * @param  string  $url
 	 * @param  int  $page
 	 * @param  string  $rel
-     * @param  int  $goto
+	 * @param  int  $goto
 	 * @return string
 	 */
 	public function getPageLinkWrapper($url, $page, $rel = null, $goto)

--- a/src/Illuminate/Pagination/BootstrapPresenter.php
+++ b/src/Illuminate/Pagination/BootstrapPresenter.php
@@ -8,9 +8,10 @@ class BootstrapPresenter extends Presenter {
 	 * @param  string  $url
 	 * @param  int  $page
 	 * @param  string  $rel
+     * @param  int  $goto
 	 * @return string
 	 */
-	public function getPageLinkWrapper($url, $page, $rel = null)
+	public function getPageLinkWrapper($url, $page, $rel = null, $goto)
 	{
 		$rel = is_null($rel) ? '' : ' rel="'.$rel.'"';
 

--- a/src/Illuminate/Pagination/Presenter.php
+++ b/src/Illuminate/Pagination/Presenter.php
@@ -42,8 +42,8 @@ abstract class Presenter {
 	 * @param  string  $url
 	 * @param  int  $page
 	 * @param  string  $rel
-     * @param  int  $goto
-     * @return string
+        * @param  int  $goto
+        * @return string
 	 */
 	abstract public function getPageLinkWrapper($url, $page, $rel = null, $goto);
 
@@ -205,11 +205,11 @@ abstract class Presenter {
 		}
 		else
 		{
-            // Present same page info to user as the url gets
-            $goto = $this->currentPage - 1;
-            $url = $this->paginator->getUrl($goto);
+			// Present same page info to user as the url gets
+			$goto = $this->currentPage - 1;
+			$url = $this->paginator->getUrl($goto);
 
-            return $this->getPageLinkWrapper($url, $text, 'prev', $goto);
+			return $this->getPageLinkWrapper($url, $text, 'prev', $goto);
 		}
 	}
 
@@ -230,11 +230,11 @@ abstract class Presenter {
 		}
 		else
 		{
-            // Present same page info to user as the url gets
-            $goto = $this->currentPage + 1;
-            $url = $this->paginator->getUrl($goto);
+			// Present same page info to user as the url gets
+			$goto = $this->currentPage + 1;
+			$url = $this->paginator->getUrl($goto);
 
-            return $this->getPageLinkWrapper($url, $text, 'next', $goto);
+			return $this->getPageLinkWrapper($url, $text, 'next', $goto);
 		}
 	}
 

--- a/src/Illuminate/Pagination/Presenter.php
+++ b/src/Illuminate/Pagination/Presenter.php
@@ -42,8 +42,8 @@ abstract class Presenter {
 	 * @param  string  $url
 	 * @param  int  $page
 	 * @param  string  $rel
-        * @param  int  $goto
-        * @return string
+	 * @param  int  $goto
+	 * @return string
 	 */
 	abstract public function getPageLinkWrapper($url, $page, $rel = null, $goto);
 

--- a/src/Illuminate/Pagination/Presenter.php
+++ b/src/Illuminate/Pagination/Presenter.php
@@ -42,9 +42,10 @@ abstract class Presenter {
 	 * @param  string  $url
 	 * @param  int  $page
 	 * @param  string  $rel
-	 * @return string
+     * @param  int  $goto
+     * @return string
 	 */
-	abstract public function getPageLinkWrapper($url, $page, $rel = null);
+	abstract public function getPageLinkWrapper($url, $page, $rel = null, $goto);
 
 	/**
 	 * Get HTML wrapper for disabled text.
@@ -204,9 +205,11 @@ abstract class Presenter {
 		}
 		else
 		{
-			$url = $this->paginator->getUrl($this->currentPage - 1);
+            // Present same page info to user as the url gets
+            $goto = $this->currentPage - 1;
+            $url = $this->paginator->getUrl($goto);
 
-			return $this->getPageLinkWrapper($url, $text, 'prev');
+            return $this->getPageLinkWrapper($url, $text, 'prev', $goto);
 		}
 	}
 
@@ -227,9 +230,11 @@ abstract class Presenter {
 		}
 		else
 		{
-			$url = $this->paginator->getUrl($this->currentPage + 1);
+            // Present same page info to user as the url gets
+            $goto = $this->currentPage + 1;
+            $url = $this->paginator->getUrl($goto);
 
-			return $this->getPageLinkWrapper($url, $text, 'next');
+            return $this->getPageLinkWrapper($url, $text, 'next', $goto);
 		}
 	}
 
@@ -253,7 +258,7 @@ abstract class Presenter {
 	{
 		$url = $this->paginator->getUrl($page);
 
-		return $this->getPageLinkWrapper($url, $page);
+		return $this->getPageLinkWrapper($url, $page, null, $page);
 	}
 
 	/**

--- a/tests/Pagination/PaginationCustomPresenterTest.php
+++ b/tests/Pagination/PaginationCustomPresenterTest.php
@@ -19,7 +19,7 @@ class PaginationCustomPresenterTest extends PHPUnit_Framework_TestCase {
 				return '<a href="' . $url . '">' . $page . '</a>';
 			});
 
-		$this->assertEquals('<a href="http://laravel.com?page=1">1</a>', $customPresenter->getPageLinkWrapper('http://laravel.com?page=1', '1', null));
+		$this->assertEquals('<a href="http://laravel.com?page=1">1</a>', $customPresenter->getPageLinkWrapper('http://laravel.com?page=1', '1', null, '1'));
 	}
 
 


### PR DESCRIPTION
Modify Presenter.php to pass real page number to next and prev links.

Sample AjaxPresenter.php used with improved code.

<?php
class AjaxPresenter extends Illuminate\Pagination\Presenter {

```
/**
 * Get HTML wrapper for a page link.
 *
 * @param  string  $url
 * @param  int  $page
 * @param  string  $rel
 * @return string
 */
public function getPageLinkWrapper($url, $page, $rel = null, $goto)
{
    $rel = is_null($rel) ? '' : ' rel="'.$rel.'"';
    // MODEL needs to be replaced on front end with the Model Object Name that is calling the paginator
    return '<li><a href="#"'.$rel.' onclick="MODEL.gotoPage('.$goto.');">'.$page.'</a></li>';
}

/**
 * Get HTML wrapper for disabled text.
 *
 * @param  string  $text
 * @return string
 */
public function getDisabledTextWrapper($text)
{
    return '<li class="disabled"><span>'.$text.'</span></li>';
}

/**
 * Get HTML wrapper for active text.
 *
 * @param  string  $text
 * @return string
 */
public function getActivePageWrapper($text)
{
    return '<li class="active"><span>'.$text.'</span></li>';
}
```

}
