### PR TITLE
LogTransport bugfix

### DIFF
--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -70,7 +70,7 @@ class LogTransport implements Swift_Transport {
 
 		foreach ($entity->getChildren() as $children)
 		{
-			$string .= PHP_EOL.PHP_EOL.$this->getMimeEntityString($entity);
+			$string .= PHP_EOL.PHP_EOL.$this->getMimeEntityString($children);
 		}
 
 		return $string;


### PR DESCRIPTION
This typo causes an infinite loop if the logged mail has a plaintext part.
