### PR TITLE
[4.2] Support : use available array_get() function

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -177,12 +177,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 */
 	public function get($key, $default = null)
 	{
-		if (array_key_exists($key, $this->items))
-		{
-			return $this->items[$key];
-		}
-
-		return value($default);
+		return array_get($this->items, $key, $default);
 	}
 
 	/**

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -37,12 +37,7 @@ class Fluent implements ArrayAccess, ArrayableInterface, JsonableInterface, Json
 	 */
 	public function get($key, $default = null)
 	{
-		if (array_key_exists($key, $this->attributes))
-		{
-			return $this->attributes[$key];
-		}
-
-		return value($default);
+		return array_get($this->attributes, $key, $default);
 	}
 
 	/**


### PR DESCRIPTION
Use available `array_get()` function and provide dotted notation for `get()`
