### PR TITLE
[5.0] Fix FormRequest's error message handling

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -154,7 +154,7 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	 */
 	protected function formatErrors(Validator $validator)
 	{
-		return $validator->errors()->all();
+		return $validator->errors()->getMessages();
 	}
 
 	/**


### PR DESCRIPTION
This change will allow the use of MessageBag's helper methods such as `first()` on a FormRequest's failed validation response... eg. `$errors->first('field_name')`

This functionality already existed in legacy, 4.2, validation. Therefore, this change brings forth a bit of consistency between the two.
