### PR TITLE
Sub-query support in from() and join()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -36,6 +36,7 @@ class Builder {
 	 */
 	protected $bindings = array(
 		'select' => [],
+		'from'   => [],
 		'join'   => [],
 		'where'  => [],
 		'having' => [],
@@ -251,13 +252,20 @@ class Builder {
 	/**
 	 * Set the table which the query is targeting.
 	 *
-	 * @param  string  $table
+	 * @param  string|array  $table
 	 * @return $this
 	 */
 	public function from($table)
 	{
-		$this->from = $table;
+		if (is_array($table) && count($table) === 1)
+		{
+			reset($table);
+			list($alias, $subquery) = each($table);
+			$this->setBindings($subquery->getBindings(), 'from');
+			$table = new Expression('(' . $subquery->toSql() . ') AS '. $alias);
+		}
 
+		$this->from = $table;
 		return $this;
 	}
 
@@ -274,6 +282,14 @@ class Builder {
 	 */
 	public function join($table, $one, $operator = null, $two = null, $type = 'inner', $where = false)
 	{
+		if (is_array($table) && count($table) === 1)
+		{
+			reset($table);
+			list($alias, $subquery) = each($table);
+			$this->addBinding($subquery->getBindings(), 'join');
+			$table = new Expression('(' . $subquery->toSql() . ') AS '. $alias);
+		}
+
 		// If the first "column" of the join is really a Closure instance the developer
 		// is trying to build a join with a complex "on" clause containing more than
 		// one condition, so we'll add the join and call a Closure with the query.

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -575,6 +575,31 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testSubQueryInFrom()
+	{
+		$subquery = $this->getBuilder();
+		$subquery->select(new Raw("concat(first, ' ', last) as name"))->from('contacts')->where('id', '<', 100);
+
+		$builder = $this->getBuilder();
+		$builder->from(array('users' => $subquery))->whereIn('name', array('john doe', 'david smith'));
+		$this->assertEquals('select * from (select concat(first, \' \', last) as name from "contacts" where "id" < ?) AS users where "name" in (?, ?)',
+		$builder->toSql());
+		$this->assertEquals(array(100, 'john doe', 'david smith'), $builder->getBindings());
+	}
+
+
+	public function testSubQueryInJoin()
+	{
+		$subquery = $this->getBuilder();
+		$subquery->select('id')->from('contacts')->where('id', '<', 100);
+
+		$builder = $this->getBuilder();
+		$builder->from('users')->join(array('foo' => $subquery), 'users.id', '=', 'foo.id');
+		$this->assertEquals('select * from "users" inner join (select "id" from "contacts" where "id" < ?) AS foo on "users"."id" = "foo"."id"', $builder->toSql());
+		$this->assertEquals(array(100), $builder->getBindings());
+	}
+
+
 	public function testComplexJoin()
 	{
 		$builder = $this->getBuilder();


### PR DESCRIPTION
Usage: $query->from(['foo' => $subquery])->join(['bar' => $subquery2], 'foo.id', '=', 'bar.id');

Taken from @jarredholman's work: 3ec55a146b4ec284e40e503088b15b47fff816a4

A previous PR was created (#4238) but was closed due to implementation. The implementation in this PR is more correct.
