### PR TITLE
Only propagate the touchOwners call if a relationship exists

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1566,7 +1566,10 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		{
 			$this->$relation()->touch();
 
-			$this->$relation->touchOwners();
+			if ( ! is_null($this->$relation))
+			{
+				$this->$relation->touchOwners();
+			}
 		}
 	}
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -903,6 +903,42 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($model->isDirty());
 	}
 
+	public function testRelationshipTouchOwnersIsPropagated()
+	{
+		$relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsTo')->setMethods(array('touch'))->disableOriginalConstructor()->getMock();
+		$relation->expects($this->once())->method('touch');
+
+		$model = m::mock('EloquentModelStub[partner]');
+		$this->addMockConnection($model);
+		$model->shouldReceive('partner')->once()->andReturn($relation);
+		$model->setTouchedRelations(['partner']);
+
+		$mockPartnerModel = m::mock('EloquentModelStub[touchOwners]');
+		$mockPartnerModel->shouldReceive('touchOwners')->once();
+		$model->setRelation('partner', $mockPartnerModel);
+
+
+		$model->touchOwners();
+	}
+
+
+	public function testRelationshipTouchOwnersIsNotPropagatedIfNoRelationshipResult()
+	{
+		$relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsTo')->setMethods(array('touch'))->disableOriginalConstructor()->getMock();
+		$relation->expects($this->once())->method('touch');
+
+		$model = m::mock('EloquentModelStub[partner]');
+		$this->addMockConnection($model);
+		$model->shouldReceive('partner')->once()->andReturn($relation);
+		$model->setTouchedRelations(['partner']);
+
+
+		$model->setRelation('partner', null);
+
+
+		$model->touchOwners();
+	}
+
 
 	protected function addMockConnection($model)
 	{

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -917,7 +917,6 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$mockPartnerModel->shouldReceive('touchOwners')->once();
 		$model->setRelation('partner', $mockPartnerModel);
 
-
 		$model->touchOwners();
 	}
 
@@ -932,9 +931,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->shouldReceive('partner')->once()->andReturn($relation);
 		$model->setTouchedRelations(['partner']);
 
-
 		$model->setRelation('partner', null);
-
 
 		$model->touchOwners();
 	}


### PR DESCRIPTION
The problem is in the case of a belongsTo relationship (that I came across).

If the foreign key is nullable and could be null, this throws an error of:

```
Fatal error: Call to a member function touchOwners() on a non-object
```

This fix checks that the relationship exists before trying to propagate the call (since the result might be null).

Unit tests attached to demonstrate the problem before and pass with the change in the Model class.
