### PR TITLE
[4.2] Pivot table correctly respects wherePivot() conditions

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -44,6 +44,13 @@ class BelongsToMany extends Relation {
 	protected $pivotColumns = array();
 
 	/**
+	 * Any pivot table restrictions.
+	 *
+	 * @var array
+	 */
+	protected $pivotWheres = [];
+
+	/**
 	 * Create a new has many relationship instance.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -85,6 +92,8 @@ class BelongsToMany extends Relation {
 	 */
 	public function wherePivot($column, $operator = null, $value = null, $boolean = 'and')
 	{
+		$this->pivotWheres[] = func_get_args();
+
 		return $this->where($this->table.'.'.$column, $operator, $value, $boolean);
 	}
 
@@ -888,6 +897,11 @@ class BelongsToMany extends Relation {
 	{
 		$query = $this->newPivotStatement();
 
+		foreach ($this->pivotWheres as $whereArgs)
+		{
+			call_user_func_array([$query, 'where'], $whereArgs);
+		}
+
 		return $query->where($this->foreignKey, $this->parent->getKey());
 	}
 
@@ -909,11 +923,7 @@ class BelongsToMany extends Relation {
 	 */
 	public function newPivotStatementForId($id)
 	{
-		$pivot = $this->newPivotStatement();
-
-		$key = $this->parent->getKey();
-
-		return $pivot->where($this->foreignKey, $key)->where($this->otherKey, $id);
+		return $this->newPivotQuery()->where($this->otherKey, $id);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -351,6 +351,38 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testWherePivotParamsUsedForNewQueries()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', ['attach', 'detach', 'touchIfTouching', 'formatSyncList'], $this->getRelationArguments());
+
+		// we expect to call $relation->wherePivot()
+		$relation->getQuery()->shouldReceive('where')->once()->andReturn($relation);
+
+		// Our sync() call will produce a new query
+		$mockQueryBuilder = m::mock('stdClass');
+		$query            = m::mock('stdClass');
+		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder);
+		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
+
+		// BelongsToMany::newPivotStatement() sets this
+		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
+
+		// BelongsToMany::newPivotQuery() sets this
+		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
+
+		// This is our test! The wherePivot() params also need to be called
+		$query->shouldReceive('where')->once()->with('foo', '=', 'bar')->andReturn($query);
+
+		// This is so $relation->sync() works
+		$query->shouldReceive('lists')->once()->with('role_id')->andReturn([1, 2, 3]);
+		$relation->expects($this->once())->method('formatSyncList')->with([1, 2, 3])->will($this->returnValue([1 => [],2 => [],3 => []]));
+
+
+		$relation = $relation->wherePivot('foo', '=', 'bar'); // these params are to be stored
+		$relation->sync([1,2,3]); // triggers the whole process above
+	}
+
+
 	public function getRelation()
 	{
 		list($builder, $parent) = $this->getRelationArguments();


### PR DESCRIPTION
Consider a pivot table being used to match pets and their owners, e.g.

```
owner_id
pet_type
pet_id
```

The classes would be:

```
abstract class Pet extends BaseModel {
    public function owner() {
        return $this->belongsToMany('Owner', 'owner_pets', 'pet_id')
                    ->wherePivot('pet_type', '=', get_class($this));
    }
}
class Cat extends Pet {}
class Dog extends Pet {}
```

This _almost_ works, the problem being that when `BelongsToMany::sync()` is called, it doesn't respect the `wherePivot()` restrictions, causing updates to apply across all pets, and not just the specific ones it should be restricted to.

This update ensures that any sub-queries also respect the same conditions/restrictions.

I also changed `BelongsToMany::newPivotStatementForId($id)` to call `BelongsToMany::newPivotQuery()` because they were almost identical, and this would also allow it to observe the restrictions neatly
