### PR TITLE
[proposal] Use PHPUnit static assertions in AssertionsTrait

### DIFF
--- a/src/Illuminate/Foundation/Testing/AssertionsTrait.php
+++ b/src/Illuminate/Foundation/Testing/AssertionsTrait.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Foundation\Testing;
 
 use Illuminate\View\View;
+use PHPUnit_Framework_Assert as PHPUnit;
 
 trait AssertionsTrait {
 
@@ -15,7 +16,7 @@ trait AssertionsTrait {
 
 		$actual = $response->getStatusCode();
 
-		return $this->assertTrue($response->isOk(), 'Expected status code 200, got ' .$actual);
+		return PHPUnit::assertTrue($response->isOk(), 'Expected status code 200, got ' .$actual);
 	}
 
 	/**
@@ -26,7 +27,7 @@ trait AssertionsTrait {
 	 */
 	public function assertResponseStatus($code)
 	{
-		return $this->assertEquals($code, $this->client->getResponse()->getStatusCode());
+		return PHPUnit::assertEquals($code, $this->client->getResponse()->getStatusCode());
 	}
 
 	/**
@@ -44,16 +45,16 @@ trait AssertionsTrait {
 
 		if ( ! isset($response->original) || ! $response->original instanceof View)
 		{
-			return $this->assertTrue(false, 'The response was not a view.');
+			return PHPUnit::assertTrue(false, 'The response was not a view.');
 		}
 
 		if (is_null($value))
 		{
-			$this->assertArrayHasKey($key, $response->original->getData());
+			PHPUnit::assertArrayHasKey($key, $response->original->getData());
 		}
 		else
 		{
-			$this->assertEquals($value, $response->original->$key);
+			PHPUnit::assertEquals($value, $response->original->$key);
 		}
 	}
 
@@ -90,10 +91,10 @@ trait AssertionsTrait {
 
 		if ( ! isset($response->original) || ! $response->original instanceof View)
 		{
-			return $this->assertTrue(false, 'The response was not a view.');
+			return PHPUnit::assertTrue(false, 'The response was not a view.');
 		}
 
-		$this->assertArrayNotHasKey($key, $response->original->getData());
+		PHPUnit::assertArrayNotHasKey($key, $response->original->getData());
 	}
 
 	/**
@@ -107,9 +108,9 @@ trait AssertionsTrait {
 	{
 		$response = $this->client->getResponse();
 
-		$this->assertInstanceOf('Illuminate\Http\RedirectResponse', $response);
+		PHPUnit::assertInstanceOf('Illuminate\Http\RedirectResponse', $response);
 
-		$this->assertEquals($this->app['url']->to($uri), $response->headers->get('Location'));
+		PHPUnit::assertEquals($this->app['url']->to($uri), $response->headers->get('Location'));
 
 		$this->assertSessionHasAll($with);
 	}
@@ -153,11 +154,11 @@ trait AssertionsTrait {
 
 		if (is_null($value))
 		{
-			$this->assertTrue($this->app['session.store']->has($key), "Session missing key: $key");
+			PHPUnit::assertTrue($this->app['session.store']->has($key), "Session missing key: $key");
 		}
 		else
 		{
-			$this->assertEquals($value, $this->app['session.store']->get($key));
+			PHPUnit::assertEquals($value, $this->app['session.store']->get($key));
 		}
 	}
 
@@ -201,11 +202,11 @@ trait AssertionsTrait {
 		{
 			if (is_int($key))
 			{
-				$this->assertTrue($errors->has($value), "Session missing error: $value");
+				PHPUnit::assertTrue($errors->has($value), "Session missing error: $value");
 			}
 			else
 			{
-				$this->assertContains($value, $errors->get($key, $format));
+				PHPUnit::assertContains($value, $errors->get($key, $format));
 			}
 		}
 	}


### PR DESCRIPTION
Since the AssertionsTrait now depends on inheritance from PHPUnit, it is not possible to use it outside of PHPUnit test cases. With this simple change, the trait can easily be used together with other testing frameworks, such as Behat.

Ps. I'm not sure if this is the right way to do proposals like this, and I understand that there have been some changes. If not, please point me in the right direction and I'll make the changes necessary.
