### PR TITLE
[4.2] Remove useless negated is_null

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -58,7 +58,7 @@ class Repository implements ArrayAccess {
 	{
 		$value = $this->store->get($key);
 
-		return ! is_null($value) ? $value : value($default);
+		return is_null($value) ? value($default) : $value;
 	}
 
 	/**
@@ -123,12 +123,10 @@ class Repository implements ArrayAccess {
 		// If the item exists in the cache we will just return this immediately
 		// otherwise we will execute the given Closure and cache the result
 		// of that execution for the given number of minutes in storage.
-		if ( ! is_null($value = $this->get($key)))
+		if (is_null($value = $this->get($key)))
 		{
-			return $value;
+			$this->put($key, $value = $callback(), $minutes);
 		}
-
-		$this->put($key, $value = $callback(), $minutes);
 
 		return $value;
 	}
@@ -157,12 +155,10 @@ class Repository implements ArrayAccess {
 		// If the item exists in the cache we will just return this immediately
 		// otherwise we will execute the given Closure and cache the result
 		// of that execution for the given number of minutes. It's easy.
-		if ( ! is_null($value = $this->get($key)))
+		if (is_null($value = $this->get($key)))
 		{
-			return $value;
+			$this->forever($key, $value = $callback());
 		}
-
-		$this->forever($key, $value = $callback());
 
 		return $value;
 	}

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -55,7 +55,7 @@ class TaggedCache implements StoreInterface {
 	{
 		$value = $this->store->get($this->taggedItemKey($key));
 
-		return ! is_null($value) ? $value : value($default);
+		return is_null($value) ? value($default) : $value;
 	}
 
 	/**

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -32,7 +32,7 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 		$charset = $config['charset'];
 
 		$names = "set names '$charset'".
-			( ! is_null($collation) ? " collate '$collation'" : '');
+			(is_null($collation) ? '' : " collate '$collation'");
 
 		$connection->prepare($names)->execute();
 

--- a/src/Illuminate/Database/Console/Migrations/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/BaseCommand.php
@@ -36,14 +36,12 @@ class BaseCommand extends Command {
 		// Finally we will check for the workbench option, which is a shortcut into
 		// specifying the full path for a "workbench" project. Workbenches allow
 		// developers to develop packages along side a "standard" app install.
-		if ( ! is_null($bench))
+		if (is_null($bench))
 		{
-			$path = "/workbench/{$bench}/src/migrations";
-
-			return $this->laravel['path.base'].$path;
+			return $this->laravel['path'].'/database/migrations';
 		}
 
-		return $this->laravel['path'].'/database/migrations';
+		return $this->laravel['path.base']."/workbench/{$bench}/src/migrations";
 	}
 
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -109,9 +109,12 @@ class Builder {
 	 */
 	public function findOrFail($id, $columns = array('*'))
 	{
-		if ( ! is_null($model = $this->find($id, $columns))) return $model;
+		if (is_null($model = $this->find($id, $columns)))
+		{
+			throw (new ModelNotFoundException)->setModel(get_class($this->model));
+		}
 
-		throw (new ModelNotFoundException)->setModel(get_class($this->model));
+		return $model;
 	}
 
 	/**
@@ -135,9 +138,12 @@ class Builder {
 	 */
 	public function firstOrFail($columns = array('*'))
 	{
-		if ( ! is_null($model = $this->first($columns))) return $model;
+		if (is_null($model = $this->first($columns)))
+		{
+			throw (new ModelNotFoundException)->setModel(get_class($this->model));
+		}
 
-		throw (new ModelNotFoundException)->setModel(get_class($this->model));
+		return $model;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -536,12 +536,12 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public static function firstOrCreate(array $attributes)
 	{
-		if ( ! is_null($instance = static::where($attributes)->first()))
+		if (is_null($instance = static::where($attributes)->first()))
 		{
-			return $instance;
+			return static::create($attributes);
 		}
 
-		return static::create($attributes);
+		return $instance;
 	}
 
 	/**
@@ -552,12 +552,12 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public static function firstOrNew(array $attributes)
 	{
-		if ( ! is_null($instance = static::where($attributes)->first()))
+		if (is_null($instance = static::where($attributes)->first()))
 		{
-			return $instance;
+			return new static($attributes);
 		}
 
-		return new static($attributes);
+		return $instance;
 	}
 
 	/**
@@ -653,9 +653,9 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public static function findOrNew($id, $columns = array('*'))
 	{
-		if ( ! is_null($model = static::find($id, $columns))) return $model;
+		if (is_null($model = static::find($id, $columns))) return new static;
 
-		return new static;
+		return $model;
 	}
 
 	/**
@@ -669,9 +669,12 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public static function findOrFail($id, $columns = array('*'))
 	{
-		if ( ! is_null($model = static::find($id, $columns))) return $model;
+		if (is_null($model = static::find($id, $columns)))
+		{
+			throw (new ModelNotFoundException)->setModel(get_called_class());
+		}
 
-		throw (new ModelNotFoundException)->setModel(get_called_class());
+		return $model;
 	}
 
 	/**
@@ -1019,7 +1022,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			return ( ! in_array($caller, Model::$manyMethods) && $caller != $self);
 		});
 
-		return ! is_null($caller) ? $caller['function'] : null;
+		return is_null($caller) ? null : $caller['function'];
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -123,9 +123,12 @@ class BelongsToMany extends Relation {
 	 */
 	public function firstOrFail($columns = array('*'))
 	{
-		if ( ! is_null($model = $this->first($columns))) return $model;
+		if (is_null($model = $this->first($columns)))
+		{
+			throw new ModelNotFoundException;
+		}
 
-		throw new ModelNotFoundException;
+		return $model;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1331,9 +1331,9 @@ class Builder {
 	 */
 	public function get($columns = array('*'))
 	{
-		if ( ! is_null($this->cacheMinutes)) return $this->getCached($columns);
+		if (is_null($this->cacheMinutes)) return $this->getFresh($columns);
 
-		return $this->getFresh($columns);
+		return $this->getCached($columns);
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -98,11 +98,12 @@ class Grammar extends BaseGrammar {
 		// If the query is actually performing an aggregating select, we will let that
 		// compiler handle the building of the select clauses, as it will need some
 		// more syntax that is best handled by that function to keep things neat.
-		if ( ! is_null($query->aggregate)) return;
+		if (is_null($query->aggregate))
+		{
+			$select = $query->distinct ? 'select distinct ' : 'select ';
 
-		$select = $query->distinct ? 'select distinct ' : 'select ';
-
-		return $select.$this->columnize($columns);
+			return $select.$this->columnize($columns);
+		}
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -45,19 +45,20 @@ class SqlServerGrammar extends Grammar {
 	 */
 	protected function compileColumns(Builder $query, $columns)
 	{
-		if ( ! is_null($query->aggregate)) return;
-
-		$select = $query->distinct ? 'select distinct ' : 'select ';
-
-		// If there is a limit on the query, but not an offset, we will add the top
-		// clause to the query, which serves as a "limit" type clause within the
-		// SQL Server system similar to the limit keywords available in MySQL.
-		if ($query->limit > 0 && $query->offset <= 0)
+		if (is_null($query->aggregate))
 		{
-			$select .= 'top '.$query->limit.' ';
-		}
+			$select = $query->distinct ? 'select distinct ' : 'select ';
 
-		return $select.$this->columnize($columns);
+			// If there is a limit on the query, but not an offset, we will add the top
+			// clause to the query, which serves as a "limit" type clause within the
+			// SQL Server system similar to the limit keywords available in MySQL.
+			if ($query->limit > 0 && $query->offset <= 0)
+			{
+				$select .= 'top '.$query->limit.' ';
+			}
+
+			return $select.$this->columnize($columns);
+		}
 	}
 
 	/**

--- a/src/Illuminate/Exception/Handler.php
+++ b/src/Illuminate/Exception/Handler.php
@@ -145,18 +145,18 @@ class Handler {
 	{
 		$response = $this->callCustomHandlers($exception);
 
-		// If one of the custom error handlers returned a response, we will send that
-		// response back to the client after preparing it. This allows a specific
-		// type of exceptions to handled by a Closure giving great flexibility.
-		if ( ! is_null($response))
-		{
-			return $this->prepareResponse($response);
-		}
-
 		// If no response was sent by this custom exception handler, we will call the
 		// default exception displayer for the current application context and let
 		// it show the exception to the user / developer based on the situation.
-		return $this->displayException($exception);
+		if (is_null($response))
+		{
+			return $this->displayException($exception);
+		}
+
+		// If one of the custom error handlers returned a response, we will send that
+		// response back to the client after preparing it. This allows a specific
+		// type of exceptions to handled by a Closure giving great flexibility.
+		return $this->prepareResponse($response);
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Artisan.php
+++ b/src/Illuminate/Foundation/Artisan.php
@@ -36,13 +36,16 @@ class Artisan {
 	 */
 	protected function getArtisan()
 	{
-		if ( ! is_null($this->artisan)) return $this->artisan;
+		if (is_null($this->artisan))
+		{
+			$this->app->loadDeferredProviders();
 
-		$this->app->loadDeferredProviders();
+			$this->artisan = ConsoleApplication::make($this->app);
 
-		$this->artisan = ConsoleApplication::make($this->app);
+			return $this->artisan->boot();
+		}
 
-		return $this->artisan->boot();
+		return $this->artisan;
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/AssetPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/AssetPublishCommand.php
@@ -63,13 +63,13 @@ class AssetPublishCommand extends Command {
 	 */
 	protected function publishAssets($package)
 	{
-		if ( ! is_null($path = $this->getPath()))
+		if (is_null($path = $this->getPath()))
 		{
-			$this->assets->publish($package, $path);
+			$this->assets->publishPackage($package);
 		}
 		else
 		{
-			$this->assets->publishPackage($package);
+			$this->assets->publish($package, $path);
 		}
 
 		$this->output->writeln('<info>Assets published for package:</info> '.$package);

--- a/src/Illuminate/Foundation/Console/CommandMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CommandMakeCommand.php
@@ -100,13 +100,13 @@ class CommandMakeCommand extends Command {
 	 */
 	protected function addNamespace($stub)
 	{
-		if ( ! is_null($namespace = $this->input->getOption('namespace')))
+		if (is_null($namespace = $this->input->getOption('namespace')))
 		{
-			return str_replace('{{namespace}}', ' namespace '.$namespace.';', $stub);
+			return str_replace('{{namespace}}', '', $stub);
 		}
 		else
 		{
-			return str_replace('{{namespace}}', '', $stub);
+			return str_replace('{{namespace}}', ' namespace '.$namespace.';', $stub);
 		}
 	}
 

--- a/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigPublishCommand.php
@@ -60,13 +60,13 @@ class ConfigPublishCommand extends Command {
 
 		if ( ! $proceed) return;
 
-		if ( ! is_null($path = $this->getPath()))
+		if (is_null($path = $this->getPath()))
 		{
-			$this->config->publish($package, $path);
+			$this->config->publishPackage($package);
 		}
 		else
 		{
-			$this->config->publishPackage($package);
+			$this->config->publish($package, $path);
 		}
 
 		$this->output->writeln('<info>Configuration published for package:</info> '.$package);

--- a/src/Illuminate/Foundation/Console/ViewPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewPublishCommand.php
@@ -50,13 +50,13 @@ class ViewPublishCommand extends Command {
 	{
 		$package = $this->input->getArgument('package');
 
-		if ( ! is_null($path = $this->getPath()))
+		if (is_null($path = $this->getPath()))
 		{
-			$this->view->publish($package, $path);
+			$this->view->publishPackage($package);
 		}
 		else
 		{
-			$this->view->publishPackage($package);
+			$this->view->publish($package, $path);
 		}
 
 		$this->output->writeln('<info>Views published for package:</info> '.$package);

--- a/src/Illuminate/Foundation/EnvironmentDetector.php
+++ b/src/Illuminate/Foundation/EnvironmentDetector.php
@@ -65,13 +65,14 @@ class EnvironmentDetector {
 		// First we will check if an environment argument was passed via console arguments
 		// and if it was that automatically overrides as the environment. Otherwise, we
 		// will check the environment as a "web" request like a typical HTTP request.
-		if ( ! is_null($value = $this->getEnvironmentArgument($args)))
+		if (is_null($value = $this->getEnvironmentArgument($args)))
 		{
-			return head(array_slice(explode('=', $value), 1));
+			return $this->detectWebEnvironment($environments);
+
 		}
 		else
 		{
-			return $this->detectWebEnvironment($environments);
+			return head(array_slice(explode('=', $value), 1));
 		}
 	}
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -375,7 +375,7 @@ class Request extends SymfonyRequest {
 	 */
 	public function flash($filter = null, $keys = array())
 	{
-		$flash = ( ! is_null($filter)) ? $this->$filter($keys) : $this->input();
+		$flash = is_null($filter) ? $this->input() : $this->$filter($keys);
 
 		$this->session()->flashInput($flash);
 	}

--- a/src/Illuminate/Pagination/Factory.php
+++ b/src/Illuminate/Pagination/Factory.php
@@ -197,9 +197,9 @@ class Factory {
 	 */
 	public function getViewName($view = null)
 	{
-		if ( ! is_null($view)) return $view;
+		if (is_null($view)) return $this->viewName ?: 'pagination::slider';
 
-		return $this->viewName ?: 'pagination::slider';
+		return $view;
 	}
 
 	/**

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -28,7 +28,11 @@ class RetryCommand extends Command {
 	{
 		$failed = $this->laravel['queue.failer']->find($this->argument('id'));
 
-		if ( ! is_null($failed))
+		if (is_null($failed))
+		{
+			$this->error('No failed job matches the given ID.');
+		}
+		else
 		{
 			$failed->payload = $this->resetAttempts($failed->payload);
 
@@ -37,10 +41,6 @@ class RetryCommand extends Command {
 			$this->laravel['queue.failer']->forget($failed->id);
 
 			$this->info('The failed job has been pushed back onto the queue!');
-		}
-		else
-		{
-			$this->error('No failed job matches the given ID.');
 		}
 	}
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -145,17 +145,17 @@ class Worker {
 		// If we're able to pull a job off of the stack, we will process it and
 		// then immediately return back out. If there is no job on the queue
 		// we will "sleep" the worker for the specified number of seconds.
-		if ( ! is_null($job))
-		{
-			return $this->process(
-				$this->manager->getName($connectionName), $job, $maxTries, $delay
-			);
-		}
-		else
+		if (is_null($job))
 		{
 			$this->sleep($sleep);
 
 			return ['job' => null, 'failed' => false];
+		}
+		else
+		{
+			return $this->process(
+				$this->manager->getName($connectionName), $job, $maxTries, $delay
+			);
 		}
 	}
 

--- a/src/Illuminate/Remote/Connection.php
+++ b/src/Illuminate/Remote/Connection.php
@@ -204,9 +204,9 @@ class Connection implements ConnectionInterface {
 	 */
 	protected function getCallback($callback)
 	{
-		if ( ! is_null($callback)) return $callback;
+		if (is_null($callback)) return function($line) { $this->display($line); };
 
-		return function($line) { $this->display($line); };
+		return $callback;
 	}
 
 	/**

--- a/src/Illuminate/Remote/RemoteManager.php
+++ b/src/Illuminate/Remote/RemoteManager.php
@@ -160,9 +160,12 @@ class RemoteManager {
 	{
 		$config = $this->app['config']['remote.connections.'.$name];
 
-		if ( ! is_null($config)) return $config;
+		if (is_null($config))
+		{
+			throw new \InvalidArgumentException("Remote connection [$name] not defined.");
+		}
 
-		throw new \InvalidArgumentException("Remote connection [$name] not defined.");
+		return $config;
 	}
 
 	/**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -223,15 +223,15 @@ class UrlGenerator {
 	{
 		$route = $route ?: $this->routes->getByName($name);
 
-		$parameters = (array) $parameters;
-
-		if ( ! is_null($route))
+		if (is_null($route))
 		{
-			return $this->toRoute($route, $parameters, $absolute);
+			throw new InvalidArgumentException("Route [{$name}] not defined.");
 		}
 		else
 		{
-			throw new InvalidArgumentException("Route [{$name}] not defined.");
+			$parameters = (array) $parameters;
+
+			return $this->toRoute($route, $parameters, $absolute);
 		}
 	}
 

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -86,12 +86,12 @@ class Response {
 	{
 		$response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
 
-		if ( ! is_null($name))
+		if (is_null($name))
 		{
-			return $response->setContentDisposition($disposition, $name, Str::ascii($name));
+			return $response;
 		}
 
-		return $response;
+		return $response->setContentDisposition($disposition, $name, Str::ascii($name));
 	}
 
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -28,12 +28,12 @@ if ( ! function_exists('app'))
 	 */
 	function app($make = null)
 	{
-		if ( ! is_null($make))
+		if (is_null($make))
 		{
-			return app()->make($make);
+			return Illuminate\Support\Facades\Facade::getFacadeApplication();
 		}
 
-		return Illuminate\Support\Facades\Facade::getFacadeApplication();
+		return app()->make($make);
 	}
 }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -266,13 +266,13 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	 */
 	protected function parseLocale($locale)
 	{
-		if ( ! is_null($locale))
+		if (is_null($locale))
 		{
-			return array_filter(array($locale, $this->fallback));
+			return array_filter(array($this->locale, $this->fallback));
 		}
 		else
 		{
-			return array_filter(array($this->locale, $this->fallback));
+			return array_filter(array($locale, $this->fallback));
 		}
 	}
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -323,14 +323,10 @@ class Validator implements MessageProviderInterface {
 	 */
 	protected function getValue($attribute)
 	{
-		if ( ! is_null($value = array_get($this->data, $attribute)))
+		if ( ! is_null($value = array_get($this->data, $attribute, array_get($this->files, $attribute))))
 		{
 			return $value;
-		}
-		elseif ( ! is_null($value = array_get($this->files, $attribute)))
-		{
-			return $value;
-		}
+		};
 	}
 
 	/**


### PR DESCRIPTION
The origin of this PR comes from 7dad0db1bded77ef1a4ec0769355aadea61473c2.
In many cases, a negated `! is_null` check is done, as a single `is_null` check could be sufficient and more performant.
