### PR TITLE
Move common method for a CapsuleManager to trait, this would reduce the ...

### DIFF
--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -1,22 +1,17 @@
 <?php namespace Illuminate\Database\Capsule;
 
 use PDO;
-use Illuminate\Support\Fluent;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Container\Container;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Connectors\ConnectionFactory;
+use Illuminate\Support\Traits\CapsuleManagerTrait;
 
 class Manager {
 
-	/**
-	 * The current globally used instance.
-	 *
-	 * @var \Illuminate\Database\Capsule\Manager
-	 */
-	protected static $instance;
+	use CapsuleManagerTrait;
 
 	/**
 	 * The database manager instance.
@@ -24,13 +19,6 @@ class Manager {
 	 * @var \Illuminate\Database\DatabaseManager
 	 */
 	protected $manager;
-
-	/**
-	 * The container instance.
-	 *
-	 * @var \Illuminate\Container\Container
-	 */
-	protected $container;
 
 	/**
 	 * Create a new database capsule manager.
@@ -48,22 +36,6 @@ class Manager {
 		$this->setupDefaultConfiguration();
 
 		$this->setupManager();
-	}
-
-	/**
-	 * Setup the IoC container instance.
-	 *
-	 * @param  \Illuminate\Container\Container|null  $container
-	 * @return void
-	 */
-	protected function setupContainer($container)
-	{
-		$this->container = $container ?: new Container;
-
-		if ( ! $this->container->bound('config'))
-		{
-			$this->container->instance('config', new Fluent);
-		}
 	}
 
 	/**
@@ -183,16 +155,6 @@ class Manager {
 	}
 
 	/**
-	 * Make this capsule instance available globally.
-	 *
-	 * @return void
-	 */
-	public function setAsGlobal()
-	{
-		static::$instance = $this;
-	}
-
-	/**
 	 * Get the database manager instance.
 	 *
 	 * @return \Illuminate\Database\Manager
@@ -248,27 +210,6 @@ class Manager {
 	public function setCacheManager(CacheManager $cache)
 	{
 		$this->container->instance('cache', $cache);
-	}
-
-	/**
-	 * Get the IoC container instance.
-	 *
-	 * @return \Illuminate\Container\Container
-	 */
-	public function getContainer()
-	{
-		return $this->container;
-	}
-
-	/**
-	 * Set the IoC container instance.
-	 *
-	 * @param  \Illuminate\Container\Container  $container
-	 * @return void
-	 */
-	public function setContainer(Container $container)
-	{
-		$this->container = $container;
 	}
 
 	/**

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -19,8 +19,7 @@
         "illuminate/cache": "4.2.*",
         "illuminate/console": "4.2.*",
         "illuminate/filesystem": "4.2.*",
-        "illuminate/pagination": "4.2.*",
-        "illuminate/support": "4.2.*"
+        "illuminate/pagination": "4.2.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -1,18 +1,13 @@
 <?php namespace Illuminate\Queue\Capsule;
 
-use Illuminate\Support\Fluent;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Container\Container;
 use Illuminate\Queue\QueueServiceProvider;
+use Illuminate\Support\Traits\CapsuleManagerTrait;
 
 class Manager {
 
-    /**
-     * The current globally used instance.
-     *
-     * @var \Illuminate\Queue\Capsule\Manager
-     */
-    protected static $instance;
+    use CapsuleManagerTrait;
 
     /**
      * The queue manager instance.
@@ -39,22 +34,6 @@ class Manager {
         $this->setupManager();
 
         $this->registerConnectors();
-    }
-
-    /**
-     * Setup the IoC container instance.
-     *
-     * @param  \Illuminate\Container\Container  $container
-     * @return void
-     */
-    protected function setupContainer($container)
-    {
-        $this->container = $container ?: new Container;
-
-        if ( ! $this->container->bound('config'))
-        {
-            $this->container->instance('config', new Fluent);
-        }
     }
 
     /**
@@ -167,16 +146,6 @@ class Manager {
     }
 
     /**
-     * Make this capsule instance available globally.
-     *
-     * @return void
-     */
-    public function setAsGlobal()
-    {
-        static::$instance = $this;
-    }
-
-    /**
      * Get the queue manager instance.
      *
      * @return \Illuminate\Queue\Manager
@@ -184,27 +153,6 @@ class Manager {
     public function getQueueManager()
     {
         return $this->manager;
-    }
-
-    /**
-     * Get the IoC container instance.
-     *
-     * @return \Illuminate\Container\Container
-     */
-    public function getContainer()
-    {
-        return $this->container;
-    }
-
-    /**
-     * Set the IoC container instance.
-     *
-     * @param  \Illuminate\Container\Container  $container
-     * @return void
-     */
-    public function setContainer(Container $container)
-    {
-        $this->container = $container;
     }
 
     /**

--- a/src/Illuminate/Support/Traits/CapsuleManagerTrait.php
+++ b/src/Illuminate/Support/Traits/CapsuleManagerTrait.php
@@ -1,0 +1,69 @@
+<?php namespace Illuminate\Support\Traits;
+
+use Illuminate\Container\Container;
+use Illuminate\Support\Fluent;
+
+trait CapsuleManagerTrait {
+
+    /**
+     * The current globally used instance.
+     *
+     * @var object
+     */
+    protected static $instance;
+
+    /**
+     * The container instance.
+     *
+     * @var \Illuminate\Container\Container
+     */
+    protected $container;
+
+    /**
+     * Setup the IoC container instance.
+     *
+     * @param  \Illuminate\Container\Container|null  $container
+     * @return void
+     */
+    protected function setupContainer($container)
+    {
+        $this->container = $container ?: new Container;
+
+        if ( ! $this->container->bound('config'))
+        {
+            $this->container->instance('config', new Fluent);
+        }
+    }
+
+    /**
+     * Make this capsule instance available globally.
+     *
+     * @return void
+     */
+    public function setAsGlobal()
+    {
+        static::$instance = $this;
+    }
+
+    /**
+     * Get the IoC container instance.
+     *
+     * @return \Illuminate\Container\Container
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
+     * Set the IoC container instance.
+     *
+     * @param  \Illuminate\Container\Container  $container
+     * @return void
+     */
+    public function setContainer(Container $container)
+    {
+        $this->container = $container;
+    }
+
+}

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Container\Container;
+use Illuminate\Support\Traits\CapsuleManagerTrait;
+
+class SupportCapsuleManagerTraitTest extends \PHPUnit_Framework_TestCase {
+
+	use CapsuleManagerTrait;
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function testSetupContainerForCapsule()
+	{
+		$this->container = null;
+		$app = new Container;
+
+		$this->assertNull($this->setupContainer($app));
+		$this->assertEquals($app, $this->getContainer());
+		$this->assertInstanceOf('\Illuminate\Support\Fluent', $app['config']);
+	}
+
+
+	public function testSetupContainerForCapsuleWhenConfigIsBound()
+	{
+		$this->container = null;
+		$app = new Container;
+		$app['config'] = m::mock('\Illuminate\Config\Repository');
+
+		$this->assertNull($this->setupContainer($app));
+		$this->assertEquals($app, $this->getContainer());
+		$this->assertInstanceOf('\Illuminate\Config\Repository', $app['config']);
+	}
+}

--- a/tests/Support/SupportMacroTraitTest.php
+++ b/tests/Support/SupportMacroTraitTest.php
@@ -28,7 +28,7 @@ class SupportMacroTraitTest extends \PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testResgisterMacroAndCallWithoutStatic()
+	public function testRegisterMacroAndCallWithoutStatic()
 	{
 		$macroTrait = $this->macroTrait;
 		$macroTrait::macro(__CLASS__, function() { return 'Taylor'; });


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | None |
| License | MIT |
| Doc PR | None |
- Move common method for a CapsuleManager to trait, this would reduce the requirement to produce new CapsuleManager for other component in the future (e.g: laravel/framework#5032)
- Also remove duplicate "require-dev" component (when already explicitly declare in "require").
