### PR TITLE
Add Mailer sending response getter method to get the result of send() operation.

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -60,6 +60,13 @@ class Mailer {
 	 * @var \Illuminate\Queue\QueueManager
 	 */
 	protected $queue;
+	
+	/**
+	 * Mail Transport sending response
+	 *
+	 * @var \GuzzleHttp\Message\Response|int
+	 */
+	protected $sendingResponse;
 
 	/**
 	 * Indicates if the actual sending is disabled.
@@ -326,7 +333,7 @@ class Mailer {
 
 		if ( ! $this->pretending)
 		{
-			$this->swift->send($message, $this->failedRecipients);
+			$this->sendingResponse = $this->swift->send($message, $this->failedRecipients);
 		}
 		elseif (isset($this->logger))
 		{
@@ -500,5 +507,14 @@ class Mailer {
 	{
 		$this->container = $container;
 	}
-
+	
+	/**
+	 * Get Mail Transport sending response
+	 *
+	 * @return \GuzzleHttp\Message\Response
+	 */
+	public function getSendingResponse()
+	{
+		return $this->sendingResponse;
+	}
 }

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -74,7 +74,7 @@ class MailgunTransport implements Swift_Transport {
 	{
 		$client = $this->getHttpClient();
 
-		$client->post($this->url, ['auth' => ['api', $this->key],
+		return $client->post($this->url, ['auth' => ['api', $this->key],
 			'body' => [
 				'to' => $this->getTo($message),
 				'message' => new PostFile('message', (string) $message),

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -56,7 +56,7 @@ class MandrillTransport implements Swift_Transport {
 	{
 		$client = $this->getHttpClient();
 
-		$client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', [
+		return $client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', [
 			'body' => [
 				'key' => $this->key,
 				'raw_message' => (string) $message,


### PR DESCRIPTION
May be when send method will return the instance of Mailer (or when Mailer instance will be injected in controller and will be taken as class property) it will be easier to getSendedCount() or getSendingResponse() from it to figure out what happened when mail was sent? I think It will solve problems of those who want to count sended mails and of those who want to get API response from mandrill/mailgun/etc.
Not returning any results of the key method of the class and making it impossible to obtain these data in any other way, it deprives the developer of flexible tools in building applications to solve business problems...

See #4405
