### PR TITLE
[4.2] Foundation - Check mbstring extension

### DIFF
--- a/src/Illuminate/Foundation/start.php
+++ b/src/Illuminate/Foundation/start.php
@@ -31,6 +31,13 @@ if ( ! extension_loaded('mcrypt'))
 	exit(1);
 }
 
+if ( ! extension_loaded('mbstring'))
+{
+	echo 'mbstring PHP extension required.'.PHP_EOL;
+
+	exit(1);
+}
+
 /*
 |--------------------------------------------------------------------------
 | Register Class Imports


### PR DESCRIPTION
mbstring is used (for Helpers etc). It's required.

@taylorotwell This is just a proposal. Feel free to close if no make sense for 4.2 branch.
