### PR TITLE
Fix the forgetMiddleware call (to not use get_class)

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -716,7 +716,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	{
 		$this->middlewares = array_filter($this->middlewares, function($m) use ($class)
 		{
-			return get_class($m['class']) != $class;
+			return $m['class'] != $class;
 		});
 	}
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -46,6 +46,7 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(0, count($app->getMiddlewares()));
 	}
 
+
 	public function testDeferredServicesMarkedAsBound()
 	{
 		$app = new Application;

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -38,6 +38,14 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testForgetMiddleware()
+	{
+		$app = new ApplicationGetMiddlewaresStub;
+		$app->middleware('Illuminate\Http\FrameGuard');
+		$app->forgetMiddleware('Illuminate\Http\FrameGuard');
+		$this->assertEquals(0, count($app->getMiddlewares()));
+	}
+
 	public function testDeferredServicesMarkedAsBound()
 	{
 		$app = new Application;
@@ -134,6 +142,14 @@ class ApplicationKernelExceptionHandlerStub extends Illuminate\Foundation\Applic
 
 	protected function setExceptionHandler(Closure $handler) { return $handler; }
 
+}
+
+class ApplicationGetMiddlewaresStub extends Illuminate\Foundation\Application
+{
+	public function getMiddlewares()
+	{
+		return $this->middlewares;
+	}
 }
 
 class ApplicationDeferredSharedServiceProviderStub extends Illuminate\Support\ServiceProvider {


### PR DESCRIPTION
Undo the changes from #5473, with unit tests to justify why.

I'll just repeat my comment from that commit since it describes the problem:

Just tried upgrading from 4.2.8 to 4.2.9 and had a App::forgetMiddleware('Illuminate\Http\FrameGuard'); call (leftover from 4.1).

This causes an error though, as $m['class'] appears to be a string. According to the middleware function as well, the $class parameter is meant to be a string.

Will try and set up a liferaft or PR with unit test for this, but just wanted to raise it for now before I forget!

Error that gets raised: get_class() expects parameter 1 to be object, string given. The error on the line return get_class($m['class']) != $class;
