### PR TITLE
Fix: login failed url

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/controller.stub
+++ b/src/Illuminate/Auth/Console/stubs/controller.stub
@@ -77,7 +77,7 @@ class AuthController extends Controller {
 			return redirect('/');
 		}
 
-		return redirect('/login')->withErrors([
+		return redirect()->back()->withErrors([
 			'email' => 'The credentials you entered did not match our records. Try again?',
 		]);
 	}


### PR DESCRIPTION
By default getLogin url have auth prefix, this not match. The best way, if attempt is failed go back.
Look at https://github.com/laravel/laravel/blob/develop/app/Http/Filters/AuthFilter.php#L26
