### PR TITLE
Bug fix: Eloquent $hidden and $visible should trump $appends

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2193,7 +2193,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		{
 			if (in_array($key, $this->hidden)) continue;
 
-			if (count($this->visible) > 0 && !in_array($key, $this->visible)) continue;
+			if (count($this->visible) > 0 && ! in_array($key, $this->visible)) continue;
 
 			$attributes[$key] = $this->mutateAttributeForArray($key, null);
 		}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2191,6 +2191,10 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// when we need to array or JSON the model for convenience to the coder.
 		foreach ($this->appends as $key)
 		{
+			if (in_array($key, $this->hidden)) continue;
+
+			if (count($this->visible) > 0 && !in_array($key, $this->visible)) continue;
+
 			$attributes[$key] = $this->mutateAttributeForArray($key, null);
 		}
 


### PR DESCRIPTION
If an attribute is appended to a Model, it should obey the `$hidden` and `$visible` arrays when converting the object to Array or JSON. Since `getArrayableAttributes()` does not included the appended attributes, it is necessary to instead check if the appended attribute key exists inside `$this->visible`
