### PR TITLE
[5.0] Make Default Action On confirmToProceed Clear

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -24,7 +24,7 @@ trait ConfirmableTrait {
 			$this->comment(str_repeat('*', strlen($warning) + 12));
 			$this->output->writeln('');
 
-			$confirmed = $this->confirm('Do you really wish to run this command?');
+			$confirmed = $this->confirm('Do you really wish to run this command? [Y/n]');
 
 			if ( ! $confirmed)
 			{


### PR DESCRIPTION
It's not clear whether this will default to Yes or No. This fixes that.

Personally, though, I feel this should be defaulting to NO due to the serious nature of it.
