### PR TITLE
[4.2] Allow remember token to be stored in the database with a non-null default

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -568,7 +568,9 @@ class Guard {
 	 */
 	protected function createRememberTokenIfDoesntExist(UserInterface $user)
 	{
-		if (is_null($user->getRememberToken()))
+		$rememberToken = $user->getRememberToken();
+
+		if (empty($rememberToken))
 		{
 			$this->refreshRememberToken($user);
 		}


### PR DESCRIPTION
Checking is_null here would make it so the user would not be remembered after the first login if you have the remember_token field default set to anything but null in the database.

Storing non-null values as default in the database is useful for high-performance applications, see:

http://stackoverflow.com/questions/1106258/mysql-null-vs/12706491#12706491

which cites:

http://shop.oreilly.com/product/0636920022343.do (High Performance MySQL Book)
