### PR TITLE
[Proposal] [5.0] Add option to enable query log and disable it by default

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -98,7 +98,7 @@ class Connection implements ConnectionInterface {
 	 *
 	 * @var bool
 	 */
-	protected $loggingQueries = true;
+	protected $loggingQueries = false;
 
 	/**
 	 * Indicates if the connection is in a "dry run".
@@ -156,6 +156,12 @@ class Connection implements ConnectionInterface {
 		$this->useDefaultQueryGrammar();
 
 		$this->useDefaultPostProcessor();
+
+		// Enable query log explicitly. Disabled query log makes sense for
+		// lon-playing background CLI scripts of for production environment.
+		if ($this->getConfig('log')) {
+			$this->enableQueryLog();
+		}
 	}
 
 	/**

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -267,7 +267,7 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase {
 	{
 		$pdo = $pdo ?: new DatabaseConnectionTestMockPDO;
 		$defaults = array('getDefaultQueryGrammar', 'getDefaultPostProcessor', 'getDefaultSchemaGrammar');
-		return $this->getMock('Illuminate\Database\Connection', array_merge($defaults, $methods), array($pdo));
+		return $this->getMock('Illuminate\Database\Connection', array_merge($defaults, $methods), array($pdo, '', '', array('log' => true)));
 	}
 
 }


### PR DESCRIPTION
#### Rationale:

On production systems, especially in long-playing CLI scripts query logs grow up and takes significant resources, especially when large inserts or updates performed.
In situations when query log required it should be enabled explicitly.

The real problem why changes required and `\Illuminate\Database\Connection::disableQueryLog` can't be used is when lazy connection initialization used, so we don't know exactly when connection will be created while underlying IoC container creates connection object immediately.

When there are a lot of background scripts (e.g. queue listeners) and there are a lot of such machines that may produce significant overhead in connections number.

PR for application part is here - https://github.com/laravel/laravel/pull/3049
