### PR TITLE
[Proposal] FileSessionHandler should not open expired sessions 

### DIFF
--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -20,16 +20,24 @@ class FileSessionHandler implements \SessionHandlerInterface {
 	protected $path;
 
 	/**
+	 * A comparator to validate the session against its lifetime.
+	 *
+	 * @var \Symfony\Component\Finder\Comparator\DateComparator
+	 */
+	protected $comparator;
+
+	/**
 	 * Create a new file driven handler instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  string  $path
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $path)
+	public function __construct(Filesystem $files, $path, $lifetime)
 	{
 		$this->path = $path;
 		$this->files = $files;
+		$this->comparator = new DateComparator('> now - '.$lifetime.' minutes');
 	}
 
 	/**
@@ -53,7 +61,7 @@ class FileSessionHandler implements \SessionHandlerInterface {
 	 */
 	public function read($sessionId)
 	{
-		if ($this->files->exists($path = $this->path.'/'.$sessionId))
+		if ($this->files->exists($path = $this->path.'/'.$sessionId) && $this->comparator->test($this->files->lastModified($path)))
 		{
 			return $this->files->get($path);
 		}

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -2,6 +2,7 @@
 
 use Symfony\Component\Finder\Finder;
 use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Finder\Comparator\DateComparator;
 
 class FileSessionHandler implements \SessionHandlerInterface {
 

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -32,6 +32,7 @@ class FileSessionHandler implements \SessionHandlerInterface {
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @param  string  $path
+	 * @param  string|int $lifetime The session lifetime in minutes
 	 * @return void
 	 */
 	public function __construct(Filesystem $files, $path, $lifetime)

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -56,8 +56,9 @@ class SessionManager extends Manager {
 	protected function createNativeDriver()
 	{
 		$path = $this->app['config']['session.files'];
+		$lifetime = $this->app['config']['session.lifetime'];
 
-		return $this->buildSession(new FileSessionHandler($this->app['files'], $path));
+		return $this->buildSession(new FileSessionHandler($this->app['files'], $path, $lifetime));
 	}
 
 	/**


### PR DESCRIPTION
Currently the garbage collector of the FileSessionHandler deletes session files randomly, based on the lottery values in the application configuration. However, before the gc kicks in, sessions seem to be valid even after the configured lifetime has expired. 
In my opinion, a secure session handler should not open expired sessions. I therefore added this pull requests that checks the timestamp of the session file before reading it.
