### PR TITLE
Allow for extra payload parameters in fireModelEvent()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1557,8 +1557,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 *
 	 * @param  string  $event
 	 * @param  bool    $halt
-         * @param  mixed   $payload     Data to be added to the payload of the event.
-         * @param  mixed   $payload,... unlimited OPTIONAL number of additional parameters.
+	 * @param  mixed   $payload     Optional data to be added to the payload of the event.
+	 * @param  mixed   $payload,... unlimited OPTIONAL number of additional parameters.
 	 * @return mixed
 	 */
 	protected function fireModelEvent($event, $halt = true)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1557,6 +1557,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 *
 	 * @param  string  $event
 	 * @param  bool    $halt
+         * @param  mixed   $payload     Data to be added to the payload of the event.
+         * @param  mixed   $payload,... unlimited OPTIONAL number of additional parameters.
 	 * @return mixed
 	 */
 	protected function fireModelEvent($event, $halt = true)
@@ -1570,7 +1572,12 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 
 		$method = $halt ? 'until' : 'fire';
 
-		return static::$dispatcher->$method($event, $this);
+		// Create the payload argument consisting of the model and any additional
+ 		// `payload` function arguments.
+		$payload = array_slice(func_get_args(), 2);
+		array_unshift($payload, $this);
+
+		return static::$dispatcher->$method($event, $payload);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -235,7 +235,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->expects($this->once())->method('updateTimestamps');
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
 		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), array($model))->andReturn(true);
-		$events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), array$model))->andReturn(true);
+		$events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), array($model))->andReturn(true);
 		$events->shouldReceive('fire')->once()->with('eloquent.updated: '.get_class($model), array($model))->andReturn(true);
 		$events->shouldReceive('fire')->once()->with('eloquent.saved: '.get_class($model), array($model))->andReturn(true);
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -143,10 +143,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
 		$model->expects($this->once())->method('updateTimestamps');
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
-		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-		$events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
-		$events->shouldReceive('fire')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
-		$events->shouldReceive('fire')->once()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), array($model))->andReturn(true);
+		$events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), array($model))->andReturn(true);
+		$events->shouldReceive('fire')->once()->with('eloquent.updated: '.get_class($model), array($model))->andReturn(true);
+		$events->shouldReceive('fire')->once()->with('eloquent.saved: '.get_class($model), array($model))->andReturn(true);
 
 		$model->id = 1;
 		$model->foo = 'bar';
@@ -184,7 +184,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
-		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(false);
+		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), array($model))->andReturn(false);
 		$model->exists = true;
 
 		$this->assertFalse($model->save());
@@ -197,8 +197,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
-		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-		$events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
+		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), array($model))->andReturn(true);
+		$events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), array($model))->andReturn(false);
 		$model->exists = true;
 		$model->foo = 'bar';
 
@@ -234,10 +234,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
 		$model->expects($this->once())->method('updateTimestamps');
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
-		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-		$events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(true);
-		$events->shouldReceive('fire')->once()->with('eloquent.updated: '.get_class($model), $model)->andReturn(true);
-		$events->shouldReceive('fire')->once()->with('eloquent.saved: '.get_class($model), $model)->andReturn(true);
+		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), array($model))->andReturn(true);
+		$events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), array$model))->andReturn(true);
+		$events->shouldReceive('fire')->once()->with('eloquent.updated: '.get_class($model), array($model))->andReturn(true);
+		$events->shouldReceive('fire')->once()->with('eloquent.saved: '.get_class($model), array($model))->andReturn(true);
 
 		$model->id = 1;
 		$model->syncOriginal();
@@ -337,10 +337,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->expects($this->once())->method('updateTimestamps');
 
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
-		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-		$events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
-		$events->shouldReceive('fire')->once()->with('eloquent.created: '.get_class($model), $model);
-		$events->shouldReceive('fire')->once()->with('eloquent.saved: '.get_class($model), $model);
+		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), array($model))->andReturn(true);
+		$events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), array($model))->andReturn(true);
+		$events->shouldReceive('fire')->once()->with('eloquent.created: '.get_class($model), array($model));
+		$events->shouldReceive('fire')->once()->with('eloquent.saved: '.get_class($model), array($model));
 
 		$model->name = 'taylor';
 		$model->exists = false;
@@ -356,10 +356,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->setIncrementing(false);
 
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
-		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-		$events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(true);
-		$events->shouldReceive('fire')->once()->with('eloquent.created: '.get_class($model), $model);
-		$events->shouldReceive('fire')->once()->with('eloquent.saved: '.get_class($model), $model);
+		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), array($model))->andReturn(true);
+		$events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), array($model))->andReturn(true);
+		$events->shouldReceive('fire')->once()->with('eloquent.created: '.get_class($model), array($model));
+		$events->shouldReceive('fire')->once()->with('eloquent.saved: '.get_class($model), array($model));
 
 		$model->name = 'taylor';
 		$model->exists = false;
@@ -375,8 +375,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
-		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
-		$events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(false);
+		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), array($model))->andReturn(true);
+		$events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), array($model))->andReturn(false);
 
 		$this->assertFalse($model->save());
 		$this->assertFalse($model->exists);


### PR DESCRIPTION
I landed myself in a complex situation where I needed to add extra data to the event and actually storing it in the DB would be overkill. I noticed that the event dispatcher allows for any arbitrary number of arguments as the payload, but that feature is not actually being utilized by the Model Event firing system. This is an attempt to solve that.
