### PR TITLE
[5.0] Normalize view names with namespaces with slashes properly

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -119,7 +119,16 @@ class Factory implements FactoryContract {
 	 */
 	protected function normalizeName($name)
 	{
-		return str_replace('/', '.', $name);
+		$delimiter = ViewFinderInterface::HINT_PATH_DELIMITER;
+
+		if (strpos($name, $delimiter) === false)
+		{
+			return str_replace('/', '.', $name);
+		}
+
+		list($namespace, $name) = explode($delimiter, $name);
+
+		return $namespace . $delimiter . str_replace('/', '.', $name);
 	}
 
 	/**

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -40,13 +40,6 @@ class FileViewFinder implements ViewFinderInterface {
 	protected $extensions = array('blade.php', 'php');
 
 	/**
-	 * Hint path delimiter value.
-	 *
-	 * @var string
-	 */
-	const HINT_PATH_DELIMITER = '::';
-
-	/**
 	 * Create a new file view loader instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files

--- a/src/Illuminate/View/ViewFinderInterface.php
+++ b/src/Illuminate/View/ViewFinderInterface.php
@@ -3,6 +3,13 @@
 interface ViewFinderInterface {
 
 	/**
+	 * Hint path delimiter value.
+	 *
+	 * @var string
+	 */
+	const HINT_PATH_DELIMITER = '::';
+
+	/**
 	 * Get the fully qualified location of the view.
 	 *
 	 * @param  string  $view

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -352,6 +352,17 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testNamespacedViewNamesAreNormalizedProperly()
+	{
+		$factory = $this->getFactory();
+		$factory->getFinder()->shouldReceive('find')->twice()->with('vendor/package::foo.bar')->andReturn('path.php');
+		$factory->getEngineResolver()->shouldReceive('resolve')->twice()->with('php')->andReturn(m::mock('Illuminate\View\Engines\EngineInterface'));
+		$factory->getDispatcher()->shouldReceive('fire');
+		$factory->make('vendor/package::foo/bar');
+		$factory->make('vendor/package::foo.bar');
+	}
+
+
 	public function testMakeWithAlias()
 	{
 		$factory = $this->getFactory();


### PR DESCRIPTION
Had to move `const HINT_PATH_DELIMITER` to the `ViewFinderInterface`. `static::HINT_PATH_DELIMITER` in classes implementing the interface still works. http://3v4l.org/Z616Z

This does prevent end users from defining their own namespace delimiter. We could make a method `ViewFinderInterface->getDelimiter()` method instead. Thoughts?

Ref https://github.com/laravel/framework/pull/5756#commitcomment-7830096
