### PR TITLE
[4.2] Console : add empty fire() method

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -113,6 +113,13 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	}
 
 	/**
+	 * Execute the console command.
+	 *
+	 * @return void
+	 */
+	public function fire() {}
+
+	/**
 	 * Call another console command.
 	 *
 	 * @param  string  $command


### PR DESCRIPTION
So that executing a command that does not yet contain the `fire` command does not throw a fatal error.
