### PR TITLE
[4.2] Iron Queue Fix

### DIFF
--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -110,7 +110,7 @@ class IronQueue extends Queue implements QueueInterface {
 
 		$payload = $this->createPayload($job, $data, $queue);
 
-		return $this->pushRaw($payload, $this->getQueue($queue), compact('delay'));
+		return $this->pushRaw($payload, $queue, compact('delay'));
 	}
 
 	/**


### PR DESCRIPTION
I've removed a double `getQueue` call. The situation here is the `later` function was calling `getQueue` and passing the result to the `pushRaw` function, which was then calling `getQueue` again. We only need get the `pushRaw` function to call `getQueue`, so the extra call can be removed from the `later` function.
