### PR TITLE
Add reload() method to Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -675,6 +675,22 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
+	 * Reload model data from the database.
+	 *
+	 * @return void
+	 */
+	public function reload()
+	{
+		if ($this->exists)
+		{
+			$model = static::find($this->getKey(), array_keys($this->getAttributes()));
+
+			// Update the current model and sync with original attributes.
+			$this->setRawAttributes($model->getAttributes(), true);
+		}
+	}
+
+	/**
 	 * Eager load relations on the model.
 	 *
 	 * @param  array|string  $relations

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -677,7 +677,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	/**
 	 * Reload model data from the database.
 	 *
-	 * @return void
+	 * @return $this
 	 */
 	public function reload()
 	{
@@ -688,6 +688,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			// Update the current model and sync with original attributes.
 			$this->setRawAttributes($model->getAttributes(), true);
 		}
+
+		return $this;
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -113,6 +113,16 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo', $result);
 	}
 
+	public function testReloadMethodSyncsNewAttributes()
+	{
+		$model = new EloquentModelReloadStub;
+		$model->foo = 'baz';
+		$this->assertTrue($model->isDirty('foo'));
+
+		$model->reload();
+		$this->assertFalse($model->isDirty('foo'));
+	}
+
 
 	public function testDestroyMethodCallsQueryBuilderCorrectly()
 	{
@@ -980,6 +990,20 @@ class EloquentModelFindManyStub extends Illuminate\Database\Eloquent\Model {
 	{
 		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
 		$mock->shouldReceive('find')->once()->with(array(1, 2), array('*'))->andReturn('foo');
+		return $mock;
+	}
+}
+
+class EloquentModelReloadStub extends Illuminate\Database\Eloquent\Model {
+	public $exists = true;
+	public function getKey()
+	{
+		return 1;
+	}
+	public function newQuery()
+	{
+		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
+		$mock->shouldReceive('find')->once()->with(1, array('foo'))->andReturn($this);
 		return $mock;
 	}
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -119,8 +119,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->foo = 'baz';
 		$this->assertTrue($model->isDirty('foo'));
 
-		$model->reload();
+		$result = $model->reload();
 		$this->assertFalse($model->isDirty('foo'));
+
+		$this->assertEquals($model, $result);
 	}
 
 


### PR DESCRIPTION
As per my earlier proposal (#5283), here is a tested `reload()` method for the Eloquent model. It will fetch the existing columns on the model and resync them with the original attributes.
