### PR TITLE
Revert a change to a symfony version constraint

### DIFF
--- a/src/Illuminate/Workbench/composer.json
+++ b/src/Illuminate/Workbench/composer.json
@@ -11,7 +11,7 @@
         "php": ">=5.4.0",
         "illuminate/filesystem": "~5.0",
         "illuminate/support": "~5.0",
-        "symfony/finder": "~2.3"
+        "symfony/finder": "2.6.*"
     },
     "require-dev": {
         "illuminate/console": "~5.0"


### PR DESCRIPTION
Before you said that you wanted to keep all the symfony versions locked. Would you re-consider for 5.0?

If you decide you still want to lock the versions, then this pull requests should be merged to restore the locking you wanted before.
