### PR TITLE
[5.0] Fixing wrong instructions from make:auth

### DIFF
--- a/src/Illuminate/Auth/Console/AuthControllerCommand.php
+++ b/src/Illuminate/Auth/Console/AuthControllerCommand.php
@@ -71,7 +71,7 @@ class AuthControllerCommand extends GeneratorCommand {
 	 */
 	protected function getArguments()
 	{
-		$default = $this->getAppNamespace().'Http\Controllers\Auth\AuthController';
+		$default = 'Auth\AuthController';
 
 		return array(
 			array('name', InputArgument::OPTIONAL, 'The name of the class', $default),

--- a/src/Illuminate/Auth/Console/AuthControllerCommand.php
+++ b/src/Illuminate/Auth/Console/AuthControllerCommand.php
@@ -35,7 +35,7 @@ class AuthControllerCommand extends GeneratorCommand {
 	{
 		parent::fire();
 
-		$this->comment('Route: $router->controller(\'auth\', \''.$this->argument('name')."');");
+		//$this->comment('Route: $router->controller(\'auth\', \''.$this->argument('name')."');");
 	}
 
 	/**

--- a/src/Illuminate/Auth/Console/RemindersControllerCommand.php
+++ b/src/Illuminate/Auth/Console/RemindersControllerCommand.php
@@ -55,7 +55,7 @@ class RemindersControllerCommand extends GeneratorCommand {
 	 */
 	protected function getArguments()
 	{
-		$default = $this->getAppNamespace().'Http\Controllers\Auth\RemindersController';
+		$default = 'Auth\RemindersController';
 
 		return array(
 			array('name', InputArgument::OPTIONAL, 'The name of the class', $default),

--- a/src/Illuminate/Auth/Console/RemindersControllerCommand.php
+++ b/src/Illuminate/Auth/Console/RemindersControllerCommand.php
@@ -35,7 +35,7 @@ class RemindersControllerCommand extends GeneratorCommand {
 	{
 		parent::fire();
 
-		$this->comment('Route: $router->controller(\'password\', \''.$this->argument('name')."');");
+		//$this->comment('Route: $router->controller(\'password\', \''.$this->argument('name')."');");
 	}
 
 	/**


### PR DESCRIPTION
The make:auth artisan command was retuning the entire namespace in routing instructions, which caused the application to not work after adding the suggested routes. I removed the $NAMESPACE\Http\Controllers part which was being duplicated.
