### PR TITLE
[5.0] Normalize view names to dot notation

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -111,6 +111,18 @@ class Factory implements FactoryContract {
 	}
 
 	/**
+	 * Normalize a view name.
+	 *
+	 * @param  string $name
+	 *
+	 * @return string
+	 */
+	protected function normalizeName($name)
+	{
+		return str_replace('/', '.', $name);
+	}
+
+	/**
 	 * Get the evaluated view contents for the given view.
 	 *
 	 * @param  string  $view
@@ -121,6 +133,8 @@ class Factory implements FactoryContract {
 	public function make($view, $data = array(), $mergeData = array())
 	{
 		if (isset($this->aliases[$view])) $view = $this->aliases[$view];
+
+		$view = $this->normalizeName($view);
 
 		$path = $this->finder->find($view);
 
@@ -363,6 +377,8 @@ class Factory implements FactoryContract {
 	 */
 	protected function addViewEvent($view, $callback, $prefix = 'composing: ', $priority = null)
 	{
+		$view = $this->normalizeName($view);
+
 		if ($callback instanceof Closure)
 		{
 			$this->addEventListener($prefix.$view, $callback, $priority);

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -224,6 +224,15 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testComposersAreRegisteredWithSlashAndDot()
+	{
+		$factory = $this->getFactory();
+		$factory->getDispatcher()->shouldReceive('listen')->with('composing: foo.bar', m::any())->twice();
+		$factory->composer('foo.bar', '');
+		$factory->composer('foo/bar', '');
+	}
+
+
 	public function testRenderCountHandling()
 	{
 		$factory = $this->getFactory();
@@ -329,6 +338,17 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 		$factory->flushSections();
 
 		$this->assertEquals(0, count($factory->getSections()));
+	}
+
+
+	public function testMakeWithSlashAndDot()
+	{
+		$factory = $this->getFactory();
+		$factory->getFinder()->shouldReceive('find')->twice()->with('foo.bar')->andReturn('path.php');
+		$factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock('Illuminate\View\Engines\EngineInterface'));
+		$factory->getDispatcher()->shouldReceive('fire');
+		$factory->make('foo/bar');
+		$factory->make('foo.bar');
 	}
 
 


### PR DESCRIPTION
I'd prefer slashes rather than dots because that's what makes sense on a file system, but since dot notation is what's been used up until now that's what I went for.
