### PR TITLE
Reduce dependencies for pagination usage.

### DIFF
--- a/src/Illuminate/Pagination/Factory.php
+++ b/src/Illuminate/Pagination/Factory.php
@@ -65,29 +65,25 @@ class Factory {
 	/**
 	 * Create a new pagination factory.
 	 *
-	 * @param  \Symfony\Component\HttpFoundation\Request  $request
-	 * @param  \Illuminate\Contracts\View\Factory  $view
-	 * @param  \Symfony\Component\Translation\TranslatorInterface  $trans
 	 * @param  string  $pageName
 	 * @return void
 	 */
-	public function __construct(Request $request, ViewFactory $view, TranslatorInterface $trans, $pageName = 'page')
+	public function __construct($pageName = 'page')
 	{
-		$this->view = $view;
-		$this->trans = $trans;
-		$this->request = $request;
 		$this->pageName = $pageName;
-		$this->setupPaginationEnvironment();
 	}
 
 	/**
 	 * Setup the pagination environment.
 	 *
+	 * @param  \Illuminate\Contracts\View\Factory  $view
 	 * @return void
 	 */
-	protected function setupPaginationEnvironment()
+	public function setupPaginationEnvironment(ViewFactory $view)
 	{
-		$this->view->addNamespace('pagination', __DIR__.'/views');
+		$view->addNamespace('pagination', __DIR__.'/views');
+
+		$this->setViewFactory($view);
 	}
 
 	/**
@@ -126,7 +122,13 @@ class Factory {
 	 */
 	public function getCurrentPage()
 	{
-		$page = (int) $this->currentPage ?: $this->request->input($this->pageName, 1);
+		if ($this->currentPage) {
+			$page = (int) $this->currentPage;
+		} elseif ( ! is_null($this->request)) {
+			$page = (int) $this->request->input($this->pageName, 1);
+		} else {
+			throw new \Exception('No currentPage was provided, and request information is not available');
+		}
 
 		if ($page < 1 || filter_var($page, FILTER_VALIDATE_INT) === false)
 		{
@@ -284,6 +286,16 @@ class Factory {
 	public function getTranslator()
 	{
 		return $this->trans;
+	}
+
+	/**
+	 * Set the translator instance.
+	 *
+	 * @param \Symfony\Component\Translation\TranslatorInterface $trans
+	 */
+	public function setTranslator($trans)
+	{
+		return $this->trans = $trans;
 	}
 
 }

--- a/src/Illuminate/Pagination/PaginationServiceProvider.php
+++ b/src/Illuminate/Pagination/PaginationServiceProvider.php
@@ -20,8 +20,12 @@ class PaginationServiceProvider extends ServiceProvider {
 	{
 		$this->app->bindShared('paginator', function($app)
 		{
-			$paginator = new Factory($app['request'], $app['view'], $app['translator']);
+			$paginator = new Factory();
+			$paginator->setRequest($app['request']);
+			$paginator->setTranslator($app['translator']);
 
+			$paginator->setupPaginationEnvironment($app['view']);
+			
 			$paginator->setViewName($app['config']['view.pagination']);
 
 			$app->refresh('request', $paginator, 'setRequest');

--- a/tests/Pagination/PaginationFactoryTest.php
+++ b/tests/Pagination/PaginationFactoryTest.php
@@ -13,90 +13,150 @@ class PaginationFactoryTest extends PHPUnit_Framework_TestCase {
 
 	public function testCreationOfEnvironment()
 	{
-		$env = $this->getFactory();
+		$factory = $this->getFactoryProper();
+		$this->assertInstanceOf('Illuminate\Pagination\Factory', $factory);
 	}
 
 
 	public function testPaginatorCanBeCreated()
 	{
-		$env = $this->getFactory();
+		$factory = $this->getFactoryProper();
 		$request = Illuminate\Http\Request::create('http://foo.com', 'GET');
-		$env->setRequest($request);
+		$factory->setRequest($request);
 
-		$this->assertInstanceOf('Illuminate\Pagination\Paginator', $env->make(array('foo', 'bar'), 2, 2));
+		$this->assertInstanceOf('Illuminate\Pagination\Paginator', $factory->make(array('foo', 'bar'), 2, 2));
 	}
 
 
 	public function testPaginationViewCanBeCreated()
 	{
-		$env = $this->getFactory();
+		$factory = $this->getFactoryProper();
 		$paginator = m::mock('Illuminate\Pagination\Paginator');
-		$env->getViewFactory()->shouldReceive('make')->once()->with('pagination::slider', array('environment' => $env, 'paginator' => $paginator))->andReturn('foo');
+		$factory->getViewFactory()->shouldReceive('make')->once()->with('pagination::slider', array('environment' => $factory, 'paginator' => $paginator))->andReturn('foo');
 
-		$this->assertEquals('foo', $env->getPaginationView($paginator));
+		$this->assertEquals('foo', $factory->getPaginationView($paginator));
 	}
 
 
 	public function testCurrentPageCanBeRetrieved()
 	{
-		$env = $this->getFactory();
+		$factory = $this->getFactoryProper();
 		$request = Illuminate\Http\Request::create('http://foo.com?page=2', 'GET');
-		$env->setRequest($request);
+		$factory->setRequest($request);
 
-		$this->assertEquals(2, $env->getCurrentPage());
+		$this->assertEquals(2, $factory->getCurrentPage());
 
-		$env = $this->getFactory();
+		$factory = $this->getFactoryProper();
 		$request = Illuminate\Http\Request::create('http://foo.com?page=-1', 'GET');
-		$env->setRequest($request);
+		$factory->setRequest($request);
 
-		$this->assertEquals(1, $env->getCurrentPage());
+		$this->assertEquals(1, $factory->getCurrentPage());
 	}
-
 
 	public function testSettingCurrentUrlOverrulesRequest()
 	{
-		$env = $this->getFactory();
+		$factory = $this->getFactoryProper();
 		$request = Illuminate\Http\Request::create('http://foo.com?page=2', 'GET');
-		$env->setRequest($request);
-		$env->setCurrentPage(3);
+		$factory->setRequest($request);
+		$factory->setCurrentPage(3);
 
-		$this->assertEquals(3, $env->getCurrentPage());
+		$this->assertEquals(3, $factory->getCurrentPage());
 	}
 
 
 	public function testCurrentUrlCanBeRetrieved()
 	{
-		$env = $this->getFactory();
+		$factory = $this->getFactoryProper();
 		$request = Illuminate\Http\Request::create('http://foo.com/bar?page=2', 'GET');
-		$env->setRequest($request);
+		$factory->setRequest($request);
 
-		$this->assertEquals('http://foo.com/bar', $env->getCurrentUrl());
+		$this->assertEquals('http://foo.com/bar', $factory->getCurrentUrl());
 
-		$env = $this->getFactory();
+		$factory = $this->getFactoryProper();
 		$request = Illuminate\Http\Request::create('http://foo.com?page=2', 'GET');
-		$env->setRequest($request);
+		$factory->setRequest($request);
 
-		$this->assertEquals('http://foo.com', $env->getCurrentUrl());
+		$this->assertEquals('http://foo.com', $factory->getCurrentUrl());
 	}
 
 
 	public function testOverridingPageParam()
 	{
-		$env = $this->getFactory();
-		$this->assertEquals('page', $env->getPageName());
-		$env->setPageName('foo');
-		$this->assertEquals('foo', $env->getPageName());
+		$factory = $this->getFactoryProper();
+		$this->assertEquals('page', $factory->getPageName());
+		$factory->setPageName('foo');
+		$this->assertEquals('foo', $factory->getPageName());
 	}
 
+	public function testInteractionWithoutRequest()
+	{
+		$factory = $this->getFactoryWithoutRequest();
 
-	protected function getFactory()
+		$perPage = 2;
+		$total = 10;
+
+		// 2 Items, because perPage is 2. Normally the paginate() method would have that covered
+		$items = array(
+			'Item 1',
+			'Item 2',
+		);
+
+		$factory->setBaseUrl('http://example.com/foo');
+		$factory->setCurrentPage(2);
+
+		$paginator = $factory->make($items, $total, $perPage);
+
+		$this->assertEquals(2, $paginator->getCurrentPage());
+		$this->assertEquals(5, $paginator->getLastPage());
+		$this->assertEquals($total, $paginator->getTotal());
+		$this->assertEquals($perPage, $paginator->getPerPage());
+		$this->assertEquals($perPage, $paginator->count());
+	}
+
+	/**
+	 * @expectedException \Exception
+	 * @expectedExceptionMessage No currentPage was provided, and request information is not available
+	 */
+	public function testUnprovidedCurrentPageWithoutRequest()
+	{
+		$factory = $this->getFactoryWithoutRequest();
+
+		$perPage = 2;
+		$total = 10;
+
+		// 2 Items, because perPage is 2. Normally the paginate() method would have that covered
+		$items = array(
+			'Item 1',
+			'Item 2',
+		);
+
+		$factory->setBaseUrl('http://example.com/foo');
+
+		$paginator = $factory->make($items, $total, $perPage);
+
+		$paginator->getCurrentPage();
+	}
+
+	protected function getFactoryWithoutRequest()
+	{
+		$factory = new Factory('page');
+		return $factory;
+	}
+
+	protected function getFactoryProper()
 	{
 		$request = m::mock('Illuminate\Http\Request');
 		$view = m::mock('Illuminate\Contracts\View\Factory');
 		$trans = m::mock('Symfony\Component\Translation\TranslatorInterface');
+
 		$view->shouldReceive('addNamespace')->once()->with('pagination', realpath(__DIR__.'/../../src/Illuminate/Pagination').'/views');
 
-		return new Factory($request, $view, $trans, 'page');
+		$factory = new Factory('page');
+		$factory->setRequest($request);
+		$factory->setTranslator($trans);
+		$factory->setupPaginationEnvironment($view);
+
+		return $factory;
 	}
 
 }


### PR DESCRIPTION
_Rebased #4582 and aimed it at master for 5.0._

It works EXACTLY the same as it currently does when used within Laravel itself, but when used as a standalone component it is drastically easier to work with at a basic level. There might be some issues where people cannot make it load view files without setting a translator, but... they can just set the translator.
Other than myself I don't think many people are using pagination solo, and if they are then they'll be happy about this.
