### PR TITLE
Schema blueprint return Illuminate\Support\Fluent when possible, this allow developer to further chain additional command such as ->after() etc.

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -639,11 +639,11 @@ class Blueprint {
 	/**
 	 * Add a "deleted at" timestamp for the table.
 	 *
-	 * @return void
+	 * @return \Illuminate\Support\Fluent
 	 */
 	public function softDeletes()
 	{
-		$this->timestamp('deleted_at')->nullable();
+		return $this->timestamp('deleted_at')->nullable();
 	}
 
 	/**
@@ -675,11 +675,11 @@ class Blueprint {
 	/**
 	 * Adds the `remember_token` column to the table.
 	 *
-	 * @return void
+	 * @return \Illuminate\Support\Fluent
 	 */
 	public function rememberToken()
 	{
-	  $this->string('remember_token', 100)->nullable();
+		return $this->string('remember_token', 100)->nullable();
 	}
 
 	/**


### PR DESCRIPTION
This should allow following syntax to be parse properly:

``` php
$table->rememberToken()->after('status');
```

Signed-off-by: crynobone crynobone@gmail.com
