### PR TITLE
updated registerInspected method

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -298,7 +298,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		// If a given controller method has been named, we will assign the name to the
 		// controller action array, which provides for a short-cut to method naming
 		// so you don't have to define an individual route for these controllers.
-		$action['as'] = array_pull($names, $method);
+		$action['as'] = array_get($names, $method);
 
 		$this->{$route['verb']}($route['uri'], $action);
 	}


### PR DESCRIPTION
Hi,

I was having a small problem using named routes. 

When assigning the route names for the uri / actions.

```

vagrant@vaprobash:/vagrant$ php artisan routes
+--------+------------------------------------------------------------------------------+----------------------+--------------------------------------------------+-------------------+---------------+
| Domain | URI                                                                          | Name                 | Action                                           | Before Filters    | After Filters |
+--------+------------------------------------------------------------------------------+----------------------+--------------------------------------------------+-------------------+---------------+
|        | GET|HEAD ad/users/{user}/edit                                             | user.edit            | AdUsersController@getEdit                     | auth |               |
|        | POST admin/users/{user}/edit                                                 | user.edit            | AdUsersController@postEdit                    | auth |               |
|        | GET|HEAD ad/users/{user}/delete                                           | user.delete          | AdUsersController@getDelete                   | auth |               |
|        | POST ad/users/{user}/delete                                               | user.delete          | AdUsersController@postDelete                  | auth |               |
|        | GET|HEAD ad/users/index/{one?}/{two?}/{three?}/{four?}/{five?}            | user.list            | AdUsersController@getIndex                    | auth |               |
|        | GET|HEAD ad/users                                                         | user.list            | AdUsersController@getIndex                    | auth |               |
|        | GET|HEAD ad/users/create/{one?}/{two?}/{three?}/{four?}/{five?}           | user.create          | AdUsersController@getCreate                   | auth |               |

```

Originally having the array_pull method will remove the name from the names array when the requests formatting is different :

```
GET|HEAD ad/users/index/{one?}/{two?}/{three?}/{four?}/{five?}  

GET|HEAD ad/users     
```

I am all ear's for comments and suggestions that will suggest a different workaround for this issue.
