### PR TITLE
change async to false in MandrillTransport

### DIFF
--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -60,7 +60,7 @@ class MandrillTransport implements Swift_Transport {
 			'body' => [
 				'key' => $this->key,
 				'raw_message' => (string) $message,
-				'async' => true,
+				'async' => false,
 			],
 		]);
 	}


### PR DESCRIPTION
With async set to false, Mandrill is able to return a result similar to this in the its API log:
[
{
"email": "chrispecoraro@gmail.com",
"status": "sent",
"_id": "19fcb428d3324d0f85053d8b2953ccc5",
"reject_reason": null
}
]

or

[
{
"email": "chrispecoraro@gmail.com",
"status": "rejected",
"_id": "19fcb428d3324d0f85053d8b2953ccc5",
"reject_reason": "hard-bounce"
}
]

Otherwise, the result will always be:
[
{
"email": "chrispecoraro@gmail.com",
"status": "queued",
"_id": "19fcb428d3324d0f85053d8b2953ccc5",
"reject_reason": null
}
]

Being able to see the status in the Mandrill API logs helps us to troubleshoot any issues.

From the Mandrill API doc:
async: enable a background sending mode that is optimized for bulk sending. In async mode, messages/send will immediately return a status of "queued" for every recipient. To handle rejections when sending in async mode, set up a webhook for the 'reject' event. Defaults to false for messages with no more than 10 recipients; messages with more than 10 recipients are always sent asynchronously, regardless of the value of async.
