### PR TITLE
[4.2] Add password helper to the schema Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -683,6 +683,17 @@ class Blueprint {
 	}
 
 	/**
+	 * Adds a password hash column to the table.
+	 *
+	 * @param  string  $password
+	 * @return \Illuminate\Support\Fluent
+	 */
+	public function password($column = 'password')
+	{
+		return $this->string($column, 60);
+	}
+
+	/**
 	 * Create a new drop index command on the blueprint.
 	 *
 	 * @param  string  $command


### PR DESCRIPTION
Like the existing `rememberToken()` helper, this makes it easy to create a 60 character string column for a hashed password (I actually forget on every new project that the hash is 60 characters and have to go look it up in an earlier project to check).

It will default to a column named password, but allows you to pick your own name for the column if you prefer.
