### PR TITLE
Fix Request::hasFile with an array of files

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Http;
 
+use SplFileInfo;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
@@ -329,13 +330,13 @@ class Request extends SymfonyRequest {
 		{
 			foreach ($file as $f)
 			{
-				if ($f instanceof \SplFileInfo && $f->getPath() != '') return true;
+				if ($f instanceof SplFileInfo && $f->getPath() != '') return true;
 			}
 
 			return false;
 		}
 
-		return $file instanceof \SplFileInfo && $file->getPath() != '';
+		return $file instanceof SplFileInfo && $file->getPath() != '';
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -325,7 +325,15 @@ class Request extends SymfonyRequest {
 	 */
 	public function hasFile($key)
 	{
-		if (is_array($file = $this->file($key))) $file = head($file);
+		if (is_array($file = $this->file($key))) 
+		{
+			foreach ($file as $f)
+			{
+				if ($f instanceof \SplFileInfo && $f->getPath() != '') return true;
+			}
+
+			return false;
+		}
 
 		return $file instanceof \SplFileInfo && $file->getPath() != '';
 	}


### PR DESCRIPTION
This fixes the following error scenario:

```
<input type="file" name="images[image1]" />
<input type="file" name="images[image2]" />
```

Before, if image2 was uploaded but image1 wasn't, `Input::hasFile('images')` would return false even though an file was uploaded.
