### PR TITLE
[Proposal] De-couple mail component a bit more

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,8 @@
         }
     },
     "suggest": {
-        "doctrine/dbal": "Allow renaming columns and dropping SQLite columns."
+        "doctrine/dbal": "Allow renaming columns and dropping SQLite columns.",
+        "guzzlehttp/guzzle": "Required for Mailgun and Mandrill mail drivers."
     },
     "minimum-stability": "dev"
 }

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -2,12 +2,6 @@
 
 use Swift_Mailer;
 use Illuminate\Support\ServiceProvider;
-use Swift_SmtpTransport as SmtpTransport;
-use Swift_MailTransport as MailTransport;
-use Illuminate\Mail\Transport\LogTransport;
-use Illuminate\Mail\Transport\MailgunTransport;
-use Illuminate\Mail\Transport\MandrillTransport;
-use Swift_SendmailTransport as SendmailTransport;
 
 class MailServiceProvider extends ServiceProvider {
 
@@ -90,161 +84,27 @@ class MailServiceProvider extends ServiceProvider {
 	 */
 	public function registerSwiftMailer()
 	{
-		$config = $this->app['config']['mail'];
-
-		$this->registerSwiftTransport($config);
+		$this->registerSwiftTransport();
 
 		// Once we have the transporter registered, we will register the actual Swift
 		// mailer instance, passing in the transport instances, which allows us to
 		// override this transporter instances during app start-up if necessary.
 		$this->app['swift.mailer'] = $this->app->share(function($app)
 		{
-			return new Swift_Mailer($app['swift.transport']);
+			return new Swift_Mailer($app['swift.transport']->driver());
 		});
 	}
 
 	/**
 	 * Register the Swift Transport instance.
 	 *
-	 * @param  array  $config
-	 * @return void
-	 *
-	 * @throws \InvalidArgumentException
-	 */
-	protected function registerSwiftTransport($config)
-	{
-		switch ($config['driver'])
-		{
-			case 'smtp':
-				return $this->registerSmtpTransport($config);
-
-			case 'sendmail':
-				return $this->registerSendmailTransport($config);
-
-			case 'mail':
-				return $this->registerMailTransport($config);
-
-			case 'mailgun':
-				return $this->registerMailgunTransport($config);
-
-			case 'mandrill':
-				return $this->registerMandrillTransport($config);
-
-			case 'log':
-				return $this->registerLogTransport($config);
-
-			default:
-				throw new \InvalidArgumentException('Invalid mail driver.');
-		}
-	}
-
-	/**
-	 * Register the SMTP Swift Transport instance.
-	 *
-	 * @param  array  $config
 	 * @return void
 	 */
-	protected function registerSmtpTransport($config)
+	protected function registerSwiftTransport()
 	{
-		$this->app['swift.transport'] = $this->app->share(function() use ($config)
+		$this->app['swift.transport'] = $this->app->share(function($app)
 		{
-			extract($config);
-
-			// The Swift SMTP transport instance will allow us to use any SMTP backend
-			// for delivering mail such as Sendgrid, Amazon SES, or a custom server
-			// a developer has available. We will just pass this configured host.
-			$transport = SmtpTransport::newInstance($host, $port);
-
-			if (isset($encryption))
-			{
-				$transport->setEncryption($encryption);
-			}
-
-			// Once we have the transport we will check for the presence of a username
-			// and password. If we have it we will set the credentials on the Swift
-			// transporter instance so that we'll properly authenticate delivery.
-			if (isset($username))
-			{
-				$transport->setUsername($username);
-
-				$transport->setPassword($password);
-			}
-
-			return $transport;
-		});
-	}
-
-	/**
-	 * Register the Sendmail Swift Transport instance.
-	 *
-	 * @param  array  $config
-	 * @return void
-	 */
-	protected function registerSendmailTransport($config)
-	{
-		$this->app['swift.transport'] = $this->app->share(function() use ($config)
-		{
-			return SendmailTransport::newInstance($config['sendmail']);
-		});
-	}
-
-	/**
-	 * Register the Mail Swift Transport instance.
-	 *
-	 * @param  array  $config
-	 * @return void
-	 */
-	protected function registerMailTransport($config)
-	{
-		$this->app['swift.transport'] = $this->app->share(function()
-		{
-			return MailTransport::newInstance();
-		});
-	}
-
-	/**
-	 * Register the Mailgun Swift Transport instance.
-	 *
-	 * @param  array  $config
-	 * @return void
-	 */
-	protected function registerMailgunTransport($config)
-	{
-		$mailgun = $this->app['config']->get('services.mailgun', array());
-
-		$this->app->bindShared('swift.transport', function() use ($mailgun)
-		{
-			return new MailgunTransport($mailgun['secret'], $mailgun['domain']);
-		});
-	}
-
-	/**
-	 * Register the Mandrill Swift Transport instance.
-	 *
-	 * @param  array  $config
-	 * @return void
-	 */
-	protected function registerMandrillTransport($config)
-	{
-		$mandrill = $this->app['config']->get('services.mandrill', array());
-
-		$this->app->bindShared('swift.transport', function() use ($mandrill)
-		{
-			return new MandrillTransport($mandrill['secret']);
-		});
-	}
-
-	/**
-	 * Register the "Log" Swift Transport instance.
-	 *
-	 * @param  array  $config
-	 * @return void
-	 */
-	protected function registerLogTransport($config)
-	{
-		$this->app->bindShared('swift.transport', function($app)
-		{
-			return new LogTransport($app['log']->getMonolog());
+			return new TransportManager($app);
 		});
 	}
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -3,7 +3,6 @@
 use Closure;
 use Swift_Mailer;
 use Swift_Message;
-use Illuminate\Log\Writer;
 use Psr\Log\LoggerInterface;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\View\Factory;

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -1,0 +1,122 @@
+<?php namespace Illuminate\Mail;
+
+use Illuminate\Support\Manager;
+use Swift_SmtpTransport as SmtpTransport;
+use Swift_MailTransport as MailTransport;
+use Illuminate\Mail\Transport\LogTransport;
+use Illuminate\Mail\Transport\MailgunTransport;
+use Illuminate\Mail\Transport\MandrillTransport;
+use Swift_SendmailTransport as SendmailTransport;
+
+class TransportManager extends Manager {
+
+	/**
+	 * Create an instance of the SMTP Swift Transport driver.
+	 *
+	 * @return \Swift_SmtpTransport
+	 */
+	protected function createSmtpDriver()
+	{
+		$config = $this->app['config']['mail'];
+
+		// The Swift SMTP transport instance will allow us to use any SMTP backend
+		// for delivering mail such as Sendgrid, Amazon SES, or a custom server
+		// a developer has available. We will just pass this configured host.
+		$transport = SmtpTransport::newInstance($config['host'], $config['port']);
+
+		if (isset($config['encryption']))
+		{
+			$transport->setEncryption($config['encryption']);
+		}
+
+		// Once we have the transport we will check for the presence of a username
+		// and password. If we have it we will set the credentials on the Swift
+		// transporter instance so that we'll properly authenticate delivery.
+		if (isset($config['username']))
+		{
+			$transport->setUsername($config['username']);
+
+			$transport->setPassword($config['password']);
+		}
+
+		return $transport;
+	}
+
+	/**
+	 * Create an instance of the Sendmail Swift Transport driver.
+	 *
+	 * @return \Swift_SendmailTransport
+	 */
+	protected function createSendmailDriver()
+	{
+		$command = $this->app['config']['mail']['sendmail'];
+
+		return SendmailTransport::newInstance($command);
+	}
+
+	/**
+	 * Create an instance of the Mail Swift Transport driver.
+	 *
+	 * @return \Swift_MailTransport
+	 */
+	protected function createMailDriver()
+	{
+		return MailTransport::newInstance();
+	}
+
+	/**
+	 * Create an instance of the Mailgun Swift Transport driver.
+	 *
+	 * @return \Illuminate\Mail\Transport\MailgunTransport
+	 */
+	protected function createMailgunDriver()
+	{
+		$config = $this->app['config']->get('services.mailgun', array());
+
+		return new MailgunTransport($config['secret'], $config['domain']);
+	}
+
+	/**
+	 * Create an instance of the Mandrill Swift Transport driver.
+	 *
+	 * @return \Illuminate\Mail\Transport\MandrillTransport
+	 */
+	protected function createMandrillDriver()
+	{
+		$config = $this->app['config']->get('services.mandrill', array());
+
+		return new MandrillTransport($config['secret']);
+	}
+
+	/**
+	 * Create an instance of the Log Swift Transport driver.
+	 *
+	 * @return \Illuminate\Mail\Transport\LogTransport
+	 */
+	protected function createLogDriver()
+	{
+		return new LogTransport($this->app['log']->getMonolog());
+	}
+
+	/**
+	 * Get the default cache driver name.
+	 *
+	 * @return string
+	 */
+	public function getDefaultDriver()
+	{
+		return $this->app['config']['mail.driver'];
+	}
+
+	/**
+	 * Set the default cache driver name.
+	 *
+	 * @param  string  $name
+	 * @return void
+	 */
+	public function setDefaultDriver($name)
+	{
+		$this->app['config']['mail.driver'] = $name;
+	}
+
+}

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -25,5 +25,8 @@
             "dev-master": "4.3-dev"
         }
     },
+    "suggest": {
+        "guzzlehttp/guzzle": "Required for Mailgun and Mandrill mail drivers."
+    },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
I wrote this PR because recently I tried integrating the mail component in a legacy Zend 1 app. I noticed some caveats with using it because at some points it was pretty tightly coupled to the Laravel framework. I made some improvements to decouple it a bit more so others may use it more easily in applications different then Laravel. ~~This PR should be without BC breaks so I could also send this to 4.2 if you'd like. Let me know.~~

Improvements:
- ~~Usage of an interface and trait for the log writer class. This allows us to more easily use our own log classes in Laravel components. I've replaced the hard-coded Writer dependency in the Mailer class with the interface so we can now easily use our own loggers with the mail component.~~
- I've added Guzzle as a suggest in `composer.json`. I didn't get the mandrill component working immediately and it turned out that it was because Guzzle didn't came along as a dependency. While I agree that it may be overkill to always include it in the "require" list we should definitely let developers know to install it if they want to use the Mailgun or Mandrill driver.
- Currently, the logic for choosing a transport based on the selected driver is hardcoded into the service provider. This makes it virtually impossible to use it outside of Laravel. I ended up just copy/pasting all the code. I've moved this to an external class so it's easier to re-use.
- ~~Some minor docblock and namespace import fixes.~~

Hope you like it! I'll write a blog post on how to integrate the mail component into other apps after this gets merged in. Enjoy!

~~PS.: I'm still wondering about cutting out the config repository as a constructor argument and just pass along an array with all the options. This will make it even more easier to re-use outside Laravel. What do you think?~~
#### Update 1
- Replaced the Writer dependency in the Mailer class with the PSR LoggerInterface.
- ~~Removed the Config Repository dependency from the Transport class and to just pass the array with options.~~
#### Update 2
- Will send the docblock and namespace fixes as a separate PR so it can be included in the 4.2 branch.
- The mail Transport class now extends the Manager class. **One big change is that `swift.transport` now is an instance of `TransportManager` rather than `Swift_Transport`**
