### PR TITLE
[Bug Fix]Fix morphToMany's pivot update and delete bug.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -14,6 +14,15 @@ class MorphPivot extends Pivot {
 	protected $morphType;
 
 	/**
+	 * The value of the polymorphic relation.
+	 *
+	 * Explicitly define this so it's not included in saved attributes.
+	 *
+	 * @var string
+	 */
+	protected $morphClass;
+
+	/**
 	 * Set the keys for a save update query.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -52,5 +61,19 @@ class MorphPivot extends Pivot {
 
 		return $this;
 	}
+
+	/**
+	 * Set the morph class for the pivot.
+	 *
+	 * @param  string  $morphClass
+	 * @return \Illuminate\Database\Eloquent\Relations\MorphPivot
+	 */
+	public function setMorphClass($morphClass)
+	{
+			$this->morphClass = $morphClass;
+
+			return $this;
+	}
+
 
 }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -128,9 +128,9 @@ class MorphToMany extends BelongsToMany {
 	{
 		$pivot = new MorphPivot($this->parent, $attributes, $this->table, $exists);
 
-		$pivot->setPivotKeys($this->foreignKey, $this->otherKey);
-
-		$pivot->setMorphType($this->morphType);
+		$pivot->setPivotKeys($this->foreignKey, $this->otherKey)
+			  ->setMorphType($this->morphType)
+			  ->setMorphClass($this->morphClass);
 
 		return $pivot;
 	}


### PR DESCRIPTION
This is related to previous PR https://github.com/laravel/framework/pull/4288 and issue https://github.com/laravel/framework/issues/3693

Without setting the morphClass, we can't do $foo->relations->find(1)->pivot->update()/delete(). Refer to https://github.com/laravel/framework/issues/3693 for the cause.

I didn't use the solution proposed in https://github.com/laravel/framework/issues/3693 as the morphClass should not be load as a model attribute, and should not be included in saved attributes.
