### PR TITLE
Fixes path to use path.base for migration publisher in 4.3

### DIFF
--- a/src/Illuminate/Foundation/Console/MigratePublishCommand.php
+++ b/src/Illuminate/Foundation/Console/MigratePublishCommand.php
@@ -27,7 +27,7 @@ class MigratePublishCommand extends Command {
 	public function fire()
 	{
 		$published = $this->laravel['migration.publisher']->publish(
-			$this->getSourcePath(), $this->laravel['path.base'].'/database/migrations'
+			$this->getSourcePath(), $this->laravel['path.database'].'/migrations'
 		);
 
 		foreach ($published as $migration)

--- a/src/Illuminate/Foundation/Console/MigratePublishCommand.php
+++ b/src/Illuminate/Foundation/Console/MigratePublishCommand.php
@@ -27,7 +27,7 @@ class MigratePublishCommand extends Command {
 	public function fire()
 	{
 		$published = $this->laravel['migration.publisher']->publish(
-			$this->getSourcePath(), $this->laravel['path'].'/database/migrations'
+			$this->getSourcePath(), $this->laravel['path.base'].'/database/migrations'
 		);
 
 		foreach ($published as $migration)


### PR DESCRIPTION
Migration publisher was still trying to publish migrations for 3rd party packages to  `app_path('database/migrations')` instead of the new base path implemented in Laravel 4.3.
