### PR TITLE
Fix artisan cache:table

### DIFF
--- a/src/Illuminate/Cache/Console/CacheTableCommand.php
+++ b/src/Illuminate/Cache/Console/CacheTableCommand.php
@@ -64,7 +64,7 @@ class CacheTableCommand extends Command {
 	{
 		$name = 'create_cache_table';
 
-		$path = $this->laravel['path'].'/database/migrations';
+		$path = $this->laravel['path.database'].'/migrations';
 
 		return $this->laravel['migration.creator']->create($name, $path);
 	}


### PR DESCRIPTION
A quick fix for the `artisan cache:table` command. It now uses `path.database` instead of `path` when creating the migration. The command would previously generate an error because it was attempting to write to a directory that did not exist.
