### PR TITLE
Fix output buffering levels

### DIFF
--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -64,15 +64,16 @@ class CompilerEngine extends PhpEngine {
 	 * Handle a view exception.
 	 *
 	 * @param  \Exception  $e
+	 * @param  int         $obLevel
 	 * @return void
 	 *
 	 * @throws $e
 	 */
-	protected function handleViewException($e)
+	protected function handleViewException($e, $obLevel)
 	{
 		$e = new \ErrorException($this->getMessage($e), 0, 1, $e->getFile(), $e->getLine(), $e);
 
-		ob_get_clean(); throw $e;
+		parent::handleViewException($e, $obLevel);
 	}
 
 	/**

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -23,6 +23,8 @@ class PhpEngine implements EngineInterface {
 	 */
 	protected function evaluatePath($__path, $__data)
 	{
+		$obLevel = ob_get_level();
+
 		ob_start();
 
 		extract($__data);
@@ -36,7 +38,7 @@ class PhpEngine implements EngineInterface {
 		}
 		catch (\Exception $e)
 		{
-			$this->handleViewException($e);
+			$this->handleViewException($e, $obLevel);
 		}
 
 		return ltrim(ob_get_clean());
@@ -46,13 +48,19 @@ class PhpEngine implements EngineInterface {
 	 * Handle a view exception.
 	 *
 	 * @param  \Exception  $e
+	 * @param  int         $obLevel
 	 * @return void
 	 *
 	 * @throws $e
 	 */
-	protected function handleViewException($e)
+	protected function handleViewException($e, $obLevel)
 	{
-		ob_get_clean(); throw $e;
+		while (ob_get_level() > $obLevel)
+		{
+			ob_end_clean();
+		}
+
+		throw $e;
 	}
 
 }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -355,6 +355,22 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testExceptionsInSectionsAreThrown()
+	{
+		$engine = new \Illuminate\View\Engines\CompilerEngine(m::mock('Illuminate\View\Compilers\CompilerInterface'));
+		$engine->getCompiler()->shouldReceive('getCompiledPath')->andReturnUsing(function($path) { return $path; });
+		$engine->getCompiler()->shouldReceive('isExpired')->twice()->andReturn(false);
+		$factory = $this->getFactory();
+		$factory->getEngineResolver()->shouldReceive('resolve')->twice()->andReturn($engine);
+		$factory->getFinder()->shouldReceive('find')->once()->with('layout')->andReturn(__DIR__.'/fixtures/section-exception-layout.php');
+		$factory->getFinder()->shouldReceive('find')->once()->with('view')->andReturn(__DIR__.'/fixtures/section-exception.php');
+		$factory->getDispatcher()->shouldReceive('fire')->times(4);
+
+		$this->setExpectedException('Exception', 'section exception message');
+		$factory->make('view')->render();
+	}
+
+
 	protected function getFactory()
 	{
 		return new Factory(

--- a/tests/View/fixtures/section-exception-layout.php
+++ b/tests/View/fixtures/section-exception-layout.php
@@ -1,0 +1,1 @@
+<?php echo $__env->yieldContent('content'); ?>

--- a/tests/View/fixtures/section-exception.php
+++ b/tests/View/fixtures/section-exception.php
@@ -1,0 +1,4 @@
+<?php echo $__env->make('layout', array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>
+<?php $__env->startSection('content'); ?>
+<?php throw new Exception('section exception message') ?>
+<?php $__env->stopSection(); ?>


### PR DESCRIPTION
Since a recent version of PHPunit (4.1 or 4.2, not sure), you get a warning that your tests are risky if output buffers are not closed properly. This seems to be the case for framework code. The added test will yield the following output without the fixes:

```
$ phpunit -vvv tests/View/ViewFactoryTest.php
PHPUnit 4.4-dev by Sebastian Bergmann.

Configuration read from /home/vagrant/web/pkg/laravel-framework/phpunit.xml

............................R

Time: 587 ms, Memory: 7.50Mb

There was 1 risky test:

1) ViewFactoryTest::testExceptionsInSectionsAreThrown
Test code or tested code did not (only) close its own output buffers

OK, but incomplete, skipped, or risky tests!
Tests: 29, Assertions: 36, Risky: 1.
```
