### PR TITLE
[4.2] Mark Test As Incomplete

### DIFF
--- a/tests/Foundation/FoundationArtisanTest.php
+++ b/tests/Foundation/FoundationArtisanTest.php
@@ -12,7 +12,7 @@ class FoundationArtisanTest extends PHPUnit_Framework_TestCase {
 
 	public function testArtisanIsCalledWithProperArguments()
 	{
-		return;
+		return $this->markTestIncomplete();
 
 		$artisan = $this->getMock('Illuminate\Foundation\Artisan', array('getArtisan'), array($app = new Illuminate\Foundation\Application));
 		$artisan->expects($this->once())->method('getArtisan')->will($this->returnValue($console = m::mock('StdClass')));


### PR DESCRIPTION
We should mark it as incomplete instead of just doing an early return to force skip it.
