### PR TITLE
Fix for #4985

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -153,6 +153,11 @@ class Guard {
 			$user = $this->getUserByRecaller($recaller);
 		}
 
+		if (is_null($user) && ! is_null($id))
+		{
+			$this->clearUserDataFromStorage();
+		}
+
 		return $this->user = $user;
 	}
 


### PR DESCRIPTION
Fix for #4985. If a logged in user gets deleted and re-created, he will still be able to use the current session. This fix forgets the current session and forces the user to login again.
