### PR TITLE
Added league/flysystem to illuminate/filesystem.

### DIFF
--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -11,7 +11,8 @@
         "php": ">=5.4.0",
         "illuminate/contracts": "4.3.*",
         "illuminate/support": "4.3.*",
-        "symfony/finder": "2.6.*"
+        "symfony/finder": "2.6.*",
+        "league/flysystem": "~0.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The illuminate subsplit was missing the league/flysystem requirement as specified in the main composer.json.
