### PR TITLE
added the ability to pass classes into route bindings

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1200,7 +1200,35 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	public function bind($key, $binder)
 	{
+		if (is_string($binder))
+		{
+			$binder = $this->createClassBinding($binder);
+		}
+
 		$this->binders[str_replace('-', '_', $key)] = $binder;
+	}
+
+	/**
+	 * Create a class based binding using the IoC container.
+	 *
+	 * @param  string    $binding
+	 * @return \Closure
+	 */
+	public function createClassBinding($binding)
+	{
+		return function($value, $route) use ($binding)
+		{
+			// If the binding has an @ sign, we will assume it's being used to delimit
+			// the class name from the bind method name. This allows for bindings
+			// to run multiple bind methods in a single class for convenience.
+			$segments = explode('@', $binding);
+
+			$method = count($segments) == 2 ? $segments[1] : 'bind';
+
+			$callable = [$this->container->make($segments[0]), $method];
+
+			return call_user_func($callable, $value, $route);
+		};
 	}
 
 	/**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -493,6 +493,24 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRouteClassBinding()
+	{
+		$router = $this->getRouter();
+		$router->get('foo/{bar}', function($name) { return $name; });
+		$router->bind('bar', 'RouteBindingStub');
+		$this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+	}
+
+
+	public function testRouteClassMethodBinding()
+	{
+		$router = $this->getRouter();
+		$router->get('foo/{bar}', function($name) { return $name; });
+		$router->bind('bar', 'RouteBindingStub@find');
+		$this->assertEquals('dragon', $router->dispatch(Request::create('foo/Dragon', 'GET'))->getContent());
+	}
+
+
 	public function testModelBinding()
 	{
 		$router = $this->getRouter();
@@ -802,6 +820,10 @@ class RouteTestControllerRemoveFilterStub extends \Illuminate\Routing\Controller
 	}
 }
 
+class RouteBindingStub {
+	public function bind($value, $route) { return strtoupper($value); }
+	public function find($value, $route) { return strtolower($value); }
+}
 
 class RouteModelBindingStub {
 	public function find($value) { return strtoupper($value); }


### PR DESCRIPTION
Copied the way it is done for events pretty much.

So allows for...

``` php
// this will bind to BindingClass@bind
Route::bind('foo', 'BindingClass');

// you can specify method too like normal
Route::bind('user', 'UserRepository@find');
```
