### PR TITLE
Fix validator digits between

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -803,7 +803,8 @@ class Validator implements MessageProviderInterface {
 
 		$length = strlen((string) $value);
 
-		return $length >= $parameters[0] && $length <= $parameters[1];
+		return $this->validateNumeric($attribute, $value)
+		  && $length >= $parameters[0] && $length <= $parameters[1];
 	}
 
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -609,6 +609,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => '12345'), array('foo' => 'digits_between:1,6'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('foo' => 'bar'), array('foo' => 'digits_between:1,10'));
+		$this->assertFalse($v->passes());
+
 		$v = new Validator($trans, array('foo' => '123'), array('foo' => 'digits_between:4,5'));
 		$this->assertFalse($v->passes());
 	}


### PR DESCRIPTION
Fixes a bug which allowed non-numeric values to pass validation rule of digits_between (only checked string length). This fix adds a numeric check first, working in the same way as digits-rule except for allowing a range.
