### PR TITLE
fix for forgetMiddleware function

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -717,7 +717,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	{
 		$this->middlewares = array_filter($this->middlewares, function($m) use ($class)
 		{
-			return $m['class'] != $class;
+			return get_class($m['class']) != $class;
 		});
 	}
 


### PR DESCRIPTION
forgetMiddleware function was checking an object against a (string) class name so it would never match and remove the middleware.
