### PR TITLE
[4.2] Performances : Integer casting

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -256,7 +256,7 @@ class Repository implements ArrayAccess {
 			return max(0, Carbon::instance($duration)->diffInMinutes());
 		}
 
-		return is_string($duration) ? intval($duration) : $duration;
+		return is_string($duration) ? (int) $duration : $duration;
 	}
 
 	/**

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -233,7 +233,7 @@ class TaggedCache implements StoreInterface {
 			return max(0, Carbon::instance($duration)->diffInMinutes());
 		}
 
-		return is_string($duration) ? intval($duration) : $duration;
+		return is_string($duration) ? (int) $duration : $duration;
 	}
 
 }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -586,7 +586,7 @@ class BelongsToMany extends Relation {
 		{
 			$this->detach($detach);
 
-			$changes['detached'] = (array) array_map('intval', $detach);
+			$changes['detached'] = (array) array_map(function($v) { return (int) $v; }, $detach);
 		}
 
 		// Now we are finally ready to attach the new records. Note that we'll disable

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -244,7 +244,7 @@ abstract class Grammar extends BaseGrammar {
 	{
 		if ($value instanceof Expression) return $value;
 
-		if (is_bool($value)) return "'".intval($value)."'";
+		if (is_bool($value)) return "'".(int) $value."'";
 
 		return "'".strval($value)."'";
 	}

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -144,7 +144,7 @@ abstract class Job {
 		}
 		else
 		{
-			return intval($delay);
+			return (int) $delay;
 		}
 	}
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -104,7 +104,7 @@ abstract class Queue {
 		}
 		else
 		{
-			return intval($delay);
+			return (int) $delay;
 		}
 	}
 


### PR DESCRIPTION
Using `(int)` is much faster than `intval()`.
See bench : https://gist.github.com/lucasmichot/89a18524e10e2af42de3/revisions
