### PR TITLE
added validator extract values if rules passes to Illuminate/Validation/...

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -315,6 +315,26 @@ class Validator implements MessageProviderInterface {
 		}
 	}
 
+    /**
+     * Handle removing extra values provided in case of data manipulation
+     * rules applied as name of fields allowed in request values
+     *
+     * @return mixed
+     */
+    public function extract()
+    {
+        if(!$this->passes())
+        {
+            return false;
+        }
+
+        $keys = array_keys($this->rules);
+        $allowed = array_fill_keys($keys, null);
+        $result = array_intersect_key($this->data, $allowed);
+
+        return $result;
+    }
+
 	/**
 	 * Get the value of a given attribute.
 	 *

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1267,6 +1267,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+    public function testValidateExtractAllowedValuesReturnArray(){
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => 1290, 'boo' => 'array'], ['foo' => 'numeric']);
+
+        $this->assertSame(['foo' => 1290], $v->extract());
+    }
+
 	protected function getTranslator()
 	{
 		return m::mock('Symfony\Component\Translation\TranslatorInterface');


### PR DESCRIPTION
Added extract values on validators to remove data manipulation when passing user input into a model, fields in rules that don't exist in **Inputs** will be ignored if the **Inputs** passes.

example (update operation on user): 

```
$rules = [
    'username' => 'required|alpha_num|min:3',
    'age' => 'numeric|min:15|max:80'
];

$inputs = [
    'username' => 'ySimple',
    'password'  => 'changes not allowed'
];

$validator = Validator::make($input, $rules);
$result = $validator->extract();
print_r($result); // [ 'username' => 'ySimple' ]
```
