### PR TITLE
Removed registering of the tail command.

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -75,7 +75,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 		}
 
 		$this->commands(
-			'command.tail', 'command.changes', 'command.environment', 'command.event.cache',
+			'command.changes', 'command.environment', 'command.event.cache',
 			'command.route.cache', 'command.route.clear', 'command.route.list',
 			'command.request.make', 'command.tinker', 'command.command.make',
 			'command.key.generate', 'command.down', 'command.up', 'command.clear-compiled',


### PR DESCRIPTION
You forgot to remove the registration of command.tail in the ArtisanServiceProvider after making it an optional component in f62a5f11045ec4e09a5e95e496d6c6c184efe2d9, thus resulting in an error when artisan was called.
