### PR TITLE
[4.2] Make LogTransport work with custom implementations of PSR LoggerInterface

### DIFF
--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -25,6 +25,11 @@ class LogServiceProvider extends ServiceProvider {
 
 		$this->app->instance('log', $logger);
 
+		$this->app->bind('Psr\Log\LoggerInterface', function($app)
+		{
+			return $app['log']->getMonolog();
+		});
+
 		// If the setup Closure has been bound in the container, we will resolve it
 		// and pass in the logger instance. This allows this to defer all of the
 		// logger class setup until the last possible second, improving speed.

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -244,7 +244,7 @@ class MailServiceProvider extends ServiceProvider {
 	{
 		$this->app->bindShared('swift.transport', function($app)
 		{
-			return new LogTransport($app['log']->getMonolog());
+			return new LogTransport($app->make('Psr\Log\LoggerInterface'));
 		});
 	}
 


### PR DESCRIPTION
I use a custom logger that I bind to the "log" IoC key to make use of the `Log::` facade, however this messes up the `LogTransport` because the `getMonolog()` method does not exist on my logger.
