### PR TITLE
Remove duplicate rows from simple pagination

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -103,8 +103,8 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 		if (is_null($perPage))
 		{
 			$this->perPage = (int) $total;
-			$this->items = array_slice($items, 0, $perPage);
-			$this->hasMore = count(array_slice($items, $this->perPage, 1)) > 0;
+			$this->items = array_slice($items, 0, $this->perPage);
+			$this->hasMore = count($items) > $this->perPage;
 		}
 		else
 		{

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -21,6 +21,29 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, $p->getCurrentPage());
 	}
 
+	public function testSimplePagination()
+	{
+		$p = new Paginator($factory = m::mock('Illuminate\Pagination\Factory'), ['foo', 'bar', 'baz'], 2);
+		$factory->shouldReceive('getCurrentPage')->once()->andReturn(1);
+		$p->setupPaginationContext();
+
+		$this->assertEquals(2, $p->getLastPage());
+		$this->assertEquals(1, $p->getCurrentPage());
+		$this->assertEquals(['foo', 'bar'], $p->getItems());
+	}
+
+
+	public function testSimplePaginationLastPage()
+	{
+		$p = new Paginator($factory = m::mock('Illuminate\Pagination\Factory'), ['foo', 'bar', 'baz'], 3);
+		$factory->shouldReceive('getCurrentPage')->once()->andReturn(1);
+		$p->setupPaginationContext();
+
+		$this->assertEquals(1, $p->getLastPage());
+		$this->assertEquals(1, $p->getCurrentPage());
+		$this->assertEquals(3, count($p->getItems()));
+	}
+
 
 	public function testPaginationContextIsSetupCorrectlyInCursorMode()
 	{


### PR DESCRIPTION
As discussed in #4977, this removes the one extra record that will be repeated on the next page.
