### PR TITLE
Reduce output length of artisan list

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -11,7 +11,7 @@ class MigrateMakeCommand extends BaseCommand {
 	 *
 	 * @var string
 	 */
-	protected $name = 'migrate:make';
+	protected $name = 'make:migration';
 
 	/**
 	 * The console command description.

--- a/src/Illuminate/Foundation/Console/AssetPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/AssetPublishCommand.php
@@ -13,7 +13,7 @@ class AssetPublishCommand extends Command {
 	 *
 	 * @var string
 	 */
-	protected $name = 'asset:publish';
+	protected $name = 'publish:asset';
 
 	/**
 	 * The console command description.

--- a/src/Illuminate/Foundation/Console/CommandMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CommandMakeCommand.php
@@ -12,7 +12,7 @@ class CommandMakeCommand extends Command {
 	 *
 	 * @var string
 	 */
-	protected $name = 'command:make';
+	protected $name = 'make:command';
 
 	/**
 	 * The console command description.

--- a/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
@@ -15,7 +15,7 @@ class ConfigPublishCommand extends Command {
 	 *
 	 * @var string
 	 */
-	protected $name = 'config:publish';
+	protected $name = 'publish:config';
 
 	/**
 	 * The console command description.

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -11,7 +11,7 @@ class KeyGenerateCommand extends Command {
 	 *
 	 * @var string
 	 */
-	protected $name = 'key:generate';
+	protected $name = 'app:key';
 
 	/**
 	 * The console command description.

--- a/src/Illuminate/Foundation/Console/MigratePublishCommand.php
+++ b/src/Illuminate/Foundation/Console/MigratePublishCommand.php
@@ -10,7 +10,7 @@ class MigratePublishCommand extends Command {
 	 *
 	 * @var string
 	 */
-	protected $name = 'migrate:publish';
+	protected $name = 'publish:migration';
 
 	/**
 	 * The console command description.

--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -11,7 +11,7 @@ class ProviderMakeCommand extends Command {
 	 *
 	 * @var string
 	 */
-	protected $name = 'provider:make';
+	protected $name = 'make:provider';
 
 	/**
 	 * The console command description.

--- a/src/Illuminate/Foundation/Console/RequestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RequestMakeCommand.php
@@ -11,7 +11,7 @@ class RequestMakeCommand extends Command {
 	 *
 	 * @var string
 	 */
-	protected $name = 'request:make';
+	protected $name = 'make:request';
 
 	/**
 	 * The console command description.

--- a/src/Illuminate/Foundation/Console/ViewPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewPublishCommand.php
@@ -12,7 +12,7 @@ class ViewPublishCommand extends Command {
 	 *
 	 * @var string
 	 */
-	protected $name = 'view:publish';
+	protected $name = 'publish:view';
 
 	/**
 	 * The console command description.

--- a/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
@@ -12,7 +12,6 @@ class ConsoleSupportServiceProvider extends ServiceProvider {
 	protected $providers = array(
 		'Illuminate\Foundation\Providers\ComposerServiceProvider',
 		'Illuminate\Foundation\Providers\PublisherServiceProvider',
-		'Illuminate\Queue\FailConsoleServiceProvider',
 		'Illuminate\Routing\GeneratorServiceProvider',
 		'Illuminate\Session\CommandsServiceProvider',
 		'Illuminate\Workbench\WorkbenchServiceProvider',

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -273,6 +273,8 @@ class QueueServiceProvider extends ServiceProvider {
 
 			return new DatabaseFailedJobProvider($app['db'], $config['database'], $config['table']);
 		});
+
+		$this->app->register('Illuminate\Queue\FailConsoleServiceProvider');
 	}
 
 	/**

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -12,7 +12,7 @@ class ControllerMakeCommand extends Command {
 	 *
 	 * @var string
 	 */
-	protected $name = 'controller:make';
+	protected $name = 'make:controller';
 
 	/**
 	 * The console command description.

--- a/src/Illuminate/Routing/Console/FilterMakeCommand.php
+++ b/src/Illuminate/Routing/Console/FilterMakeCommand.php
@@ -11,7 +11,7 @@ class FilterMakeCommand extends Command {
 	 *
 	 * @var string
 	 */
-	protected $name = 'filter:make';
+	protected $name = 'make:filter';
 
 	/**
 	 * The console command description.


### PR DESCRIPTION
```
$ php artisan | wc -l
83
```

83 lines of output just to list available commands. This doesn't even fit on my screen, which is 1200 pixels tall, using a font size of 10 points.

If I never use the queue system in one of my applications I expect to be able to remove the queue service provider and the commands should be gone, but they're not.

The generator commands' names can be reversed to save space (`make:controller` instead of `controller:make`), and personally I'd like to be able to disable them as well. You could reverse the names of all the `publish` commands as well.

I was able to bring it down to 76 lines by renaming commands. Disabling the queue service provider now reduces it to 66. This is a backwards breaking change.

Comparison of the new/old artisan list command: https://gist.github.com/anonymous/948cd0e4462cde21e76d
