### PR TITLE
[4.2] Db memory leak : failing test

### DIFF
--- a/tests/Database/DatabaseQueryBuilderMemoryLeakTest.php
+++ b/tests/Database/DatabaseQueryBuilderMemoryLeakTest.php
@@ -38,6 +38,8 @@ class DatabaseJoinMemoryLeakTest extends PHPUnit_Framework_TestCase {
 
         $last = null;
 
+	    gc_collect_cycles();
+
         while($i--)
         {
             $callback();

--- a/tests/Database/DatabaseQueryBuilderMemoryLeakTest.php
+++ b/tests/Database/DatabaseQueryBuilderMemoryLeakTest.php
@@ -5,58 +5,58 @@ use Illuminate\Database\Query\Builder;
 
 class DatabaseJoinMemoryLeakTest extends PHPUnit_Framework_TestCase {
 
-    public function tearDown()
-    {
-        m::close();
-    }
+	public function tearDown()
+	{
+		m::close();
+	}
 
-    public function testItDoesNotLeakMemoryOnNewQuery()
-    {
-        $builderMain = $this->getBuilder();
+	public function testItDoesNotLeakMemoryOnNewQuery()
+	{
+		$builderMain = $this->getBuilder();
 
-        $this->runMemoryTest(function() use($builderMain){
-            $builder = $builderMain->newQuery();
-            $builder->select('*')->from('users');
+		$this->runMemoryTest(function() use($builderMain){
+			$builder = $builderMain->newQuery();
+			$builder->select('*')->from('users');
 
-        });
-    }
+		});
+	}
 
-    public function testItDoesNotLeakMemoryOnNewQueryWithJoin()
-    {
-        $builderMain = $this->getBuilder();
+	public function testItDoesNotLeakMemoryOnNewQueryWithJoin()
+	{
+		$builderMain = $this->getBuilder();
 
-        $this->runMemoryTest(function() use($builderMain){
-            $builder = $builderMain->newQuery();
-            $builder->select('*')->join('new', 'col', '=', 'col2')->from('users');
+		$this->runMemoryTest(function() use($builderMain){
+			$builder = $builderMain->newQuery();
+			$builder->select('*')->join('new', 'col', '=', 'col2')->from('users');
 
-        });
-    }
+		});
+	}
 
-    protected function runMemoryTest(\Closure $callback)
-    {
-        $i = 5;
+	protected function runMemoryTest(\Closure $callback)
+	{
+		$i = 5;
 
-        $last = null;
+		$last = null;
 
-	    gc_collect_cycles();
+		gc_collect_cycles();
 
-        while($i--)
-        {
-            $callback();
+		while($i--)
+		{
+			$callback();
 
-            $prev = $last;
-            $last = memory_get_usage();
-        }
+			$prev = $last;
+			$last = memory_get_usage();
+		}
 
-        $this->assertEquals($prev, $last);
-    }
+		$this->assertEquals($prev, $last);
+	}
 
 
-    protected function getBuilder()
-    {
-        $grammar = new Illuminate\Database\Query\Grammars\SqlServerGrammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
-        return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
-    }
+	protected function getBuilder()
+	{
+		$grammar = new Illuminate\Database\Query\Grammars\SqlServerGrammar;
+		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+		return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+	}
 
 }


### PR DESCRIPTION
Fix `runMemoryTest`
Also convert spaces with tabs
See https://github.com/laravel/framework/pull/5825#issuecomment-57058180
Related to https://github.com/laravel/framework/pull/5825 and https://github.com/laravel/framework/issues/5568
