### PR TITLE
Owners should only be touched if they exist

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1566,7 +1566,10 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		{
 			$this->$relation()->touch();
 
-			$this->$relation->touchOwners();
+			if ($this->$relation)
+			{
+				$this->$relation->touchOwners();				
+			}
 		}
 	}
 


### PR DESCRIPTION
If the model has an optional belongs to relationship then the call to `touchOwners()` would be called upon `null`, crashing the app. For this reason, touching should only continue if the relation actually exists.

Edit: it might be worth noting that this change turned up on v4.2.9 and broke the previous functionality.
