### PR TITLE
[5.0] Allow single parameter to be passed to route generator

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -231,6 +231,8 @@ class UrlGenerator implements UrlGeneratorContract {
 	{
 		if ( ! is_null($route = $this->routes->getByName($name)))
 		{
+			$parameters = (array) $parameters;
+			
 			return $this->toRoute($route, $parameters, $absolute);
 		}
 		else


### PR DESCRIPTION
In 4.2 when using route helpers you can do route('routename', $singleparam);

This pull request brings this behaviour back as currently you need to do route('routename', [$singleparam]);
