### PR TITLE
[5.0] make $app->call also inject dependencies for calls with the @ sign based classnames

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -523,14 +523,25 @@ class Container implements ArrayAccess, ContainerContract {
 			return $this->callClass($callback, $parameters, $defaultMethod);
 		}
 
-		$dependencies = [];
+		$dependencies = $this->getMethodDependencies($callback,$parameters);
 
+		return call_user_func_array($callback, $dependencies);
+	}
+
+	/**
+	 * Get all dependencies for a given method
+	 * @param \Closure|array  $callback
+	 * @param array  $parameters
+	 * @return array
+	 */
+	protected function getMethodDependencies($callback,$parameters = array()) {
+		$dependencies = [];
 		foreach ($this->getCallReflector($callback)->getParameters() as $key => $parameter)
 		{
 			$dependencies[] = $this->getDependencyForCallParameter($parameter, $parameters);
 		}
 
-		return call_user_func_array($callback, $dependencies);
+		return array_merge($dependencies,$parameters);
 	}
 
 	/**
@@ -601,7 +612,9 @@ class Container implements ArrayAccess, ContainerContract {
 		// received in this method into this listener class instance's methods.
 		$callable = array($this->make($segments[0]), $method);
 
-		return call_user_func_array($callable, $parameters);
+		$dependencies = $this->getMethodDependencies($callable,$parameters);
+
+		return call_user_func_array($callable, $dependencies);
 	}
 
 	/**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -523,25 +523,28 @@ class Container implements ArrayAccess, ContainerContract {
 			return $this->callClass($callback, $parameters, $defaultMethod);
 		}
 
-		$dependencies = $this->getMethodDependencies($callback,$parameters);
+		$dependencies = $this->getMethodDependencies($callback, $parameters);
 
 		return call_user_func_array($callback, $dependencies);
 	}
 
 	/**
-	 * Get all dependencies for a given method
+	 * Get all dependencies for a given method.
+	 *
 	 * @param \Closure|array  $callback
 	 * @param array  $parameters
 	 * @return array
 	 */
-	protected function getMethodDependencies($callback,$parameters = array()) {
+	protected function getMethodDependencies($callback, $parameters = [])
+	{
 		$dependencies = [];
+
 		foreach ($this->getCallReflector($callback)->getParameters() as $key => $parameter)
 		{
 			$dependencies[] = $this->getDependencyForCallParameter($parameter, $parameters);
 		}
 
-		return array_merge($dependencies,$parameters);
+		return array_merge($dependencies, $parameters);
 	}
 
 	/**
@@ -612,7 +615,7 @@ class Container implements ArrayAccess, ContainerContract {
 		// received in this method into this listener class instance's methods.
 		$callable = array($this->make($segments[0]), $method);
 
-		$dependencies = $this->getMethodDependencies($callable,$parameters);
+		$dependencies = $this->getMethodDependencies($callable, $parameters);
 
 		return call_user_func_array($callable, $dependencies);
 	}

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -380,13 +380,13 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 
 		$container = new Container;
 		$result = $container->call('ContainerTestCallStub@inject');
-		$this->assertInstanceOf('ContainerConcreteStub',$result[0]);
-		$this->assertEquals('taylor',$result[1]);
+		$this->assertInstanceOf('ContainerConcreteStub', $result[0]);
+		$this->assertEquals('taylor', $result[1]);
 
 		$container = new Container;
-		$result = $container->call('ContainerTestCallStub@inject',['default'=>'foo']);
-		$this->assertInstanceOf('ContainerConcreteStub',$result[0]);
-		$this->assertEquals('foo',$result[1]);
+		$result = $container->call('ContainerTestCallStub@inject', ['default' => 'foo']);
+		$this->assertInstanceOf('ContainerConcreteStub', $result[0]);
+		$this->assertEquals('foo', $result[1]);
 
 		$container = new Container;
 		$result = $container->call('ContainerTestCallStub', ['foo', 'bar'], 'work');
@@ -510,7 +510,9 @@ class ContainerTestCallStub {
 	public function work() {
 		return func_get_args();
 	}
-	public function inject(ContainerConcreteStub $stub,$default = 'taylor') {
+
+	public function inject(ContainerConcreteStub $stub, $default = 'taylor')
+	{
 		return func_get_args();
 	}
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -379,6 +379,16 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(['foo', 'bar'], $result);
 
 		$container = new Container;
+		$result = $container->call('ContainerTestCallStub@inject');
+		$this->assertInstanceOf('ContainerConcreteStub',$result[0]);
+		$this->assertEquals('taylor',$result[1]);
+
+		$container = new Container;
+		$result = $container->call('ContainerTestCallStub@inject',['default'=>'foo']);
+		$this->assertInstanceOf('ContainerConcreteStub',$result[0]);
+		$this->assertEquals('foo',$result[1]);
+
+		$container = new Container;
 		$result = $container->call('ContainerTestCallStub', ['foo', 'bar'], 'work');
 		$this->assertEquals(['foo', 'bar'], $result);
 	}
@@ -498,6 +508,9 @@ class ContainerLazyExtendStub {
 
 class ContainerTestCallStub {
 	public function work() {
+		return func_get_args();
+	}
+	public function inject(ContainerConcreteStub $stub,$default = 'taylor') {
 		return func_get_args();
 	}
 }


### PR DESCRIPTION
IMO `App::call('ClassName@method')` should inject dependencies the same way that `$app->call([$app->make('ClassName'),'method']);`. 
If that really is an expected behavior, I've made this PR with some changes that allow that.
