### PR TITLE
Add with_empty helper to help with Form::select

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1016,3 +1016,19 @@ if ( ! function_exists('with'))
 		return $object;
 	}
 }
+
+if ( ! function_exists('with_empty'))
+{
+	/**
+	 * Return list with empty option prepended. Useful in Form::select.
+	 * 
+	 * @param array  $list
+	 * @param mixed  $empty
+	 */
+	function with_empty($list, $empty='')
+	{
+		if(!is_array($empty)) $empty = array(''=>$empty);
+
+		return  $empty + $list;
+	}
+}


### PR DESCRIPTION
Prepends empty option to array. Used for Form::select.

The 3 practical use cases for this : 

```
Form::select('size', with_empty(array('L' => 'Large', 'S' => 'Small')));
Form::select('size', with_empty(array('L' => 'Large', 'S' => 'Small'), 'Select an option'));
Form::select('size', with_empty(array('L' => 'Large', 'S' => 'Small'), array('-1'=>'Select an option')));
```
