### PR TITLE
[4.2] Fixed Throws Docblocks

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2030,6 +2030,8 @@ class Builder {
 	 * @param  mixed   $value
 	 * @param  string  $type
 	 * @return \Illuminate\Database\Query\Builder
+	 *
+	 * @throws \InvalidArgumentException
 	 */
 	public function addBinding($value, $type = 'where')
 	{

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -106,6 +106,8 @@ class Encrypter {
 	 * @param  string  $value
 	 * @param  string  $iv
 	 * @return string
+	 *
+	 * @throws \Exception
 	 */
 	protected function mcryptDecrypt($value, $iv)
 	{
@@ -125,7 +127,7 @@ class Encrypter {
 	 * @param  string  $payload
 	 * @return array
 	 *
-	 * @throws DecryptException
+	 * @throws \Illuminate\Encryption\DecryptException
 	 */
 	protected function getJsonPayload($payload)
 	{

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -696,6 +696,8 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	 * @param  int   $type
 	 * @param  bool  $catch
 	 * @return \Symfony\Component\HttpFoundation\Response
+	 *
+	 * @throws \Exception
 	 */
 	public function handle(SymfonyRequest $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
 	{

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -215,6 +215,8 @@ class Validator implements MessageProviderInterface {
 	 * @param  string  $attribute
 	 * @param  string|array  $rules
 	 * @return void
+	 *
+	 * @throws \InvalidArgumentException
 	 */
 	public function each($attribute, $rules)
 	{

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -246,6 +246,8 @@ class Factory {
 	 *
 	 * @param  string  $path
 	 * @return \Illuminate\View\Engines\EngineInterface
+	 *
+	 * @throws \InvalidArgumentException
 	 */
 	public function getEngineFromPath($path)
 	{


### PR DESCRIPTION
I've added 6 missing `@throws` annotations and have fixed another to use the fully qualified name like all other Laravel annotations do.
