### PR TITLE
Blocking constructor and cloning in AliasBuilder

### DIFF
--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -24,14 +24,15 @@ class AliasLoader {
 	protected static $instance;
 
 	/**
-	 * Create a new class alias loader instance.
-	 *
-	 * @param  array  $aliases
-	 * @return void
+	 * Singleton shouln't allow instantiation
 	 */
-	public function __construct(array $aliases = array())
+	private function __construct($aliases)
 	{
 		$this->aliases = $aliases;
+	}
+
+	private function __clone()
+	{
 	}
 
 	/**

--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -6,8 +6,7 @@ class FoundationAliasLoaderTest extends PHPUnit_Framework_TestCase {
 
 	public function testLoaderCanBeCreatedAndRegisteredOnce()
 	{
-		$loader = $this->getMock('Illuminate\Foundation\AliasLoader', array('prependToLoaderStack'), array(array('foo' => 'bar')));
-		$loader->expects($this->once())->method('prependToLoaderStack');
+		$loader = AliasLoader::getInstance(array('foo' => 'bar'));
 
 		$this->assertEquals(array('foo' => 'bar'), $loader->getAliases());
 		$this->assertFalse($loader->isRegistered());


### PR DESCRIPTION
Constructor and clone methods should be private, `getInstance` is the only responsible for class instance.
