### PR TITLE
[4.2] Split Tests For Response And RedirectResponse

### DIFF
--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -18,4 +18,14 @@ class HttpJsonResponseTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame(JSON_PRETTY_PRINT, $response->getJsonOptions());
 	}
 
+	public function testSetAndRetrieveStatusCode()
+	{
+		$response = new Illuminate\Http\JsonResponse(['foo' => 'bar'], 404);
+		$this->assertSame(404, $response->getStatusCode());
+
+		$response = new Illuminate\Http\JsonResponse(['foo' => 'bar']);
+		$response->setStatusCode(404);
+		$this->assertSame(404, $response->getStatusCode());
+	}
+
 }

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+
+class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function testHeaderOnRedirect()
+	{
+		$response = new RedirectResponse('foo.bar');
+		$this->assertNull($response->headers->get('foo'));
+		$response->header('foo', 'bar');
+		$this->assertEquals('bar', $response->headers->get('foo'));
+		$response->header('foo', 'baz', false);
+		$this->assertEquals('bar', $response->headers->get('foo'));
+		$response->header('foo', 'baz');
+		$this->assertEquals('baz', $response->headers->get('foo'));
+	}
+
+
+	public function testWithOnRedirect()
+{
+		$response = new RedirectResponse('foo.bar');
+		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
+		$response->setSession($session = m::mock('Illuminate\Session\Store'));
+		$session->shouldReceive('flash')->twice();
+		$response->with(array('name', 'age'));
+	}
+
+
+	public function testWithCookieOnRedirect()
+	{
+		$response = new RedirectResponse('foo.bar');
+		$this->assertEquals(0, count($response->headers->getCookies()));
+		$this->assertEquals($response, $response->withCookie(new \Symfony\Component\HttpFoundation\Cookie('foo', 'bar')));
+		$cookies = $response->headers->getCookies();
+		$this->assertEquals(1, count($cookies));
+		$this->assertEquals('foo', $cookies[0]->getName());
+		$this->assertEquals('bar', $cookies[0]->getValue());
+	}
+
+
+	public function testInputOnRedirect()
+	{
+		$response = new RedirectResponse('foo.bar');
+		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
+		$response->setSession($session = m::mock('Illuminate\Session\Store'));
+		$session->shouldReceive('flashInput')->once()->with(array('name' => 'Taylor', 'age' => 26));
+		$response->withInput();
+	}
+
+
+	public function testOnlyInputOnRedirect()
+	{
+		$response = new RedirectResponse('foo.bar');
+		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
+		$response->setSession($session = m::mock('Illuminate\Session\Store'));
+		$session->shouldReceive('flashInput')->once()->with(array('name' => 'Taylor'));
+		$response->onlyInput('name');
+	}
+
+
+	public function testExceptInputOnRedirect()
+	{
+		$response = new RedirectResponse('foo.bar');
+		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
+		$response->setSession($session = m::mock('Illuminate\Session\Store'));
+		$session->shouldReceive('flashInput')->once()->with(array('name' => 'Taylor'));
+		$response->exceptInput('age');
+	}
+
+
+	public function testFlashingErrorsOnRedirect()
+	{
+		$response = new RedirectResponse('foo.bar');
+		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
+		$response->setSession($session = m::mock('Illuminate\Session\Store'));
+		$session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new Illuminate\Support\ViewErrorBag);
+		$session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
+		$provider = m::mock('Illuminate\Support\Contracts\MessageProviderInterface');
+		$provider->shouldReceive('getMessageBag')->once()->andReturn(new Illuminate\Support\MessageBag);
+		$response->withErrors($provider);
+	}
+
+
+	public function testSettersGettersOnRequest()
+	{
+		$response = new RedirectResponse('foo.bar');
+		$this->assertNull($response->getRequest());
+		$this->assertNull($response->getSession());
+
+		$request = Request::create('/', 'GET');
+		$session = m::mock('Illuminate\Session\Store');
+		$response->setRequest($request);
+		$response->setSession($session);
+		$this->assertSame($request, $response->getRequest());
+		$this->assertSame($session, $response->getSession());
+	}
+
+
+	public function testRedirectWithErrorsArrayConvertsToMessageBag()
+	{
+		$response = new RedirectResponse('foo.bar');
+		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
+		$response->setSession($session = m::mock('Illuminate\Session\Store'));
+		$session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new Illuminate\Support\ViewErrorBag);
+		$session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
+		$provider = array('foo' => 'bar');
+		$response->withErrors($provider);
+	}
+
+
+	public function testMagicCall()
+	{
+		$response = new RedirectResponse('foo.bar');
+		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
+		$response->setSession($session = m::mock('Illuminate\Session\Store'));
+		$session->shouldReceive('flash')->once()->with('foo', 'bar');
+		$response->withFoo('bar');
+	}
+
+
+	public function testMagicCallException()
+	{
+		$this->setExpectedException('BadMethodCallException');
+		$response = new RedirectResponse('foo.bar');
+		$response->doesNotExist('bar');
+	}
+
+}

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Mockery as m;
-use Illuminate\Http\Request;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Contracts\JsonableInterface;
 
 class HttpResponseTest extends PHPUnit_Framework_TestCase {
@@ -69,126 +67,14 @@ class HttpResponseTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testHeaderOnRedirect()
+	public function testSetAndRetrieveStatusCode()
 	{
-		$response = new RedirectResponse('foo.bar');
-		$this->assertNull($response->headers->get('foo'));
-		$response->header('foo', 'bar');
-		$this->assertEquals('bar', $response->headers->get('foo'));
-		$response->header('foo', 'baz', false);
-		$this->assertEquals('bar', $response->headers->get('foo'));
-		$response->header('foo', 'baz');
-		$this->assertEquals('baz', $response->headers->get('foo'));
-	}
+		$response = new Illuminate\Http\Response('foo', 404);
+		$this->assertSame(404, $response->getStatusCode());
 
-
-	public function testWithOnRedirect()
-{
-		$response = new RedirectResponse('foo.bar');
-		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
-		$session->shouldReceive('flash')->twice();
-		$response->with(array('name', 'age'));
-	}
-
-
-	public function testWithCookieOnRedirect()
-	{
-		$response = new RedirectResponse('foo.bar');
-		$this->assertEquals(0, count($response->headers->getCookies()));
-		$this->assertEquals($response, $response->withCookie(new \Symfony\Component\HttpFoundation\Cookie('foo', 'bar')));
-		$cookies = $response->headers->getCookies();
-		$this->assertEquals(1, count($cookies));
-		$this->assertEquals('foo', $cookies[0]->getName());
-		$this->assertEquals('bar', $cookies[0]->getValue());
-	}
-
-
-	public function testInputOnRedirect()
-	{
-		$response = new RedirectResponse('foo.bar');
-		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
-		$session->shouldReceive('flashInput')->once()->with(array('name' => 'Taylor', 'age' => 26));
-		$response->withInput();
-	}
-
-
-	public function testOnlyInputOnRedirect()
-	{
-		$response = new RedirectResponse('foo.bar');
-		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
-		$session->shouldReceive('flashInput')->once()->with(array('name' => 'Taylor'));
-		$response->onlyInput('name');
-	}
-
-
-	public function testExceptInputOnRedirect()
-	{
-		$response = new RedirectResponse('foo.bar');
-		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
-		$session->shouldReceive('flashInput')->once()->with(array('name' => 'Taylor'));
-		$response->exceptInput('age');
-	}
-
-
-	public function testFlashingErrorsOnRedirect()
-	{
-		$response = new RedirectResponse('foo.bar');
-		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
-		$session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new Illuminate\Support\ViewErrorBag);
-		$session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
-		$provider = m::mock('Illuminate\Support\Contracts\MessageProviderInterface');
-		$provider->shouldReceive('getMessageBag')->once()->andReturn(new Illuminate\Support\MessageBag);
-		$response->withErrors($provider);
-	}
-
-
-	public function testSettersGettersOnRequest()
-	{
-		$response = new RedirectResponse('foo.bar');
-		$this->assertNull($response->getRequest());
-		$this->assertNull($response->getSession());
-
-		$request = Request::create('/', 'GET');
-		$session = m::mock('Illuminate\Session\Store');
-		$response->setRequest($request);
-		$response->setSession($session);
-		$this->assertSame($request, $response->getRequest());
-		$this->assertSame($session, $response->getSession());
-	}
-
-
-	public function testRedirectWithErrorsArrayConvertsToMessageBag()
-	{
-		$response = new RedirectResponse('foo.bar');
-		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
-		$session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new Illuminate\Support\ViewErrorBag);
-		$session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
-		$provider = array('foo' => 'bar');
-		$response->withErrors($provider);
-	}
-
-
-	public function testMagicCall()
-	{
-		$response = new RedirectResponse('foo.bar');
-		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
-		$session->shouldReceive('flash')->once()->with('foo', 'bar');
-		$response->withFoo('bar');
-	}
-
-
-	public function testMagicCallException()
-	{
-		$this->setExpectedException('BadMethodCallException');
-		$response = new RedirectResponse('foo.bar');
-		$response->doesNotExist('bar');
+		$response = new Illuminate\Http\Response('foo');
+		$response->setStatusCode(404);
+		$this->assertSame(404, $response->getStatusCode());
 	}
 
 }


### PR DESCRIPTION
Also add tests to ensure get and retrieval of `statusCode` for `Response` and `JsonResponse`: `testSetAndRetrieveStatusCode`
Fix https://github.com/laravel/framework/issues/5808
