### PR TITLE
Add Translator::getLoaded method

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -364,4 +364,14 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 		$this->fallback = $fallback;
 	}
 
+	/**
+	 * Get the raw array of loaded translation strings.
+	 *
+	 * @return array
+	 */
+	public function getLoaded()
+	{
+		return $this->loaded;
+	}
+
 }


### PR DESCRIPTION
I'm doing `if ($translator->has($key)) $string = $translator->get($key)` in a loop which is turning out to be taxing performance wise. Being able to access the raw array of translation strings would help out in cases like this.
