### PR TITLE
[4.2] Auth : call where only once in auth

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -104,13 +104,9 @@ class DatabaseUserProvider implements UserProviderInterface {
 		// generic "user" object that will be utilized by the Guard instances.
 		$query = $this->conn->table($this->table);
 
-		foreach ($credentials as $key => $value)
-		{
-			if ( ! str_contains($key, 'password'))
-			{
-				$query->where($key, $value);
-			}
-		}
+		array_forget($credentials, 'password');
+
+		$query->where($credentials);
 
 		// Now we are ready to execute the query to see if we have an user matching
 		// the given credentials. If not, we will just return nulls and indicate

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -42,7 +42,7 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 	{
 		$conn = m::mock('Illuminate\Database\Connection');
 		$conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
-		$conn->shouldReceive('where')->once()->with('username', 'dayle');
+		$conn->shouldReceive('where')->once()->with(['username' => 'dayle']);
 		$conn->shouldReceive('first')->once()->andReturn(array('id' => 1, 'name' => 'taylor'));
 		$hasher = m::mock('Illuminate\Hashing\HasherInterface');
 		$provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
@@ -58,7 +58,7 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 	{
 		$conn = m::mock('Illuminate\Database\Connection');
 		$conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
-		$conn->shouldReceive('where')->once()->with('username', 'dayle');
+		$conn->shouldReceive('where')->once()->with(['username' => 'dayle']);
 		$conn->shouldReceive('first')->once()->andReturn(null);
 		$hasher = m::mock('Illuminate\Hashing\HasherInterface');
 		$provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');


### PR DESCRIPTION
Instead of calling`where` many times, we can call it only once as `where` accepts an array as an argument.
Also ensure the password field is `password`, and not a field containing which name contains `password`
