### PR TITLE
fixes empty namespace error

### DIFF
--- a/src/Illuminate/Routing/RouteServiceProvider.php
+++ b/src/Illuminate/Routing/RouteServiceProvider.php
@@ -57,7 +57,14 @@ class RouteServiceProvider extends ServiceProvider {
 	{
 		$namespace = trim($this->app['config']['namespaces.controllers'], '\\');
 
-		$this->app['router']->group(['namespace' => $namespace], $callback);
+		if (!empty($namespace))
+		{
+			$this->app['router']->group(['namespace' => $namespace], $callback);
+		}
+		else
+		{
+			$callback($this->app['router']);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes the empty namespace error which causes it to always prefix `\`, disallowing the use of `redirector()->action(...)` because that is auto-stripped of `\`. This should be done at the group( ... ).

Personally, I think the auto stripping of `\` shouldn't be there. If I prepend with `\` I expect it to stay.
