### PR TITLE
[4.2] Routing : useless $controller argument

### DIFF
--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -63,10 +63,9 @@ class ControllerInspector {
 	 * Determine if the given controller method is routable.
 	 *
 	 * @param  \ReflectionMethod  $method
-	 * @param  string  $controller
 	 * @return bool
 	 */
-	public function isRoutable(ReflectionMethod $method, $controller)
+	public function isRoutable(ReflectionMethod $method)
 	{
 		if ($method->class == 'Illuminate\Routing\Controller') return false;
 


### PR DESCRIPTION
`$controller` is never used in isRoutable and could be removed. I am targeting 4.2, but feel free @taylorotwell to tell me if I should retarget
