### PR TITLE
Fix guest filter method name.

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/controller.stub
+++ b/src/Illuminate/Auth/Console/stubs/controller.stub
@@ -26,7 +26,7 @@ class AuthController extends Controller {
 		$this->auth = $auth;
 
 		$this->beforeFilter('csrf', ['on' => ['post']]);
-		$this->beforeFilter('guest', ['except' => ['logout']]);
+		$this->beforeFilter('guest', ['except' => ['getLogout']]);
 	}
 
 	/**


### PR DESCRIPTION
At the moment `getLogout` won't get called if the value is `logout`.
