### PR TITLE
Add disabled attribute to select options with empty value.

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -545,6 +545,11 @@ class FormBuilder {
 
 		$options = array('value' => e($value), 'selected' => $selected);
 
+		if ($value == '')
+		{
+			$options[] = 'disabled';
+		}
+
 		return '<option'.$this->html->attributes($options).'>'.e($display).'</option>';
 	}
 


### PR DESCRIPTION
There is currently no way to set attributes on a select option using FormBuilder::select.  This tiny patch adds the disabled attribute to an option if the value is an empty string.  An initial option with empty value is used as the "placeholder label option," as per HTML5 spec, but it should not be selectable by the user.
