### PR TITLE
Set index name of morph relation

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -663,13 +663,13 @@ class Blueprint {
 	 * @param  string  $name
 	 * @return void
 	 */
-	public function morphs($name)
+	public function morphs($name, $indexName = null)
 	{
 		$this->unsignedInteger("{$name}_id");
 
 		$this->string("{$name}_type");
 
-		$this->index(array("{$name}_id", "{$name}_type"));
+		$this->index(array("{$name}_id", "{$name}_type"), $indexName);
 	}
 
 	/**


### PR DESCRIPTION
The index name auto generated index name can become long and with this method it can be overridden
