### PR TITLE
[5.0] Defer Query Builder Bindings Until The Query Is Being Compiled

### DIFF
--- a/src/Illuminate/Database/Query/CompiledQuery.php
+++ b/src/Illuminate/Database/Query/CompiledQuery.php
@@ -1,0 +1,50 @@
+<?php namespace Illuminate\Database\Query;
+
+class CompiledQuery {
+
+	/**
+	 * The sql query string.
+	 *
+	 * @var string
+	 */
+	public $sql;
+
+	/**
+	 * The query value bindings.
+	 *
+	 * @var array
+	 */
+	public $bindings;
+
+	/**
+	 * Create a new compile query
+	 *
+	 * @param string  $sql
+	 * @param array  $bindings
+	 */
+	public function __construct($sql = '', $bindings = [])
+	{
+		$this->sql = $sql;
+		$this->bindings = $bindings;
+	}
+
+	/**
+	 * Concatenate this compiled query into this query by joining the sql strings and merging the binding arrays.
+	 *
+	 * @param CompiledQuery  $compiled
+	 * @return CompiledQuery|static
+	 */
+	public function concatenate(CompiledQuery $compiled = null, $glue = ' ')
+	{
+		if (!is_null($compiled)) {
+			$this->sql = trim(implode($glue, array_filter([trim($this->sql), trim($compiled->sql)], function ($value) {
+				return (string)$value !== '';
+			})));
+
+			$this->bindings = array_merge((array)$this->bindings, (array)$compiled->bindings);
+		}
+
+		return $this;
+	}
+
+}

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1,7 +1,10 @@
 <?php namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Query\CompiledQuery;
 use Illuminate\Database\Grammar as BaseGrammar;
+
 
 class Grammar extends BaseGrammar {
 
@@ -29,13 +32,13 @@ class Grammar extends BaseGrammar {
 	 * Compile a select query into SQL.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileSelect(Builder $query)
 	{
-		if (is_null($query->columns)) $query->columns = array('*');
+		if (is_null($query->columns)) $query->setSelect(array('*'));
 
-		return trim($this->concatenate($this->compileComponents($query)));
+		return $this->concatenate($this->compileComponents($query));
 	}
 
 	/**
@@ -46,7 +49,7 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function compileComponents(Builder $query)
 	{
-		$sql = array();
+		$compiledComponents = array();
 
 		foreach ($this->selectComponents as $component)
 		{
@@ -57,11 +60,11 @@ class Grammar extends BaseGrammar {
 			{
 				$method = 'compile'.ucfirst($component);
 
-				$sql[$component] = $this->$method($query, $query->$component);
+				$compiledComponents[$component] = $this->$method($query, $query->$component);
 			}
 		}
 
-		return $sql;
+		return $compiledComponents;
 	}
 
 	/**
@@ -69,7 +72,7 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $aggregate
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileAggregate(Builder $query, $aggregate)
 	{
@@ -83,7 +86,7 @@ class Grammar extends BaseGrammar {
 			$column = 'distinct '.$column;
 		}
 
-		return 'select '.$aggregate['function'].'('.$column.') as aggregate';
+		return new CompiledQuery('select '.$aggregate['function'].'('.$column.') as aggregate');
 	}
 
 	/**
@@ -91,7 +94,7 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $columns
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileColumns(Builder $query, $columns)
 	{
@@ -102,7 +105,11 @@ class Grammar extends BaseGrammar {
 
 		$select = $query->distinct ? 'select distinct ' : 'select ';
 
-		return $select.$this->columnize($columns);
+		$bindings = array_flatten(array_fetch($columns, 'bindings'));
+
+		$columns = array_flatten(array_fetch($columns, 'columns'));
+
+		return new CompiledQuery($select.$this->columnize($columns), $bindings);
 	}
 
 	/**
@@ -110,11 +117,11 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  string  $table
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileFrom(Builder $query, $table)
 	{
-		return 'from '.$this->wrapTable($table);
+		return new CompiledQuery('from '.$this->wrapTable($table));
 	}
 
 	/**
@@ -126,50 +133,46 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function compileJoins(Builder $query, $joins)
 	{
-		$sql = array();
+		$complied = new CompiledQuery;
 
 		foreach ($joins as $join)
 		{
 			$table = $this->wrapTable($join->table);
+			$type = $join->type;
+
+			$compiledJoin = new CompiledQuery("$type join $table on", $join->bindings);
 
 			// First we need to build all of the "on" clauses for the join. There may be many
 			// of these clauses so we will need to iterate through each one and build them
 			// separately, then we'll join them up into a single string when we're done.
-			$clauses = array();
+			$compiledClauses = new CompiledQuery;
 
 			foreach ($join->clauses as $clause)
 			{
-				$clauses[] = $this->compileJoinConstraint($clause);
-			}
-
-			foreach ($join->bindings as $binding)
-			{
-				$query->addBinding($binding, 'join');
+				$compiledClauses->concatenate($this->compileJoinConstraint($clause));
 			}
 
 			// Once we have constructed the clauses, we'll need to take the boolean connector
 			// off of the first clause as it obviously will not be required on that clause
 			// because it leads the rest of the clauses, thus not requiring any boolean.
-			$clauses[0] = $this->removeLeadingBoolean($clauses[0]);
+			$compiledClauses->sql = $this->removeLeadingBoolean($compiledClauses->sql);
 
-			$clauses = implode(' ', $clauses);
-
-			$type = $join->type;
+			$compiledJoin->concatenate($compiledClauses);
 
 			// Once we have everything ready to go, we will just concatenate all the parts to
 			// build the final join statement SQL for the query and we can then return the
 			// final clause back to the callers as a single, stringified join statement.
-			$sql[] = "$type join $table on $clauses";
+			$complied->concatenate($compiledJoin);
 		}
 
-		return implode(' ', $sql);
+		return $complied;
 	}
 
 	/**
 	 * Create a join clause constraint segment.
 	 *
 	 * @param  array   $clause
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileJoinConstraint(array $clause)
 	{
@@ -177,20 +180,20 @@ class Grammar extends BaseGrammar {
 
 		$second = $clause['where'] ? '?' : $this->wrap($clause['second']);
 
-		return "{$clause['boolean']} $first {$clause['operator']} $second";
+		return new CompiledQuery("{$clause['boolean']} $first {$clause['operator']} $second");
 	}
 
 	/**
 	 * Compile the "where" portions of the query.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileWheres(Builder $query)
 	{
-		$sql = array();
+		if (is_null($query->wheres)) return;
 
-		if (is_null($query->wheres)) return '';
+		$compiledWheres = new CompiledQuery;
 
 		// Each type of where clauses has its own compiler function which is responsible
 		// for actually creating the where clauses SQL. This helps keep the code nice
@@ -199,20 +202,20 @@ class Grammar extends BaseGrammar {
 		{
 			$method = "where{$where['type']}";
 
-			$sql[] = $where['boolean'].' '.$this->$method($query, $where);
+			$compiledWheres->concatenate(new CompiledQuery($where['boolean']))->concatenate($this->$method($query, $where));
 		}
 
 		// If we actually have some where clauses, we will strip off the first boolean
 		// operator, which is added by the query builders for convenience so we can
 		// avoid checking for the first clauses in each of the compilers methods.
-		if (count($sql) > 0)
+		if (count($compiledWheres->sql) > 0)
 		{
-			$sql = implode(' ', $sql);
+			$compiledWheres->sql = 'where '.$this->removeLeadingBoolean($compiledWheres->sql);
 
-			return 'where '.preg_replace('/and |or /', '', $sql, 1);
+			return $compiledWheres;
 		}
 
-		return '';
+		return new CompiledQuery;
 	}
 
 	/**
@@ -220,13 +223,18 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereNested(Builder $query, $where)
 	{
 		$nested = $where['query'];
 
-		return '('.substr($this->compileWheres($nested), 6).')';
+		$wheres = $this->compileWheres($nested);
+
+		// strip off the first 'wheres '
+		$wheres->sql = '('. substr($wheres->sql, 6). ')';
+
+		return $wheres;
 	}
 
 	/**
@@ -234,13 +242,15 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder $query
 	 * @param  array   $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereSub(Builder $query, $where)
 	{
 		$select = $this->compileSelect($where['query']);
 
-		return $this->wrap($where['column']).' '.$where['operator']." ($select)";
+		$select->sql = $this->wrap($where['column']).' '.$where['operator']." ($select->sql)";
+
+		return $select;
 	}
 
 	/**
@@ -248,13 +258,18 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereBasic(Builder $query, $where)
 	{
-		$value = $this->parameter($where['value']);
+		$value = $where['value'];
+		$bindings = ! $value instanceof Expression ? [$value] : null;
 
-		return $this->wrap($where['column']).' '.$where['operator'].' '.$value;
+		$value = $this->parameter($value);
+
+		$sql = $this->wrap($where['column']).' '.$where['operator'].' '.$value;
+
+		return new CompiledQuery($sql, $bindings);
 	}
 
 	/**
@@ -262,13 +277,15 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereBetween(Builder $query, $where)
 	{
 		$between = $where['not'] ? 'not between' : 'between';
 
-		return $this->wrap($where['column']).' '.$between.' ? and ?';
+		$sql = $this->wrap($where['column']).' '.$between.' ? and ?';
+
+		return new CompiledQuery($sql, $where['values']);
 	}
 
 	/**
@@ -276,11 +293,15 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereExists(Builder $query, $where)
 	{
-		return 'exists ('.$this->compileSelect($where['query']).')';
+		$select = $this->compileSelect($where['query']);
+
+		$select->sql = "exists ($select->sql)";
+
+		return $select;
 	}
 
 	/**
@@ -288,11 +309,15 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereNotExists(Builder $query, $where)
 	{
-		return 'not exists ('.$this->compileSelect($where['query']).')';
+		$select = $this->compileSelect($where['query']);
+
+		$select->sql = "not exists ($select->sql)";
+
+		return $select;
 	}
 
 	/**
@@ -300,13 +325,15 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereIn(Builder $query, $where)
 	{
 		$values = $this->parameterize($where['values']);
 
-		return $this->wrap($where['column']).' in ('.$values.')';
+		$sql = $this->wrap($where['column']).' in ('.$values.')';
+
+		return new CompiledQuery($sql, $where['values']);
 	}
 
 	/**
@@ -314,13 +341,15 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereNotIn(Builder $query, $where)
 	{
 		$values = $this->parameterize($where['values']);
 
-		return $this->wrap($where['column']).' not in ('.$values.')';
+		$sql = $this->wrap($where['column']).' not in ('.$values.')';
+
+		return new CompiledQuery($sql, $where['values']);
 	}
 
 	/**
@@ -328,13 +357,15 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereInSub(Builder $query, $where)
 	{
 		$select = $this->compileSelect($where['query']);
 
-		return $this->wrap($where['column']).' in ('.$select.')';
+		$select->sql = $this->wrap($where['column']).' in ('.$select->sql.')';
+
+		return $select;
 	}
 
 	/**
@@ -342,13 +373,15 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereNotInSub(Builder $query, $where)
 	{
 		$select = $this->compileSelect($where['query']);
 
-		return $this->wrap($where['column']).' not in ('.$select.')';
+		$select->sql = $this->wrap($where['column']).' not in ('.$select->sql.')';
+
+		return $select;
 	}
 
 	/**
@@ -356,11 +389,11 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereNull(Builder $query, $where)
 	{
-		return $this->wrap($where['column']).' is null';
+		return new CompiledQuery($this->wrap($where['column']).' is null');
 	}
 
 	/**
@@ -368,11 +401,11 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereNotNull(Builder $query, $where)
 	{
-		return $this->wrap($where['column']).' is not null';
+		return new CompiledQuery($this->wrap($where['column']).' is not null');
 	}
 
 	/**
@@ -380,7 +413,7 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereDay(Builder $query, $where)
 	{
@@ -392,7 +425,7 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereMonth(Builder $query, $where)
 	{
@@ -404,7 +437,7 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereYear(Builder $query, $where)
 	{
@@ -417,13 +450,15 @@ class Grammar extends BaseGrammar {
 	 * @param  string  $type
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function dateBasedWhere($type, Builder $query, $where)
 	{
 		$value = $this->parameter($where['value']);
 
-		return $type.'('.$this->wrap($where['column']).') '.$where['operator'].' '.$value;
+		$sql = $type.'('.$this->wrap($where['column']).') '.$where['operator'].' '.$value;
+
+		return new CompiledQuery($sql, $where['value']);
 	}
 
 	/**
@@ -431,11 +466,24 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereRaw(Builder $query, $where)
 	{
-		return $where['sql'];
+		$sql = $where['sql'];
+		$bindings = $where['bindings'];
+
+		// if we have a value and an operator then wrap the raw sql in braces and compare it to the value.
+		if (isset($where['value']) && isset($where['operator']))
+		{
+			$value = $where['value'];
+			$operator = $where['operator'];
+			if (! $value instanceof Expression) $bindings[] = $value;
+			$value = $this->parameter($value);
+			$sql = '('.$sql.') '.$operator.' '.$value;
+		}
+
+		return new CompiledQuery($sql, $bindings);
 	}
 
 	/**
@@ -443,11 +491,11 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $groups
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileGroups(Builder $query, $groups)
 	{
-		return 'group by '.$this->columnize($groups);
+		return new CompiledQuery('group by '.$this->columnize($groups));
 	}
 
 	/**
@@ -455,47 +503,56 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $havings
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileHavings(Builder $query, $havings)
 	{
-		$sql = implode(' ', array_map(array($this, 'compileHaving'), $havings));
+		$compiled = new CompiledQuery('having');
 
-		return 'having '.preg_replace('/and /', '', $sql, 1);
+		$compiledHavings = new CompiledQuery;
+
+		foreach ($havings as $having)
+		{
+			$compiledHavings->concatenate($this->compileHaving($query, $having));
+		}
+
+		$compiledHavings->sql = preg_replace('/and /', '', $compiledHavings->sql, 1);
+
+		return $compiled->concatenate($compiledHavings);
 	}
 
 	/**
 	 * Compile a single having clause.
 	 *
 	 * @param  array   $having
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
-	protected function compileHaving(array $having)
+	protected function compileHaving(Builder $query, array $having)
 	{
 		// If the having clause is "raw", we can just return the clause straight away
 		// without doing any more processing on it. Otherwise, we will compile the
 		// clause into SQL based on the components that make it up from builder.
 		if ($having['type'] === 'raw')
 		{
-			return $having['boolean'].' '.$having['sql'];
+			return new CompiledQuery($having['boolean'].' '.$having['sql'], $having['bindings']);
 		}
 
-		return $this->compileBasicHaving($having);
+		return $this->compileBasicHaving($query, $having);
 	}
 
 	/**
 	 * Compile a basic having clause.
 	 *
 	 * @param  array   $having
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
-	protected function compileBasicHaving($having)
+	protected function compileBasicHaving(Builder $query, $having)
 	{
 		$column = $this->wrap($having['column']);
 
 		$parameter = $this->parameter($having['value']);
 
-		return $having['boolean'].' '.$column.' '.$having['operator'].' '.$parameter;
+		return new CompiledQuery($having['boolean'].' '.$column.' '.$having['operator'].' '.$parameter, $having['value']);
 	}
 
 	/**
@@ -503,17 +560,29 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $orders
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileOrders(Builder $query, $orders)
 	{
-		return 'order by '.implode(', ', array_map(function($order)
-		{
-			if (isset($order['sql'])) return $order['sql'];
+		$compiled = new CompiledQuery('order by');
 
-			return $this->wrap($order['column']).' '.$order['direction'];
+		$compiledOrders = new CompiledQuery;
+
+		foreach($orders as $order)
+		{
+			if (isset($order['sql']))
+			{
+				$compiledOrder = new CompiledQuery($order['sql'], $order['bindings']);
+			}
+			else
+			{
+				$compiledOrder = new CompiledQuery($this->wrap($order['column']).' '.$order['direction']);
+			}
+
+			$compiledOrders->concatenate($compiledOrder, ', ');
 		}
-		, $orders));
+
+		return $compiled->concatenate($compiledOrders);
 	}
 
 	/**
@@ -521,11 +590,11 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  int  $limit
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileLimit(Builder $query, $limit)
 	{
-		return 'limit '.(int) $limit;
+		return new CompiledQuery('limit '.(int) $limit);
 	}
 
 	/**
@@ -533,42 +602,44 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  int  $offset
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileOffset(Builder $query, $offset)
 	{
-		return 'offset '.(int) $offset;
+		return new CompiledQuery('offset '.(int) $offset);
 	}
 
 	/**
 	 * Compile the "union" queries attached to the main query.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
-	protected function compileUnions(Builder $query)
+	protected function compileUnions(Builder $query, $unions)
 	{
-		$sql = '';
+		$compiled = new CompiledQuery;
 
-		foreach ($query->unions as $union)
+		foreach ($unions as $union)
 		{
-			$sql .= $this->compileUnion($union);
+			$compiled->concatenate($this->compileUnion($union));
 		}
 
-		return ltrim($sql);
+		return $compiled;
 	}
 
 	/**
 	 * Compile a single union statement.
 	 *
 	 * @param  array  $union
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileUnion(array $union)
 	{
-		$joiner = $union['all'] ? ' union all ' : ' union ';
+		$joiner = $union['all'] ? 'union all' : 'union';
 
-		return $joiner.$union['query']->toSql();
+		$compiled = new CompiledQuery($joiner);
+
+		return $compiled->concatenate($this->compileSelect($union['query']));
 	}
 
 	/**
@@ -576,7 +647,7 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $values
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileInsert(Builder $query, array $values)
 	{
@@ -601,7 +672,7 @@ class Grammar extends BaseGrammar {
 
 		$parameters = implode(', ', $value);
 
-		return "insert into $table ($columns) values $parameters";
+		return new CompiledQuery("insert into $table ($columns) values $parameters");
 	}
 
 	/**
@@ -610,7 +681,7 @@ class Grammar extends BaseGrammar {
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array   $values
 	 * @param  string  $sequence
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileInsertGetId(Builder $query, $values, $sequence)
 	{
@@ -622,11 +693,20 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $values
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileUpdate(Builder $query, $values)
 	{
 		$table = $this->wrapTable($query->from);
+
+		$compiled = new CompiledQuery("update {$table}");
+
+		// If the query has any "join" clauses, we will setup the joins on the builder
+		// and compile them so we can attach them to this update, as update queries
+		// can get join statements to attach to other tables when they're needed.
+
+		$joins = isset($query->joins) ? $this->compileJoins($query, $query->joins) : null;
+		$compiled->concatenate($joins);
 
 		// Each one of the columns in the update statements needs to be wrapped in the
 		// keyword identifiers, also a place-holder needs to be created for each of
@@ -640,39 +720,32 @@ class Grammar extends BaseGrammar {
 
 		$columns = implode(', ', $columns);
 
-		// If the query has any "join" clauses, we will setup the joins on the builder
-		// and compile them so we can attach them to this update, as update queries
-		// can get join statements to attach to other tables when they're needed.
-		if (isset($query->joins))
-		{
-			$joins = ' '.$this->compileJoins($query, $query->joins);
-		}
-		else
-		{
-			$joins = '';
-		}
+		$compiled->concatenate(new CompiledQuery("set $columns"));
 
 		// Of course, update queries may also be constrained by where clauses so we'll
 		// need to compile the where clauses and attach it to the query so only the
 		// intended records are updated by the SQL statements we generate to run.
 		$where = $this->compileWheres($query);
+		$compiled->concatenate($where);
 
-		return trim("update {$table}{$joins} set $columns $where");
+		return $compiled;
 	}
 
 	/**
 	 * Compile a delete statement into SQL.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileDelete(Builder $query)
 	{
 		$table = $this->wrapTable($query->from);
 
-		$where = is_array($query->wheres) ? $this->compileWheres($query) : '';
+		$compiled = new CompiledQuery("delete from $table");
 
-		return trim("delete from $table ".$where);
+		$where = is_array($query->wheres) ? $this->compileWheres($query) : null;
+
+		return $compiled->concatenate($where);
 	}
 
 	/**
@@ -691,25 +764,29 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  bool|string  $value
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileLock(Builder $query, $value)
 	{
-		return is_string($value) ? $value : '';
+		return new CompiledQuery(is_string($value) ? $value : '');
 	}
 
 	/**
 	 * Concatenate an array of segments, removing empties.
 	 *
 	 * @param  array   $segments
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function concatenate($segments)
 	{
-		return implode(' ', array_filter($segments, function($value)
+		$compiled = new CompiledQuery;
+
+		foreach($segments as $key => $segment)
 		{
-			return (string) $value !== '';
-		}));
+			$compiled->concatenate($segment);
+		}
+
+		return $compiled;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\CompiledQuery;
 
 class SQLiteGrammar extends Grammar {
 
@@ -20,7 +21,7 @@ class SQLiteGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $values
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileInsert(Builder $query, array $values)
 	{
@@ -56,7 +57,7 @@ class SQLiteGrammar extends Grammar {
 
 		$columns = array_fill(0, count($values), implode(', ', $columns));
 
-		return "insert into $table ($names) select ".implode(' union select ', $columns);
+		return new CompiledQuery("insert into $table ($names) select ".implode(' union select ', $columns));
 	}
 
 	/**
@@ -79,7 +80,7 @@ class SQLiteGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereDay(Builder $query, $where)
 	{
@@ -91,7 +92,7 @@ class SQLiteGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereMonth(Builder $query, $where)
 	{
@@ -103,7 +104,7 @@ class SQLiteGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereYear(Builder $query, $where)
 	{
@@ -116,7 +117,7 @@ class SQLiteGrammar extends Grammar {
 	 * @param  string  $type
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function dateBasedWhere($type, Builder $query, $where)
 	{
@@ -124,7 +125,9 @@ class SQLiteGrammar extends Grammar {
 
 		$value = $this->parameter($value);
 
-		return 'strftime(\''.$type.'\', '.$this->wrap($where['column']).') '.$where['operator'].' '.$value;
+		$sql = 'strftime(\''.$type.'\', '.$this->wrap($where['column']).') '.$where['operator'].' '.$value;
+
+		return new CompiledQuery($sql, $where['value']);
 	}
 
 }

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\CompiledQuery;
 
 class SqlServerGrammar extends Grammar {
 
@@ -19,7 +20,7 @@ class SqlServerGrammar extends Grammar {
 	 * Compile a select query into SQL.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileSelect(Builder $query)
 	{
@@ -41,7 +42,7 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $columns
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileColumns(Builder $query, $columns)
 	{
@@ -57,7 +58,12 @@ class SqlServerGrammar extends Grammar {
 			$select .= 'top '.$query->limit.' ';
 		}
 
-		return $select.$this->columnize($columns);
+		// include the binding logic from the parent method
+		$bindings = array_flatten(array_fetch($columns, 'bindings'));
+
+		$columns = array_flatten(array_fetch($columns, 'columns'));
+
+		return new CompiledQuery($select.$this->columnize($columns), $bindings);
 	}
 
 	/**
@@ -65,17 +71,19 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  string  $table
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileFrom(Builder $query, $table)
 	{
 		$from = parent::compileFrom($query, $table);
 
-		if (is_string($query->lock)) return $from.' '.$query->lock;
+		if (is_string($query->lock)) return $from->concatenate(new CompiledQuery($query->lock));
 
 		if ( ! is_null($query->lock))
 		{
-			return $from.' with(rowlock,'.($query->lock ? 'updlock,' : '').'holdlock)';
+			$from->sql .= ' with(rowlock,'.($query->lock ? 'updlock,' : '').'holdlock)';
+
+			return $from;
 		}
 
 		return $from;
@@ -86,7 +94,7 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $components
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileAnsiOffset(Builder $query, $components)
 	{
@@ -95,7 +103,7 @@ class SqlServerGrammar extends Grammar {
 		// does not complain about the queries for not having an "order by" clause.
 		if ( ! isset($components['orders']))
 		{
-			$components['orders'] = 'order by (select 0)';
+			$components['orders'] = new CompiledQuery('order by (select 0)');
 		}
 
 		// We need to add the row number to the query so we can compare it to the offset
@@ -103,7 +111,7 @@ class SqlServerGrammar extends Grammar {
 		// the "select" that will give back the row numbers on each of the records.
 		$orderings = $components['orders'];
 
-		$components['columns'] .= $this->compileOver($orderings);
+		$components['columns']->sql .= $this->compileOver($orderings->sql);
 
 		unset($components['orders']);
 
@@ -112,12 +120,12 @@ class SqlServerGrammar extends Grammar {
 		// set we will just handle the offset only since that is all that matters.
 		$constraint = $this->compileRowConstraint($query);
 
-		$sql = $this->concatenate($components);
+		$compiled = $this->concatenate($components);
 
 		// We are now ready to build the final SQL query so we'll create a common table
 		// expression from the query and get the records with row numbers within our
 		// given limit and offset value that we just put on as a query constraint.
-		return $this->compileTableExpression($sql, $constraint);
+		return $this->compileTableExpression($compiled, $constraint);
 	}
 
 	/**
@@ -156,11 +164,13 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @param  string  $sql
 	 * @param  string  $constraint
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
-	protected function compileTableExpression($sql, $constraint)
+	protected function compileTableExpression(CompiledQuery $compiled, $constraint)
 	{
-		return "select * from ({$sql}) as temp_table where row_num {$constraint}";
+		$compiled->sql = "select * from ({$compiled->sql}) as temp_table where row_num {$constraint}";
+
+		return $compiled;
 	}
 
 	/**
@@ -168,11 +178,11 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  int  $limit
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileLimit(Builder $query, $limit)
 	{
-		return '';
+		return;
 	}
 
 	/**
@@ -180,11 +190,11 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  int  $offset
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileOffset(Builder $query, $offset)
 	{
-		return '';
+		return;
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -490,7 +490,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testRealHas()
+	public function testHas()
 	{
 		$expectedSql = 'select * from "table" where (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "status" = ?) >= 1';
 		$expectedBindings = ['active'];
@@ -502,7 +502,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertBuilderCompile($query, $expectedSql, $expectedBindings);
 	}
 
-	public function testRealHasWithOperatorAndCount()
+	public function testHasWithOperatorAndCount()
 	{
 		$expectedSql = 'select * from "table" where (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "status" = ?) = 4';
 		$expectedBindings = ['active'];
@@ -514,7 +514,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertBuilderCompile($query, $expectedSql, $expectedBindings);
 	}
 
-	public function testRealOrHas()
+	public function testOrHas()
 	{
 		$expectedSql = 'select * from "table" where "foo" = ? or (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "status" = ?) >= 1';
 		$expectedBindings = ['bar', 'active'];
@@ -527,7 +527,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testRealWhereHas()
+	public function testWhereHas()
 	{
 		$expectedSql = 'select * from "table" where (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "foo" = ? and "status" = ?) >= 1';
 		$expectedBindings = ['bar', 'active'];
@@ -540,7 +540,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testRealOrWhereHas()
+	public function testOrWhereHas()
 	{
 		$expectedSql = 'select * from "table" where "foo" = ? or (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "fizz" = ? and "status" = ?) >= 1';
 		$expectedBindings = ['bar', 'buzz', 'active'];
@@ -553,7 +553,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testRealHasWithScopes()
+	public function testHasWithScopes()
 	{
 		$expectedSql = 'select * from "table" where (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "subTable"."deleted_at" is null and "status" = ?) >= 1';
 		$expectedBindings = ['active'];
@@ -566,7 +566,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testRealHasWithScopesOperatorAndCount()
+	public function testHasWithScopesOperatorAndCount()
 	{
 		$expectedSql = 'select * from "table" where (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "subTable"."deleted_at" is null and "status" = ?) = 4';
 		$expectedBindings = ['active'];
@@ -579,7 +579,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testRealOrHasWithScopes()
+	public function testOrHasWithScopes()
 	{
 		$expectedSql = 'select * from "table" where "foo" = ? or (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "subTable"."deleted_at" is null and "status" = ?) >= 1';
 		$expectedBindings = ['bar', 'active'];
@@ -592,7 +592,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testRealWhereHasWithScopes()
+	public function testWhereHasWithScopes()
 	{
 		$expectedSql = 'select * from "table" where (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "foo" = ? and "subTable"."deleted_at" is null and "status" = ?) >= 1';
 		$expectedBindings = ['bar', 'active'];
@@ -605,7 +605,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testRealOrWhereHasWithScopes()
+	public function testOrWhereHasWithScopes()
 	{
 		$expectedSql = 'select * from "table" where "foo" = ? or (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "fizz" = ? and "subTable"."deleted_at" is null and "status" = ?) >= 1';
 		$expectedBindings = ['bar', 'buzz', 'active'];

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -487,6 +487,144 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRealHas()
+	{
+		$expectedSql = 'select * from "table" where (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "status" = ?) >= 1';
+		$expectedBindings = ['active'];
+
+		$model = new EloquentBuilderTestHasStub;
+		$this->mockConnectionForModel($model, 'SQLite');
+		$query = $model->newQuery()->has('subs');
+
+		$this->assertEquals($expectedSql, $query->toSql());
+		$this->assertEquals($expectedBindings, $query->getBindings());
+	}
+
+	public function testRealHasWithOperatorAndCount()
+	{
+		$expectedSql = 'select * from "table" where (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "status" = ?) = 4';
+		$expectedBindings = ['active'];
+
+		$model = new EloquentBuilderTestHasStub;
+		$this->mockConnectionForModel($model, 'SQLite');
+		$query = $model->newQuery()->has('subs', '=', 4);
+
+		$this->assertEquals($expectedSql, $query->toSql());
+		$this->assertEquals($expectedBindings, $query->getBindings());
+	}
+
+	public function testRealOrHas()
+	{
+		$expectedSql = 'select * from "table" where "foo" = ? or (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "status" = ?) >= 1';
+		$expectedBindings = ['bar', 'active'];
+
+		$model = new EloquentBuilderTestHasStub;
+		$this->mockConnectionForModel($model, 'SQLite');
+		$query = $model->newQuery()->where('foo', 'bar')->orHas('subs');
+
+		$this->assertEquals($expectedSql, $query->toSql());
+		$this->assertEquals($expectedBindings, $query->getBindings());
+	}
+
+
+	public function testRealWhereHas()
+	{
+		$expectedSql = 'select * from "table" where (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "foo" = ? and "status" = ?) >= 1';
+		$expectedBindings = ['bar', 'active'];
+
+		$model = new EloquentBuilderTestHasStub;
+		$this->mockConnectionForModel($model, 'SQLite');
+		$query = $model->newQuery()->whereHas('subs', function($subs) { $subs->where('foo', '=', 'bar');});
+
+		$this->assertEquals($expectedSql, $query->toSql());
+		$this->assertEquals($expectedBindings, $query->getBindings());
+	}
+
+
+	public function testRealOrWhereHas()
+	{
+		$expectedSql = 'select * from "table" where "foo" = ? or (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "fizz" = ? and "status" = ?) >= 1';
+		$expectedBindings = ['bar', 'buzz', 'active'];
+
+		$model = new EloquentBuilderTestHasStub;
+		$this->mockConnectionForModel($model, 'SQLite');
+		$query = $model->newQuery()->where('foo', '=', 'bar')->orWhereHas('subs', function($subs) { $subs->where('fizz', '=', 'buzz');});
+
+		$this->assertEquals($expectedSql, $query->toSql());
+		$this->assertEquals($expectedBindings, $query->getBindings());
+	}
+
+
+	public function testRealHasWithScopes()
+	{
+		$expectedSql = 'select * from "table" where (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "subTable"."deleted_at" is null and "status" = ?) >= 1';
+		$expectedBindings = ['active'];
+
+		$model = new EloquentBuilderTestHasScopeStub;
+		$this->mockConnectionForModel($model, 'SQLite');
+		$query = $model->newQuery()->has('subs');
+
+		$this->assertEquals($expectedSql, $query->toSql());
+		$this->assertEquals($expectedBindings, $query->getBindings());
+	}
+
+
+	public function testRealHasWithScopesOperatorAndCount()
+	{
+		$expectedSql = 'select * from "table" where (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "subTable"."deleted_at" is null and "status" = ?) = 4';
+		$expectedBindings = ['active'];
+
+		$model = new EloquentBuilderTestHasScopeStub;
+		$this->mockConnectionForModel($model, 'SQLite');
+		$query = $model->newQuery()->has('subs', '=', 4);
+
+		$this->assertEquals($expectedSql, $query->toSql());
+		$this->assertEquals($expectedBindings, $query->getBindings());
+	}
+
+
+	public function testRealOrHasWithScopes()
+	{
+		$expectedSql = 'select * from "table" where "foo" = ? or (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "subTable"."deleted_at" is null and "status" = ?) >= 1';
+		$expectedBindings = ['bar', 'active'];
+
+		$model = new EloquentBuilderTestHasScopeStub;
+		$this->mockConnectionForModel($model, 'SQLite');
+		$query = $model->newQuery()->where('foo', 'bar')->orHas('subs');
+
+		$this->assertEquals($expectedSql, $query->toSql());
+		$this->assertEquals($expectedBindings, $query->getBindings());
+	}
+
+
+	public function testRealWhereHasWithScopes()
+	{
+		$expectedSql = 'select * from "table" where (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "foo" = ? and "subTable"."deleted_at" is null and "status" = ?) >= 1';
+		$expectedBindings = ['bar', 'active'];
+
+		$model = new EloquentBuilderTestHasScopeStub;
+		$this->mockConnectionForModel($model, 'SQLite');
+		$query = $model->newQuery()->whereHas('subs', function($subs) { $subs->where('foo', '=', 'bar');});
+
+		$this->assertEquals($expectedSql, $query->toSql());
+		$this->assertEquals($expectedBindings, $query->getBindings());
+	}
+
+
+	public function testRealOrWhereHasWithScopes()
+	{
+		$expectedSql = 'select * from "table" where "foo" = ? or (select count(*) from "subTable" where "subTable"."table_id" = "table"."id" and "fizz" = ? and "subTable"."deleted_at" is null and "status" = ?) >= 1';
+		$expectedBindings = ['bar', 'buzz', 'active'];
+
+		$model = new EloquentBuilderTestHasScopeStub;
+		$this->mockConnectionForModel($model, 'SQLite');
+		$query = $model->newQuery()->where('foo', '=', 'bar')->orWhereHas('subs', function($subs) { $subs->where('fizz', '=', 'buzz');});
+
+		$this->assertEquals($expectedSql, $query->toSql());
+		$this->assertEquals($expectedBindings, $query->getBindings());
+	}
+
+
 	protected function mockConnectionForModel($model, $database)
 	{
 		$grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';
@@ -542,6 +680,30 @@ class EloquentBuilderTestWithTrashedStub extends Illuminate\Database\Eloquent\Mo
 
 class EloquentBuilderTestNestedStub extends Illuminate\Database\Eloquent\Model {
 	protected $table = 'table';
+	use Illuminate\Database\Eloquent\SoftDeletingTrait;
+}
+
+
+class EloquentBuilderTestHasStub extends Illuminate\Database\Eloquent\Model {
+	protected $table = 'table';
+	public function subs() {
+		return $this->hasMany('EloquentBuilderTestHasRelationStub', 'table_id')->where('status', '=', 'active');
+	}
+}
+
+class EloquentBuilderTestHasRelationStub extends Illuminate\Database\Eloquent\Model {
+	protected $table = 'subTable';
+}
+
+class EloquentBuilderTestHasScopeStub extends Illuminate\Database\Eloquent\Model {
+	protected $table = 'table';
+	public function subs() {
+		return $this->hasMany('EloquentBuilderTestHasRelationScopeStub', 'table_id')->where('status', '=', 'active');
+	}
+}
+
+class EloquentBuilderTestHasRelationScopeStub extends Illuminate\Database\Eloquent\Model {
+	protected $table = 'subTable';
 	use Illuminate\Database\Eloquent\SoftDeletingTrait;
 }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -16,7 +16,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users');
-		$this->assertEquals('select * from "users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users"');
 	}
 
 
@@ -24,21 +24,21 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('some"table');
-		$this->assertEquals('select * from "some""table"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "some""table"');
 	}
 
 	public function testAliasWrappingAsWholeConstant()
 	{
 		$builder = $this->getBuilder();
 		$builder->select('x.y as foo.bar')->from('baz');
-		$this->assertEquals('select "x"."y" as "foo.bar" from "baz"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select "x"."y" as "foo.bar" from "baz"');
 	}
 
 	public function testAddingSelects()
 	{
 		$builder = $this->getBuilder();
 		$builder->select('foo')->addSelect('bar')->addSelect(array('baz', 'boom'))->from('users');
-		$this->assertEquals('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select "foo", "bar", "baz", "boom" from "users"');
 	}
 
 
@@ -47,7 +47,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->getGrammar()->setTablePrefix('prefix_');
 		$builder->select('*')->from('users');
-		$this->assertEquals('select * from "prefix_users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "prefix_users"');
 	}
 
 
@@ -55,7 +55,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->distinct()->select('foo', 'bar')->from('users');
-		$this->assertEquals('select distinct "foo", "bar" from "users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select distinct "foo", "bar" from "users"');
 	}
 
 
@@ -123,7 +123,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('foo as bar')->from('users');
-		$this->assertEquals('select "foo" as "bar" from "users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select "foo" as "bar" from "users"');
 	}
 
 
@@ -131,7 +131,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('public.users');
-		$this->assertEquals('select * from "public"."users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "public"."users"');
 	}
 
 
@@ -139,8 +139,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1);
-		$this->assertEquals('select * from "users" where "id" = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ?', [1]);
 	}
 
 
@@ -148,7 +147,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->From('some`table');
-		$this->assertEquals('select * from `some``table`', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from `some``table`');
 	}
 
 
@@ -156,8 +155,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('users')->whereDay('created_at', '=', 1);
-		$this->assertEquals('select * from `users` where day(`created_at`) = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from `users` where day(`created_at`) = ?', [1]);
 	}
 
 
@@ -165,8 +163,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
-		$this->assertEquals('select * from `users` where month(`created_at`) = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 5), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from `users` where month(`created_at`) = ?', [5]);
 	}
 
 
@@ -174,8 +171,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
-		$this->assertEquals('select * from `users` where year(`created_at`) = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 2014), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from `users` where year(`created_at`) = ?', [2014]);
 	}
 
 
@@ -183,8 +179,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('users')->whereDay('created_at', '=', 1);
-		$this->assertEquals('select * from "users" where day("created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where day("created_at") = ?', [1]);
 	}
 
 
@@ -192,8 +187,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
-		$this->assertEquals('select * from "users" where month("created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 5), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where month("created_at") = ?', [5]);
 	}
 
 
@@ -201,8 +195,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
-		$this->assertEquals('select * from "users" where year("created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 2014), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where year("created_at") = ?', [2014]);
 	}
 
 
@@ -210,8 +203,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getSQLiteBuilder();
 		$builder->select('*')->from('users')->whereDay('created_at', '=', 1);
-		$this->assertEquals('select * from "users" where strftime(\'%d\', "created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where strftime(\'%d\', "created_at") = ?', [1]);
 	}
 
 
@@ -219,8 +211,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getSQLiteBuilder();
 		$builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
-		$this->assertEquals('select * from "users" where strftime(\'%m\', "created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 5), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where strftime(\'%m\', "created_at") = ?', [5]);
 	}
 
 
@@ -228,8 +219,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getSQLiteBuilder();
 		$builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
-		$this->assertEquals('select * from "users" where strftime(\'%Y\', "created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 2014), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where strftime(\'%Y\', "created_at") = ?', [2014]);
 	}
 
 
@@ -237,8 +227,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('users')->whereDay('created_at', '=', 1);
-		$this->assertEquals('select * from "users" where day("created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where day("created_at") = ?', [1]);
 	}
 
 
@@ -246,8 +235,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
-		$this->assertEquals('select * from "users" where month("created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 5), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where month("created_at") = ?', [5]);
 	}
 
 
@@ -255,8 +243,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
-		$this->assertEquals('select * from "users" where year("created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 2014), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where year("created_at") = ?', [2014]);
 	}
 
 
@@ -264,13 +251,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereBetween('id', array(1, 2));
-		$this->assertEquals('select * from "users" where "id" between ? and ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 2), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" between ? and ?', [1, 2]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereNotBetween('id', array(1, 2));
-		$this->assertEquals('select * from "users" where "id" not between ? and ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 2), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" not between ? and ?', [1, 2]);
 	}
 
 
@@ -278,8 +263,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1)->orWhere('email', '=', 'foo');
-		$this->assertEquals('select * from "users" where "id" = ? or "email" = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 'foo'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or "email" = ?', [1, 'foo']);
 	}
 
 
@@ -287,8 +271,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereRaw('id = ? or email = ?', array(1, 'foo'));
-		$this->assertEquals('select * from "users" where id = ? or email = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 'foo'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where id = ? or email = ?', [1, 'foo']);
 	}
 
 
@@ -296,8 +279,31 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1)->orWhereRaw('email = ?', array('foo'));
-		$this->assertEquals('select * from "users" where "id" = ? or email = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 'foo'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or email = ?', [1, 'foo']);
+	}
+
+
+	public function testRawWheresWithOperator()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->whereRaw('select count(*) from "photos" where "photo"."user_id" = "user"."id" and "type" = ?', array('profile'), '<', 1);
+		$this->assertBuilderCompile($builder, 'select * from "users" where (select count(*) from "photos" where "photo"."user_id" = "user"."id" and "type" = ?) < ?', ['profile', 1]);
+	}
+
+
+	public function testRawWheresWithOperatorAndValueExpression()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->whereRaw('select count(*) from "photos" where "photo"."user_id" = "user"."id" and "type" = ?', array('profile'), '<', new Raw('1'));
+		$this->assertBuilderCompile($builder, 'select * from "users" where (select count(*) from "photos" where "photo"."user_id" = "user"."id" and "type" = ?) < 1', ['profile']);
+	}
+
+
+	public function testRawOrWheresWithOperator()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->where('id', '=', 10)->orWhereRaw('select count(*) from "photos" where "photo"."user_id" = "user"."id" and "type" = ?', array('profile'), '<', 1);
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or (select count(*) from "photos" where "photo"."user_id" = "user"."id" and "type" = ?) < ?', [10, 'profile', 1]);
 	}
 
 
@@ -305,13 +311,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereIn('id', array(1, 2, 3));
-		$this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 2, 2 => 3), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" in (?, ?, ?)', [1, 2, 3]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', array(1, 2, 3));
-		$this->assertEquals('select * from "users" where "id" = ? or "id" in (?, ?, ?)', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 1, 2 => 2, 3 => 3), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or "id" in (?, ?, ?)', [1, 1, 2, 3]);
 	}
 
 
@@ -319,13 +323,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereNotIn('id', array(1, 2, 3));
-		$this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 2, 2 => 3), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" not in (?, ?, ?)', [1, 2, 3]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotIn('id', array(1, 2, 3));
-		$this->assertEquals('select * from "users" where "id" = ? or "id" not in (?, ?, ?)', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 1, 2 => 2, 3 => 3), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or "id" not in (?, ?, ?)', [1, 1, 2, 3]);
 	}
 
 
@@ -334,14 +336,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1);
 		$builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
-		$this->assertEquals('select * from "users" where "id" = ? union select * from "users" where "id" = ?', $builder->toSql());
-		$this->assertEquals([1, 2], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? union select * from "users" where "id" = ?', [1, 2]);
 
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1);
 		$builder->union($this->getMySqlBuilder()->select('*')->from('users')->where('id', '=', 2));
-		$this->assertEquals('(select * from `users` where `id` = ?) union (select * from `users` where `id` = ?)', $builder->toSql());
-		$this->assertEquals([1, 2], $builder->getBindings());
+		$this->assertBuilderCompile($builder, '(select * from `users` where `id` = ?) union (select * from `users` where `id` = ?)', [1, 2]);
 	}
 
 
@@ -350,58 +350,53 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1);
 		$builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
-		$this->assertEquals('select * from "users" where "id" = ? union all select * from "users" where "id" = ?', $builder->toSql());
-		$this->assertEquals([1, 2], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? union all select * from "users" where "id" = ?', [1, 2]);
 
-    $builder = $this->getMySqlBuilder();
-    $builder->select('*')->from('users')->where('id', '=', 1);
-    $builder->unionAll($this->getMySqlBuilder()->select('*')->from('users')->where('id', '=', 2));
-    $this->assertEquals('(select * from `users` where `id` = ?) union all (select * from `users` where `id` = ?)', $builder->toSql());
-    $this->assertEquals([1, 2], $builder->getBindings());
+		$builder = $this->getMySqlBuilder();
+		$builder->select('*')->from('users')->where('id', '=', 1);
+		$builder->unionAll($this->getMySqlBuilder()->select('*')->from('users')->where('id', '=', 2));
+		$this->assertBuilderCompile($builder, '(select * from `users` where `id` = ?) union all (select * from `users` where `id` = ?)', [1, 2]);
 	}
 
 
-  public function testUnionsWithJoins()
-  {
-    $expectedSql = 'select * from "users" inner join "photos" on "users"."id" = ? where "id" = ? union select * from "users" inner join "photos" on "users"."id" = ? where "id" = ?';
-    $expectedBindings = ['foo', 1, 'bar', 2];
+	public function testUnionsWithJoins()
+	{
+		$expectedSql = 'select * from "users" inner join "photos" on "users"."id" = ? where "id" = ? union select * from "users" inner join "photos" on "users"."id" = ? where "id" = ?';
+		$expectedBindings = ['foo', 1, 'bar', 2];
 
-    $first = $this->getBuilder();
-    $first->select('*')->from('users')->join('photos', function($join) {$join->where('users.id', '=', 'foo');})->where('id', '=', 1);
-    $second = $this->getBuilder()->select('*')->from('users')->join('photos', function($join) {$join->where('users.id', '=', 'bar');})->where('id', '=', 2);
-    $first->union($second);
-    $this->assertEquals($expectedSql, $first->toSql());
-    $this->assertEquals($expectedBindings, $first->getBindings());
-  }
+		$first = $this->getBuilder();
+		$first->select('*')->from('users')->join('photos', function($join) {$join->where('users.id', '=', 'foo');})->where('id', '=', 1);
+		$second = $this->getBuilder()->select('*')->from('users')->join('photos', function($join) {$join->where('users.id', '=', 'bar');})->where('id', '=', 2);
+		$first->union($second);
+		$this->assertBuilderCompile($first, $expectedSql, $expectedBindings);
+	}
 
 
-  public function testUnionsWithOrder()
-  {
-    $expectedSql = 'select * from "users" where "id" = ? order by "email" asc, "age" ? desc union select * from "users" where "id" = ? order by "email" asc, "age" ? desc';
-    $expectedBindings = [1, 'foo', 2, 'bar'];
+	public function testUnionsWithOrder()
+	{
+		$expectedSql = 'select * from "users" where "id" = ? order by "email" asc, "age" ? desc union select * from "users" where "id" = ? order by "email" asc, "age" ? desc';
+		$expectedBindings = [1, 'foo', 2, 'bar'];
 
-    $first = $this->getBuilder();
-    $first->select('*')->from('users')->where('id', '=', 1)->orderBy('email')->orderByRaw('"age" ? desc', array('foo'));
-    $second = $this->getBuilder()->select('*')->from('users')->where('id', '=', 2)->orderBy('email')->orderByRaw('"age" ? desc', array('bar'));
-    $first->union($second);
+		$first = $this->getBuilder();
+		$first->select('*')->from('users')->where('id', '=', 1)->orderBy('email')->orderByRaw('"age" ? desc', array('foo'));
+		$second = $this->getBuilder()->select('*')->from('users')->where('id', '=', 2)->orderBy('email')->orderByRaw('"age" ? desc', array('bar'));
+		$first->union($second);
 
-    $this->assertEquals($expectedSql, $first->toSql());
-    $this->assertEquals($expectedBindings, $first->getBindings());
-  }
+		$this->assertBuilderCompile($first, $expectedSql, $expectedBindings);
+	}
 
-  public function testUnionsWithHavings()
-  {
-    $expectedSql = 'select * from "users" where "id" = ? group by "email" having "email" = ? union select * from "users" where "id" = ? group by "email" having "email" = ?';
-    $expectedBindings = [1, 'me@email.com', 2, 'you@email.com'];
+	public function testUnionsWithHavings()
+	{
+		$expectedSql = 'select * from "users" where "id" = ? group by "email" having "email" = ? union select * from "users" where "id" = ? group by "email" having "email" = ?';
+		$expectedBindings = [1, 'me@email.com', 2, 'you@email.com'];
 
-    $first = $this->getBuilder();
-    $first->select('*')->from('users')->where('id', '=', 1)->groupBy('email')->having('email', '=', 'me@email.com');
-    $second = $this->getBuilder()->select('*')->from('users')->where('id', '=', 2)->groupBy('email')->having('email', '=', 'you@email.com');
-    $first->union($second);
+		$first = $this->getBuilder();
+		$first->select('*')->from('users')->where('id', '=', 1)->groupBy('email')->having('email', '=', 'me@email.com');
+		$second = $this->getBuilder()->select('*')->from('users')->where('id', '=', 2)->groupBy('email')->having('email', '=', 'you@email.com');
+		$first->union($second);
 
-    $this->assertEquals($expectedSql, $first->toSql());
-    $this->assertEquals($expectedBindings, $first->getBindings());
-  }
+		$this->assertBuilderCompile($first, $expectedSql, $expectedBindings);
+	}
 
 
 	public function testMultipleUnions()
@@ -410,8 +405,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->select('*')->from('users')->where('id', '=', 1);
 		$builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
 		$builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 3));
-		$this->assertEquals('select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 2, 2 => 3), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?', [1, 2, 3]);
 	}
 
 
@@ -421,8 +415,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->select('*')->from('users')->where('id', '=', 1);
 		$builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
 		$builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 3));
-		$this->assertEquals('select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 2, 2 => 3), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?', [1, 2, 3]);
 	}
 
 
@@ -433,70 +426,62 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			$q->select('id')->from('users')->where('age', '>', 25)->take(3);
 		});
-		$this->assertEquals('select * from "users" where "id" in (select "id" from "users" where "age" > ? limit 3)', $builder->toSql());
-		$this->assertEquals(array(25), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" in (select "id" from "users" where "age" > ? limit 3)', [25]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereNotIn('id', function($q)
 		{
 			$q->select('id')->from('users')->where('age', '>', 25)->take(3);
 		});
-		$this->assertEquals('select * from "users" where "id" not in (select "id" from "users" where "age" > ? limit 3)', $builder->toSql());
-		$this->assertEquals(array(25), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" not in (select "id" from "users" where "age" > ? limit 3)', [25]);
 	}
 
 
-  public function testSubSelectWhereInsWithHavings()
-  {
-    $builder = $this->getBuilder();
-    $builder->select('*')->from('users')->groupBy('email')->having('email', '!=', 'me@email.com')->whereIn('id', function($q)
-    {
-      $q->select('id')->from('users')->where('age', '>', 25)->take(3);
-    });
-    $this->assertEquals('select * from "users" where "id" in (select "id" from "users" where "age" > ? limit 3) group by "email" having "email" != ?', $builder->toSql());
-    $this->assertEquals([ 25, 'me@email.com'], $builder->getBindings());
+	public function testSubSelectWhereInsWithHavings()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->groupBy('email')->having('email', '!=', 'me@email.com')->whereIn('id', function($q)
+		{
+			$q->select('id')->from('users')->where('age', '>', 25)->take(3);
+		});
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" in (select "id" from "users" where "age" > ? limit 3) group by "email" having "email" != ?', [ 25, 'me@email.com']);
 
-    $builder = $this->getBuilder();
-    $builder->select('*')->from('users')->groupBy('email')->having('email', '!=', 'me@email.com')->whereNotIn('id', function($q)
-    {
-      $q->select('id')->from('users')->where('age', '>', 25)->take(3);
-    });
-    $this->assertEquals('select * from "users" where "id" not in (select "id" from "users" where "age" > ? limit 3) group by "email" having "email" != ?', $builder->toSql());
-    $this->assertEquals([ 25, 'me@email.com'], $builder->getBindings());
-  }
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->groupBy('email')->having('email', '!=', 'me@email.com')->whereNotIn('id', function($q)
+		{
+			$q->select('id')->from('users')->where('age', '>', 25)->take(3);
+		});
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" not in (select "id" from "users" where "age" > ? limit 3) group by "email" having "email" != ?', [ 25, 'me@email.com']);
+	}
 
 
-  public function testSubSelectWhereInsWithJoins()
-  {
-    $builder = $this->getBuilder();
-    $builder->select('*')->from('users')->joinWhere('photos', 'users.id', '=', 'foo')->whereIn('id', function($q)
-    {
-      $q->select('id')->from('users')->joinWhere('photos', 'users.id', '!=', 'bar')->where('age', '>', 25)->take(3);
-    });
-    $this->assertEquals('select * from "users" inner join "photos" on "users"."id" = ? where "id" in (select "id" from "users" inner join "photos" on "users"."id" != ? where "age" > ? limit 3)', $builder->toSql());
-    $this->assertEquals(['foo', 'bar', 25], $builder->getBindings());
+	public function testSubSelectWhereInsWithJoins()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->joinWhere('photos', 'users.id', '=', 'foo')->whereIn('id', function($q)
+		{
+			$q->select('id')->from('users')->joinWhere('photos', 'users.id', '!=', 'bar')->where('age', '>', 25)->take(3);
+		});
+		$this->assertBuilderCompile($builder, 'select * from "users" inner join "photos" on "users"."id" = ? where "id" in (select "id" from "users" inner join "photos" on "users"."id" != ? where "age" > ? limit 3)', ['foo', 'bar', 25]);
 
-    $builder = $this->getBuilder();
-    $builder->select('*')->from('users')->joinWhere('photos', 'users.id', '=', 'foo')->whereNotIn('id', function($q)
-    {
-      $q->select('id')->from('users')->joinWhere('photos', 'users.id', '!=', 'bar')->where('age', '>', 25)->take(3);
-    });
-    $this->assertEquals('select * from "users" inner join "photos" on "users"."id" = ? where "id" not in (select "id" from "users" inner join "photos" on "users"."id" != ? where "age" > ? limit 3)', $builder->toSql());
-    $this->assertEquals(['foo', 'bar', 25], $builder->getBindings());
-  }
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->joinWhere('photos', 'users.id', '=', 'foo')->whereNotIn('id', function($q)
+		{
+			$q->select('id')->from('users')->joinWhere('photos', 'users.id', '!=', 'bar')->where('age', '>', 25)->take(3);
+		});
+		$this->assertBuilderCompile($builder, 'select * from "users" inner join "photos" on "users"."id" = ? where "id" not in (select "id" from "users" inner join "photos" on "users"."id" != ? where "age" > ? limit 3)', ['foo', 'bar', 25]);
+	}
 
 
 	public function testBasicWhereNulls()
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereNull('id');
-		$this->assertEquals('select * from "users" where "id" is null', $builder->toSql());
-		$this->assertEquals(array(), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" is null');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1)->orWhereNull('id');
-		$this->assertEquals('select * from "users" where "id" = ? or "id" is null', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or "id" is null', [1]);
 	}
 
 
@@ -504,13 +489,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereNotNull('id');
-		$this->assertEquals('select * from "users" where "id" is not null', $builder->toSql());
-		$this->assertEquals(array(), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" is not null');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '>', 1)->orWhereNotNull('id');
-		$this->assertEquals('select * from "users" where "id" > ? or "id" is not null', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" > ? or "id" is not null', [1]);
 	}
 
 
@@ -518,11 +501,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->groupBy('id', 'email');
-		$this->assertEquals('select * from "users" group by "id", "email"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" group by "id", "email"');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->groupBy(['id', 'email']);
-		$this->assertEquals('select * from "users" group by "id", "email"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" group by "id", "email"');
 	}
 
 
@@ -530,12 +513,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->orderBy('email')->orderBy('age', 'desc');
-		$this->assertEquals('select * from "users" order by "email" asc, "age" desc', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" order by "email" asc, "age" desc');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->orderBy('email')->orderByRaw('"age" ? desc', array('foo'));
-		$this->assertEquals('select * from "users" order by "email" asc, "age" ? desc', $builder->toSql());
-		$this->assertEquals(array('foo'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" order by "email" asc, "age" ? desc', ['foo']);
 	}
 
 
@@ -543,18 +525,15 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->having('email', '>', 1);
-		$this->assertEquals('select * from "users" having "email" > ?', $builder->toSql());
-    $this->assertEquals([1], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" having "email" > ?', [1]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->groupBy('email')->having('email', '>', 1);
-		$this->assertEquals('select * from "users" group by "email" having "email" > ?', $builder->toSql());
-    $this->assertEquals([1], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" group by "email" having "email" > ?', [1]);
 
 		$builder = $this->getBuilder();
 		$builder->select('email as foo_email')->from('users')->having('foo_email', '>', 1);
-		$this->assertEquals('select "email" as "foo_email" from "users" having "foo_email" > ?', $builder->toSql());
-    $this->assertEquals([1], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select "email" as "foo_email" from "users" having "foo_email" > ?', [1]);
 	}
 
 
@@ -562,17 +541,15 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->havingRaw('user_foo < user_bar');
-		$this->assertEquals('select * from "users" having user_foo < user_bar', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" having user_foo < user_bar');
 
-    $builder = $this->getBuilder();
-    $builder->select('*')->from('users')->havingRaw('user_foo < ?', [1]);
-    $this->assertEquals('select * from "users" having user_foo < ?', $builder->toSql());
-    $this->assertEquals([1], $builder->getBindings());
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->havingRaw('user_foo < ?', [1]);
+		$this->assertBuilderCompile($builder, 'select * from "users" having user_foo < ?', [1]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->having('baz', '=', 1)->orHavingRaw('user_foo < user_bar');
-		$this->assertEquals('select * from "users" having "baz" = ? or user_foo < user_bar', $builder->toSql());
-    $this->assertEquals([1], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" having "baz" = ? or user_foo < user_bar', [1]);
 	}
 
 
@@ -580,23 +557,23 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->offset(5)->limit(10);
-		$this->assertEquals('select * from "users" limit 10 offset 5', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" limit 10 offset 5');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->skip(5)->take(10);
-		$this->assertEquals('select * from "users" limit 10 offset 5', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" limit 10 offset 5');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->skip(-5)->take(10);
-		$this->assertEquals('select * from "users" limit 10 offset 0', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" limit 10 offset 0');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->forPage(2, 15);
-		$this->assertEquals('select * from "users" limit 15 offset 15', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" limit 15 offset 15');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->forPage(-2, 15);
-		$this->assertEquals('select * from "users" limit 15 offset 0', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" limit 15 offset 0');
 	}
 
 
@@ -604,8 +581,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', 1)->orWhere('name', 'foo');
-		$this->assertEquals('select * from "users" where "id" = ? or "name" = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 'foo'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or "name" = ?', [1, 'foo']);
 	}
 
 
@@ -616,8 +592,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			$q->where('name', '=', 'bar')->where('age', '=', 25);
 		});
-		$this->assertEquals('select * from "users" where "email" = ? or ("name" = ? and "age" = ?)', $builder->toSql());
-		$this->assertEquals(array(0 => 'foo', 1 => 'bar', 2 => 25), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "email" = ? or ("name" = ? and "age" = ?)', ['foo', 'bar', 25]);
 	}
 
 
@@ -629,8 +604,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 			$q->select(new Raw('max(id)'))->from('users')->where('email', '=', 'bar');
 		});
 
-		$this->assertEquals('select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)', $builder->toSql());
-		$this->assertEquals(array(0 => 'foo', 1 => 'bar'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)', ['foo', 'bar']);
 	}
 
 
@@ -641,28 +615,28 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			$q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
 		});
-		$this->assertEquals('select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('orders')->whereNotExists(function($q)
 		{
 			$q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
 		});
-		$this->assertEquals('select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."id")');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('orders')->where('id', '=', 1)->orWhereExists(function($q)
 		{
 			$q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
 		});
-		$this->assertEquals('select * from "orders" where "id" = ? or exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "orders" where "id" = ? or exists (select * from "products" where "products"."id" = "orders"."id")', [1]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('orders')->where('id', '=', 1)->orWhereNotExists(function($q)
 		{
 			$q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
 		});
-		$this->assertEquals('select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")', [1]);
 	}
 
 
@@ -670,12 +644,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->leftJoin('photos', 'users.id', '=', 'photos.id');
-		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" left join "photos" on "users"."id" = "photos"."id"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" left join "photos" on "users"."id" = "photos"."id"');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->leftJoinWhere('photos', 'users.id', '=', 'bar')->joinWhere('photos', 'users.id', '=', 'foo');
-		$this->assertEquals('select * from "users" left join "photos" on "users"."id" = ? inner join "photos" on "users"."id" = ?', $builder->toSql());
-		$this->assertEquals(array('bar', 'foo'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" left join "photos" on "users"."id" = ? inner join "photos" on "users"."id" = ?', ['bar', 'foo']);
 	}
 
 
@@ -686,15 +659,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			$j->on('users.id', '=', 'contacts.id')->orOn('users.name', '=', 'contacts.name');
 		});
-		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "users"."name" = "contacts"."name"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "users"."name" = "contacts"."name"');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->join('contacts', function($j)
 		{
 			$j->where('users.id', '=', 'foo')->orWhere('users.name', '=', 'bar');
 		});
-		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = ? or "users"."name" = ?', $builder->toSql());
-		$this->assertEquals(array('foo', 'bar'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" inner join "contacts" on "users"."id" = ? or "users"."name" = ?', ['foo', 'bar']);
 	}
 
 	public function testJoinWhereNull()
@@ -704,14 +676,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			$j->on('users.id', '=', 'contacts.id')->whereNull('contacts.deleted_at');
 		});
-		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."deleted_at" is null', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."deleted_at" is null');
 	}
 
 	public function testRawExpressionsInSelect()
 	{
 		$builder = $this->getBuilder();
 		$builder->select(new Raw('substr(foo, 6)'))->from('users');
-		$this->assertEquals('select substr(foo, 6) from "users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select substr(foo, 6) from "users"');
 	}
 
 
@@ -1094,7 +1066,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('users');
-		$this->assertEquals('select * from `users`', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from `users`');
 	}
 
 
@@ -1102,7 +1074,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getSQLiteBuilder();
 		$builder->select('*')->from('users')->orderBy('email', 'desc');
-		$this->assertEquals('select * from "users" order by "email" desc', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" order by "email" desc');
 	}
 
 
@@ -1110,19 +1082,19 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getSqlServerBuilder();
 		$builder->select('*')->from('users')->take(10);
-		$this->assertEquals('select top 10 * from [users]', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select top 10 * from [users]');
 
 		$builder = $this->getSqlServerBuilder();
 		$builder->select('*')->from('users')->skip(10);
-		$this->assertEquals('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num >= 11', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num >= 11');
 
 		$builder = $this->getSqlServerBuilder();
 		$builder->select('*')->from('users')->skip(10)->take(10);
-		$this->assertEquals('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20');
 
 		$builder = $this->getSqlServerBuilder();
 		$builder->select('*')->from('users')->skip(10)->take(10)->orderBy('email', 'desc');
-		$this->assertEquals('select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 11 and 20', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 11 and 20');
 	}
 
 
@@ -1139,7 +1111,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('foo', null);
-		$this->assertEquals('select * from "users" where "foo" is null', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "foo" is null');
 	}
 
 
@@ -1210,13 +1182,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
-		$this->assertEquals('select * from `foo` where `bar` = ? for update', $builder->toSql());
-		$this->assertEquals(array('baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from `foo` where `bar` = ? for update', ['baz']);
 
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock(false);
-		$this->assertEquals('select * from `foo` where `bar` = ? lock in share mode', $builder->toSql());
-		$this->assertEquals(array('baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from `foo` where `bar` = ? lock in share mode', ['baz']);
 	}
 
 
@@ -1224,13 +1194,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
-		$this->assertEquals('select * from "foo" where "bar" = ? for update', $builder->toSql());
-		$this->assertEquals(array('baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "foo" where "bar" = ? for update', ['baz']);
 
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock(false);
-		$this->assertEquals('select * from "foo" where "bar" = ? for share', $builder->toSql());
-		$this->assertEquals(array('baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "foo" where "bar" = ? for share', ['baz']);
 	}
 
 
@@ -1238,13 +1206,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getSqlServerBuilder();
 		$builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
-		$this->assertEquals('select * from [foo] with(rowlock,updlock,holdlock) where [bar] = ?', $builder->toSql());
-		$this->assertEquals(array('baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from [foo] with(rowlock,updlock,holdlock) where [bar] = ?', ['baz']);
 
 		$builder = $this->getSqlServerBuilder();
 		$builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock(false);
-		$this->assertEquals('select * from [foo] with(rowlock,holdlock) where [bar] = ?', $builder->toSql());
-		$this->assertEquals(array('baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from [foo] with(rowlock,holdlock) where [bar] = ?', ['baz']);
 	}
 
 
@@ -1255,23 +1221,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->join('othertable', function($join) { $join->where('bar', '=', 'foo'); })->where('registered', 1)->groupBy('city')->having('population', '>', 3)->orderByRaw('match ("foo") against(?)', array('bar'));
-		$this->assertEquals($expectedSql, $builder->toSql());
-		$this->assertEquals($expectedBindings, $builder->getBindings());
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
 
 		// order of statements reversed
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->orderByRaw('match ("foo") against(?)', array('bar'))->having('population', '>', 3)->groupBy('city')->where('registered', 1)->join('othertable', function($join) { $join->where('bar', '=', 'foo'); });
-		$this->assertEquals($expectedSql, $builder->toSql());
-		$this->assertEquals($expectedBindings, $builder->getBindings());
-	}
-
-
-	public function testAddBindingWithArrayMergesBindings()
-	{
-		$builder = $this->getBuilder();
-		$builder->addBinding(array('foo', 'bar'));
-		$builder->addBinding(array('baz'));
-		$this->assertEquals(array('foo', 'bar', 'baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
 	}
 
 
@@ -1283,72 +1238,66 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->from('one')->select(['foo', 'bar'])->where('key', '=', 'val');
 		$builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval'); }, 'sub');
-		$this->assertEquals($expectedSql, $builder->toSql());
-		$this->assertEquals($expectedBindings, $builder->getBindings());
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
 
 		$builder = $this->getBuilder();
 		$builder->from('one')->select(['foo', 'bar'])->where('key', '=', 'val');
 		$subBuilder = $this->getBuilder();
 		$subBuilder->from('two')->select('baz')->where('subkey', '=', 'subval');
 		$builder->selectSub($subBuilder, 'sub');
-		$this->assertEquals($expectedSql, $builder->toSql());
-		$this->assertEquals($expectedBindings, $builder->getBindings());
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
 	}
 
 
-  public function testSubSelectWithOrder()
-  {
-    $expectedSql = 'select "foo", "bar", (select "baz" from "two" where "subkey" = ? order by "age" ? desc) as "sub" from "one" where "key" = ? order by "age" ? desc';
-    $expectedBindings = ['subval', 'buzz', 'val', 'fuzz'];
+	public function testSubSelectWithOrder()
+	{
+		$expectedSql = 'select "foo", "bar", (select "baz" from "two" where "subkey" = ? order by "age" ? desc) as "sub" from "one" where "key" = ? order by "age" ? desc';
+		$expectedBindings = ['subval', 'buzz', 'val', 'fuzz'];
 
-    $builder = $this->getBuilder();
-    $builder->from('one')->select(['foo', 'bar'])->where('key', '=', 'val')->orderByRaw('"age" ? desc', array('fuzz'));
-    $builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->orderByRaw('"age" ? desc', array('buzz')); }, 'sub');
-    $this->assertEquals($expectedSql, $builder->toSql());
-    $this->assertEquals($expectedBindings, $builder->getBindings());
-  }
-
-
-  public function testSubSelectWithHavings()
-  {
-    $expectedSql = 'select "foo", "bar", (select "baz" from "two" where "subkey" = ? having "age" > ?) as "sub" from "one" where "key" = ? having "email" != ?';
-    $expectedBindings = ['subval', 25, 'val', 'me@email.com'];
-
-    $builder = $this->getBuilder();
-    $builder->from('one')->select(['foo', 'bar']);
-    $builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->having('age', '>', 25); }, 'sub');
-    $builder->where('key', '=', 'val')->having('email', '!=', 'me@email.com');
-    $this->assertEquals($expectedSql, $builder->toSql());
-    $this->assertEquals($expectedBindings, $builder->getBindings());
-  }
+		$builder = $this->getBuilder();
+		$builder->from('one')->select(['foo', 'bar'])->where('key', '=', 'val')->orderByRaw('"age" ? desc', array('fuzz'));
+		$builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->orderByRaw('"age" ? desc', array('buzz')); }, 'sub');
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
+	}
 
 
-  public function testSubSelectWithJoins()
-  {
-    $expectedSql = 'select "foo", "bar", (select "baz" from "two" inner join "photos" on "users"."id" != ? where "subkey" = ?) as "sub" from "one" inner join "photos" on "users"."id" = ? where "key" = ?';
-    $expectedBindings = ['bar', 'subval', 'foo', 'val'];
+	public function testSubSelectWithHavings()
+	{
+		$expectedSql = 'select "foo", "bar", (select "baz" from "two" where "subkey" = ? having "age" > ?) as "sub" from "one" where "key" = ? having "email" != ?';
+		$expectedBindings = ['subval', 25, 'val', 'me@email.com'];
 
-    $builder = $this->getBuilder();
-    $builder->from('one')->select(['foo', 'bar']);
-    $builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->joinWhere('photos', 'users.id', '!=', 'bar'); }, 'sub');
-    $builder->where('key', '=', 'val')->joinWhere('photos', 'users.id', '=', 'foo');
-    $this->assertEquals($expectedSql, $builder->toSql());
-    $this->assertEquals($expectedBindings, $builder->getBindings());
-  }
+		$builder = $this->getBuilder();
+		$builder->from('one')->select(['foo', 'bar']);
+		$builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->having('age', '>', 25); }, 'sub');
+		$builder->where('key', '=', 'val')->having('email', '!=', 'me@email.com');
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
+	}
 
 
-  public function testSubSelectWithRawSelect()
-  {
-    $expectedSql = 'select (select ? from "two" where "subkey" = ?) as "sub", "foo", "bar", ? from "one" where "key" = ?';
-    $expectedBindings = ['baz', 'subval', 'buzz', 'val'];
+	public function testSubSelectWithJoins()
+	{
+		$expectedSql = 'select "foo", "bar", (select "baz" from "two" inner join "photos" on "users"."id" != ? where "subkey" = ?) as "sub" from "one" inner join "photos" on "users"."id" = ? where "key" = ?';
+		$expectedBindings = ['bar', 'subval', 'foo', 'val'];
 
-    $builder = $this->getBuilder();
-    $builder->from('one');
-    $builder->selectSub(function($query) { $query->from('two')->selectRaw('?', ['baz'])->where('subkey', '=', 'subval'); }, 'sub');
-    $builder->addSelect(['foo', 'bar'])->selectRaw('?', ['buzz'])->where('key', '=', 'val');
-    $this->assertEquals($expectedSql, $builder->toSql());
-    $this->assertEquals($expectedBindings, $builder->getBindings());
-  }
+		$builder = $this->getBuilder();
+		$builder->from('one')->select(['foo', 'bar']);
+		$builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->joinWhere('photos', 'users.id', '!=', 'bar'); }, 'sub');
+		$builder->where('key', '=', 'val')->joinWhere('photos', 'users.id', '=', 'foo');
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
+	}
+
+
+	public function testSubSelectWithRawSelect()
+	{
+		$expectedSql = 'select (select ? from "two" where "subkey" = ?) as "sub", "foo", "bar", ? from "one" where "key" = ?';
+		$expectedBindings = ['baz', 'subval', 'buzz', 'val'];
+
+		$builder = $this->getBuilder();
+		$builder->from('one');
+		$builder->selectSub(function($query) { $query->from('two')->selectRaw('?', ['baz'])->where('subkey', '=', 'subval'); }, 'sub');
+		$builder->addSelect(['foo', 'bar'])->selectRaw('?', ['buzz'])->where('key', '=', 'val');
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
+	}
 
 
 	protected function getBuilder()
@@ -1388,6 +1337,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$grammar = new Illuminate\Database\Query\Grammars\SqlServerGrammar;
 		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
 		return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+	}
+
+	protected function assertBuilderCompile($buidler, $expectedSql, $expectedBindings = []) {
+		$compiled = $buidler->compile();
+		$this->assertEquals($expectedSql, $compiled->sql);
+		$this->assertEquals($expectedBindings, $compiled->bindings);
 	}
 
 }

--- a/tests/Database/DatabaseQueryCompiledQueryTest.php
+++ b/tests/Database/DatabaseQueryCompiledQueryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use \Illuminate\Database\Query\CompiledQuery;
+
+class DatabaseQueryCompiledQueryTest extends PHPUnit_Framework_TestCase {
+
+	public function testConstruction()
+	{
+		$compiled = new CompiledQuery('select *', [1]);
+		$this->assertEquals('select *', $compiled->sql);
+		$this->assertEquals([1], $compiled->bindings);
+	}
+
+
+	public function testSimpleConcatenation()
+	{
+		$compiled = new CompiledQuery('select *');
+		$compiled->concatenate(new CompiledQuery('from users'));
+		$this->assertEquals('select * from users', $compiled->sql);
+	}
+
+
+	public function testConcatenationHandlesEmptyAndNullStrings()
+	{
+		$select = new CompiledQuery('select *');
+		$select->concatenate(new CompiledQuery);
+		$this->assertEquals('select *', $select->sql);
+
+		$select->concatenate(new CompiledQuery(''));
+		$this->assertEquals('select *', $select->sql);
+
+		$null = new CompiledQuery;
+		$null->concatenate($select);
+		$this->assertEquals('select *', $null->sql);
+
+		$empty = new CompiledQuery('');
+		$empty->concatenate($select);
+		$this->assertEquals('select *', $empty->sql);
+
+		$null = new CompiledQuery;
+		$null->concatenate(new CompiledQuery());
+		$this->assertEquals('', $null->sql);
+	}
+
+
+	public function testGluedConcatenation()
+	{
+		$compiled = new CompiledQuery('order by name');
+		$compiled->concatenate(new CompiledQuery('age'), ', ');
+		$this->assertEquals('order by name, age', $compiled->sql);
+	}
+
+
+	public function testConcatenationTrims()
+	{
+		$compiled = new CompiledQuery(' select * ');
+		$compiled->concatenate(new CompiledQuery(' from users '));
+		$this->assertEquals('select * from users', $compiled->sql);
+	}
+
+
+	public function testSimpleBindingMerge()
+	{
+		$compiled = new CompiledQuery('', [1]);
+		$compiled->concatenate(new CompiledQuery('', [2]));
+		$this->assertEquals([1,2], $compiled->bindings);
+	}
+
+	public function testConcatenationHandlesEmptyAndNullBindings()
+	{
+		$select = new CompiledQuery('', [1]);
+		$select->concatenate(new CompiledQuery);
+		$this->assertEquals([1], $select->bindings);
+
+		$select->concatenate(new CompiledQuery('', null));
+		$this->assertEquals([1], $select->bindings);
+
+		$null = new CompiledQuery;
+		$null->concatenate($select);
+		$this->assertEquals([1], $select->bindings);
+
+		$empty = new CompiledQuery('', []);
+		$empty->concatenate($select);
+		$this->assertEquals([1], $select->bindings);
+
+		$null = new CompiledQuery;
+		$null->concatenate(new CompiledQuery);
+		$this->assertEquals([], $null->bindings);
+	}
+
+	public function testFullConcatenate()
+	{
+		$select = new CompiledQuery('select ?', ['*']);
+		$from = new CompiledQuery('from users');
+		$where = new CompiledQuery('where email = ?', ['you@email.com']);
+		$select->concatenate($from)->concatenate($where);
+		$this->assertEquals('select ? from users where email = ?', $select->sql);
+		$this->assertEquals(['*', 'you@email.com'], $select->bindings);
+	}
+
+	public function testConcatenateReturnsSelf()
+	{
+		$select = new CompiledQuery('select *');
+		$return = $select->concatenate(new CompiledQuery);
+		$this->assertEquals($select, $return);
+	}
+
+	public function testConcatenateDoesNotMutatePassedInCompiledQuery()
+	{
+		$select = new CompiledQuery('select *');
+		$from = new CompiledQuery('from users', [1]);
+		$select->concatenate($from);
+		$this->assertEquals('from users', $from->sql);
+		$this->assertEquals([1], $from->bindings);
+	}
+
+} 


### PR DESCRIPTION
## The problem

The old design of adding bindings as clauses are added to the query worked most of the time had two major issues:
1. For some complex queries, like unions or sub queries involving joins, the bindings fail to apply or are applied in the wrong order. See #5833 for examples.
2. Cleanly removing global scopes that introduced bindings is impossible to guarantee, especially if other global scopes are in use.
## The fix

To fix this we take a very simple approach to defer assigning the query bindings until the query is being compiled. We introduce a CompiledQuery class that holds the sql string and the bindings array. It also takes care of a lot of the complexity of the concatenating and trimming sql string so the Grammar doesn't have to care about those details or imploding arrays of strings. This has two effects:
1. Query bindings are guaranteed to be added in the same order that the sql string is concatenated.
2. When removing global scopes you don't need to worry about removing bindings. Just remove the appropriate query clauses and the bindings will be taken care of at compile time.
## Unit tests

Note that all unit tests pass as is with only a minor refactoring to allow us to assert the sql string and bindings in one helper method. I've added a significant number of new tests some of which failed without the fixes.
## API changes

There are a fewAPI change:
1. Remove all the `Query\Builder` binging methods `getBindings`, `getRawBindings`, `addBinding`, `setBindings` and `mergeBindings` which have no meaning in the world of compile deferred bindings. This API was most being used by developers of Global Scopes so they could attempt to remove the bindings. A problem they don't need to solve anymore.
2. Rename `Query\Builder` `toSql` to `compile`

We could add some backwards compatible `toSql` and `getBindings` methods and mark them as deprecated but I'm not sure its really safe to do so. Anyone using those old APIs need to think hard about how to use the new `compile` method.
## Removing Bindings and Global Scopes

The early assignment of bindings makes the removal of global scope particularly challenging. See for example this SO question: [laravel-how-to-disable-a-global-scope-in-order-to-include-inactive-objects](http://stackoverflow.com/questions/25312386/laravel-how-to-disable-a-global-scope-in-order-to-include-inactive-objects). The problem is that there is no guaranteed way to identify the bindings a global scope added and its therefore hard to ensure that you remove them cleanly. Most techniques are relying on storing the index into the where and binding arrays when the scope was added and then using that when removing. However, that technique, and all others, are extremely brittle if more than one global scope are involved.
