### PR TITLE
[4.2] Database Collection : move max and min functions

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -81,34 +81,6 @@ class Collection extends BaseCollection {
 	}
 
 	/**
-	 * Get the max value of a given key.
-	 *
-	 * @param  string  $key
-	 * @return mixed
-	 */
-	public function max($key)
-	{
-		return $this->reduce(function($result, $item) use ($key)
-		{
-			return (is_null($result) || $item->{$key} > $result) ? $item->{$key} : $result;
-		});
-	}
-
-	/**
-	 * Get the min value of a given key.
-	 *
-	 * @param  string  $key
-	 * @return mixed
-	 */
-	public function min($key)
-	{
-		return $this->reduce(function($result, $item) use ($key)
-		{
-			return (is_null($result) || $item->{$key} < $result) ? $item->{$key} : $result;
-		});
-	}
-
-	/**
 	 * Get the array of primary keys
 	 *
 	 * @return array

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -331,6 +331,19 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	}
 
 	/**
+	 * Get the max value of a given key.
+	 *
+	 * @param  string|null  $key
+	 * @return mixed
+	 */
+	public function max($key = null)
+	{
+		$keys = static::keyBy($key)->keys();
+
+		return empty($keys) ? null : max($keys);
+	}
+
+	/**
 	 * Merge the collection with the given items.
 	 *
 	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
@@ -339,6 +352,19 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	public function merge($items)
 	{
 		return new static(array_merge($this->items, $this->getArrayableItems($items)));
+	}
+
+	/**
+	 * Get the min value of a given key.
+	 *
+	 * @param  string|null  $key
+	 * @return mixed
+	 */
+	public function min($key = null)
+	{
+		$keys = static::keyBy($key)->keys();
+
+		return empty($keys) ? null : min($keys);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -19,20 +19,6 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testGettingMaxItemsFromCollection()
-	{
-		$c = new Collection(array((object) array('foo' => 10), (object) array('foo' => 20)));
-		$this->assertEquals(20, $c->max('foo'));
-	}
-
-
-	public function testGettingMinItemsFromCollection()
-	{
-		$c = new Collection(array((object) array('foo' => 10), (object) array('foo' => 20)));
-		$this->assertEquals(10, $c->min('foo'));
-	}
-
-
 	public function testContainsIndicatesIfModelInArray()
 	{
 		$mockModel = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -155,6 +155,38 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testGettingMaxItemsFromCollection()
+	{
+		$c = new Collection(array((object) array('foo' => 10), (object) array('foo' => 20)));
+		$this->assertEquals(20, $c->max('foo'));
+
+		$c = new Collection(array(array('foo' => 10), array('foo' => 20)));
+		$this->assertEquals(20, $c->max('foo'));
+
+		$c = new Collection([1, 2, 3, 4]);
+		$this->assertEquals(4, $c->max());
+
+		$c = new Collection();
+		$this->assertNull($c->max());
+	}
+
+
+	public function testGettingMinItemsFromCollection()
+	{
+		$c = new Collection(array((object) array('foo' => 10), (object) array('foo' => 20)));
+		$this->assertEquals(10, $c->min('foo'));
+
+		$c = new Collection(array(array('foo' => 10), array('foo' => 20)));
+		$this->assertEquals(10, $c->min('foo'));
+
+		$c = new Collection([1, 2, 3, 4]);
+		$this->assertEquals(1, $c->min());
+
+		$c = new Collection();
+		$this->assertNull($c->min());
+	}
+
+
 	public function testDiffCollection()
 	{
 		$c = new Collection(array('id' => 1, 'first_word' => 'Hello'));


### PR DESCRIPTION
Move min and max functions so that we can use them in a "normal" Support\Collection
