### PR TITLE
isset to array_key_exists

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -257,7 +257,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	 */
 	public function detectEnvironment($envs)
 	{
-		$args = isset($_SERVER['argv']) ? $_SERVER['argv'] : null;
+		$args = array_key_exists('argv', $_SERVER) ? $_SERVER['argv'] : null;
 
 		return $this['env'] = (new EnvironmentDetector())->detect($envs, $args);
 	}


### PR DESCRIPTION
This avoids an unwanted side-effect that may rarely happen. To add, array_key_exists was meant for this kind of job.
