### PR TITLE
Fixed the *ix plural regular expression replacing the pattern in the middle of a word

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -11,7 +11,7 @@ class Pluralizer {
 		'/(quiz)$/i' => "$1zes",
 		'/^(ox)$/i' => "$1en",
 		'/([m|l])ouse$/i' => "$1ice",
-		'/(matr|vert|ind)ix|ex$/i' => "$1ices",
+		'/(matr|vert|ind)ix$|ex$/i' => "$1ices",
 		'/(stoma|epo|monar|matriar|patriar|oligar|eunu)ch$/i' => "$1chs",
 		'/(x|ch|ss|sh)$/i' => "$1es",
 		'/([^aeiouy]|qu)y$/i' => "$1ies",

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -33,4 +33,12 @@ class SupportPluralizerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('CRITERION', str_singular('CRITERIA'));
 	}
 
+	public function testIfEndOfWord()
+	{
+		$this->assertEquals('VortexFields', str_plural('VortexField'));
+		$this->assertEquals('MatrixFields', str_plural('MatrixField'));
+		$this->assertEquals('IndexFields', str_plural('IndexField'));
+		$this->assertEquals('VertexFields', str_plural('VertexField'));
+	}
+
 }


### PR DESCRIPTION
Fixed the *ix plural regular expression replacing the pattern in the middle of a word
