### PR TITLE
[5.0] Fixed An Encrypter Contract Docblock

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -178,7 +178,7 @@ abstract class Queue {
 	/**
 	 * Set the encrypter instance.
 	 *
-	 * @param  \Illuminate\Contracts\Encryption\EncrypterContract  $crypt
+	 * @param  \Illuminate\Contracts\Encryption\Encrypter  $crypt
 	 * @return void
 	 */
 	public function setEncrypter(EncrypterContract $crypt)


### PR DESCRIPTION
The correct class name is `Illuminate\Contracts\Encryption\Encrypter`.
