### PR TITLE
fixed bug in sortBy where incorrectly formatted object was being returned

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -568,12 +568,13 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 		// Once we have sorted all of the keys in the array, we will loop through them
 		// and grab the corresponding model so we can set the underlying items list
 		// to the sorted version. Then we'll just return the collection instance.
-		foreach (array_keys($results) as $key)
-		{
-			$results[$key] = $this->items[$key];
-		}
+		$sorted = array();
+        foreach(array_keys($results) as $key)
+        {
+        	$sorted[] = $this->items[$key];
+        }
 
-		$this->items = $results;
+		$this->items = $sorted;
 
 		return $this;
 	}


### PR DESCRIPTION
The Illuminate\Support\Collection sortBy() method currently reuses the original $results array which means it returns an object that is formatted differently than the Eloquent object passed into the method.  It also causes ajax requests to read the response as one model rather than a collection of models.

I declared a new $sorted array and used it to create a new correctly sorted array from the $results keys.  This results in returning a sorted Eloquent object of the same format as the one passed into the method.
