### PR TITLE
Update the Travis file of the workbench

### DIFF
--- a/src/Illuminate/Workbench/stubs/.travis.yml
+++ b/src/Illuminate/Workbench/stubs/.travis.yml
@@ -1,14 +1,13 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - hhvm
 
 before_script:
-  - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+  - travis_retry composer self-update
+  - travis_retry composer install --prefer-source --no-interaction --dev
 
 script: phpunit


### PR DESCRIPTION
- Since `"php": ">=5.4.0"` is required, there is no point to test the PHP 5.3 version with Travis
- Use `travis_retry` with Composer
