### PR TITLE
PDOException: SQLSTATE[HY000]: General error: 1 ambiguous column name: id

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -77,7 +77,7 @@ class Builder {
 			return $this->findMany($id, $columns);
 		}
 
-		$this->query->where($this->model->getKeyName(), '=', $id);
+		$this->query->where($this->model->getQualifiedKeyName(), '=', $id);
 
 		return $this->first($columns);
 	}
@@ -93,7 +93,7 @@ class Builder {
 	{
 		if (empty($id)) return $this->model->newCollection();
 
-		$this->query->whereIn($this->model->getKeyName(), $id);
+		$this->query->whereIn($this->model->getQualifiedKeyName(), $id);
 
 		return $this->get($columns);
     }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -16,7 +16,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', array($this->getMockQueryBuilder()));
 		$builder->setModel($this->getMockModel());
-		$builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'bar');
+		$builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
 		$builder->shouldReceive('first')->with(array('column'))->andReturn('baz');
 
 		$result = $builder->find('bar', array('column'));
@@ -31,7 +31,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', array($this->getMockQueryBuilder()));
 		$builder->setModel($model);
-		$builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'bar');
+		$builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
 		$builder->shouldReceive('first')->with(array('column'))->andReturn('baz');
 
 		$expected = $model->findOrNew('bar', array('column'));
@@ -47,7 +47,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', array($this->getMockQueryBuilder()));
 		$builder->setModel($model);
-		$builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'bar');
+		$builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
 		$builder->shouldReceive('first')->with(array('column'))->andReturn(null);
 
 		$result = $model->findOrNew('bar', array('column'));
@@ -63,7 +63,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', array($this->getMockQueryBuilder()));
 		$builder->setModel($this->getMockModel());
-		$builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'bar');
+		$builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
 		$builder->shouldReceive('first')->with(array('column'))->andReturn(null);
 		$result = $builder->findOrFail('bar', array('column'));
 	}
@@ -83,7 +83,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testFindWithMany()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', array($this->getMockQueryBuilder()));
-		$builder->getQuery()->shouldReceive('whereIn')->once()->with('foo', array(1, 2));
+		$builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', array(1, 2));
 		$builder->setModel($this->getMockModel());
 		$builder->shouldReceive('get')->with(array('column'))->andReturn('baz');
 
@@ -511,6 +511,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$model = m::mock('Illuminate\Database\Eloquent\Model');
 		$model->shouldReceive('getKeyName')->andReturn('foo');
 		$model->shouldReceive('getTable')->andReturn('foo_table');
+		$model->shouldReceive('getQualifiedKeyName')->andReturn('foo_table.foo');
 		return $model;
 	}
 


### PR DESCRIPTION
Global scopes that join tables will break the Model::find() methods.

Make Builder::find and Builder::findMany use the fully qualified names so global scopes can still work.

Setup a global scope that will join a table:

``` php
trait AccountAttachedTrait {

    /**
     * Boot the account attached trait for a model.
     *
     * @return void
     */
    public static function bootAccountAttachedTrait()
    {
        static::addGlobalScope(new AccountAttachedScope);
    }

}
```

``` php
use Illuminate\Database\Eloquent\ScopeInterface;
use Illuminate\Database\Eloquent\Builder;

class AccountAttachedScope implements ScopeInterface {

    /**
     * Apply the scope to a given Eloquent query builder.
     *
     * @param  \Illuminate\Database\Eloquent\Builder  $builder
     * @return void
     */
    public function apply(Builder $builder)
    {
        $model = $builder->getModel();

        // join the accounts table
        $builder->join('accounts', $model->getTable().'.account_id', '=', 'accounts.id');

        // Add account Id to the query
        $builder->where($model->getTable().'.account_id', '=', \Account::getId());  //= 1
    }

    /**
     * Remove the scope from the given Eloquent query builder.
     *
     * @param  \Illuminate\Database\Eloquent\Builder  $builder
     * @return void
     */
    public function remove(Builder $builder)
    {
        $column = $builder->getModel()->getTable().'.account_id';

        $query = $builder->getQuery();

        foreach ((array) $query->wheres as $key => $where)
        {
            // If the where clause is an account constraint, we will remove it from
            // the query and reset the keys on the wheres. This allows this developer to
            // include account attached model in a relationship result set that is lazy loaded.
            if ($this->isAccountConstraint($where, $column))
            {
                unset($query->wheres[$key]);

                $query->wheres = array_values($query->wheres);
            }
        }
    }

    /**
     * Determine if the given where clause is an account constraint.
     *
     * @param  array   $where
     * @param  string  $column
     * @return bool
     */
    protected function isAccountConstraint(array $where, $column)
    {
        return $where['type'] === 'Basic' && $where['column'] === $column && $where['operator'] === '=';
    }
}
```

Make Product model use global account scope:

``` php
class Product extends BaseSoftModel
{
    use AccountAttachedTrait;

    protected $table = 'products';
    ...
}
```

Now attempt to call find method:
`$product = Product::find('1');`

``` php
PDOException: SQLSTATE[HY000]: General error: 1 ambiguous column name: id

Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1 ambiguous column name: id (SQL: select * from "products" inner join "accounts" on "products"."account_id" = "accounts"."id" where "products"."account_id" = 1 and "products"."deleted_at" is null and "id" = 1 limit 1)

/vendor/laravel/framework/src/Illuminate/Database/Connection.php:600
/vendor/laravel/framework/src/Illuminate/Database/Connection.php:556
/vendor/laravel/framework/src/Illuminate/Database/Connection.php:290
/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:1359
/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:1349
/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:1336
/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:415
/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:151
/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:125
/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:82
/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:644
/app/tests/models/ProductTest.php:108

Caused by
PDOException: SQLSTATE[HY000]: General error: 1 ambiguous column name: id
```
