### PR TITLE
[4.2] Corrected A Return Type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1326,7 +1326,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Update the model in the database.
 	 *
 	 * @param  array  $attributes
-	 * @return mixed
+	 * @return bool|int
 	 */
 	public function update(array $attributes = array())
 	{


### PR DESCRIPTION
I've corrected return type on the eloquent model update function.

The line `return $this->newQuery()->update($attributes);` returns an `int`, and the line `$this->fill($attributes)->save();` returns a `bool`.

Therefore, the appropriate return type for the entire update function would be `bool|int`.
