### PR TITLE
[5.0] Remove Unused Path

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -87,7 +87,6 @@ class AppNameCommand extends Command {
 	{
 		$files = Finder::create()
                             ->in($this->laravel['path'])
-                            ->exclude($this->laravel['path'].'/Http/Views')
                             ->name('*.php');
 
 		foreach ($files as $file)


### PR DESCRIPTION
No longer relevant since views path is at `resources/views`.

Signed-off-by: crynobone crynobone@gmail.com
