### PR TITLE
Add support for configuring AWS S3 region.

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -94,7 +94,9 @@ class FilesystemManager implements FactoryContract {
 	public function createS3Driver(array $config)
 	{
 		$client = S3Client::factory([
-			'key' => $config['key'], 'secret' => $config['secret'],
+			'key' => $config['key'],
+			'secret' => $config['secret'],
+			'region' => $config['region'],
 		]);
 
 		return $this->adapt(


### PR DESCRIPTION
AWS S3 buckets that are created using a non-default region does need to set `region` key on `S3Client::factory()` call.

Not configuring this way throws an `Aws\S3\Exception\PermanentRedirectException` as follows:

<pre>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint: "...".</pre>


This was detailed on https://github.com/aws/aws-sdk-php-laravel/issues/13#issuecomment-22770974.

This PR depends on https://github.com/laravel/laravel/pull/3026 to be pushed.
