### PR TITLE
Fixing cascade behaviour for package config.

### DIFF
--- a/src/Illuminate/Config/FileLoader.php
+++ b/src/Illuminate/Config/FileLoader.php
@@ -159,7 +159,7 @@ class FileLoader implements LoaderInterface {
 
 		if ($this->files->exists($path = $this->defaultPath.'/'.$file))
 		{
-			$items = array_merge($items, $this->getRequire($path));
+			$items = array_replace_recursive($items, $this->getRequire($path));
 		}
 
 		// Once we have merged the regular package configuration we need to look for
@@ -169,7 +169,7 @@ class FileLoader implements LoaderInterface {
 
 		if ($this->files->exists($path))
 		{
-			$items = array_merge($items, $this->getRequire($path));
+			$items = array_replace_recursive($items, $this->getRequire($path));
 		}
 
 		return $items;


### PR DESCRIPTION
Normal configs were cascading with array_replace_recursive(), which
merged recursive arrays nicely, however Package configs were using
array_merge(), which only merged the top-level arrays. This is
inconsistent across the configuration handling, and is confusing for
users trying to override specific package configuration.

It looks like this fix was proposed in Issue #757, but missed when the
Issue #1225 was proposed, considered a duplicate, and eventually
merged.
