### PR TITLE
[BUGFIX] Validator date format and relative before/after rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1288,11 +1288,7 @@ class Validator implements MessageProviderInterface {
 	{
 		$param = $this->getValue($parameters[0]) ?: $parameters[0];
 
-		$dateValue = DateTime::createFromFormat($format, $value);
-
-		$dateParam = DateTime::createFromFormat($format, $param) ?: new DateTime($param);
-
-		return ($dateValue && $dateParam) && ($dateValue < $dateParam);
+		return $this->checkDateTimeOrder($format, $value, $param);
 	}
 
 	/**
@@ -1334,11 +1330,47 @@ class Validator implements MessageProviderInterface {
 	{
 		$param = $this->getValue($parameters[0]) ?: $parameters[0];
 
-		$dateValue = DateTime::createFromFormat($format, $value);
+		return $this->checkDateTimeOrder($format, $param, $value);
+	}
 
-		$dateParam = DateTime::createFromFormat($format, $param) ?: new DateTime($param);
+	/**
+	 * Given two date/time strings, check that one is after the other.
+	 *
+	 * @param  string $format
+	 * @param  string $before
+	 * @param  string $after
+	 * @return bool
+	 */
+	protected function checkDateTimeOrder($format, $before, $after)
+	{
+		$before = $this->getDateTimeWithOptionalFormat($format, $before);
 
-		return ($dateValue && $dateParam) && ($dateValue > $dateParam);
+		$after = $this->getDateTimeWithOptionalFormat($format, $after);
+
+		return ($before && $after) && ($after > $before);
+	}
+
+	/**
+	 * Get a DateTime instance from a string.
+	 *
+	 * @param  string $format
+	 * @param  string $value
+	 * @return \DateTime|null
+	 */
+	protected function getDateTimeWithOptionalFormat($format, $value)
+	{
+		$date = DateTime::createFromFormat($format, $value);
+
+		if ($date) return $date;
+
+		try
+		{
+			return new DateTime($value);
+		}
+		catch (\Exception $e)
+		{
+			return null;
+		}
 	}
 
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1119,6 +1119,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('start' => '31/12/2012', 'ends' => '31/12/2000'), array('start' => 'date_format:d/m/Y|before:ends', 'ends' => 'date_format:d/m/Y|after:start'));
 		$this->assertTrue($v->fails());
 
+		$v = new Validator($trans, array('start' => 'invalid', 'ends' => 'invalid'), array('start' => 'date_format:d/m/Y|before:ends', 'ends' => 'date_format:d/m/Y|after:start'));
+		$this->assertTrue($v->fails());
+
 		$v = new Validator($trans, array('x' => date('d/m/Y')), array('x' => 'date_format:d/m/Y|after:yesterday|before:tomorrow'));
 		$this->assertTrue($v->passes());
 


### PR DESCRIPTION
As shown in the updated test, there is a problem using relative before/after rules when one of the fields is an invalid datetime format because the validator calls `new DateTime($param)`, which will throw an exception.

``` php
$data = array('start' => 'invalid', 'ends' => 'invalid');
$rules = array(
    'start' => 'date_format:d/m/Y|before:ends',
    'ends' => 'date_format:d/m/Y|after:start',
);
Validator::make($data, $rules)->passes();
```
