### PR TITLE
[5.0] AuthController - Correct redirection

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/controller.stub
+++ b/src/Illuminate/Auth/Console/stubs/controller.stub
@@ -77,7 +77,7 @@ class AuthController extends Controller {
 			return redirect('/');
 		}
 
-		return redirect('/login')->withErrors([
+		return redirect()->back()->withErrors([
 			'email' => 'The credentials you entered did not match our records. Try again?',
 		]);
 	}


### PR DESCRIPTION
Redirect back on invalid credentials (or, more explicitly, `/auth/login`?).
