### PR TITLE
[4.2] Remove useless else...return

### DIFF
--- a/src/Illuminate/Auth/Reminders/PasswordBroker.php
+++ b/src/Illuminate/Auth/Reminders/PasswordBroker.php
@@ -230,10 +230,8 @@ class PasswordBroker {
 		{
 			return call_user_func($this->passwordValidator, $credentials) && $password === $confirm;
 		}
-		else
-		{
-			return $this->validatePasswordWithDefaults($credentials);
-		}
+
+		return $this->validatePasswordWithDefaults($credentials);
 	}
 
 	/**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -277,10 +277,8 @@ class Repository implements ArrayAccess {
 		{
 			return $this->macroCall($method, $parameters);
 		}
-		else
-		{
-			return call_user_func_array(array($this->store, $method), $parameters);
-		}
+
+		return call_user_func_array(array($this->store, $method), $parameters);
 	}
 
 }

--- a/src/Illuminate/Config/FileEnvironmentVariablesLoader.php
+++ b/src/Illuminate/Config/FileEnvironmentVariablesLoader.php
@@ -45,10 +45,8 @@ class FileEnvironmentVariablesLoader implements EnvironmentVariablesLoaderInterf
 		{
 			return array();
 		}
-		else
-		{
-			return array_dot($this->files->getRequire($path));
-		}
+
+		return array_dot($this->files->getRequire($path));
 	}
 
 	/**
@@ -63,10 +61,8 @@ class FileEnvironmentVariablesLoader implements EnvironmentVariablesLoaderInterf
 		{
 			return $this->path.'/.env.'.$environment.'.php';
 		}
-		else
-		{
-			return $this->path.'/.env.php';
-		}
+
+		return $this->path.'/.env.php';
 	}
 
 }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -395,10 +395,8 @@ class Container implements ArrayAccess {
 		{
 			return $this->reboundCallbacks[$abstract];
 		}
-		else
-		{
-			return array();
-		}
+
+		return array();
 	}
 
 	/**
@@ -469,10 +467,8 @@ class Container implements ArrayAccess {
 
 			return $abstract;
 		}
-		else
-		{
-			return $this->bindings[$abstract]['concrete'];
-		}
+
+		return $this->bindings[$abstract]['concrete'];
 	}
 
 	/**

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -42,10 +42,8 @@ class ConnectionFactory {
 		{
 			return $this->createReadWriteConnection($config);
 		}
-		else
-		{
-			return $this->createSingleConnection($config);
-		}
+
+		return $this->createSingleConnection($config);
 	}
 
 	/**
@@ -126,10 +124,8 @@ class ConnectionFactory {
 		{
 			return $config[$type][array_rand($config[$type])];
 		}
-		else
-		{
-			return $config[$type];
-		}
+
+		return $config[$type];
 	}
 
 	/**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -126,10 +126,8 @@ class DatabaseManager implements ConnectionResolverInterface {
 		{
 			return $this->connection($name);
 		}
-		else
-		{
-			return $this->refreshPdoConnections($name);
-		}
+
+		return $this->refreshPdoConnections($name);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -242,10 +242,8 @@ class Builder {
 		{
 			return $this->groupedPaginate($paginator, $perPage, $columns);
 		}
-		else
-		{
-			return $this->ungroupedPaginate($paginator, $perPage, $columns);
-		}
+
+		return $this->ungroupedPaginate($paginator, $perPage, $columns);
 	}
 
 	/**
@@ -374,10 +372,8 @@ class Builder {
 		{
 			return call_user_func($this->onDelete, $this);
 		}
-		else
-		{
-			return $this->query->delete();
-		}
+
+		return $this->query->delete();
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1626,10 +1626,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		{
 			return $this->original[$this->getKeyName()];
 		}
-		else
-		{
-			return $this->getAttribute($this->getKeyName());
-		}
+
+		return $this->getAttribute($this->getKeyName());
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -766,10 +766,8 @@ class BelongsToMany extends Relation {
 		{
 			return array($key, array_merge($value, $attributes));
 		}
-		else
-		{
-			return array($value, $attributes);
-		}
+
+		return array($value, $attributes);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
@@ -44,10 +44,8 @@ trait SoftDeletingTrait {
 		{
 			$this->withTrashed()->where($this->getKeyName(), $this->getKey())->forceDelete();
 		}
-		else
-		{
-			return $this->runSoftDelete();
-		}
+
+		return $this->runSoftDelete();
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1385,10 +1385,8 @@ class Builder {
 		{
 			return $cache->rememberForever($key, $callback);
 		}
-		else
-		{
-			return $cache->remember($key, $minutes, $callback);
-		}
+
+		return $cache->remember($key, $minutes, $callback);
 	}
 
 	/**
@@ -1552,10 +1550,8 @@ class Builder {
 		{
 			return $this->groupedPaginate($paginator, $perPage, $columns);
 		}
-		else
-		{
-			return $this->ungroupedPaginate($paginator, $perPage, $columns);
-		}
+
+		return $this->ungroupedPaginate($paginator, $perPage, $columns);
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -117,10 +117,8 @@ class PostgresGrammar extends Grammar {
 		{
 			return 'where '.$this->removeLeadingBoolean($joinWhere);
 		}
-		else
-		{
-			return $baseWhere.' '.$joinWhere;
-		}
+
+		return $baseWhere.' '.$joinWhere;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -77,10 +77,8 @@ class SqlServerGrammar extends Grammar {
 		{
 			return $from.' with(rowlock,'.($query->lock ? 'updlock,' : '').'holdlock)';
 		}
-		else
-		{
-			return $from;
-		}
+
+		return $from;
 	}
 
 	/**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -182,10 +182,8 @@ class Builder {
 		{
 			return call_user_func($this->resolver, $table, $callback);
 		}
-		else
-		{
-			return new Blueprint($table, $callback);
-		}
+
+		return new Blueprint($table, $callback);
 	}
 
 	/**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -401,10 +401,8 @@ class MySqlGrammar extends Grammar {
 		{
 			return "double({$column->total}, {$column->places})";
 		}
-		else
-		{
-			return 'double';
-		}
+
+		return 'double';
 	}
 
 	/**

--- a/src/Illuminate/Exception/SymfonyDisplayer.php
+++ b/src/Illuminate/Exception/SymfonyDisplayer.php
@@ -49,10 +49,8 @@ class SymfonyDisplayer implements ExceptionDisplayerInterface {
 				'line' => $exception->getLine(),
 			), 500);
 		}
-		else
-		{
-			return $this->symfony->createResponse($exception);
-		}
+
+		return $this->symfony->createResponse($exception);
 	}
 
 }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -82,10 +82,8 @@ class Filesystem {
 		{
 			return $this->put($path, $data.$this->get($path));
 		}
-		else
-		{
-			return $this->put($path, $data);
-		}
+
+		return $this->put($path, $data);
 	}
 
 	/**
@@ -295,10 +293,8 @@ class Filesystem {
 		{
 			return @mkdir($path, $mode, $recursive);
 		}
-		else
-		{
-			return mkdir($path, $mode, $recursive);
-		}
+
+		return mkdir($path, $mode, $recursive);
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -234,10 +234,8 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 		{
 			return in_array($this['env'], func_get_args());
 		}
-		else
-		{
-			return $this['env'];
-		}
+
+		return $this['env'];
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/ChangesCommand.php
+++ b/src/Illuminate/Foundation/Console/ChangesCommand.php
@@ -83,10 +83,8 @@ class ChangesCommand extends Command {
 
 			return array($latest, $changes[$latest]);
 		}
-		else
-		{
-			return array($version, array_get($changes, $version, array()));
-		}
+
+		return array($version, array_get($changes, $version, array()));
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/CommandMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CommandMakeCommand.php
@@ -104,10 +104,8 @@ class CommandMakeCommand extends Command {
 		{
 			return str_replace('{{namespace}}', ' namespace '.$namespace.';', $stub);
 		}
-		else
-		{
-			return str_replace('{{namespace}}', '', $stub);
-		}
+
+		return str_replace('{{namespace}}', '', $stub);
 	}
 
 	/**
@@ -123,10 +121,8 @@ class CommandMakeCommand extends Command {
 		{
 			return $this->laravel['path'].'/commands';
 		}
-		else
-		{
-			return $this->laravel['path.base'].'/'.$path;
-		}
+
+		return $this->laravel['path.base'].'/'.$path;
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/RoutesCommand.php
+++ b/src/Illuminate/Foundation/Console/RoutesCommand.php
@@ -197,10 +197,8 @@ class RoutesCommand extends Command {
 		{
 			return null;
 		}
-		else
-		{
-			return $route;
-		}
+
+		return $route;
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/TailCommand.php
+++ b/src/Illuminate/Foundation/Console/TailCommand.php
@@ -121,10 +121,8 @@ class TailCommand extends Command {
 		{
 			return storage_path('/logs/laravel.log');
 		}
-		else
-		{
-			return $this->getRoot($connection).str_replace(base_path(), '', storage_path()).'/logs/laravel.log';
-		}
+
+		return $this->getRoot($connection).str_replace(base_path(), '', storage_path()).'/logs/laravel.log';
 	}
 
 	/**

--- a/src/Illuminate/Foundation/EnvironmentDetector.php
+++ b/src/Illuminate/Foundation/EnvironmentDetector.php
@@ -17,10 +17,8 @@ class EnvironmentDetector {
 		{
 			return $this->detectConsoleEnvironment($environments, $consoleArgs);
 		}
-		else
-		{
-			return $this->detectWebEnvironment($environments);
-		}
+
+		return $this->detectWebEnvironment($environments);
 	}
 
 	/**
@@ -69,10 +67,8 @@ class EnvironmentDetector {
 		{
 			return head(array_slice(explode('=', $value), 1));
 		}
-		else
-		{
-			return $this->detectWebEnvironment($environments);
-		}
+
+		return $this->detectWebEnvironment($environments);
 	}
 
 	/**

--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -280,10 +280,8 @@ class HtmlBuilder {
 		{
 			return $this->nestedListing($key, $type, $value);
 		}
-		else
-		{
-			return '<li>'.e($value).'</li>';
-		}
+
+		return '<li>'.e($value).'</li>';
 	}
 
 	/**
@@ -300,10 +298,8 @@ class HtmlBuilder {
 		{
 			return $this->listing($type, $value);
 		}
-		else
-		{
-			return '<li>'.$key.$this->listing($type, $value).'</li>';
-		}
+
+		return '<li>'.$key.$this->listing($type, $value).'</li>';
 	}
 
 	/**

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -138,10 +138,8 @@ class RedirectResponse extends \Symfony\Component\HttpFoundation\RedirectRespons
 		{
 			return $provider->getMessageBag();
 		}
-		else
-		{
-			return new MessageBag((array) $provider);
-		}
+
+		return new MessageBag((array) $provider);
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -456,10 +456,8 @@ class Request extends SymfonyRequest {
 		{
 			return $this->$source->all();
 		}
-		else
-		{
-			return $this->$source->get($key, $default, true);
-		}
+
+		return $this->$source->get($key, $default, true);
 	}
 
 	/**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -321,10 +321,8 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 		{
 			return $this->currentPage;
 		}
-		else
-		{
-			return min($this->currentPage, (int) ceil($total / $this->perPage));
-		}
+
+		return min($this->currentPage, (int) ceil($total / $this->perPage));
 	}
 
 	/**

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -98,13 +98,11 @@ class WorkCommand extends Command {
 				$this->option('sleep'), $this->option('tries')
 			);
 		}
-		else
-		{
-			return $this->worker->pop(
-				$connection, $queue, $delay,
-				$this->option('sleep'), $this->option('tries')
-			);
-		}
+
+		return $this->worker->pop(
+			$connection, $queue, $delay,
+			$this->option('sleep'), $this->option('tries')
+		);
 	}
 
 	/**

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -142,10 +142,8 @@ abstract class Job {
 		{
 			return max(0, $delay->getTimestamp() - $this->getTime());
 		}
-		else
-		{
-			return (int) $delay;
-		}
+
+		return (int) $delay;
 	}
 
 	/**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -55,10 +55,8 @@ abstract class Queue {
 		{
 			return json_encode($this->createClosurePayload($job, $data));
 		}
-		else
-		{
-			return json_encode(array('job' => $job, 'data' => $data));
-		}
+
+		return json_encode(array('job' => $job, 'data' => $data));
 	}
 
 	/**
@@ -102,10 +100,8 @@ abstract class Queue {
 		{
 			return max(0, $delay->getTimestamp() - $this->getTime());
 		}
-		else
-		{
-			return (int) $delay;
-		}
+
+		return (int) $delay;
 	}
 
 	/**

--- a/src/Illuminate/Remote/RemoteManager.php
+++ b/src/Illuminate/Remote/RemoteManager.php
@@ -35,10 +35,8 @@ class RemoteManager {
 		{
 			return $this->connection($name);
 		}
-		else
-		{
-			return $this->connection(func_get_args());
-		}
+
+		return $this->connection(func_get_args());
 	}
 
 	/**

--- a/src/Illuminate/Routing/Generators/ControllerGenerator.php
+++ b/src/Illuminate/Routing/Generators/ControllerGenerator.php
@@ -140,10 +140,8 @@ class ControllerGenerator {
 
 			return str_replace('{{namespace}}', ' namespace '.$namespace.';', $stub);
 		}
-		else
-		{
-			return str_replace('{{namespace}}', '', $stub);
-		}
+
+		return str_replace('{{namespace}}', '', $stub);
 	}
 
 	/**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1152,10 +1152,8 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		{
 			return $callback.'@filter';
 		}
-		else
-		{
-			return $callback;
-		}
+
+		return $callback;
 	}
 
 	/**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -191,10 +191,8 @@ class UrlGenerator {
 		{
 			return $this->forceSchema ?: $this->request->getScheme().'://';
 		}
-		else
-		{
-			return $secure ? 'https://' : 'http://';
-		}
+
+		return $secure ? 'https://' : 'http://';
 	}
 
 	/**
@@ -402,10 +400,8 @@ class UrlGenerator {
 		{
 			return $domain;
 		}
-		else
-		{
-			return $domain .= ':'.$this->request->getPort();
-		}
+
+		return $domain.':'.$this->request->getPort();
 	}
 
 	/**
@@ -436,10 +432,8 @@ class UrlGenerator {
 		{
 			return $this->getScheme(true);
 		}
-		else
-		{
-			return $this->getScheme(null);
-		}
+
+		return $this->getScheme(null);
 	}
 
 	/**

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -57,10 +57,8 @@ class FileSessionHandler implements \SessionHandlerInterface {
 		{
 			return $this->files->get($path);
 		}
-		else
-		{
-			return '';
-		}
+
+		return '';
 	}
 
 	/**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -149,10 +149,8 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 		{
 			return count($this->items) > 0 ? reset($this->items) : null;
 		}
-		else
-		{
-			return array_first($this->items, $callback, $default);
-		}
+
+		return array_first($this->items, $callback, $default);
 	}
 
 	/**
@@ -235,10 +233,8 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 		{
 			return $groupBy($value, $key);
 		}
-		else
-		{
-			return data_get($value, $groupBy);
-		}
+
+		return data_get($value, $groupBy);
 	}
 
 	/**

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -52,10 +52,8 @@ class FileLoader implements LoaderInterface {
 		{
 			return $this->loadPath($this->path, $locale, $group);
 		}
-		else
-		{
-			return $this->loadNamespaced($locale, $group, $namespace);
-		}
+
+		return $this->loadNamespaced($locale, $group, $namespace);
 	}
 
 	/**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -270,10 +270,8 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 		{
 			return array_filter(array($locale, $this->fallback));
 		}
-		else
-		{
-			return array_filter(array($this->locale, $this->fallback));
-		}
+
+		return array_filter(array($this->locale, $this->fallback));
 	}
 
 	/**

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -146,10 +146,8 @@ class Factory {
 		{
 			return new Validator($this->translator, $data, $rules, $messages, $customAttributes);
 		}
-		else
-		{
-			return call_user_func($this->resolver, $this->translator, $data, $rules, $messages, $customAttributes);
-		}
+
+		return call_user_func($this->resolver, $this->translator, $data, $rules, $messages, $customAttributes);
 	}
 
 	/**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -397,10 +397,8 @@ class Validator implements MessageProviderInterface {
 			return array_key_exists($attribute, array_dot($this->data))
                 || array_key_exists($attribute, $this->files);
 		}
-		else
-		{
-			return true;
-		}
+
+		return true;
 	}
 
 	/**
@@ -500,10 +498,8 @@ class Validator implements MessageProviderInterface {
 		{
 			return $this->validateRequired($attribute, $value);
 		}
-		else
-		{
-			return true;
-		}
+
+		return true;
 	}
 
 	/**
@@ -897,10 +893,8 @@ class Validator implements MessageProviderInterface {
 		{
 			return $value->getSize() / 1024;
 		}
-		else
-		{
-			return $this->getStringSize($value);
-		}
+
+		return $this->getStringSize($value);
 	}
 
 	/**
@@ -1011,10 +1005,8 @@ class Validator implements MessageProviderInterface {
 		{
 			return $this->getExtraConditions(array_slice($parameters, 4));
 		}
-		else
-		{
-			return array();
-		}
+
+		return array();
 	}
 
 	/**
@@ -1060,10 +1052,8 @@ class Validator implements MessageProviderInterface {
 		{
 			return $verifier->getMultiCount($table, $column, $value, $extra);
 		}
-		else
-		{
-			return $verifier->getCount($table, $column, $value, null, null, $extra);
-		}
+
+		return $verifier->getCount($table, $column, $value, null, null, $extra);
 	}
 
 	/**
@@ -1186,10 +1176,8 @@ class Validator implements MessageProviderInterface {
 		{
 			return in_array($value->guessExtension(), $parameters);
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**
@@ -1299,10 +1287,8 @@ class Validator implements MessageProviderInterface {
 		{
 			return strtotime($value) < strtotime($this->getValue($parameters[0]));
 		}
-		else
-		{
-			return strtotime($value) < $date;
-		}
+
+		return strtotime($value) < $date;
 	}
 
 	/**
@@ -1341,10 +1327,8 @@ class Validator implements MessageProviderInterface {
 		{
 			return strtotime($value) > strtotime($this->getValue($parameters[0]));
 		}
-		else
-		{
-			return strtotime($value) > $date;
-		}
+
+		return strtotime($value) > $date;
 	}
 
 	/**
@@ -1639,10 +1623,7 @@ class Validator implements MessageProviderInterface {
 		// If no language line has been specified for the attribute all of the
 		// underscores are removed from the attribute name and that will be
 		// used as default versions of the attribute's displayable names.
-		else
-		{
-			return str_replace('_', ' ', snake_case($attribute));
-		}
+		return str_replace('_', ' ', snake_case($attribute));
 	}
 
 	/**
@@ -1665,10 +1646,8 @@ class Validator implements MessageProviderInterface {
 		{
 			return $line;
 		}
-		else
-		{
-			return $value;
-		}
+
+		return $value;
 	}
 
 	/**
@@ -1921,10 +1900,8 @@ class Validator implements MessageProviderInterface {
 		{
 			return str_replace(':date', $this->getAttribute($parameters[0]), $message);
 		}
-		else
-		{
-			return str_replace(':date', $parameters[0], $message);
-		}
+
+		return str_replace(':date', $parameters[0], $message);
 	}
 
 	/**

--- a/src/Illuminate/Workbench/PackageCreator.php
+++ b/src/Illuminate/Workbench/PackageCreator.php
@@ -307,10 +307,8 @@ class PackageCreator {
 		{
 			return $this->files->get(__DIR__.'/stubs/plain.provider.stub');
 		}
-		else
-		{
-			return $this->files->get(__DIR__.'/stubs/provider.stub');
-		}
+
+		return $this->files->get(__DIR__.'/stubs/provider.stub');
 	}
 
 	/**


### PR DESCRIPTION
No performance consideration, remove useless usage of `else` so that every `if (...) return ...; return...;` are formatted the same way
As for https://github.com/laravel/framework/blob/4.2/src/Illuminate/Auth/AuthManager.php#L37-L39
