### PR TITLE
Added ability to set custom collection class to instantiate in paginator

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -88,6 +88,13 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	protected $fragment;
 
 	/**
+	 * The collection.
+	 * 
+	 * @var mixed
+	 */
+	protected $collection;
+
+	/**
 	 * Create a new Paginator instance.
 	 *
 	 * @param  \Illuminate\Pagination\Factory  $factory
@@ -370,11 +377,11 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	/**
 	 * Get a collection instance containing the items.
 	 *
-	 * @return \Illuminate\Support\Collection
+	 * @return mixed
 	 */
 	public function getCollection()
 	{
-		return new Collection($this->items);
+		return $this->collection ?: new \Illuminate\Support\Collection($this->items);
 	}
 
 	/**
@@ -396,6 +403,17 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 	public function setItems($items)
 	{
 		$this->items = $items;
+	}
+
+	/**
+	 * Set the collection.
+	 * 
+	 * @param ArrayableInterface $class
+	 * @return void
+	 */
+	public function setCollection(ArrayableInterface $collection)
+	{
+		$this->collection = $collection;
 	}
 
 	/**

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -201,6 +201,11 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://foo.com?sort=desc&page=1', $p->getUrl(1));
 	}
 
+	public function testPaginatorGetsIlluminateCollectionAsDefaultCollection()
+	{
+		$p = new Paginator(m::mock('Illuminate\Pagination\Factory'), array(), 0, 0);
+		$this->assertInstanceOf('Illuminate\Support\Collection', $p->getCollection());
+	}
 
 	public function testPaginatorDecoratesCollection()
 	{
@@ -208,6 +213,14 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 		$last = $p->last();
 
 		$this->assertEquals('c', $last);
+	}
+
+	public function testPaginatorSetCollection()
+	{
+		$p = new Paginator(m::mock('Illuminate\Pagination\Factory'), array(), 0, 0);
+		$collection = m::mock('Illuminate\Support\Contracts\ArrayableInterface');
+		$p->setCollection($collection);
+		$this->assertInstanceOf('Illuminate\Support\Contracts\ArrayableInterface', $p->getCollection());
 	}
 
 }


### PR DESCRIPTION
This is useful for when you have e.g. a custom collection being generated on your model through `newCollection()`. For instance:

**_Model:**_

```
class User {
    public function newCollection(array $items = array())
    {
        return new UserCollection($items);
    }
}
```

**Will instantiate a UserCollection**

```
$users = User::all();
```

**Will NOT instantiate a UserCollection**

```
$users = User::paginate(20)->getCollection(); // Currently the paginator will always create a new Illuminate\Support\Collection
```

**With this PR:**

Can now at least configure it to return the collection:

```
$users = User::paginate(20)->setCollectionClass('UserCollection')->getCollection(); // UserCollection
```
