### PR TITLE
[4.2] Enable Fast Finish For HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script: vendor/bin/phpunit --verbose
 matrix:
   allow_failures:
     - php: hhvm
+  fast_finish: true


### PR DESCRIPTION
This means we don't have to wait for hhvm to complete. If the other builds are successful, we can mark the build as green without waiting for hhvm.

---

http://blog.travis-ci.com/2013-11-27-fast-finishing-builds/
