### PR TITLE
[4.2] Routing : $parameters cast too early

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -223,10 +223,10 @@ class UrlGenerator {
 	{
 		$route = $route ?: $this->routes->getByName($name);
 
-		$parameters = (array) $parameters;
-
 		if ( ! is_null($route))
 		{
+			$parameters = (array) $parameters;
+
 			return $this->toRoute($route, $parameters, $absolute);
 		}
 		else


### PR DESCRIPTION
`$parameters` doesn't need to be cast that early
