### PR TITLE
[4.2] Implement validation exceptions and passOrFail

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -1,0 +1,131 @@
+<?php namespace Illuminate\Validation;
+
+use Exception;
+use JsonSerializable;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\Contracts\JsonableInterface;
+use Illuminate\Support\Contracts\ArrayableInterface;
+use Illuminate\Support\Contracts\MessageProviderInterface;
+
+class ValidationException extends Exception implements ArrayableInterface, JsonableInterface, JsonSerializable, MessageProviderInterface {
+
+	/**
+	 * The validator data.
+	 *
+	 * @var array
+	 */
+	protected $data;
+
+	/**
+	 * The validator rules.
+	 *
+	 * @var array
+	 */
+	protected $rules;
+
+	/**
+	 * The message bag instance.
+	 *
+	 * @var \Illuminate\Support\MessageBag
+	 */
+	protected $errors;
+
+	/**
+	 * Construct a new validation exception instance.
+	 *
+	 * @param \Illuminate\Validation\Validator  $validator
+	 * @param string  $message
+	 */
+	public function __construct(Validator $validator, $message = null)
+	{
+		$this->data = $validator->getData();
+		$this->rules = $validator->getRules();
+		$this->errors = clone $validator->getMessageBag();
+
+		parent::__construct($message ?: 'Validation failed');
+	}
+
+	/**
+	 * Get the array of data the validation was done with.
+	 *
+	 * @return array
+	 */
+	public function getData()
+	{
+		return $this->data;
+	}
+
+	/**
+	 * Get the array of rules that the validation was done with.
+	 *
+	 * @return array
+	 */
+	public function getRules()
+	{
+		return $this->rules;
+	}
+
+	/**
+	 * Get a flat array of all error messages.
+	 *
+	 * @return array
+	 */
+	public function getErrors()
+	{
+		return $this->errors->all();
+	}
+
+	/**
+	 * Get the message bag instance.
+	 *
+	 * @return \Illuminate\Support\MessageBag
+	 */
+	public function getMessageBag()
+	{
+		return $this->errors;
+	}
+
+	/**
+	 * Convert the object into something JSON serializable.
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize()
+	{
+		return ['errors' => $this->getErrors()];
+	}
+
+	/**
+	 * Convert the object to its JSON representation.
+	 *
+	 * @param  int  $options
+	 * @return string
+	 */
+	public function toJson($options = 0)
+	{
+		return json_encode($this->jsonSerialize(), $options);
+	}
+
+	/**
+	 * Get the instance as an array.
+	 *
+	 * @return array
+	 */
+	public function toArray()
+	{
+		return $this->getErrors();
+	}
+
+	/**
+	 * Convert the exception to its string representation.
+	 *
+	 * @return string
+	 */
+	public function __toString()
+	{
+		$errors = implode(PHP_EOL, $this->getErrors());
+
+		return $this->getMessage() . PHP_EOL . $errors;
+	}
+
+}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -288,6 +288,20 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
+	 * If the data does not pass the validation rules, throw an exception.
+	 *
+	 * @param  string  $message
+	 * @return void
+	 * @throws \Illuminate\Validation\ValidationException
+	 */
+	public function passOrFail($message = null)
+	{
+		if ($this->passes()) return;
+
+		throw new ValidationException($this, $message);
+	}
+
+	/**
 	 * Validate a given attribute against a rule.
 	 *
 	 * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1264,6 +1264,26 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testPassOrFailThrowsException()
+	{
+		try
+		{
+			$trans = $this->getRealTranslator();
+			$v = new Validator($trans, ['bar' => 'baz'], ['foo' => ['required']]);
+			$v->passOrFail();
+		}
+		catch (\Illuminate\Validation\ValidationException $e)
+		{
+			$this->assertEquals($v->getData(), $e->getData());
+			$this->assertEquals($v->getRules(), $e->getRules());
+			$this->assertEquals($v->getMessageBag(), $e->getMessageBag());
+			return;
+		}
+
+		$this->fail('ValidationException was not thrown');
+	}
+
+
 	protected function getTranslator()
 	{
 		return m::mock('Symfony\Component\Translation\TranslatorInterface');


### PR DESCRIPTION
Sometimes you want validation errors to bubble up, for example from a repository/model/entity through one or several service layer classes all the way up to the controller. Implementing a `getErrors()` method on 3 layers of classes gets extremely annoying. Validation exceptions make this easier - it doesn't matter where it's been thrown as long as it's inside a try/catch block somewhere. Example usage in a controller:

``` php
public function someAction()
{
    try {
        $this->someService->doSomething(Input::all());
        return Redirect::route('someroute')->with('success', 'Success!');
    } catch (ValidationException $e) {
        return Redirect::route('thisroute')->withErrors($e);
    }
}

public function jsonAction()
{
    try {
        $this->someService->doSomething(Input::all());
        return Response::json(['message' => 'success']);
    } catch (ValidationException $e) {
        return Response::json($e, 400);
    }
}
```

or as a global exception handler:

``` php
App::error(function(ValidationException $e) {
    return Response::json($e, 400);
});
```
