### PR TITLE
[4.2] Introduce Skipped Filters

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -169,7 +169,21 @@ class Route {
 	{
 		if ( ! isset($this->action['before'])) return array();
 
-		return $this->parseFilters($this->action['before']);
+		$filters = $this->parseFilters($this->action['before']);
+
+		return array_diff_key($filters, $this->notBeforeFilters());
+	}
+
+	/**
+	 * Get the "not before" filters for the route.
+	 *
+	 * @return array
+	 */
+	public function notBeforeFilters()
+	{
+		if ( ! isset($this->action['notBefore'])) return array();
+
+		return $this->parseFilters($this->action['notBefore']);
 	}
 
 	/**
@@ -181,7 +195,21 @@ class Route {
 	{
 		if ( ! isset($this->action['after'])) return array();
 
-		return $this->parseFilters($this->action['after']);
+		$filters = $this->parseFilters($this->action['after']);
+
+		return array_diff_key($filters, $this->notAfterFilters());
+	}
+
+	/**
+	 * Get the "not after" filters for the route.
+	 *
+	 * @return array
+	 */
+	public function notAfterFilters()
+	{
+		if ( ! isset($this->action['notAfter'])) return array();
+
+		return $this->parseFilters($this->action['notAfter']);
 	}
 
 	/**
@@ -192,10 +220,34 @@ class Route {
 	 */
 	public static function parseFilters($filters)
 	{
-		return array_build(static::explodeFilters($filters), function($key, $value)
+		$filters = array_build(static::explodeFilters($filters), function($key, $value)
 		{
 			return Route::parseFilter($value);
 		});
+
+		return static::skipFilters($filters);
+	}
+
+	/**
+	 * Skip filters.
+	 *
+	 * @param  string  $filters
+	 * @return array
+	 */
+	protected static function skipFilters($filters)
+	{
+		$skipped = [];
+
+		foreach ($filters as $name => $filter)
+		{
+			if (starts_with($name, '-'))
+			{
+				$skipped[ltrim($name, '-')] = $name;
+				$skipped[$name] = $name;
+			}
+		}
+
+		return array_diff_key($filters, $skipped);
 	}
 
 	/**


### PR DESCRIPTION
The Idea of this feature came after a discussion on https://github.com/dingo/api/issues/146.

Group filters are very useful as routes can inherit their filters, but sometimes there can be a need to skip some inherited before/after filters for a specific route.
This can be now be achieved in _skipping_ a filter with a minus sign : `-filtername`

Filters can also be skipped using `notBefore` and `notAfter` parameters.

``` php
Route::group(['before' => 'b1|b2', 'after' => 'a1|a2'], function () {
    Route::group(['before' => 'b3|b4', 'after' => 'a3|a4'], function () {
        Route::get('foo', [
            'as'     => 'foo',
            'uses'   => 'MyController@foo',
        ]);
        Route::get('bar', [
            'as'     => 'bar',
            'uses'   => 'MyController@bar',
            'before' => 'b5|b6|-b1',
            'notBefore' => 'b4',
            'after'  => ['a5', 'a6', '-a1'],
            'notAfter'  => ['a4'],
        ]);
    });
});
```

In this examples:

Route `foo` : 
- before filters b1, b2, b3, b4, b5 and b6 will be applied
- after filters a1, a2, a3, a4, a5 and a6 will be applied.

Route `bar` :
- before filters b1 and b4 are skipped; before filters b2, b3, b5 and b6 will be applied
- before filters a1 and a4 are skipped; before filters a2, a3, a5 and a6 will be applied

**Feel free to provide feedback**
