### PR TITLE
[Queue\Capsule] Only create a "config" instance if only it not yet created.

### DIFF
--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -51,7 +51,10 @@ class Manager {
     {
         $this->container = $container ?: new Container;
 
-        $this->container->instance('config', new Fluent);
+        if ( ! $this->container->bound('config'))
+        {
+            $this->container->instance('config', new Fluent);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | Yes (in some use case where you use illuminate/config with illuminate/queue |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | None |
| License | MIT |
| Doc PR | None |

Make it consistent with changes to Illuminate\Database\Capsule\Manager
merged in laravel/framework#4598

Signed-off-by: crynobone crynobone@gmail.com
