### PR TITLE
Ensure that PHP_BINARY is used, instead of hardcoded PHP path

### DIFF
--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -90,7 +90,7 @@ class Listener {
 	 */
 	public function makeProcess($connection, $queue, $delay, $memory, $timeout)
 	{
-		$string = 'php artisan queue:work %s --queue="%s" --delay=%s --memory=%s --sleep=%s';
+		$string = PHP_BINARY . ' artisan queue:work %s --queue="%s" --delay=%s --memory=%s --sleep=%s';
 
 		// If the environment is set, we will append it to the command string so the
 		// workers will run under the specified environment. Otherwise, they will


### PR DESCRIPTION
Crudely backport a feature of Laravel 4.1+ that allows child processes for queue:work to be launched with the location of the current PHP process, rather then the system-defined version.
