### PR TITLE
[4.2] Auth: short arrays syntax

### DIFF
--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -36,7 +36,7 @@ class AuthServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('auth');
+		return ['auth'];
 	}
 
 }

--- a/src/Illuminate/Auth/Console/RemindersControllerCommand.php
+++ b/src/Illuminate/Auth/Console/RemindersControllerCommand.php
@@ -85,9 +85,9 @@ class RemindersControllerCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('path', null, InputOption::VALUE_OPTIONAL, 'The directory where the controller should be placed.', null),
-		);
+		return [
+			['path', null, InputOption::VALUE_OPTIONAL, 'The directory where the controller should be placed.', null],
+		];
 	}
 
 }

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -88,7 +88,7 @@ class DatabaseUserProvider implements UserProviderInterface {
 	{
 		$this->conn->table($this->table)
                             ->where('id', $user->getAuthIdentifier())
-                            ->update(array('remember_token' => $token));
+                            ->update(['remember_token' => $token]);
 	}
 
 	/**

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -233,7 +233,7 @@ class Guard {
 	 * @param  array  $credentials
 	 * @return bool
 	 */
-	public function once(array $credentials = array())
+	public function once(array $credentials = [])
 	{
 		if ($this->validate($credentials))
 		{
@@ -251,7 +251,7 @@ class Guard {
 	 * @param  array  $credentials
 	 * @return bool
 	 */
-	public function validate(array $credentials = array())
+	public function validate(array $credentials = [])
 	{
 		return $this->attempt($credentials, false, false);
 	}
@@ -317,7 +317,7 @@ class Guard {
 	 */
 	protected function getBasicCredentials(Request $request, $field)
 	{
-		return array($field => $request->getUser(), 'password' => $request->getPassword());
+		return [$field => $request->getUser(), 'password' => $request->getPassword()];
 	}
 
 	/**
@@ -327,7 +327,7 @@ class Guard {
 	 */
 	protected function getBasicResponse()
 	{
-		$headers = array('WWW-Authenticate' => 'Basic');
+		$headers = ['WWW-Authenticate' => 'Basic'];
 
 		return new Response('Invalid credentials.', 401, $headers);
 	}
@@ -340,7 +340,7 @@ class Guard {
 	 * @param  bool   $login
 	 * @return bool
 	 */
-	public function attempt(array $credentials = array(), $remember = false, $login = true)
+	public function attempt(array $credentials = [], $remember = false, $login = true)
 	{
 		$this->fireAttemptEvent($credentials, $remember, $login);
 
@@ -383,7 +383,7 @@ class Guard {
 	{
 		if ($this->events)
 		{
-			$payload = array($credentials, $remember, $login);
+			$payload = [$credentials, $remember, $login];
 
 			$this->events->fire('auth.attempt', $payload);
 		}
@@ -429,7 +429,7 @@ class Guard {
 		// based on the login and logout events fired from the guard instances.
 		if (isset($this->events))
 		{
-			$this->events->fire('auth.login', array($user, $remember));
+			$this->events->fire('auth.login', [$user, $remember]);
 		}
 
 		$this->setUser($user);
@@ -522,7 +522,7 @@ class Guard {
 
 		if (isset($this->events))
 		{
-			$this->events->fire('auth.logout', array($user));
+			$this->events->fire('auth.logout', [$user]);
 		}
 
 		// Once we have fired the logout event we will clear the users out of memory

--- a/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
+++ b/src/Illuminate/Auth/Reminders/DatabaseReminderRepository.php
@@ -92,7 +92,7 @@ class DatabaseReminderRepository implements ReminderRepositoryInterface {
 	 */
 	protected function getPayload($email, $token)
 	{
-		return array('email' => $email, 'token' => $token, 'created_at' => new Carbon);
+		return ['email' => $email, 'token' => $token, 'created_at' => new Carbon];
 	}
 
 	/**

--- a/src/Illuminate/Auth/Reminders/PasswordBroker.php
+++ b/src/Illuminate/Auth/Reminders/PasswordBroker.php
@@ -224,7 +224,7 @@ class PasswordBroker {
 	 */
 	protected function validNewPasswords(array $credentials)
 	{
-		list($password, $confirm) = array($credentials['password'], $credentials['password_confirmation']);
+		list($password, $confirm) = [$credentials['password'], $credentials['password_confirmation']];
 
 		if (isset($this->passwordValidator))
 		{
@@ -257,7 +257,7 @@ class PasswordBroker {
 	 */
 	public function getUser(array $credentials)
 	{
-		$credentials = array_except($credentials, array('token'));
+		$credentials = array_except($credentials, ['token']);
 
 		$user = $this->users->retrieveByCredentials($credentials);
 

--- a/src/Illuminate/Auth/Reminders/ReminderServiceProvider.php
+++ b/src/Illuminate/Auth/Reminders/ReminderServiceProvider.php
@@ -116,7 +116,7 @@ class ReminderServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('auth.reminder', 'auth.reminder.repository', 'command.auth.reminders');
+		return ['auth.reminder', 'auth.reminder.repository', 'command.auth.reminders'];
 	}
 
 }

--- a/tests/Auth/AuthDatabaseReminderRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseReminderRepositoryTest.php
@@ -48,7 +48,7 @@ class AuthDatabaseReminderRepositoryTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('token', 'token')->andReturn($query);
 		$date = date('Y-m-d H:i:s', time() - 300000);
-		$query->shouldReceive('first')->andReturn((object) array('created_at' => $date));
+		$query->shouldReceive('first')->andReturn((object) ['created_at' => $date]);
 		$user = m::mock('Illuminate\Auth\Reminders\RemindableInterface');
 		$user->shouldReceive('getReminderEmail')->andReturn('email');
 
@@ -63,7 +63,7 @@ class AuthDatabaseReminderRepositoryTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('token', 'token')->andReturn($query);
 		$date = date('Y-m-d H:i:s', time() - 600);
-		$query->shouldReceive('first')->andReturn((object) array('created_at' => $date));
+		$query->shouldReceive('first')->andReturn((object) ['created_at' => $date]);
 		$user = m::mock('Illuminate\Auth\Reminders\RemindableInterface');
 		$user->shouldReceive('getReminderEmail')->andReturn('email');
 

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -14,7 +14,7 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 	{
 		$conn = m::mock('Illuminate\Database\Connection');
 		$conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
-		$conn->shouldReceive('find')->once()->with(1)->andReturn(array('id' => 1, 'name' => 'Dayle'));
+		$conn->shouldReceive('find')->once()->with(1)->andReturn(['id' => 1, 'name' => 'Dayle']);
 		$hasher = m::mock('Illuminate\Hashing\HasherInterface');
 		$provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
 		$user = $provider->retrieveByID(1);
@@ -43,10 +43,10 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 		$conn = m::mock('Illuminate\Database\Connection');
 		$conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
 		$conn->shouldReceive('where')->once()->with('username', 'dayle');
-		$conn->shouldReceive('first')->once()->andReturn(array('id' => 1, 'name' => 'taylor'));
+		$conn->shouldReceive('first')->once()->andReturn(['id' => 1, 'name' => 'taylor']);
 		$hasher = m::mock('Illuminate\Hashing\HasherInterface');
 		$provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
-		$user = $provider->retrieveByCredentials(array('username' => 'dayle', 'password' => 'foo'));
+		$user = $provider->retrieveByCredentials(['username' => 'dayle', 'password' => 'foo']);
 
 		$this->assertInstanceOf('Illuminate\Auth\GenericUser', $user);
 		$this->assertEquals(1, $user->getAuthIdentifier());
@@ -62,7 +62,7 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 		$conn->shouldReceive('first')->once()->andReturn(null);
 		$hasher = m::mock('Illuminate\Hashing\HasherInterface');
 		$provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
-		$user = $provider->retrieveByCredentials(array('username' => 'dayle'));
+		$user = $provider->retrieveByCredentials(['username' => 'dayle']);
 
 		$this->assertNull($user);
 	}
@@ -76,7 +76,7 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 		$provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
 		$user = m::mock('Illuminate\Auth\UserInterface');
 		$user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
-		$result = $provider->validateCredentials($user, array('password' => 'plain'));
+		$result = $provider->validateCredentials($user, ['password' => 'plain']);
 
 		$this->assertTrue($result);
 	}

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -31,7 +31,7 @@ class AuthEloquentUserProviderTest extends PHPUnit_Framework_TestCase {
 		$mock->shouldReceive('where')->once()->with('username', 'dayle');
 		$mock->shouldReceive('first')->once()->andReturn('bar');
 		$provider->expects($this->once())->method('createModel')->will($this->returnValue($mock));
-		$user = $provider->retrieveByCredentials(array('username' => 'dayle', 'password' => 'foo'));
+		$user = $provider->retrieveByCredentials(['username' => 'dayle', 'password' => 'foo']);
 
 		$this->assertEquals('bar', $user);
 	}
@@ -45,7 +45,7 @@ class AuthEloquentUserProviderTest extends PHPUnit_Framework_TestCase {
 		$provider = new Illuminate\Auth\EloquentUserProvider($hasher, 'foo');
 		$user = m::mock('Illuminate\Auth\UserInterface');
 		$user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
-		$result = $provider->validateCredentials($user, array('password' => 'plain'));
+		$result = $provider->validateCredentials($user, ['password' => 'plain']);
 
 		$this->assertTrue($result);
 	}
@@ -65,7 +65,7 @@ class AuthEloquentUserProviderTest extends PHPUnit_Framework_TestCase {
 	protected function getProviderMock()
 	{
 		$hasher = m::mock('Illuminate\Hashing\HasherInterface');
-		return $this->getMock('Illuminate\Auth\EloquentUserProvider', array('createModel'), array($hasher, 'foo'));
+		return $this->getMock('Illuminate\Auth\EloquentUserProvider', ['createModel'], [$hasher, 'foo']);
 	}
 
 }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -14,10 +14,10 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	public function testBasicReturnsNullOnValidAttempt()
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
-		$guard = m::mock('Illuminate\Auth\Guard[check,attempt]', array($provider, $session));
+		$guard = m::mock('Illuminate\Auth\Guard[check,attempt]', [$provider, $session]);
 		$guard->shouldReceive('check')->once()->andReturn(false);
-		$guard->shouldReceive('attempt')->once()->with(array('email' => 'foo@bar.com', 'password' => 'secret'))->andReturn(true);
-		$request = Symfony\Component\HttpFoundation\Request::create('/', 'GET', array(), array(), array(), array('PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret'));
+		$guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret'])->andReturn(true);
+		$request = Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
 
 		$guard->basic('email', $request);
 	}
@@ -26,10 +26,10 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	public function testBasicReturnsNullWhenAlreadyLoggedIn()
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
-		$guard = m::mock('Illuminate\Auth\Guard[check]', array($provider, $session));
+		$guard = m::mock('Illuminate\Auth\Guard[check]', [$provider, $session]);
 		$guard->shouldReceive('check')->once()->andReturn(true);
 		$guard->shouldReceive('attempt')->never();
-		$request = Symfony\Component\HttpFoundation\Request::create('/', 'GET', array(), array(), array(), array('PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret'));
+		$request = Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
 
 		$guard->basic('email', $request);
 	}
@@ -38,10 +38,10 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	public function testBasicReturnsResponseOnFailure()
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
-		$guard = m::mock('Illuminate\Auth\Guard[check,attempt]', array($provider, $session));
+		$guard = m::mock('Illuminate\Auth\Guard[check,attempt]', [$provider, $session]);
 		$guard->shouldReceive('check')->once()->andReturn(false);
-		$guard->shouldReceive('attempt')->once()->with(array('email' => 'foo@bar.com', 'password' => 'secret'))->andReturn(false);
-		$request = Symfony\Component\HttpFoundation\Request::create('/', 'GET', array(), array(), array(), array('PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret'));
+		$guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret'])->andReturn(false);
+		$request = Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
 		$response = $guard->basic('email', $request);
 
 		$this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
@@ -53,23 +53,23 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	{
 		$guard = $this->getGuard();
 		$guard->setDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
-		$events->shouldReceive('fire')->once()->with('auth.attempt', array(array('foo'), false, true));
-		$guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(array('foo'));
-		$guard->attempt(array('foo'));
+		$events->shouldReceive('fire')->once()->with('auth.attempt', [['foo'], false, true]);
+		$guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->with(['foo']);
+		$guard->attempt(['foo']);
 	}
 
 
 	public function testAttemptReturnsUserInterface()
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
-		$guard = $this->getMock('Illuminate\Auth\Guard', array('login'), array($provider, $session, $request));
+		$guard = $this->getMock('Illuminate\Auth\Guard', ['login'], [$provider, $session, $request]);
 		$guard->setDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
-		$events->shouldReceive('fire')->once()->with('auth.attempt', array(array('foo'), false, true));
+		$events->shouldReceive('fire')->once()->with('auth.attempt', [['foo'], false, true]);
 		$user = $this->getMock('Illuminate\Auth\UserInterface');
 		$guard->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn($user);
-		$guard->getProvider()->shouldReceive('validateCredentials')->with($user, array('foo'))->andReturn(true);
+		$guard->getProvider()->shouldReceive('validateCredentials')->with($user, ['foo'])->andReturn(true);
 		$guard->expects($this->once())->method('login')->with($this->equalTo($user));
-		$this->assertTrue($guard->attempt(array('foo')));
+		$this->assertTrue($guard->attempt(['foo']));
 	}
 
 
@@ -77,16 +77,16 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	{
 		$mock = $this->getGuard();
 		$mock->setDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
-		$events->shouldReceive('fire')->once()->with('auth.attempt', array(array('foo'), false, true));
+		$events->shouldReceive('fire')->once()->with('auth.attempt', [['foo'], false, true]);
 		$mock->getProvider()->shouldReceive('retrieveByCredentials')->once()->andReturn(null);
-		$this->assertFalse($mock->attempt(array('foo')));
+		$this->assertFalse($mock->attempt(['foo']));
 	}
 
 
 	public function testLoginStoresIdentifierInSession()
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
-		$mock = $this->getMock('Illuminate\Auth\Guard', array('getName'), array($provider, $session, $request));
+		$mock = $this->getMock('Illuminate\Auth\Guard', ['getName'], [$provider, $session, $request]);
 		$user = m::mock('Illuminate\Auth\UserInterface');
 		$mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
 		$user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
@@ -99,10 +99,10 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	public function testLoginFiresLoginEvent()
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
-		$mock = $this->getMock('Illuminate\Auth\Guard', array('getName'), array($provider, $session, $request));
+		$mock = $this->getMock('Illuminate\Auth\Guard', ['getName'], [$provider, $session, $request]);
 		$mock->setDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
 		$user = m::mock('Illuminate\Auth\UserInterface');
-		$events->shouldReceive('fire')->once()->with('auth.login', array($user, false));
+		$events->shouldReceive('fire')->once()->with('auth.login', [$user, false]);
 		$mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
 		$user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
 		$mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
@@ -124,7 +124,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	public function testIsAuthedReturnsFalseWhenUserIsNull()
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
-		$mock = $this->getMock('Illuminate\Auth\Guard', array('user'), array($provider, $session, $request));
+		$mock = $this->getMock('Illuminate\Auth\Guard', ['user'], [$provider, $session, $request]);
 		$mock->expects($this->exactly(2))->method('user')->will($this->returnValue(null));
 		$this->assertFalse($mock->check());
 		$this->assertTrue($mock->guest());
@@ -162,7 +162,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	public function testLogoutRemovesSessionTokenAndRememberMeCookie()
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
-		$mock = $this->getMock('Illuminate\Auth\Guard', array('getName', 'getRecallerName'), array($provider, $session, $request));
+		$mock = $this->getMock('Illuminate\Auth\Guard', ['getName', 'getRecallerName'], [$provider, $session, $request]);
 		$mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
 		$user = m::mock('Illuminate\Auth\UserInterface');
 		$user->shouldReceive('setRememberToken')->once();
@@ -183,14 +183,14 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	public function testLogoutFiresLogoutEvent()
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
-		$mock = $this->getMock('Illuminate\Auth\Guard', array('clearUserDataFromStorage'), array($provider, $session, $request));
+		$mock = $this->getMock('Illuminate\Auth\Guard', ['clearUserDataFromStorage'], [$provider, $session, $request]);
 		$mock->expects($this->once())->method('clearUserDataFromStorage');
 		$mock->setDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
 		$user = m::mock('Illuminate\Auth\UserInterface');
 		$user->shouldReceive('setRememberToken')->once();
 		$provider->shouldReceive('updateRememberToken')->once();
 		$mock->setUser($user);
-		$events->shouldReceive('fire')->once()->with('auth.logout', array($user));
+		$events->shouldReceive('fire')->once()->with('auth.logout', [$user]);
 		$mock->logout();
 	}
 
@@ -236,7 +236,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	public function testLoginUsingIdStoresInSessionAndLogsInWithUser()
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
-		$guard = $this->getMock('Illuminate\Auth\Guard', array('login', 'user'), array($provider, $session, $request));
+		$guard = $this->getMock('Illuminate\Auth\Guard', ['login', 'user'], [$provider, $session, $request]);
 		$guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 10);
 		$guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user = m::mock('Illuminate\Auth\UserInterface'));
 		$guard->expects($this->once())->method('login')->with($this->equalTo($user), $this->equalTo(false))->will($this->returnValue($user));
@@ -249,7 +249,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	{
 		$guard = $this->getGuard();
 		list($session, $provider, $request, $cookie) = $this->getMocks();
-		$request = Symfony\Component\HttpFoundation\Request::create('/', 'GET', array(), array($guard->getRecallerName() => 'id|recaller'));
+		$request = Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [$guard->getRecallerName() => 'id|recaller']);
 		$guard = new Illuminate\Auth\Guard($provider, $session, $request);
 		$guard->getSession()->shouldReceive('get')->once()->with($guard->getName())->andReturn(null);
 		$user = m::mock('Illuminate\Auth\UserInterface');
@@ -268,18 +268,18 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 
 	protected function getMocks()
 	{
-		return array(
+		return [
 			m::mock('Illuminate\Session\Store'),
 			m::mock('Illuminate\Auth\UserProviderInterface'),
 			Symfony\Component\HttpFoundation\Request::create('/', 'GET'),
 			m::mock('Illuminate\Cookie\CookieJar'),
-		);
+		];
 	}
 
 
 	protected function getCookieJar()
 	{
-		return new Illuminate\Cookie\CookieJar(Request::create('/foo', 'GET'), m::mock('Illuminate\Encryption\Encrypter'), array('domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false));
+		return new Illuminate\Cookie\CookieJar(Request::create('/foo', 'GET'), m::mock('Illuminate\Encryption\Encrypter'), ['domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false]);
 	}
 
 }

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -14,10 +14,10 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 	public function testIfUserIsNotFoundErrorRedirectIsReturned()
 	{
 		$mocks = $this->getMocks();
-		$broker = $this->getMock('Illuminate\Auth\Reminders\PasswordBroker', array('getUser', 'makeErrorRedirect'), array_values($mocks));
+		$broker = $this->getMock('Illuminate\Auth\Reminders\PasswordBroker', ['getUser', 'makeErrorRedirect'], array_values($mocks));
 		$broker->expects($this->once())->method('getUser')->will($this->returnValue(null));
 
-		$this->assertEquals(PasswordBroker::INVALID_USER, $broker->remind(array('credentials')));
+		$this->assertEquals(PasswordBroker::INVALID_USER, $broker->remind(['credentials']));
 	}
 
 
@@ -27,18 +27,18 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 	public function testGetUserThrowsExceptionIfUserDoesntImplementRemindable()
 	{
 		$broker = $this->getBroker($mocks = $this->getMocks());
-		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(array('foo'))->andReturn('bar');
+		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn('bar');
 
-		$broker->getUser(array('foo'));
+		$broker->getUser(['foo']);
 	}
 
 
 	public function testUserIsRetrievedByCredentials()
 	{
 		$broker = $this->getBroker($mocks = $this->getMocks());
-		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(array('foo'))->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
+		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
 
-		$this->assertEquals($user, $broker->getUser(array('foo')));
+		$this->assertEquals($user, $broker->getUser(['foo']));
 	}
 
 
@@ -46,13 +46,13 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 	{
 		unset($_SERVER['__reminder.test']);
 		$mocks = $this->getMocks();
-		$broker = $this->getMock('Illuminate\Auth\Reminders\PasswordBroker', array('sendReminder', 'getUri'), array_values($mocks));
-		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(array('foo'))->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
+		$broker = $this->getMock('Illuminate\Auth\Reminders\PasswordBroker', ['sendReminder', 'getUri'], array_values($mocks));
+		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
 		$mocks['reminders']->shouldReceive('create')->once()->with($user)->andReturn('token');
 		$callback = function() {};
 		$broker->expects($this->once())->method('sendReminder')->with($this->equalTo($user), $this->equalTo('token'), $this->equalTo($callback));
 
-		$this->assertEquals(PasswordBroker::REMINDER_SENT, $broker->remind(array('foo'), $callback));
+		$this->assertEquals(PasswordBroker::REMINDER_SENT, $broker->remind(['foo'], $callback));
 	}
 
 
@@ -62,7 +62,7 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 		$broker = $this->getBroker($mocks = $this->getMocks());
 		$callback = function($message, $user) { $_SERVER['__auth.reminder'] = true; };
 		$user = m::mock('Illuminate\Auth\Reminders\RemindableInterface');
-		$mocks['mailer']->shouldReceive('send')->once()->with('reminderView', array('token' => 'token', 'user' => $user), m::type('Closure'))->andReturnUsing(function($view, $data, $callback)
+		$mocks['mailer']->shouldReceive('send')->once()->with('reminderView', ['token' => 'token', 'user' => $user], m::type('Closure'))->andReturnUsing(function($view, $data, $callback)
 		{
 			return $callback;
 		});
@@ -79,15 +79,15 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 	public function testRedirectIsReturnedByResetWhenUserCredentialsInvalid()
 	{
 		$broker = $this->getBroker($mocks = $this->getMocks());
-		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(array('creds'))->andReturn(null);
+		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['creds'])->andReturn(null);
 
-		$this->assertEquals(PasswordBroker::INVALID_USER, $broker->reset(array('creds'), function() {}));
+		$this->assertEquals(PasswordBroker::INVALID_USER, $broker->reset(['creds'], function() {}));
 	}
 
 
 	public function testRedirectReturnedByRemindWhenPasswordsDontMatch()
 	{
-		$creds = array('password' => 'foo', 'password_confirmation' => 'bar');
+		$creds = ['password' => 'foo', 'password_confirmation' => 'bar'];
 		$broker = $this->getBroker($mocks = $this->getMocks());
 		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
 
@@ -97,7 +97,7 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 
 	public function testRedirectReturnedByRemindWhenPasswordNotSet()
 	{
-		$creds = array('password' => null, 'password_confirmation' => null);
+		$creds = ['password' => null, 'password_confirmation' => null];
 		$broker = $this->getBroker($mocks = $this->getMocks());
 		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
 
@@ -107,7 +107,7 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 
 	public function testRedirectReturnedByRemindWhenPasswordsLessThanSixCharacters()
 	{
-		$creds = array('password' => 'abc', 'password_confirmation' => 'abc');
+		$creds = ['password' => 'abc', 'password_confirmation' => 'abc'];
 		$broker = $this->getBroker($mocks = $this->getMocks());
 		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
 
@@ -117,7 +117,7 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 
 	public function testRedirectReturnedByRemindWhenPasswordDoesntPassValidator()
 	{
-		$creds = array('password' => 'abcdef', 'password_confirmation' => 'abcdef');
+		$creds = ['password' => 'abcdef', 'password_confirmation' => 'abcdef'];
 		$broker = $this->getBroker($mocks = $this->getMocks());
 		$broker->validator(function($credentials) { return strlen($credentials['password']) >= 7; });
 		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
@@ -128,9 +128,9 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 
 	public function testRedirectReturnedByRemindWhenRecordDoesntExistInTable()
 	{
-		$creds = array('token' => 'token');
-		$broker = $this->getMock('Illuminate\Auth\Reminders\PasswordBroker', array('validNewPasswords'), array_values($mocks = $this->getMocks()));
-		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(array_except($creds, array('token')))->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
+		$creds = ['token' => 'token'];
+		$broker = $this->getMock('Illuminate\Auth\Reminders\PasswordBroker', ['validNewPasswords'], array_values($mocks = $this->getMocks()));
+		$mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(array_except($creds, ['token']))->andReturn($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface'));
 		$broker->expects($this->once())->method('validNewPasswords')->will($this->returnValue(true));
 		$mocks['reminders']->shouldReceive('exists')->with($user, 'token')->andReturn(false);
 
@@ -141,7 +141,7 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 	public function testResetRemovesRecordOnReminderTableAndCallsCallback()
 	{
 		unset($_SERVER['__auth.reminder']);
-		$broker = $this->getMock('Illuminate\Auth\Reminders\PasswordBroker', array('validateReset', 'getPassword', 'getToken'), array_values($mocks = $this->getMocks()));
+		$broker = $this->getMock('Illuminate\Auth\Reminders\PasswordBroker', ['validateReset', 'getPassword', 'getToken'], array_values($mocks = $this->getMocks()));
 		$broker->expects($this->once())->method('validateReset')->will($this->returnValue($user = m::mock('Illuminate\Auth\Reminders\RemindableInterface')));
 		$mocks['reminders']->shouldReceive('delete')->once()->with('token');
 		$callback = function($user, $password)
@@ -150,8 +150,8 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 			return 'foo';
 		};
 
-		$this->assertEquals(PasswordBroker::PASSWORD_RESET, $broker->reset(array('password' => 'password', 'token' => 'token'), $callback));
-		$this->assertEquals(array('user' => $user, 'password' => 'password'), $_SERVER['__auth.reminder']);
+		$this->assertEquals(PasswordBroker::PASSWORD_RESET, $broker->reset(['password' => 'password', 'token' => 'token'], $callback));
+		$this->assertEquals(['user' => $user, 'password' => 'password'], $_SERVER['__auth.reminder']);
 	}
 
 
@@ -163,12 +163,12 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 
 	protected function getMocks()
 	{
-		$mocks = array(
+		$mocks = [
 			'reminders' => m::mock('Illuminate\Auth\Reminders\ReminderRepositoryInterface'),
 			'users'     => m::mock('Illuminate\Auth\UserProviderInterface'),
 			'mailer'    => m::mock('Illuminate\Mail\Mailer'),
 			'view'      => 'reminderView',
-		);
+		];
 
 		return $mocks;
 	}


### PR DESCRIPTION
As laravel/framework is for > 5.4, it would be appropriate now to switch to short arrays notation, as this is already the case for laravel/laravel.
In order to find the easiest method to ease review, PR should be properly organized.
This can be achieved in many ways
1PR / package, src and tests in different commits, 1 global PR with split commits, 1 PR for 9/10 packages ? @taylorotwell @GrahamCampbell , let me know
