### PR TITLE
[5.0] Add ability to set name for MessageBag in FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -65,6 +65,13 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	protected $dontFlash = ['password', 'password_confirmation'];
 
 	/**
+	 * The name for the MessageBag of errors.
+	 *
+	 * @var string
+	 */
+	protected $messageBagName = 'default';
+
+	/**
 	 * Get the validator instance for the request.
 	 *
 	 * @return \Illuminate\Validation\Validator
@@ -146,7 +153,7 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 
 		return $this->redirector->to($this->getRedirectUrl())
                                         ->withInput($this->except($this->dontFlash))
-                                        ->withErrors($errors);
+                                        ->withErrors($errors, $this->messageBagName);
 	}
 
 	/**


### PR DESCRIPTION
MessageBag instances can be named<sup>[1](http://laravel.com/docs/4.2/validation#error-messages-and-views)</sup> and this is useful for when a particular route returns a view with multiple forms on the page.

This change adds a field to the FormRequest class and allows the MessageBag's name to be set.
