### PR TITLE
Added a simple validation for new app name

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -57,7 +57,7 @@ class AppNameCommand extends Command {
 	 */
 	public function fire()
 	{
-		if (!$this->isValidAppName())
+		if ( ! $this->isValidAppName())
 		{
 			$this->error('Application name contains invalid characters!');
 
@@ -77,6 +77,7 @@ class AppNameCommand extends Command {
 
 	/**
 	 * Check app name contains valid characters.
+	 * 
 	 * @return bool 
 	 */
 	protected function isValidAppName()
@@ -168,7 +169,7 @@ class AppNameCommand extends Command {
 		$normalizedNewAppName = str_replace('\\', '\\\\', $this->argument('name'));
 
 		$this->replaceIn(
-			$this->getComposerPath(), $this->root() . '\\\\', $normalizedNewAppName . '\\\\'
+			$this->getComposerPath(), $this->root().'\\\\', $normalizedNewAppName.'\\\\'
 		);
 	}
 

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -57,6 +57,13 @@ class AppNameCommand extends Command {
 	 */
 	public function fire()
 	{
+		if (!$this->isValidAppName())
+		{
+			$this->error('Application name contains invalid characters!');
+
+			return false;
+		}
+
 		$this->setAppDirectoryNamespace();
 
 		$this->setConfigNamespaces();
@@ -66,6 +73,15 @@ class AppNameCommand extends Command {
 		$this->info('Application namespace set!');
 
 		$this->composer->dumpAutoloads();
+	}
+
+	/**
+	 * Check app name contains valid characters.
+	 * @return bool 
+	 */
+	protected function isValidAppName()
+	{
+		return preg_match('~^[A-Za-z0-9_\\\\]+~', $this->argument('name')) != 0;
 	}
 
 	/**
@@ -149,8 +165,10 @@ class AppNameCommand extends Command {
 	 */
 	protected function setComposerNamespace()
 	{
+		$normalizedNewAppName = str_replace('\\', '\\\\', $this->argument('name'));
+
 		$this->replaceIn(
-			$this->getComposerPath(), $this->root().'\\\\', $this->argument('name').'\\\\'
+			$this->getComposerPath(), $this->root() . '\\\\', $normalizedNewAppName . '\\\\'
 		);
 	}
 


### PR DESCRIPTION
Currently there are no validation for app name. For example when user entered like `Vendor;Product` or like this `Vendor§§Produc` name, Laravel gives syntax error.

I added a simple validaton for this issue. And PR contains a little improvement for Composer's namespace about this issue.
