### PR TITLE
Implement RouteableInterface to ease routing with Eloquent models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1882,7 +1882,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function getRouteKey()
 	{
-	    $this->getAttribute($this->getRouteKeyName());
+	    return $this->getAttribute($this->getRouteKeyName());
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Contracts\JsonableInterface;
 use Illuminate\Support\Contracts\ArrayableInterface;
+use Illuminate\Support\Contracts\RouteableInterface;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
@@ -22,7 +23,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
-abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterface, JsonSerializable {
+abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterface, RouteableInterface, JsonSerializable {
 
 	/**
 	 * The connection name for the model.
@@ -1872,6 +1873,26 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	public function getQualifiedKeyName()
 	{
 		return $this->getTable().'.'.$this->getKeyName();
+	}
+
+	/**
+	 * Get the value of the model's route key.
+	 *
+	 * @return mixed
+	 */
+	public function getRouteKey()
+	{
+	    $this->getAttribute($this->getRouteKeyName());
+	}
+
+	/**
+	 * Get the route key for the model.
+	 *
+	 * @return string
+	 */
+	public function getRouteKeyName()
+	{
+	    return $this->getKeyName();
 	}
 
 	/**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
+use Illuminate\Support\Contracts\RouteableInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
@@ -1205,10 +1206,12 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		{
 			if (is_null($value)) return null;
 
-			// For model binders, we will attempt to retrieve the models using the find
+			// For model binders, we will attempt to retrieve the models using the first
 			// method on the model instance. If we cannot retrieve the models we'll
 			// throw a not found exception otherwise we will return the instance.
-			if ($model = (new $class)->find($value))
+			$instance = (new $class);
+
+			if ($model = $instance->firstByAttributes([$instance->getRouteKeyName() => $value]))
 			{
 				return $model;
 			}

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -322,7 +322,7 @@ class UrlGenerator {
 		{
 			if ($parameter instanceof RouteableInterface)
 			{
-				$parameter = $parameter->getRouteParameter();
+				$parameter = $parameter->getRouteKey();
 			}
 		}
 

--- a/src/Illuminate/Support/Contracts/RouteableInterface.php
+++ b/src/Illuminate/Support/Contracts/RouteableInterface.php
@@ -1,0 +1,19 @@
+<?php namespace Illuminate\Support\Contracts;
+
+interface RouteableInterface {
+
+    /**
+     * Get the value of the model's route key.
+     *
+     * @return mixed
+     */
+    public function getRouteKey();
+
+    /**
+     * Get the route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteKeyName();
+
+}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -744,6 +744,14 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRouteNameIsPrimaryKeyName()
+	{
+		$model = new EloquentModelStub;
+		$this->assertEquals('id', $model->getRouteKeyName());
+	}
+
+
+
 	public function testCloneModelMakesAFreshCopyOfTheModel()
 	{
 		$class = new EloquentModelStub;
@@ -868,6 +876,7 @@ class EloquentTestObserverStub {
 class EloquentModelStub extends Illuminate\Database\Eloquent\Model {
 	protected $table = 'stub';
 	protected $guarded = array();
+	protected $primaryKey = 'id';
 	protected $morph_to_stub_type = 'EloquentModelSaveStub';
 	public function getListItemsAttribute($value)
 	{

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -744,12 +744,19 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRouteKeyIsPrimaryKey()
+	{
+		$model = new EloquentModelStub;
+		$model->id = 'foo';
+		$this->assertEquals('foo', $model->getRouteKey());
+	}
+
+
 	public function testRouteNameIsPrimaryKeyName()
 	{
 		$model = new EloquentModelStub;
 		$this->assertEquals('id', $model->getRouteKeyName());
 	}
-
 
 
 	public function testCloneModelMakesAFreshCopyOfTheModel()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -919,11 +919,13 @@ class RouteBindingStub {
 }
 
 class RouteModelBindingStub {
-	public function find($value) { return strtoupper($value); }
+	public function firstByAttributes($attributes) { return strtoupper($attributes[$this->getRouteKeyName()]); }
+	public function getRouteKeyName() { return 'foo'; }
 }
 
 class RouteModelBindingNullStub {
-	public function find($value) {}
+	public function firstByAttributes($attributes) {}
+	public function getRouteKeyName() {}
 }
 
 class RouteTestFilterStub {

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Contracts\RouteableInterface;
 
 class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
@@ -95,6 +96,21 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', array('taylor', 'otwell', 'wall', 'woz')));
 		$this->assertEquals('http://www.foo.com/foo/bar/%C3%A5%CE%B1%D1%84/%C3%A5%CE%B1%D1%84', $url->route('foobarbaz', array('baz' => 'åαф')));
 
+	}
+
+	public function testRouteableInterfaceRouting()
+	{
+		$url = new UrlGenerator(
+			$routes = new Illuminate\Routing\RouteCollection,
+			$request = Illuminate\Http\Request::create('http://www.foo.com/')
+		);
+
+		$route = new Illuminate\Routing\Route(array('GET'), 'foo/{bar}', array('as' => 'routeable'));
+		$routes->add($route);
+
+		$model = new RouteableInterfaceStub;
+
+		$this->assertEquals('/foo/routeable', $url->route('routeable', array($model), false));
 	}
 
 
@@ -235,4 +251,9 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('https://www.bar.com/foo', $url->route('plain'));
 	}
 
+}
+
+class RouteableInterfaceStub implements RouteableInterface {
+	public function getRouteKey() { return 'routeable'; }
+	public function getRouteKeyName() {}
 }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -109,6 +109,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$routes->add($route);
 
 		$model = new RouteableInterfaceStub;
+		$model->key = 'routeable';
 
 		$this->assertEquals('/foo/routeable', $url->route('routeable', array($model), false));
 	}
@@ -254,6 +255,6 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 }
 
 class RouteableInterfaceStub implements RouteableInterface {
-	public function getRouteKey() { return 'routeable'; }
-	public function getRouteKeyName() {}
+	public function getRouteKey() { return $this->{$this->getRouteKeyName()}; }
+	public function getRouteKeyName() { return 'key'; }
 }


### PR DESCRIPTION
As originally discussed in #5253, here is a potential implementation of Eloquent routing. The model implements the `RouteableInterface` out of the box to use the model's primary key, but this can be overridden as needed.

If you attempt to build a URL using an Eloquent model, or any class that implements the `RouteableInterface`, it's route key will be used as the parameter in the path.

Furthermore, if you use route model binding, it will find the model by it's route key instead of it's primary key.
