### PR TITLE
[4.2] Parse $dates Values When Using fromDateTime

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2590,7 +2590,15 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// can return back the finally formatted DateTime instances to the devs.
 		else
 		{
-			$value = Carbon::createFromFormat($format, $value);
+			try
+			{
+				$value = Carbon::createFromFormat($format, $value);
+			}
+			catch (\InvalidArgumentException $e)
+			{
+				// If all else fails, we'll attempt to use Carbon to parse it
+				$value = Carbon::parse($value);
+			}
 		}
 
 		return $value->format($format);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -332,6 +332,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model = new EloquentDateModelStub;
 		$model->created_at = '2012-01-01';
 		$this->assertInstanceOf('Carbon\Carbon', $model->created_at);
+
+		$model = new EloquentDateModelStub;
+		$model->created_at = 'first day of December 2008';
+		$this->assertInstanceOf('Carbon\Carbon', $model->created_at);
 	}
 
 


### PR DESCRIPTION
Allows model to be assigned a date like strings, without it having to match the database format exactly.

Main advantage is this allows for more forgiving parsing of incoming json / user formatted dates.
This would fix #5528 - although has similarities to #3799 which was rejected.

IMO, writing a mutator for every date value is not an appropriate solution, particularly if you have a large number of date fields.

If this doesn't get accepted, a workaround is to use a trait, overriding fromDateTime, call the parent and if it fails, parse with Carbon then push it through the parent again.

``````
    /**
     * @see \Illuminate\Database\Eloquent\Model::fromDateTime
     *
     * Overridden to attenpt a Carbon parse of value if it fails
     *
     * @param $value
     * @return mixed
     */
    public function fromDateTime($value)
    {
        try {
            return parent::fromDateTime($value);
        } catch (\InvalidArgumentException $e) {
            $value = Carbon::parse($value);
            return parent::fromDateTime($value);
        }
    }```
``````
