### PR TITLE
[5.0] Options for model fill/create including grouped fillable rules and without_protection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -241,13 +241,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, UrlRoutable, J
 	 * @param  array  $attributes
 	 * @return void
 	 */
-	public function __construct(array $attributes = array())
+	public function __construct(array $attributes = array(), array $options = array())
 	{
 		$this->bootIfNotBooted();
 
 		$this->syncOriginal();
 
-		$this->fill($attributes);
+		$this->fill($attributes, $options);
 	}
 
 	/**
@@ -392,18 +392,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, UrlRoutable, J
 	 *
 	 * @throws \Illuminate\Database\Eloquent\MassAssignmentException
 	 */
-	public function fill(array $attributes)
+	public function fill(array $attributes, array $options = array())
 	{
 		$totallyGuarded = $this->totallyGuarded();
 
-		foreach ($this->fillableFromArray($attributes) as $key => $value)
+		foreach ($this->fillableFromArray($attributes, $options) as $key => $value)
 		{
 			$key = $this->removeTableFromKey($key);
 
 			// The developers may choose to place some attributes in the "fillable"
 			// array, which means only those attributes may be set through mass
 			// assignment to the model, and all others will just be ignored.
-			if ($this->isFillable($key))
+			if ($this->isFillable($key, $options))
 			{
 				$this->setAttribute($key, $value);
 			}
@@ -422,14 +422,71 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, UrlRoutable, J
 	 * @param  array  $attributes
 	 * @return array
 	 */
-	protected function fillableFromArray(array $attributes)
+	protected function fillableFromArray(array $attributes, array $options = array())
 	{
-		if (count($this->fillable) > 0 && ! static::$unguarded)
+		if (!$this->fillWithoutProtection($options) && count($this->fillable) > 0 && ! static::$unguarded)
 		{
-			return array_intersect_key($attributes, array_flip($this->fillable));
+			return array_intersect_key($attributes, array_flip($this->getFillableForRole($options)));
 		}
 
 		return $attributes;
+	}
+
+	/**
+	 * Determine if the with_protection argument has been used.
+	 *
+	 * @param  array  $options
+	 * @return bool
+	 */
+	protected function fillWithoutProtection(array $options = array())
+	{
+		return isset($options['without_protection']) && $options['without_protection'];
+	}
+
+	/**
+	 * Group $fillable rules by role.
+	 *
+	 * @return array
+	 */
+	public function groupedFillableAttributes()
+	{
+		$groupedFillableAttributes = array();
+
+		foreach ($this->fillable as $role => $fillable)
+		{
+			if (is_array($fillable))
+			{
+				if ($role)
+				{
+					$groupedFillableAttributes[$role] = $fillable;
+				}
+				else
+				{
+					$groupedFillableAttributes['default'] = $fillable;
+				}
+			}
+			else
+			{
+				$groupedFillableAttributes['default'] = $this->fillable;
+				break;
+			}
+		}
+
+		return $groupedFillableAttributes;
+	}
+
+	/**
+	 * Get the fillable attributes for a given role.
+	 * @param  array  $options
+	 * @return array
+	 */
+	protected function getFillableForRole(array $options = array())
+	{
+		$groupedFillableAttributes = $this->groupedFillableAttributes();
+
+		$role = isset($options['as']) ? $options['as'] : 'default';
+
+		return isset($groupedFillableAttributes[$role]) ? $groupedFillableAttributes[$role] : array();
 	}
 
 	/**
@@ -439,12 +496,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, UrlRoutable, J
 	 * @param  bool   $exists
 	 * @return static
 	 */
-	public function newInstance($attributes = array(), $exists = false)
+	public function newInstance($attributes = array(), $exists = false, $options = array())
 	{
 		// This method just provides a convenient way for us to generate fresh model
 		// instances of this current model. It is particularly useful during the
 		// hydration of new objects via the Eloquent query builder instances.
-		$model = new static((array) $attributes);
+		$model = new static((array) $attributes, $options);
 
 		$model->exists = $exists;
 
@@ -520,9 +577,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, UrlRoutable, J
 	 * @param  array  $attributes
 	 * @return static
 	 */
-	public static function create(array $attributes)
+	public static function create(array $attributes, array $options = array())
 	{
-		$model = new static($attributes);
+		$model = new static($attributes, $options);
 
 		$model->save();
 
@@ -551,14 +608,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, UrlRoutable, J
 	 * @param  array  $attributes
 	 * @return static
 	 */
-	public static function firstOrNew(array $attributes)
+	public static function firstOrNew(array $attributes, array $options = array())
 	{
 		if ( ! is_null($instance = static::where($attributes)->first()))
 		{
 			return $instance;
 		}
 
-		return new static($attributes);
+		return new static($attributes, $options);
 	}
 
 	/**
@@ -568,11 +625,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, UrlRoutable, J
 	 * @param  array  $values
 	 * @return static
 	 */
-	public static function updateOrCreate(array $attributes, array $values = array())
+	public static function updateOrCreate(array $attributes, array $values = array(), array $options = array())
 	{
-		$instance = static::firstOrNew($attributes);
+		$instance = static::firstOrNew($attributes, $options);
 
-		$instance->fill($values)->save();
+		$instance->fill($values, $options)->save();
 
 		return $instance;
 	}
@@ -1387,14 +1444,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, UrlRoutable, J
 	 * @param  array  $attributes
 	 * @return bool|int
 	 */
-	public function update(array $attributes = array())
+	public function update(array $attributes = array(), array $options = array())
 	{
 		if ( ! $this->exists)
 		{
 			return $this->newQuery()->update($attributes);
 		}
 
-		return $this->fill($attributes)->save();
+		return $this->fill($attributes, $options)->save();
 	}
 
 	/**
@@ -2140,14 +2197,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, UrlRoutable, J
 	 * @param  string  $key
 	 * @return bool
 	 */
-	public function isFillable($key)
+	public function isFillable($key, array $options = array())
 	{
-		if (static::$unguarded) return true;
+		if (static::$unguarded || $this->fillWithoutProtection($options)) return true;
 
 		// If the key is in the "fillable" array, we can of course assume that it's
 		// a fillable attribute. Otherwise, we will check the guarded array when
 		// we need to determine if the attribute is black-listed on the model.
-		if (in_array($key, $this->fillable)) return true;
+
+		if (in_array($key, $this->getFillableForRole($options))) return true;
 
 		if ($this->isGuarded($key)) return false;
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -927,6 +927,53 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->getConnection()->shouldReceive('getPostProcessor')->andReturn(m::mock('Illuminate\Database\Query\Processors\Processor'));
 	}
 
+
+	public function testWithoutProtectionOption()
+	{
+		$model = new EloquentModelStub;
+		$model->fillable(array('name'));
+		$model->fill(array('name' => 'foo', 'age' => 'bar'), array('without_protection' => true));
+		$this->assertEquals('foo', $model->name);
+		$this->assertEquals('bar', $model->age);
+	}
+
+
+	public function testScopedFillable()
+	{
+		$model = new EloquentModelStub;
+		$model->fillable(array('default' => array('name'), 'admin' => array('name', 'age')));
+
+		$model->fill(array('name' => 'foo', 'age' => 'bar'), array('as' => 'default'));
+		$this->assertFalse(isset($model->age));
+		$this->assertEquals('foo', $model->name);
+
+		$model->fill(array('name' => 'bar', 'age' => 'baz'), array('as' => 'admin'));
+		$this->assertEquals('bar', $model->name);
+		$this->assertEquals('baz', $model->age);
+	}
+
+
+	public function testScopedFillableUsesDefault()
+	{
+		$model = new EloquentModelStub;
+		$model->fillable(array('default' => array('name'), 'admin' => array('name', 'age')));
+
+		$model->fill(array('name' => 'foo', 'age' => 'bar'));
+		$this->assertFalse(isset($model->age));
+		$this->assertEquals('foo', $model->name);
+	}
+
+
+	public function testPassingInvalidFillableAs()
+	{
+		$model = new EloquentModelStub;
+		$model->fillable(array('default' => array('name'), 'admin' => array('name', 'age')));
+
+		$model->fill(array('age' => 'bar', 'name' => 'foo'), array('as' => 'tester'));
+		$this->assertFalse(isset($model->age));
+		$this->assertFalse(isset($model->name));
+	}
+
 }
 
 class EloquentTestObserverStub {


### PR DESCRIPTION
**These may still need some tweaks and work, so mainly looking for feedback.**
## Multiple grouped fillable rules

This is a suggestion to improve fillable to make it easier to assign multiple values for fillable. This would be useful if a site had different roles, for example if an admin can edit things a user cannot. The goal is to also maintain backwards compatibility with the current way to define fillable. This is how it would be used.

```
<?php
// In model
class User extends Eloquent 
{
    protected $fillable = [
        'default' =>  ['name', 'email'],
        'admin'   => ['name', 'email', 'role']
    ];
}

// When creating a model you can now do the following to control which "fillable" is used for mass assignment protection
User::create(Input::all(), 'default');
User::create(Input::all(), 'admin');
User::fill(Input::all(), 'admin');

// The following uses the default key, by default.
User::create(Input::all());
```
## Without Protection Option

I've also added another option called `without_protection` that will disable mass assignment protection for a single call to create, fill, etc. This would be simpler than calling guard and unguard over and over.

```
<?php
class User extends Eloquent 
{
    protected $fillable = ['name', 'email'];
}

// The following would ignore mass assignment protection and work properly. 
User::create(['name' => 'Ryan', 'email' => 'email@example.com', 'age' => 25], ['without_protection' => true]);

```
