### PR TITLE
Update PostgresGrammar timestamp format

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -5,6 +5,17 @@ use Illuminate\Database\Query\Builder;
 class PostgresGrammar extends Grammar {
 
 	/**
+	* Get the format for database stored dates.
+	*
+	* @return string
+	*/
+	public function getDateFormat()
+	{
+		return 'Y-m-d H:i:s.u';
+	}
+
+
+	/**
 	 * All of the available clause operators.
 	 *
 	 * @var array


### PR DESCRIPTION
The default Postgres timestamp format includes milliseconds.  Without this change, Carbon throws an exception when hydrating postgresql timestamps,
