### PR TITLE
Remove superfluous `if` condition in Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2542,7 +2542,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// If this value is some other type of string, we'll create the DateTime with
 		// the format used by the database connection. Once we get the instance we
 		// can return back the finally formatted DateTime instances to the devs.
-		elseif ( ! $value instanceof DateTime)
+		else
 		{
 			$value = Carbon::createFromFormat($format, $value);
 		}


### PR DESCRIPTION
The method `Model::fromDateTime()` method has an if/else chain that terminates in a statement that will always evaluate to true given the control flow. The first if condition in the chain is `if ($value instanceof DateTime)`, while the final elseif condition is `elseif ( ! $value instanceof DateTime)`. Since the first condition must be true to arrive at the final check, the negation will always be true at that point, so it is a superfluous condition.
