### PR TITLE
Session flash input now filters Symfony uploaded files, because they are...

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -374,20 +374,18 @@ class Store implements SessionInterface {
 	 */
 	public function flashInput(array $value)
 	{
-		$value = $this->recursiveArrayValueFilter(
-			$value,
-			function ($v)
-			{
-				return $v instanceof \Symfony\Component\HttpFoundation\File\UploadedFile === false;
-			}
-		);
+		$value = $this->recursiveArrayValueFilter($value, function($v)
+		{
+			return $v instanceof \Symfony\Component\HttpFoundation\File\UploadedFile === false;
+		});
 		$this->flash('_old_input', $value);
 	}
 
 	/**
 	 * Filter array recursively with callback.
-	 * @param array $arrayValue
-	 * @param callable $callback
+	 *
+	 * @param  array     $arrayValue
+	 * @param  callable  $callback
 	 * @return array
 	 */
 	protected function recursiveArrayValueFilter(array $arrayValue, callable $callback)

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -374,7 +374,35 @@ class Store implements SessionInterface {
 	 */
 	public function flashInput(array $value)
 	{
+		$value = $this->recursiveArrayValueFilter(
+			$value,
+			function ($v)
+			{
+				return $v instanceof \Symfony\Component\HttpFoundation\File\UploadedFile === false;
+			}
+		);
 		$this->flash('_old_input', $value);
+	}
+
+	/**
+	 * Filter array recursively with callback.
+	 * @param array $arrayValue
+	 * @param callable $callback
+	 * @return array
+	 */
+	protected function recursiveArrayValueFilter(array $arrayValue, callable $callback)
+	{
+		foreach ($arrayValue as $key => $value)
+		{
+			if (is_array($value))
+			{
+				$value = $this->recursiveArrayValueFilter($value, $callback);
+			}
+
+			$arrayValue[$key] = $value;
+		}
+
+		return array_filter($arrayValue, $callback);
 	}
 
 	/**

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -120,6 +120,18 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($session->hasOldInput('boom'));
 	}
 
+	public function testOldInputWithUploadedFileFlashing()
+	{
+		$file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', null, array(__FILE__, 'photo.jpg'));
+
+		$session = $this->getSession();
+		$session->flashInput(array('bar' => array('baz' => array('name' => 'foo', 'file' => $file))));
+
+		$this->assertTrue($session->hasOldInput('bar.baz.name'));
+		$this->assertEquals('foo', $session->getOldInput('bar.baz.name'));
+		$this->assertFalse($session->hasOldInput('bar.baz.file'));
+	}
+
 
 	public function testDataFlashing()
 	{


### PR DESCRIPTION
When you try to write in your controller code like this:
    \Redirect::route('home')->withInput();

And if you have uploaded file (Symfony\Component\HttpFoundation\File\UploadedFile) in your input, you will get an error:
    Serialization of '...' is not allowed

Which is an error because saving session serializes data and symfony object extends \SplFileInfo, which is not allowed to serialization.
It's normal because this object represents a resource.

But I think, redirect with old input is normal. Uploading files is normal too. So, that error should not happen.
In this case I suggest filtering such values on saving input to session.

First time I thought to just filter all unserializable values on save in Store class. But, I guess, it better to see an error when you do such things without saving old input ot you try to store another unserializable object.
