### PR TITLE
setKeyName in Eloquent/Model: Set the primary key for the model.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1858,6 +1858,16 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
+	 * Set the primary key for the model.
+	 *
+	 * @return void
+	 */
+	public function setKeyName($key)
+	{
+		$this->primaryKey = $key;
+	}
+
+	/**
 	 * Get the table qualified key name.
 	 *
 	 * @return string


### PR DESCRIPTION
There are 'set' methods defined for table name and other properties, but there are no 'set' for the primary key.

This method will be useful in models of tables representing many-to-many relationship, that have foreign keys attributes but doesn't have primary key defined. Also, it can be used to create custom models which are not inherited from Eloquent/Model.
