### PR TITLE
[4.2] Ensure we can Fetch An Array With Non-Existing Keys

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -110,9 +110,10 @@ class Arr {
 
 			foreach ($array as $value)
 			{
-				$value = (array) $value;
-
-				$results[] = $value[$segment];
+				if (array_key_exists($segment, $value = (array) $value))
+				{
+					$results[] = $value[$segment];
+				}
 			}
 
 			$array = array_values($results);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -133,6 +133,8 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		), array_fetch($data, 'comments'));
 
 		$this->assertEquals(array(array('#foo', '#bar'), array('#baz')), array_fetch($data, 'comments.tags'));
+		$this->assertEquals([], array_fetch($data, 'foo'));
+		$this->assertEquals([], array_fetch($data, 'foo.bar'));
 	}
 
 


### PR DESCRIPTION
Ensure we can fetch an array with a non-existing key, so that the result will be an empty array
