### PR TITLE
Add messages() method stub

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -224,5 +224,15 @@ class FormRequest extends Request {
 	{
 		return $this->input($key);
 	}
+	
+	/**
+	* Set custom messages for validator errors.
+	*
+	* @return array
+	*/
+	public function messages()
+	{
+		return [];
+	}
 
 }


### PR DESCRIPTION
Add `messages()` method that returns empty array, when missing a
reflection exception is thrown Method
`App\Http\Requests\RegistrationRequest::messages()` does not exist

Fix to pull request: https://github.com/laravel/framework/pull/5675
