### PR TITLE
[Proposal] Add ability to set beanstalkd port in config

### DIFF
--- a/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
+++ b/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
@@ -13,7 +13,7 @@ class BeanstalkdConnector implements ConnectorInterface {
 	 */
 	public function connect(array $config)
 	{
-		$pheanstalk = new Pheanstalk($config['host']);
+		$pheanstalk = new Pheanstalk($config['host'], array_get($config, 'port', Pheanstalk::DEFAULT_PORT));
 
 		return new BeanstalkdQueue(
 			$pheanstalk, $config['queue'], array_get($config, 'ttr', Pheanstalk::DEFAULT_TTR)


### PR DESCRIPTION
``` php
'beanstalkd' => array(
     'driver' => 'beanstalkd',
     'host' => 'localhost',
     'port' => 11300,
     'queue' => 'default',
     'ttr' => 60,
),
```
