### PR TITLE
Updated class_uses_recursive to use array() not []

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -408,9 +408,9 @@ if ( ! function_exists('class_uses_recursive'))
 	 */
 	function class_uses_recursive($class)
 	{
-		$results = [];
+		$results = array();
 
-		foreach (array_merge([$class => $class], class_parents($class)) as $class)
+		foreach (array_merge(array($class => $class), class_parents($class)) as $class)
 		{
 			$results += trait_uses_recursive($class);
 		}


### PR DESCRIPTION
The use of square array brackets causes breakage when using PHP < 5.4.

``` php
// Orginal code @line2 #401-420
if ( ! function_exists('class_uses_recursive'))
{
    /**
     * Returns all traits used by a class, it's subclasses and trait of their traits
     *
     * @param  string  $class
     * @return array
     */
    function class_uses_recursive($class)
    {
        $results = [];

        foreach (array_merge([$class => $class], class_parents($class)) as $class)
        {
            $results += trait_uses_recursive($class);
        }

        return array_unique($results);
    }
}
```

``` php
// Replacement code for lines #401-420
if ( ! function_exists('class_uses_recursive'))
{
    /**
     * Returns all traits used by a class, it's subclasses and trait of their traits
     *
     * @param  string  $class
     * @return array
     */
    function class_uses_recursive($class)
    {
        $results = array();

        foreach (array_merge(array($class => $class), class_parents($class)) as $class)
        {
            $results += trait_uses_recursive($class);
        }

        return array_unique($results);
    }
}
``
```
