### PR TITLE
Add the opposite of array_dot

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -82,6 +82,22 @@ class Arr {
 
 		return $results;
 	}
+	
+	/**
+	 * Transform an array with dots notation to a multi-dimensional array
+	 * 
+	 * @param array $arrayDotted
+	 * @return array
+	 * /
+	public static function dot_array($arrayDotted){
+		$array = array();
+        
+		foreach ($arrayDotted as $key => $value) {
+			static::set($array, $key, $value);
+        	}
+
+		return $array;
+	}
 
 	/**
 	 * Get all of the given array except for a specified array of items.

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -88,7 +88,7 @@ class Arr {
 	 * 
 	 * @param array $arrayDotted
 	 * @return array
-	 * /
+	 */
 	public static function dot_array($arrayDotted){
 		$array = array();
         

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -501,6 +501,27 @@ if ( ! function_exists('dd'))
 	}
 }
 
+if( ! function_exists('dot_array')){
+
+	/**
+	* Transform an array with dot notation into a multidimensional array
+	* 
+	* @param array $arrayDotted
+	* @return array
+	*/
+	function dot_array($arrayDotted)
+	{
+
+		$array = array();
+        
+		foreach ($arrayDotted as $key => $value) {
+			array_set($array, $key, $value);
+        	}
+
+		return $array;
+	}
+}
+
 if ( ! function_exists('e'))
 {
 	/**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -504,21 +504,14 @@ if ( ! function_exists('dd'))
 if( ! function_exists('dot_array')){
 
 	/**
-	* Transform an array with dot notation into a multidimensional array
+	* Transform an array with dot notation into a multi-dimensional array
 	* 
 	* @param array $arrayDotted
 	* @return array
 	*/
 	function dot_array($arrayDotted)
 	{
-
-		$array = array();
-        
-		foreach ($arrayDotted as $key => $value) {
-			array_set($array, $key, $value);
-        	}
-
-		return $array;
+		return Arr::dot_array($arrayDotted);
 	}
 }
 


### PR DESCRIPTION
Seems that I cannot find the opposite of the array_dot helpers so I made this very practical little helper to help me to transform an array with dot notation to a multidimensional object : 

Ex : 

$arrayDotted = [
  'name' => 'name'
  'data.categories.0' => 'cat-0',
  'data.categories.1' => 'cat-1',
  'data.location.name' => 'location name'
];

$response = dot_array($arrayDotted);

Will return a response like : 

[
  'name' => 'name'
  'data' => [
    'categories' => ['cat-0', 'cat-1'],
    'location' => ['name' => 'location name']
];

The dot notation is very practical to flatten a multidimensional array with this helper you can use it in the opposite for example if you have data from a csv that you cannot have in a multidimensional way => you can use the dot notation an dot_array to handle this.
