### PR TITLE
[5.0] preg_quote escapes custom Blade tags

### DIFF
--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -470,6 +470,17 @@ empty
 	}
 
 
+	public function testRenderIdenticalDelimiters()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		//Demonstrate that it is working as expected
+		$this->assertEquals(['{{','}}'], $compiler->getContentTags());
+		$compiler->setContentTags('{{', '}}');
+		//uhoh, what happened?
+		$this->assertEquals(['{{','}}'], $compiler->getContentTags());
+	}
+
+
 	protected function getFiles()
 	{
 		return m::mock('Illuminate\Filesystem\Filesystem');


### PR DESCRIPTION
This is expected but not desirable. If you set custom tags with `\Blade::setContentTags('{{', '}}')` it will escape these with backslashes, causing it not to work if you attempt to use them.
