### PR TITLE
Completely revert "remove useless contructor" changes on Illuminate\Support\Fluent where it doesn't respect object that implements IteratorAggregate and ArrayIterator.

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -22,7 +22,10 @@ class Fluent implements ArrayAccess, ArrayableInterface, JsonableInterface, Json
 	 */
 	public function __construct($attributes = array())
 	{
-		$this->attributes = (array) $attributes;
+		foreach ($attributes as $key => $value)
+		{
+			$this->attributes[$key] = $value;
+		}
 	}
 
 	/**

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -24,15 +24,33 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 
 
 	/**
-	 * Test the Fluent constructor.
+	 * Test the Fluent constructor when given \stdClass/object.
 	 *
 	 * @test
 	 */
 	public function testAttributesAreSetByConstructorGivenStdClass()
 	{
 		$array  = array('name' => 'Taylor', 'age' => 25);
-
 		$fluent = new Fluent((object) $array);
+
+		$refl = new \ReflectionObject($fluent);
+		$attributes = $refl->getProperty('attributes');
+		$attributes->setAccessible(true);
+
+		$this->assertEquals($array, $attributes->getValue($fluent));
+		$this->assertEquals($array, $fluent->getAttributes());
+	}
+
+
+	/**
+	 * Test the Fluent constructor when given ArrayIterator interface.
+	 *
+	 * @test
+	 */
+	public function testAttributesAreSetByConstructorGivenArrayIterator()
+	{
+		$array  = array('name' => 'Taylor', 'age' => 25);
+		$fluent = new Fluent(new FluentArrayIteratorStub($array));
 
 		$refl = new \ReflectionObject($fluent);
 		$attributes = $refl->getProperty('attributes');
@@ -112,5 +130,20 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 		$results = $fluent->toJson();
 
 		$this->assertEquals(json_encode('foo'), $results);
+	}
+}
+
+
+class FluentArrayIteratorStub implements \IteratorAggregate {
+	protected $items = array();
+
+	public function __construct(array $items = array())
+	{
+		$this->items = (array) $items;
+	}
+
+	public function getIterator()
+	{
+		return new \ArrayIterator($this->items);
 	}
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |
- it should respect object that implements `IteratorAggregate` and `ArrayIterator`.
- it should respect if you extend Fluent and provide default `$attributes` (#5570).

Signed-off-by: crynobone crynobone@gmail.com
