### PR TITLE
4.2-fix-insertGetId-for-batch-inserts

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1797,6 +1797,20 @@ class Builder {
 	 * @return bool
 	 */
 	public function insert(array $values)
+	{	
+		$sql = $this->grammar->compileInsert($this, $values);
+
+		$bindings = $this->structureBindings($values);
+
+		// Once we have compiled the insert statement's SQL we can execute it on the
+		// connection and return a result as a boolean success indicator as that
+		// is the same type of result returned by the raw connection instance.
+		$bindings = $this->cleanBindings($bindings);
+
+		return $this->connection->insert($sql, $bindings);
+	}
+
+	protected function structureBindings(array $values)
 	{
 		// Since every insert gets treated like a batch insert, we will make sure the
 		// bindings are structured in a way that is convenient for building these
@@ -1830,14 +1844,7 @@ class Builder {
 			}
 		}
 
-		$sql = $this->grammar->compileInsert($this, $values);
-
-		// Once we have compiled the insert statement's SQL we can execute it on the
-		// connection and return a result as a boolean success indicator as that
-		// is the same type of result returned by the raw connection instance.
-		$bindings = $this->cleanBindings($bindings);
-
-		return $this->connection->insert($sql, $bindings);
+		return $bindings;
 	}
 
 	/**
@@ -1851,9 +1858,11 @@ class Builder {
 	{
 		$sql = $this->grammar->compileInsertGetId($this, $values, $sequence);
 
-		$values = $this->cleanBindings($values);
+		$bindings = $this->structureBindings($values);
 
-		return $this->processor->processInsertGetId($this, $sql, $values, $sequence);
+		$bindings = $this->cleanBindings($bindings);
+
+		return $this->processor->processInsertGetId($this, $sql, $bindings, $sequence);
 	}
 
 	/**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -856,6 +856,15 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testInsertGetIdMethodBatchStatement()
+	{
+		$builder = $this->getBuilder();
+		$builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email", "name") values (?, ?), (?, ?)', array('foo', 'taylor', 'bar', 'jarek'), 'id')->andReturn(1);
+		$result = $builder->from('users')->insertGetId(array(array('email' => 'foo', 'name' => 'taylor'), array('email' => 'bar', 'name' => 'jarek')), 'id');
+		$this->assertEquals(1, $result);
+	}
+
+
 	public function testInsertGetIdMethod()
 	{
 		$builder = $this->getBuilder();


### PR DESCRIPTION
`insertGetId` worked only for single row statement, while in fact it used the same algo and just had different return value.

ps. build errors are HHVM issue only. All tests green.
