### PR TITLE
[4.2] Validate passwords more safely

### DIFF
--- a/src/Illuminate/Auth/Reminders/PasswordBroker.php
+++ b/src/Illuminate/Auth/Reminders/PasswordBroker.php
@@ -246,7 +246,7 @@ class PasswordBroker {
 	{
 		list($password, $confirm) = array($credentials['password'], $credentials['password_confirmation']);
 
-		return strcmp($password, $confirm) === 0 && $credentials['password'] && mb_strlen($password) >= 6;
+		return strcmp($password, $confirm) === 0 && mb_strlen($password) >= 6;
 	}
 
 	/**

--- a/src/Illuminate/Auth/Reminders/PasswordBroker.php
+++ b/src/Illuminate/Auth/Reminders/PasswordBroker.php
@@ -228,7 +228,7 @@ class PasswordBroker {
 
 		if (isset($this->passwordValidator))
 		{
-			return call_user_func($this->passwordValidator, $credentials) && $password == $confirm;
+			return call_user_func($this->passwordValidator, $credentials) && strcmp($password, $confirm) === 0;
 		}
 		else
 		{
@@ -244,9 +244,9 @@ class PasswordBroker {
 	 */
 	protected function validatePasswordWithDefaults(array $credentials)
 	{
-		$matches = $credentials['password'] == $credentials['password_confirmation'];
+		list($password, $confirm) = array($credentials['password'], $credentials['password_confirmation']);
 
-		return $matches && $credentials['password'] && strlen($credentials['password']) >= 6;
+		return strcmp($password, $confirm) === 0 && $credentials['password'] && mb_strlen($password) >= 6;
 	}
 
 	/**


### PR DESCRIPTION
With `==` is a little bit dangerous. Example:

``` php
var_dump( "1e3" == "1000" ); // true
```
