### PR TITLE
Make isValid() check only for UploadedFile instances

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1148,10 +1148,15 @@ class Validator implements MessageProviderInterface {
 			return false;
 		}
 
+		if ($value instanceof UploadedFile && ! $value->isValid())
+		{
+			return false;
+		}
+
 		// The Symfony File class should do a decent job of guessing the extension
 		// based on the true MIME type so we'll just loop through the array of
 		// extensions and compare it to the guessed extension of the files.
-		if ($value->isValid() && $value->getPath() != '')
+		if ($value->getPath() != '')
 		{
 			return in_array($value->guessExtension(), $parameters);
 		}


### PR DESCRIPTION
This should fix: https://github.com/laravel/framework/issues/5455

Simply moved the `isValid` out so it only runs for uploaded files as the method only exists on the UploadedFile class, not the underlying File class.
