### PR TITLE
[4.2] Fixed The Manager Names In Capsule Docblocks

### DIFF
--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -157,7 +157,7 @@ class Manager {
 	/**
 	 * Get the database manager instance.
 	 *
-	 * @return \Illuminate\Database\Manager
+	 * @return \Illuminate\Database\DatabaseManager
 	 */
 	public function getDatabaseManager()
 	{
@@ -191,7 +191,7 @@ class Manager {
 	/**
 	 * Get the current cache manager instance.
 	 *
-	 * @return \Illuminate\Cache\Manager
+	 * @return \Illuminate\Cache\CacheManager
 	 */
 	public function getCacheManager()
 	{

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -148,7 +148,7 @@ class Manager {
 	/**
 	 * Get the queue manager instance.
 	 *
-	 * @return \Illuminate\Queue\Manager
+	 * @return \Illuminate\Queue\QueueManager
 	 */
 	public function getQueueManager()
 	{


### PR DESCRIPTION
This fixes 3 typos.
