### PR TITLE
Db memory leak fix #5568

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -279,7 +279,7 @@ class Builder {
 		// one condition, so we'll add the join and call a Closure with the query.
 		if ($one instanceof Closure)
 		{
-			$this->joins[] = new JoinClause($this, $type, $table);
+			$this->joins[] = new JoinClause($type, $table);
 
 			call_user_func($one, end($this->joins));
 		}
@@ -289,7 +289,7 @@ class Builder {
 		// this simple join clauses attached to it. There is not a join callback.
 		else
 		{
-			$join = new JoinClause($this, $type, $table);
+			$join = new JoinClause($type, $table);
 
 			$this->joins[] = $join->on(
 				$one, $operator, $two, 'and', $where

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -142,6 +142,11 @@ class Grammar extends BaseGrammar {
 				$clauses[] = $this->compileJoinConstraint($clause);
 			}
 
+			foreach ($join->bindings as $binding)
+			{
+				$query->addBinding($binding, 'join');
+			}
+
 			// Once we have constructed the clauses, we'll need to take the boolean connector
 			// off of the first clause as it obviously will not be required on that clause
 			// because it leads the rest of the clauses, thus not requiring any boolean.

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -3,13 +3,6 @@
 class JoinClause {
 
 	/**
-	 * The query builder instance.
-	 *
-	 * @var \Illuminate\Database\Query\Builder
-	 */
-	public $query;
-
-	/**
 	 * The type of join being performed.
 	 *
 	 * @var string
@@ -31,17 +24,22 @@ class JoinClause {
 	public $clauses = array();
 
 	/**
+	* The "on" bindings for the join.
+	*
+	* @var array
+	*/
+	public $bindings = array();
+
+	/**
 	 * Create a new join clause instance.
 	 *
-	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  string  $type
 	 * @param  string  $table
 	 * @return void
 	 */
-	public function __construct(Builder $query, $type, $table)
+	public function __construct($type, $table)
 	{
 		$this->type = $type;
-		$this->query = $query;
 		$this->table = $table;
 	}
 
@@ -59,7 +57,7 @@ class JoinClause {
 	{
 		$this->clauses[] = compact('first', 'operator', 'second', 'boolean', 'where');
 
-		if ($where) $this->query->addBinding($second, 'join');
+		if ($where) $this->bindings[] = $second;
 
 		return $this;
 	}

--- a/tests/Database/DatabaseQueryBuilderMemoryLeakTest.php
+++ b/tests/Database/DatabaseQueryBuilderMemoryLeakTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Database\Query\Builder;
+
+class DatabaseJoinMemoryLeakTest extends PHPUnit_Framework_TestCase {
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testItDoesNotLeakMemoryOnNewQuery()
+    {
+        $builderMain = $this->getBuilder();
+
+        $this->runMemoryTest(function() use($builderMain){
+            $builder = $builderMain->newQuery();
+            $builder->select('*')->from('users');
+
+        });
+    }
+
+    public function testItDoesNotLeakMemoryOnNewQueryWithJoin()
+    {
+        $builderMain = $this->getBuilder();
+
+        $this->runMemoryTest(function() use($builderMain){
+            $builder = $builderMain->newQuery();
+            $builder->select('*')->join('new', 'col', '=', 'col2')->from('users');
+
+        });
+    }
+
+    protected function runMemoryTest(\Closure $callback)
+    {
+        $i = 5;
+
+        $last = null;
+
+        while($i--)
+        {
+            $callback();
+
+            $prev = $last;
+            $last = memory_get_usage();
+        }
+
+        $this->assertEquals($prev, $last);
+    }
+
+
+    protected function getBuilder()
+    {
+        $grammar = new Illuminate\Database\Query\Grammars\SqlServerGrammar;
+        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+    }
+
+}


### PR DESCRIPTION
PR to test for and fix memory leak from issue #5568

The leak was due to a circular dependency between JoinClause and QueryBuilder, which meant neither object was eligible for garbage collection.

QueryBuilder had a dependency on JoinClause to add "on" bindings, but these can be stored internally on the JoinClause object, and added to the QueryBuilder when compiling the join in the Grammar object.

This removes the dependency and allows expected GC to take place.
