### PR TITLE
[5.0] Improve And Fix Scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/ScopeInterface.php
+++ b/src/Illuminate/Database/Eloquent/ScopeInterface.php
@@ -6,16 +6,19 @@ interface ScopeInterface {
 	 * Apply the scope to a given Eloquent query builder.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $builder
+	 * @param  \Illuminate\Database\Eloquent\Model  $model
 	 * @return void
 	 */
-	public function apply(Builder $builder);
+	public function apply(Builder $builder, Model $model);
 
 	/**
 	 * Remove the scope from the given Eloquent query builder.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $builder
+	 * @param  \Illuminate\Database\Eloquent\Model  $model
+	 *
 	 * @return void
 	 */
-	public function remove(Builder $builder);
+	public function remove(Builder $builder, Model $model);
 
 }

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -13,12 +13,11 @@ class SoftDeletingScope implements ScopeInterface {
 	 * Apply the scope to a given Eloquent query builder.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $builder
+	 * @param  \Illuminate\Database\Eloquent\Model  $model
 	 * @return void
 	 */
-	public function apply(Builder $builder)
+	public function apply(Builder $builder, Model $model)
 	{
-		$model = $builder->getModel();
-
 		$builder->whereNull($model->getQualifiedDeletedAtColumn());
 
 		$this->extend($builder);
@@ -28,11 +27,12 @@ class SoftDeletingScope implements ScopeInterface {
 	 * Remove the scope from the given Eloquent query builder.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $builder
+	 * @param  \Illuminate\Database\Eloquent\Model  $model
 	 * @return void
 	 */
-	public function remove(Builder $builder)
+	public function remove(Builder $builder, Model $model)
 	{
-		$column = $builder->getModel()->getQualifiedDeletedAtColumn();
+		$column = $model->getQualifiedDeletedAtColumn();
 
 		$query = $builder->getQuery();
 
@@ -113,7 +113,7 @@ class SoftDeletingScope implements ScopeInterface {
 	{
 		$builder->macro('withTrashed', function(Builder $builder)
 		{
-			$this->remove($builder);
+			$this->remove($builder, $builder->getModel());
 
 			return $builder;
 		});
@@ -129,9 +129,11 @@ class SoftDeletingScope implements ScopeInterface {
 	{
 		$builder->macro('onlyTrashed', function(Builder $builder)
 		{
-			$this->remove($builder);
+			$model = $builder->getModel();
 
-			$builder->getQuery()->whereNotNull($builder->getModel()->getQualifiedDeletedAtColumn());
+			$this->remove($builder, $model);
+
+			$builder->getQuery()->whereNotNull($model->getQualifiedDeletedAtColumn());
 
 			return $builder;
 		});


### PR DESCRIPTION
Since time immemorial, `Model::applyGlobalScopes()` has been passing in the model as a second parameter to `$scope::apply()` (and `$scope::remove()`), but `ScopeInterface` didn't have that parameter specified so it couldn't be used. This fixes that.

Now instead of this:

``` php
public function apply(Builder $builder)
{
    $model = $builder->getModel();

    //... other stuff
}
```

You now do this:

``` php
public function apply(Builder $builder, Model $model)
{
    //... just do stuff
}
```

I've also updated `SoftDeletingScope`, and updated the tests.

I've made this PR against `master` because this is a breaking change (it requires you to update your implementations of `apply()` and `remove()`).
