### PR TITLE
Ignore white spaces when adding multiple filters to routes

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -211,7 +211,7 @@ class Route {
 		if (is_array($filters)) return static::explodeArrayFilters($filters);
 		
 		
-		return array_map('trim', explode('|', $filters);
+		return array_map('trim', explode('|', $filters));
 	}
 
 	/**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -209,8 +209,9 @@ class Route {
 	protected static function explodeFilters($filters)
 	{
 		if (is_array($filters)) return static::explodeArrayFilters($filters);
-
-		return explode('|', $filters);
+		
+		
+		return array_map('trim', explode('|', $filters);
 	}
 
 	/**
@@ -225,7 +226,7 @@ class Route {
 
 		foreach ($filters as $filter)
 		{
-			$results = array_merge($results, explode('|', $filter));
+			$results = array_merge($results, array_map('trim', explode('|', $filter)));
 		}
 
 		return $results;


### PR DESCRIPTION
Trim all white spaces from the filter string explode to array to that the white spaces will be ignored when applying filters.

```
Route::group(array('prefix' => 'admin', 'before' => 'auth | permissions'), function () {
```
