### PR TITLE
Docblock fixes, namespace imports and link in contributing.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Pull requests for bugs may be sent without creating any proposal issue. If you b
 
 ### Feature Requests
 
-If you have an idea for a new feature you would like to see added to Laravel, you may create an issue on GitHub with `[Request]` in the title. The feature request will then be reviewed by @taylorotwell.
+If you have an idea for a new feature you would like to see added to Laravel, you may create an issue on GitHub with `[Request]` in the title. The feature request will then be reviewed by [@taylorotwell](https://github.com/taylorotwell).
 
 ## Coding Guidelines
 

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -16,9 +16,9 @@ class LogTransport implements Swift_Transport {
 	protected $logger;
 
 	/**
-	 * Create a new Mandrill transport instance.
+	 * Create a new log transport instance.
 	 *
-	 * @param  string  $key
+	 * @param  \Psr\Log\LoggerInterface  $logger
 	 * @return void
 	 */
 	public function __construct(LoggerInterface $logger)

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Mail\Transport;
 
 use Swift_Transport;
+use GuzzleHttp\Client;
 use Swift_Mime_Message;
 use GuzzleHttp\Post\PostFile;
 use Swift_Events_EventListener;
@@ -118,7 +119,7 @@ class MailgunTransport implements Swift_Transport {
 	 */
 	protected function getHttpClient()
 	{
-		return new \GuzzleHttp\Client;
+		return new Client;
 	}
 
 	/**

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Mail\Transport;
 
 use Swift_Transport;
+use GuzzleHttp\Client;
 use Swift_Mime_Message;
 use Swift_Events_EventListener;
 
@@ -75,11 +76,11 @@ class MandrillTransport implements Swift_Transport {
 	/**
 	 * Get a new HTTP client instance.
 	 *
-	 * @return \Guzzle\Http\Client
+	 * @return \GuzzleHttp\Client
 	 */
 	protected function getHttpClient()
 	{
-		return new \GuzzleHttp\Client;
+		return new Client;
 	}
 
 	/**


### PR DESCRIPTION
Some minor stuff. A few docblock fixes, namespace imports and added a link to your Github account in the contributing.md file (which I think was the point for the @ notation?).
