### PR TITLE
[5.0] Add setter for route name, and maybe get rid of $router->get() array syntax?

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -675,6 +675,19 @@ class Route {
 	}
 
 	/**
+	 * Add a name to the route.
+	 *
+	 * @param  string  $name
+	 * @return $this
+	 */
+	public function name($name)
+	{
+		$this->action['as'] = $name;
+
+		return $this;
+	}
+
+	/**
 	 * Add a prefix to the route URI.
 	 *
 	 * @param  string  $prefix


### PR DESCRIPTION
This enables us instead of doing this:

``` php
$router->get('/', ['uses' => 'Controller@method', 'as' => 'route.name']);
```

to do this:

``` php
$router->get('/', 'Controller@method')->name('route.name');
```

Which is a lot nicer.

(**Note:** It's called `name()` because `as` is a restricted term)

I also would like to propose that the Router be refactored to remove the array syntax for the second parameter altogether, and replace it with chainable methods. This seems like a much better approach for many reasons, including:
- It's more OOP-like
- It's self-documenting
- It's more IDE-friendly
- It's less error-prone
- It's prettier
- It'll do your dishes

I've started doing this just to see if it can be done, and I think it wouldn't be that big of a deal, but I don't want to put all the time into it if it'll get dismissed as either impossible or unwanted.

Thanks for reading! :beers: 
