### PR TITLE
Chunk function should return the value of closure

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1505,12 +1505,14 @@ class Builder {
 			// On each chunk result set, we will pass them to the callback and then let the
 			// developer take care of everything within the callback, which allows us to
 			// keep the memory low for spinning through large result sets for working.
-			call_user_func($callback, $results);
+			$return = call_user_func($callback, $results);
 
 			$page++;
 
 			$results = $this->forPage($page, $count)->get();
 		}
+
+		return $return;
 	}
 
 	/**


### PR DESCRIPTION
When using the chunk closure, we should still be able to get the value of the return in the closure.

```
 $return = Products::chunk(10, function($products) { return false; });
 var_dump($return); // (bool) false
```
