### PR TITLE
[4.2] Fixes #5216 [OPTION 2]

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -7,11 +7,11 @@ trait ConfirmableTrait {
 	/**
 	 * Confirm before proceeding with the action
 	 *
-	 * @param  bool      $warning
+	 * @param  string    $warning
 	 * @param  \Closure  $callback
 	 * @return bool
 	 */
-	public function confirmToProceed($warning = null, Closure $callback = null)
+	public function confirmToProceed($warning = 'Application In Production!', Closure $callback = null)
 	{
 		$shouldConfirm = $callback ?: $this->getDefaultConfirmCallback();
 


### PR DESCRIPTION
By **modifying** the behaviour introduced by 6e672d708b1baffee6210e12be2d3e1f5be1a64e, this fixes #5216.
I also have an alternative fix available (#5217). I don't know which way you'd prefer @taylorotwell. Since you have a default callback that deals with "production", I'd say this fix is probably more appropriate than the other one.
