### PR TITLE
[4.2] Foundation : ensure aliases are not set twice on instanciation

### DIFF
--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -42,7 +42,7 @@ class AliasLoader {
 	 */
 	public static function getInstance(array $aliases = array())
 	{
-		if (is_null(static::$instance)) static::$instance = new static($aliases);
+		if (is_null(static::$instance)) return static::$instance = new static($aliases);
 
 		$aliases = array_merge(static::$instance->getAliases(), $aliases);
 


### PR DESCRIPTION
If the instance does not exists yet, ensure the aliases are not uselessly set a second time.
