### PR TITLE
[5.0] Added A Missing Dependency To The Routing Component

### DIFF
--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -16,7 +16,8 @@
         "illuminate/support": "5.0.*",
         "symfony/http-foundation": "2.6.*",
         "symfony/http-kernel": "2.6.*",
-        "symfony/routing": "2.6.*"
+        "symfony/routing": "2.6.*",
+        "doctrine/annotations": "~1.0"
     },
     "require-dev": {
         "illuminate/console": "5.0.*",


### PR DESCRIPTION
In bf0f4691c2e77f86c04676772583490475c2416c you added this dependency to the main composer.json, but forgot to add it to the routing component's composer.json too.
