### PR TITLE
[PHPDoc] Update phpdocs for better chaining (return $this)

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -690,7 +690,7 @@ class Guard {
 	 * Set the current request instance.
 	 *
 	 * @param  \Symfony\Component\HttpFoundation\Request
-	 * @return \Illuminate\Auth\Guard
+	 * @return $this
 	 */
 	public function setRequest(Request $request)
 	{

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -56,7 +56,7 @@ class Application extends \Symfony\Component\Console\Application {
 	/**
 	 * Boot the Console application.
 	 *
-	 * @return \Illuminate\Console\Application
+	 * @return $this
 	 */
 	public function boot()
 	{
@@ -200,7 +200,7 @@ class Application extends \Symfony\Component\Console\Application {
 	 * Set the exception handler instance.
 	 *
 	 * @param  \Illuminate\Exception\Handler  $handler
-	 * @return \Illuminate\Console\Application
+	 * @return $this
 	 */
 	public function setExceptionHandler($handler)
 	{
@@ -213,7 +213,7 @@ class Application extends \Symfony\Component\Console\Application {
 	 * Set the Laravel application instance.
 	 *
 	 * @param  \Illuminate\Foundation\Application  $laravel
-	 * @return \Illuminate\Console\Application
+	 * @return $this
 	 */
 	public function setLaravel($laravel)
 	{
@@ -226,7 +226,7 @@ class Application extends \Symfony\Component\Console\Application {
 	 * Set whether the Console app should auto-exit when done.
 	 *
 	 * @param  bool  $boolean
-	 * @return \Illuminate\Console\Application
+	 * @return $this
 	 */
 	public function setAutoExit($boolean)
 	{

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -145,7 +145,7 @@ class CookieJar {
 	 *
 	 * @param  string  $path
 	 * @param  string  $domain
-	 * @return self
+	 * @return $this
 	 */
 	public function setDefaultPathAndDomain($path, $domain)
 	{

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -173,7 +173,7 @@ class Manager {
 	 * Set the fetch mode for the database connections.
 	 *
 	 * @param  int  $fetchMode
-	 * @return \Illuminate\Database\Capsule\Manager
+	 * @return $this
 	 */
 	public function setFetchMode($fetchMode)
 	{

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -688,7 +688,7 @@ class Connection implements ConnectionInterface {
 	 * Set the PDO connection.
 	 *
 	 * @param  \PDO  $pdo
-	 * @return \Illuminate\Database\Connection
+	 * @return $this
 	 */
 	public function setPdo(PDO $pdo)
 	{
@@ -701,7 +701,7 @@ class Connection implements ConnectionInterface {
 	 * Set the PDO connection used for reading.
 	 *
 	 * @param  \PDO  $pdo
-	 * @return \Illuminate\Database\Connection
+	 * @return $this
 	 */
 	public function setReadPdo(PDO $pdo)
 	{

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -556,7 +556,7 @@ class Builder {
 	 * @param  string  $operator
 	 * @param  mixed   $value
 	 * @param  string  $boolean
-	 * @return \Illuminate\Database\Eloquent\Builder|static
+	 * @return $this
 	 */
 	public function where($column, $operator = null, $value = null, $boolean = 'and')
 	{
@@ -712,7 +712,7 @@ class Builder {
 	 * Set the relationships that should be eager loaded.
 	 *
 	 * @param  dynamic  $relations
-	 * @return \Illuminate\Database\Eloquent\Builder|static
+	 * @return $this
 	 */
 	public function with($relations)
 	{
@@ -855,7 +855,7 @@ class Builder {
 	 * Set a model instance for the model being queried.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Model  $model
-	 * @return \Illuminate\Database\Eloquent\Builder
+	 * @return $this
 	 */
 	public function setModel(Model $model)
 	{

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -73,7 +73,7 @@ class Collection extends BaseCollection {
 	 * Fetch a nested element of the collection.
 	 *
 	 * @param  string  $key
-	 * @return \Illuminate\Database\Eloquent\Collection
+	 * @return static
 	 */
 	public function fetch($key)
 	{
@@ -122,7 +122,7 @@ class Collection extends BaseCollection {
 	 * Merge the collection with the given items.
 	 *
 	 * @param  \ArrayAccess|array  $items
-	 * @return \Illuminate\Database\Eloquent\Collection
+	 * @return static
 	 */
 	public function merge($items)
 	{
@@ -140,7 +140,7 @@ class Collection extends BaseCollection {
 	 * Diff the collection with the given items.
 	 *
 	 * @param  \ArrayAccess|array  $items
-	 * @return \Illuminate\Database\Eloquent\Collection
+	 * @return static
 	 */
 	public function diff($items)
 	{
@@ -163,7 +163,7 @@ class Collection extends BaseCollection {
 	 * Intersect the collection with the given items.
 	 *
  	 * @param  \ArrayAccess|array  $items
-	 * @return \Illuminate\Database\Eloquent\Collection
+	 * @return static
 	 */
 	public function intersect($items)
 	{
@@ -185,7 +185,7 @@ class Collection extends BaseCollection {
 	/**
 	 * Return only unique items from the collection.
 	 *
-	 * @return \Illuminate\Database\Eloquent\Collection
+	 * @return static
 	 */
 	public function unique()
 	{
@@ -198,7 +198,7 @@ class Collection extends BaseCollection {
 	 * Returns only the models from the collection with the specified keys.
 	 *
 	 * @param  mixed  $keys
-	 * @return \Illuminate\Database\Eloquent\Collection
+	 * @return static
 	 */
 	public function only($keys)
 	{
@@ -211,7 +211,7 @@ class Collection extends BaseCollection {
 	 * Returns all models in the collection except the models with specified keys.
 	 *
 	 * @param  mixed  $keys
-	 * @return \Illuminate\Database\Eloquent\Collection
+	 * @return static
 	 */
 	public function except($keys)
 	{

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -28,8 +28,8 @@ class Collection extends BaseCollection {
 	/**
 	 * Load a set of relationships onto the collection.
 	 *
-	 * @param  dynamic  $relations
-	 * @return \Illuminate\Database\Eloquent\Collection
+	 * @param  mixed  $relations
+	 * @return $this
 	 */
 	public function load($relations)
 	{
@@ -49,7 +49,7 @@ class Collection extends BaseCollection {
 	 * Add an item to the collection.
 	 *
 	 * @param  mixed  $item
-	 * @return \Illuminate\Database\Eloquent\Collection
+	 * @return $this
 	 */
 	public function add($item)
 	{

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -436,7 +436,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 *
 	 * @param  array  $attributes
 	 * @param  bool   $exists
-	 * @return \Illuminate\Database\Eloquent\Model|static
+	 * @return static
 	 */
 	public function newInstance($attributes = array(), $exists = false)
 	{
@@ -454,7 +454,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Create a new model instance that is existing.
 	 *
 	 * @param  array  $attributes
-	 * @return \Illuminate\Database\Eloquent\Model|static
+	 * @return static
 	 */
 	public function newFromBuilder($attributes = array())
 	{
@@ -517,7 +517,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Save a new model and return the instance.
 	 *
 	 * @param  array  $attributes
-	 * @return \Illuminate\Database\Eloquent\Model|static
+	 * @return static
 	 */
 	public static function create(array $attributes)
 	{
@@ -532,7 +532,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Get the first record matching the attributes or create it.
 	 *
 	 * @param  array  $attributes
-	 * @return \Illuminate\Database\Eloquent\Model
+	 * @return static
 	 */
 	public static function firstOrCreate(array $attributes)
 	{
@@ -548,7 +548,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Get the first record matching the attributes or instantiate it.
 	 *
 	 * @param  array  $attributes
-	 * @return \Illuminate\Database\Eloquent\Model
+	 * @return static
 	 */
 	public static function firstOrNew(array $attributes)
 	{
@@ -565,7 +565,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 *
 	 * @param  array  $attributes
 	 * @param  array  $values
-	 * @return \Illuminate\Database\Eloquent\Model
+	 * @return static
 	 */
 	public static function updateOrCreate(array $attributes, array $values = array())
 	{
@@ -580,7 +580,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Get the first model for the given attributes.
 	 *
 	 * @param  array  $attributes
-	 * @return \Illuminate\Database\Eloquent\Model|null
+	 * @return static|null
 	 */
 	protected static function firstByAttributes($attributes)
 	{
@@ -633,7 +633,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 *
 	 * @param  mixed  $id
 	 * @param  array  $columns
-	 * @return \Illuminate\Database\Eloquent\Model|Collection|static
+	 * @return \Illuminate\Support\Collection|static
 	 */
 	public static function find($id, $columns = array('*'))
 	{
@@ -649,7 +649,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 *
 	 * @param  mixed  $id
 	 * @param  array  $columns
-	 * @return \Illuminate\Database\Eloquent\Model|Collection|static
+	 * @return \Illuminate\Support\Collection|static
 	 */
 	public static function findOrNew($id, $columns = array('*'))
 	{
@@ -663,7 +663,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 *
 	 * @param  mixed  $id
 	 * @param  array  $columns
-	 * @return \Illuminate\Database\Eloquent\Model|Collection|static
+	 * @return \Illuminate\Support\Collection|static
 	 *
 	 * @throws ModelNotFoundException
 	 */

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -387,7 +387,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Fill the model with an array of attributes.
 	 *
 	 * @param  array  $attributes
-	 * @return \Illuminate\Database\Eloquent\Model|static
+	 * @return $this
 	 *
 	 * @throws MassAssignmentException
 	 */
@@ -678,7 +678,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Eager load relations on the model.
 	 *
 	 * @param  array|string  $relations
-	 * @return \Illuminate\Database\Eloquent\Model
+	 * @return $this
 	 */
 	public function load($relations)
 	{
@@ -1990,7 +1990,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Set the fillable attributes for the model.
 	 *
 	 * @param  array  $fillable
-	 * @return \Illuminate\Database\Eloquent\Model
+	 * @return $this
 	 */
 	public function fillable(array $fillable)
 	{
@@ -2003,7 +2003,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Set the guarded attributes for the model.
 	 *
 	 * @param  array  $guarded
-	 * @return \Illuminate\Database\Eloquent\Model
+	 * @return $this
 	 */
 	public function guard(array $guarded)
 	{
@@ -2657,7 +2657,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	/**
 	 * Sync the original attributes with the current.
 	 *
-	 * @return \Illuminate\Database\Eloquent\Model
+	 * @return $this
 	 */
 	public function syncOriginal()
 	{
@@ -2670,7 +2670,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Sync a single original attribute with its current value.
 	 *
 	 * @param  string  $attribute
-	 * @return \Illuminate\Database\Eloquent\Model
+	 * @return $this
 	 */
 	public function syncOriginalAttribute($attribute)
 	{
@@ -2765,7 +2765,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 *
 	 * @param  string  $relation
 	 * @param  mixed   $value
-	 * @return \Illuminate\Database\Eloquent\Model
+	 * @return $this
 	 */
 	public function setRelation($relation, $value)
 	{
@@ -2778,7 +2778,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Set the entire relations array on the model.
 	 *
 	 * @param  array  $relations
-	 * @return \Illuminate\Database\Eloquent\Model
+	 * @return $this
 	 */
 	public function setRelations(array $relations)
 	{
@@ -2811,7 +2811,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Set the connection associated with the model.
 	 *
 	 * @param  string  $name
-	 * @return \Illuminate\Database\Eloquent\Model
+	 * @return $this
 	 */
 	public function setConnection($name)
 	{

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -13,7 +13,7 @@ class ModelNotFoundException extends \RuntimeException {
 	 * Set the affected Eloquent model.
 	 *
 	 * @param  string   $model
-	 * @return ModelNotFoundException
+	 * @return $this
 	 */
 	public function setModel($model)
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -327,7 +327,7 @@ class BelongsToMany extends Relation {
 	 * Set the join clause for the relation query.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder|null
-	 * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+	 * @return $this
 	 */
 	protected function setJoin($query = null)
 	{
@@ -348,7 +348,7 @@ class BelongsToMany extends Relation {
 	/**
 	 * Set the where clause for the relation query.
 	 *
-	 * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+	 * @return $this
 	 */
 	protected function setWhere()
 	{
@@ -942,7 +942,7 @@ class BelongsToMany extends Relation {
 	 * Set the columns on the pivot table to retrieve.
 	 *
 	 * @param  array  $columns
-	 * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+	 * @return $this
 	 */
 	public function withPivot($columns)
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -44,7 +44,7 @@ class MorphPivot extends Pivot {
 	 * Set the morph type for the pivot.
 	 *
 	 * @param  string  $morphType
-	 * @return \Illuminate\Database\Eloquent\Relations\MorphPivot
+	 * @return $this
 	 */
 	public function setMorphType($morphType)
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -207,7 +207,7 @@ class MorphTo extends BelongsTo {
 	/**
 	 * Fetch soft-deleted model instances with query
 	 *
-	 * @return MorphTo
+	 * @return $this
 	 */
 	public function withTrashed()
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -53,7 +53,7 @@ class MorphToMany extends BelongsToMany {
 	/**
 	 * Set the where clause for the relation query.
 	 *
-	 * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+	 * @return $this
 	 */
 	protected function setWhere()
 	{

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -127,7 +127,7 @@ class Pivot extends Model {
 	 *
 	 * @param  string  $foreignKey
 	 * @param  string  $otherKey
-	 * @return \Illuminate\Database\Eloquent\Relations\Pivot
+	 * @return $this
 	 */
 	public function setPivotKeys($foreignKey, $otherKey)
 	{

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -167,7 +167,7 @@ abstract class Grammar {
 	 * Set the grammar's table prefix.
 	 *
 	 * @param  string  $prefix
-	 * @return \Illuminate\Database\Grammar
+	 * @return $this
 	 */
 	public function setTablePrefix($prefix)
 	{

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -201,7 +201,7 @@ class Builder {
 	 * Set the columns to be selected.
 	 *
 	 * @param  array  $columns
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function select($columns = array('*'))
 	{
@@ -225,7 +225,7 @@ class Builder {
 	 * Add a new select column to the query.
 	 *
 	 * @param  mixed  $column
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function addSelect($column)
 	{
@@ -239,7 +239,7 @@ class Builder {
 	/**
 	 * Force the query to only return distinct results.
 	 *
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function distinct()
 	{
@@ -252,7 +252,7 @@ class Builder {
 	 * Set the table which the query is targeting.
 	 *
 	 * @param  string  $table
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function from($table)
 	{
@@ -270,7 +270,7 @@ class Builder {
 	 * @param  string  $two
 	 * @param  string  $type
 	 * @param  bool    $where
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function join($table, $one, $operator = null, $two = null, $type = 'inner', $where = false)
 	{
@@ -377,7 +377,7 @@ class Builder {
 	 * @param  string  $operator
 	 * @param  mixed   $value
 	 * @param  string  $boolean
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 *
 	 * @throws \InvalidArgumentException
 	 */
@@ -489,7 +489,7 @@ class Builder {
 	 * @param  string  $sql
 	 * @param  array   $bindings
 	 * @param  string  $boolean
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function whereRaw($sql, array $bindings = array(), $boolean = 'and')
 	{
@@ -521,7 +521,7 @@ class Builder {
 	 * @param  array   $values
 	 * @param  string  $boolean
 	 * @param  bool  $not
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function whereBetween($column, array $values, $boolean = 'and', $not = false)
 	{
@@ -597,7 +597,7 @@ class Builder {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder|static $query
 	 * @param  string  $boolean
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function addNestedWhereQuery($query, $boolean = 'and')
 	{
@@ -620,7 +620,7 @@ class Builder {
 	 * @param  string   $operator
 	 * @param  \Closure $callback
 	 * @param  string   $boolean
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	protected function whereSub($column, $operator, Closure $callback, $boolean)
 	{
@@ -646,7 +646,7 @@ class Builder {
 	 * @param  \Closure $callback
 	 * @param  string   $boolean
 	 * @param  bool     $not
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function whereExists(Closure $callback, $boolean = 'and', $not = false)
 	{
@@ -708,7 +708,7 @@ class Builder {
 	 * @param  mixed   $values
 	 * @param  string  $boolean
 	 * @param  bool    $not
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function whereIn($column, $values, $boolean = 'and', $not = false)
 	{
@@ -773,7 +773,7 @@ class Builder {
 	 * @param  \Closure $callback
 	 * @param  string   $boolean
 	 * @param  bool     $not
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	protected function whereInSub($column, Closure $callback, $boolean, $not)
 	{
@@ -797,7 +797,7 @@ class Builder {
 	 * @param  string  $column
 	 * @param  string  $boolean
 	 * @param  bool    $not
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function whereNull($column, $boolean = 'and', $not = false)
 	{
@@ -892,7 +892,7 @@ class Builder {
 	 * @param  string  $operator
 	 * @param  int  $value
 	 * @param  string  $boolean
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	protected function addDateBasedWhere($type, $column, $operator, $value, $boolean = 'and')
 	{
@@ -908,7 +908,7 @@ class Builder {
 	 *
 	 * @param  string  $method
 	 * @param  string  $parameters
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function dynamicWhere($method, $parameters)
 	{
@@ -969,8 +969,7 @@ class Builder {
 	/**
 	 * Add a "group by" clause to the query.
 	 *
-	 * @param  dynamic  $columns
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function groupBy()
 	{
@@ -989,7 +988,7 @@ class Builder {
 	 * @param  string  $operator
 	 * @param  string  $value
 	 * @param  string  $boolean
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function having($column, $operator = null, $value = null, $boolean = 'and')
 	{
@@ -1021,7 +1020,7 @@ class Builder {
 	 * @param  string  $sql
 	 * @param  array   $bindings
 	 * @param  string  $boolean
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function havingRaw($sql, array $bindings = array(), $boolean = 'and')
 	{
@@ -1051,7 +1050,7 @@ class Builder {
 	 *
 	 * @param  string  $column
 	 * @param  string  $direction
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function orderBy($column, $direction = 'asc')
 	{
@@ -1089,7 +1088,7 @@ class Builder {
 	 *
 	 * @param  string  $sql
 	 * @param  array  $bindings
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function orderByRaw($sql, $bindings = array())
 	{
@@ -1106,7 +1105,7 @@ class Builder {
 	 * Set the "offset" value of the query.
 	 *
 	 * @param  int  $value
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function offset($value)
 	{
@@ -1130,7 +1129,7 @@ class Builder {
 	 * Set the "limit" value of the query.
 	 *
 	 * @param  int  $value
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function limit($value)
 	{
@@ -1195,8 +1194,8 @@ class Builder {
 	/**
 	 * Lock the selected rows in the table.
 	 *
-	 * @param  bool  $update
-	 * @return \Illuminate\Database\Query\Builder
+	 * @param  bool  $value
+	 * @return $this
 	 */
 	public function lock($value = true)
 	{
@@ -1240,7 +1239,7 @@ class Builder {
 	 *
 	 * @param  \DateTime|int  $minutes
 	 * @param  string  $key
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function remember($minutes, $key = null)
 	{
@@ -1264,7 +1263,7 @@ class Builder {
 	 * Indicate that the results, if cached, should use the given cache tags.
 	 *
 	 * @param  array|dynamic  $cacheTags
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function cacheTags($cacheTags)
 	{
@@ -1277,7 +1276,7 @@ class Builder {
 	 * Indicate that the results, if cached, should use the given cache driver.
 	 *
 	 * @param  string  $cacheDriver
-	 * @return \Illuminate\Database\Query\Builder|static
+	 * @return $this
 	 */
 	public function cacheDriver($cacheDriver)
 	{
@@ -2010,7 +2009,7 @@ class Builder {
 	 *
 	 * @param  array   $bindings
 	 * @param  string  $type
-	 * @return \Illuminate\Database\Query\Builder
+	 * @return $this
 	 *
 	 * @throws \InvalidArgumentException
 	 */
@@ -2031,7 +2030,7 @@ class Builder {
 	 *
 	 * @param  mixed   $value
 	 * @param  string  $type
-	 * @return \Illuminate\Database\Query\Builder
+	 * @return $this
 	 *
 	 * @throws \InvalidArgumentException
 	 */
@@ -2058,7 +2057,7 @@ class Builder {
 	 * Merge an array of bindings into our bindings.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
-	 * @return \Illuminate\Database\Query\Builder
+	 * @return $this
 	 */
 	public function mergeBindings(Builder $query)
 	{

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -53,7 +53,7 @@ class JoinClause {
 	 * @param  string  $second
 	 * @param  string  $boolean
 	 * @param  bool  $where
-	 * @return \Illuminate\Database\Query\JoinClause
+	 * @return $this
 	 */
 	public function on($first, $operator, $second, $boolean = 'and', $where = false)
 	{

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -765,7 +765,7 @@ class Blueprint {
 	 * Remove a column from the schema blueprint.
 	 *
 	 * @param  string  $name
-	 * @return \Illuminate\Database\Schema\Blueprint
+	 * @return $this
 	 */
 	public function removeColumn($name)
 	{

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -202,7 +202,7 @@ class Builder {
 	 * Set the database connection instance.
 	 *
 	 * @param  \Illuminate\Database\Connection
-	 * @return \Illuminate\Database\Schema\Builder
+	 * @return $this
 	 */
 	public function setConnection(Connection $connection)
 	{

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -73,7 +73,7 @@ class Seeder {
 	 * Set the IoC container instance.
 	 *
 	 * @param  \Illuminate\Container\Container  $container
-	 * @return \Illuminate\Database\Seeder
+	 * @return $this
 	 */
 	public function setContainer(Container $container)
 	{
@@ -86,7 +86,7 @@ class Seeder {
 	 * Set the console command instance.
 	 *
 	 * @param  \Illuminate\Console\Command  $command
-	 * @return \Illuminate\Database\Seeder
+	 * @return $this
 	 */
 	public function setCommand(Command $command)
 	{

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -698,7 +698,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	 *
 	 * @param  string  $class
 	 * @param  array  $parameters
-	 * @return \Illuminate\Foundation\Application
+	 * @return $this
 	 */
 	public function middleware($class, array $parameters = array())
 	{

--- a/src/Illuminate/Foundation/Composer.php
+++ b/src/Illuminate/Foundation/Composer.php
@@ -86,7 +86,7 @@ class Composer {
 	 * Set the working path used by the class.
 	 *
 	 * @param  string  $path
-	 * @return \Illuminate\Foundation\Composer
+	 * @return $this
 	 */
 	public function setWorkingPath($path)
 	{

--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -960,7 +960,7 @@ class FormBuilder {
 	 * Set the session store implementation.
 	 *
 	 * @param  \Illuminate\Session\Store  $session
-	 * @return \Illuminate\Html\FormBuilder
+	 * @return $this
 	 */
 	public function setSessionStore(Session $session)
 	{

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -28,7 +28,7 @@ class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectRespons
 	 * @param  string  $key
 	 * @param  string  $value
 	 * @param  bool  $replace
-	 * @return \Illuminate\Http\RedirectResponse
+	 * @return $this
 	 */
 	public function header($key, $value, $replace = true)
 	{
@@ -62,7 +62,7 @@ class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectRespons
 	 * Add a cookie to the response.
 	 *
 	 * @param  \Symfony\Component\HttpFoundation\Cookie  $cookie
-	 * @return \Illuminate\Http\RedirectResponse
+	 * @return $this
 	 */
 	public function withCookie(Cookie $cookie)
 	{
@@ -75,7 +75,7 @@ class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectRespons
 	 * Flash an array of input to the session.
 	 *
 	 * @param  array  $input
-	 * @return \Illuminate\Http\RedirectResponse
+	 * @return $this
 	 */
 	public function withInput(array $input = null)
 	{
@@ -89,8 +89,8 @@ class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectRespons
 	/**
 	 * Flash an array of input to the session.
 	 *
-	 * @param  dynamic  string
-	 * @return \Illuminate\Http\RedirectResponse
+	 * @param  mixed  string
+	 * @return $this
 	 */
 	public function onlyInput()
 	{
@@ -113,7 +113,7 @@ class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectRespons
 	 *
 	 * @param  \Illuminate\Support\Contracts\MessageProviderInterface|array  $provider
 	 * @param  string  $key
-	 * @return \Illuminate\Http\RedirectResponse
+	 * @return $this
 	 */
 	public function withErrors($provider, $key = 'default')
 	{

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -22,7 +22,7 @@ class Request extends SymfonyRequest {
 	/**
 	 * Return the Request instance.
 	 *
-	 * @return \Illuminate\Http\Request
+	 * @return $this
 	 */
 	public function instance()
 	{

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -10,7 +10,7 @@ trait ResponseTrait {
 	 * @param  string  $key
 	 * @param  string  $value
 	 * @param  bool    $replace
-	 * @return \Illuminate\Http\Response
+	 * @return $this
 	 */
 	public function header($key, $value, $replace = true)
 	{
@@ -23,7 +23,7 @@ trait ResponseTrait {
 	 * Add a cookie to the response.
 	 *
 	 * @param  \Symfony\Component\HttpFoundation\Cookie  $cookie
-	 * @return \Illuminate\Http\Response
+	 * @return $this
 	 */
 	public function withCookie(Cookie $cookie)
 	{

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -468,7 +468,7 @@ class Mailer {
 	 * Set the log writer instance.
 	 *
 	 * @param  \Illuminate\Log\Writer  $logger
-	 * @return \Illuminate\Mail\Mailer
+	 * @return $this
 	 */
 	public function setLogger(Writer $logger)
 	{
@@ -481,7 +481,7 @@ class Mailer {
 	 * Set the queue manager instance.
 	 *
 	 * @param  \Illuminate\Queue\QueueManager  $queue
-	 * @return \Illuminate\Mail\Mailer
+	 * @return $this
 	 */
 	public function setQueue(QueueManager $queue)
 	{

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -28,7 +28,7 @@ class Message {
 	 *
 	 * @param  string  $address
 	 * @param  string  $name
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	public function from($address, $name = null)
 	{
@@ -42,7 +42,7 @@ class Message {
 	 *
 	 * @param  string  $address
 	 * @param  string  $name
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	public function sender($address, $name = null)
 	{
@@ -55,7 +55,7 @@ class Message {
 	 * Set the "return path" of the message.
 	 *
 	 * @param  string  $address
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	public function returnPath($address)
 	{
@@ -69,7 +69,7 @@ class Message {
 	 *
 	 * @param  string|array  $address
 	 * @param  string  $name
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	public function to($address, $name = null)
 	{
@@ -81,7 +81,7 @@ class Message {
 	 *
 	 * @param  string  $address
 	 * @param  string  $name
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	public function cc($address, $name = null)
 	{
@@ -93,7 +93,7 @@ class Message {
 	 *
 	 * @param  string  $address
 	 * @param  string  $name
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	public function bcc($address, $name = null)
 	{
@@ -105,7 +105,7 @@ class Message {
 	 *
 	 * @param  string  $address
 	 * @param  string  $name
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	public function replyTo($address, $name = null)
 	{
@@ -118,7 +118,7 @@ class Message {
 	 * @param  string|array  $address
 	 * @param  string  $name
 	 * @param  string  $type
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	protected function addAddresses($address, $name, $type)
 	{
@@ -138,7 +138,7 @@ class Message {
 	 * Set the subject of the message.
 	 *
 	 * @param  string  $subject
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	public function subject($subject)
 	{
@@ -151,7 +151,7 @@ class Message {
 	 * Set the message priority level.
 	 *
 	 * @param  int  $level
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	public function priority($level)
 	{
@@ -165,7 +165,7 @@ class Message {
 	 *
 	 * @param  string  $file
 	 * @param  array   $options
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	public function attach($file, array $options = array())
 	{
@@ -191,7 +191,7 @@ class Message {
 	 * @param  string  $data
 	 * @param  string  $name
 	 * @param  array   $options
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	public function attachData($data, $name, array $options = array())
 	{
@@ -243,7 +243,7 @@ class Message {
 	 *
 	 * @param  \Swift_Attachment  $attachment
 	 * @param  array  $options
-	 * @return \Illuminate\Mail\Message
+	 * @return $this
 	 */
 	protected function prepAttachment($attachment, $options = array())
 	{

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -117,7 +117,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	/**
 	 * Setup the pagination context (current and last page).
 	 *
-	 * @return \Illuminate\Pagination\Paginator
+	 * @return $this
 	 */
 	public function setupPaginationContext()
 	{
@@ -233,7 +233,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	 * Get / set the URL fragment to be appended to URLs.
 	 *
 	 * @param  string|null  $fragment
-	 * @return \Illuminate\Pagination\Paginator|string
+	 * @return $this|string
 	 */
 	public function fragment($fragment = null)
 	{
@@ -257,7 +257,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	 *
 	 * @param  string  $key
 	 * @param  string  $value
-	 * @return \Illuminate\Pagination\Paginator
+	 * @return $this
 	 */
 	public function appends($key, $value = null)
 	{
@@ -270,7 +270,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	 * Add an array of query string values.
 	 *
 	 * @param  array  $keys
-	 * @return \Illuminate\Pagination\Paginator
+	 * @return $this
 	 */
 	protected function appendArray(array $keys)
 	{
@@ -287,7 +287,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	 *
 	 * @param  string  $key
 	 * @param  string  $value
-	 * @return \Illuminate\Pagination\Paginator
+	 * @return $this
 	 */
 	public function addQuery($key, $value)
 	{

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -372,7 +372,7 @@ class Route {
 	 * Bind the route to a given request for execution.
 	 *
 	 * @param  \Illuminate\Http\Request  $request
-	 * @return \Illuminate\Routing\Route
+	 * @return $this
 	 */
 	public function bind(Request $request)
 	{
@@ -537,7 +537,7 @@ class Route {
 	 * Add before filters to the route.
 	 *
 	 * @param  string  $filters
-	 * @return \Illuminate\Routing\Route
+	 * @return $this
 	 */
 	public function before($filters)
 	{
@@ -548,7 +548,7 @@ class Route {
 	 * Add after filters to the route.
 	 *
 	 * @param  string  $filters
-	 * @return \Illuminate\Routing\Route
+	 * @return $this
 	 */
 	public function after($filters)
 	{
@@ -560,7 +560,7 @@ class Route {
 	 *
 	 * @param  string  $type
 	 * @param  string  $filters
-	 * @return \Illuminate\Routing\Route
+	 * @return $this
 	 */
 	protected function addFilters($type, $filters)
 	{
@@ -581,7 +581,7 @@ class Route {
 	 *
 	 * @param  string  $key
 	 * @param  mixed  $value
-	 * @return \Illuminate\Routing\Route
+	 * @return $this
 	 */
 	public function defaults($key, $value)
 	{
@@ -595,7 +595,7 @@ class Route {
 	 *
 	 * @param  array|string  $name
 	 * @param  string  $expression
-	 * @return \Illuminate\Routing\Route
+	 * @return $this
 	 */
 	public function where($name, $expression = null)
 	{
@@ -612,7 +612,7 @@ class Route {
 	 *
 	 * @param  array|string  $name
 	 * @param  string  $expression
-	 * @return \Illuminate\Routing\Route
+	 * @return array
 	 */
 	protected function parseWhere($name, $expression)
 	{
@@ -623,7 +623,7 @@ class Route {
 	 * Set a list of regular expression requirements on the route.
 	 *
 	 * @param  array  $wheres
-	 * @return \Illuminate\Routing\Route
+	 * @return $this
 	 */
 	protected function whereArray(array $wheres)
 	{
@@ -639,7 +639,7 @@ class Route {
 	 * Add a prefix to the route URI.
 	 *
 	 * @param  string  $prefix
-	 * @return \Illuminate\Routing\Route
+	 * @return $this
 	 */
 	public function prefix($prefix)
 	{
@@ -795,7 +795,7 @@ class Route {
 	 * Set the action array for the route.
 	 *
 	 * @param  array  $action
-	 * @return \Illuminate\Routing\Route
+	 * @return $this
 	 */
 	public function setAction(array $action)
 	{

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -118,7 +118,7 @@ class DatabaseSessionHandler implements \SessionHandlerInterface, ExistenceAware
 	 * Set the existence state for the session.
 	 *
 	 * @param  bool  $value
-	 * @return \SessionHandlerInterface
+	 * @return $this
 	 */
 	public function setExists($value)
 	{

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -34,7 +34,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Create a new collection instance if the value isn't one already.
 	 *
 	 * @param  mixed  $items
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public static function make($items)
 	{
@@ -58,7 +58,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	/**
 	 * Collapse the collection items into a single array.
 	 *
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function collapse()
 	{
@@ -92,7 +92,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Diff the collection with the given items.
 	 *
 	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function diff($items)
 	{
@@ -426,7 +426,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Create a colleciton of all elements that do not pass a given truth test.
 	 *
 	 * @param  \Closure|mixed  $callback
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function reject($callback)
 	{

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -103,7 +103,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Execute a callback over each item.
 	 *
 	 * @param  \Closure  $callback
-	 * @return \Illuminate\Support\Collection
+	 * @return $this
 	 */
 	public function each(Closure $callback)
 	{
@@ -116,7 +116,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Fetch a nested element of the collection.
 	 *
 	 * @param  string  $key
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function fetch($key)
 	{
@@ -127,7 +127,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Run a filter over each of the items.
 	 *
 	 * @param  \Closure  $callback
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function filter(Closure $callback)
 	{
@@ -156,7 +156,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	/**
 	 * Get a flattened array of the items in the collection.
 	 *
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function flatten()
 	{
@@ -166,7 +166,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	/**
 	 * Flip the items in the collection.
 	 *
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function flip()
 	{
@@ -205,7 +205,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Group an associative array by a field or Closure value.
 	 *
 	 * @param  callable|string  $groupBy
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function groupBy($groupBy)
 	{
@@ -225,7 +225,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Key an associative array by a field.
 	 *
 	 * @param  string  $keyBy
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function keyBy($keyBy)
 	{
@@ -270,7 +270,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Intersect the collection with the given items.
 	 *
  	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function intersect($items)
 	{
@@ -323,7 +323,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Run a map over each of the items.
 	 *
 	 * @param  \Closure  $callback
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function map(Closure $callback)
 	{
@@ -334,7 +334,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Merge the collection with the given items.
 	 *
 	 * @param  \Illuminate\Support\Collection|\Illuminate\Support\Contracts\ArrayableInterface|array  $items
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function merge($items)
 	{
@@ -453,7 +453,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	/**
 	 * Reverse items order.
 	 *
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function reverse()
 	{
@@ -485,7 +485,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	/**
 	 * Shuffle the items in the collection.
 	 *
-	 * @return \Illuminate\Support\Collection
+	 * @return $this
 	 */
 	public function shuffle()
 	{
@@ -500,7 +500,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * @param  int   $offset
 	 * @param  int   $length
 	 * @param  bool  $preserveKeys
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function slice($offset, $length = null, $preserveKeys = false)
 	{
@@ -512,7 +512,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 *
 	 * @param  int   $size
 	 * @param  bool  $preserveKeys
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function chunk($size, $preserveKeys = false)
 	{
@@ -530,7 +530,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Sort through each item with a callback.
 	 *
 	 * @param  \Closure  $callback
-	 * @return \Illuminate\Support\Collection
+	 * @return $this
 	 */
 	public function sort(Closure $callback)
 	{
@@ -545,7 +545,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * @param  \Closure|string  $callback
 	 * @param  int   $options
 	 * @param  bool  $descending
-	 * @return \Illuminate\Support\Collection
+	 * @return $this
 	 */
 	public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
 	{
@@ -583,7 +583,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 *
 	 * @param  \Closure|string  $callback
 	 * @param  int  $options
-	 * @return \Illuminate\Support\Collection
+	 * @return $this
 	 */
 	public function sortByDesc($callback, $options = SORT_REGULAR)
 	{
@@ -596,7 +596,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * @param  int    $offset
 	 * @param  int    $length
 	 * @param  mixed  $replacement
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function splice($offset, $length = 0, $replacement = array())
 	{
@@ -627,7 +627,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Take the first or last {$limit} items.
 	 *
 	 * @param  int  $limit
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function take($limit = null)
 	{
@@ -640,7 +640,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Transform each item in the collection using a callback.
 	 *
 	 * @param  \Closure  $callback
-	 * @return \Illuminate\Support\Collection
+	 * @return $this
 	 */
 	public function transform(Closure $callback)
 	{
@@ -652,7 +652,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	/**
 	 * Return only unique items from the collection array.
 	 *
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function unique()
 	{
@@ -662,7 +662,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	/**
 	 * Reset the keys on the underlying array.
 	 *
-	 * @return \Illuminate\Support\Collection
+	 * @return static
 	 */
 	public function values()
 	{

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -136,7 +136,7 @@ class Fluent implements ArrayAccess, ArrayableInterface, JsonableInterface, Json
 	 *
 	 * @param  string  $method
 	 * @param  array   $parameters
-	 * @return \Illuminate\Support\Fluent
+	 * @return $this
 	 */
 	public function __call($method, $parameters)
 	{

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -107,7 +107,7 @@ abstract class Manager {
 	 *
 	 * @param  string    $driver
 	 * @param  \Closure  $callback
-	 * @return \Illuminate\Support\Manager|static
+	 * @return $this
 	 */
 	public function extend($driver, Closure $callback)
 	{

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -41,7 +41,7 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 	 *
 	 * @param  string  $key
 	 * @param  string  $message
-	 * @return \Illuminate\Support\MessageBag
+	 * @return $this
 	 */
 	public function add($key, $message)
 	{
@@ -57,7 +57,7 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 	 * Merge a new array of messages into the bag.
 	 *
 	 * @param  \Illuminate\Support\Contracts\MessageProviderInterface|array  $messages
-	 * @return \Illuminate\Support\MessageBag
+	 * @return $this
 	 */
 	public function merge($messages)
 	{

--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -27,7 +27,7 @@ class ViewErrorBag implements Countable {
 	 *
 	 * @param  string  $key
 	 * @param  \Illuminate\Support\MessageBag  $bag
-	 * @return \Illuminate\Support\ViewErrorBag
+	 * @return $this
 	 */
 	public function put($key, MessageBag $bag)
 	{

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2130,7 +2130,7 @@ class Validator implements MessageProviderInterface {
 	 * Set the validation rules.
 	 *
 	 * @param  array  $rules
-	 * @return \Illuminate\Validation\Validator
+	 * @return $this
 	 */
 	public function setRules(array $rules)
 	{
@@ -2143,7 +2143,7 @@ class Validator implements MessageProviderInterface {
 	 * Set the custom attributes on the validator.
 	 *
 	 * @param  array  $attributes
-	 * @return \Illuminate\Validation\Validator
+	 * @return $this
 	 */
 	public function setAttributeNames(array $attributes)
 	{
@@ -2166,7 +2166,7 @@ class Validator implements MessageProviderInterface {
 	 * Set the files under validation.
 	 *
 	 * @param  array  $files
-	 * @return \Illuminate\Validation\Validator
+	 * @return $this
 	 */
 	public function setFiles(array $files)
 	{

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -159,7 +159,7 @@ class View implements ArrayAccess, Renderable {
 	 *
 	 * @param  string|array  $key
 	 * @param  mixed   $value
-	 * @return \Illuminate\View\View
+	 * @return $this
 	 */
 	public function with($key, $value = null)
 	{
@@ -181,7 +181,7 @@ class View implements ArrayAccess, Renderable {
 	 * @param  string  $key
 	 * @param  string  $view
 	 * @param  array   $data
-	 * @return \Illuminate\View\View
+	 * @return $this
 	 */
 	public function nest($key, $view, array $data = array())
 	{
@@ -192,7 +192,7 @@ class View implements ArrayAccess, Renderable {
 	 * Add validation errors to the view.
 	 *
 	 * @param  \Illuminate\Support\Contracts\MessageProviderInterface|array  $provider
-	 * @return \Illuminate\View\View
+	 * @return $this
 	 */
 	public function withErrors($provider)
 	{


### PR DESCRIPTION
[PSR-5 Proposal](https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#keyword) suggests `self`, `static` and `$this`, with `self` for returning a class with the same type wherein the method is defined, `static` when it returns the same class as the class the method is called on, `$this` when it returns the same instance, so mostly for chaining methods.

PhpStorm: supports `self`, `static`, `$this` ([ticket](http://youtrack.jetbrains.com/issue/WI-2225))
Scrutinizer: supports `self`, `static`, `$this` (https://github.com/scrutinizer-ci/php-analyzer/issues/45 )
Netbeans: doesn't support `$this` but `this` (and `self`/`static`), but this is wrong and should be fixed by Netbeans ([bug](https://netbeans.org/bugzilla/show_bug.cgi?id=239987))
Eclipse supports `$this` also. (https://github.com/symfony/symfony/pull/11523)

Drupal has also taken `static` and `$this` up in their coding standards 6 months ago ([Discussion](https://www.drupal.org/node/2158497) / [CS Guide](https://www.drupal.org/coding-standards/docs#types)

So I suggest we follow the PSR-5 proposal and use `@return $this` for chaining methods. (and `static` for when a new instance is returned, eg. a new Collection)

I searched for any methods with explicitly having 'return $this;', so this might not be complete, but should cover a lot of cases. Also fixed some incorrect phpdocs when I saw them.
