### PR TITLE
Make getRememberTokenName() Static in UserTrait

### DIFF
--- a/src/Illuminate/Auth/UserTrait.php
+++ b/src/Illuminate/Auth/UserTrait.php
@@ -48,7 +48,7 @@ trait UserTrait {
 	 *
 	 * @return string
 	 */
-	public function getRememberTokenName()
+	public static function getRememberTokenName()
 	{
 		return 'remember_token';
 	}


### PR DESCRIPTION
This method should be static because it just return a static string. It is helpful in migrations.

```
<?php

use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Schema\Blueprint;

class AddRememberTokenToUsersTable extends Migration {

    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::table('users', function(Blueprint $table)
        {
            $table->rememberToken();
        });
    }


    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::table('users', function(Blueprint $table)
        {
            $table->dropColumn(User::getRememberTokenName());
        });
    }

}
```

It will not create problems for people already using arrow notation `->`.
