### PR TITLE
Tail local daily log files if they exist

### DIFF
--- a/src/Illuminate/Foundation/Console/TailCommand.php
+++ b/src/Illuminate/Foundation/Console/TailCommand.php
@@ -119,12 +119,27 @@ class TailCommand extends Command {
 
 		if (is_null($connection))
 		{
-			return base_path().'/app/storage/logs/laravel.log';
+			return $this->getLocalPath();
 		}
 		else
 		{
 			return $this->getRoot($connection).'/app/storage/logs/laravel.log';
 		}
+	}
+
+	/**
+	 * Search locally for daily log files, otherwise return a global log file.
+	 *
+	 * @return string
+	 */
+	protected function getLocalPath()
+	{
+		if ($dailyLogs = File::glob(base_path().'/app/storage/logs/log-*.txt'))
+		{
+			return last($dailyLogs);
+		}
+
+		return base_path().'/app/storage/logs/laravel.log';
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/TailCommand.php
+++ b/src/Illuminate/Foundation/Console/TailCommand.php
@@ -134,7 +134,7 @@ class TailCommand extends Command {
 	 */
 	protected function getLocalPath()
 	{
-		if ($dailyLogs = File::glob(base_path().'/app/storage/logs/log-*.txt'))
+		if ($dailyLogs = $this->laravel['file']->glob(base_path().'/app/storage/logs/log-*.txt'))
 		{
 			return last($dailyLogs);
 		}


### PR DESCRIPTION
This will search for local daily log files first (matching the filename used by the original versions of Laravel 4.0) and fall back to the global log file.
