### PR TITLE
Allow chunk to exit when the closure returns false

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1505,7 +1505,10 @@ class Builder {
 			// On each chunk result set, we will pass them to the callback and then let the
 			// developer take care of everything within the callback, which allows us to
 			// keep the memory low for spinning through large result sets for working.
-			call_user_func($callback, $results);
+			$return = call_user_func($callback, $results);
+
+			if ($return === false)
+				continue;
 
 			$page++;
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1508,7 +1508,7 @@ class Builder {
 			$return = call_user_func($callback, $results);
 
 			if ($return === false)
-				continue;
+				break;
 
 			$page++;
 


### PR DESCRIPTION
When looping through all of the different rows returned by an SQL statement using a chunk closure, you should be able to specify to Builder that you wish to no longer continue processing chunks by simply returning false inside the closure, without having to exit.
### Usage Example

```
  DB::table('download_files')
        ->where('downloaded', 0)
        ->chunk(5000, function($urls) use (&$post, &$loop, $time_queries, $time_started) {

            foreach($urls as $url) {
                Download::file($url->path, $url->filename);

                // only allow to run for 20 seconds...
                if ($time_started+20 > microtime(true)) {
                    return false
                }
            }

        })
```
