### PR TITLE
Changed errors::all to errors::getMessages

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -146,7 +146,7 @@ class FormRequest extends Request {
 	 */
 	protected function formatErrors(Validator $validator)
 	{
-		return $validator->errors()->all();
+		return $validator->errors()->getMessages();
 	}
 
 	/**


### PR DESCRIPTION
Changing $validator->errors()->all() to $validator->errors()->getMessages() it's possible to use the MessageBag method for named errors, like first('email'), has('password') and so on, wince the all method remove the named parameters.
