### PR TITLE
password reset token security bug

### DIFF
--- a/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
+++ b/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
@@ -64,7 +64,7 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 		// If yes, delete the active token before generating new a token
 		$existingToken = $this->requested($email);
 
-		if($existingToken)
+		if ($existingToken)
 		{
 			$this->delete($existingToken);
 		}
@@ -119,7 +119,7 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 
 		$reminder = (array) $this->getTable()->where('email', $email)->first();
 
-		if($reminder && ! $this->reminderExpired($reminder))
+		if ($reminder && ! $this->reminderExpired($reminder))
 		{
 			return $reminder['token'];
 		}

--- a/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
+++ b/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
@@ -60,6 +60,15 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	{
 		$email = $user->getReminderEmail();
 
+		// Check if user already have a valid and active token
+		// If yes, delete it first before generating new token
+		$existingToken = $this->requested($email);
+
+		if($existingToken){
+
+			$this->delete($existingToken);
+		}
+
 		// We will create a new, random token for the user so that we can e-mail them
 		// a safe link to the password reset form. Then we will insert a record in
 		// the database so that we can verify the token within the actual reset.
@@ -96,6 +105,27 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 		$reminder = (array) $this->getTable()->where('email', $email)->where('token', $token)->first();
 
 		return $reminder && ! $this->reminderExpired($reminder);
+	}
+
+	/**
+	 * Determine if a reminder record already exists user and is valid
+	 * Return the valid token is exist
+	 *
+	 * @param  string $email
+	 * @return mixed
+	 */
+	public function requested($email)
+	{
+
+		$reminder = (array) $this->getTable()->where('email', $email)->first();
+
+		if($reminder && ! $this->reminderExpired($reminder)){
+
+			return $reminder['token'];
+
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
+++ b/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
@@ -61,11 +61,11 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 		$email = $user->getReminderEmail();
 
 		// Check if user already have a valid and active token
-		// If yes, delete it first before generating new token
+		// If yes, delete the active token before generating new a token
 		$existingToken = $this->requested($email);
 
-		if($existingToken){
-
+		if($existingToken)
+		{
 			$this->delete($existingToken);
 		}
 
@@ -108,8 +108,8 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	}
 
 	/**
-	 * Determine if a reminder record already exists user and is valid
-	 * Return the valid token is exist
+	 * Determine if a valid reminder record already exists for a specific user
+	 * Return the valid token if exist
 	 *
 	 * @param  string $email
 	 * @return mixed
@@ -119,10 +119,9 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 
 		$reminder = (array) $this->getTable()->where('email', $email)->first();
 
-		if($reminder && ! $this->reminderExpired($reminder)){
-
+		if($reminder && ! $this->reminderExpired($reminder))
+		{
 			return $reminder['token'];
-
 		}
 
 		return false;

--- a/src/Illuminate/Auth/Reminders/ReminderRepositoryInterface.php
+++ b/src/Illuminate/Auth/Reminders/ReminderRepositoryInterface.php
@@ -20,6 +20,15 @@ interface ReminderRepositoryInterface {
 	public function exists(RemindableInterface $user, $token);
 
 	/**
+	 * Determine if a reminder record already exists user and is valid
+	 * Return the valid token is exist
+	 *
+	 * @param  string $email
+	 * @return mixed
+	 */
+	public function requested($email);
+	
+	/**
 	 * Delete a reminder record by token.
 	 *
 	 * @param  string  $token

--- a/src/Illuminate/Auth/Reminders/ReminderRepositoryInterface.php
+++ b/src/Illuminate/Auth/Reminders/ReminderRepositoryInterface.php
@@ -20,8 +20,8 @@ interface ReminderRepositoryInterface {
 	public function exists(RemindableInterface $user, $token);
 
 	/**
-	 * Determine if a reminder record already exists user and is valid
-	 * Return the valid token is exist
+	 * Determine if a valid reminder record already exists for a specific user
+	 * Return the valid token if exist
 	 *
 	 * @param  string $email
 	 * @return mixed

--- a/tests/Auth/AuthDatabaseReminderRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseReminderRepositoryTest.php
@@ -13,7 +13,14 @@ class AuthDatabaseReminderRepositoryTest extends PHPUnit_Framework_TestCase {
 	public function testCreateInsertsNewRecordIntoTable()
 	{
 		$repo = $this->getRepo();
+
 		$repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock('StdClass'));
+		$query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+		$date = date('Y-m-d H:i:s', time() - 300000);
+		$query->shouldReceive('first')->andReturn((object) array('token' => 'token','created_at' => $date));
+		$query->shouldReceive('where')->with('token', 'token')->andReturn($query);
+		$query->shouldReceive('delete')->andReturn($query);
+		$repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query);
 		$query->shouldReceive('insert')->once();
 		$user = m::mock('Illuminate\Auth\Reminders\RemindableInterface');
 		$user->shouldReceive('getReminderEmail')->andReturn('email');


### PR DESCRIPTION
When a user request for password reset more than once within the validity period, all the token is valid, so if any other people managed to get hold of the unused token before it expires, he/she can simply change new password.
