### PR TITLE
Created an abstract Publisher class to simplify configuration, view, and asset publishers

### DIFF
--- a/src/Illuminate/Foundation/AssetPublisher.php
+++ b/src/Illuminate/Foundation/AssetPublisher.php
@@ -2,93 +2,27 @@
 
 use Illuminate\Filesystem\Filesystem;
 
-class AssetPublisher {
+class AssetPublisher extends Publisher {
 
 	/**
-	 * The filesystem instance.
-	 *
-	 * @var \Illuminate\Filesystem\Filesystem
-	 */
-	protected $files;
-
-	/**
-	 * The path where assets should be published.
-	 *
-	 * @var string
-	 */
-	protected $publishPath;
-
-	/**
-	 * The path where packages are located.
-	 *
-	 * @var string
-	 */
-	protected $packagePath;
-
-	/**
-	 * Create a new asset publisher instance.
-	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @param  string  $publishPath
-	 * @return void
-	 */
-	public function __construct(Filesystem $files, $publishPath)
-	{
-		$this->files = $files;
-		$this->publishPath = $publishPath;
-	}
-
-	/**
-	 * Copy all assets from a given path to the publish path.
-	 *
-	 * @param  string  $name
-	 * @param  string  $source
-	 * @return bool
-	 *
-	 * @throws \RuntimeException
-	 */
-	public function publish($name, $source)
-	{
-		$destination = $this->publishPath."/packages/{$name}";
-
-		$success = $this->files->copyDirectory($source, $destination);
-
-		if ( ! $success)
-		{
-			throw new \RuntimeException("Unable to publish assets.");
-		}
-
-		return $success;
-	}
-
-	/**
-	 * Publish a given package's assets to the publish path.
+	 * Get the source assets directory to publish.
 	 *
 	 * @param  string  $package
 	 * @param  string  $packagePath
-	 * @return bool
+	 * @return string
+	 *
+	 * @throws \InvalidArgumentException
 	 */
-	public function publishPackage($package, $packagePath = null)
+	protected function getSource($package, $packagePath)
 	{
-		$packagePath = $packagePath ?: $this->packagePath;
-
-		// Once we have the package path we can just create the source and destination
-		// path and copy the directory from one to the other. The directory copy is
-		// recursive so all nested files and directories will get copied as well.
 		$source = $packagePath."/{$package}/public";
 
-		return $this->publish($package, $source);
-	}
+		if ( ! $this->files->isDirectory($source))
+		{
+			throw new \InvalidArgumentException("Assets not found.");
+		}
 
-	/**
-	 * Set the default package path.
-	 *
-	 * @param  string  $packagePath
-	 * @return void
-	 */
-	public function setPackagePath($packagePath)
-	{
-		$this->packagePath = $packagePath;
+		return $source;
 	}
 
 }

--- a/src/Illuminate/Foundation/ConfigPublisher.php
+++ b/src/Illuminate/Foundation/ConfigPublisher.php
@@ -2,76 +2,7 @@
 
 use Illuminate\Filesystem\Filesystem;
 
-class ConfigPublisher {
-
-	/**
-	 * The filesystem instance.
-	 *
-	 * @var \Illuminate\Filesystem\Filesystem
-	 */
-	protected $files;
-
-	/**
-	 * The destination of the config files.
-	 *
-	 * @var string
-	 */
-	protected $publishPath;
-
-	/**
-	 * The path to the application's packages.
-	 *
-	 * @var string
-	 */
-	protected $packagePath;
-
-	/**
-	 * Create a new configuration publisher instance.
-	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @param  string  $publishPath
-	 * @return void
-	 */
-	public function __construct(Filesystem $files, $publishPath)
-	{
-		$this->files = $files;
-		$this->publishPath = $publishPath;
-	}
-
-	/**
-	 * Publish configuration files from a given path.
-	 *
-	 * @param  string  $package
-	 * @param  string  $source
-	 * @return bool
-	 */
-	public function publish($package, $source)
-	{
-		$destination = $this->getDestinationPath($package);
-
-		$this->makeDestination($destination);
-
-		return $this->files->copyDirectory($source, $destination);
-	}
-
-	/**
-	 * Publish the configuration files for a package.
-	 *
-	 * @param  string  $package
-	 * @param  string  $packagePath
-	 * @return bool
-	 */
-	public function publishPackage($package, $packagePath = null)
-	{
-		// First we will figure out the source of the package's configuration location
-		// which we do by convention. Once we have that we will move the files over
-		// to the "main" configuration directory for this particular application.
-		$path = $packagePath ?: $this->packagePath;
-
-		$source = $this->getSource($package, $path);
-
-		return $this->publish($package, $source);
-	}
+class ConfigPublisher extends Publisher {
 
 	/**
 	 * Get the source configuration directory to publish.
@@ -92,53 +23,6 @@ class ConfigPublisher {
 		}
 
 		return $source;
-	}
-
-	/**
-	 * Create the destination directory if it doesn't exist.
-	 *
-	 * @param  string  $destination
-	 * @return void
-	 */
-	protected function makeDestination($destination)
-	{
-		if ( ! $this->files->isDirectory($destination))
-		{
-			$this->files->makeDirectory($destination, 0777, true);
-		}
-	}
-
-	/**
-	 * Determine if a given package has already been published.
-	 *
-	 * @param  string  $package
-	 * @return bool
-	 */
-	public function alreadyPublished($package)
-	{
-		return $this->files->isDirectory($this->getDestinationPath($package));
-	}
-
-	/**
-	 * Get the target destination path for the configuration files.
-	 *
-	 * @param  string  $package
-	 * @return string
-	 */
-	public function getDestinationPath($package)
-	{
-		return $this->publishPath."/packages/{$package}";
-	}
-
-	/**
-	 * Set the default package path.
-	 *
-	 * @param  string  $packagePath
-	 * @return void
-	 */
-	public function setPackagePath($packagePath)
-	{
-		$this->packagePath = $packagePath;
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/AssetPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/AssetPublishCommand.php
@@ -1,12 +1,15 @@
 <?php namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Foundation\AssetPublisher;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
 class AssetPublishCommand extends Command {
+
+	use ConfirmableTrait;
 
 	/**
 	 * The console command name.
@@ -63,6 +66,13 @@ class AssetPublishCommand extends Command {
 	 */
 	protected function publishAssets($package)
 	{
+		$proceed = $this->confirmToProceed('Assets Already Published!', function() use ($package)
+		{
+			return $this->assets->alreadyPublished($package);
+		});
+
+		if ( ! $proceed) return;
+
 		if ( ! is_null($path = $this->getPath()))
 		{
 			$this->assets->publish($package, $path);

--- a/src/Illuminate/Foundation/Publisher.php
+++ b/src/Illuminate/Foundation/Publisher.php
@@ -1,0 +1,129 @@
+<?php namespace Illuminate\Foundation;
+
+use Illuminate\Filesystem\Filesystem;
+
+abstract class Publisher {
+
+	/**
+	 * The filesystem instance.
+	 *
+	 * @var \Illuminate\Filesystem\Filesystem
+	 */
+	protected $files;
+
+	/**
+	 * The destination of the config files.
+	 *
+	 * @var string
+	 */
+	protected $publishPath;
+
+	/**
+	 * The path to the application's packages.
+	 *
+	 * @var string
+	 */
+	protected $packagePath;
+
+	/**
+	 * Create a new publisher instance.
+	 *
+	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  string  $publishPath
+	 * @return void
+	 */
+	public function __construct(Filesystem $files, $publishPath)
+	{
+		$this->files = $files;
+		$this->publishPath = $publishPath;
+	}
+
+	/**
+	 * Publish files from a given path.
+	 *
+	 * @param  string  $package
+	 * @param  string  $source
+	 * @return bool
+	 */
+	public function publish($package, $source)
+	{
+		$destination = $this->getDestinationPath($package);
+
+		$this->makeDestination($destination);
+
+		return $this->files->copyDirectory($source, $destination);
+	}
+
+	/**
+	 * Publish the files for a package.
+	 *
+	 * @param  string  $package
+	 * @param  string  $packagePath
+	 * @return bool
+	 */
+	public function publishPackage($package, $packagePath = null)
+	{
+		$source = $this->getSource($package, $packagePath ?: $this->packagePath);
+
+		return $this->publish($package, $source);
+	}
+
+	/**
+	 * Create the destination directory if it doesn't exist.
+	 *
+	 * @param  string  $destination
+	 * @return void
+	 */
+	protected function makeDestination($destination)
+	{
+		if ( ! $this->files->isDirectory($destination))
+		{
+			$this->files->makeDirectory($destination, 0777, true);
+		}
+	}
+
+	/**
+	 * Determine if a given package has already been published.
+	 *
+	 * @param  string  $package
+	 * @return bool
+	 */
+	public function alreadyPublished($package)
+	{
+		return $this->files->isDirectory($this->getDestinationPath($package));
+	}
+
+	/**
+	 * Get the target destination path for the files.
+	 *
+	 * @param  string  $package
+	 * @return string
+	 */
+	public function getDestinationPath($package)
+	{
+		return $this->publishPath."/packages/{$package}";
+	}
+
+	/**
+	 * Set the default package path.
+	 *
+	 * @param  string  $packagePath
+	 * @return void
+	 */
+	public function setPackagePath($packagePath)
+	{
+		$this->packagePath = $packagePath;
+	}
+
+	/**
+	 * Get the source directory to publish.
+	 *
+	 * @param  string  $package
+	 * @param  string  $packagePath
+	 * @return string
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	abstract protected function getSource($package, $packagePath);
+
+}

--- a/src/Illuminate/Foundation/ViewPublisher.php
+++ b/src/Illuminate/Foundation/ViewPublisher.php
@@ -2,71 +2,7 @@
 
 use Illuminate\Filesystem\Filesystem;
 
-class ViewPublisher {
-
-	/**
-	 * The filesystem instance.
-	 *
-	 * @var \Illuminate\Filesystem\Filesystem
-	 */
-	protected $files;
-
-	/**
-	 * The destination of the view files.
-	 *
-	 * @var string
-	 */
-	protected $publishPath;
-
-	/**
-	 * The path to the application's packages.
-	 *
-	 * @var string
-	 */
-	protected $packagePath;
-
-	/**
-	 * Create a new view publisher instance.
-	 *
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @param  string  $publishPath
-	 * @return void
-	 */
-	public function __construct(Filesystem $files, $publishPath)
-	{
-		$this->files = $files;
-		$this->publishPath = $publishPath;
-	}
-
-	/**
-	 * Publish view files from a given path.
-	 *
-	 * @param  string  $package
-	 * @param  string  $source
-	 * @return void
-	 */
-	public function publish($package, $source)
-	{
-		$destination = $this->publishPath."/packages/{$package}";
-
-		$this->makeDestination($destination);
-
-		return $this->files->copyDirectory($source, $destination);
-	}
-
-	/**
-	 * Publish the view files for a package.
-	 *
-	 * @param  string  $package
-	 * @param  string  $packagePath
-	 * @return void
-	 */
-	public function publishPackage($package, $packagePath = null)
-	{
-		$source = $this->getSource($package, $packagePath ?: $this->packagePath);
-
-		return $this->publish($package, $source);
-	}
+class ViewPublisher extends Publisher {
 
 	/**
 	 * Get the source views directory to publish.
@@ -87,31 +23,6 @@ class ViewPublisher {
 		}
 
 		return $source;
-	}
-
-	/**
-	 * Create the destination directory if it doesn't exist.
-	 *
-	 * @param  string  $destination
-	 * @return void
-	 */
-	protected function makeDestination($destination)
-	{
-		if ( ! $this->files->isDirectory($destination))
-		{
-			$this->files->makeDirectory($destination, 0777, true);
-		}
-	}
-
-	/**
-	 * Set the default package path.
-	 *
-	 * @param  string  $packagePath
-	 * @return void
-	 */
-	public function setPackagePath($packagePath)
-	{
-		$this->packagePath = $packagePath;
 	}
 
 }

--- a/tests/Foundation/FoundationAssetPublishCommandTest.php
+++ b/tests/Foundation/FoundationAssetPublishCommandTest.php
@@ -13,6 +13,7 @@ class FoundationAssetPublishCommandTest extends PHPUnit_Framework_TestCase {
 	public function testCommandCallsPublisherWithProperPackageName()
 	{
 		$command = new Illuminate\Foundation\Console\AssetPublishCommand($pub = m::mock('Illuminate\Foundation\AssetPublisher'));
+		$pub->shouldReceive('alreadyPublished')->andReturn(false);
 		$pub->shouldReceive('publishPackage')->once()->with('foo');
 		$command->run(new Symfony\Component\Console\Input\ArrayInput(array('package' => 'foo')), new Symfony\Component\Console\Output\NullOutput);
 	}

--- a/tests/Foundation/FoundationAssetPublisherTest.php
+++ b/tests/Foundation/FoundationAssetPublisherTest.php
@@ -13,6 +13,7 @@ class FoundationAssetPublisherTest extends PHPUnit_Framework_TestCase {
 	public function testBasicPathPublishing()
 	{
 		$pub = new Illuminate\Foundation\AssetPublisher($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+		$files->shouldReceive('isDirectory')->once()->with(__DIR__.'/packages/bar')->andReturn(true);
 		$files->shouldReceive('copyDirectory')->once()->with('foo', __DIR__.'/packages/bar')->andReturn(true);
 
 		$this->assertTrue($pub->publish('bar', 'foo'));
@@ -23,11 +24,15 @@ class FoundationAssetPublisherTest extends PHPUnit_Framework_TestCase {
 	{
 		$pub = new Illuminate\Foundation\AssetPublisher($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
 		$pub->setPackagePath(__DIR__.'/vendor');
+		$files->shouldReceive('isDirectory')->once()->with(__DIR__.'/vendor/foo/public')->andReturn(true);
+		$files->shouldReceive('isDirectory')->once()->with(__DIR__.'/packages/foo')->andReturn(true);
 		$files->shouldReceive('copyDirectory')->once()->with(__DIR__.'/vendor/foo/public', __DIR__.'/packages/foo')->andReturn(true);
 
 		$this->assertTrue($pub->publishPackage('foo'));
 
 		$pub = new Illuminate\Foundation\AssetPublisher($files2 = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+		$files2->shouldReceive('isDirectory')->once()->with(__DIR__.'/custom-packages/foo/public')->andReturn(true);
+		$files2->shouldReceive('isDirectory')->once()->with(__DIR__.'/packages/foo')->andReturn(true);
 		$files2->shouldReceive('copyDirectory')->once()->with(__DIR__.'/custom-packages/foo/public', __DIR__.'/packages/foo')->andReturn(true);
 
 		$this->assertTrue($pub->publishPackage('foo', __DIR__.'/custom-packages'));


### PR DESCRIPTION
ConfigurationPublisher, ViewPublisher, and AssetPublisher all function basically the same, so I abstracted the similar code out into a Publisher class. This DRYs up the code a bunch and should make it easy to create different type of asset publishers in the future. Also, AssetPublisher used to through a runtime exception, but I just made them all throw ArgumentExceptions since ConfigPublisher and ViewPublisher were doing that already. Not sure if there was a reason AssetPublisher was different or not.

One thing I'm unsure of, is that currently it throws an exception if the directory you're trying to publish doesn't exist. I'm wondering if we want to get rid of that and instead print some red text that says something like `Views not found for package: vendor/package` in the same way to outputs a message when successful. This could fix some of the problems mentioned in #5114.

Status: Fixed Tests
