### PR TITLE
[Propoal] Add multiple attribute support to Model::isDirty

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2680,18 +2680,29 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
-	 * Determine if the model or a given attribute has been modified.
+	 * Determine if the model or given attribute(s) have been modified.
 	 *
-	 * @param  string|null  $attribute
+	 * @param  string|array|null  $attribute
 	 * @return bool
 	 */
 	public function isDirty($attribute = null)
 	{
 		$dirty = $this->getDirty();
 
+		if (func_num_args() > 1) $attribute = func_get_args();
+
 		if (is_null($attribute))
 		{
 			return count($dirty) > 0;
+		}
+		elseif (is_array($attribute))
+		{
+			foreach ($attribute as $attr)
+			{
+				if (array_key_exists($attr, $dirty)) return true;
+			}
+
+			return false;
 		}
 		else
 		{

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2682,32 +2682,23 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	/**
 	 * Determine if the model or given attribute(s) have been modified.
 	 *
-	 * @param  string|array|null  $attribute
+	 * @param  string|array|null  $attributes
 	 * @return bool
 	 */
-	public function isDirty($attribute = null)
+	public function isDirty($attributes = null)
 	{
 		$dirty = $this->getDirty();
 
-		if (func_num_args() > 1) $attribute = func_get_args();
+		if (is_null($attributes)) return count($dirty) > 0;
 
-		if (is_null($attribute))
+		if ( ! is_array($attributes)) $attributes = func_get_args();
+		
+		foreach ($attributes as $attr)
 		{
-			return count($dirty) > 0;
+			if (array_key_exists($attr, $dirty)) return true;
 		}
-		elseif (is_array($attribute))
-		{
-			foreach ($attribute as $attr)
-			{
-				if (array_key_exists($attr, $dirty)) return true;
-			}
 
-			return false;
-		}
-		else
-		{
-			return array_key_exists($attribute, $dirty);
-		}
+		return false;
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -32,10 +32,17 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	public function testDirtyAttributes()
 	{
-		$model = new EloquentModelStub(array('foo' => '1'));
+		$model = new EloquentModelStub(array('foo' => '1', 'bar' => 2, 'baz' => 3));
 		$model->syncOriginal();
 		$model->foo = 1;
+		$model->bar = 20;
+		$model->baz = 30;
+
+		$this->assertTrue($model->isDirty());
 		$this->assertFalse($model->isDirty('foo'));
+		$this->assertTrue($model->isDirty('bar'));
+		$this->assertTrue($model->isDirty('foo', 'bar'));
+		$this->assertTrue($model->isDirty(['foo', 'bar']));
 	}
 
 


### PR DESCRIPTION
This adds support for checking multiple attributes at once with Model::isDirty without breaking compatibility. 
Attributes to check can be passed as an array of attribute names or as multiple arguments:

``` php
$model->isDirty(); // true if any attribute is dirty
$model->isDirty('foo'); // true if attribute 'foo' is dirty
$model->isDirty('foo', 'bar'); // true if 'foo' or 'bar' is dirty
$model->isDirty(['foo', 'bar', 'baz']); // true if at least one of 'foo', 'bar', or 'baz' is dirty
```
