### PR TITLE
Query grammar should not explode segments on alias

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -50,7 +50,7 @@ abstract class Grammar {
 		{
 			$segments = explode(' ', $value);
 
-			return $this->wrap($segments[0]).' as '.$this->wrap($segments[2]);
+			return $this->wrap($segments[0]).' as '.$this->wrapValue($segments[2]);
 		}
 
 		$wrapped = array();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -27,6 +27,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('select * from "some""table"', $builder->toSql());
 	}
 
+	public function testAliasWrappingAsWholeConstant()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('x.y as foo.bar')->from('baz');
+		$this->assertEquals('select "x"."y" as "foo.bar" from "baz"', $builder->toSql());
+	}
 
 	public function testAddingSelects()
 	{


### PR DESCRIPTION
While trying to wrangle `DB::table()->insert()` into supporting this crazy schema (not mine, attempting a legacy interface):

```
mysql> create table test (`foo.bar` int);
Query OK, 0 rows affected (0.05 sec)

mysql> describe test;
+---------+---------+------+-----+---------+-------+
| Field   | Type    | Null | Key | Default | Extra |
+---------+---------+------+-----+---------+-------+
| foo.bar | int(11) | YES  |     | NULL    |       |
+---------+---------+------+-----+---------+-------+
1 row in set (0.00 sec)
```

I noticed that `Illuminate\Database\Grammar::wrap()` explodes the alias into segments, which doesn't seem right: the alias must always be treated as a constant value, devoid of any special meaning with reserved characters.

This PR simply makes `select x.y as foo.bar` become logically wrapped to `select "x"."y" as "foo.bar"`, instead of `foo.bar` being treated as a table and column reference (which isn't possible).
