### PR TITLE
[5.0] Create new session and fire event when user authenticates via remember me cookie

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -154,6 +154,13 @@ class Guard implements AuthenticatorContract {
 		if (is_null($user) && ! is_null($recaller))
 		{
 			$user = $this->getUserByRecaller($recaller);
+			
+			$this->session->put($this->getName(), $user->getAuthIdentifier());
+			
+			if (isset($this->events))
+			{
+			    $this->events->fire('auth.login', array($user));
+			}
 		}
 
 		return $this->user = $user;

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -254,6 +254,8 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		$guard->getSession()->shouldReceive('get')->once()->with($guard->getName())->andReturn(null);
 		$user = m::mock('Illuminate\Contracts\Auth\User');
 		$guard->getProvider()->shouldReceive('retrieveByToken')->once()->with('id', 'recaller')->andReturn($user);
+		$guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
+		$user->shouldReceive('getAuthIdentifier')->andReturn('foo');
 		$this->assertEquals($user, $guard->user());
 		$this->assertTrue($guard->viaRemember());
 	}


### PR DESCRIPTION
When user authenticates via form (and form has remember me cookie), session is created that holds user info/id. On browser close or session expiry, user must login again or is authenticated via remember me cookie.

I think that in that process, new session should be created and 'auth.login' event should be fired.

User, who explicitly stated via remember me checkbox that wants to be automatically logged in, returns to site (after certain time) and is logged in via cookie -- that process of automated login deserves to be treated as login and I believe session should be created and event should be raised.

In my case, I use example from docs to register when was a last user login:

```
Event::listen('auth.login', function($user)
{
    $user->last_login = new DateTime;

    $user->save();
});
```

Until now, when a user is logged in via cookie, no event is fired and user is never updated as returned and date shows his last login from form, even though user returned to site and was logged in via cookie.
