### PR TITLE
Allow for Eloquent model attributes to be type juggled (casted).

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2350,9 +2350,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// value.
 		elseif (array_key_exists($key, $casts = $this->getCasts()))
 		{
-			$type = strtolower($casts[$key]);
-
-			if ($value) return $this->castAttribute($type, $value);
+			if ($value) return $this->castAttribute($casts[$key], $value);
 		}
 
 		return $value;
@@ -2367,6 +2365,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	protected function castAttribute($type, $value)
 	{
+		$type = strtolower($type);
+
 		if ($type === 'date')
 		{
 			return $this->asDateTime($value);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2369,10 +2369,10 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		if ($type === 'date')
 		{
-			return $this->asDateTime($value);
+			if ($value) return $this->asDateTime($value);
 		}
 
-		settype($value, $type);
+		if ($value !== null) settype($value, $type);
 
 		return $value;
 	}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -294,6 +294,17 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAttributesInCastingArrayAreReturnedAsCorrectType()
+	{
+		$model = new EloquentModelWithCastsStub;
+		$model->first = 1337;
+		$model->second = 1;
+		$model->third = '13.77';
+		$this->assertTrue(is_string($model->first));
+		$this->assertTrue(is_bool($model->second));
+		$this->assertTrue(is_float($model->third));
+	}
+
 	public function testDateTimeAttributesReturnNullIfSetToNull()
 	{
 		$timestamps = array(
@@ -849,7 +860,7 @@ class EloquentModelStub extends Illuminate\Database\Eloquent\Model {
 	{
 		return 'foo';
 	}
-	public function getDates()
+	public function getCasts()
 	{
 		return array();
 	}
@@ -864,9 +875,9 @@ class EloquentModelCamelStub extends EloquentModelStub {
 }
 
 class EloquentDateModelStub extends EloquentModelStub {
-	public function getDates()
+	public function getCasts()
 	{
-		return array('created_at', 'updated_at');
+		return array('created_at' => 'date', 'updated_at' => 'date');
 	}
 }
 
@@ -948,4 +959,12 @@ class EloquentModelBootingTestStub extends Illuminate\Database\Eloquent\Model {
 	{
 		return array_key_exists(get_called_class(), static::$booted);
 	}
+}
+
+class EloquentModelWithCastsStub extends Illuminate\Database\Eloquent\Model {
+	protected $cast = array(
+		'first' 	=> 'string',
+		'second' 	=> 'bool',
+		'third' 	=> 'float',
+	);
 }


### PR DESCRIPTION
Right now if you retrieve an attribute from an Eloquent model, it may not be in the right format. For example, a `boolean` value in the database will be returned as an `integer` because Eloquent has no knowledge about the table schema.

This PR solves this problem by providing the `$cast` array where you can specify default set/get attribute types for Eloquent model attributes. Here's an example.

``` php
<?php

class Book extends Eloquent
{
    protected $cast = [
        'name'          => 'string',
        'read'          => 'bool',
        'read_when'     => 'date',
        'price'         => 'double'
    ];
}
```

Now all of the attributes provided as keys in the above array, are set and retrieved in the appropriate type. As you can see, dates have been added to this `$cast` array as a replacement for `$dates` due to their similarity. This change has been made backwards compatible, and will respect the original `$dates` array to allow for hotfix.
