### PR TITLE
[4.2] Eloquent BelongsToMany Pivot Timestamps

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -327,6 +327,17 @@ class BelongsToMany extends Relation {
 	}
 
 	/**
+	 * Determine whether the given column is defined as a pivot column.
+	 *
+	 * @param  string  $column
+	 * @return bool
+	 */
+	protected function hasPivotColumn($column)
+	{
+		return in_array($column, $this->pivotColumns);
+	}
+
+	/**
 	 * Set the join clause for the relation query.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder|null
@@ -718,7 +729,7 @@ class BelongsToMany extends Relation {
 	{
 		$records = array();
 
-		$timed = in_array($this->createdAt(), $this->pivotColumns);
+		$timed = ($this->hasPivotColumn('created_at') || $this->hasPivotColumn('updated_at'));
 
 		// To create the attachment records, we will simply spin through the IDs given
 		// and create a new record to insert for each ID. Each ID may actually be a
@@ -807,9 +818,15 @@ class BelongsToMany extends Relation {
 	{
 		$fresh = $this->parent->freshTimestamp();
 
-		if ( ! $exists) $record[$this->createdAt()] = $fresh;
+		if ( ! $exists && $this->hasPivotColumn('created_at'))
+		{
+			$record[$this->createdAt()] = $fresh;
+		}
 
-		$record[$this->updatedAt()] = $fresh;
+		if ($this->hasPivotColumn('updated_at'))
+		{
+			$record[$this->updatedAt()] = $fresh;
+		}
 
 		return $record;
 	}

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -729,7 +729,7 @@ class BelongsToMany extends Relation {
 	{
 		$records = array();
 
-		$timed = ($this->hasPivotColumn('created_at') || $this->hasPivotColumn('updated_at'));
+		$timed = ($this->hasPivotColumn($this->createdAt()) || $this->hasPivotColumn($this->updatedAt()));
 
 		// To create the attachment records, we will simply spin through the IDs given
 		// and create a new record to insert for each ID. Each ID may actually be a
@@ -818,12 +818,12 @@ class BelongsToMany extends Relation {
 	{
 		$fresh = $this->parent->freshTimestamp();
 
-		if ( ! $exists && $this->hasPivotColumn('created_at'))
+		if ( ! $exists && $this->hasPivotColumn($this->createdAt()))
 		{
 			$record[$this->createdAt()] = $fresh;
 		}
 
-		if ($this->hasPivotColumn('updated_at'))
+		if ($this->hasPivotColumn($this->updatedAt()))
 		{
 			$record[$this->updatedAt()] = $fresh;
 		}

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -180,6 +180,38 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAttachInsertsPivotTableRecordWithACreatedAtTimestamp()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation->withPivot('created_at');
+		$query = m::mock('stdClass');
+		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+		$query->shouldReceive('insert')->once()->with(array(array('user_id' => 1, 'role_id' => 2, 'foo' => 'bar', 'created_at' => 'time')))->andReturn(true);
+		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+		$relation->getParent()->shouldReceive('freshTimestamp')->once()->andReturn('time');
+		$relation->expects($this->once())->method('touchIfTouching');
+
+		$relation->attach(2, array('foo' => 'bar'));
+	}
+
+
+	public function testAttachInsertsPivotTableRecordWithAnUpdatedAtTimestamp()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation->withPivot('updated_at');
+		$query = m::mock('stdClass');
+		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+		$query->shouldReceive('insert')->once()->with(array(array('user_id' => 1, 'role_id' => 2, 'foo' => 'bar', 'updated_at' => 'time')))->andReturn(true);
+		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
+		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+		$relation->getParent()->shouldReceive('freshTimestamp')->once()->andReturn('time');
+		$relation->expects($this->once())->method('touchIfTouching');
+
+		$relation->attach(2, array('foo' => 'bar'));
+	}
+
+
 	public function testDetachRemovesPivotTableRecord()
 	{
 		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());


### PR DESCRIPTION
This pull request fixes an issue with timestamps that occur on pivot tables when using the Eloquent BelongsToMany relationship.

**The Issue**

In the BelongsToMany relationship class there is an explicit check for the existence of the 'created_at' column on the pivot table. Once this check is passed, 'created_at' and 'updated_at' are **both** assigned. This introduces the following issues:
- Pivot tables that contain _only_ a 'created_at' column will receive an error upon attaching. This is because the 'updated_at' column is also set, which doesn't exist.
- Pivot tables that contain _only_ an 'updated_at' column will not have their 'updated_at' timestamps updated. This is because if no 'created_at' column is set in the pivot columns, the whole timestamp process is skipped.

**What This PR Changes**

This PR adds an extra condition to the `createAttachRecords` method, allowing for more flexibility in the usage of timestamps. This allows the 'created_at' and 'updated_at' column to be used both in combination or separately. It also adds extra checks in the `setTimestampsOnAttach` to check if the 'created_at' or 'updated_at' exists before assigning it.
