### PR TITLE
[Bugfix] Illuminate\Support\Fluent should allow to use stdClass/object instead of just array.

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -17,12 +17,12 @@ class Fluent implements ArrayAccess, ArrayableInterface, JsonableInterface, Json
 	/**
 	 * Create a new fluent container instance.
 	 *
-	 * @param  array  $attributes
+	 * @param  array|object	$attributes
 	 * @return void
 	 */
 	public function __construct($attributes = array())
 	{
-		$this->attributes = $attributes;
+		$this->attributes = (array) $attributes;
 	}
 
 	/**

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -23,6 +23,28 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Test the Fluent constructor.
+	 *
+	 * @test
+	 */
+	public function testAttributesAreSetByConstructorGivenStdClass()
+	{
+		$array  = array('name' => 'Taylor', 'age' => 25);
+
+		$object = new \stdClass;
+		$object->name = $array['name'];
+		$object->age  = $array['age'];
+		$fluent = new Fluent($object);
+
+		$refl = new \ReflectionObject($fluent);
+		$attributes = $refl->getProperty('attributes');
+		$attributes->setAccessible(true);
+
+		$this->assertEquals($array, $attributes->getValue($fluent));
+		$this->assertEquals($array, $fluent->getAttributes());
+	}
+
+	/**
 	 * Test the Fluent::get() method.
 	 *
 	 * @test

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -22,6 +22,7 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($array, $fluent->getAttributes());
 	}
 
+
 	/**
 	 * Test the Fluent constructor.
 	 *
@@ -43,6 +44,7 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($array, $attributes->getValue($fluent));
 		$this->assertEquals($array, $fluent->getAttributes());
 	}
+
 
 	/**
 	 * Test the Fluent::get() method.
@@ -77,6 +79,7 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(25, $fluent->age);
 		$this->assertInstanceOf('Illuminate\Support\Fluent', $fluent->programmer());
 	}
+
 
 	/**
 	 * Test the Fluent::__isset() method.


### PR DESCRIPTION
The behaviour was change since "Useless foreach in constructor" was accepted from laravel/framework#5342

Signed-off-by: crynobone crynobone@gmail.com
