### PR TITLE
Add ability to add and remove model observable events

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1271,6 +1271,54 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
+	 * Set the observable event names.
+	 *
+	 * @return void
+	 */
+	public function setObservableEvents(array $observables)
+	{
+		$this->observables = $observables;
+	}
+
+	/**
+	 * Add an observable event name.
+	 *
+	 * @param  mixed  $observables
+	 * @return void
+	 */
+	public function addObservableEvents($observables)
+	{
+		$observables = is_array($observables) ? $observables : func_get_args();
+
+		foreach ($observables as $observable)
+		{	
+			if ( ! in_array($observable, $this->observables))
+			{
+				$this->observables[] = $observable;
+			}			
+		}
+	}
+
+	/**
+	 * Remove an observable event name.
+	 *
+	 * @param  mixed  $observables
+	 * @return void
+	 */
+	public function removeObservableEvents($observables)
+	{
+		$observables = is_array($observables) ? $observables : func_get_args();
+
+		foreach ($observables as $observable)
+		{
+			if ($index = array_search($observable, $this->observables) !== false)
+			{
+				unset($this->observables[$index]);
+			}	
+		}
+	}
+
+	/**
 	 * Increment a column's value by a given amount.
 	 *
 	 * @param  string  $column

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -774,6 +774,32 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testSetObservableEvents()
+	{
+		$class = new EloquentModelStub;
+		$class->setObservableEvents(array('foo'));
+
+		$this->assertContains('foo', $class->getObservableEvents());
+	}
+
+	public function testAddObservableEvent()
+	{
+		$class = new EloquentModelStub;
+		$class->addObservableEvents('foo');
+
+		$this->assertContains('foo', $class->getObservableEvents());
+	}
+
+	public function testRemoveObservableEvent()
+	{
+		$class = new EloquentModelStub;
+		$class->setObservableEvents(array('foo', 'bar'));
+		$class->removeObservableEvents('bar');
+
+		$this->assertNotContains('bar', $class->getObservableEvents());
+	}
+
+
 	/**
 	 * @expectedException LogicException
 	 */


### PR DESCRIPTION
I would like to be able to implement observable events in a model trait, but by setting the `$observables` property on a trait I would override it if it was set on a model. These methods will allow traits to add and remove observable events as necessary without impacting the events already set on the model they are on.
