### PR TITLE
[4.3] Upgrade To Predis 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "nesbot/carbon": "~1.0",
         "patchwork/utf8": "1.1.*",
         "phpseclib/phpseclib": "0.3.*",
-        "predis/predis": "0.8.*",
+        "predis/predis": "~1.0",
         "stack/builder": "~1.0",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/browser-kit": "2.5.*",

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "4.3.*",
-        "predis/predis": "0.8.*"
+        "predis/predis": "~1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This was actually surprisingly simple. I've been through the changes in 1.0 with a fine-tooth comb, and noticed one small error affecting both predis 0.8 and 1.0; see #5156.

NB: predis 1.0 will be released in ~10 days time, so if you want to wait for a stable release before merging, it shouldn't be long now.
