### PR TITLE
Adding missing `guest` method to `Authentificator` interface

### DIFF
--- a/src/Illuminate/Contracts/Auth/Authenticator.php
+++ b/src/Illuminate/Contracts/Auth/Authenticator.php
@@ -10,6 +10,13 @@ interface Authenticator {
 	public function check();
 
 	/**
+	 * Determine if the current user is a guest.
+	 *
+	 * @return bool
+	 */
+	public function guest();
+
+	/**
 	 * Get the currently authenticated user.
 	 *
 	 * @return \Illuminate\Contracts\Auth\User|null


### PR DESCRIPTION
Within `auth` filter provided with `laravel/laravel` the `guest` method of `Authentificator` interface is used (see https://github.com/laravel/laravel/blob/develop/app/Http/Filters/AuthFilter.php#L47). For now the `Guard` class implementing that interface has that method (see https://github.com/laravel/framework/blob/master/src/Illuminate/Auth/Guard.php#L115), but interface itself doesn't.

If anybody would need to implement their own authentification just based on interface then they will get Fatal Error because `guest` method would be called no matter what regardless of what interface says.
