### PR TITLE
[4.2] Fixed Environment Variables Docblock

### DIFF
--- a/src/Illuminate/Config/EnvironmentVariables.php
+++ b/src/Illuminate/Config/EnvironmentVariables.php
@@ -10,14 +10,14 @@ class EnvironmentVariables {
 	/**
 	 * The environment loader implementation.
 	 *
-	 * @var \Illuminate\Config\EnvironmentLoaderInterface  $loader
+	 * @var \Illuminate\Config\EnvironmentVariablesLoaderInterface  $loader
 	 */
 	protected $loader;
 
 	/**
 	 * The server environment instance.
 	 *
-	 * @param  \Illuminate\Config\EnvironmentLoaderInterface  $loader
+	 * @param  \Illuminate\Config\EnvironmentVariablesLoaderInterface  $loader
 	 * @return void
 	 */
 	public function __construct(EnvironmentVariablesLoaderInterface $loader)


### PR DESCRIPTION
The correct interface name is `EnvironmentVariablesLoaderInterface`, not `EnvironmentLoaderInterface`.
