### PR TITLE
[4.2] Annotate Psr\Log\LoggerInterface as provided by LogServiceProvider.

### DIFF
--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -49,7 +49,7 @@ class LogServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('log');
+		return array('log', 'Psr\Log\LoggerInterface');
 	}
 
 }


### PR DESCRIPTION
The Psr\Log\LoggerInterface was added to app->bind but not added to the
provides array in the LogServiceProvider.

See: https://github.com/itsgoingd/clockwork/issues/67
