### PR TITLE
Please revert breaking change in Illuminate\Database\Eloquent::performUpdate()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1450,11 +1450,9 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 				$this->fireModelEvent('updated', false);
 			}
-			
-			return true;
 		}
 
-		return false;
+		return true;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1415,7 +1415,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Perform a model update operation.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $query
-	 * @return bool|null
+	 * @return bool
 	 */
 	protected function performUpdate(Builder $query)
 	{
@@ -1450,9 +1450,11 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 				$this->fireModelEvent('updated', false);
 			}
-
+			
 			return true;
 		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
This PR reverts two bad commits that constitute breaking changes and were pushed back to 4.0 and 4.1.

The problem is the assertion that  "performUpdate should return false if no update is performed". This is debatable at best, and is a clear breaking change for vanilla use cases.

Here's a typical resource controller's update handler:

``` php
<?php

$success = $model->update($fillable_fields);

if ($success) {
  // ...manually update unfillable fields
  // ...manually update complex relations
  // ...and so on
}
```

Although a possible workaround is

``` php
<?php

if ($success !== false) {
  // ...
}
```

it's atypical to have to be this specific, and the real problem is that an update that doesn't actually update database columns is (conceptually) vacuously successful in typical application architecture. A much better design is:

``` php
<?php

if ($success === true) {
  // ...
}
```

Basically, my assertion is that Illuminate\Database\Eloquent::performUpdate() should return a boolean, and it should return true iff the update did not fail.
