### PR TITLE
[4.2] Graceful `@parent` directive handling [#4942]

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -574,13 +574,9 @@ class Factory {
 		if (isset($this->sections[$section]))
 		{
 			$content = str_replace('@parent', $content, $this->sections[$section]);
+		}
 
-			$this->sections[$section] = $content;
-		}
-		else
-		{
-			$this->sections[$section] = $content;
-		}
+		$this->sections[$section] = $content;
 	}
 
 	/**
@@ -592,7 +588,16 @@ class Factory {
 	 */
 	public function yieldContent($section, $default = '')
 	{
-		return isset($this->sections[$section]) ? $this->sections[$section] : $default;
+		$sectionContent = $default;
+
+		if (isset($this->sections[$section]))
+		{
+			$sectionContent = $this->sections[$section];
+		}
+
+		$sectionContent = str_replace('@parent', '', $sectionContent);
+
+		return $sectionContent;
 	}
 
 	/**


### PR DESCRIPTION
Remove `@parent` from output contents when the section hasn't been previously extended.

Addresses #4942 for version 4.2
