### PR TITLE
Configurable path for environment "dot" files

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1018,7 +1018,9 @@ class Application extends Container implements HttpKernelInterface,
 	 */
 	public function getEnvironmentVariablesLoader()
 	{
-		return new FileEnvironmentVariablesLoader(new Filesystem, $this['path.base']);
+		$env = $this->bound('path.env') ? $this['path.env'] : $this['path.base'];
+
+		return new FileEnvironmentVariablesLoader(new Filesystem, $env);
 	}
 
 	/**


### PR DESCRIPTION
As per laravel-dev discussion, adds the ability to specify a path other than path.base that contains environment "dot" files.

The particular use case is a server with multiple laravel codebases that share the same configuration information (S3 keys etc), should be able to have their *.env.php external to the project root for ease of configuration.

I have created an associated pull request for laravel/laravel that adds a path.env entry to paths.php
https://github.com/laravel/laravel/pull/3015
