### PR TITLE
Add tag and contentTag methods to HtmlBuilder

### DIFF
--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -376,4 +376,33 @@ class HtmlBuilder {
 		return $safe;
 	}
 
+	/**
+	 * Returns an HTML tag of type name surrounding the given content.
+	 *
+	 * @param  string  $name
+	 * @param  array   $attributes
+	 * @param  boolean $open
+	 * @return string
+	 */
+	public function tag($name, $attributes = array(), $open = false)
+	{
+		return '<'.$name.$this->attributes($attributes).($open ? '>' : ' />');
+	}
+
+	/**
+	 * Returns an empty HTML tag of type name.
+	 *
+	 * @param  string  $name
+	 * @param  mixed   $content
+	 * @param  array   $attributes
+	 * @param  boolean $escape
+	 * @return string
+	 */
+	public function contentTag($name, $content = null, $attributes = array(), $escape = true)
+	{
+		$content = $escape ? $this->entities($content) : $content;
+
+		return '<'.$name.$this->attributes($attributes).'>'.$content.'</'.$name.'>';
+	}
+
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1148,3 +1148,36 @@ if ( ! function_exists('with'))
 		return $object;
 	}
 }
+
+if ( ! function_exists('tag'))
+{
+	/**
+	 * Returns an HTML tag of type name surrounding the given content.
+	 *
+	 * @param  string  $name
+	 * @param  array   $attributes
+	 * @param  boolean $open
+	 * @return string
+	 */
+	function tag($name, $attributes = array(), $open = false)
+	{
+		return app('html')->tag($name, $attributes, $open);
+	}
+}
+
+if ( ! function_exists('content_tag'))
+{
+	/**
+	 * Returns an empty HTML tag of type name.
+	 *
+	 * @param  string  $name
+	 * @param  mixed   $content
+	 * @param  array $attributes
+	 * @param  boolean $escape
+	 * @return string
+	 */
+	function content_tag($name, $content = null, $attributes = array(), $escape = true)
+	{
+		return app('html')->contentTag($name, $content, $attributes, $escape);
+	}
+}

--- a/tests/Html/HtmlBuilderTest.php
+++ b/tests/Html/HtmlBuilderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Http\Request;
+use Illuminate\Html\HtmlBuilder;
+use Illuminate\Routing\UrlGenerator;
+use Illuminate\Routing\RouteCollection;
+
+class HtmlBuilderTest extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * Setup the test environment.
+	 */
+	public function setUp()
+	{
+		$this->urlGenerator = new UrlGenerator(new RouteCollection, Request::create('/foo', 'GET'));
+		$this->htmlBuilder = new HtmlBuilder($this->urlGenerator);
+	}
+
+
+	/**
+	 * Destroy the test environment.
+	 */
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testTag()
+	{
+		$tag1 = $this->htmlBuilder->tag('br');
+		$tag2 = $this->htmlBuilder->tag('br', null, true);
+		$tag3 = $this->htmlBuilder->tag('input', array('type' => 'text', 'required'));
+		$tag4 = $this->htmlBuilder->tag('img', array('src' => 'test.png'), false);
+		$tag5 = $this->htmlBuilder->tag('div', array('data-language' => 'PHP', 'data-framework' => 'Laravel'));
+
+		$this->assertEquals('<br />', $tag1);
+		$this->assertEquals('<br>', $tag2);
+		$this->assertEquals('<input type="text" required="required" />', $tag3);
+		$this->assertEquals('<img src="test.png" />', $tag4);
+		$this->assertEquals('<div data-language="PHP" data-framework="Laravel" />', $tag5);
+	}
+
+
+	public function testContentTag()
+	{
+		$tag1 = $this->htmlBuilder->contentTag('p', 'Hello world');
+		$tag2 = $this->htmlBuilder->contentTag('div', $this->htmlBuilder->contentTag('p', 'Hello world'), array('class' => 'hide'));
+		$tag3 = $this->htmlBuilder->contentTag('div', $this->htmlBuilder->contentTag('p', 'Hello world'), array('class' => 'hide'), false);
+		$tag4 = $this->htmlBuilder->contentTag('div');
+
+		$this->assertEquals('<p>Hello world</p>', $tag1);
+		$this->assertEquals('<div class="hide">&lt;p&gt;Hello world&lt;/p&gt;</div>', $tag2);
+		$this->assertEquals('<div class="hide"><p>Hello world</p></div>', $tag3);
+		$this->assertEquals('<div></div>', $tag4);
+	}
+}


### PR DESCRIPTION
This pull request implements the feature mentioned in Proposal #5087. See the proposal for more detailed information.

It adds a tag and contentTag method to the HtmlBuilder class, and also adds a few helper methods to make them easier to use in views. Although I didn't do it in this pull request, HtmlBuilder and FormBuilder could be rewritten to use these additions to simplify the existing methods like `link`, `image`, etc. I think this would be an improvement over the manual create of html tags in each method.
