### PR TITLE
Fix artisan queue:failed-table

### DIFF
--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -62,7 +62,7 @@ class FailedTableCommand extends Command {
 	{
 		$name = 'create_failed_jobs_table';
 
-		$path = $this->laravel['path'].'/database/migrations';
+		$path = $this->laravel['path.database'].'/migrations';
 
 		return $this->laravel['migration.creator']->create($name, $path);
 	}


### PR DESCRIPTION
Not going to include a failing test as it'd just be a waste of time. 
Running `php artisan queue:failed-table` spits out "... failed to open stream: No such file or directory".

I guess this is left over from before /database was moved out of /app.
