### PR TITLE
Add casting to Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -130,6 +130,13 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	protected $dates = array();
 
 	/**
+	 * Attributes to cast to their proper type.
+	 *
+	 * @var array
+	 */
+	protected $casts = array();
+
+	/**
 	 * The relationships that should be touched on save.
 	 *
 	 * @var array
@@ -214,6 +221,13 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	protected static $mutatorCache = array();
 
 	/**
+	 * The cache of the cast array for each class.
+	 *
+	 * @var array
+	 */
+	protected static $castsCache = array();
+
+	/**
 	 * The many to many relationship methods.
 	 *
 	 * @var array
@@ -295,6 +309,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		}
 
 		static::bootTraits();
+
+		static::cacheCasts();
 	}
 
 	/**
@@ -2167,11 +2183,12 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// If an attribute is a date, we will cast it to a string after converting it
 		// to a DateTime / Carbon instance. This is so we will get some consistent
 		// formatting while accessing attributes vs. arraying / JSONing a model.
-		foreach ($this->getDates() as $key)
+		foreach ($attributes as $key => $value)
 		{
-			if ( ! isset($attributes[$key])) continue;
-
-			$attributes[$key] = (string) $this->asDateTime($attributes[$key]);
+			if ($value instanceof DateTime)
+			{
+				$attributes[$key] = (string) $value;
+			}
 		}
 
 		// We want to spin through all the mutated attributes for this model and call
@@ -2337,14 +2354,6 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			return $this->mutateAttribute($key, $value);
 		}
 
-		// If the attribute is listed as a date, we will convert it to a DateTime
-		// instance on retrieval, which makes it quite convenient to work with
-		// date fields without having to create a mutator for each property.
-		elseif (in_array($key, $this->getDates()))
-		{
-			if ($value) return $this->asDateTime($value);
-		}
-
 		return $value;
 	}
 
@@ -2440,18 +2449,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			return $this->{$method}($value);
 		}
 
-		// If an attribute is listed as a "date", we'll convert it from a DateTime
-		// instance into a form proper for storage on the database tables using
-		// the connection grammar's date format. We will auto set the values.
-		elseif (in_array($key, $this->getDates()))
-		{
-			if ($value)
-			{
-				$value = $this->fromDateTime($value);
-			}
-		}
-
-		$this->attributes[$key] = $value;
+		$this->setRawAttribute($key, $value);
 	}
 
 	/**
@@ -2463,6 +2461,62 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	public function hasSetMutator($key)
 	{
 		return method_exists($this, 'set'.studly_case($key).'Attribute');
+	}
+
+	/**
+	 * Cache the cast array for legacy support.
+	 *
+	 * @return void
+	 */
+	static protected function cacheCasts()
+	{
+		$class = get_class($instance = new static);
+
+		static::$castsCache[$class] = $instance->casts;
+
+		foreach ($instance->getDates() as $key)
+		{
+			static::$castsCache[$class][$key] = 'date';
+		}
+	}
+
+	/**
+	 * Add an attribute to the cast array.
+	 *
+	 * @param string  $attribute
+	 * @param string  $type
+	 */
+	protected function addCast($attribute, $type)
+	{
+		$class = get_class($this);
+
+		static::$castsCache[$class][$attribute] = $type;
+	}
+
+	/**
+	 * Get the cast type for a given attribute.
+	 *
+	 * @param  string  $attribute
+	 * @return string|null
+	 */
+	protected function getCastType($attribute)
+	{
+		$casts = $this->getCasts();
+
+		if (array_key_exists($attribute, $casts))
+		{
+			return $casts[$attribute];
+		}
+	}
+
+	/**
+	 * Get the casts array for the current class.
+	 *
+	 * @return array
+	 */
+	protected function getCasts()
+	{
+		return static::$castsCache[get_class($this)];
 	}
 
 	/**
@@ -2594,7 +2648,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
-	 * Set the array of model attributes. No checking is done.
+	 * Set the array of model attributes. No mutators are called.
 	 *
 	 * @param  array  $attributes
 	 * @param  bool   $sync
@@ -2602,9 +2656,46 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function setRawAttributes(array $attributes, $sync = false)
 	{
-		$this->attributes = $attributes;
+		$this->attributes = [];
+
+		foreach ($attributes as $key => $value)
+		{
+			$this->setRawAttribute($key, $value);
+		}
 
 		if ($sync) $this->syncOriginal();
+	}
+
+	/**
+	 * Set a given attribute on the model. No mutators are called.
+	 *
+	 * @param  string  $key
+	 * @param  mixed   $value
+	 * @return void
+	 */
+	protected function setRawAttribute($key, $value)
+	{
+		$this->attributes[$key] = $this->castAttribute($key, $value);
+	}
+
+	/**
+	 * Cast an attribute to its proper type.
+	 *
+	 * @param  string $key
+	 * @param  mixed  $value
+	 * @return mixed
+	 */
+	protected function castAttribute($key, $value)
+	{
+		if (is_null($value)) return null;
+
+		if (is_null($type = $this->getCastType($key))) return $value;
+
+		if ($type == 'date') return $this->asDateTime($value);
+
+		settype($value, $type);
+
+		return $value;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
@@ -17,6 +17,10 @@ trait SoftDeletingTrait {
 	public static function bootSoftDeletingTrait()
 	{
 		static::addGlobalScope(new SoftDeletingScope);
+
+		$instance = new static;
+
+		$instance->addCast($instance->getDeletedAtColumn(), 'date');
 	}
 
 	/**


### PR DESCRIPTION
This PR is based on the work done by @daylerees in #4948. See that PR for more info.

``` php
class Book extends Eloquent
{
    protected $casts = [
        'name'          => 'string',
        'pages'         => 'integer',
        'read'          => 'boolean',
        'read_on'       => 'date',
        'price'         => 'double',
    ];
}
```

It basically allows any type that [`settype`](http://www.php.net/manual/en/function.settype.php) accepts, plus `date` (not sure how useful `array`, `object` and `null` could be. Maybe we should prevent that?).

---

This improves upon @daylerees's work thus:
1. The casts are cached so they don't have to be recalculated for every attribute.
2. The casts are performed when the attributes are set, so that there's no need to mutate again on get.
3. Allows for traits to add their own casts. This has been implemented here in the `SoftDeletingTrait` to cast `deleted_at` to a date (it had been working automatically in 4.1 and has been restored here).

---

**There are no tests yet**.

I'm trying to get a consensus about what people think of this implementation and if @taylorotwell thinks this should be added (and whether to 4.2 or 4.3).

Once everything is ironed out I'll be more than happy to write the tests.
