### PR TITLE
[4.2] Revert Change Casuing An Extra Function Call

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -654,9 +654,12 @@ class BelongsToMany extends Relation {
 			// Now we'll try to update an existing pivot record with the attributes that were
 			// given to the method. If the model is actually updated we will add it to the
 			// list of updated pivot records so we return them back out to the consumer.
-			elseif (count($attributes) > 0 && $this->updateExistingPivot($id, $attributes, $touch))
+			elseif (count($attributes) > 0)
 			{
-				$changes['updated'][] = (int) $id;
+				if ($this->updateExistingPivot($id, $attributes, $touch))
+				{
+					$changes['updated'][] = (int) $id;
+				}
 			}
 		}
 		return $changes;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -654,8 +654,7 @@ class BelongsToMany extends Relation {
 			// Now we'll try to update an existing pivot record with the attributes that were
 			// given to the method. If the model is actually updated we will add it to the
 			// list of updated pivot records so we return them back out to the consumer.
-			elseif (count($attributes) > 0 &&
-				$this->updateExistingPivot($id, $attributes, $touch))
+			elseif (count($attributes) > 0 && $this->updateExistingPivot($id, $attributes, $touch))
 			{
 				$changes['updated'][] = (int) $id;
 			}


### PR DESCRIPTION
PHP will always evaluate both sides of the &&, so we are always calling the updateExistingPivot function, even in the wrong context.

---

Reverts: b7922063faf28e32fdf32f1fa890fd97afa5e32d.
