### PR TITLE
[4.2] [IMPORTANT] Made Dependencies Stricter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "classpreloader/classpreloader": "~1.0",
+        "classpreloader/classpreloader": "~1.0.2",
         "d11wtq/boris": "~1.0",
         "ircmaxell/password-compat": "~1.0",
         "filp/whoops": "1.1.*",
-        "jeremeamia/superclosure": "~1.0",
+        "jeremeamia/superclosure": "~1.0.1",
         "monolog/monolog": "~1.6",
         "nesbot/carbon": "~1.0",
         "patchwork/utf8": "1.1.*",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -11,7 +11,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "jeremeamia/superclosure": "~1.0",
+        "jeremeamia/superclosure": "~1.0.1",
         "patchwork/utf8": "1.1.*"
     },
     "autoload": {


### PR DESCRIPTION
There is a bug in super closure 1.0.0 that allows composer to select the incorrect version of php parser. This needs patching immediately by fixing the version constraint in laravel.

Current laravel users are currently having the wrong version of php parser installed:

Running composer update on any laravel install will currently result in this:
http://i.imgur.com/yCArPCQ.png
http://i.imgur.com/0EV1imH.png

That is not the desired behaviour. We want class preloader 1.0.2 and super closure 1.0.1.

This will require another 4.2.x tag.
