### PR TITLE
Fixes #5376 DateTime to minutes

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -89,7 +89,10 @@ class Repository implements ArrayAccess {
 	{
 		$minutes = $this->getMinutes($minutes);
 
-		$this->store->put($key, $value, $minutes);
+		if ( ! is_null($minutes))
+		{
+			$this->store->put($key, $value, $minutes);
+		}
 	}
 
 	/**
@@ -247,13 +250,20 @@ class Repository implements ArrayAccess {
 	 * Calculate the number of minutes with the given duration.
 	 *
 	 * @param  \DateTime|int  $duration
-	 * @return int
+	 * @return int|null
 	 */
 	protected function getMinutes($duration)
 	{
 		if ($duration instanceof DateTime)
 		{
-			return max(0, Carbon::instance($duration)->diffInMinutes());
+			$minutes_from_now = Carbon::instance($duration)->diffInMinutes();
+			
+			if ($minutes_from_now <= 0) 
+			{
+				return null;
+			}
+			
+			return $minutes_from_now;
 		}
 
 		return is_string($duration) ? intval($duration) : $duration;

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -70,7 +70,10 @@ class TaggedCache implements StoreInterface {
 	{
 		$minutes = $this->getMinutes($minutes);
 
-		return $this->store->put($this->taggedItemKey($key), $value, $minutes);
+		if ( ! is_null($minutes))
+		{
+			$this->store->put($this->taggedItemKey($key), $value, $minutes);
+		}
 	}
 
 	/**
@@ -224,13 +227,20 @@ class TaggedCache implements StoreInterface {
 	 * Calculate the number of minutes with the given duration.
 	 *
 	 * @param  \DateTime|int  $duration
-	 * @return int
+	 * @return int|null
 	 */
 	protected function getMinutes($duration)
 	{
 		if ($duration instanceof DateTime)
 		{
-			return max(0, Carbon::instance($duration)->diffInMinutes());
+			$minutes_from_now = Carbon::instance($duration)->diffInMinutes();
+			
+			if ($minutes_from_now <= 0) 
+			{
+				return null;
+			}
+			
+			return $minutes_from_now;
 		}
 
 		return is_string($duration) ? intval($duration) : $duration;


### PR DESCRIPTION
Due to the way DateTime objects are converted to a number of minutes from now, it's possible to unintentionally cache something forever.

Example: the following code will put a value into the cache that lasts forever, but the code reads as if it should expire in 1 minute. In real use-cases, sleep(60) would be effected by a slow running database query, some slow network operation, or whatever.

```
$expiresAt = Carbon::now()->addMinutes(1);

$value = Cache::remember('users', $expiresAt, function()
{
    sleep(60);
    return true;
});
```

This PR changes the behaviour so that the value is simply not cached in this situation.
