### PR TITLE
Bug fix: Encode asset urls

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -152,7 +152,7 @@ class UrlGenerator {
 		// for asset paths, but only for routes to endpoints in the application.
 		$root = $this->getRootUrl($this->getScheme($secure));
 
-		return $this->removeIndex($root).'/'.trim($path, '/');
+		return $this->removeIndex($root).'/'.strtr(rawurlencode(trim($path, '/')), $this->dontEncode); //
 	}
 
 	/**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -34,6 +34,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertEquals('http://www.foo.com/foo/bar', $url->asset('foo/bar'));
+		$this->assertEquals('http://www.foo.com/%CF%80', $url->asset('π'));
 		$this->assertEquals('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
 	}
 


### PR DESCRIPTION
Before this commit, urls of assets containing non ascii characters (example: τεστ.jpg) are not properly encoded.
