### PR TITLE
Allow Custom Messages

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -63,7 +63,7 @@ class FormRequest extends Request {
 	public function validate(ValidationFactory $factory)
 	{
 		$instance = $factory->make(
-			$this->input(), $this->container->call([$this, 'rules'])
+			$this->input(), $this->container->call([$this, 'rules']), $this->container->call([$this, 'messages'])
 		);
 
 		if ($instance->fails())


### PR DESCRIPTION
Allow usage of adding a `messages` function to any FormRequest item.

``` php
    /**
     * Get the error messages that apply to the request.
     * 
     * @return array
     */
    public function messages() {
        return [
                'email.required' => 'We need to know your e-mail address!',
        ];
    }
```

Request #5592 :)
