### PR TITLE
[4.2] The Return Of "hhvm-nightly"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.5
   - 5.6
   - hhvm
+  - hhvm-nightly
 
 before_script:
   - travis_retry composer self-update
@@ -15,3 +16,4 @@ script: vendor/bin/phpunit --verbose
 matrix:
   allow_failures:
     - php: hhvm
+    - php: hhvm-nightly


### PR DESCRIPTION
Because the hhvm project is still so fragile, we better test against hhvm-nightly so we can spot issues earlier, and see when current issues are fixed.
