### PR TITLE
[4.2] Cache : ensure the minimum TTL is always one minute

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -253,10 +253,10 @@ class Repository implements ArrayAccess {
 	{
 		if ($duration instanceof DateTime)
 		{
-			return max(0, Carbon::instance($duration)->diffInMinutes());
+			$duration = Carbon::instance($duration)->max()->diffInMinutes();
 		}
 
-		return is_string($duration) ? intval($duration) : $duration;
+		return max(1, intval($duration));
 	}
 
 	/**

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -230,10 +230,10 @@ class TaggedCache implements StoreInterface {
 	{
 		if ($duration instanceof DateTime)
 		{
-			return max(0, Carbon::instance($duration)->diffInMinutes());
+			$duration = Carbon::instance($duration)->max()->diffInMinutes();
 		}
 
-		return is_string($duration) ? intval($duration) : $duration;
+		return max(1, intval($duration));
 	}
 
 }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -72,6 +72,7 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase {
 		$repo = new ObjectReflector($this->getRepository());
 
 		$this->assertSame(1, $repo->getMinutes(1));
+		$this->assertSame(1, $repo->getMinutes(0));
 		$this->assertSame(1, $repo->getMinutes(- 1));
 		$this->assertSame(1, $repo->getMinutes(- 2));
 		$this->assertSame(1, $repo->getMinutes(0.5));

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -69,7 +69,7 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetMinutes()
 	{
-		$repo = new ClassReflector($this->getRepository());
+		$repo = new ObjectReflector($this->getRepository());
 
 		$this->assertSame(1, $repo->getMinutes(1));
 		$this->assertSame(1, $repo->getMinutes(- 1));
@@ -113,7 +113,7 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class ClassReflector {
+class ObjectReflector {
 
 	protected $object;
 


### PR DESCRIPTION
When settings a cache key with a `Carbon` or `Datetime` instance either in the past or less than 1 minute in the future, the minutes can be set to 0 and interpreted as a `forever` command.
This PR solves this and ensures that, when a cache key is set with a duration, the minimum calculated duration will always be 1 minute.

Related: https://github.com/laravel/framework/issues/5401

Also add some tests for `getMinutes`.
