### PR TITLE
Fixed the bug of replication of redis queue jobs

### DIFF
--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -86,8 +86,10 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 	{
 		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
-		$redis->shouldReceive('zrangebyscore')->once()->with('from', '-inf', 1)->andReturn(array('foo', 'bar'));
-		$redis->shouldReceive('zremrangebyscore')->once()->with('from', '-inf', 1);
+		$redis->shouldReceive('transaction')->once()->andReturn($redis);
+		$redis->shouldReceive('zrangebyscore')->once()->with('from', '-inf', 1)->andReturn($redis);
+		$redis->shouldReceive('zremrangebyscore')->once()->with('from', '-inf', 1)->andReturn($redis);
+		$redis->shouldReceive('execute')->once()->andReturn(array(array('foo', 'bar'), 1));
 		$redis->shouldReceive('rpush')->once()->with('to', 'foo', 'bar');
 
 		$queue->migrateExpiredJobs('from', 'to');


### PR DESCRIPTION
The bug arose in a very special case - when there are more than one worker processing the jobs off the Redis queue.

When a job fails, it is passed into `:delayed` sorted set where worker gets to pick it up in next call of `pop()` method. The `pop()` method gets the jobs from `:delayed` sorted set in one query and then remove them in another query. As this process of **fetching and removing** is not atomic, many workers can fetch the job simultaneously before anyone removes it from the sorted set, thus creating a copy of job with each worker.

The solution to this bug is to process the **fetching and removing** in a transaction, which this pull request does.
