### PR TITLE
Fix Collection::each not returning modified items

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -103,13 +103,11 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * Execute a callback over each item.
 	 *
 	 * @param  \Closure  $callback
-	 * @return $this
+	 * @return static
 	 */
 	public function each(Closure $callback)
 	{
-		array_map($callback, $this->items);
-
-		return $this;
+		return new static(array_map($callback, $this->items));
 	}
 
 	/**


### PR DESCRIPTION
I assume this was unintentional; or was it meant to be used for repeating an external action instead of manipulating the internal array?

Keeping in line with the other immutable collection methods, this returns a new instance instead of modifying the existing one.
