### PR TITLE
[4.2] Performances : use isset() instead of count comparator

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -70,7 +70,7 @@ class RedisTaggedCache extends TaggedCache {
 	{
 		$forever = array_unique($this->store->connection()->lrange($foreverKey, 0, -1));
 
-		if (count($forever) > 0)
+		if ( ! empty($forever))
 		{
 			call_user_func_array(array($this->store->connection(), 'del'), $forever);
 		}

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -264,7 +264,7 @@ class Connection implements ConnectionInterface {
 	{
 		$records = $this->select($query, $bindings);
 
-		return count($records) > 0 ? reset($records) : null;
+		return ! empty($records) ? reset($records) : null;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -153,7 +153,7 @@ class Builder {
 		// If we actually found models we will also eager load any relationships that
 		// have been specified as needing to be eager loaded, which will solve the
 		// n+1 query issue for the developers to avoid running a lot of queries.
-		if (count($models) > 0)
+		if ( ! empty($models))
 		{
 			$models = $this->eagerLoadRelations($models);
 		}
@@ -185,7 +185,7 @@ class Builder {
 	{
 		$results = $this->forPage($page = 1, $count)->get();
 
-		while (count($results) > 0)
+		while ( ! empty($results))
 		{
 			// On each chunk result set, we will pass them to the callback and then let the
 			// developer take care of everything within the callback, which allows us to
@@ -503,7 +503,7 @@ class Builder {
 		// If there are nested relationships set on the query, we will put those onto
 		// the query instances so that they can be handled after this relationship
 		// is loaded. In this way they will all trickle down as they are loaded.
-		if (count($nested) > 0)
+		if ( ! empty($nested))
 		{
 			$query->getQuery()->with($nested);
 		}

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -33,7 +33,7 @@ class Collection extends BaseCollection {
 	 */
 	public function load($relations)
 	{
-		if (count($this->items) > 0)
+		if ( ! empty($this->items))
 		{
 			if (is_string($relations)) $relations = func_get_args();
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -423,7 +423,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	protected function fillableFromArray(array $attributes)
 	{
-		if (count($this->fillable) > 0 && ! static::$unguarded)
+		if ( ! empty($this->fillable) && ! static::$unguarded)
 		{
 			return array_intersect_key($attributes, array_flip($this->fillable));
 		}
@@ -1461,7 +1461,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	{
 		$dirty = $this->getDirty();
 
-		if (count($dirty) > 0)
+		if ( ! empty($dirty))
 		{
 			// If the updating event returns false, we will cancel the update operation so
 			// developers can hook Validation systems into their models and cancel this
@@ -1484,7 +1484,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			// models are updated, giving them a chance to do any special processing.
 			$dirty = $this->getDirty();
 
-			if (count($dirty) > 0)
+			if ( ! empty($dirty))
 			{
 				$this->setKeysForSaveQuery($query)->update($dirty);
 
@@ -2129,7 +2129,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function totallyGuarded()
 	{
-		return count($this->fillable) == 0 && $this->guarded == array('*');
+		return empty($this->fillable) && $this->guarded == array('*');
 	}
 
 	/**
@@ -2279,7 +2279,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	protected function getArrayableAppends()
 	{
-		if ( ! count($this->appends)) return [];
+		if (empty($this->appends)) return [];
 
 		return $this->getArrayableItems(
 			array_combine($this->appends, $this->appends)
@@ -2353,7 +2353,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	protected function getArrayableItems(array $values)
 	{
-		if (count($this->visible) > 0)
+		if ( ! empty($this->visible))
 		{
 			return array_intersect_key($values, array_flip($this->visible));
 		}
@@ -2737,7 +2737,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	{
 		$dirty = $this->getDirty();
 
-		if (is_null($attributes)) return count($dirty) > 0;
+		if (is_null($attributes)) return ! empty($dirty);
 
 		if ( ! is_array($attributes)) $attributes = func_get_args();
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -131,7 +131,7 @@ class BelongsTo extends Relation {
 		// If there are no keys that were not null we will just return an array with 0 in
 		// it so the query doesn't fail, but will not return any results, which should
 		// be what this developer is expecting in a case where this happens to them.
-		if (count($keys) == 0)
+		if (empty($keys))
 		{
 			return array(0);
 		}

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -599,7 +599,7 @@ class BelongsToMany extends Relation {
 			$changes, $this->attachNew($records, $current, false)
 		);
 
-		if (! empty($changes['attached']) || ! empty($changes['updated']))
+		if ( ! empty($changes['attached']) || ! empty($changes['updated']))
 		{
 			$this->touchIfTouching();
 		}

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -111,7 +111,7 @@ class BelongsToMany extends Relation {
 	{
 		$results = $this->take(1)->get($columns);
 
-		return count($results) > 0 ? $results->first() : null;
+		return ! empty($results) ? $results->first() : null;
 	}
 
 	/**
@@ -151,7 +151,7 @@ class BelongsToMany extends Relation {
 		// If we actually found models we will also eager load any relationships that
 		// have been specified as needing to be eager loaded. This will solve the
 		// n + 1 query problem for the developer and also increase performance.
-		if (count($models) > 0)
+		if ( ! empty($models))
 		{
 			$models = $this->query->eagerLoadRelations($models);
 		}
@@ -459,7 +459,7 @@ class BelongsToMany extends Relation {
 		// to the parent models. This will help us keep any caching synced up here.
 		$ids = $this->getRelatedIds();
 
-		if (count($ids) > 0)
+		if ( ! empty($ids))
 		{
 			$this->getRelated()->newQuery()->whereIn($key, $ids)->update($columns);
 		}
@@ -585,7 +585,7 @@ class BelongsToMany extends Relation {
 		// Next, we will take the differences of the currents and given IDs and detach
 		// all of the entities that exist in the "current" array but are not in the
 		// the array of the IDs given to the method which will complete the sync.
-		if ($detaching && count($detach) > 0)
+		if ($detaching && ! empty($detach))
 		{
 			$this->detach($detach);
 
@@ -599,7 +599,7 @@ class BelongsToMany extends Relation {
 			$changes, $this->attachNew($records, $current, false)
 		);
 
-		if (count($changes['attached']) || count($changes['updated']))
+		if (! empty($changes['attached']) || ! empty($changes['updated']))
 		{
 			$this->touchIfTouching();
 		}
@@ -657,7 +657,7 @@ class BelongsToMany extends Relation {
 			// Now we'll try to update an existing pivot record with the attributes that were
 			// given to the method. If the model is actually updated we will add it to the
 			// list of updated pivot records so we return them back out to the consumer.
-			elseif (count($attributes) > 0 &&
+			elseif ( ! empty($attributes) &&
 				$this->updateExistingPivot($id, $attributes, $touch))
 			{
 				$changes['updated'][] = (int) $id;
@@ -832,7 +832,7 @@ class BelongsToMany extends Relation {
 		// We'll return the numbers of affected rows when we do the deletes.
 		$ids = (array) $ids;
 
-		if (count($ids) > 0)
+		if ( ! empty($ids))
 		{
 			$query->whereIn($this->otherKey, (array) $ids);
 		}

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -209,7 +209,7 @@ class HasManyThrough extends Relation {
 		// If we actually found models we will also eager load any relationships that
 		// have been specified as needing to be eager loaded. This will solve the
 		// n + 1 query problem for the developer and also increase performance.
-		if (count($models) > 0)
+		if ( ! empty($models))
 		{
 			$models = $this->query->eagerLoadRelations($models);
 		}

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -94,7 +94,7 @@ class Migrator {
 		// First we will just make sure that there are any migrations to run. If there
 		// aren't, we will just make a note of it to the developer so they're aware
 		// that all of the migrations have been run against this database system.
-		if (count($migrations) == 0)
+		if (empty($migrations))
 		{
 			$this->note('<info>Nothing to migrate.</info>');
 
@@ -157,7 +157,7 @@ class Migrator {
 		// of them "down" to reverse the last migration "operation" which ran.
 		$migrations = $this->repository->getLast();
 
-		if (count($migrations) == 0)
+		if (empty($migrations))
 		{
 			$this->note('<info>Nothing to rollback.</info>');
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -601,7 +601,7 @@ class Builder {
 	 */
 	public function addNestedWhereQuery($query, $boolean = 'and')
 	{
-		if (count($query->wheres))
+		if ( ! empty($query->wheres))
 		{
 			$type = 'Nested';
 
@@ -1307,7 +1307,7 @@ class Builder {
 	{
 		$result = (array) $this->first(array($column));
 
-		return count($result) > 0 ? reset($result) : null;
+		return  ! empty($result) ? reset($result) : null;
 	}
 
 	/**
@@ -1320,7 +1320,7 @@ class Builder {
 	{
 		$results = $this->take(1)->get($columns);
 
-		return count($results) > 0 ? reset($results) : null;
+		return ! empty($results) > 0 ? reset($results) : null;
 	}
 
 	/**
@@ -1457,7 +1457,7 @@ class Builder {
 	{
 		$results = $this->forPage($page = 1, $count)->get();
 
-		while (count($results) > 0)
+		while ( ! empty($results))
 		{
 			// On each chunk result set, we will pass them to the callback and then let the
 			// developer take care of everything within the callback, which allows us to
@@ -1491,7 +1491,7 @@ class Builder {
 		// If a key was specified and we have results, we will go ahead and combine
 		// the values with the keys of all of the records so that the values can
 		// be accessed by the key of the rows instead of simply being numeric.
-		if ( ! is_null($key) && count($results) > 0)
+		if ( ! is_null($key) && ! empty($results))
 		{
 			$keys = $results->fetch($key)->all();
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -200,7 +200,7 @@ class Grammar extends BaseGrammar {
 		// If we actually have some where clauses, we will strip off the first boolean
 		// operator, which is added by the query builders for convenience so we can
 		// avoid checking for the first clauses in each of the compilers methods.
-		if (count($sql) > 0)
+		if ( ! empty($sql))
 		{
 			$sql = implode(' ', $sql);
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -103,7 +103,7 @@ class Blueprint {
 	 */
 	protected function addImpliedCommands()
 	{
-		if (count($this->columns) > 0 && ! $this->creating())
+		if ( ! empty($this->columns) && ! $this->creating())
 		{
 			array_unshift($this->commands, $this->createCommand('add'));
 		}

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -160,7 +160,7 @@ abstract class Grammar extends BaseGrammar {
 	{
 		$commands = $this->getCommandsByName($blueprint, $name);
 
-		if (count($commands) > 0)
+		if ( ! empty($commands))
 		{
 			return reset($commands);
 		}

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -230,7 +230,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	 */
 	public function environment()
 	{
-		if (count(func_get_args()) > 0)
+		if (func_num_args() > 0)
 		{
 			return in_array($this['env'], func_get_args());
 		}

--- a/src/Illuminate/Foundation/Console/RoutesCommand.php
+++ b/src/Illuminate/Foundation/Console/RoutesCommand.php
@@ -66,7 +66,7 @@ class RoutesCommand extends Command {
 	 */
 	public function fire()
 	{
-		if (count($this->routes) == 0)
+		if (empty($this->routes))
 		{
 			return $this->error("Your application doesn't have any routes.");
 		}

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -94,7 +94,7 @@ class ProviderRepository {
 	 */
 	protected function registerLoadEvents(Application $app, $provider, array $events)
 	{
-		if (count($events) < 1) return;
+		if (empty($events)) return;
 
 		$app->make('events')->listen($events, function() use ($app, $provider)
 		{

--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -251,7 +251,7 @@ class HtmlBuilder {
 	{
 		$html = '';
 
-		if (count($list) == 0) return $html;
+		if (empty($list)) return $html;
 
 		// Essentially we will just spin through the list and build the list of the HTML
 		// elements from the array. We will also handled nested lists in case that is
@@ -326,7 +326,7 @@ class HtmlBuilder {
 			if ( ! is_null($element)) $html[] = $element;
 		}
 
-		return count($html) > 0 ? ' '.implode(' ', $html) : '';
+		return ! empty($html) ? ' '.implode(' ', $html) : '';
 	}
 
 	/**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -219,7 +219,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 		// If we have any extra query string key / value pairs that need to be added
 		// onto the URL, we will put them in query string form and then attach it
 		// to the URL. This allows for extra information like sortings storage.
-		if (count($this->query) > 0)
+		if ( ! empty($this->query))
 		{
 			$parameters = array_merge($this->query, $parameters);
 		}

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -32,7 +32,7 @@ class ListFailedCommand extends Command {
 			$rows[] = $this->parseFailedJob((array) $failed);
 		}
 
-		if (count($rows) == 0)
+		if (empty($rows))
 		{
 			return $this->info('No failed jobs!');
 		}

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -175,7 +175,7 @@ class RedisQueue extends Queue implements QueueInterface {
 			// If we actually found any jobs, we will remove them from the old queue and we
 			// will insert them onto the new (ready) "queue". This means they will stand
 			// ready to be processed by the queue worker whenever their turn comes up.
-			if (count($jobs) > 0)
+			if ( ! empty($jobs))
 			{
 				$this->removeExpiredJobs($transaction, $from, $time);
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -96,7 +96,7 @@ class SqsQueue extends Queue implements QueueInterface {
 			array('QueueUrl' => $queue, 'AttributeNames' => array('ApproximateReceiveCount'))
 		);
 
-		if (count($response['Messages']) > 0)
+		if ( ! empty($response['Messages']))
 		{
 			return new SqsJob($this->container, $this->sqs, $queue, $response['Messages'][0]);
 		}

--- a/src/Illuminate/Routing/Generators/ControllerGenerator.php
+++ b/src/Illuminate/Routing/Generators/ControllerGenerator.php
@@ -194,7 +194,7 @@ class ControllerGenerator {
 	 */
 	protected function getMethods($options)
 	{
-		if (isset($options['only']) && count($options['only']) > 0)
+		if (isset($options['only']) && ! empty($options['only']))
 		{
 			return $options['only'];
 		}

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -140,7 +140,7 @@ class RouteCollection implements Countable, IteratorAggregate {
 		// inform the user agent of which HTTP verb it should use for this route.
 		$others = $this->checkForAlternateVerbs($request);
 
-		if (count($others) > 0)
+		if ( ! empty($others))
 		{
 			return $this->getOtherMethodsRoute($request, $others);
 		}

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -277,7 +277,7 @@ class UrlGenerator {
 	 */
 	protected function replaceRouteParameters($path, array &$parameters)
 	{
-		if (count($parameters))
+		if ( ! empty($parameters))
 		{
 			$path = preg_replace_sub(
 				'/\{.*?\}/', $parameters, $this->replaceNamedParameters($path, $parameters)
@@ -314,7 +314,7 @@ class UrlGenerator {
 		// First we will get all of the string parameters that are remaining after we
 		// have replaced the route wildcards. We'll then build a query string from
 		// these string parameters then use it as a starting point for the rest.
-		if (count($parameters) == 0) return '';
+		if (empty($parameters)) return '';
 
 		$query = http_build_query(
 			$keyed = $this->getStringParameters($parameters)

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -303,7 +303,7 @@ class Store implements SessionInterface {
 	{
 		$old = $this->getOldInput($key);
 
-		return is_null($key) ? count($old) > 0 : ! is_null($old);
+		return is_null($key) ? ! empty($old) : ! is_null($old);
 	}
 
 	/**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -147,7 +147,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	{
 		if (is_null($callback))
 		{
-			return count($this->items) > 0 ? reset($this->items) : null;
+			return ! empty($this->items) ? reset($this->items) : null;
 		}
 		else
 		{
@@ -324,7 +324,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	*/
 	public function last()
 	{
-		return count($this->items) > 0 ? end($this->items) : null;
+		return ! empty($this->items) ? end($this->items) : null;
 	}
 
 	/**

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -140,7 +140,7 @@ class Fluent implements ArrayAccess, ArrayableInterface, JsonableInterface, Json
 	 */
 	public function __call($method, $parameters)
 	{
-		$this->attributes[$method] = count($parameters) > 0 ? $parameters[0] : true;
+		$this->attributes[$method] = ! empty($parameters) ? $parameters[0] : true;
 
 		return $this;
 	}

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -107,7 +107,7 @@ class MessageBag implements ArrayableInterface, Countable, JsonableInterface, Me
 	{
 		$messages = is_null($key) ? $this->all($format) : $this->get($key, $format);
 
-		return (count($messages) > 0) ? $messages[0] : '';
+		return ! empty($messages) ? $messages[0] : '';
 	}
 
 	/**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -112,7 +112,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 		{
 			return $this->makeReplacements($line, $replace);
 		}
-		elseif (is_array($line) && count($line) > 0)
+		elseif (is_array($line) && ! empty($line))
 		{
 			return $line;
 		}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -475,7 +475,7 @@ class Validator implements MessageProviderInterface {
 		{
 			return false;
 		}
-		elseif (is_array($value) && count($value) < 1)
+		elseif (is_array($value) && empty($value))
 		{
 			return false;
 		}

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -123,7 +123,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 		// If there are any footer lines that need to get added to a template we will
 		// add them here at the end of the template. This gets used mainly for the
 		// template inheritance via the extends keyword that should be appended.
-		if (count($this->footer) > 0)
+		if ( ! empty($this->footer))
 		{
 			$result = ltrim($result, PHP_EOL)
 					.PHP_EOL.implode(PHP_EOL, array_reverse($this->footer));

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -213,7 +213,7 @@ class Factory {
 		// If is actually data in the array, we will loop through the data and append
 		// an instance of the partial view to the final result HTML passing in the
 		// iterated value of this data array, allowing the views to access them.
-		if (count($data) > 0)
+		if ( ! empty($data))
 		{
 			foreach ($data as $key => $value)
 			{


### PR DESCRIPTION
Using `isset` is much faster than using `count` and comparing with a value.
See benchmark https://gist.github.com/lucasmichot/63880030192144960084/894369e9936d30ce06d095fe18800a574ba574b3

count : 8.9168548583984E-5
isset : 2.3126602172852E-5
