### PR TITLE
Fix calling BelongsToMany::detach() with a single id (Fixes #5593)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -829,9 +829,13 @@ class BelongsToMany extends Relation {
 		// We'll return the numbers of affected rows when we do the deletes.
 		$ids = (array) $ids;
 
-		if (count($ids) > 0)
+		if (count($ids) > 1)
 		{
 			$query->whereIn($this->otherKey, $ids);
+		}
+		elseif (count($ids) === 1)
+		{
+			$query->where($this->otherKey, reset($ids));
 		}
 
 		if ($touch) $this->touchIfTouching();

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -190,6 +190,22 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDetachWithSingleIDRemovesPivotTableRecord()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$query = m::mock('stdClass');
+		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
+		$query->shouldReceive('where')->once()->with('role_id', 1);
+		$query->shouldReceive('delete')->once()->andReturn(true);
+		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+		$relation->expects($this->once())->method('touchIfTouching');
+
+		$this->assertTrue($relation->detach(array(1)));
+	}
+
+
 	public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
 	{
 		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());


### PR DESCRIPTION
See issue https://github.com/laravel/framework/issues/5593
