### PR TITLE
Update Blueprint.php

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -299,6 +299,7 @@ class Blueprint {
 	 */
 	public function primary($columns, $name = null)
 	{
+		$name = ! empty($name) ? $name : '';
 		return $this->indexCommand('primary', $columns, $name);
 	}
 


### PR DESCRIPTION
Change on primary method:

I think there is no reason to autogenerate name for primary keys. At least for mysql and SQLpostgre there is no need of this. Usually it is ignored when table is generate. But When the table name and field name are a bit longer that normal, you get this error:

SQLSTATE[42000]: Syntax error or access violation: 1059 Identifier name 'attribute_option_languages_attribute_option_id_language_id_primary' is too long (SQL: alter table attribute_option_languages add primary key attribute_option_languages_attribute_option_id_language_id_primary(attribute_option_id, language_id))
