### PR TITLE
[4.2] fix bug 'cache paginated query with key'

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1622,14 +1622,15 @@ class Builder {
 	 */
 	public function getPaginationCount()
 	{
-		$this->backupFieldsForCount();
-
 		// Because some database engines may throw errors if we leave the ordering
 		// statements on the query, we will "back them up" and remove them from
 		// the query. Once we have the count we will put them back onto this.
+		$this->backupFieldsForPaginationCount();
+
+		$this->setCacheKeyForPaginationCount();
 		$total = $this->count();
 
-		$this->restoreFieldsForCount();
+		$this->restoreFieldsForPaginationCount();
 
 		return $total;
 	}
@@ -1661,9 +1662,9 @@ class Builder {
 	 *
 	 * @return void
 	 */
-	protected function backupFieldsForCount()
+	protected function backupFieldsForPaginationCount()
 	{
-		foreach (array('orders', 'limit', 'offset') as $field)
+		foreach (array('orders', 'limit', 'offset', 'cacheKey') as $field)
 		{
 			$this->backups[$field] = $this->{$field};
 
@@ -1677,14 +1678,24 @@ class Builder {
 	 *
 	 * @return void
 	 */
-	protected function restoreFieldsForCount()
+	protected function restoreFieldsForPaginationCount()
 	{
-		foreach (array('orders', 'limit', 'offset') as $field)
+		foreach (array('orders', 'limit', 'offset', 'cacheKey') as $field)
 		{
 			$this->{$field} = $this->backups[$field];
 		}
 
 		$this->backups = array();
+	}
+
+	/**
+	 * Modify cacheKey for a pagination count when it set for base query.
+	 *
+	 * @return void
+	 */
+	protected function setCacheKeyForPaginationCount()
+	{
+		$this->cacheKey = $this->backups['cacheKey'] ? $this->backups['cacheKey'].'_paginate' : '';
 	}
 
 	/**


### PR DESCRIPTION
see problem for example here:
 https://laracasts.com/forum/?p=53-how-to-cache-paginated-query-with-key/0
 http://laravel.io/forum/05-17-2014-query-builder-with-rememberrememberforever-and-paginate

When we make cached paginate query with cache key 
(like `DB::...->remember($time, $key) ->paginate($count)`). 
There should be two queries (get count and the limited query), and second query does not executes, because it gets from cache.
