### PR TITLE
[4.2] Queue : add Carbon dependencies to Queue

### DIFF
--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -13,7 +13,8 @@
         "illuminate/container": "4.2.*",
         "illuminate/http": "4.2.*",
         "illuminate/support": "4.2.*",
-        "symfony/process": "2.5.*"
+        "symfony/process": "2.5.*",
+        "nesbot/carbon": "~1.0"
     },
     "require-dev": {
         "illuminate/cache": "4.2.*",


### PR DESCRIPTION
`Carbon` is used in https://github.com/laravel/framework/blob/4.2/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php and should be added as a composer dependency
