### PR TITLE
[FIX #4938] Override PostgresGrammar.getDateFormat

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -172,5 +172,16 @@ class PostgresGrammar extends Grammar {
 	{
 		return array('truncate '.$this->wrapTable($query->from).' restart identity' => array());
 	}
+	
+	/**
+	 * Get the format for database stored dates.
+	 * Postgres includes the partial seconds
+	 *
+	 * @return string
+	 */
+	public function getDateFormat()
+	{
+		return 'Y-m-d H:i:s.u';
+	}
 
 }


### PR DESCRIPTION
Fix for #4938

Override getDateFormat in PostgresGrammar to include the partial seconds
