### PR TITLE
[4.2] Routing : fix some docblocks

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -100,7 +100,7 @@ class UrlGenerator {
 	 *
 	 * @param  string  $path
 	 * @param  mixed  $extra
-	 * @param  bool  $secure
+	 * @param  bool|null  $secure
 	 * @return string
 	 */
 	public function to($path, $extra = array(), $secure = null)
@@ -140,7 +140,7 @@ class UrlGenerator {
 	 * Generate a URL to an application asset.
 	 *
 	 * @param  string  $path
-	 * @param  bool    $secure
+	 * @param  bool|null  $secure
 	 * @return string
 	 */
 	public function asset($path, $secure = null)
@@ -182,7 +182,7 @@ class UrlGenerator {
 	/**
 	 * Get the scheme for a raw URL.
 	 *
-	 * @param  bool    $secure
+	 * @param  bool|null  $secure
 	 * @return string
 	 */
 	protected function getScheme($secure)


### PR DESCRIPTION
As `getScheme` allows `$secure` to be `null`
