### PR TITLE
[4.2] Removed A Semicolon From A Docblock

### DIFF
--- a/src/Illuminate/Queue/Connectors/IronConnector.php
+++ b/src/Illuminate/Queue/Connectors/IronConnector.php
@@ -17,7 +17,7 @@ class IronConnector implements ConnectorInterface {
 	/**
 	 * The current request instance.
 	 *
-	 * @var \Illuminate\Http\Request;
+	 * @var \Illuminate\Http\Request
 	 */
 	protected $request;
 


### PR DESCRIPTION
This fixes a typo.
