### PR TITLE
[4.2] Improved The Test Suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - travis_retry composer self-update
   - travis_retry composer install --prefer-source --no-interaction --dev
 
-script: vendor/bin/phpunit --verbose
+script: vendor/bin/phpunit
 
 matrix:
   allow_failures:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,21 +7,20 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
+         stopOnError="false"
          stopOnFailure="false"
-         syntaxCheck="false"
+         syntaxCheck="true"
+         strict="true"
+         verbose="true"
 >
     <testsuites>
         <testsuite name="Laravel Test Suite">
-            <directory>./tests/</directory>
+            <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-
     <filter>
-        <whitelist addUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">src</directory>
-            <exclude>
-                <directory suffix=".php">vendor</directory>
-            </exclude>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/tests/Auth/AuthDatabaseReminderRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseReminderRepositoryTest.php
@@ -6,6 +6,8 @@ class AuthDatabaseReminderRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -6,6 +6,8 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -6,6 +6,8 @@ class AuthEloquentUserProviderTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -7,6 +7,8 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -7,6 +7,8 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -7,6 +7,8 @@ class CacheDatabaseStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -6,6 +6,8 @@ class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -6,6 +6,8 @@ class CacheRedisStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -6,6 +6,8 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -7,6 +7,8 @@ class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Config/ConfigFileLoaderTest.php
+++ b/tests/Config/ConfigFileLoaderTest.php
@@ -6,6 +6,8 @@ class ConfigFileLoaderTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Config/ConfigRepositoryTest.php
+++ b/tests/Config/ConfigRepositoryTest.php
@@ -6,6 +6,8 @@ class ConfigRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -6,6 +6,8 @@ class ConsoleApplicationTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -8,6 +8,8 @@ class CookieTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -10,6 +10,8 @@ class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -6,6 +6,8 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -6,6 +6,8 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -8,6 +8,8 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -8,6 +8,8 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -8,6 +8,8 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -7,6 +7,8 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -8,6 +8,8 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseEloquentHasManyThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughTest.php
@@ -8,6 +8,8 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -8,6 +8,8 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -6,6 +6,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 
 		Illuminate\Database\Eloquent\Model::unsetEventDispatcher();

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -8,6 +8,8 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -7,6 +7,8 @@ class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -8,6 +8,8 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -7,6 +7,8 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -7,6 +7,8 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -7,6 +7,8 @@ class DatabaseMigrationCreatorTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -6,6 +6,8 @@ class DatabaseMigrationInstallCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -7,6 +7,8 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -7,6 +7,8 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -7,6 +7,8 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -7,6 +7,8 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -7,6 +7,8 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -6,6 +6,8 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -7,6 +7,8 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -7,6 +7,8 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -6,6 +6,8 @@ class DatabaseProcessorTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -8,6 +8,8 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -7,6 +7,8 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -7,6 +7,8 @@ class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -7,6 +7,8 @@ class DatabaseSchemaBuilderTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -7,6 +7,8 @@ class DatabaseSeederTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -6,6 +6,8 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -6,6 +6,8 @@ class DatabaseSoftDeletingTraitTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -7,6 +7,8 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -7,6 +7,8 @@ class EventsDispatcherTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Exception/WhoopsDisplayerTest.php
+++ b/tests/Exception/WhoopsDisplayerTest.php
@@ -8,6 +8,8 @@ class WhoopsDisplayerTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -7,6 +7,8 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Foundation/FoundationArtisanTest.php
+++ b/tests/Foundation/FoundationArtisanTest.php
@@ -6,6 +6,8 @@ class FoundationArtisanTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Foundation/FoundationAssetPublishCommandTest.php
+++ b/tests/Foundation/FoundationAssetPublishCommandTest.php
@@ -6,6 +6,8 @@ class FoundationAssetPublishCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Foundation/FoundationAssetPublisherTest.php
+++ b/tests/Foundation/FoundationAssetPublisherTest.php
@@ -6,6 +6,8 @@ class FoundationAssetPublisherTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -6,6 +6,8 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Foundation/FoundationConfigPublishCommandTest.php
+++ b/tests/Foundation/FoundationConfigPublishCommandTest.php
@@ -6,6 +6,8 @@ class FoundationConfigPublishCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Foundation/FoundationConfigPublisherTest.php
+++ b/tests/Foundation/FoundationConfigPublisherTest.php
@@ -6,6 +6,8 @@ class FoundationConfigPublisherTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -6,6 +6,8 @@ class FoundationEnvironmentDetectorTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Foundation/FoundationViewPublishCommandTest.php
+++ b/tests/Foundation/FoundationViewPublishCommandTest.php
@@ -6,6 +6,8 @@ class FoundationViewPublishCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Foundation/FoundationViewPublisherTest.php
+++ b/tests/Foundation/FoundationViewPublisherTest.php
@@ -6,6 +6,8 @@ class FoundationViewPublisherTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Foundation/ProviderRepositoryTest.php
+++ b/tests/Foundation/ProviderRepositoryTest.php
@@ -6,6 +6,8 @@ class ProviderRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -25,6 +25,8 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -7,6 +7,8 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -9,6 +9,8 @@ class HttpResponseTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -7,6 +7,8 @@ class LogWriterTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -6,6 +6,8 @@ class MailMailerTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -6,6 +6,8 @@ class MailMessageTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Pagination/PaginationBootstrapPresenterTest.php
+++ b/tests/Pagination/PaginationBootstrapPresenterTest.php
@@ -7,6 +7,8 @@ class PaginationBootstrapPresenterTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Pagination/PaginationCustomPresenterTest.php
+++ b/tests/Pagination/PaginationCustomPresenterTest.php
@@ -6,6 +6,8 @@ class PaginationCustomPresenterTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Pagination/PaginationFactoryTest.php
+++ b/tests/Pagination/PaginationFactoryTest.php
@@ -7,6 +7,8 @@ class PaginationFactoryTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -7,6 +7,8 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -6,6 +6,8 @@ class QueueBeanstalkdJobTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -6,6 +6,8 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueIronJobTest.php
+++ b/tests/Queue/QueueIronJobTest.php
@@ -6,6 +6,8 @@ class QueueIronJobTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueIronQueueTest.php
+++ b/tests/Queue/QueueIronQueueTest.php
@@ -6,6 +6,8 @@ class QueueIronQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -6,6 +6,8 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -7,6 +7,8 @@ class QueueManagerTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -6,6 +6,8 @@ class QueueRedisJobTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -6,6 +6,8 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -49,6 +49,8 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -9,6 +9,8 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueSyncJobTest.php
+++ b/tests/Queue/QueueSyncJobTest.php
@@ -6,6 +6,8 @@ class QueueSyncJobTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -6,6 +6,8 @@ class QueueSyncQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -7,6 +7,8 @@ class QueueWorkerTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Remote/RemoteSecLibTest.php
+++ b/tests/Remote/RemoteSecLibTest.php
@@ -6,6 +6,8 @@ class RemoteSecLibGatewayTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Routing/RoutingControllerDispatcherTest.php
+++ b/tests/Routing/RoutingControllerDispatcherTest.php
@@ -18,6 +18,8 @@ class RoutingControllerDispatcherTest extends PHPUnit_Framework_TestCase {
 	public function tearDown()
 	{
 		unset($_SERVER['ControllerDispatcherTestControllerStub']);
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Routing/RoutingControllerGeneratorTest.php
+++ b/tests/Routing/RoutingControllerGeneratorTest.php
@@ -7,6 +7,8 @@ class RoutingControllerGeneratorTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Routing/RoutingMakeControllerCommandTest.php
+++ b/tests/Routing/RoutingMakeControllerCommandTest.php
@@ -6,6 +6,8 @@ class RoutingMakeControllerCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -35,6 +35,8 @@ class RoutingRedirectorTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Session/SessionMiddlewareTest.php
+++ b/tests/Session/SessionMiddlewareTest.php
@@ -6,6 +6,8 @@ class SessionMiddlewareTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -6,6 +6,8 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -10,6 +10,8 @@ class SupportCapsuleManagerTraitTest extends \PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Support/SupportFacadeResponseTest.php
+++ b/tests/Support/SupportFacadeResponseTest.php
@@ -7,6 +7,8 @@ class SupportFacadeResponseTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -13,6 +13,8 @@ class SupportFacadeTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -7,6 +7,8 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -8,6 +8,8 @@ class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -7,6 +7,8 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -6,6 +6,8 @@ class ValidationDatabasePresenceVerifierTest extends PHPUnit_Framework_TestCase 
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -7,6 +7,8 @@ class ValidationFactoryTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -8,6 +8,8 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -7,6 +7,8 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -7,6 +7,8 @@ class ViewCompilerEngineTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -7,6 +7,8 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -6,6 +6,8 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -7,6 +7,8 @@ class ViewPhpEngineTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -8,6 +8,8 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 
 	public function tearDown()
 	{
+		$this->addToAssertionCount(m::getContainer()->mockery_getExpectationCount());
+
 		m::close();
 	}
 


### PR DESCRIPTION
This does 3 things:
- This makes phpunit know about all the assertions mockery is doing under the hood.
- This enables phpunit strict mode so we know about output buffers left open (for example, anlutro was using strict mode when he found this bug: #5560) and buggy tests.
- I've changed `addUncoveredFilesFromWhitelist` to the newer `processUncoveredFilesFromWhitelist`.
