### PR TITLE
Ensure to propagate touchOwner on relationships.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1529,6 +1529,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		foreach ($this->touches as $relation)
 		{
 			$this->$relation()->touch();
+			$this->$relation->touchOwners();
 		}
 	}
 


### PR DESCRIPTION
Considering the following relationships: Album  1 <-> n Article 1 <-> n Lang

Article belongsTo Album
Lang belongsTo Article

Using the $touches protected attribute of Eloquent model, when updating a Lang, it touches its Article as well but doesn't update the related Album.
