### PR TITLE
[4.2] Fixed empty string in database connection config 'unix_socket'

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -48,7 +48,8 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 	}
 
 	/**
-	 * Create a DSN string from a configuration.
+	 * Create a DSN string from a configuration. Chooses socket or host/port based on
+	 * the 'unix_socket' config value
 	 *
 	 * @param  array   $config
 	 * @return string

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -55,7 +55,7 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 	 */
 	protected function getDsn(array $config)
 	{
-		return isset($config['unix_socket']) ? $this->getSocketDsn($config) : $this->getHostDsn($config);
+		return isset($config['unix_socket']) && !empty($config['unix_socket']) ? $this->getSocketDsn($config) : $this->getHostDsn($config);
 	}
 
 	/**


### PR DESCRIPTION
Issue causes system to default to socket connection instead of host connection. The intention of someone passing an empty string as a socket value would be to not use a socket. The default config includes this value, and in previous versions you could safely ignore it.

Issue described here: http://stackoverflow.com/questions/25035135/laravel-failing-to-connect-to-db-after-4-2-upgrade/25035973
