### PR TITLE
Remove hardcoded middlewares

### DIFF
--- a/src/Illuminate/Cookie/CookieServiceProvider.php
+++ b/src/Illuminate/Cookie/CookieServiceProvider.php
@@ -18,4 +18,16 @@ class CookieServiceProvider extends ServiceProvider {
 			return (new CookieJar)->setDefaultPathAndDomain($config['path'], $config['domain']);
 		});
 	}
+
+	/**
+	 * Bootstrap the application events.
+	 *
+	 * @return void
+	 */
+	public function boot()
+	{
+		$this->app->middleware('Illuminate\Cookie\Guard', [$this->app['encrypter']]);
+		$this->app->middleware('Illuminate\Cookie\Queue', [$this->app['cookie']]);
+	}
+
 }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -116,8 +116,6 @@ class Application extends Container implements HttpKernelInterface,
 		$this->registerBaseBindings($request ?: $this->createNewRequest());
 
 		$this->registerBaseServiceProviders();
-
-		$this->registerBaseMiddlewares();
 	}
 
 	/**
@@ -676,25 +674,19 @@ class Application extends Container implements HttpKernelInterface,
 	 */
 	protected function getStackedClient()
 	{
-		$sessionReject = $this->bound('session.reject') ? $this['session.reject'] : null;
-
-		$client = (new Builder)
-                    ->push('Illuminate\Cookie\Guard', $this['encrypter'])
-                    ->push('Illuminate\Cookie\Queue', $this['cookie'])
-                    ->push('Illuminate\Session\Middleware', $this['session'], $sessionReject);
-
-		$this->mergeCustomMiddlewares($client);
+		$client = new Builder;
+		$this->mergeMiddlewares($client);
 
 		return $client->resolve($this);
 	}
 
 	/**
-	 * Merge the developer defined middlewares onto the stack.
+	 * Merge the middlewares onto the stack.
 	 *
 	 * @param  \Stack\Builder
 	 * @return void
 	 */
-	protected function mergeCustomMiddlewares(Builder $stack)
+	protected function mergeMiddlewares(Builder $stack)
 	{
 		foreach ($this->middlewares as $middleware)
 		{
@@ -704,16 +696,6 @@ class Application extends Container implements HttpKernelInterface,
 
 			call_user_func_array(array($stack, 'push'), $parameters);
 		}
-	}
-
-	/**
-	 * Register the default, but optional middlewares.
-	 *
-	 * @return void
-	 */
-	protected function registerBaseMiddlewares()
-	{
-		//
 	}
 
 	/**

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -17,6 +17,18 @@ class SessionServiceProvider extends ServiceProvider {
 
 		$this->registerSessionDriver();
 	}
+	
+	/**
+	 * Bootstrap the application events.
+	 *
+	 * @return void
+	 */
+	public function boot()
+	{
+		$sessionReject = $this->app->bound('session.reject') ? $this->app['session.reject'] : null;
+		
+		$this->app->middleware('Illuminate\Session\Middleware', [$this->app['session'], $sessionReject]);
+	}
 
 	/**
 	 * Setup the default session driver for the application.


### PR DESCRIPTION
This goes back to issue #3440 (for anybody with access to the GitHub database, hehe).

The original problem: Cookies will always be encrypted, which is fine until you want to do either of these things:
- access cookies from other applications (which means you'll have to use the `$_COOKIE` superglobal, yuck)
- share a cookie with a JS frontend

At the core of the problem was the old `getStackedClient()` method, which had some middlewares hardcoded. One of them was `Illuminate\Cookie\Guard`, which encrypts all the cookies. Yay!

Making them configurable (or at least removable, using the `forgetMiddleware()` method) would mean using the `middleware()` method to register them.

We could do that in the application class (best place: right before service providers are booted). Or we could move it to service providers, which is what I did now.

Another problem arises when we go that way: the order of the middleware matters, the guard middleware has to be first, because it encrypts all the cookies. Both of the other ones set cookies. This is no problem for the cookie queue, but for the session middleware I can only guarantee the order by making sure the session service provider is booted after the cookie service provider (which happens to be the case in laravel/laravel right now). Thus: not a good solution.

An old proposal by @leesherwood was to make the middlewares configurable (just like service providers and facades), that might be an easy solution.

Regarding the original discussion and not encrypting cookies: we may have to add a flag or another class for un-encrypted cookies. But that's another discussion...
