### PR TITLE
Separate config, lang and view package component registration to separate method.

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -44,6 +44,65 @@ abstract class ServiceProvider {
 	abstract public function register();
 
 	/**
+	 * Register the package's config component namespaces.
+	 *
+	 * @param  string  $package
+	 * @param  string  $namespace
+	 * @param  string  $path
+	 * @return void
+	 */
+	public function addConfigComponent($package, $namespace, $path)
+	{
+		if ($this->app['files']->isDirectory($path))
+		{
+			$this->app['config']->package($package, $path, $namespace);
+		}
+	}
+
+	/**
+	 * Register the package's language component namespaces.
+	 *
+	 * @param  string  $package
+	 * @param  string  $namespace
+	 * @param  string  $path
+	 * @return void
+	 */
+	public function addLanguageComponent($package, $namespace, $path)
+	{
+		if ($this->app['files']->isDirectory($path))
+		{
+			$this->app['translator']->addNamespace($namespace, $path);
+		}
+	}
+
+	/**
+	 * Register the package's view component namespaces.
+	 *
+	 * @param  string  $package
+	 * @param  string  $namespace
+	 * @param  string  $path
+	 * @return void
+	 */
+	public function addViewComponent($package, $namespace, $path)
+	{
+		$appView = $this->getAppViewPath($package);
+
+		if ($this->app['files']->isDirectory($appView))
+		{
+			$this->app['view']->addNamespace($namespace, $appView);
+		}
+
+		// Finally we will register the view namespace so that we can access each of
+		// the views available in this package. We use a standard convention when
+		// registering the paths to every package's views and other components.
+
+		if ($this->app['files']->isDirectory($path))
+		{
+			$this->app['view']->addNamespace($namespace, $path);
+		}
+	}
+
+	/**
 	 * Register the package's component namespaces.
 	 *
 	 * @param  string  $package
@@ -60,42 +119,19 @@ abstract class ServiceProvider {
 		// folder to make the developers lives much easier in maintaining them.
 		$path = $path ?: $this->guessPackagePath();
 
-		$config = $path.'/config';
+		$this->addConfigComponent($package, $namespace, $path.'/config');
 
-		if ($this->app['files']->isDirectory($config))
-		{
-			$this->app['config']->package($package, $config, $namespace);
-		}
-
-		// Next we will check for any "language" components. If language files exist
+		// Next, we will check for any "language" components. If language files exist
 		// we will register them with this given package's namespace so that they
 		// may be accessed using the translation facilities of the application.
-		$lang = $path.'/lang';
 
-		if ($this->app['files']->isDirectory($lang))
-		{
-			$this->app['translator']->addNamespace($namespace, $lang);
-		}
+		$this->addLanguageComponent($package, $namespace, $path.'/lang');
 
 		// Next, we will see if the application view folder contains a folder for the
 		// package and namespace. If it does, we'll give that folder precedence on
 		// the loader list for the views so the package views can be overridden.
-		$appView = $this->getAppViewPath($package);
 
-		if ($this->app['files']->isDirectory($appView))
-		{
-			$this->app['view']->addNamespace($namespace, $appView);
-		}
-
-		// Finally we will register the view namespace so that we can access each of
-		// the views available in this package. We use a standard convention when
-		// registering the paths to every package's views and other components.
-		$view = $path.'/views';
-
-		if ($this->app['files']->isDirectory($view))
-		{
-			$this->app['view']->addNamespace($namespace, $view);
-		}
+		$this->addViewComponent($package, $namespace, $path.'/views');
 	}
 
 	/**

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -1,6 +1,14 @@
 <?php
 
+use Mockery as m;
+
 class SupportServiceProviderTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
 
 	public static function setUpBeforeClass()
 	{
@@ -16,6 +24,68 @@ class SupportServiceProviderTest extends PHPUnit_Framework_TestCase {
 
 		$superSuperProvider = new SuperSuperProvider(null);
 		$this->assertEquals(realpath(__DIR__.'/'), $superSuperProvider->guessPackagePath());
+	}
+
+
+	public function testPackageWithRegisterComponents()
+	{
+		$superProvider = m::mock('SuperProvider[addConfigComponent,addLanguageComponent,addViewComponent]', [null]);
+
+		$superProvider->shouldReceive('addConfigComponent')->once()->with('foo/bar', 'foo', __DIR__.'/config')->andReturnNull()
+			->shouldReceive('addLanguageComponent')->once()->with('foo/bar', 'foo', __DIR__.'/lang')->andReturnNull()
+			->shouldReceive('addViewComponent')->once()->with('foo/bar', 'foo', __DIR__.'/views')->andReturnNull();
+
+		$superProvider->package('foo/bar', 'foo', __DIR__);
+	}
+
+
+	public function testPackageAddConfigComponent()
+	{
+		$app['config'] = $config = m::mock('\Illuminate\Config\Repository');
+		$app['files'] = $files = m::mock('\Illuminate\Filesystem\Filesystem');
+		$path = __DIR__.'/config';
+
+		$config->shouldReceive('package')->once()->with('foo/bar', $path, 'foo')->andReturnNull();
+		$files->shouldReceive('isDirectory')->once()->with($path)->andReturn(true);
+
+		$superProvider = new SuperProvider($app);
+
+		$superProvider->addConfigComponent('foo/bar', 'foo', $path);
+	}
+
+
+	public function testPackageAddLanguageComponent()
+	{
+		$app['translator'] = $translator = m::mock('\Illuminate\Translation\Translator');
+		$app['files'] = $files = m::mock('\Illuminate\Filesystem\Filesystem');
+		$path = __DIR__.'/lang';
+
+		$translator->shouldReceive('addNamespace')->once()->with('foo', $path)->andReturnNull();
+		$files->shouldReceive('isDirectory')->once()->with($path)->andReturn(true);
+
+		$superProvider = new SuperProvider($app);
+
+		$superProvider->addLanguageComponent('foo/bar', 'foo', $path);
+	}
+
+
+	public function testPackageAddViewComponent()
+	{
+		$app['view'] = $view = m::mock('\Illuminate\View\Factory');
+		$app['files'] = $files = m::mock('\Illuminate\Filesystem\Filesystem');
+		$app['path'] = __DIR__;
+
+		$viewAppPath = $app['path'].'/views/packages';
+		$path = __DIR__.'/views';
+
+		$view->shouldReceive('addNamespace')->once()->with('foo', $viewAppPath.'/foo/bar')->andReturnNull()
+			->shouldReceive('addNamespace')->once()->with('foo', $path)->andReturnNull();
+		$files->shouldReceive('isDirectory')->once()->with($viewAppPath.'/foo/bar')->andReturn(true)
+			->shouldReceive('isDirectory')->once()->with($path)->andReturn(true);
+
+		$superProvider = new SuperProvider($app);
+
+		$superProvider->addViewComponent('foo/bar', 'foo', $path);
 	}
 
 }


### PR DESCRIPTION
This would allow customization for advanced developer to choose if they only need to register specific component type instead of all three, it also give the freedom to developer to define the path for config, lang and views if they feel the need to.

Relevant to #4928

Signed-off-by: crynobone crynobone@gmail.com
