### PR TITLE
[4.2] Tail Daily Log Files If They Exist

### DIFF
--- a/src/Illuminate/Foundation/Console/TailCommand.php
+++ b/src/Illuminate/Foundation/Console/TailCommand.php
@@ -121,10 +121,8 @@ class TailCommand extends Command {
 		{
 			return $this->getLocalPath();
 		}
-		else
-		{
-			return $this->getRoot($connection).'/app/storage/logs/laravel.log';
-		}
+
+		return $this->getRoot($connection).'/app/storage/logs/laravel.log';
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/TailCommand.php
+++ b/src/Illuminate/Foundation/Console/TailCommand.php
@@ -122,7 +122,7 @@ class TailCommand extends Command {
 			return $this->getLocalPath();
 		}
 
-		return $this->getRoot($connection).'/app/storage/logs/laravel.log';
+		return $this->getRoot($connection).str_replace(base_path(), '', storage_path()).'/logs/laravel.log';
 	}
 
 	/**
@@ -132,12 +132,12 @@ class TailCommand extends Command {
 	 */
 	protected function getLocalPath()
 	{
-		if ($dailyLogs = $this->laravel['files']->glob(base_path().'/app/storage/logs/log-*.txt'))
+		if ($dailyLogs = $this->laravel['files']->glob(storage_path('logs/log-*.txt')))
 		{
 			return last($dailyLogs);
 		}
 
-		return base_path().'/app/storage/logs/laravel.log';
+		return storage_path('logs/laravel.log');
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/TailCommand.php
+++ b/src/Illuminate/Foundation/Console/TailCommand.php
@@ -119,10 +119,27 @@ class TailCommand extends Command {
 
 		if (is_null($connection))
 		{
-			return storage_path('/logs/laravel.log');
+			return $this->getLocalPath();
+		}
+		else
+		{
+			return $this->getRoot($connection).'/app/storage/logs/laravel.log';
+		}
+	}
+
+	/**
+	 * Search locally for daily log files, otherwise return a global log file.
+	 *
+	 * @return string
+	 */
+	protected function getLocalPath()
+	{
+		if ($dailyLogs = $this->laravel['files']->glob(base_path().'/app/storage/logs/log-*.txt'))
+		{
+			return last($dailyLogs);
 		}
 
-		return $this->getRoot($connection).str_replace(base_path(), '', storage_path()).'/logs/laravel.log';
+		return base_path().'/app/storage/logs/laravel.log';
 	}
 
 	/**


### PR DESCRIPTION
This will search for local daily log files first (matching the filename used by the original versions of Laravel 4.0) and fall back to the global log file.

Made this against 4.2 instead of master and including the changes suggested in #5220. Also see the proposal in #5211. This replaces PR #5227.
