### PR TITLE
[4.2] Routing : let getRoutable only fetch public methods

### DIFF
--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -30,9 +30,9 @@ class ControllerInspector {
 		// To get the routable methods, we will simply spin through all methods on the
 		// controller instance checking to see if it belongs to the given class and
 		// is a publicly routable method. If so, we will add it to this listings.
-		foreach ($reflection->getMethods() as $method)
+		foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method)
 		{
-			if ($this->isRoutable($method, $reflection->name))
+			if ($this->isRoutable($method))
 			{
 				$data = $this->getMethodData($method, $prefix);
 
@@ -69,7 +69,7 @@ class ControllerInspector {
 	{
 		if ($method->class == 'Illuminate\Routing\Controller') return false;
 
-		return $method->isPublic() && starts_with($method->name, $this->verbs);
+		return starts_with($method->name, $this->verbs);
 	}
 
 	/**

--- a/tests/Routing/RoutingControllerInspectorTest.php
+++ b/tests/Routing/RoutingControllerInspectorTest.php
@@ -32,6 +32,7 @@ class RoutingControllerInspectorTest extends PHPUnit_Framework_TestCase {
 
 class RoutingControllerInspectorBaseStub {
 	public function getBreeze() {}
+	private function patchTest() {}
 }
 
 class RoutingControllerInspectorStub extends RoutingControllerInspectorBaseStub {
@@ -39,4 +40,5 @@ class RoutingControllerInspectorStub extends RoutingControllerInspectorBaseStub 
 	public function getFooBar() {}
 	public function postBaz() {}
 	protected function getBoom() {}
+	private function putTest() {}
 }


### PR DESCRIPTION
`getRoutable` does not need to iterate non-public methods

As 41dea014476704c8f85c89329f63da47f8ccaf75 suggests, `isRoutable` is primary used by `getRoutable`. We can then remove the `isPublic` check as the public methods are already filtered in `getRoutable`.
