### PR TITLE
Fix nested inline if parsing

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -218,7 +218,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 			return isset($match[3]) ? $match[0] : $match[0].$match[2];
 		};
 
-		return preg_replace_callback('/\B@(\w+)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', $callback, $value);
+		return preg_replace_callback('/@(\w+)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', $callback, $value);
 	}
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -452,6 +452,15 @@ empty
 	}
 
 
+	public function testNestedInlineIfStatementsAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$string   = '@if ($foo)<span class="@if ($bar)has-class@endif"></span>@endif';
+		$expected = '<?php if($foo): ?><span class="<?php if($bar): ?>has-class<?php endif; ?>"></span><?php endif; ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
+
+
 	protected function getFiles()
 	{
 		return m::mock('Illuminate\Filesystem\Filesystem');


### PR DESCRIPTION
This should fix the issue in #5661 as reported by @frankmichel, and all tests still pass. I'm not sure if the \B was added to the regex for any particular reason, but if it was just ignore this.

Now lines like `@if ($foo)<span class="@if ($bar)has-class@endif"></span>@endif` will be correctly compiled into `<?php if($foo): ?><span class="<?php if($bar): ?>has-class<?php endif; ?>"></span><?php endif; ?>` whereas previously it was compiled into `<?php if($foo): ?><span class="<?php if($bar): ?>has-class@endif"></span><?php endif; ?>`
