### PR TITLE
[4.2] Database : Ensure replicate can also skip timestamps

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2593,7 +2593,13 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function replicate()
 	{
-		$attributes = array_except($this->attributes, array($this->getKeyName()));
+		$except = [
+			$this->getKeyName(),
+			$this->getCreatedAtColumn(),
+			$this->getUpdatedAtColumn(),
+		];
+
+		$attributes = array_except($this->attributes, $except);
 
 		with($instance = new static)->setRawAttributes($attributes);
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -751,6 +751,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$class->exists = true;
 		$class->first = 'taylor';
 		$class->last = 'otwell';
+		$class->created_at = $class->freshTimestamp();
+		$class->updated_at = $class->freshTimestamp();
 		$class->setRelation('foo', array('bar'));
 
 		$clone = $class->replicate();
@@ -759,6 +761,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($clone->exists);
 		$this->assertEquals('taylor', $clone->first);
 		$this->assertEquals('otwell', $clone->last);
+		$this->assertObjectNotHasAttribute('created_at', $clone);
+		$this->assertObjectNotHasAttribute('updated_at', $clone);
 		$this->assertEquals(array('bar'), $clone->foo);
 	}
 


### PR DESCRIPTION
As an instance can be replicated it does not exist, in database at least.
The option is offered to skip original timestamps, so that when the duplicated object is saved, it has relevant `created_at` and `updated_at` properties.
