### PR TITLE
Changed @forelse syntax and allow for nesting them

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -52,6 +52,13 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	protected $footer = array();
 
 	/**
+	 * Counter to keep track of nested forelse statements.
+	 *
+	 * @var int
+	 */
+	protected $forelseCounter = 0;
+
+	/**
 	 * Compile the view at the given path.
 	 *
 	 * @param  string  $path
@@ -428,7 +435,20 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	protected function compileForeach($expression)
 	{
-		return "<?php \$__empty = true; foreach{$expression}: \$__empty = false; ?>";
+		return "<?php foreach{$expression}: ?>";
+	}
+
+	/**
+	 * Compile the forelse statements into valid PHP.
+	 *
+	 * @param string  $expression
+	 * @return string
+	 */
+	protected function compileForelse($expression)
+	{
+		$empty = '$__empty_' . ++$this->forelseCounter;
+
+		return "<?php {$empty} = true; foreach{$expression}: {$empty} = false; ?>";
 	}
 
 	/**
@@ -459,9 +479,11 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 * @param string  $expression
 	 * @return string
 	 */
-	protected function compileForelse($expression)
+	protected function compileEmpty($expression)
 	{
-		return "<?php endforeach; if (\$__empty): ?>";
+		$empty = '$__empty_' . $this->forelseCounter--;
+
+		return "<?php endforeach; if ({$empty}): ?>";
 	}
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -283,14 +283,39 @@ breeze
 	public function testForelseStatementsAreCompiled()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
-		$string = '@foreach ($this->getUsers() as $user)
+		$string = '@forelse ($this->getUsers() as $user)
 breeze
-@forelse
+@empty
 empty
 @endforelse';
-		$expected = '<?php $__empty = true; foreach($this->getUsers() as $user): $__empty = false; ?>
+		$expected = '<?php $__empty_1 = true; foreach($this->getUsers() as $user): $__empty_1 = false; ?>
 breeze
-<?php endforeach; if ($__empty): ?>
+<?php endforeach; if ($__empty_1): ?>
+empty
+<?php endif; ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
+
+
+	public function testNestedForelseStatementsAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$string = '@forelse ($this->getUsers() as $user)
+@forelse ($user->tags as $tag)
+breeze
+@empty
+tag empty
+@endforelse
+@empty
+empty
+@endforelse';
+		$expected = '<?php $__empty_1 = true; foreach($this->getUsers() as $user): $__empty_1 = false; ?>
+<?php $__empty_2 = true; foreach($user->tags as $tag): $__empty_2 = false; ?>
+breeze
+<?php endforeach; if ($__empty_2): ?>
+tag empty
+<?php endif; ?>
+<?php endforeach; if ($__empty_1): ?>
 empty
 <?php endif; ?>';
 		$this->assertEquals($expected, $compiler->compileString($string));


### PR DESCRIPTION
The syntax with this PR becomes the same as it was with L3:

``` php
@forelse ($users as $user)
    <p>{{ $user->name }}</p>
@empty
    <p>No users</p>
@endforelse
```
