### PR TITLE
4.2-fix-associate-on-morphTo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -104,7 +104,7 @@ class MorphTo extends BelongsTo {
 	{
 		$this->parent->setAttribute($this->foreignKey, $model->getKey());
 
-		$this->parent->setAttribute($this->morphType, get_class($model));
+		$this->parent->setAttribute($this->morphType, $model->getMorphClass());
 
 		return $this->parent->setRelation($this->relation, $model);
 	}

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -90,9 +90,10 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 
 		$associate = m::mock('Illuminate\Database\Eloquent\Model');
 		$associate->shouldReceive('getKey')->once()->andReturn(1);
+		$associate->shouldReceive('getMorphClass')->once()->andReturn('Model');
 
 		$parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
-		$parent->shouldReceive('setAttribute')->once()->with('morph_type', get_class($associate));
+		$parent->shouldReceive('setAttribute')->once()->with('morph_type', 'Model');
 		$parent->shouldReceive('setRelation')->once()->with('relation', $associate);
 
 		$relation->associate($associate);


### PR DESCRIPTION
Fix associate to work correctly when `protected $morphClass` is overriden on the Model (after `getMorphClass()` method was added).

```
namespace My\Space;
class Category extends \Eloquent {
  protected $morphClass = 'Category';
}

// currently (using get_class):
$category = My\Space\Category::first();
$tag->taggable()->associate($category);
$tag->taggable_type; // 'My\\Space\\Category'

// should be:
$tag->taggable_type; // 'Category'
```
