### PR TITLE
[4.3] Loosened Patchwork UTF8 Version Constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "jeremeamia/superclosure": "~1.0",
         "monolog/monolog": "~1.6",
         "nesbot/carbon": "~1.0",
-        "patchwork/utf8": "1.1.*",
+        "patchwork/utf8": "~1.1",
         "phpseclib/phpseclib": "0.3.*",
         "predis/predis": "0.8.*",
         "stack/builder": "~1.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -12,7 +12,7 @@
     },
     "require-dev": {
         "jeremeamia/superclosure": "~1.0",
-        "patchwork/utf8": "1.1.*"
+        "patchwork/utf8": "~1.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This should be safe to do. I've checked: https://github.com/nicolas-grekas/Patchwork-UTF8/issues/22.
