### PR TITLE
Resolve traits

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -436,6 +436,8 @@ class Container implements ArrayAccess {
 			$object = $this->make($concrete, $parameters);
 		}
 
+		if (is_object($object)) $this->resolveTraits($object);
+
 		// If the requested type is registered as a singleton we'll want to cache off
 		// the instances in "memory" so we can return it later without creating an
 		// entirely new instance of an object on each subsequent request for it.
@@ -449,6 +451,39 @@ class Container implements ArrayAccess {
 		$this->resolved[$abstract] = true;
 
 		return $object;
+	}
+
+	/**
+	 * Recursively resolve an object's traits.
+	 *
+	 * @param  object  $object
+	 * @return void
+	 */
+	protected function resolveTraits($object)
+	{
+		foreach (class_uses_recursive(get_class($object)) as $trait)
+		{
+			if (method_exists($object, $method = 'construct'.class_basename($trait)))
+			{
+				$this->resolveMethod($object, $method);
+			}
+		}
+	}
+
+	/**
+	 * Resolve a method with its dependencies.
+	 *
+	 * @param  object  $object
+	 * @param  string  $method
+	 * @return void
+	 */
+	public function resolveMethod($object, $method)
+	{
+		$reflectorMethod = (new ReflectionClass($object))->getMethod($method);
+
+		$parameters = $this->getDependencies($reflectorMethod->getParameters());
+
+		call_user_func_array([$object, $method], $parameters);
 	}
 
 	/**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -38,6 +38,14 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testTraitResolution()
+	{
+		$container = new Container;
+		$stub = $container->make('ContainerConcreteTraitStub');
+		$this->assertInstanceOf('ContainerConcreteStub', $stub->container);
+	}
+
+
 	public function testSlashesAreHandled()
 	{
 		$container = new Container;
@@ -384,4 +392,16 @@ class ContainerConstructorParameterLoggingStub {
 class ContainerLazyExtendStub {
 	public static $initialized = false;
 	public function init() { static::$initialized = true; }
+}
+
+trait ContainerTraitStub {
+	public $container;
+	public function constructContainerTraitStub(ContainerConcreteStub $container)
+	{
+		$this->container = $container;
+	}
+}
+
+class ContainerConcreteTraitStub {
+	use ContainerTraitStub;
 }


### PR DESCRIPTION
As it stands, there's no way to inject stuff into a trait. To use other classes you have to either new them up or use a facade (if it has one).

This PR would allow for traits to declare their own pseudo constructors (closely following [the convention for Eloquent model booting](http://laravel.com/docs/eloquent#global-scopes)), which would then be resolved out of the IoC Container. For example, let's modify @JeffreyWay's [CommanderTrait](https://github.com/laracasts/Commander/blob/master/src/Laracasts/Commander/CommanderTrait.php):

``` php
use Illuminate\Foundation\Application;

public function constructCommanderTrait(Application $app)
{
    $this->app = $app;
}

public function getCommandBus()
{
    return $this->app->make('Laracasts\Commander\CommandBus');
}
```

Here we're injecting the whole container, but this is just an example. You might want to inject the logger or the mailer or just about anything else.

I think this would be very useful.
