### PR TITLE
Update to Session/Store.php put method

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -330,7 +330,7 @@ class Store implements SessionInterface {
 	 * @param  mixed|null  	 $value
 	 * @return void
 	 */
-	public function put($key, $value)
+	public function put($key, $value = null)
 	{
 		if ( ! is_array($key)) $key = array($key => $value);
 


### PR DESCRIPTION
Unable to pass an array of key/value pairs to Session::put(). As it was previously, you had to pass a string to the $value argument to avoid the Missing argument 2 ErrorException.
