### PR TITLE
[4.2] Fix for #5937 Connection::run breaks transaction logic when connection lost inside transaction.

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -831,6 +831,8 @@ class Connection implements ConnectionInterface {
 	 */
 	public function setPdo($pdo)
 	{
+		if ($this->transactions >= 1) throw new \RuntimeException("Attempt to change PDO inside running transaction");
+
 		$this->pdo = $pdo;
 
 		return $this;

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -182,6 +182,27 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase {
 		}
 	}
 
+	/**
+	 * @expectedException RuntimeException
+	 * @expectedExceptionMessage Attempt to change PDO inside running transaction
+	 */
+	public function testTransactionMethodDisallowPDOChanging()
+	{
+		$pdo = $this->getMock('DatabaseConnectionTestMockPDO', array('beginTransaction', 'commit', 'rollBack'));
+		$pdo->expects($this->once())->method('beginTransaction');
+		$pdo->expects($this->once())->method('rollBack');
+		$pdo->expects($this->never())->method('commit');
+
+		$mock = $this->getMockConnection(array(), $pdo);
+
+		$mock->setReconnector(function ($connection)
+		{
+			$connection->setPDO(null);
+		});
+
+		$mock->transaction(function ($connection) { $connection->reconnect(); });
+	}
+
 
 	public function testFromCreatesNewQueryBuilder()
 	{


### PR DESCRIPTION
This PR provides demonstration and fix for issue https://github.com/laravel/framework/issues/5937.
