### PR TITLE
[5.0] Refactor AppNameCommand And AppNamespaceDetectorTrait

### DIFF
--- a/src/Illuminate/Console/AppNamespaceDetectorTrait.php
+++ b/src/Illuminate/Console/AppNamespaceDetectorTrait.php
@@ -5,15 +5,16 @@ trait AppNamespaceDetectorTrait {
 	/**
 	 * Get the application namespace from the Composer file.
 	 *
+	 * @param  string  $namespacePath
 	 * @return string
 	 */
-	protected function getAppNamespace()
+	protected function getAppNamespace($namespacePath = 'app')
 	{
 		$composer = (array) json_decode(file_get_contents(base_path().'/composer.json', true));
 
 		foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path)
 		{
-			if ($path == 'app/') return $namespace;
+			if ($path == "{$namespacePath}/") return $namespace;
 		}
 
 		throw new \RuntimeException("Unable to detect application namespace.");

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -4,9 +4,12 @@ use Illuminate\Console\Command;
 use Illuminate\Foundation\Composer;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Console\AppNamespaceDetectorTrait;
 use Symfony\Component\Console\Input\InputArgument;
 
 class AppNameCommand extends Command {
+
+	use AppNamespaceDetectorTrait;
 
 	/**
 	 * The console command name.
@@ -48,16 +51,14 @@ class AppNameCommand extends Command {
 	 *
 	 * @param  \Illuminate\Foundation\Composer  $composer
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
-	 * @param  string  $currentRoot
 	 * @return void
 	 */
-	public function __construct(Composer $composer, Filesystem $files, $currentRoot)
+	public function __construct(Composer $composer, Filesystem $files)
 	{
 		parent::__construct();
 
 		$this->files = $files;
 		$this->composer = $composer;
-		$this->currentRoot = trim($currentRoot, '\\');
 	}
 
 	/**
@@ -67,6 +68,8 @@ class AppNameCommand extends Command {
 	 */
 	public function fire()
 	{
+		$this->currentRoot = trim($this->getAppNamespace(), '\\');
+
 		$this->setAppDirectoryNamespace();
 
 		$this->setConfigNamespaces();

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -7,7 +7,6 @@ use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\ServeCommand;
 use Illuminate\Foundation\Console\TinkerCommand;
 use Illuminate\Foundation\Console\AppNameCommand;
-use Illuminate\Console\AppNamespaceDetectorTrait;
 use Illuminate\Foundation\Console\ChangesCommand;
 use Illuminate\Foundation\Console\OptimizeCommand;
 use Illuminate\Foundation\Console\RouteListCommand;
@@ -21,8 +20,6 @@ use Illuminate\Foundation\Console\ProviderMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
 
 class ArtisanServiceProvider extends ServiceProvider {
-
-	use AppNamespaceDetectorTrait;
 
 	/**
 	 * Indicates if loading of the provider is deferred.
@@ -87,7 +84,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	{
 		$this->app->bindShared('command.app.name', function($app)
 		{
-			return new AppNameCommand($app['composer'], $app['files'], $this->getAppNamespace());
+			return new AppNameCommand($app['composer'], $app['files']);
 		});
 	}
 


### PR DESCRIPTION
- Allow `AppNamespaceDetectorTrait::getAppNamespace()` to specify custom path allowing it to be reusable for other purpose.
- Move app namespace detection and loading of `composer.json` when the command is fired (and not on every artisan request). This would avoid bugs when testing packages such as evident in https://travis-ci.org/orchestral/testbench/jobs/36551279
- Hardcode `AppNameCommand::$currentRoot` to "app" path since the whole command rely on hardcoded `$this->laravel['path']`.

Signed-off-by: crynobone crynobone@gmail.com
