### PR TITLE
[Proposal] Reboot application for testing purposes

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -573,6 +573,18 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	{
 		return $this->booted;
 	}
+	
+	/**
+	 * Reboots application in unit testing mode.
+	 * Allows multi-request testing of controllers
+	 * 
+	 * @return void
+	 */
+	public function reboot()
+	{
+		if ($this->runningUnitTests() and $this->booted) $this->booted = false;
+		$this->boot();
+	}
 
 	/**
 	 * Boot the application's service providers.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -583,6 +583,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	public function reboot()
 	{
 		if ($this->runningUnitTests() and $this->booted) $this->booted = false;
+		
 		$this->boot();
 	}
 


### PR DESCRIPTION
It would be quite handy if application could be rebooted for testing purposes.
Currently application needs to be recreated for every request. With this PR it can be rebooted, without relaunching all services. This allows testing multi-request scenarios (as it is done in functional tests of Codeception).
