### PR TITLE
Make EloquentUserProvider use setRememberToken

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -68,7 +68,7 @@ class EloquentUserProvider implements UserProviderInterface {
 	 */
 	public function updateRememberToken(UserInterface $user, $token)
 	{
-		$user->setAttribute($user->getRememberTokenName(), $token);
+		$user->setRememberToken($token);
 
 		$user->save();
 	}


### PR DESCRIPTION
See #5277.

PHPUnit appears to pass all tests though I'm not sure that EloquentUserProvider#updateRememberToken is actually covered in the tests.

Supersedes #5286.
