### PR TITLE
Fixes the required_if messages if multiple values are passed

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1796,7 +1796,7 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function replaceRequiredIf($message, $attribute, $rule, $parameters)
 	{
-		$parameters[1] = $this->getDisplayableValue($parameters[0], $parameters[1]);
+		$parameters[1] = $this->getDisplayableValue($parameters[0], array_get($this->data, $parameters[0]));
 
 		$parameters[0] = $this->getAttribute($parameters[0]);
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -389,6 +389,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$trans = $this->getRealTranslator();
 		$v = new Validator($trans, array('first' => 'dayle', 'last' => 'rees'), array('last' => 'required_if:first,taylor,dayle'));
 		$this->assertTrue($v->passes());
+
+		// error message when passed multiple values (required_if:foo,bar,baz)
+		$trans = $this->getRealTranslator();
+		$trans->addResource('array', array('validation.required_if' => 'The :attribute field is required when :other is :value.'), 'en', 'messages');
+		$v = new Validator($trans, array('first' => 'dayle', 'last' => ''), array('last' => 'RequiredIf:first,taylor,dayle'));
+		$this->assertFalse($v->passes());
+		$this->assertEquals('The last field is required when first is dayle.', $v->messages()->first('last'));
 	}
 
 


### PR DESCRIPTION
**Closed the previous pull request #5260. This contains the rebased code.**

When passing in multiple values in `required_if` (like so: `required_if:type,mobile,email`) for a attribute in rules, then the error message always showed errors with the first value ('mobile' in this case) replaced in the message string. This was due to the following code in `Illuminate\Validation\Validator` line `1799`:

```
$parameters[1] = $this->getDisplayableValue($parameters[0], $parameters[1]);
```

But, error can be generated by any value in the rule (by 'mobile' or by 'email'). This pull request fixes the problem and also adds a test to verify the same.
