### PR TITLE
Fix pagination when a "having" clause is added to the query

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -83,7 +83,18 @@ class Grammar extends BaseGrammar {
 			$column = 'distinct '.$column;
 		}
 
-		return 'select '.$aggregate['function'].'('.$column.') as aggregate';
+		$sql = 'select ';
+
+		if (count($query->havings) > 0)
+		{
+			$extraColumns = array_diff($query->columns, $aggregate['columns']);
+
+			$sql .= $this->columnize($extraColumns) . ', ';
+		}
+
+		$sql .= $aggregate['function'].'('.$column.') as aggregate';
+
+		return $sql;
 	}
 
 	/**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -731,6 +731,30 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testPaginateWithSelectPreservesColumns()
+	{
+		$builder = $this->getBuilder();
+		$connection = $builder->getConnection();
+		$paginator = m::mock('Illuminate\Pagination\Factory');
+		$paginator->shouldReceive('getCurrentPage')->once()->andReturn(1);
+		$connection->shouldReceive('getPaginator')->once()->andReturn($paginator);
+		$connection->shouldReceive('select')->once()
+			->with('select FUNC(foo) AS bar, count(*) as aggregate from "users" having "bar" > ?', array('100'))
+			->andReturn(array(array('aggregate' => 1)));
+		$connection->shouldReceive('select')->once()
+			->with('select FUNC(foo) AS bar, * from "users" having "bar" > ? limit 15 offset 0', array('100'))
+			->andReturn(['results']);
+		$builder->getProcessor()->shouldReceive('processSelect')->twice()->andReturnUsing(function($query, $results) { return $results; });
+		$paginator->shouldReceive('make')->once()->with(['results'], 1, 15)
+			->andReturn('paginated');
+		$builder->from('users');
+		$builder->selectRaw('FUNC(foo) AS bar');
+		$builder->addSelect('*');
+		$builder->having('bar', '>', '100');
+		$this->assertEquals('paginated', $builder->paginate(15));
+	}
+
+
 	public function testQuickPaginateCorrectlyCreatesPaginatorInstance()
 	{
 		$connection = m::mock('Illuminate\Database\ConnectionInterface');


### PR DESCRIPTION
When using a "having" clause on a query builder, paginating is impossible because the column you're trying to check against won't be part of the select clause. This is crudely fixed by checking if the query has a having clause and then adding the necessary columns as selects.

This honestly feels like somewhat of a hack to me, but all tests pass. The array_diff is there to prevent `select *, count(*)` but there may be a better way.

Related: #3105, #3416, #4532
