### PR TITLE
[4.3] Fix auth make comments

### DIFF
--- a/src/Illuminate/Auth/Console/AuthControllerCommand.php
+++ b/src/Illuminate/Auth/Console/AuthControllerCommand.php
@@ -42,7 +42,7 @@ class AuthControllerCommand extends GeneratorCommand {
 	{
 		parent::fire();
 
-		$this->comment("Route: Route::controller('auth', '".$this->argument('name').";");
+		$this->comment("Route: Route::controller('auth', '".$this->argument('name')."');");
 	}
 
 	/**

--- a/src/Illuminate/Auth/Console/RemindersControllerCommand.php
+++ b/src/Illuminate/Auth/Console/RemindersControllerCommand.php
@@ -42,7 +42,7 @@ class RemindersControllerCommand extends GeneratorCommand {
 	{
 		parent::fire();
 
-		$this->comment("Route: Route::controller('password', '".$this->argument('name').";");
+		$this->comment("Route: Route::controller('password', '".$this->argument('name')."');");
 	}
 
 	/**


### PR DESCRIPTION
Simple typo fix so when you run the auth:make, auth:controller or auth:reminders-controller commands they output the correct route syntax.
