### PR TITLE
[5.0] Fix loading of controller namespaces

### DIFF
--- a/src/Illuminate/Routing/RouteServiceProvider.php
+++ b/src/Illuminate/Routing/RouteServiceProvider.php
@@ -58,7 +58,12 @@ class RouteServiceProvider extends ServiceProvider {
 	 */
 	protected function namespaced(Closure $callback)
 	{
-		$namespace = trim($this->app['config']['namespaces.controllers'], '\\');
+		$namespace = $this->app['url']->getRootControllerNamespace();
+
+		if (empty($namespace))
+		{
+			$namespace = trim($this->app['config']['namespaces.controllers'], '\\');
+		}
 
 		if (empty($namespace))
 		{

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -610,4 +610,14 @@ class UrlGenerator implements UrlGeneratorContract {
 		return $this;
 	}
 
+	/**
+	 * Get the current controller namespace.
+	 *
+	 * @return string
+	 */
+	public function getRootControllerNamespace()
+	{
+		return $this->rootNamespace;
+	}
+
 }


### PR DESCRIPTION
The Method value of property **rootNamespace** that is set with **setRootControllerNamespace** method was not being used by the router.
