### PR TITLE
[4.2] Fix Issue #5820

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -232,6 +232,32 @@ class HasManyThrough extends Relation {
 
 		return array_merge($columns, array($this->parent->getTable().'.'.$this->firstKey));
 	}
+	
+	/**
+	 * Execute the query and get the first result.
+	 *
+	 * @param  array  $columns
+	 * @return \Illuminate\Database\Eloquent\Model|static|null
+	 */
+	public function first($columns = array('*'))
+	{
+		return $this->take(1)->get($this->getSelectColumns($columns))->first();
+	}
+	
+	/**
+	 * Execute the query and get the first result or throw an exception.
+	 *
+	 * @param  array  $columns
+	 * @return \Illuminate\Database\Eloquent\Model|static
+	 *
+	 * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+	 */
+	public function firstOrFail($columns = array('*'))
+	{
+		if ( ! is_null($model = $this->first($columns))) return $model;
+
+		throw (new ModelNotFoundException)->setModel(get_class($this->model));
+	}
 
 	/**
 	 * Get a paginator for the "select" statement.


### PR DESCRIPTION
Except for get() and paginate(), the request with an HasManyThrough relationship return all columns (select _) except of only the column of the model asked (select model._).

More information here : http://stackoverflow.com/questions/26023582/get-only-main-columns-in-eloquent.

---

Replaces: https://github.com/laravel/framework/issues/5820
