### PR TITLE
[4.3] Added Mcrypt As A Dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-mcrypt": "*",
         "classpreloader/classpreloader": "~1.0",
         "d11wtq/boris": "~1.0",
         "ircmaxell/password-compat": "~1.0",

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -9,6 +9,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-mcrypt": "*",
         "illuminate/support": "4.3.*",
         "symfony/security-core": "2.5.*"
     },


### PR DESCRIPTION
Since this is required, we should specify this a dependency. I've gone for 4.3 rather than 4.2 because it could be a an unexpected change in dependencies for 4.2 users (although, surely they must have the extension).

I toyed with adding openssl as a dependency too, but if there are running composer, they must have openssl installed, surely?
