### PR TITLE
[4.2] HHVM fixes for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ script: vendor/bin/phpunit --verbose
 matrix:
   allow_failures:
     - php: hhvm
+    - php: hhvm-nightly
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,15 @@ php:
   - 5.5
   - 5.6
   - hhvm
+  - hhvm-nightly
 
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --prefer-source --no-interaction --dev
 
 script: vendor/bin/phpunit --verbose
+
+matrix:
+  allow_failures:
+    - php: hhvm
+  fast_finish: true


### PR DESCRIPTION
Allow hhvm failures atm, and added nightly so we can see when facebook fix the issue.

---

I've made an issue on the hhvm repo: https://github.com/facebook/hhvm/issues/3320, but I'd hope the team are already aware of this issue anyway since they have automated framework tests.
