### PR TITLE
Reminder token bug

### DIFF
--- a/src/Illuminate/Auth/Reminders/ReminderRepositoryInterface.php
+++ b/src/Illuminate/Auth/Reminders/ReminderRepositoryInterface.php
@@ -20,6 +20,15 @@ interface ReminderRepositoryInterface {
 	 * @return bool
 	 */
 	public function exists(Remindable $user, $token);
+	
+	/**
+	 * Determine if a reminder record already exists user and is valid
+	 * Return the valid token is exist
+	 *
+	 * @param  string $email
+	 * @return mixed
+	 */
+	public function requested($email);
 
 	/**
 	 * Delete a reminder record by token.


### PR DESCRIPTION
When a user request for password reset more than once within the validity period, all the generated token is valid, so if any other people managed to get hold of the unused token before it expires, he/she can simply change new password.
