### PR TITLE
Increase getStringSize() compatibility

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -889,7 +889,7 @@ class Validator implements MessageProviderInterface {
 	{
 		if (function_exists('mb_strlen')) return mb_strlen($value);
 
-		return strlen($value);
+		return strlen(utf8_decode($value));
 	}
 
 	/**


### PR DESCRIPTION
Who doesn't have support for Multibyte String Extension will get a more accurate result.

``` php
var_dump( strlen('lập trình') ); // 12 ***

var_dump( strlen(utf8_decode('lập trình')) ); // 9 (Ok)
var_dump( mb_strlen('lập trình') ); // 9 (Ok)
```
