### PR TITLE
simplePaginate() incorrect limit

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -303,7 +303,7 @@ class Builder {
 
 		$perPage = $perPage ?: $this->model->getPerPage();
 
-		$this->query->skip(($page - 1) * $perPage)->take($perPage + 1);
+		$this->query->skip(($page - 1) * $perPage)->take($perPage);
 
 		return $paginator->make($this->get($columns)->all(), $perPage);
 	}

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -275,7 +275,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$conn->shouldReceive('getPaginator')->once()->andReturn($paginator);
 		$query->expects($this->once())->method('getConnection')->will($this->returnValue($conn));
 		$query->expects($this->once())->method('skip')->with(0)->will($this->returnValue($query));
-		$query->expects($this->once())->method('take')->with(16)->will($this->returnValue($query));
+		$query->expects($this->once())->method('take')->with(15)->will($this->returnValue($query));
 		$builder->expects($this->once())->method('get')->with($this->equalTo(array('*')))->will($this->returnValue(new Collection(array('results'))));
 		$paginator->shouldReceive('make')->once()->with(array('results'), 15)->andReturn(array('results'));
 


### PR DESCRIPTION
simplePaginate(4) will return `limit 5 offset 0` for page 1 and `limit 5 offset 4` for page 2. This causes next page to show a duplicate from previous page.

Expected result of simplePaginate(4) should be `limit 4 offset 0` for page 1 and `limit 4 offset 4` for page 2 respectively.

Unless I am missing something?
