### PR TITLE
Stop queue:work --daemon processing when app down.

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -197,6 +197,16 @@ class QueueManager {
 	}
 
 	/**
+	* Determine if the worker should run in maintenance mode.
+	*
+	* @return bool
+	*/
+	public function isDownForMaintenance()
+	{
+		return $this->app->isDownForMaintenance();
+	}
+
+	/**
 	 * Dynamically pass calls to the default connection.
 	 *
 	 * @param  string  $method

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -123,6 +123,11 @@ class Worker {
 	 */
 	protected function daemonShouldRun()
 	{
+		if ($this->manager->isDownForMaintenance())
+		{
+			return false;
+		}
+
 		return $this->events->until('illuminate.queue.looping') !== false;
 	}
 


### PR DESCRIPTION
Contrary to the documentation (http://laravel.com/docs/queues#daemon-queue-worker > Coding For Daemon Queue Workers), the `queue:work --daemon` command happily
continues on processing events after the `down` command has been called,
which could lead to queue events being processed while database and code
migrations make the application unstable.

This fix adds a `isDownForMaintenance()` function into the QueueManager to
provide the Worker a way to find out if the application is down or not.

Implemented as part of the existing `daemonShouldRun()` function, since
that function already performs the required process of blocking future
events from being processed.
