### PR TITLE
Support lowercase VERB name

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -229,7 +229,7 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	 */
 	public function match($methods, $uri, $action)
 	{
-		return $this->addRoute($methods, $uri, $action);
+		return $this->addRoute(array_map('strtoupper', (array) $methods), $uri, $action);
 	}
 
 	/**


### PR DESCRIPTION
When I use something like the following lowercase VERB name will throw an 'NotFound' exception:

``` php
Route::match(array('get', 'post'), '/', function()
{
    return View::make('hello');
});

```
