### PR TITLE
[4.2] Allows Arr::only To Handle Dotted Keys

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -239,9 +239,7 @@ class Arr {
 
 		if (empty($array) || empty($keys)) return [];
 
-		$dotted = static::dot($array);
-
-		$dotted = array_intersect_key($dotted, array_flip($keys));
+		$dotted = array_intersect_key(static::dot($array), array_flip($keys));
 
 		$result = [];
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -235,7 +235,22 @@ class Arr {
 	 */
 	public static function only($array, $keys)
 	{
-		return array_intersect_key($array, array_flip((array) $keys));
+		$keys = array_filter(is_array($keys) ? $keys : (array) $keys);
+
+		if (empty($array) || empty($keys)) return [];
+
+		$dotted = static::dot($array);
+
+		$dotted = array_intersect_key($dotted, array_flip($keys));
+
+		$result = [];
+
+		foreach ($dotted as $key => $value)
+		{
+			static::set($result, $key, $value);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -72,9 +72,16 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 
 	public function testArrayOnly()
 	{
-		$array = array('name' => 'taylor', 'age' => 26);
+		$array = array('name' => 'taylor', 'age' => 26, 'skills' => array('php' => 'Laravel'));
 		$this->assertEquals(array('name' => 'taylor'), array_only($array, array('name')));
 		$this->assertSame(array(), array_only($array, array('nonExistingKey')));
+		$this->assertSame(['skills' => ['php' => 'Laravel']], array_only($array, ['skills.php']));
+		$this->assertSame(['name'   => 'taylor', 'skills' => ['php' => 'Laravel']], array_only($array, ['skills.php', 'name']));
+		$this->assertSame([], array_only([], ['name']));
+		$this->assertSame([], array_only($array, []));
+		$this->assertSame([], array_only($array, ''));
+		$this->assertSame([], array_only($array, null));
+		$this->assertSame([], array_only($array, [null, '']));
 	}
 
 


### PR DESCRIPTION
Also ensure that an empty array is returned when `$array` or `$keys` arguments are empty
