### PR TITLE
[4.2] Revert Change Casuing A Double Connect

### DIFF
--- a/src/Illuminate/Remote/Connection.php
+++ b/src/Illuminate/Remote/Connection.php
@@ -235,9 +235,12 @@ class Connection implements ConnectionInterface {
 	 */
 	public function getGateway()
 	{
-		if ( ! $this->gateway->connected() && ! $this->gateway->connect($this->username))
+		if ( ! $this->gateway->connected())
 		{
-			throw new \RuntimeException("Unable to connect to remote server.");
+			if ( ! $this->gateway->connect($this->username))
+			{
+				throw new \RuntimeException("Unable to connect to remote server.");
+			}
 		}
 
 		return $this->gateway;


### PR DESCRIPTION
PHP will always evaluate both sides of the &&, so we are always calling the connect function.

---

This reverts f1ab0a4cfdbc6d9df20719444f088a6ac4366bb7.
