### PR TITLE
Adjusted the compileDelete function to allow joins when deleting

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -665,9 +665,14 @@ class Grammar extends BaseGrammar {
 	{
 		$table = $this->wrapTable($query->from);
 
-		$where = is_array($query->wheres) ? $this->compileWheres($query) : '';
+		$components = implode(' ', array_filter([
+			is_array($query->joins) ? $this->compileJoins($query, $query->joins) : '',
+			is_array($query->wheres) ? $this->compileWheres($query, $query->wheres) : '',
+			is_array($query->limit) ? $this->compilelimit($query, $query->limit) : '',
+			is_array($query->offset) ? $this->compileOffset($query, $query->offset) : ''
+		]));
 
-		return trim("delete from $table ".$where);
+		return trim("delete $table from $table ".$components);
 	}
 
 	/**


### PR DESCRIPTION
It makes no sense to disallow calling delete() for queries with joins, especially when it is such a simple fix to get it working. This commit adjusts the compileDelete function so that the following will work:

App::make('A')->join('b', 'b.x', '=', 'a.x')->where('b.y', 'z')->delete();

Previously it was (counter-intuitively) stripping out the "join" from the delete call, resulting in unpredictable results - usually an exception, but on rare occasions (e.g. when using a join to restrct the result set by the presence of a value in another table) it could execute incorrect sql, causing hard to track down heisenbugs.

I've also allowed limit and offset, mainly because I could not think of any reason to exclude them.
