### PR TITLE
Remove forgotten method

### DIFF
--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -62,14 +62,4 @@ class SessionServiceProvider extends ServiceProvider {
 		});
 	}
 
-	/**
-	 * Get the session driver name.
-	 *
-	 * @return string
-	 */
-	protected function getDriver()
-	{
-		return $this->app['config']['session.driver'];
-	}
-
 }


### PR DESCRIPTION
It seems like this method was left over a long time ago in [this commit](https://github.com/laravel/framework/commit/e0fe79e398003e54d54f2626e1283e97209b7f50).
