### PR TITLE
[4.2] Route parameter() default value

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -283,7 +283,7 @@ class Route {
 	 */
 	public function parameter($name, $default = null)
 	{
-		return array_get($this->parameters(), $name) ?: $default;
+		return array_get($this->parameters(), $name, $default);
 	}
 
 	/**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -133,6 +133,15 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$route->bind($request2);
 		$this->assertEquals('12', $route->parameter('id'));
 		$this->assertEquals('png', $route->parameter('ext'));
+                
+		// Test parameter() default value
+		$route = new Route('GET', 'foo/{foo?}', function() {});
+
+		$request3 = Request::create('foo', 'GET');
+		$this->assertTrue($route->matches($request3));
+		$route->bind($request3);
+		$this->assertEquals('bar', $route->parameter('foo', 'bar'));
+                
 	}
 
 


### PR DESCRIPTION
Now uses behavior of  `array_get()`.
