### PR TITLE
[5.0] Use container to resolve objects in Illuminate/Routing/Router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -129,8 +129,8 @@ class Router implements HttpKernelInterface, RegistrarContract, RouteFiltererInt
 	public function __construct(Dispatcher $events, Container $container = null)
 	{
 		$this->events = $events;
-		$this->routes = new RouteCollection;
 		$this->container = $container ?: new Container;
+		$this->routes = $this->container->make('Illuminate\\Routing\\RouteCollection');
 
 		$this->bind('_missing', function($v) { return explode('/', $v); });
 	}
@@ -854,7 +854,8 @@ class Router implements HttpKernelInterface, RegistrarContract, RouteFiltererInt
 	 */
 	protected function newRoute($methods, $uri, $action)
 	{
-		return (new Route($methods, $uri, $action))->setContainer($this->container);
+		return $this->container->make('Illuminate\\Routing\\Route', [$methods, $uri, $action])
+			->setContainer($this->container);
 	}
 
 	/**
@@ -1497,7 +1498,7 @@ class Router implements HttpKernelInterface, RegistrarContract, RouteFiltererInt
 	{
 		if ( ! $response instanceof SymfonyResponse)
 		{
-			$response = new Response($response);
+			$response = $this->container->make('Illuminate\\Http\\Response', [$response]);
 		}
 
 		return $response->prepare($request);
@@ -1712,7 +1713,7 @@ class Router implements HttpKernelInterface, RegistrarContract, RouteFiltererInt
 	{
 		if (is_null($this->controllerDispatcher))
 		{
-			$this->controllerDispatcher = new ControllerDispatcher($this, $this->container);
+			$this->controllerDispatcher = $this->container->make('Illuminate\\Routing\\ControllerDispatcher', [$this, $this->container]);
 		}
 
 		return $this->controllerDispatcher;


### PR DESCRIPTION
In order to allow overriding of the default Route, RouteCollection, and ControllerDispatcher, the IoC container (which is already available to the router) should be used to build new objects rather than hard coupling to the actual class.

This may also be worth creating contracts for Route, RouteCollection, and ControllerDispatcher.
