### PR TITLE
[BUG?] MacroableTrait has old comment

### DIFF
--- a/src/Illuminate/Support/Traits/MacroableTrait.php
+++ b/src/Illuminate/Support/Traits/MacroableTrait.php
@@ -52,7 +52,7 @@ trait MacroableTrait {
 	}
 
 	/**
-	 * Dynamically handle calls to the form builder.
+	 * Dynamically handle calls to the class.
 	 *
 	 * @param  string  $method
 	 * @param  array   $parameters


### PR DESCRIPTION
This is really anal - probably the most anal and unimportant PR i've ever made, but the docblock for `Illuminate\Support\MacroableTrait::__call` still has a comment that was presumably left over from when the code was copied from `Illuminate\Html\FormBuilder` as part of the 4.2 upgrade.
