### PR TITLE
[4.2] Test Route Dispatching With Request Params

### DIFF
--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -76,6 +76,12 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('hello', $router->dispatch(Request::create('foo/bar/%C3%A5%CE%B1%D1%84', 'GET'))->getContent());
 	}
 
+	public function testRouteDispatchingWithQueryParameters()
+	{
+		$router = $this->getRouter();
+		$router->get('api', function() { return Request::has('foo') ? 'true' : 'false'; });
+		$this->assertEquals('true', $router->dispatch(Request::create('api', 'GET', array('foo' => array('bar', 'baz'))))->getContent());
+	}
 
 	public function testOptionsResponsesAreGeneratedByDefault()
 	{

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -76,12 +76,14 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('hello', $router->dispatch(Request::create('foo/bar/%C3%A5%CE%B1%D1%84', 'GET'))->getContent());
 	}
 
-	public function testRouteDispatchingWithQueryParameters()
+
+	public function testRouteDispatchingWithParameters()
 	{
 		$router = $this->getRouter();
 		$router->get('api', function() { return Request::has('foo') ? 'true' : 'false'; });
 		$this->assertEquals('true', $router->dispatch(Request::create('api', 'GET', array('foo' => array('bar', 'baz'))))->getContent());
 	}
+
 
 	public function testOptionsResponsesAreGeneratedByDefault()
 	{


### PR DESCRIPTION
Currently , if you create a request with parameters and dispatch it to a router, the new request will have none of those paremeters set:

```
Route::get('test', function() 
{
    $params = ['method' => 'POST', 'user_id' => '2'];

    $request = Request::create('/api', strtoupper($params['method']), $params);

    Route::dispatch($request)->getContent();
});

Route::post('api', function() 
{
    dd(Request::instance()->query->all());
});
```

Discovered it from a SO question I was trying to answer: http://stackoverflow.com/questions/26084628/laravel-requestinstance-returns-original-instance#26084628
