### PR TITLE
[4.2] Cache : add events

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -154,6 +154,8 @@ class CacheManager extends Manager {
 	 */
 	protected function repository(StoreInterface $store)
 	{
+		$events = $this->app['events'];
+
 		return new Repository($store);
 	}
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -154,8 +154,6 @@ class CacheManager extends Manager {
 	 */
 	protected function repository(StoreInterface $store)
 	{
-		$events = $this->app['events'];
-
 		return new Repository($store);
 	}
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -70,13 +70,13 @@ class Repository implements ArrayAccess {
 
 		if (is_null($value))
 		{
-			$this->events->fire('cache.missed', ['key' => $key]);
+			$this->events->fire('cache.missed', [$key]);
 
 			$value = value($default);
 		}
 		else
 		{
-			$this->events->fire('cache.hit', ['key' => $key, 'value' => $value]);
+			$this->events->fire('cache.hit', [$key, $value]);
 		}
 
 		return $value;
@@ -114,7 +114,7 @@ class Repository implements ArrayAccess {
 		{
 			$this->store->put($key, $value, $minutes);
 
-			$this->events->fire('cache.write', ['key' => $key, 'value' => $value, 'duration' => $minutes]);
+			$this->events->fire('cache.write', [$key, $value, $minutes]);
 		}
 	}
 
@@ -147,7 +147,7 @@ class Repository implements ArrayAccess {
 	{
 		$this->store->forever($key, $value);
 
-		$this->events->fire('cache.write', ['key' => $key, 'value' => $value, 'duration' => 0]);
+		$this->events->fire('cache.write', [$key, $value, 0]);
 	}
 
 	/**
@@ -160,7 +160,7 @@ class Repository implements ArrayAccess {
 	{
 		$this->store->forget($key);
 
-		$this->events->fire('cache.delete', ['key' => $key]);
+		$this->events->fire('cache.delete', [$key]);
 	}
 
 	/**

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -85,7 +85,9 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	protected function getRepository()
 	{
-		return new Illuminate\Cache\Repository(m::mock('Illuminate\Cache\StoreInterface'));
+		$dispatcher = new \Illuminate\Events\Dispatcher(m::mock('Illuminate\Container\Container'));
+
+		return new Illuminate\Cache\Repository(m::mock('Illuminate\Cache\StoreInterface'), $dispatcher);
 	}
 
 }


### PR DESCRIPTION
Add cache events, so that the following events can now be listened:

``` php
// when a cache item is not found
Event::listen('cache.missed', function($key) { ... });

// when a cache item is successfully retrieved
// note : $duration = 0 when using Cache::forever()
Event::listen('cache.hit', function($key, $value) { ... });

// when a cache entry is written
Event::listen('cache.write', function($key, $value, $duration) { ... });

// when a cache entry is deleted
Event::listen('cache.delete', function($key) { ... });
```

Also related to https://github.com/laravel/framework/issues/5581
