### PR TITLE
Differentiate between laravel base and composer base

### DIFF
--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -108,7 +108,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	{
 		$this->app->bindShared('command.migrate', function($app)
 		{
-			$packagePath = $app['path.base'].'/vendor';
+			$packagePath = $app['path.composer'].'/vendor';
 
 			return new MigrateCommand($app['migrator'], $packagePath);
 		});
@@ -190,7 +190,7 @@ class MigrationServiceProvider extends ServiceProvider {
 			// creation of the migrations, and may be extended by these developers.
 			$creator = $app['migration.creator'];
 
-			$packagePath = $app['path.base'].'/vendor';
+			$packagePath = $app['path.composer'].'/vendor';
 
 			return new MigrateMakeCommand($creator, $packagePath);
 		});

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -193,6 +193,12 @@ class Application extends Container implements HttpKernelInterface,
 	{
 		$this->instance('path', realpath($paths['app']));
 
+		// Defaults path.composer to path.base
+		if (!isset($paths['composer']) && isset($paths['base']))
+		{
+			$paths['composer'] = $paths['base'];
+		}
+
 		// Here we will bind the install paths into the container as strings that can be
 		// accessed from any point in the system. Each path key is prefixed with path
 		// so that they have the consistent naming convention inside the container.

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -255,7 +255,7 @@ class AppNameCommand extends Command {
 	 */
 	protected function getComposerPath()
 	{
-		return $this->laravel['path.base'].'/composer.json';
+		return $this->laravel['path.composer'].'/composer.json';
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/AssetPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/AssetPublishCommand.php
@@ -101,7 +101,7 @@ class AssetPublishCommand extends Command {
 	 */
 	protected function findAllAssetPackages()
 	{
-		$vendor = $this->laravel['path.base'].'/vendor';
+		$vendor = $this->laravel['path.composer'].'/vendor';
 
 		$packages = array();
 

--- a/src/Illuminate/Foundation/Console/MigratePublishCommand.php
+++ b/src/Illuminate/Foundation/Console/MigratePublishCommand.php
@@ -43,7 +43,7 @@ class MigratePublishCommand extends Command {
 	 */
 	protected function getSourcePath()
 	{
-		$vendor = $this->laravel['path.base'].'/vendor';
+		$vendor = $this->laravel['path.composer'].'/vendor';
 
 		return $vendor.'/'.$this->argument('package').'/src/migrations';
 	}

--- a/src/Illuminate/Foundation/Console/Optimize/config.php
+++ b/src/Illuminate/Foundation/Console/Optimize/config.php
@@ -1,6 +1,6 @@
 <?php
 
-$basePath = $app['path.base'];
+$basePath = $app['path.composer'];
 
 return array_map('realpath', array(
     $basePath.'/vendor/laravel/framework/src/Illuminate/Contracts/Container/Container.php',

--- a/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
@@ -22,7 +22,7 @@ class ComposerServiceProvider extends ServiceProvider {
 	{
 		$this->app->bindShared('composer', function($app)
 		{
-			return new Composer($app['files'], $app['path.base']);
+			return new Composer($app['files'], $app['path.composer']);
 		});
 
 		$this->app->bindShared('command.dump-autoload', function($app)


### PR DESCRIPTION
This change makes the difference between the following paths explicit, whereas currently they both run off `path.base`:
- the path where the laravel/laravel app is installed
- the path where `composer.json` is stored, it's assumed that `vendor/` in the same place

This change supports the following use case, which we're using on a current project, and likely to use on more.
- we like having all our code in one repository for a particular application
- we have multiple endpoints to this application, that we want to keep separate
  - public facing front-end
  - backend for administration
  - an API
- we want each of these to sit in their own directory, with their own controllers, assets, routes and what-not.
- each of these `ports` interacts with an separate domain model, which uses illuminate packages.

So, we need each `port` to be in a sub-directory, and hence we this commit allows us to do that, whilst still defaulting to the current behaviour.

I will follow this up shortly with a PR on https://github.com/laravel/laravel.
