### PR TITLE
Added conditional echoes to blade compiler

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -235,7 +235,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 		{
 			$whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-			return $matches[1] ? substr($matches[0], 1) : '<?php echo '.$this->compileEchoDefaults($matches[2]).'; ?>'.$whitespace;
+			return $matches[1] ? substr($matches[0], 1) : '<?php echo '.$this->compileEchoDefaultsAndConditionals($matches[2]).'; ?>'.$whitespace;
 		};
 
 		return preg_replace_callback($pattern, $callback, $value);
@@ -255,10 +255,21 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 		{
 			$whitespace = empty($matches[2]) ? '' : $matches[2].$matches[2];
 
-			return '<?php echo e('.$this->compileEchoDefaults($matches[1]).'); ?>'.$whitespace;
+			return '<?php echo e('.$this->compileEchoDefaultsAndConditionals($matches[1]).'); ?>'.$whitespace;
 		};
 
 		return preg_replace_callback($pattern, $callback, $value);
+	}
+
+	/**
+	 * Compile the default and conditional values for the echo statement
+	 *
+	 * @param  string $value
+	 * @return string
+	 */
+	public function compileEchoDefaultsAndConditionals($value)
+	{
+		return $this->compileEchoDefaults($this->compileEchoConditionals($value));
 	}
 
 	/**
@@ -270,6 +281,17 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	public function compileEchoDefaults($value)
 	{
 		return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s', 'isset($1) ? $1 : $2', $value);
+	}
+
+	/**
+	 * Compile the conditional values for the echo statement.
+	 *
+	 * @param  string $value
+	 * @return string
+	 */
+	public function compileEchoConditionals($value)
+	{
+		return preg_replace('/^(?=\$)(.+?)(?:\s+if\s+)(.+?)$/s', '$2 ? $1 : \'\'', $value);
 	}
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -93,7 +93,12 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals("<?php echo \$name; ?>\r\n\r\n", $compiler->compileString("{{ \$name }}\r\n"));
 		$this->assertEquals("<?php echo \$name; ?>\n\n", $compiler->compileString("{{ \$name }}\n"));
 		$this->assertEquals("<?php echo \$name; ?>\r\n\r\n", $compiler->compileString("{{ \$name }}\r\n"));
+	}
 
+
+	public function testEchosWithDefaultsAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
 		$this->assertEquals('<?php echo isset($name) ? $name : "foo"; ?>', $compiler->compileString('{{ $name or "foo" }}'));
 		$this->assertEquals('<?php echo isset($user->name) ? $user->name : "foo"; ?>', $compiler->compileString('{{ $user->name or "foo" }}'));
 		$this->assertEquals('<?php echo isset($name) ? $name : "foo"; ?>', $compiler->compileString('{{$name or "foo"}}'));
@@ -129,6 +134,46 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<?php echo myfunc(\'foo or bar\'); ?>', $compiler->compileString('{{ myfunc(\'foo or bar\') }}'));
 		$this->assertEquals('<?php echo myfunc("foo or bar"); ?>', $compiler->compileString('{{ myfunc("foo or bar") }}'));
 		$this->assertEquals('<?php echo myfunc("$name or \'foo\'"); ?>', $compiler->compileString('{{ myfunc("$name or \'foo\'") }}'));
+	}
+
+	public function testEchosWithConditionsAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$this->assertEquals('<?php echo $condition ? $name : \'\'; ?>', $compiler->compileString('{{ $name if $condition }}'));
+		$this->assertEquals('<?php echo $condition ? $user->name : \'\'; ?>', $compiler->compileString('{{ $user->name if $condition }}'));
+		$this->assertEquals('<?php echo $condition ? $name : \'\'; ?>', $compiler->compileString('{{$name if $condition}}'));
+		$this->assertEquals('<?php echo $condition ? $name : \'\'; ?>', $compiler->compileString('{{
+			$name if $condition
+		}}'));
+
+		$this->assertEquals('<?php echo \'foo\' ? $name : \'\'; ?>', $compiler->compileString('{{ $name if \'foo\' }}'));
+		$this->assertEquals('<?php echo \'foo\' ? $name : \'\'; ?>', $compiler->compileString('{{$name if \'foo\'}}'));
+		$this->assertEquals('<?php echo \'foo\' ? $name : \'\'; ?>', $compiler->compileString('{{
+			$name if \'foo\'
+		}}'));
+
+		$this->assertEquals('<?php echo 90 ? $age : \'\'; ?>', $compiler->compileString('{{ $age if 90 }}'));
+		$this->assertEquals('<?php echo 90 ? $age : \'\'; ?>', $compiler->compileString('{{$age if 90}}'));
+		$this->assertEquals('<?php echo 90 ? $age : \'\'; ?>', $compiler->compileString('{{
+			$age if 90
+		}}'));
+
+		$this->assertEquals('<?php echo "Hello world if foo"; ?>', $compiler->compileString('{{ "Hello world if foo" }}'));
+		$this->assertEquals('<?php echo "Hello world if foo"; ?>', $compiler->compileString('{{"Hello world if foo"}}'));
+		$this->assertEquals('<?php echo $foo + $if + $baz; ?>', $compiler->compileString('{{$foo + $if + $baz}}'));
+		$this->assertEquals('<?php echo "Hello world if foo"; ?>', $compiler->compileString('{{
+			"Hello world if foo"
+		}}'));
+
+		$this->assertEquals('<?php echo \'Hello world if foo\'; ?>', $compiler->compileString('{{ \'Hello world if foo\' }}'));
+		$this->assertEquals('<?php echo \'Hello world if foo\'; ?>', $compiler->compileString('{{\'Hello world if foo\'}}'));
+		$this->assertEquals('<?php echo \'Hello world if foo\'; ?>', $compiler->compileString('{{
+			\'Hello world if foo\'
+		}}'));
+
+		$this->assertEquals('<?php echo myfunc(\'foo if bar\'); ?>', $compiler->compileString('{{ myfunc(\'foo if bar\') }}'));
+		$this->assertEquals('<?php echo myfunc("foo if bar"); ?>', $compiler->compileString('{{ myfunc("foo if bar") }}'));
+		$this->assertEquals('<?php echo myfunc("$name if \'foo\'"); ?>', $compiler->compileString('{{ myfunc("$name if \'foo\'") }}'));
 	}
 
 


### PR DESCRIPTION
This pull request adds the new blade syntax:

``` php
{{ $value if $condition }}
```

which compiles to:

``` php
<?php echo $condition ? $value : ''; ?>
```

I find myself wanting this a lot, as a shorter, more readable syntax for only echoing a variable if some condition is true (only add this error class if the `$errors` array has something in it, for example).
