### PR TITLE
Add failing test: Tagged caching (driver "redis")

### DIFF
--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -106,5 +106,14 @@ class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase {
 
 		$redis->flush();
 	}
+	
+	public function testTaggedCacheForever()
+	{
+		$data = ['foo' => 'bar'];
+		Cache::tags('tag')->flush();
+		Cache::tags('tag')->forever('data', $data);
+		$cachedData = Cache::tags('tag')->get('data');
+		$this->assertTrue($cachedData === ['foo' => 'bar']);
+	}
 
 }


### PR DESCRIPTION
This test passes with cache driver "array" but fails with cache driver "redis". I came across the issue in my own app and double-checked with a fresh vanilla 4.3 install. My Redis installation should be alright.

Could not find the problem myself but just realized that the test passes when line 114 is changed to `Cache::tags('tag')->put('data', $data, 100);` so the tags()->forever() combo appears to be the issue.

PS: Hope I got the new bug report flow right.
