### PR TITLE
'base_url' config option for S3 filesystem driver

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -95,6 +95,7 @@ class FilesystemManager implements FactoryContract {
 	{
 		$client = S3Client::factory([
 			'key' => $config['key'], 'secret' => $config['secret'],
+				'base_url' => $config['base_url'],
 		]);
 
 		return $this->adapt(


### PR DESCRIPTION
By adding a base_url config option to the S3 driver, other cloud storage platforms that use the S3 API can be utilized. Google Cloud Storage and DreamHosts' DreamObjects are two examples of cloud storage platforms that use the S3 API. Flysystem and the AWS SDK support custom `base_url` endpoints when creating the S3Client.
