### PR TITLE
[5.0] Add sanitization to form requests

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -17,6 +17,16 @@ class {{class}} extends Request {
 	}
 
 	/**
+	 * Get the sanitized input for the request.
+	 *
+	 * @return array
+	 */
+	public function sanitize()
+	{
+		return $this->all();
+	}
+
+	/**
 	 * Determine if the user is authorized to make this request.
 	 *
 	 * @return bool

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -30,6 +30,13 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	protected $redirector;
 
 	/**
+	 * The sanitized input.
+	 *
+	 * @var array
+	 */
+	protected $sanitized;
+
+	/**
 	 * The URI to redirect to if validation fails.
 	 *
 	 * @var string
@@ -79,18 +86,37 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 		}
 
 		return $factory->make(
-			$this->formatInput(), $this->container->call([$this, 'rules']), $this->messages()
+			$this->sanitizeInput(), $this->container->call([$this, 'rules']), $this->messages()
 		);
 	}
 
 	/**
-	 * Get the input that should be fed to the validator.
+	 * Sanitize the input.
 	 *
 	 * @return array
 	 */
-	protected function formatInput()
+	protected function sanitizeInput()
 	{
+		if (method_exists($this, 'sanitize'))
+		{
+			return $this->sanitized = $this->container->call([$this, 'sanitize']);
+		}
+
 		return $this->all();
+	}
+
+	/**
+	 * Get sanitized input.
+	 *
+	 * @param  string  $key
+	 * @param  mixed  $default
+	 * @return mixed
+	 */
+	public function sanitized($key = null, $default = null)
+	{
+		$input = is_null($this->sanitized) ? $this->all() : $this->sanitized;
+
+		return array_get($input, $key, $default);
 	}
 
 	/**


### PR DESCRIPTION
There are two points to this:
1. Sanitize the input before validation, so that we don't reject valid data.
2. Access the sanitized data in the controller, so that we don't have to sanitize twice.

---

Here's how you would use this:

The `FormRequest`:

``` php
use Illuminate\Foundation\Http\FormRequest;

class UserFormRequest extends FormRequest {

    protected function rules()
    {
        return ['home_phone' => 'length:10'];
    }

    protected function sanitize(SomeSanitizer $sanitizer)
    {
        return $sanitizer->make($this->all(), ['home_phone' => 'numeric'])->sanitize();
    }

}
```

The `Controller`:

``` php
class UserController extends BaseController {

    public function store(UserFormRequest $request, User $user)
    {
        $user->fill($request->sanitized())->save();

        // or...
        $user->home_phone = $request->sanitized('home_phone');
        $user->save();
    }

}
```
