### PR TITLE
[4.2] Fall Back To DateTime::__construct() In Date Mutators

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -5,6 +5,7 @@ use ArrayAccess;
 use Carbon\Carbon;
 use LogicException;
 use JsonSerializable;
+use InvalidArgumentException;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -2592,7 +2593,14 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// can return back the finally formatted DateTime instances to the devs.
 		else
 		{
-			$value = Carbon::createFromFormat($format, $value);
+			try
+			{
+				$value = Carbon::createFromFormat($format, $value);
+			}
+			catch (InvalidArgumentException $e)
+			{
+				$value = new Carbon($value);
+			}
 		}
 
 		return $value->format($format);
@@ -2629,7 +2637,14 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		{
 			$format = $this->getDateFormat();
 
-			return Carbon::createFromFormat($format, $value);
+			try
+			{
+				return Carbon::createFromFormat($format, $value);
+			}
+			catch (InvalidArgumentException $e)
+			{
+				return new Carbon($value);
+			}
 		}
 
 		return Carbon::instance($value);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -326,6 +326,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf('Carbon\Carbon', $model->created_at);
 
 		$model = new EloquentDateModelStub;
+		$model->created_at = '2013-05-22 00:00:00.0000';
+		$this->assertInstanceOf('Carbon\Carbon', $model->created_at);
+
+		$model = new EloquentDateModelStub;
 		$model->created_at = time();
 		$this->assertInstanceOf('Carbon\Carbon', $model->created_at);
 


### PR DESCRIPTION
For example, when using `CURRENT_TIMESTAMP` as a column's default value with Postgres, microseconds are included, causing an `InvalidArgumentException` from `Carbon`.

This is slower, but more flexible in detecting the correct format before failing.

See laravel/laravel#3009 for original bug report.

**Note** There was one test failing already when I forked, but the test I added for this particular case is passing with my changes.
