### PR TITLE
[5.0] Fixed Queue Contracts Docblocks

### DIFF
--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -72,7 +72,7 @@ class Manager {
 	 * Get a connection instance from the global manager.
 	 *
 	 * @param  string  $connection
-	 * @return \Illuminate\Queue\QueueInterface
+	 * @return \Illuminate\Contracts\Queue\Queue
 	 */
 	public static function connection($connection = null)
 	{
@@ -126,7 +126,7 @@ class Manager {
 	 * Get a registered connection instance.
 	 *
 	 * @param  string  $name
-	 * @return \Illuminate\Queue\QueueInterface
+	 * @return \Illuminate\Contracts\Queue\Queue
 	 */
 	public function getConnection($name = null)
 	{

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -78,7 +78,7 @@ class QueueManager implements FactoryContract {
 	 * Resolve a queue connection instance.
 	 *
 	 * @param  string  $name
-	 * @return \Illuminate\Queue\QueueInterface
+	 * @return \Illuminate\Contracts\Queue\Queue
 	 */
 	public function connection($name = null)
 	{
@@ -103,7 +103,7 @@ class QueueManager implements FactoryContract {
 	 * Resolve a queue connection.
 	 *
 	 * @param  string  $name
-	 * @return \Illuminate\Queue\QueueInterface
+	 * @return \Illuminate\Contracts\Queue\Queue
 	 */
 	protected function resolve($name)
 	{


### PR DESCRIPTION
`Illuminate\Queue\QueueInterface` was moved to `Illuminate\Contracts\Queue\Queue`, but these docblocks were never updated to reflect the change.
