### PR TITLE
[4.2] Fix a bug with Expressions using false as value

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -129,7 +129,7 @@ abstract class Grammar {
 	 */
 	public function getValue($expression)
 	{
-		return $expression->getValue();
+		return (string) $expression;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Expression.php
+++ b/src/Illuminate/Database/Query/Expression.php
@@ -37,6 +37,8 @@ class Expression {
 	 */
 	public function __toString()
 	{
+		if ($this->getValue() === false) return "0";
+		
 		return (string) $this->getValue();
 	}
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -138,6 +138,24 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testWhereBooleanExpression()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->
+			where('active', '=', new Illuminate\Database\Query\Expression(false))->
+			where('banned', '=', new Illuminate\Database\Query\Expression(true));
+		$this->assertEquals('select * from "users" where "active" = 0 and "banned" = 1', $builder->toSql());
+		$this->assertEquals(array(), $builder->getBindings());
+	}
+
+	public function testWhereIntegerExpression()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->where('num_posts', '=', new Illuminate\Database\Query\Expression(25));
+		$this->assertEquals('select * from "users" where "num_posts" = 25', $builder->toSql());
+		$this->assertEquals(array(), $builder->getBindings());
+	}
+
 	public function testMySqlWrappingProtectsQuotationMarks()
 	{
 		$builder = $this->getMySqlBuilder();


### PR DESCRIPTION
As illustrated in the added unit test, the query builder (or rather, the underlying Grammar class) incorrectly converts `where('attribute', new Expression(false))` into `'where attribute = '`, leading to SQL errors. The reason for this is actually PHP related, since `false` evaluates to an empty string, while `true` evaluates to `'1'`. Either way, I added an exception for this in Expression's `toString`, and changed the Grammar method to use the string value rather than the actual value.

An alternative solution would be to just return `$expression` and the string conversion would happen automatically as it is appended to the query string, but then I think you might as well just take out the entire `getValue` method.

I came across this issue while I was trying to add a global scope to a Model, where I realized I couldn't revert setting the query bindings in `remove`. Then I found out that using Expression as a wrapper circumvents bindings by just injecting the actual value in the query rather than '?'. Would it be an idea to add a way to remove where clauses from a query, other than looping over all of them as is done in the SoftDeletingScope?
