### PR TITLE
Support for sslmode in PostgresConnector.php

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -74,6 +74,15 @@ class PostgresConnector extends Connector implements ConnectorInterface {
 		{
 			$dsn .= ";port={$port}";
 		}
+		
+		// If sslmode was specified, add it to this Postgres DSN connections
+		// format. This setting will turn on/off the encryption of the connection
+		// between the app and database. For example, set it to 'require' to ensure 
+		// encrypted connection.
+		if (isset($config['sslmode']))
+		{
+			$dsn .= ";sslmode={$sslmode}";
+		}
 
 		return $dsn;
 	}


### PR DESCRIPTION
This change makes it possible to specify sslmode when connecting to PostgreSQL, ie use SSL encrypted connection between the web app and the database. Of course it requires some configuration of your PostgreSQL instance to make it work. I've tested this with the database config value 'require' to make the SSL connection mandatory and setting hostssl in pg_hba.conf for all connections. 

Possible sslmode values depend on the version of the pgsql library: 'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full'. The default value is 'prefer'. The value 'require' is backwards compatible.

For further info check the PostgreSQL docs: http://www.postgresql.org/docs/9.3/static/libpq-ssl.html
