### PR TITLE
Reduce with no callback should reduce the array

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -417,9 +417,14 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * @param  mixed     $initial
 	 * @return mixed
 	 */
-	public function reduce(callable $callback, $initial = null)
+	public function reduce(callable $callback = null, $initial = null)
 	{
-		return array_reduce($this->items, $callback, $initial);
+		if ($callback) return array_reduce($this->items, $callback, $initial);
+
+		return new static($this->reduce(function($result, $item)
+		{
+			return array_merge($result, $item);
+		}, []));
 	}
 
 	/**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -285,6 +285,18 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertCount(3, $random);
 	}
 
+	public function testReduce()
+	{
+		$data1 = new Collection([1, 2, 3]);
+		$data2 = new Collection([[1,2,3], [4,5,6], [7,8,9]]);
+
+		$result1 = $data1->reduce(function ($sum, $item){ return $sum + $item; }, 0);
+		$result2 = $data2->reduce()->all();
+
+		$this->assertEquals(6, $result1);
+		$this->assertEquals([1,2,3,4,5,6,7,8,9], $result2);
+	}
+
 
 	public function testTakeLast()
 	{


### PR DESCRIPTION
If no callback is passed to `reduce`, it will now collapse a multi-dimensional array into a single array.

---

Sample usage:

``` php
// Get all tags for the latest blog posts
$tags = Post::with('tags')->latest()->take(30)->get()->fetch('tags')->reduce()->unique();
```

Previously, the above would have had to be written like this:

``` php
$tags = Post::with('tags')->latest()->take(30)->get()->fetch('tags');

$tags = $tags->reduce(function ($result, $tags)
{
    return array_merge($result, $tags);
}, []);

$tags = new Illuminate\Eloquent\Collection($tags)->unique();
```
