### PR TITLE
Only include migrations that need to run to preserve RAM.

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -68,7 +68,7 @@ class Migrator {
 	{
 		$this->notes = array();
 
-                $files = $this->getMigrationFiles($path);
+		$files = $this->getMigrationFiles($path);
 
 		// Once we grab all of the migration files for the path, we will compare them
 		// against the migrations that have already been run for this package then

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -68,7 +68,7 @@ class Migrator {
 	{
 		$this->notes = array();
 
-		$this->requireFiles($path, $files = $this->getMigrationFiles($path));
+                $files = $this->getMigrationFiles($path);
 
 		// Once we grab all of the migration files for the path, we will compare them
 		// against the migrations that have already been run for this package then
@@ -76,6 +76,7 @@ class Migrator {
 		$ran = $this->repository->getRan();
 
 		$migrations = array_diff($files, $ran);
+		$this->requireFiles($path, $migrations);
 
 		$this->runMigrationList($migrations, $pretend);
 	}


### PR DESCRIPTION
Previous code included all migration files, including the old, already-ran ones, before running the outstanding ones. Eventually, as a project naturally accumulates migrations, it gets to a point where the 'artisan migrate' command is unable to load all migrations in RAM and fails.

This simple fix only includes outstanding migrations before running them.
