### PR TITLE
Add reset methods to container, application, dispatcher and view in order to reduce memory leak during tests

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -59,6 +59,20 @@ class Container implements ArrayAccess {
 	protected $globalResolvingCallbacks = array();
 
 	/**
+	 * Remove all data contained within the container.
+	 */
+	public function reset()
+	{
+		$this->resolved = [];
+		$this->bindings = [];
+		$this->instances = [];
+		$this->aliases = [];
+		$this->reboundCallbacks = [];
+		$this->resolvingCallbacks = [];
+		$this->globalResolvingCallbacks = [];
+	}
+
+	/**
 	 * Determine if a given string is resolvable.
 	 *
 	 * @param  string  $abstract

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -51,6 +51,18 @@ class Dispatcher {
 	}
 
 	/**
+	 * Remove all data contained within the dispatcher.
+	 */
+	public function reset()
+	{
+		$this->container = null;
+		$this->listeners = [];
+		$this->wildcards = [];
+		$this->sorted = [];
+		$this->firing = [];
+	}
+
+	/**
 	 * Register an event listener with the dispatcher.
 	 *
 	 * @param  string|array  $events

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -200,6 +200,26 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	}
 
 	/**
+	 * Remove all data contained within the application.
+	 */
+	public function reset()
+	{
+		$this['events']->reset();
+		$this['view']->reset();
+
+		parent::reset();
+
+		$this->bootingCallbacks = [];
+		$this->bootedCallbacks = [];
+		$this->finishCallbacks = [];
+		$this->shutdownCallbacks = [];
+		$this->middlewares = [];
+		$this->serviceProviders = [];
+		$this->loadedProviders = [];
+		$this->deferredServices = [];
+	}
+
+	/**
 	 * Get the application bootstrap file.
 	 *
 	 * @return string

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -17,6 +17,15 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
+	public function tearDown()
+	{
+		parent::tearDown();
+
+		$this->app->reset();
+
+		$this->app = null;
+	}
+
 	/**
 	 * Creates the application.
 	 *

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -110,6 +110,19 @@ class Factory {
 	}
 
 	/**
+	 * Remove all data contained within the factory.
+	 */
+	public function reset()
+	{
+		$this->shared = [];
+		$this->aliases = [];
+		$this->names = [];
+		$this->composers = [];
+		$this->sections = [];
+		$this->sectionStack = [];
+	}
+
+	/**
 	 * Get the evaluated view contents for the given view.
 	 *
 	 * @param  string  $view


### PR DESCRIPTION
The primary goal of this change is to reduce the amount of memory leak occurring while running tests using the TestCase class.

The following is a before/after of running a simple testcase with $this->assertTrue(true); with varying iteration counts (number of tests). Time is in seconds, memory usage is in MB. Compared is running the test using the TestCase class vs the PHPUnit_Framework_TestCase.

|  | phpunit | phpunit | testcase (before) | testcase (before) | testcase (after) | testcase (after) |
| --- | --- | --- | --- | --- | --- | --- |
| iterations | time (s) | memory (MB) | time (s) | memory (MB) | time (s) | memory (MB) |
| 50 | 0.2 | 3.25 | 1.8 | 23 | 1.5 | 9 |
| 500 | 0.3 | 4.25 | 14.4 | 172.75 | 11.7 | 14 |
| 5000 | 1.7 | 14.25 | 225.6 | 1632 | 119.4 | 58 |
