### PR TITLE
Update Guard.php

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -152,6 +152,13 @@ class Guard {
 		{
 			$user = $this->getUserByRecaller($recaller);
 		}
+		
+		// If at this point the user is null, we need to logout in order to clear
+		// any data leftover and assure consistency.
+		if (is_null($user))
+		{
+			$this->logout();
+		}
 
 		return $this->user = $user;
 	}


### PR DESCRIPTION
Fix for #4985.

If a user gets deleted from database while he's logged in his session data will remain.

While he won't be able to do anything, since `$user = null` and `check()` will deal with it, if a new user is created (with the same id [and attributes]), he will get logged in automatically.
