### PR TITLE
Allow column names to be wrapped in '`'.

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -53,6 +53,8 @@ abstract class Grammar {
 			return $this->wrap($segments[0]).' as '.$this->wrap($segments[2]);
 		}
 
+		if ($value[0] === '`' && substr($value, -1) === '`' && substr_count($value, '`', 2)) return $value;
+
 		$wrapped = array();
 
 		$segments = explode('.', $value);


### PR DESCRIPTION
Column names with a dot (for example `my.column` in them don't currently work as the Grammar class will see the `my` as the table name and the `column` as the column name. This allows you to wrap a column in backticks   like so: ``my.column``

Currently this gets interpreted as: ````my`.`column````
