### PR TITLE
Add failing unit test related to timezones

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -335,6 +335,16 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testTimestampsCreatedFromObjectsHandleTimezone()
+	{
+		$model = new EloquentDateModelStub;
+		$testDate = Carbon\Carbon::parse('2000-01-01 12:00:00 PST');
+		$model->created_at = $testDate;
+		$retrievedDate = $model->created_at;
+		$this->assertTrue($testDate->eq($retrievedDate));
+	}
+
+
 	public function testInsertProcess()
 	{
 		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));


### PR DESCRIPTION
When a date attribute is assigned a Carbon object with a timezone
other than the application's configured timezone, it is not taken into
account and the time is changed by whatever the offset is.

This is a failing test for the issue described in
https://github.com/laravel/laravel/pull/3044
