### PR TITLE
Modified collection each method to be runnable fluently

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -103,10 +103,15 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Execute a callback over each item.
 	 *
 	 * @param  \Closure  $callback
-	 * @return $this
+	 * @return $this|\Illuminate\Support\Collection\Each
 	 */
-	public function each(Closure $callback)
+	public function each(Closure $callback = null)
 	{
+		if ($callback === null)
+		{
+			return new \Illuminate\Support\Collection\Each($this);
+		}
+
 		array_map($callback, $this->items);
 
 		return $this;

--- a/src/Illuminate/Support/Collection/Each.php
+++ b/src/Illuminate/Support/Collection/Each.php
@@ -1,0 +1,23 @@
+<?php namespace Illuminate\Support\Collection;
+
+class Each {
+
+	protected $collection;
+
+	public function __construct($collection)
+	{
+		$this->collection = $collection;
+	}
+
+	public function __call($name, $arguments)
+	{
+		$output_objects = array();
+
+		foreach($this->collection as $object)
+		{
+			$output_objects[] = call_user_func_array(array($object, $name), $arguments);
+		}
+
+		return new Collection($output_objects);
+	}
+}


### PR DESCRIPTION
Adapted the collection models each() method so that it can be run as part of a fluent query.

Previously, if you wanted to run (for instance) update(array('a' => $x)) on each element of a collection, you had to do something like this:

```
$collection->each(function($c) use($x){
    $c->update(array('a' => $x));
});
```

Which is horribly untidy. But now, you can do this:

```
$collection->each()->update(array('a' => $x));
```

Which is much neater!
