### PR TITLE
Prevent array_forget() from mixing up references

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -176,6 +176,8 @@ class Arr {
 	 */
 	public static function forget(&$array, $keys)
 	{
+		$original =& $array;
+
 		foreach ((array) $keys as $key)
 		{
 			$parts = explode('.', $key);
@@ -191,6 +193,9 @@ class Arr {
 			}
 
 			unset($array[array_shift($parts)]);
+
+			// clean up after each pass
+			$array =& $original;
 		}
 	}
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -47,6 +47,11 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse(isset($array['names']['developer']));
 		$this->assertFalse(isset($array['names']['otherDeveloper']));
 		$this->assertTrue(isset($array['names']['thirdDeveloper']));
+
+		$array = ['names' => ['developer' => 'taylor', 'otherDeveloper' => 'dayle'], 'otherNames' => ['developer' => 'Lucas', 'otherDeveloper' => 'Graham']];
+		array_forget($array, ['names.developer', 'otherNames.otherDeveloper']);
+		$expected = ['names' => ['otherDeveloper' => 'dayle'], 'otherNames' => ['developer' => 'Lucas']];
+		$this->assertEquals($expected, $array);
 	}
 
 


### PR DESCRIPTION
As `Arr::forget()` iteratively descends through `$array`, it changes the reference. If only one key is provided, or if all keys to forget have the same parent, that's ok. But since it never ascends back up to the original `$array`, additional unrelated keys cause some very funny things to start happening.

This PR includes the fix and an addition to `testArrayForget()` which will reproduce the problem in the old code.
