### PR TITLE
Add public iterate() method to validator

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -244,6 +244,8 @@ class Validator implements MessageProviderInterface {
 	 * @param  string  $attribute
 	 * @param  array   $ruleSet
 	 * @param  array   $messages
+	 * @return void
+	 *
 	 * @throws \InvalidArgumentException
 	 */
 	public function iterate($attribute, array $ruleSet = [], $messages = [])
@@ -267,7 +269,6 @@ class Validator implements MessageProviderInterface {
 			$this->addIteratedValidationRules($attribute.'.'.$i.'.', $ruleSet, $messages);
 		}
 	}
-
 
 	/**
 	 * Merge additional rules into a given attribute.
@@ -2556,7 +2557,6 @@ class Validator implements MessageProviderInterface {
 			throw new \InvalidArgumentException("Validation rule $rule requires at least $count parameters.");
 		}
 	}
-
 
 	/**
 	 * Add rules for a particular index of an array.

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -239,6 +239,37 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
+	 * Add rules to be applied to a repeatable indexed array
+	 *
+	 * @param $attribute
+	 * @param array $ruleSet
+	 * @param array $messages
+	 * @throws \InvalidArgumentException
+	 */
+	public function iterate($attribute, array $ruleSet = [], $messages = [])
+	{
+		$payload = array_merge($this->data, $this->files);
+		$input = array_get($payload, $attribute);
+
+		if (!is_null($input) && !is_array($input))
+		{
+			throw new \InvalidArgumentException('Attribute for iterate() must be an array.');
+		}
+
+		if (!$entries = count($input))
+		{
+			//Whatever you're trying to iterate, the payload didn't have any
+			return;
+		}
+
+		for ($i = 0; $i < $entries; $i++)
+		{
+			$this->addIteratedValidationRules($attribute.'.'.$i.'.', $ruleSet, $messages);
+		}
+	}
+
+
+	/**
 	 * Merge additional rules into a given attribute.
 	 *
 	 * @param  string  $attribute
@@ -2524,6 +2555,74 @@ class Validator implements MessageProviderInterface {
 		{
 			throw new \InvalidArgumentException("Validation rule $rule requires at least $count parameters.");
 		}
+	}
+
+
+	/**
+	 * Add rules for a particular index of an array
+	 *
+	 * @param string $attribute
+	 * @param array $ruleSet
+	 * @param array $messages
+	 *
+	 * @return void
+	 */
+	protected function addIteratedValidationRules($attribute, $ruleSet = [], $messages = [])
+	{
+		foreach ($ruleSet as $field => $rules)
+		{
+			$rules = str_replace('required_with_parent', rtrim('required_with:'.$attribute, '.'), $rules);
+			$rules = is_string($rules) ? explode('|', $rules) : $rules;
+
+			//If it contains nested iterated items, recursively add validation rules for them too
+			if(isset($rules['iterate']))
+			{
+				$this->iterateNestedRuleSet($attribute.$field, $rules);
+				unset($rules['iterate']);
+			}
+
+			$this->mergeRules($attribute.$field, $rules);
+		}
+
+		$this->addIteratedValidationMessages($attribute, $messages);
+	}
+
+	/**
+	 * Add custom messages to be applied at a particular index of a repeating input array
+	 *
+	 * @param $attribute
+	 * @param array $messages
+	 *
+	 * @return void
+	 */
+	protected function addIteratedValidationMessages($attribute, $messages = [])
+	{
+		foreach ($messages as $field => $message)
+		{
+			$field_name = $attribute.$field;
+			$messages[$field_name] = $message;
+		}
+
+		$this->setCustomMessages($messages);
+	}
+
+	/**
+	 * Apply the iterate() function to a set of rules and messages
+	 * Used for cleaner recursive calls to iterate(), when nested
+	 * repeatable fields are present
+	 *
+	 * @see addIteratedValidationRules()
+	 * @param $attribute
+	 * @param $rules
+	 *
+	 * @return void
+	 */
+	protected function iterateNestedRuleSet($attribute, $rules)
+	{
+		$nestedRuleSet = isset($rules['iterate']['rules']) ? $rules['iterate']['rules'] : [];
+		$nestedMessages = isset($rules['iterate']['messages']) ? $rules['iterate']['messages'] : [];
+
+		$this->iterate($attribute, $nestedRuleSet, $nestedMessages);
 	}
 
 	/**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -239,11 +239,11 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
-	 * Add rules to be applied to a repeatable indexed array
+	 * Add rules to be applied to a repeatable indexed array.
 	 *
-	 * @param $attribute
-	 * @param array $ruleSet
-	 * @param array $messages
+	 * @param  string  $attribute
+	 * @param  array  $ruleSet
+	 * @param  array  $messages
 	 * @throws \InvalidArgumentException
 	 */
 	public function iterate($attribute, array $ruleSet = [], $messages = [])
@@ -2559,12 +2559,11 @@ class Validator implements MessageProviderInterface {
 
 
 	/**
-	 * Add rules for a particular index of an array
+	 * Add rules for a particular index of an array.
 	 *
-	 * @param string $attribute
-	 * @param array $ruleSet
-	 * @param array $messages
-	 *
+	 * @param  string  $attribute
+	 * @param  array  $ruleSet
+	 * @param  array  $messages
 	 * @return void
 	 */
 	protected function addIteratedValidationRules($attribute, $ruleSet = [], $messages = [])
@@ -2574,7 +2573,7 @@ class Validator implements MessageProviderInterface {
 			$rules = str_replace('required_with_parent', rtrim('required_with:'.$attribute, '.'), $rules);
 			$rules = is_string($rules) ? explode('|', $rules) : $rules;
 
-			//If it contains nested iterated items, recursively add validation rules for them too
+			//If it contains nested iterated items, recursively add validation rules for them too.
 			if(isset($rules['iterate']))
 			{
 				$this->iterateNestedRuleSet($attribute.$field, $rules);
@@ -2588,11 +2587,10 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
-	 * Add custom messages to be applied at a particular index of a repeating input array
+	 * Add custom messages to be applied at a particular index of a repeating input array.
 	 *
-	 * @param $attribute
-	 * @param array $messages
-	 *
+	 * @param  string  $attribute
+	 * @param  array  $messages
 	 * @return void
 	 */
 	protected function addIteratedValidationMessages($attribute, $messages = [])
@@ -2609,12 +2607,11 @@ class Validator implements MessageProviderInterface {
 	/**
 	 * Apply the iterate() function to a set of rules and messages
 	 * Used for cleaner recursive calls to iterate(), when nested
-	 * repeatable fields are present
+	 * repeatable fields are present.
 	 *
 	 * @see addIteratedValidationRules()
-	 * @param $attribute
-	 * @param $rules
-	 *
+	 * @param  string  $attribute
+	 * @param  array  $rules
 	 * @return void
 	 */
 	protected function iterateNestedRuleSet($attribute, $rules)

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2608,7 +2608,7 @@ class Validator implements MessageProviderInterface {
 	 * Apply the iterate() function to a set of rules and messages.
 	 *
 	 * @see addIteratedValidationRules()
-	 * 
+	 *
 	 * @param  string  $attribute
 	 * @param  array   $rules
 	 * @return void

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -242,8 +242,8 @@ class Validator implements MessageProviderInterface {
 	 * Add rules to be applied to a repeatable indexed array.
 	 *
 	 * @param  string  $attribute
-	 * @param  array  $ruleSet
-	 * @param  array  $messages
+	 * @param  array   $ruleSet
+	 * @param  array   $messages
 	 * @throws \InvalidArgumentException
 	 */
 	public function iterate($attribute, array $ruleSet = [], $messages = [])
@@ -2562,8 +2562,8 @@ class Validator implements MessageProviderInterface {
 	 * Add rules for a particular index of an array.
 	 *
 	 * @param  string  $attribute
-	 * @param  array  $ruleSet
-	 * @param  array  $messages
+	 * @param  array   $ruleSet
+	 * @param  array   $messages
 	 * @return void
 	 */
 	protected function addIteratedValidationRules($attribute, $ruleSet = [], $messages = [])
@@ -2590,7 +2590,7 @@ class Validator implements MessageProviderInterface {
 	 * Add custom messages to be applied at a particular index of a repeating input array.
 	 *
 	 * @param  string  $attribute
-	 * @param  array  $messages
+	 * @param  array   $messages
 	 * @return void
 	 */
 	protected function addIteratedValidationMessages($attribute, $messages = [])
@@ -2609,7 +2609,7 @@ class Validator implements MessageProviderInterface {
 	 *
 	 * @see addIteratedValidationRules()
 	 * @param  string  $attribute
-	 * @param  array  $rules
+	 * @param  array   $rules
 	 * @return void
 	 */
 	protected function iterateNestedRuleSet($attribute, $rules)

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2605,9 +2605,7 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
-	 * Apply the iterate() function to a set of rules and messages
-	 * Used for cleaner recursive calls to iterate(), when nested
-	 * repeatable fields are present.
+	 * Apply the iterate() function to a set of rules and messages.
 	 *
 	 * @see addIteratedValidationRules()
 	 * @param  string  $attribute

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -239,11 +239,13 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
-	 * Add rules to be applied to a repeatable indexed array
+	 * Add rules to be applied to a repeatable indexed array.
 	 *
-	 * @param $attribute
-	 * @param array $ruleSet
-	 * @param array $messages
+	 * @param  string  $attribute
+	 * @param  array   $ruleSet
+	 * @param  array   $messages
+	 * @return void
+	 *
 	 * @throws \InvalidArgumentException
 	 */
 	public function iterate($attribute, array $ruleSet = [], $messages = [])
@@ -267,7 +269,6 @@ class Validator implements MessageProviderInterface {
 			$this->addIteratedValidationRules($attribute.'.'.$i.'.', $ruleSet, $messages);
 		}
 	}
-
 
 	/**
 	 * Merge additional rules into a given attribute.
@@ -2557,14 +2558,12 @@ class Validator implements MessageProviderInterface {
 		}
 	}
 
-
 	/**
-	 * Add rules for a particular index of an array
+	 * Add rules for a particular index of an array.
 	 *
-	 * @param string $attribute
-	 * @param array $ruleSet
-	 * @param array $messages
-	 *
+	 * @param  string  $attribute
+	 * @param  array   $ruleSet
+	 * @param  array   $messages
 	 * @return void
 	 */
 	protected function addIteratedValidationRules($attribute, $ruleSet = [], $messages = [])
@@ -2574,7 +2573,7 @@ class Validator implements MessageProviderInterface {
 			$rules = str_replace('required_with_parent', rtrim('required_with:'.$attribute, '.'), $rules);
 			$rules = is_string($rules) ? explode('|', $rules) : $rules;
 
-			//If it contains nested iterated items, recursively add validation rules for them too
+			//If it contains nested iterated items, recursively add validation rules for them too.
 			if(isset($rules['iterate']))
 			{
 				$this->iterateNestedRuleSet($attribute.$field, $rules);
@@ -2588,11 +2587,10 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
-	 * Add custom messages to be applied at a particular index of a repeating input array
+	 * Add custom messages to be applied at a particular index of a repeating input array.
 	 *
-	 * @param $attribute
-	 * @param array $messages
-	 *
+	 * @param  string  $attribute
+	 * @param  array   $messages
 	 * @return void
 	 */
 	protected function addIteratedValidationMessages($attribute, $messages = [])
@@ -2607,14 +2605,12 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
-	 * Apply the iterate() function to a set of rules and messages
-	 * Used for cleaner recursive calls to iterate(), when nested
-	 * repeatable fields are present
+	 * Apply the iterate() function to a set of rules and messages.
 	 *
 	 * @see addIteratedValidationRules()
-	 * @param $attribute
-	 * @param $rules
 	 *
+	 * @param  string  $attribute
+	 * @param  array   $rules
 	 * @return void
 	 */
 	protected function iterateNestedRuleSet($attribute, $rules)

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2608,6 +2608,7 @@ class Validator implements MessageProviderInterface {
 	 * Apply the iterate() function to a set of rules and messages.
 	 *
 	 * @see addIteratedValidationRules()
+	 * 
 	 * @param  string  $attribute
 	 * @param  array   $rules
 	 * @return void

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1347,7 +1347,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 	}
 
-	
+
 	public function testIteratingValidatorCanFailWithNoNesting()
 	{
 		$input = $this->iteratingInput();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1347,6 +1347,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 	}
 
+	
 	public function testIteratingValidatorCanFailWithNoNesting()
 	{
 		$input = $this->iteratingInput();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1332,6 +1332,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($v->passes());
 	}
 
+
 	public function testIterableValidator()
 	{
 		// Test that it can pass with no nested arrays
@@ -1419,10 +1420,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertTrue($v->fails());
-
 	}
-
-
 
 
 	protected function getTranslator()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1332,23 +1332,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($v->passes());
 	}
 
-	public function testIterableValidator()
+
+	public function testIteratingValidatorCanPasWithNoNesting()
 	{
-		// Test that it can pass with no nested arrays
+		$input = $this->iteratingInput();
 		$trans = $this->getRealTranslator();
-		$input = array(
-			'iterable' => array(
-				array(
-					'foo' => 'bar',
-					'baz' => 'buz'
-				),
-				array(
-					'foo' => 'ping',
-			  		'baz' => 'pong'
-				),
-		  	),
-			'foo' => 'bar'
-		);
 		$v = new Validator(
 			$trans,
 			$input,
@@ -1357,8 +1345,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v->iterate('iterable', array('foo' => 'required|alpha', 'baz' => 'required|alpha'));
 		$this->assertTrue($v->passes());
+	}
 
-		// Test that it can fail with no nested arrays
+
+	public function testIteratingValidatorCanFailWithNoNesting()
+	{
+		$input = $this->iteratingInput();
 		$trans = $this->getRealTranslator();
 		$v = new Validator(
 			$trans,
@@ -1368,9 +1360,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v->iterate('iterable', array('foo' => 'required|alpha', 'baz' => 'required|integer'));
 		$this->assertTrue($v->fails());
+	}
 
-		// Test that it passes for nested repeating arrays
+
+	public function testIteratingValidatorCanPassWithNesting()
+	{
 		$trans = $this->getRealTranslator();
+		$input = $this->iteratingInput();
 		$input['foo'] = array(
 			array(
 				'bar' => array(
@@ -1401,8 +1397,27 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 			)
 		);
 		$this->assertTrue($v->passes());
+	}
 
-		// Test it can fail for nested repeating arrays
+
+	public function testIteratingValidatorCanFailWithNesting()
+	{
+		$trans = $this->getRealTranslator();
+		$input = $this->iteratingInput();
+		$input['foo'] = array(
+			array(
+				'bar' => array(
+					array('baz' => 'buz'),
+					array('baz' => 'foo'),
+				),
+			),
+		);
+
+		$v = new Validator(
+			$trans,
+			$input,
+			array('iterable' => 'array', 'foo' => 'array')
+		);
 		$v->iterate('iterable', array('foo' => 'required|alpha', 'baz' => 'required|alpha'));
 		$v->iterate(
 			'foo',
@@ -1419,10 +1434,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertTrue($v->fails());
-
 	}
-
-
 
 
 	protected function getTranslator()
@@ -1436,6 +1448,27 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$trans = new Symfony\Component\Translation\Translator('en', new Symfony\Component\Translation\MessageSelector);
 		$trans->addLoader('array', new Symfony\Component\Translation\Loader\ArrayLoader);
 		return $trans;
+	}
+
+	/**
+	 * @return array
+	 */
+	protected function iteratingInput()
+	{
+		$input = array(
+		  'iterable' => array(
+			array(
+			  'foo' => 'bar',
+			  'baz' => 'buz'
+			),
+			array(
+			  'foo' => 'ping',
+			  'baz' => 'pong'
+			),
+		  ),
+		  'foo' => 'bar'
+		);
+		return $input;
 	}
 
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1333,23 +1333,10 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testIterableValidator()
+	public function testIteratingValidatorCanPasWithNoNesting()
 	{
-		// Test that it can pass with no nested arrays
+		$input = $this->iteratingInput();
 		$trans = $this->getRealTranslator();
-		$input = array(
-			'iterable' => array(
-				array(
-					'foo' => 'bar',
-					'baz' => 'buz'
-				),
-				array(
-					'foo' => 'ping',
-			  		'baz' => 'pong'
-				),
-		  	),
-			'foo' => 'bar'
-		);
 		$v = new Validator(
 			$trans,
 			$input,
@@ -1358,8 +1345,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v->iterate('iterable', array('foo' => 'required|alpha', 'baz' => 'required|alpha'));
 		$this->assertTrue($v->passes());
+	}
 
-		// Test that it can fail with no nested arrays
+	public function testIteratingValidatorCanFailWithNoNesting()
+	{
+		$input = $this->iteratingInput();
 		$trans = $this->getRealTranslator();
 		$v = new Validator(
 			$trans,
@@ -1369,9 +1359,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v->iterate('iterable', array('foo' => 'required|alpha', 'baz' => 'required|integer'));
 		$this->assertTrue($v->fails());
+	}
 
-		// Test that it passes for nested repeating arrays
+
+	public function testIteratingValidatorCanPassWithNesting()
+	{
 		$trans = $this->getRealTranslator();
+		$input = $this->iteratingInput();
 		$input['foo'] = array(
 			array(
 				'bar' => array(
@@ -1402,8 +1396,27 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 			)
 		);
 		$this->assertTrue($v->passes());
+	}
 
-		// Test it can fail for nested repeating arrays
+
+	public function testIteratingValidatorCanFailWithNesting()
+	{
+		$trans = $this->getRealTranslator();
+		$input = $this->iteratingInput();
+		$input['foo'] = array(
+			array(
+				'bar' => array(
+					array('baz' => 'buz'),
+					array('baz' => 'foo'),
+				),
+			),
+		);
+
+		$v = new Validator(
+			$trans,
+			$input,
+			array('iterable' => 'array', 'foo' => 'array')
+		);
 		$v->iterate('iterable', array('foo' => 'required|alpha', 'baz' => 'required|alpha'));
 		$v->iterate(
 			'foo',
@@ -1434,6 +1447,27 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$trans = new Symfony\Component\Translation\Translator('en', new Symfony\Component\Translation\MessageSelector);
 		$trans->addLoader('array', new Symfony\Component\Translation\Loader\ArrayLoader);
 		return $trans;
+	}
+
+	/**
+	 * @return array
+	 */
+	protected function iteratingInput()
+	{
+		$input = array(
+		  'iterable' => array(
+			array(
+			  'foo' => 'bar',
+			  'baz' => 'buz'
+			),
+			array(
+			  'foo' => 'ping',
+			  'baz' => 'pong'
+			),
+		  ),
+		  'foo' => 'bar'
+		);
+		return $input;
 	}
 
 }


### PR DESCRIPTION
I needed to be able to loop through some repeated array input, but the validator didn't allow that functionality out of the box. So I extended it with an "iterate()" public method (which is called on the resolved validator instance) and thought I'd see if it was worth a merge.

You pass the name of the repeating attribute, rules and messages to the iterate() method. It also uses recursion to allow for validating against nested repeating sets of rules. I.e., you can validate X number of books with X number of authors with X number of credentials and so on.

Better explanation and examples here: https://github.com/penoonan/laravel-iterable-validator

PS: This is my second attempt at this pull request. I closed the first one, and I am bad at git.
