### PR TITLE
Add gzip options to the application and DIRECTORY_SEPARATOR in Filesystem files method

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -240,7 +240,7 @@ class Filesystem {
 	 */
 	public function files($directory)
 	{
-		$glob = glob($directory.'/*');
+		$glob = glob($directory.DIRECTORY_SEPARATOR.'*');
 
 		if ($glob === false) return array();
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -640,6 +640,8 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 		$request = $request ?: $this['request'];
 
 		$response = with($stack = $this->getStackedClient())->handle($request);
+		
+		if (!runningInConsole() && !runningUnitTests() && $this['config']->get('app.gzip')) ob_start('ob_gzhandler');
 
 		$response->send();
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -641,7 +641,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 
 		$response = with($stack = $this->getStackedClient())->handle($request);
 		
-		if (!runningInConsole() && !runningUnitTests() && $this['config']->get('app.gzip')) ob_start('ob_gzhandler');
+		if (!$this->runningInConsole() && !$this->runningUnitTests() && $this['config']->get('app.gzip')) ob_start('ob_gzhandler');
 
 		$response->send();
 


### PR DESCRIPTION
It is not always possible to add gzip to .htaccess or web.config. A simple configuration option in the application can send the html zipped to the client.
