### PR TITLE
[4.2] Added now() Helper With Timezone Support

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1016,3 +1016,24 @@ if ( ! function_exists('with'))
 		return $object;
 	}
 }
+
+if ( ! function_exists('now'))
+{
+	/**
+	 * Return the current datetime.
+	 *
+	 * @param  DateTimeZone|mixed  DateTimeZone
+	 * @return DateTime
+	 */
+	function now($timezone = null)
+	{
+		if (is_null($timezone)) return new DateTime;
+
+		if ( ! $timezone instanceof DateTimeZone)
+		{
+			$timezone = @timezone_open((string) $timezone);
+		}
+
+		return $timezone === false ? new DateTime : new DateTime(null, $timezone);
+	}
+}

--- a/tests/Support/SupportNowTest.php
+++ b/tests/Support/SupportNowTest.php
@@ -1,0 +1,37 @@
+<?php
+
+class SupportNowTest extends PHPUnit_Framework_TestCase {
+
+	public function testNowReturnsDatetime()
+	{
+		$datetime = now();
+		$this->assertInstanceOf('Datetime', $datetime);
+	}
+
+
+	public function testNowSkipUnknownTimezone()
+	{
+		$datetime = now('foo');
+		$defaultTimezone = new DateTimeZone(date_default_timezone_get());
+		$this->assertEquals($defaultTimezone, $datetime->getTimezone());
+	}
+
+
+	public function testNowHandlesTimezone()
+	{
+		$datetime = now('Europe/Berlin');
+		$defaultTimezone = new DateTimeZone('Europe/Berlin');
+		$this->assertEquals($defaultTimezone, $datetime->getTimezone());
+	}
+
+
+	public function testNowProvidesActualDatetime()
+	{
+		$datetime = now();
+		$before = new DateTime('yesterday');
+		$after = new DateTime('tomorrow');
+		$this->assertGreaterThan($before, $datetime);
+		$this->assertLessThan($after, $datetime);
+	}
+
+}


### PR DESCRIPTION
Replace https://github.com/laravel/framework/pull/5841
`Datetime` is used instead of `Carbon`, which is pretty fine: getting actual datetime does not require the use of `Carbon`, so that we do not have to had another dependency to `illuminate/support`
