### PR TITLE
[5.0] Derive name of app folder from output of app_path() vs hard-coding "app/"

### DIFF
--- a/src/Illuminate/Console/AppNamespaceDetectorTrait.php
+++ b/src/Illuminate/Console/AppNamespaceDetectorTrait.php
@@ -13,7 +13,9 @@ trait AppNamespaceDetectorTrait {
 
 		foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path)
 		{
-			if ($path == 'app/') return $namespace;
+			$app_path = explode('/', app_path());
+			$app_folder_name = array_pop($app_path);
+			if ($path == $app_folder_name . '/') return $namespace;
 		}
 
 		throw new \RuntimeException("Unable to detect application namespace.");

--- a/src/Illuminate/Console/AppNamespaceDetectorTrait.php
+++ b/src/Illuminate/Console/AppNamespaceDetectorTrait.php
@@ -13,9 +13,9 @@ trait AppNamespaceDetectorTrait {
 
 		foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path)
 		{
-			$app_path = explode('/', app_path());
-			$app_folder_name = array_pop($app_path);
-			if ($path == $app_folder_name . '/') return $namespace;
+			$appPath = explode('/', app_path());
+			$appFolderName = array_pop($appPath);
+			if ($path == $appFolderName . '/') return $namespace;
 		}
 
 		throw new \RuntimeException("Unable to detect application namespace.");


### PR DESCRIPTION
Recently added was the new AppNamespaceDetectorTrait in Illuminate\Console. In it, it attempts to figure out the base namespace for the application by inspecting the PSR-4 autoload section of the composer.json. It currently is hard-coded to look for a namespace mapped to "app/". However, since this folder can be changed via settings in bootstrap/paths.php, it shouldn't assume the name of the app folder.

For instance, I like to have an app_server folder for my Laravel application and an app_client folder for my Angular application. I then have a gulp task that compiles my Angular application and publishes it in the public/js folder
