### PR TITLE
[4.2] Pagination : remove FILTER_VALIDATE_INT check

### DIFF
--- a/src/Illuminate/Pagination/Factory.php
+++ b/src/Illuminate/Pagination/Factory.php
@@ -126,14 +126,7 @@ class Factory {
 	 */
 	public function getCurrentPage()
 	{
-		$page = (int) $this->currentPage ?: $this->request->input($this->pageName, 1);
-
-		if ($page < 1 || filter_var($page, FILTER_VALIDATE_INT) === false)
-		{
-			return 1;
-		}
-
-		return $page;
+		return max(1, (int) ($this->currentPage ?: $this->request->input($this->pageName, 1)));
 	}
 
 	/**

--- a/tests/Pagination/PaginationFactoryTest.php
+++ b/tests/Pagination/PaginationFactoryTest.php
@@ -46,6 +46,12 @@ class PaginationFactoryTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(2, $env->getCurrentPage());
 
 		$env = $this->getFactory();
+		$request = Illuminate\Http\Request::create('http://foo.com?page=5a', 'GET');
+		$env->setRequest($request);
+
+		$this->assertEquals(5, $env->getCurrentPage());
+
+		$env = $this->getFactory();
 		$request = Illuminate\Http\Request::create('http://foo.com?page=-1', 'GET');
 		$env->setRequest($request);
 
@@ -61,6 +67,13 @@ class PaginationFactoryTest extends PHPUnit_Framework_TestCase {
 		$env->setCurrentPage(3);
 
 		$this->assertEquals(3, $env->getCurrentPage());
+
+		$env = $this->getFactory();
+		$request = Illuminate\Http\Request::create('http://foo.com?page=xx', 'GET');
+		$env->setRequest($request);
+		$env->setCurrentPage(2);
+
+		$this->assertEquals(2, $env->getCurrentPage());
 	}
 
 


### PR DESCRIPTION
As $page is already an integer
