### PR TITLE
adding a `laravel_session[]=` cookie crashes laravel

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -144,7 +144,23 @@ class Store implements SessionInterface {
 	 */
 	public function setId($id)
 	{
-		$this->id = $id ?: $this->generateSessionId();
+		if (!$this->isValidId($id))
+		{
+			$id = $this->generateSessionId();
+		}
+
+		$this->id = $id;
+	}
+
+	/**
+	 * Determine if this is a valid session ID.
+	 *
+	 * @param  string  $id
+	 * @return bool
+	 */
+	public function isValidId($id)
+	{
+		return is_string($id) && preg_match('/^[a-f0-9]{40}$/', $id);
 	}
 
 	/**


### PR DESCRIPTION
On laravel.com you can get 500 by adding a `laravel_session[]` cookie, or by changing the `laravel_session` value to something like `../../routes.php`.

The session id should be validated before being used, especially for the file session driver.
This PR makes sure the session id is a valid sha1 hash.
