### PR TITLE
Add support for nested @forelse statements

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -45,6 +45,13 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	protected $escapedTags = array('{{{', '}}}');
 
 	/**
+	 * The depth of the nested foreach statements.
+	 *
+	 * @var integer
+	 */
+	protected $foreachDepth = 0;
+
+	/**
 	 * Array of footer lines to be added to template.
 	 *
 	 * @var array
@@ -428,7 +435,9 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	protected function compileForeach($expression)
 	{
-		return "<?php \$__empty = true; foreach{$expression}: \$__empty = false; ?>";
+		$empty = '$__empty_' . ++$this->foreachDepth;
+
+		return "<?php $empty = true; foreach{$expression}: $empty = false; ?>";
 	}
 
 	/**
@@ -461,7 +470,9 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	protected function compileForelse($expression)
 	{
-		return "<?php endforeach; if (\$__empty): ?>";
+		$empty = '$__empty_' . $this->foreachDepth--;
+
+		return "<?php endforeach; if ($empty): ?>";
 	}
 
 	/**
@@ -505,9 +516,10 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	protected function compileEndforeach($expression)
 	{
+		$this->foreachDepth--;
+
 		return "<?php endforeach; ?>";
 	}
-
 	/**
 	 * Compile the end-if statements into valid PHP.
 	 *

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -280,18 +280,34 @@ breeze
 	}
 
 
-	public function testForelseStatementsAreCompiled()
+	public function testNestedForelseStatementsAreCompiled()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
 		$string = '@foreach ($this->getUsers() as $user)
-breeze
+breeze1
+@foreach ($nested1 as $nest1)
+breeze2
+@foreach ($nested2 as $nest2)
+breeze3
 @forelse
-empty
+empty3
+@endforelse
+@endforeach
+@forelse
+empty1
 @endforelse';
-		$expected = '<?php $__empty = true; foreach($this->getUsers() as $user): $__empty = false; ?>
-breeze
-<?php endforeach; if ($__empty): ?>
-empty
+		$expected = '<?php $__empty_1 = true; foreach($this->getUsers() as $user): $__empty_1 = false; ?>
+breeze1
+<?php $__empty_2 = true; foreach($nested1 as $nest1): $__empty_2 = false; ?>
+breeze2
+<?php $__empty_3 = true; foreach($nested2 as $nest2): $__empty_3 = false; ?>
+breeze3
+<?php endforeach; if ($__empty_3): ?>
+empty3
+<?php endif; ?>
+<?php endforeach; ?>
+<?php endforeach; if ($__empty_1): ?>
+empty1
 <?php endif; ?>';
 		$this->assertEquals($expected, $compiler->compileString($string));
 	}


### PR DESCRIPTION
This is an alternative to #5043, sticking to the syntax introduced in #5028.

``` php
@foreach($users as $user)
    {{ $user->name }}
    @foreach($user->posts as $post)
        {{ $post->title }}
        @foreach($post->tags as $tag)
            {{ $tag->name }}
        @endforeach
    @forelse
        No posts.
    @endforelse
@forelse
    No users.
@endforelse
```
