### PR TITLE
[4.3] Fixes `php artisan key:generate` failed due to used of hardcoded app path config.

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -69,7 +69,7 @@ class KeyGenerateCommand extends Command {
 	{
 		$env = $this->option('env') ? $this->option('env').'/' : '';
 
-		$contents = $this->files->get($path = $this->laravel['path']."/config/{$env}app.php");
+		$contents = $this->files->get($path = $this->laravel['path.config']."/{$env}app.php");
 
 		return array($path, $contents);
 	}


### PR DESCRIPTION
Signed-off-by: crynobone crynobone@gmail.com
