### PR TITLE
[Proposal] Add @prepend blade statement

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -322,6 +322,17 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	}
 
 	/**
+	 * Compile the prepend statement into valid PHP.
+	 *
+	 * @param  string  $expression
+	 * @return string
+	 */
+	protected function compilePrepend($expression)
+	{
+		return "<?php \$__env->prependSection(); ?>";
+	}
+
+	/**
 	 * Compile the end-section statements into valid PHP.
 	 *
 	 * @param string  $expression

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -563,6 +563,27 @@ class Factory {
 	}
 
 	/**
+	 * Stop injecting content into a section and prepend it.
+	 *
+	 * @return string
+	 */
+	public function prependSection()
+	{
+		$last = array_pop($this->sectionStack);
+
+		if (isset($this->sections[$last]))
+		{
+			$this->sections[$last] = ob_get_clean().$this->sections[$last];
+		}
+		else
+		{
+			$this->sections[$last] = ob_get_clean();
+		}
+
+		return $last;
+	}
+
+	/**
 	 * Append content to a given section.
 	 *
 	 * @param  string  $section

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -374,6 +374,12 @@ empty
 		$this->assertEquals('<?php $__env->appendSection(); ?>', $compiler->compileString('@append'));
 	}
 
+	public function testPrependSectionsAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$this->assertEquals('<?php $__env->prependSection(); ?>', $compiler->compileString('@prepend'));
+	}
+
 
 	public function testCustomPhpCodeIsCorrectlyHandled()
 	{

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -293,6 +293,19 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testSectionPrepending()
+	{
+		$factory = $this->getFactory();
+		$factory->startSection('foo');
+		echo 'there';
+		$factory->prependSection();
+		$factory->startSection('foo');
+		echo 'hi';
+		$factory->prependSection();
+		$this->assertEquals('hithere', $factory->yieldContent('foo'));
+	}
+
+
 	public function testYieldSectionStopsAndYields()
 	{
 		$factory = $this->getFactory();


### PR DESCRIPTION
This PR adds a new statement to blade: `@prepend`.

**Use Case**

While working on a project that has multiple layouts, I created a 'footer' partial that is added in every of these layouts. One of the layouts, which has many sub views, requires a script to be run _before_ the view-specific scripts, but _after_ the always included scripts (like jQuery, etc.). I have tried using every type of Blade section to accomplish the prepending of that specific script, and found that it is not possible.

The `@prepend` statement can be used like this:

**_footer.blade.php**

```
    <script src="{{ asset('assets/js/vendor/jquery.min.js') }}"></script>
    @yield('scripts')
</body>
</html>
```

**layout.blade.php**

```
@include('_header')

    @yield('content')

    @section('scripts')
       <script src="/js/file/that/needs/to/run/before/other/scripts.js"></script>
    @prepend

@include('_footer')
```

**some-other-view.blade.php**

```
@section('content')
    {{-- content --}}
@stop

@section('scripts')
    <script src="/view/specific/scripts.js"></script>
@prepend
```

**ouput**

``` html
    <!-- header & content -->

    <script src="assets/js/vendor/jquery.min.js"></script>
    <script src="/js/file/that/needs/to/run/before/other/scripts.js"></script>
    <script src="/view/specific/scripts.js"></script>    
</body>
</html>
```
