### PR TITLE
Fixed small comment indentation issue

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -260,14 +260,14 @@ class Command extends \Symfony\Component\Console\Command\Command {
 		return $helper->ask($this->input, $this->output, $question);
 	}
 
-    /**
-     * Format input to textual table
-     *
-     * @param  array   $headers
-     * @param  array   $rows
-     * @param  string  $style
-     * @return void
-     */
+	/**
+	 * Format input to textual table
+	 *
+	 * @param  array   $headers
+	 * @param  array   $rows
+	 * @param  string  $style
+	 * @return void
+	 */
 	public function table(array $headers, array $rows, $style = 'default')
 	{
 		$table = new Table($this->output);


### PR DESCRIPTION
Fixes some indentation with a docblock that uses spaces instead of tabs.
