### PR TITLE
Fixed roque @parent tags showing in first section

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -582,6 +582,7 @@ class Factory {
 			$content = str_replace('@parent', $content, $this->sections[$section]);
 		}
 
+		$content = str_replace('@parent', '', $content);
 		$this->sections[$section] = $content;
 	}
 


### PR DESCRIPTION
If a partial has a @parent tag in it it works perfectly as designed unless it is the first component of that type called. In my case:

Main Section

``` php
    @extends('layouts.main')

    @section('main')

      @include('layouts.partials.component1')
      @include('layouts.partials.component2')

    @stop
```

component1

``` php
    text text text
    @section('scripts')
        @parent
        <script type="text/javascript"></script>
    @stop
```

component2

``` php
    text text text
    @section('scripts')
        <script type="text/javascript></script>
    @stop
```

In the case of the main section, component1 would have its @parent tag rendered due to there being no parent.

so by adding 

``` php
$content = str_replace('@parent', '', $content);
```

in the case of it being the first section of that type it will just remove hte @parent since there is not a parent.
