### PR TITLE
Not passing columns to model constructor

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -655,7 +655,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	{
 		if ( ! is_null($model = static::find($id, $columns))) return $model;
 
-		return new static($columns);
+		return new static;
 	}
 
 	/**


### PR DESCRIPTION
Unless I'm stupid, blind or both, `$columns` has no business being passed to the constructor.
