### PR TITLE
Have BelongsToMany inherit constraints from relationship query (Issue #5589)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -885,6 +885,11 @@ class BelongsToMany extends Relation {
 	{
 		$query = $this->newPivotStatement();
 
+		// Inherit constraints from the relationship query
+		$builderQuery = $this->query->getQuery();
+		$bindings = $builderQuery->getRawBindings();
+		$query->mergeWheres($builderQuery->wheres, $bindings['where']);
+
 		return $query->where($this->foreignKey, $this->parent->getKey());
 	}
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -605,6 +605,30 @@ class BelongsToMany extends Relation {
 	}
 
 	/**
+	 * Extract attributes from the relationship query to apply to new records
+	 *
+	 * @return array
+	 */
+	protected function getConstraintsAsAttributes()
+	{
+		$builderQuery = $this->query->getQuery();
+
+		$inheritedAttributes = array();
+
+		foreach ($builderQuery->wheres as $where)
+		{
+			list($table, $column) = explode('.', $where['column']);
+
+			if ($table == $this->table)
+			{
+				$inheritedAttributes[$column] = $where['value'];
+			}
+		}
+
+		return $inheritedAttributes;
+	}
+
+	/**
 	 * Format the sync list so that it is keyed by ID.
 	 *
 	 * @param  array  $records
@@ -621,7 +645,8 @@ class BelongsToMany extends Relation {
 				list($id, $attributes) = array($attributes, array());
 			}
 
-			$results[$id] = $attributes;
+			// Inherit attributes from relationship query constraint
+			$results[$id] = array_merge($this->getConstraintsAsAttributes(), $attributes);
 		}
 
 		return $results;

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -179,10 +179,16 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+		$query->shouldReceive('mergeWheres')->once()->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
 		$query->shouldReceive('whereIn')->once()->with('role_id', array(1, 2, 3));
 		$query->shouldReceive('delete')->once()->andReturn(true);
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+
+		$mockQueryBuilder->wheres = array();
+		$mockQueryBuilder->shouldReceive('getRawBindings')->once()->andReturn(array('where' => array()));
+
+		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder);
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
 		$relation->expects($this->once())->method('touchIfTouching');
 
@@ -195,10 +201,13 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+		$query->shouldReceive('mergeWheres')->once()->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
 		$query->shouldReceive('whereIn')->never();
 		$query->shouldReceive('delete')->once()->andReturn(true);
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->wheres = array();
+		$mockQueryBuilder->shouldReceive('getRawBindings')->once()->andReturn(array('where' => array()));
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
 		$relation->expects($this->once())->method('touchIfTouching');
 
@@ -226,8 +235,11 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+		$query->shouldReceive('mergeWheres')->once()->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->wheres = [];
+		$mockQueryBuilder->shouldReceive('getRawBindings')->once()->andReturn(array('where' => array()));
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
 		$query->shouldReceive('lists')->once()->with('role_id')->andReturn(array(1, 2, 3));
 		$relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(array()), $this->equalTo(false));
@@ -253,9 +265,12 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach', 'touchIfTouching', 'updateExistingPivot'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+		$query->shouldReceive('mergeWheres')->once()->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->wheres = array();
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+		$mockQueryBuilder->shouldReceive('getRawBindings')->once()->andReturn(array('where' => array()));
 		$query->shouldReceive('lists')->once()->with('role_id')->andReturn(array(1, 2, 3));
 		$relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(array('foo' => 'bar')), $this->equalTo(false));
 		$relation->expects($this->once())->method('updateExistingPivot')->with($this->equalTo(3), $this->equalTo(array('baz' => 'qux')), $this->equalTo(false))->will($this->returnValue(true));
@@ -271,9 +286,12 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach', 'touchIfTouching', 'updateExistingPivot'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+		$query->shouldReceive('mergeWheres')->once()->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->wheres = array();
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+		$mockQueryBuilder->shouldReceive('getRawBindings')->once()->andReturn(array('where' => array()));
 		$query->shouldReceive('lists')->once()->with('role_id')->andReturn(array(1, 2, 3));
 		$relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(array('foo' => 'bar')), $this->equalTo(false));
 		$relation->expects($this->once())->method('updateExistingPivot')->with($this->equalTo(3), $this->equalTo(array('baz' => 'qux')), $this->equalTo(false))->will($this->returnValue(false));
@@ -317,9 +335,12 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach', 'touchIfTouching', 'formatSyncList'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+		$query->shouldReceive('mergeWheres')->once()->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->wheres = array();
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+		$mockQueryBuilder->shouldReceive('getRawBindings')->once()->andReturn(array('where' => array()));
 		$query->shouldReceive('lists')->once()->with('role_id')->andReturn(array(1, 2, 3));
 
 		$collection = m::mock('Illuminate\Database\Eloquent\Collection');

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -44,11 +44,14 @@ class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\MorphToMany', array('touchIfTouching'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
+		$query->shouldReceive('mergeWheres')->once()->andReturn($query);
 		$query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
 		$query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
 		$query->shouldReceive('whereIn')->once()->with('tag_id', array(1, 2, 3));
 		$query->shouldReceive('delete')->once()->andReturn(true);
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->wheres = array();
+		$mockQueryBuilder->shouldReceive('getRawBindings')->once()->andReturn(array('where' => array()));
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
 		$relation->expects($this->once())->method('touchIfTouching');
 
@@ -61,11 +64,14 @@ class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\MorphToMany', array('touchIfTouching'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
+		$query->shouldReceive('mergeWheres')->once()->andReturn($query);
 		$query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
 		$query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
 		$query->shouldReceive('whereIn')->never();
 		$query->shouldReceive('delete')->once()->andReturn(true);
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->wheres = array();
+		$mockQueryBuilder->shouldReceive('getRawBindings')->once()->andReturn(array('where' => array()));
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
 		$relation->expects($this->once())->method('touchIfTouching');
 


### PR DESCRIPTION
Allows me to turn this

``` php
$optionalItems = $basket->items(Item::TYPE_OPTIONAL);
$existingIds = $optionalItems->get()->fetch('id')->toArray();
if (count($existingIds)) {
    if (count($existingIds) === 1) {
        $existingIds = reset($existingIds);
    } else {
        $existingIds = array_unique($existingIds);
    }
    $optionalItems->detach($existingIds);
}
$optionalItems->attach(Input::get('items-optional'), ['relationship' => Item::TYPE_OPTIONAL]);
```

into this:

``` php
$optionalItems = $basket->items(Item::TYPE_OPTIONAL);
$optionalItems->sync(Input::get('items-optional'));
```
