### PR TITLE
[4.2] Initialise array in Collection::groupBy()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -213,7 +213,11 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 
 		foreach ($this->items as $key => $value)
 		{
-			$results[$this->getGroupbyKey($groupBy, $key, $value)][] = $value;
+			$groupbyKey = $this->getGroupbyKey($groupBy, $key, $value);
+			
+			if ( ! array_key_exists($groupbyKey, $results)) $results[$groupbyKey] = [];
+			
+			$results[$groupbyKey][] = $value;
 		}
 
 		return new static($results);


### PR DESCRIPTION
This is best practice as mentioned [in the PHP docs](http://php.net/manual/en/language.types.array.php#language.types.array.syntax.modifying).
