### PR TITLE
[4.2] Ensure Equivalent Dates Are Stored

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2567,9 +2567,12 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// If the value is already a DateTime instance, we will just skip the rest of
 		// these checks since they will be a waste of time, and hinder performance
 		// when checking the field. We will just return the DateTime right away.
+		// However, we must ensure the incoming DateTime is in the same timezone
+		// as the application before it is later converted to a string (losing timezone
+		// information) or the represented time will be silently shifted.
 		if ($value instanceof DateTime)
 		{
-			//
+			$value = Carbon::instance($value)->setTimezone(date_default_timezone_get());
 		}
 
 		// If the value is totally numeric, we will assume it is a UNIX timestamp and

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -335,6 +335,37 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testTimestampsCreatedFromObjectsHandleTimezone()
+	{
+		$model = new EloquentDateModelStub;
+		$inputDate = Carbon\Carbon::parse('2000-01-01 12:00:00 PST');
+		$model->created_at = $inputDate;
+		$outputDate = $model->created_at;
+		$this->assertSame('2000-01-01T12:00:00-08:00', $inputDate->toW3cString());
+		$this->assertSame('2000-01-01T20:00:00+00:00', $outputDate->toW3cString());
+		$this->assertInstanceOf('Carbon\Carbon', $outputDate);
+		$this->assertSame($inputDate->getTimestamp(), $outputDate->getTimestamp());
+	}
+
+
+	public function testTimestampsCreatedFromObjectsHandleTimezoneWithoutUTC()
+	{
+		$previousTimezone = date_default_timezone_get();
+		date_default_timezone_set('Europe/Berlin');
+
+		$model = new EloquentDateModelStub;
+		$inputDate = Carbon\Carbon::parse('2000-01-01 12:00:00 PST');
+		$model->created_at = $inputDate;
+		$outputDate = $model->created_at;
+		$this->assertSame('2000-01-01T12:00:00-08:00', $inputDate->toW3cString());
+		$this->assertSame('2000-01-01T21:00:00+01:00', $outputDate->toW3cString());
+		$this->assertInstanceOf('Carbon\Carbon', $outputDate);
+		$this->assertSame($inputDate->getTimestamp(), $outputDate->getTimestamp());
+
+		date_default_timezone_set($previousTimezone);
+	}
+
+
 	public function testInsertProcess()
 	{
 		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));


### PR DESCRIPTION
So that inputing a date with a different timezone than the application timezone, will not store the same date (as the timezone is not store), but at least an equivalent date.
Fix https://github.com/laravel/framework/pull/5882
