### PR TITLE
Errors array should be associative to keep the field names usable

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -146,7 +146,7 @@ class FormRequest extends Request {
 	 */
 	protected function formatErrors(Validator $validator)
 	{
-		return $validator->errors()->all();
+		return $validator->errors()->getMessages();
 	}
 
 	/**


### PR DESCRIPTION
Using `all()` method is preventing the array to return to view in an associative way, since there is no more track, it becomes impossible to match fields and their respective errors, using `getMessages()` instead solves the problem.
