### PR TITLE
[5.0] GeneratorCommand : Missing type declaration

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -20,6 +20,13 @@ abstract class GeneratorCommand extends Command {
 	protected $configKey = '';
 
 	/**
+	 * The type of class being generated.
+	 *
+	 * @var string
+	 */
+	protected $type;
+
+	/**
 	 * Create a new controller creator command instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files


### PR DESCRIPTION
As `$type` is used in abstract `GeneratorCommand`, it should be declared.
