### PR TITLE
[5.0] Compile Query Builder With Bindings

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -666,7 +666,7 @@ class Builder {
 			$count = new Expression($count);
 		}
 
-		return $this->where(new Expression('('.$hasQuery->toSql().')'), $operator, $count, $boolean);
+		return $this->where(new Expression('('.$hasQuery->toSql()->sql.')'), $operator, $count, $boolean);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -680,14 +680,10 @@ class Builder {
 	{
 		// Here we have the "has" query and the original relation. We need to copy over any
 		// where clauses the developer may have put in the relationship function over to
-		// the has query, and then copy the bindings from the "has" query to the main.
+		// the has query.
 		$relationQuery = $relation->getBaseQuery();
 
-		$hasQuery->mergeWheres(
-			$relationQuery->wheres, $relationQuery->getBindings()
-		);
-
-		$this->query->mergeBindings($hasQuery->getQuery());
+		$hasQuery->mergeWheres($relationQuery->wheres);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -770,8 +770,8 @@ class Builder {
 
 			if ( ! isset($results[$last = implode('.', $progress)]))
 			{
- 				$results[$last] = function() {};
- 			}
+				$results[$last] = function() {};
+			}
 		}
 
 		return $results;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2012,7 +2012,7 @@ class Builder {
 	/**
 	 * Set the bindings on the query builder.
 	 *
-	 * @param  array $bindings
+	 * @param  array  $bindings
 	 * @return $this
 	 *
 	 */
@@ -2026,7 +2026,7 @@ class Builder {
 	/**
 	 * Add a binding to the query.
 	 *
-	 * @param  mixed $value
+	 * @param  mixed  $value
 	 * @return $this
 	 *
 	 */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -199,7 +199,7 @@ class Builder {
 	 */
 	public function select($columns = array('*'))
 	{
-    $columns = is_array($columns) ? $columns : func_get_args();
+		$columns = is_array($columns) ? $columns : func_get_args();
 		$this->setSelect($columns);
 
 		return $this;
@@ -239,9 +239,9 @@ class Builder {
 		{
 			$sql = $query->toSql();
 
-      $bindings = $query->getBindings();
+			$bindings = $query->getBindings();
 
-      $query = $sql;
+			$query = $sql;
 		}
 		elseif (is_string($query))
 		{
@@ -270,20 +270,20 @@ class Builder {
 		return $this;
 	}
 
-  /**
-   * Add a new select column to the query.
-   *
-   * @param  mixed  $column
-   * @return $this
-   */
-  public function setSelect($column, $bindings = [])
-  {
-    $this->columns = [];
+	/**
+	 * Add a new select column to the query.
+	 *
+	 * @param  mixed  $column
+	 * @return $this
+	 */
+	public function setSelect($column, $bindings = [])
+	{
+		$this->columns = [];
 
-    $this->addSelect($column, $bindings);
+		$this->addSelect($column, $bindings);
 
-    return $this;
-  }
+		return $this;
+	}
 
 	/**
 	 * Force the query to only return distinct results.
@@ -1883,7 +1883,7 @@ class Builder {
 	public function update(array $values)
 	{
 		$sql = $this->grammar->compileUpdate($this, $values);
-    $bindings = array_values(array_merge($values, $this->getBindings()));
+		$bindings = array_values(array_merge($values, $this->getBindings()));
 
 		return $this->connection->update($sql, $this->cleanBindings($bindings));
 	}
@@ -2009,13 +2009,13 @@ class Builder {
 		return $this->bindings;
 	}
 
-  /**
-   * Set the bindings on the query builder.
-   *
-   * @param  array $bindings
-   * @return $this
-   *
-   */
+	/**
+	 * Set the bindings on the query builder.
+	 *
+	 * @param  array $bindings
+	 * @return $this
+	 *
+	 */
 	public function setBindings(array $bindings)
 	{
 		$this->bindings = $bindings;
@@ -2023,13 +2023,13 @@ class Builder {
 		return $this;
 	}
 
-  /**
-   * Add a binding to the query.
-   *
-   * @param  mixed $value
-   * @return $this
-   *
-   */
+	/**
+	 * Add a binding to the query.
+	 *
+	 * @param  mixed $value
+	 * @return $this
+	 *
+	 */
 	public function addBinding($value)
 	{
 		if (is_array($value))

--- a/src/Illuminate/Database/Query/CompiledQuery.php
+++ b/src/Illuminate/Database/Query/CompiledQuery.php
@@ -1,0 +1,50 @@
+<?php namespace Illuminate\Database\Query;
+
+class CompiledQuery {
+
+	/**
+	 * The sql query string.
+	 *
+	 * @var string
+	 */
+	public $sql;
+
+	/**
+	 * The query value bindings.
+	 *
+	 * @var array
+	 */
+	public $bindings;
+
+	/**
+	 * Create a new compile query
+	 *
+	 * @param string  $sql
+	 * @param array  $bindings
+	 */
+	public function __construct($sql = '', $bindings = [])
+	{
+		$this->sql = $sql;
+		$this->bindings = $bindings;
+	}
+
+	/**
+	 * Concatenate this compiled query into this query by joining the sql strings and merging the binding arrays.
+	 *
+	 * @param CompiledQuery  $compiled
+	 * @return CompiledQuery|static
+	 */
+	public function concatenate(CompiledQuery $compiled = null, $glue = ' ')
+	{
+		if (!is_null($compiled)) {
+			$this->sql = trim(implode($glue, array_filter([trim($this->sql), trim($compiled->sql)], function ($value) {
+				return (string)$value !== '';
+			})));
+
+			$this->bindings = array_merge((array)$this->bindings, (array)$compiled->bindings);
+		}
+
+		return $this;
+	}
+
+} 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -38,6 +38,7 @@ class Grammar extends BaseGrammar {
 		if (is_null($query->columns)) $query->setSelect(array('*'));
 		// reset the bindings each time we compile.
 		$query->setBindings([]);
+
 		return trim($this->concatenate($this->compileComponents($query)));
 	}
 
@@ -107,9 +108,7 @@ class Grammar extends BaseGrammar {
 
 		$bindings = array_flatten(array_fetch($columns, 'bindings'));
 
-		if ($bindings) {
-			$query->addBinding($bindings);
-		}
+		if ($bindings) $query->addBinding($bindings);
 
 		$columns = array_flatten(array_fetch($columns, 'columns'));
 
@@ -269,10 +268,7 @@ class Grammar extends BaseGrammar {
 	protected function whereBasic(Builder $query, $where)
 	{
 		$value = $where['value'];
-		if ( ! $value instanceof Expression)
-		{
-			$query->addBinding($value);
-		}
+		if ( ! $value instanceof Expression) $query->addBinding($value);
 
 		$value = $this->parameter($value);
 
@@ -478,6 +474,7 @@ class Grammar extends BaseGrammar {
 	protected function whereRaw(Builder $query, $where)
 	{
 		$query->addBinding($where['bindings']);
+
 		return $where['sql'];
 	}
 
@@ -564,6 +561,7 @@ class Grammar extends BaseGrammar {
 		{
 			if (isset($order['sql'])) {
 				$query->addBinding($order['bindings']);
+
 				return $order['sql'];
 			}
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1,8 +1,9 @@
 <?php namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
-use Illuminate\Database\Grammar as BaseGrammar;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Grammar as BaseGrammar;
+
 
 class Grammar extends BaseGrammar {
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -35,8 +35,8 @@ class Grammar extends BaseGrammar {
 	public function compileSelect(Builder $query)
 	{
 		if (is_null($query->columns)) $query->setSelect(array('*'));
-    // reset the bindings each time we compile.
-    $query->setBindings([]);
+		// reset the bindings each time we compile.
+		$query->setBindings([]);
 		return trim($this->concatenate($this->compileComponents($query)));
 	}
 
@@ -104,13 +104,13 @@ class Grammar extends BaseGrammar {
 
 		$select = $query->distinct ? 'select distinct ' : 'select ';
 
-    $bindings = array_flatten(array_fetch($columns, 'bindings'));
+		$bindings = array_flatten(array_fetch($columns, 'bindings'));
 
-    if ($bindings) {
-      $query->addBinding($bindings);
-    }
+		if ($bindings) {
+			$query->addBinding($bindings);
+		}
 
-    $columns = array_flatten(array_fetch($columns, 'columns'));
+		$columns = array_flatten(array_fetch($columns, 'columns'));
 
 		return $select.$this->columnize($columns);
 	}
@@ -236,8 +236,8 @@ class Grammar extends BaseGrammar {
 	{
 		$nested = $where['query'];
 
-    $wheres = substr($this->compileWheres($nested), 6);
-    $query->addBinding($nested->getBindings());
+		$wheres = substr($this->compileWheres($nested), 6);
+		$query->addBinding($nested->getBindings());
 
 		return "($wheres)";
 	}
@@ -253,7 +253,7 @@ class Grammar extends BaseGrammar {
 	{
 		$select = $this->compileSelect($where['query']);
 
-    $query->addBinding($where['query']->getBindings());
+		$query->addBinding($where['query']->getBindings());
 
 		return $this->wrap($where['column']).' '.$where['operator']." ($select)";
 	}
@@ -267,11 +267,11 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function whereBasic(Builder $query, $where)
 	{
-    $value = $where['value'];
-    if ( ! $value instanceof Expression)
-    {
-      $query->addBinding($value);
-    }
+		$value = $where['value'];
+		if ( ! $value instanceof Expression)
+		{
+			$query->addBinding($value);
+		}
 
 		$value = $this->parameter($value);
 
@@ -289,7 +289,7 @@ class Grammar extends BaseGrammar {
 	{
 		$between = $where['not'] ? 'not between' : 'between';
 
-    $query->addBinding($where['values']);
+		$query->addBinding($where['values']);
 
 		return $this->wrap($where['column']).' '.$between.' ? and ?';
 	}
@@ -303,9 +303,9 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function whereExists(Builder $query, $where)
 	{
-    $select = $this->compileSelect($where['query']);
+		$select = $this->compileSelect($where['query']);
 
-    $query->addBinding($where['query']->getBindings());
+		$query->addBinding($where['query']->getBindings());
 
 		return "exists ($select)";
 	}
@@ -319,9 +319,9 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function whereNotExists(Builder $query, $where)
 	{
-    $select = $this->compileSelect($where['query']);
+		$select = $this->compileSelect($where['query']);
 
-    $query->addBinding($where['query']->getBindings());
+		$query->addBinding($where['query']->getBindings());
 
 		return "not exists ($select)";
 	}
@@ -337,7 +337,7 @@ class Grammar extends BaseGrammar {
 	{
 		$values = $this->parameterize($where['values']);
 
-    $query->addBinding($where['values']);
+		$query->addBinding($where['values']);
 
 		return $this->wrap($where['column']).' in ('.$values.')';
 	}
@@ -353,7 +353,7 @@ class Grammar extends BaseGrammar {
 	{
 		$values = $this->parameterize($where['values']);
 
-    $query->addBinding($where['values']);
+		$query->addBinding($where['values']);
 
 		return $this->wrap($where['column']).' not in ('.$values.')';
 	}
@@ -369,7 +369,7 @@ class Grammar extends BaseGrammar {
 	{
 		$select = $this->compileSelect($where['query']);
 
-    $query->addBinding($where['query']->getBindings());
+		$query->addBinding($where['query']->getBindings());
 
 		return $this->wrap($where['column']).' in ('.$select.')';
 	}
@@ -385,7 +385,7 @@ class Grammar extends BaseGrammar {
 	{
 		$select = $this->compileSelect($where['query']);
 
-    $query->addBinding($where['query']->getBindings());
+		$query->addBinding($where['query']->getBindings());
 
 		return $this->wrap($where['column']).' not in ('.$select.')';
 	}
@@ -462,7 +462,7 @@ class Grammar extends BaseGrammar {
 	{
 		$value = $this->parameter($where['value']);
 
-    $query->addBinding($where['value']);
+		$query->addBinding($where['value']);
 
 		return $type.'('.$this->wrap($where['column']).') '.$where['operator'].' '.$value;
 	}
@@ -476,7 +476,7 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function whereRaw(Builder $query, $where)
 	{
-    $query->addBinding($where['bindings']);
+		$query->addBinding($where['bindings']);
 		return $where['sql'];
 	}
 
@@ -501,12 +501,12 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function compileHavings(Builder $query, $havings)
 	{
-    $sql = [];
+		$sql = [];
 
-    foreach ($havings as $having)
-    {
-      $sql[] = $this->compileHaving($query, $having);
-    }
+		foreach ($havings as $having)
+		{
+			$sql[] = $this->compileHaving($query, $having);
+		}
 
 		$sql = implode(' ', $sql);
 
@@ -526,7 +526,7 @@ class Grammar extends BaseGrammar {
 		// clause into SQL based on the components that make it up from builder.
 		if ($having['type'] === 'raw')
 		{
-      $query->addBinding($having['bindings']);
+			$query->addBinding($having['bindings']);
 			return $having['boolean'].' '.$having['sql'];
 		}
 
@@ -543,7 +543,7 @@ class Grammar extends BaseGrammar {
 	{
 		$column = $this->wrap($having['column']);
 
-    $query->addBinding($having['value']);
+		$query->addBinding($having['value']);
 
 		$parameter = $this->parameter($having['value']);
 
@@ -562,9 +562,9 @@ class Grammar extends BaseGrammar {
 		return 'order by '.implode(', ', array_map(function($order) use($query)
 		{
 			if (isset($order['sql'])) {
-        $query->addBinding($order['bindings']);
-        return $order['sql'];
-      }
+				$query->addBinding($order['bindings']);
+				return $order['sql'];
+			}
 
 			return $this->wrap($order['column']).' '.$order['direction'];
 		}
@@ -608,7 +608,7 @@ class Grammar extends BaseGrammar {
 		foreach ($query->unions as $union)
 		{
 			$sql .= $this->compileUnion($union);
-      $query->addBinding($union['query']->getBindings());
+			$query->addBinding($union['query']->getBindings());
 		}
 
 		return ltrim($sql);
@@ -624,9 +624,9 @@ class Grammar extends BaseGrammar {
 	{
 		$joiner = $union['all'] ? ' union all ' : ' union ';
 
-    $select = $this->compileSelect($union['query']);
+		$select = $this->compileSelect($union['query']);
 
-    return $joiner.$select;
+		return $joiner.$select;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -51,7 +51,7 @@ class MySqlGrammar extends Grammar {
 	{
 		$joiner = $union['all'] ? ' union all ' : ' union ';
 
-    $select = $this->compileSelect($union['query']);
+		$select = $this->compileSelect($union['query']);
 
 		return "$joiner($select)";
 	}

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -51,7 +51,9 @@ class MySqlGrammar extends Grammar {
 	{
 		$joiner = $union['all'] ? ' union all ' : ' union ';
 
-		return $joiner.'('.$union['query']->toSql().')';
+    $select = $this->compileSelect($union['query']);
+
+		return "$joiner($select)";
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\CompiledQuery;
 
 class MySqlGrammar extends Grammar {
 
@@ -31,29 +32,32 @@ class MySqlGrammar extends Grammar {
 	 */
 	public function compileSelect(Builder $query)
 	{
-		$sql = parent::compileSelect($query);
+		$select = parent::compileSelect($query);
 
 		if ($query->unions)
 		{
-			$sql = '('.$sql.') '.$this->compileUnions($query);
+			$select->sql = '('.$select->sql.')';
+			$select->concatenate($this->compileUnions($query, $query->unions));
 		}
 
-		return $sql;
+		return $select;
 	}
 
 	/**
 	 * Compile a single union statement.
 	 *
 	 * @param  array  $union
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileUnion(array $union)
 	{
-		$joiner = $union['all'] ? ' union all ' : ' union ';
+		$joiner = $union['all'] ? 'union all ' : 'union ';
 
 		$select = $this->compileSelect($union['query']);
 
-		return "$joiner($select)";
+		$select->sql = "$joiner({$select->sql})";
+
+		return $select;
 	}
 
 	/**
@@ -61,13 +65,13 @@ class MySqlGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  bool|string  $value
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileLock(Builder $query, $value)
 	{
-		if (is_string($value)) return $value;
+		if (is_string($value)) return CompiledQuery($value);
 
-		return $value ? 'for update' : 'lock in share mode';
+		return new CompiledQuery($value ? 'for update' : 'lock in share mode');
 	}
 
 	/**
@@ -75,45 +79,49 @@ class MySqlGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $values
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileUpdate(Builder $query, $values)
 	{
-		$sql = parent::compileUpdate($query, $values);
+		$update = parent::compileUpdate($query, $values);
 
 		if (isset($query->orders))
 		{
-			$sql .= ' '.$this->compileOrders($query, $query->orders);
+			$update->concatenate($this->compileOrders($query, $query->orders));
 		}
 
 		if (isset($query->limit))
 		{
-			$sql .= ' '.$this->compileLimit($query, $query->limit);
+			$update->concatenate($this->compileLimit($query, $query->limit));
 		}
 
-		return rtrim($sql);
+		return $update;
 	}
 
 	/**
 	 * Compile a delete statement into SQL.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileDelete(Builder $query)
 	{
 		$table = $this->wrapTable($query->from);
 
-		$where = is_array($query->wheres) ? $this->compileWheres($query) : '';
+		$where = is_array($query->wheres) ? $this->compileWheres($query) : null;
 
 		if (isset($query->joins))
 		{
-			$joins = ' '.$this->compileJoins($query, $query->joins);
+			$joins = $this->compileJoins($query, $query->joins);
 
-			return trim("delete $table from {$table}{$joins} $where");
+			$compiled = new CompiledQuery("delete $table from {$table}");
+
+			return $compiled->concatenate($joins)->concatenate($where);
 		}
 
-		return trim("delete from $table $where");
+		$compiled = new CompiledQuery("delete from $table");
+
+		return $compiled->concatenate($where);
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\CompiledQuery;
 
 class PostgresGrammar extends Grammar {
 
@@ -20,13 +21,13 @@ class PostgresGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  bool|string  $value
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileLock(Builder $query, $value)
 	{
-		if (is_string($value)) return $value;
+		if (is_string($value)) return CompiledQuery($value);
 
-		return $value ? 'for update' : 'for share';
+		return new CompiledQuery($value ? 'for update' : 'for share');
 	}
 
 	/**
@@ -34,7 +35,7 @@ class PostgresGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $values
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileUpdate(Builder $query, $values)
 	{
@@ -45,11 +46,13 @@ class PostgresGrammar extends Grammar {
 		// the values in the list of bindings so we can make the sets statements.
 		$columns = $this->compileUpdateColumns($values);
 
+		$update = new CompiledQuery("update {$table} set {$columns}");
+
 		$from = $this->compileUpdateFrom($query);
 
 		$where = $this->compileUpdateWheres($query);
 
-		return trim("update {$table} set {$columns}{$from} $where");
+		return $update->concatenate(new CompiledQuery($from))->concatenate($where);
 	}
 
 	/**
@@ -93,14 +96,14 @@ class PostgresGrammar extends Grammar {
 			$froms[] = $this->wrapTable($join->table);
 		}
 
-		if (count($froms) > 0) return ' from '.implode(', ', $froms);
+		if (count($froms) > 0) return 'from '.implode(', ', $froms);
 	}
 
 	/**
 	 * Compile the additional where clauses for updates with joins.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileUpdateWheres(Builder $query)
 	{
@@ -113,23 +116,25 @@ class PostgresGrammar extends Grammar {
 		// strip the leading boolean we will do so when using as the only where.
 		$joinWhere = $this->compileUpdateJoinWheres($query);
 
-		if (trim($baseWhere) == '')
+		if ($baseWhere->sql == '')
 		{
-			return 'where '.$this->removeLeadingBoolean($joinWhere);
+			$joinWhere->sql = 'where '.$this->removeLeadingBoolean($joinWhere);
+
+			return $joinWhere;
 		}
 
-		return $baseWhere.' '.$joinWhere;
+		return $baseWhere->concatenate($joinWhere);
 	}
 
 	/**
 	 * Compile the "join" clauses for an update.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileUpdateJoinWheres(Builder $query)
 	{
-		$joinWheres = array();
+		$joinWheres = new CompiledQuery();
 
 		// Here we will just loop through all of the join constraints and compile them
 		// all out then implode them. This should give us "where" like syntax after
@@ -138,11 +143,11 @@ class PostgresGrammar extends Grammar {
 		{
 			foreach ($join->clauses as $clause)
 			{
-				$joinWheres[] = $this->compileJoinConstraint($clause);
+				$joinWheres->concatenate($this->compileJoinConstraint($clause));
 			}
 		}
 
-		return implode(' ', $joinWheres);
+		return $joinWheres;
 	}
 
 	/**
@@ -151,13 +156,16 @@ class PostgresGrammar extends Grammar {
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array   $values
 	 * @param  string  $sequence
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileInsertGetId(Builder $query, $values, $sequence)
 	{
 		if (is_null($sequence)) $sequence = 'id';
 
-		return $this->compileInsert($query, $values).' returning '.$this->wrap($sequence);
+		$insert = $this->compileInsert($query, $values);
+		$insert->sql .= ' returning '.$this->wrap($sequence);
+
+		return $insert;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -120,6 +120,7 @@ class SQLiteGrammar extends Grammar {
 	 */
 	protected function dateBasedWhere($type, Builder $query, $where)
 	{
+    $query->addBinding($where['value']);
 		$value = str_pad($where['value'], 2, '0', STR_PAD_LEFT);
 
 		$value = $this->parameter($value);

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -120,7 +120,7 @@ class SQLiteGrammar extends Grammar {
 	 */
 	protected function dateBasedWhere($type, Builder $query, $where)
 	{
-    $query->addBinding($where['value']);
+		$query->addBinding($where['value']);
 		$value = str_pad($where['value'], 2, '0', STR_PAD_LEFT);
 
 		$value = $this->parameter($value);

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\CompiledQuery;
 
 class SQLiteGrammar extends Grammar {
 
@@ -20,7 +21,7 @@ class SQLiteGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $values
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileInsert(Builder $query, array $values)
 	{
@@ -56,7 +57,7 @@ class SQLiteGrammar extends Grammar {
 
 		$columns = array_fill(0, count($values), implode(', ', $columns));
 
-		return "insert into $table ($names) select ".implode(' union select ', $columns);
+		return new CompiledQuery("insert into $table ($names) select ".implode(' union select ', $columns));
 	}
 
 	/**
@@ -79,7 +80,7 @@ class SQLiteGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereDay(Builder $query, $where)
 	{
@@ -91,7 +92,7 @@ class SQLiteGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereMonth(Builder $query, $where)
 	{
@@ -103,7 +104,7 @@ class SQLiteGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function whereYear(Builder $query, $where)
 	{
@@ -116,16 +117,17 @@ class SQLiteGrammar extends Grammar {
 	 * @param  string  $type
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $where
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function dateBasedWhere($type, Builder $query, $where)
 	{
-		$query->addBinding($where['value']);
 		$value = str_pad($where['value'], 2, '0', STR_PAD_LEFT);
 
 		$value = $this->parameter($value);
 
-		return 'strftime(\''.$type.'\', '.$this->wrap($where['column']).') '.$where['operator'].' '.$value;
+		$sql = 'strftime(\''.$type.'\', '.$this->wrap($where['column']).') '.$where['operator'].' '.$value;
+
+		return new CompiledQuery($sql, $where['value']);
 	}
 
 }

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -57,6 +57,15 @@ class SqlServerGrammar extends Grammar {
 			$select .= 'top '.$query->limit.' ';
 		}
 
+    // include the binding logic from the parent method
+    $bindings = array_flatten(array_fetch($columns, 'bindings'));
+
+    if ($bindings) {
+      $query->addBinding($bindings);
+    }
+
+    $columns = array_flatten(array_fetch($columns, 'columns'));
+
 		return $select.$this->columnize($columns);
 	}
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -57,14 +57,14 @@ class SqlServerGrammar extends Grammar {
 			$select .= 'top '.$query->limit.' ';
 		}
 
-    // include the binding logic from the parent method
-    $bindings = array_flatten(array_fetch($columns, 'bindings'));
+		// include the binding logic from the parent method
+		$bindings = array_flatten(array_fetch($columns, 'bindings'));
 
-    if ($bindings) {
-      $query->addBinding($bindings);
-    }
+		if ($bindings) {
+			$query->addBinding($bindings);
+		}
 
-    $columns = array_flatten(array_fetch($columns, 'columns'));
+		$columns = array_flatten(array_fetch($columns, 'columns'));
 
 		return $select.$this->columnize($columns);
 	}

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Database\Query\Grammars;
 
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\CompiledQuery;
 
 class SqlServerGrammar extends Grammar {
 
@@ -19,7 +20,7 @@ class SqlServerGrammar extends Grammar {
 	 * Compile a select query into SQL.
 	 *
 	 * @param  \Illuminate\Database\Query\Builder
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	public function compileSelect(Builder $query)
 	{
@@ -41,7 +42,7 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  array  $columns
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileColumns(Builder $query, $columns)
 	{
@@ -60,11 +61,9 @@ class SqlServerGrammar extends Grammar {
 		// include the binding logic from the parent method
 		$bindings = array_flatten(array_fetch($columns, 'bindings'));
 
-		if ($bindings) $query->addBinding($bindings);
-
 		$columns = array_flatten(array_fetch($columns, 'columns'));
 
-		return $select.$this->columnize($columns);
+		return new CompiledQuery($select.$this->columnize($columns), $bindings);
 	}
 
 	/**
@@ -72,17 +71,19 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  string  $table
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileFrom(Builder $query, $table)
 	{
 		$from = parent::compileFrom($query, $table);
 
-		if (is_string($query->lock)) return $from.' '.$query->lock;
+		if (is_string($query->lock)) return $from->concatenate(new CompiledQuery($query->lock));
 
 		if ( ! is_null($query->lock))
 		{
-			return $from.' with(rowlock,'.($query->lock ? 'updlock,' : '').'holdlock)';
+			$from->sql .= ' with(rowlock,'.($query->lock ? 'updlock,' : '').'holdlock)';
+
+			return $from;
 		}
 
 		return $from;
@@ -102,7 +103,7 @@ class SqlServerGrammar extends Grammar {
 		// does not complain about the queries for not having an "order by" clause.
 		if ( ! isset($components['orders']))
 		{
-			$components['orders'] = 'order by (select 0)';
+			$components['orders'] = new CompiledQuery('order by (select 0)');
 		}
 
 		// We need to add the row number to the query so we can compare it to the offset
@@ -110,7 +111,7 @@ class SqlServerGrammar extends Grammar {
 		// the "select" that will give back the row numbers on each of the records.
 		$orderings = $components['orders'];
 
-		$components['columns'] .= $this->compileOver($orderings);
+		$components['columns']->sql .= $this->compileOver($orderings->sql);
 
 		unset($components['orders']);
 
@@ -119,12 +120,12 @@ class SqlServerGrammar extends Grammar {
 		// set we will just handle the offset only since that is all that matters.
 		$constraint = $this->compileRowConstraint($query);
 
-		$sql = $this->concatenate($components);
+		$compiled = $this->concatenate($components);
 
 		// We are now ready to build the final SQL query so we'll create a common table
 		// expression from the query and get the records with row numbers within our
 		// given limit and offset value that we just put on as a query constraint.
-		return $this->compileTableExpression($sql, $constraint);
+		return $this->compileTableExpression($compiled, $constraint);
 	}
 
 	/**
@@ -163,11 +164,13 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @param  string  $sql
 	 * @param  string  $constraint
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
-	protected function compileTableExpression($sql, $constraint)
+	protected function compileTableExpression(CompiledQuery $compiled, $constraint)
 	{
-		return "select * from ({$sql}) as temp_table where row_num {$constraint}";
+		$compiled->sql = "select * from ({$compiled->sql}) as temp_table where row_num {$constraint}";
+
+		return $compiled;
 	}
 
 	/**
@@ -175,11 +178,11 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  int  $limit
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileLimit(Builder $query, $limit)
 	{
-		return '';
+		return new CompiledQuery;
 	}
 
 	/**
@@ -187,11 +190,11 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @param  \Illuminate\Database\Query\Builder  $query
 	 * @param  int  $offset
-	 * @return string
+	 * @return \Illuminate\Database\Query\CompiledQuery
 	 */
 	protected function compileOffset(Builder $query, $offset)
 	{
-		return '';
+		return new CompiledQuery;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -60,9 +60,7 @@ class SqlServerGrammar extends Grammar {
 		// include the binding logic from the parent method
 		$bindings = array_flatten(array_fetch($columns, 'bindings'));
 
-		if ($bindings) {
-			$query->addBinding($bindings);
-		}
+		if ($bindings) $query->addBinding($bindings);
 
 		$columns = array_flatten(array_fetch($columns, 'columns'));
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -462,8 +462,9 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$model = new EloquentBuilderTestNestedStub;
 		$this->mockConnectionForModel($model, 'SQLite');
 		$query = $model->newQuery()->where('foo', '=', 'bar')->where(function($query) { $query->where('baz', '>', 9000); });
-		$this->assertEquals('select * from "table" where "table"."deleted_at" is null and "foo" = ? and ("baz" > ?)', $query->toSql());
-		$this->assertEquals(array('bar', 9000), $query->getBindings());
+		$compiled = $query->toSql();
+		$this->assertEquals('select * from "table" where "table"."deleted_at" is null and "foo" = ? and ("baz" > ?)', $compiled->sql);
+		$this->assertEquals(array('bar', 9000), $compiled->bindings);
 	}
 
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -16,7 +16,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users');
-		$this->assertEquals('select * from "users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users"');
 	}
 
 
@@ -24,21 +24,21 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('some"table');
-		$this->assertEquals('select * from "some""table"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "some""table"');
 	}
 
 	public function testAliasWrappingAsWholeConstant()
 	{
 		$builder = $this->getBuilder();
 		$builder->select('x.y as foo.bar')->from('baz');
-		$this->assertEquals('select "x"."y" as "foo.bar" from "baz"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select "x"."y" as "foo.bar" from "baz"');
 	}
 
 	public function testAddingSelects()
 	{
 		$builder = $this->getBuilder();
 		$builder->select('foo')->addSelect('bar')->addSelect(array('baz', 'boom'))->from('users');
-		$this->assertEquals('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select "foo", "bar", "baz", "boom" from "users"');
 	}
 
 
@@ -47,7 +47,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->getGrammar()->setTablePrefix('prefix_');
 		$builder->select('*')->from('users');
-		$this->assertEquals('select * from "prefix_users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "prefix_users"');
 	}
 
 
@@ -55,7 +55,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->distinct()->select('foo', 'bar')->from('users');
-		$this->assertEquals('select distinct "foo", "bar" from "users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select distinct "foo", "bar" from "users"');
 	}
 
 
@@ -123,7 +123,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('foo as bar')->from('users');
-		$this->assertEquals('select "foo" as "bar" from "users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select "foo" as "bar" from "users"');
 	}
 
 
@@ -131,7 +131,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('public.users');
-		$this->assertEquals('select * from "public"."users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "public"."users"');
 	}
 
 
@@ -139,8 +139,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1);
-		$this->assertEquals('select * from "users" where "id" = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ?', [1]);
 	}
 
 
@@ -148,7 +147,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->From('some`table');
-		$this->assertEquals('select * from `some``table`', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from `some``table`');
 	}
 
 
@@ -156,8 +155,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('users')->whereDay('created_at', '=', 1);
-		$this->assertEquals('select * from `users` where day(`created_at`) = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from `users` where day(`created_at`) = ?', [1]);
 	}
 
 
@@ -165,8 +163,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
-		$this->assertEquals('select * from `users` where month(`created_at`) = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 5), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from `users` where month(`created_at`) = ?', [5]);
 	}
 
 
@@ -174,8 +171,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
-		$this->assertEquals('select * from `users` where year(`created_at`) = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 2014), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from `users` where year(`created_at`) = ?', [2014]);
 	}
 
 
@@ -183,8 +179,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('users')->whereDay('created_at', '=', 1);
-		$this->assertEquals('select * from "users" where day("created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where day("created_at") = ?', [1]);
 	}
 
 
@@ -192,8 +187,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
-		$this->assertEquals('select * from "users" where month("created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 5), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where month("created_at") = ?', [5]);
 	}
 
 
@@ -201,8 +195,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
-		$this->assertEquals('select * from "users" where year("created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 2014), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where year("created_at") = ?', [2014]);
 	}
 
 
@@ -210,8 +203,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getSQLiteBuilder();
 		$builder->select('*')->from('users')->whereDay('created_at', '=', 1);
-		$this->assertEquals('select * from "users" where strftime(\'%d\', "created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where strftime(\'%d\', "created_at") = ?', [1]);
 	}
 
 
@@ -219,8 +211,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getSQLiteBuilder();
 		$builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
-		$this->assertEquals('select * from "users" where strftime(\'%m\', "created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 5), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where strftime(\'%m\', "created_at") = ?', [5]);
 	}
 
 
@@ -228,8 +219,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getSQLiteBuilder();
 		$builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
-		$this->assertEquals('select * from "users" where strftime(\'%Y\', "created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 2014), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where strftime(\'%Y\', "created_at") = ?', [2014]);
 	}
 
 
@@ -237,8 +227,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('users')->whereDay('created_at', '=', 1);
-		$this->assertEquals('select * from "users" where day("created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where day("created_at") = ?', [1]);
 	}
 
 
@@ -246,8 +235,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
-		$this->assertEquals('select * from "users" where month("created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 5), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where month("created_at") = ?', [5]);
 	}
 
 
@@ -255,8 +243,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
-		$this->assertEquals('select * from "users" where year("created_at") = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 2014), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where year("created_at") = ?', [2014]);
 	}
 
 
@@ -264,13 +251,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereBetween('id', array(1, 2));
-		$this->assertEquals('select * from "users" where "id" between ? and ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 2), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" between ? and ?', [1, 2]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereNotBetween('id', array(1, 2));
-		$this->assertEquals('select * from "users" where "id" not between ? and ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 2), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" not between ? and ?', [1, 2]);
 	}
 
 
@@ -278,8 +263,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1)->orWhere('email', '=', 'foo');
-		$this->assertEquals('select * from "users" where "id" = ? or "email" = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 'foo'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or "email" = ?', [1, 'foo']);
 	}
 
 
@@ -287,8 +271,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereRaw('id = ? or email = ?', array(1, 'foo'));
-		$this->assertEquals('select * from "users" where id = ? or email = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 'foo'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where id = ? or email = ?', [1, 'foo']);
 	}
 
 
@@ -296,8 +279,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1)->orWhereRaw('email = ?', array('foo'));
-		$this->assertEquals('select * from "users" where "id" = ? or email = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 'foo'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or email = ?', [1, 'foo']);
 	}
 
 
@@ -305,13 +287,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereIn('id', array(1, 2, 3));
-		$this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 2, 2 => 3), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" in (?, ?, ?)', [1, 2, 3]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', array(1, 2, 3));
-		$this->assertEquals('select * from "users" where "id" = ? or "id" in (?, ?, ?)', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 1, 2 => 2, 3 => 3), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or "id" in (?, ?, ?)', [1, 1, 2, 3]);
 	}
 
 
@@ -319,13 +299,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereNotIn('id', array(1, 2, 3));
-		$this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 2, 2 => 3), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" not in (?, ?, ?)', [1, 2, 3]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotIn('id', array(1, 2, 3));
-		$this->assertEquals('select * from "users" where "id" = ? or "id" not in (?, ?, ?)', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 1, 2 => 2, 3 => 3), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or "id" not in (?, ?, ?)', [1, 1, 2, 3]);
 	}
 
 
@@ -334,14 +312,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1);
 		$builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
-		$this->assertEquals('select * from "users" where "id" = ? union select * from "users" where "id" = ?', $builder->toSql());
-		$this->assertEquals([1, 2], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? union select * from "users" where "id" = ?', [1, 2]);
 
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1);
 		$builder->union($this->getMySqlBuilder()->select('*')->from('users')->where('id', '=', 2));
-		$this->assertEquals('(select * from `users` where `id` = ?) union (select * from `users` where `id` = ?)', $builder->toSql());
-		$this->assertEquals([1, 2], $builder->getBindings());
+		$this->assertBuilderCompile($builder, '(select * from `users` where `id` = ?) union (select * from `users` where `id` = ?)', [1, 2]);
 	}
 
 
@@ -350,14 +326,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1);
 		$builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
-		$this->assertEquals('select * from "users" where "id" = ? union all select * from "users" where "id" = ?', $builder->toSql());
-		$this->assertEquals([1, 2], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? union all select * from "users" where "id" = ?', [1, 2]);
 
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1);
 		$builder->unionAll($this->getMySqlBuilder()->select('*')->from('users')->where('id', '=', 2));
-		$this->assertEquals('(select * from `users` where `id` = ?) union all (select * from `users` where `id` = ?)', $builder->toSql());
-		$this->assertEquals([1, 2], $builder->getBindings());
+		$this->assertBuilderCompile($builder, '(select * from `users` where `id` = ?) union all (select * from `users` where `id` = ?)', [1, 2]);
 	}
 
 
@@ -370,8 +344,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$first->select('*')->from('users')->join('photos', function($join) {$join->where('users.id', '=', 'foo');})->where('id', '=', 1);
 		$second = $this->getBuilder()->select('*')->from('users')->join('photos', function($join) {$join->where('users.id', '=', 'bar');})->where('id', '=', 2);
 		$first->union($second);
-		$this->assertEquals($expectedSql, $first->toSql());
-		$this->assertEquals($expectedBindings, $first->getBindings());
+		$this->assertBuilderCompile($first, $expectedSql, $expectedBindings);
 	}
 
 
@@ -385,8 +358,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$second = $this->getBuilder()->select('*')->from('users')->where('id', '=', 2)->orderBy('email')->orderByRaw('"age" ? desc', array('bar'));
 		$first->union($second);
 
-		$this->assertEquals($expectedSql, $first->toSql());
-		$this->assertEquals($expectedBindings, $first->getBindings());
+		$this->assertBuilderCompile($first, $expectedSql, $expectedBindings);
 	}
 
 	public function testUnionsWithHavings()
@@ -399,8 +371,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$second = $this->getBuilder()->select('*')->from('users')->where('id', '=', 2)->groupBy('email')->having('email', '=', 'you@email.com');
 		$first->union($second);
 
-		$this->assertEquals($expectedSql, $first->toSql());
-		$this->assertEquals($expectedBindings, $first->getBindings());
+		$this->assertBuilderCompile($first, $expectedSql, $expectedBindings);
 	}
 
 
@@ -410,8 +381,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->select('*')->from('users')->where('id', '=', 1);
 		$builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
 		$builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 3));
-		$this->assertEquals('select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 2, 2 => 3), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? union select * from "users" where "id" = ? union select * from "users" where "id" = ?', [1, 2, 3]);
 	}
 
 
@@ -421,8 +391,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->select('*')->from('users')->where('id', '=', 1);
 		$builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
 		$builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 3));
-		$this->assertEquals('select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 2, 2 => 3), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? union all select * from "users" where "id" = ? union all select * from "users" where "id" = ?', [1, 2, 3]);
 	}
 
 
@@ -433,16 +402,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			$q->select('id')->from('users')->where('age', '>', 25)->take(3);
 		});
-		$this->assertEquals('select * from "users" where "id" in (select "id" from "users" where "age" > ? limit 3)', $builder->toSql());
-		$this->assertEquals(array(25), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" in (select "id" from "users" where "age" > ? limit 3)', [25]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereNotIn('id', function($q)
 		{
 			$q->select('id')->from('users')->where('age', '>', 25)->take(3);
 		});
-		$this->assertEquals('select * from "users" where "id" not in (select "id" from "users" where "age" > ? limit 3)', $builder->toSql());
-		$this->assertEquals(array(25), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" not in (select "id" from "users" where "age" > ? limit 3)', [25]);
 	}
 
 
@@ -453,16 +420,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			$q->select('id')->from('users')->where('age', '>', 25)->take(3);
 		});
-		$this->assertEquals('select * from "users" where "id" in (select "id" from "users" where "age" > ? limit 3) group by "email" having "email" != ?', $builder->toSql());
-		$this->assertEquals([ 25, 'me@email.com'], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" in (select "id" from "users" where "age" > ? limit 3) group by "email" having "email" != ?', [ 25, 'me@email.com']);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->groupBy('email')->having('email', '!=', 'me@email.com')->whereNotIn('id', function($q)
 		{
 			$q->select('id')->from('users')->where('age', '>', 25)->take(3);
 		});
-		$this->assertEquals('select * from "users" where "id" not in (select "id" from "users" where "age" > ? limit 3) group by "email" having "email" != ?', $builder->toSql());
-		$this->assertEquals([ 25, 'me@email.com'], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" not in (select "id" from "users" where "age" > ? limit 3) group by "email" having "email" != ?', [ 25, 'me@email.com']);
 	}
 
 
@@ -473,16 +438,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			$q->select('id')->from('users')->joinWhere('photos', 'users.id', '!=', 'bar')->where('age', '>', 25)->take(3);
 		});
-		$this->assertEquals('select * from "users" inner join "photos" on "users"."id" = ? where "id" in (select "id" from "users" inner join "photos" on "users"."id" != ? where "age" > ? limit 3)', $builder->toSql());
-		$this->assertEquals(['foo', 'bar', 25], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" inner join "photos" on "users"."id" = ? where "id" in (select "id" from "users" inner join "photos" on "users"."id" != ? where "age" > ? limit 3)', ['foo', 'bar', 25]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->joinWhere('photos', 'users.id', '=', 'foo')->whereNotIn('id', function($q)
 		{
 			$q->select('id')->from('users')->joinWhere('photos', 'users.id', '!=', 'bar')->where('age', '>', 25)->take(3);
 		});
-		$this->assertEquals('select * from "users" inner join "photos" on "users"."id" = ? where "id" not in (select "id" from "users" inner join "photos" on "users"."id" != ? where "age" > ? limit 3)', $builder->toSql());
-		$this->assertEquals(['foo', 'bar', 25], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" inner join "photos" on "users"."id" = ? where "id" not in (select "id" from "users" inner join "photos" on "users"."id" != ? where "age" > ? limit 3)', ['foo', 'bar', 25]);
 	}
 
 
@@ -490,13 +453,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereNull('id');
-		$this->assertEquals('select * from "users" where "id" is null', $builder->toSql());
-		$this->assertEquals(array(), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" is null');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1)->orWhereNull('id');
-		$this->assertEquals('select * from "users" where "id" = ? or "id" is null', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or "id" is null', [1]);
 	}
 
 
@@ -504,13 +465,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereNotNull('id');
-		$this->assertEquals('select * from "users" where "id" is not null', $builder->toSql());
-		$this->assertEquals(array(), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" is not null');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '>', 1)->orWhereNotNull('id');
-		$this->assertEquals('select * from "users" where "id" > ? or "id" is not null', $builder->toSql());
-		$this->assertEquals(array(0 => 1), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" > ? or "id" is not null', [1]);
 	}
 
 
@@ -518,11 +477,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->groupBy('id', 'email');
-		$this->assertEquals('select * from "users" group by "id", "email"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" group by "id", "email"');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->groupBy(['id', 'email']);
-		$this->assertEquals('select * from "users" group by "id", "email"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" group by "id", "email"');
 	}
 
 
@@ -530,12 +489,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->orderBy('email')->orderBy('age', 'desc');
-		$this->assertEquals('select * from "users" order by "email" asc, "age" desc', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" order by "email" asc, "age" desc');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->orderBy('email')->orderByRaw('"age" ? desc', array('foo'));
-		$this->assertEquals('select * from "users" order by "email" asc, "age" ? desc', $builder->toSql());
-		$this->assertEquals(array('foo'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" order by "email" asc, "age" ? desc', ['foo']);
 	}
 
 
@@ -543,18 +501,15 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->having('email', '>', 1);
-		$this->assertEquals('select * from "users" having "email" > ?', $builder->toSql());
-		$this->assertEquals([1], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" having "email" > ?', [1]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->groupBy('email')->having('email', '>', 1);
-		$this->assertEquals('select * from "users" group by "email" having "email" > ?', $builder->toSql());
-		$this->assertEquals([1], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" group by "email" having "email" > ?', [1]);
 
 		$builder = $this->getBuilder();
 		$builder->select('email as foo_email')->from('users')->having('foo_email', '>', 1);
-		$this->assertEquals('select "email" as "foo_email" from "users" having "foo_email" > ?', $builder->toSql());
-		$this->assertEquals([1], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select "email" as "foo_email" from "users" having "foo_email" > ?', [1]);
 	}
 
 
@@ -562,17 +517,15 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->havingRaw('user_foo < user_bar');
-		$this->assertEquals('select * from "users" having user_foo < user_bar', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" having user_foo < user_bar');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->havingRaw('user_foo < ?', [1]);
-		$this->assertEquals('select * from "users" having user_foo < ?', $builder->toSql());
-		$this->assertEquals([1], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" having user_foo < ?', [1]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->having('baz', '=', 1)->orHavingRaw('user_foo < user_bar');
-		$this->assertEquals('select * from "users" having "baz" = ? or user_foo < user_bar', $builder->toSql());
-		$this->assertEquals([1], $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" having "baz" = ? or user_foo < user_bar', [1]);
 	}
 
 
@@ -580,23 +533,23 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->offset(5)->limit(10);
-		$this->assertEquals('select * from "users" limit 10 offset 5', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" limit 10 offset 5');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->skip(5)->take(10);
-		$this->assertEquals('select * from "users" limit 10 offset 5', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" limit 10 offset 5');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->skip(-5)->take(10);
-		$this->assertEquals('select * from "users" limit 10 offset 0', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" limit 10 offset 0');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->forPage(2, 15);
-		$this->assertEquals('select * from "users" limit 15 offset 15', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" limit 15 offset 15');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->forPage(-2, 15);
-		$this->assertEquals('select * from "users" limit 15 offset 0', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" limit 15 offset 0');
 	}
 
 
@@ -604,8 +557,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', 1)->orWhere('name', 'foo');
-		$this->assertEquals('select * from "users" where "id" = ? or "name" = ?', $builder->toSql());
-		$this->assertEquals(array(0 => 1, 1 => 'foo'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "id" = ? or "name" = ?', [1, 'foo']);
 	}
 
 
@@ -616,8 +568,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			$q->where('name', '=', 'bar')->where('age', '=', 25);
 		});
-		$this->assertEquals('select * from "users" where "email" = ? or ("name" = ? and "age" = ?)', $builder->toSql());
-		$this->assertEquals(array(0 => 'foo', 1 => 'bar', 2 => 25), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "email" = ? or ("name" = ? and "age" = ?)', ['foo', 'bar', 25]);
 	}
 
 
@@ -629,8 +580,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 			$q->select(new Raw('max(id)'))->from('users')->where('email', '=', 'bar');
 		});
 
-		$this->assertEquals('select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)', $builder->toSql());
-		$this->assertEquals(array(0 => 'foo', 1 => 'bar'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)', ['foo', 'bar']);
 	}
 
 
@@ -641,28 +591,28 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			$q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
 		});
-		$this->assertEquals('select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('orders')->whereNotExists(function($q)
 		{
 			$q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
 		});
-		$this->assertEquals('select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."id")');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('orders')->where('id', '=', 1)->orWhereExists(function($q)
 		{
 			$q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
 		});
-		$this->assertEquals('select * from "orders" where "id" = ? or exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "orders" where "id" = ? or exists (select * from "products" where "products"."id" = "orders"."id")', [1]);
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('orders')->where('id', '=', 1)->orWhereNotExists(function($q)
 		{
 			$q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
 		});
-		$this->assertEquals('select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")', [1]);
 	}
 
 
@@ -670,12 +620,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->leftJoin('photos', 'users.id', '=', 'photos.id');
-		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" left join "photos" on "users"."id" = "photos"."id"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" left join "photos" on "users"."id" = "photos"."id"');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->leftJoinWhere('photos', 'users.id', '=', 'bar')->joinWhere('photos', 'users.id', '=', 'foo');
-		$this->assertEquals('select * from "users" left join "photos" on "users"."id" = ? inner join "photos" on "users"."id" = ?', $builder->toSql());
-		$this->assertEquals(array('bar', 'foo'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" left join "photos" on "users"."id" = ? inner join "photos" on "users"."id" = ?', ['bar', 'foo']);
 	}
 
 
@@ -686,15 +635,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			$j->on('users.id', '=', 'contacts.id')->orOn('users.name', '=', 'contacts.name');
 		});
-		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "users"."name" = "contacts"."name"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "users"."name" = "contacts"."name"');
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->join('contacts', function($j)
 		{
 			$j->where('users.id', '=', 'foo')->orWhere('users.name', '=', 'bar');
 		});
-		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = ? or "users"."name" = ?', $builder->toSql());
-		$this->assertEquals(array('foo', 'bar'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "users" inner join "contacts" on "users"."id" = ? or "users"."name" = ?', ['foo', 'bar']);
 	}
 
 	public function testJoinWhereNull()
@@ -704,14 +652,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			$j->on('users.id', '=', 'contacts.id')->whereNull('contacts.deleted_at');
 		});
-		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."deleted_at" is null', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."deleted_at" is null');
 	}
 
 	public function testRawExpressionsInSelect()
 	{
 		$builder = $this->getBuilder();
 		$builder->select(new Raw('substr(foo, 6)'))->from('users');
-		$this->assertEquals('select substr(foo, 6) from "users"', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select substr(foo, 6) from "users"');
 	}
 
 
@@ -1094,7 +1042,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('users');
-		$this->assertEquals('select * from `users`', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from `users`');
 	}
 
 
@@ -1102,7 +1050,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getSQLiteBuilder();
 		$builder->select('*')->from('users')->orderBy('email', 'desc');
-		$this->assertEquals('select * from "users" order by "email" desc', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" order by "email" desc');
 	}
 
 
@@ -1110,19 +1058,19 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getSqlServerBuilder();
 		$builder->select('*')->from('users')->take(10);
-		$this->assertEquals('select top 10 * from [users]', $builder->toSql());
+		$this->assertBuilderCompile($builder,'select top 10 * from [users]');
 
 		$builder = $this->getSqlServerBuilder();
 		$builder->select('*')->from('users')->skip(10);
-		$this->assertEquals('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num >= 11', $builder->toSql());
+		$this->assertBuilderCompile($builder,'select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num >= 11');
 
 		$builder = $this->getSqlServerBuilder();
 		$builder->select('*')->from('users')->skip(10)->take(10);
-		$this->assertEquals('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20');
 
 		$builder = $this->getSqlServerBuilder();
 		$builder->select('*')->from('users')->skip(10)->take(10)->orderBy('email', 'desc');
-		$this->assertEquals('select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 11 and 20', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 11 and 20');
 	}
 
 
@@ -1139,7 +1087,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('foo', null);
-		$this->assertEquals('select * from "users" where "foo" is null', $builder->toSql());
+		$this->assertBuilderCompile($builder, 'select * from "users" where "foo" is null');
 	}
 
 
@@ -1210,13 +1158,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
-		$this->assertEquals('select * from `foo` where `bar` = ? for update', $builder->toSql());
-		$this->assertEquals(array('baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from `foo` where `bar` = ? for update', ['baz']);
 
 		$builder = $this->getMySqlBuilder();
 		$builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock(false);
-		$this->assertEquals('select * from `foo` where `bar` = ? lock in share mode', $builder->toSql());
-		$this->assertEquals(array('baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from `foo` where `bar` = ? lock in share mode', ['baz']);
 	}
 
 
@@ -1224,13 +1170,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
-		$this->assertEquals('select * from "foo" where "bar" = ? for update', $builder->toSql());
-		$this->assertEquals(array('baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "foo" where "bar" = ? for update', ['baz']);
 
 		$builder = $this->getPostgresBuilder();
 		$builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock(false);
-		$this->assertEquals('select * from "foo" where "bar" = ? for share', $builder->toSql());
-		$this->assertEquals(array('baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from "foo" where "bar" = ? for share', ['baz']);
 	}
 
 
@@ -1238,13 +1182,11 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getSqlServerBuilder();
 		$builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
-		$this->assertEquals('select * from [foo] with(rowlock,updlock,holdlock) where [bar] = ?', $builder->toSql());
-		$this->assertEquals(array('baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from [foo] with(rowlock,updlock,holdlock) where [bar] = ?', ['baz']);
 
 		$builder = $this->getSqlServerBuilder();
 		$builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock(false);
-		$this->assertEquals('select * from [foo] with(rowlock,holdlock) where [bar] = ?', $builder->toSql());
-		$this->assertEquals(array('baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, 'select * from [foo] with(rowlock,holdlock) where [bar] = ?', ['baz']);
 	}
 
 
@@ -1255,23 +1197,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->join('othertable', function($join) { $join->where('bar', '=', 'foo'); })->where('registered', 1)->groupBy('city')->having('population', '>', 3)->orderByRaw('match ("foo") against(?)', array('bar'));
-		$this->assertEquals($expectedSql, $builder->toSql());
-		$this->assertEquals($expectedBindings, $builder->getBindings());
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
 
 		// order of statements reversed
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->orderByRaw('match ("foo") against(?)', array('bar'))->having('population', '>', 3)->groupBy('city')->where('registered', 1)->join('othertable', function($join) { $join->where('bar', '=', 'foo'); });
-		$this->assertEquals($expectedSql, $builder->toSql());
-		$this->assertEquals($expectedBindings, $builder->getBindings());
-	}
-
-
-	public function testAddBindingWithArrayMergesBindings()
-	{
-		$builder = $this->getBuilder();
-		$builder->addBinding(array('foo', 'bar'));
-		$builder->addBinding(array('baz'));
-		$this->assertEquals(array('foo', 'bar', 'baz'), $builder->getBindings());
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
 	}
 
 
@@ -1283,16 +1214,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->from('one')->select(['foo', 'bar'])->where('key', '=', 'val');
 		$builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval'); }, 'sub');
-		$this->assertEquals($expectedSql, $builder->toSql());
-		$this->assertEquals($expectedBindings, $builder->getBindings());
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
 
 		$builder = $this->getBuilder();
 		$builder->from('one')->select(['foo', 'bar'])->where('key', '=', 'val');
 		$subBuilder = $this->getBuilder();
 		$subBuilder->from('two')->select('baz')->where('subkey', '=', 'subval');
 		$builder->selectSub($subBuilder, 'sub');
-		$this->assertEquals($expectedSql, $builder->toSql());
-		$this->assertEquals($expectedBindings, $builder->getBindings());
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
 	}
 
 
@@ -1304,8 +1233,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->from('one')->select(['foo', 'bar'])->where('key', '=', 'val')->orderByRaw('"age" ? desc', array('fuzz'));
 		$builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->orderByRaw('"age" ? desc', array('buzz')); }, 'sub');
-		$this->assertEquals($expectedSql, $builder->toSql());
-		$this->assertEquals($expectedBindings, $builder->getBindings());
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
 	}
 
 
@@ -1318,8 +1246,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->from('one')->select(['foo', 'bar']);
 		$builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->having('age', '>', 25); }, 'sub');
 		$builder->where('key', '=', 'val')->having('email', '!=', 'me@email.com');
-		$this->assertEquals($expectedSql, $builder->toSql());
-		$this->assertEquals($expectedBindings, $builder->getBindings());
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
 	}
 
 
@@ -1332,8 +1259,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->from('one')->select(['foo', 'bar']);
 		$builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->joinWhere('photos', 'users.id', '!=', 'bar'); }, 'sub');
 		$builder->where('key', '=', 'val')->joinWhere('photos', 'users.id', '=', 'foo');
-		$this->assertEquals($expectedSql, $builder->toSql());
-		$this->assertEquals($expectedBindings, $builder->getBindings());
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
 	}
 
 
@@ -1346,8 +1272,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->from('one');
 		$builder->selectSub(function($query) { $query->from('two')->selectRaw('?', ['baz'])->where('subkey', '=', 'subval'); }, 'sub');
 		$builder->addSelect(['foo', 'bar'])->selectRaw('?', ['buzz'])->where('key', '=', 'val');
-		$this->assertEquals($expectedSql, $builder->toSql());
-		$this->assertEquals($expectedBindings, $builder->getBindings());
+		$this->assertBuilderCompile($builder, $expectedSql, $expectedBindings);
 	}
 
 
@@ -1388,6 +1313,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$grammar = new Illuminate\Database\Query\Grammars\SqlServerGrammar;
 		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
 		return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+	}
+
+	protected function assertBuilderCompile($buidler, $expectedSql, $expectedBindings = []) {
+		$compiled = $buidler->toSql();
+		$this->assertEquals($expectedSql, $compiled->sql);
+		$this->assertEquals($expectedBindings, $compiled->bindings);
 	}
 
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -353,55 +353,55 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('select * from "users" where "id" = ? union all select * from "users" where "id" = ?', $builder->toSql());
 		$this->assertEquals([1, 2], $builder->getBindings());
 
-    $builder = $this->getMySqlBuilder();
-    $builder->select('*')->from('users')->where('id', '=', 1);
-    $builder->unionAll($this->getMySqlBuilder()->select('*')->from('users')->where('id', '=', 2));
-    $this->assertEquals('(select * from `users` where `id` = ?) union all (select * from `users` where `id` = ?)', $builder->toSql());
-    $this->assertEquals([1, 2], $builder->getBindings());
+		$builder = $this->getMySqlBuilder();
+		$builder->select('*')->from('users')->where('id', '=', 1);
+		$builder->unionAll($this->getMySqlBuilder()->select('*')->from('users')->where('id', '=', 2));
+		$this->assertEquals('(select * from `users` where `id` = ?) union all (select * from `users` where `id` = ?)', $builder->toSql());
+		$this->assertEquals([1, 2], $builder->getBindings());
 	}
 
 
-  public function testUnionsWithJoins()
-  {
-    $expectedSql = 'select * from "users" inner join "photos" on "users"."id" = ? where "id" = ? union select * from "users" inner join "photos" on "users"."id" = ? where "id" = ?';
-    $expectedBindings = ['foo', 1, 'bar', 2];
+	public function testUnionsWithJoins()
+	{
+		$expectedSql = 'select * from "users" inner join "photos" on "users"."id" = ? where "id" = ? union select * from "users" inner join "photos" on "users"."id" = ? where "id" = ?';
+		$expectedBindings = ['foo', 1, 'bar', 2];
 
-    $first = $this->getBuilder();
-    $first->select('*')->from('users')->join('photos', function($join) {$join->where('users.id', '=', 'foo');})->where('id', '=', 1);
-    $second = $this->getBuilder()->select('*')->from('users')->join('photos', function($join) {$join->where('users.id', '=', 'bar');})->where('id', '=', 2);
-    $first->union($second);
-    $this->assertEquals($expectedSql, $first->toSql());
-    $this->assertEquals($expectedBindings, $first->getBindings());
-  }
+		$first = $this->getBuilder();
+		$first->select('*')->from('users')->join('photos', function($join) {$join->where('users.id', '=', 'foo');})->where('id', '=', 1);
+		$second = $this->getBuilder()->select('*')->from('users')->join('photos', function($join) {$join->where('users.id', '=', 'bar');})->where('id', '=', 2);
+		$first->union($second);
+		$this->assertEquals($expectedSql, $first->toSql());
+		$this->assertEquals($expectedBindings, $first->getBindings());
+	}
 
 
-  public function testUnionsWithOrder()
-  {
-    $expectedSql = 'select * from "users" where "id" = ? order by "email" asc, "age" ? desc union select * from "users" where "id" = ? order by "email" asc, "age" ? desc';
-    $expectedBindings = [1, 'foo', 2, 'bar'];
+	public function testUnionsWithOrder()
+	{
+		$expectedSql = 'select * from "users" where "id" = ? order by "email" asc, "age" ? desc union select * from "users" where "id" = ? order by "email" asc, "age" ? desc';
+		$expectedBindings = [1, 'foo', 2, 'bar'];
 
-    $first = $this->getBuilder();
-    $first->select('*')->from('users')->where('id', '=', 1)->orderBy('email')->orderByRaw('"age" ? desc', array('foo'));
-    $second = $this->getBuilder()->select('*')->from('users')->where('id', '=', 2)->orderBy('email')->orderByRaw('"age" ? desc', array('bar'));
-    $first->union($second);
+		$first = $this->getBuilder();
+		$first->select('*')->from('users')->where('id', '=', 1)->orderBy('email')->orderByRaw('"age" ? desc', array('foo'));
+		$second = $this->getBuilder()->select('*')->from('users')->where('id', '=', 2)->orderBy('email')->orderByRaw('"age" ? desc', array('bar'));
+		$first->union($second);
 
-    $this->assertEquals($expectedSql, $first->toSql());
-    $this->assertEquals($expectedBindings, $first->getBindings());
-  }
+		$this->assertEquals($expectedSql, $first->toSql());
+		$this->assertEquals($expectedBindings, $first->getBindings());
+	}
 
-  public function testUnionsWithHavings()
-  {
-    $expectedSql = 'select * from "users" where "id" = ? group by "email" having "email" = ? union select * from "users" where "id" = ? group by "email" having "email" = ?';
-    $expectedBindings = [1, 'me@email.com', 2, 'you@email.com'];
+	public function testUnionsWithHavings()
+	{
+		$expectedSql = 'select * from "users" where "id" = ? group by "email" having "email" = ? union select * from "users" where "id" = ? group by "email" having "email" = ?';
+		$expectedBindings = [1, 'me@email.com', 2, 'you@email.com'];
 
-    $first = $this->getBuilder();
-    $first->select('*')->from('users')->where('id', '=', 1)->groupBy('email')->having('email', '=', 'me@email.com');
-    $second = $this->getBuilder()->select('*')->from('users')->where('id', '=', 2)->groupBy('email')->having('email', '=', 'you@email.com');
-    $first->union($second);
+		$first = $this->getBuilder();
+		$first->select('*')->from('users')->where('id', '=', 1)->groupBy('email')->having('email', '=', 'me@email.com');
+		$second = $this->getBuilder()->select('*')->from('users')->where('id', '=', 2)->groupBy('email')->having('email', '=', 'you@email.com');
+		$first->union($second);
 
-    $this->assertEquals($expectedSql, $first->toSql());
-    $this->assertEquals($expectedBindings, $first->getBindings());
-  }
+		$this->assertEquals($expectedSql, $first->toSql());
+		$this->assertEquals($expectedBindings, $first->getBindings());
+	}
 
 
 	public function testMultipleUnions()
@@ -446,44 +446,44 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-  public function testSubSelectWhereInsWithHavings()
-  {
-    $builder = $this->getBuilder();
-    $builder->select('*')->from('users')->groupBy('email')->having('email', '!=', 'me@email.com')->whereIn('id', function($q)
-    {
-      $q->select('id')->from('users')->where('age', '>', 25)->take(3);
-    });
-    $this->assertEquals('select * from "users" where "id" in (select "id" from "users" where "age" > ? limit 3) group by "email" having "email" != ?', $builder->toSql());
-    $this->assertEquals([ 25, 'me@email.com'], $builder->getBindings());
+	public function testSubSelectWhereInsWithHavings()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->groupBy('email')->having('email', '!=', 'me@email.com')->whereIn('id', function($q)
+		{
+			$q->select('id')->from('users')->where('age', '>', 25)->take(3);
+		});
+		$this->assertEquals('select * from "users" where "id" in (select "id" from "users" where "age" > ? limit 3) group by "email" having "email" != ?', $builder->toSql());
+		$this->assertEquals([ 25, 'me@email.com'], $builder->getBindings());
 
-    $builder = $this->getBuilder();
-    $builder->select('*')->from('users')->groupBy('email')->having('email', '!=', 'me@email.com')->whereNotIn('id', function($q)
-    {
-      $q->select('id')->from('users')->where('age', '>', 25)->take(3);
-    });
-    $this->assertEquals('select * from "users" where "id" not in (select "id" from "users" where "age" > ? limit 3) group by "email" having "email" != ?', $builder->toSql());
-    $this->assertEquals([ 25, 'me@email.com'], $builder->getBindings());
-  }
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->groupBy('email')->having('email', '!=', 'me@email.com')->whereNotIn('id', function($q)
+		{
+			$q->select('id')->from('users')->where('age', '>', 25)->take(3);
+		});
+		$this->assertEquals('select * from "users" where "id" not in (select "id" from "users" where "age" > ? limit 3) group by "email" having "email" != ?', $builder->toSql());
+		$this->assertEquals([ 25, 'me@email.com'], $builder->getBindings());
+	}
 
 
-  public function testSubSelectWhereInsWithJoins()
-  {
-    $builder = $this->getBuilder();
-    $builder->select('*')->from('users')->joinWhere('photos', 'users.id', '=', 'foo')->whereIn('id', function($q)
-    {
-      $q->select('id')->from('users')->joinWhere('photos', 'users.id', '!=', 'bar')->where('age', '>', 25)->take(3);
-    });
-    $this->assertEquals('select * from "users" inner join "photos" on "users"."id" = ? where "id" in (select "id" from "users" inner join "photos" on "users"."id" != ? where "age" > ? limit 3)', $builder->toSql());
-    $this->assertEquals(['foo', 'bar', 25], $builder->getBindings());
+	public function testSubSelectWhereInsWithJoins()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->joinWhere('photos', 'users.id', '=', 'foo')->whereIn('id', function($q)
+		{
+			$q->select('id')->from('users')->joinWhere('photos', 'users.id', '!=', 'bar')->where('age', '>', 25)->take(3);
+		});
+		$this->assertEquals('select * from "users" inner join "photos" on "users"."id" = ? where "id" in (select "id" from "users" inner join "photos" on "users"."id" != ? where "age" > ? limit 3)', $builder->toSql());
+		$this->assertEquals(['foo', 'bar', 25], $builder->getBindings());
 
-    $builder = $this->getBuilder();
-    $builder->select('*')->from('users')->joinWhere('photos', 'users.id', '=', 'foo')->whereNotIn('id', function($q)
-    {
-      $q->select('id')->from('users')->joinWhere('photos', 'users.id', '!=', 'bar')->where('age', '>', 25)->take(3);
-    });
-    $this->assertEquals('select * from "users" inner join "photos" on "users"."id" = ? where "id" not in (select "id" from "users" inner join "photos" on "users"."id" != ? where "age" > ? limit 3)', $builder->toSql());
-    $this->assertEquals(['foo', 'bar', 25], $builder->getBindings());
-  }
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->joinWhere('photos', 'users.id', '=', 'foo')->whereNotIn('id', function($q)
+		{
+			$q->select('id')->from('users')->joinWhere('photos', 'users.id', '!=', 'bar')->where('age', '>', 25)->take(3);
+		});
+		$this->assertEquals('select * from "users" inner join "photos" on "users"."id" = ? where "id" not in (select "id" from "users" inner join "photos" on "users"."id" != ? where "age" > ? limit 3)', $builder->toSql());
+		$this->assertEquals(['foo', 'bar', 25], $builder->getBindings());
+	}
 
 
 	public function testBasicWhereNulls()
@@ -544,17 +544,17 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->having('email', '>', 1);
 		$this->assertEquals('select * from "users" having "email" > ?', $builder->toSql());
-    $this->assertEquals([1], $builder->getBindings());
+		$this->assertEquals([1], $builder->getBindings());
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->groupBy('email')->having('email', '>', 1);
 		$this->assertEquals('select * from "users" group by "email" having "email" > ?', $builder->toSql());
-    $this->assertEquals([1], $builder->getBindings());
+		$this->assertEquals([1], $builder->getBindings());
 
 		$builder = $this->getBuilder();
 		$builder->select('email as foo_email')->from('users')->having('foo_email', '>', 1);
 		$this->assertEquals('select "email" as "foo_email" from "users" having "foo_email" > ?', $builder->toSql());
-    $this->assertEquals([1], $builder->getBindings());
+		$this->assertEquals([1], $builder->getBindings());
 	}
 
 
@@ -564,15 +564,15 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->select('*')->from('users')->havingRaw('user_foo < user_bar');
 		$this->assertEquals('select * from "users" having user_foo < user_bar', $builder->toSql());
 
-    $builder = $this->getBuilder();
-    $builder->select('*')->from('users')->havingRaw('user_foo < ?', [1]);
-    $this->assertEquals('select * from "users" having user_foo < ?', $builder->toSql());
-    $this->assertEquals([1], $builder->getBindings());
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->havingRaw('user_foo < ?', [1]);
+		$this->assertEquals('select * from "users" having user_foo < ?', $builder->toSql());
+		$this->assertEquals([1], $builder->getBindings());
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->having('baz', '=', 1)->orHavingRaw('user_foo < user_bar');
 		$this->assertEquals('select * from "users" having "baz" = ? or user_foo < user_bar', $builder->toSql());
-    $this->assertEquals([1], $builder->getBindings());
+		$this->assertEquals([1], $builder->getBindings());
 	}
 
 
@@ -1296,59 +1296,59 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-  public function testSubSelectWithOrder()
-  {
-    $expectedSql = 'select "foo", "bar", (select "baz" from "two" where "subkey" = ? order by "age" ? desc) as "sub" from "one" where "key" = ? order by "age" ? desc';
-    $expectedBindings = ['subval', 'buzz', 'val', 'fuzz'];
+	public function testSubSelectWithOrder()
+	{
+		$expectedSql = 'select "foo", "bar", (select "baz" from "two" where "subkey" = ? order by "age" ? desc) as "sub" from "one" where "key" = ? order by "age" ? desc';
+		$expectedBindings = ['subval', 'buzz', 'val', 'fuzz'];
 
-    $builder = $this->getBuilder();
-    $builder->from('one')->select(['foo', 'bar'])->where('key', '=', 'val')->orderByRaw('"age" ? desc', array('fuzz'));
-    $builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->orderByRaw('"age" ? desc', array('buzz')); }, 'sub');
-    $this->assertEquals($expectedSql, $builder->toSql());
-    $this->assertEquals($expectedBindings, $builder->getBindings());
-  }
-
-
-  public function testSubSelectWithHavings()
-  {
-    $expectedSql = 'select "foo", "bar", (select "baz" from "two" where "subkey" = ? having "age" > ?) as "sub" from "one" where "key" = ? having "email" != ?';
-    $expectedBindings = ['subval', 25, 'val', 'me@email.com'];
-
-    $builder = $this->getBuilder();
-    $builder->from('one')->select(['foo', 'bar']);
-    $builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->having('age', '>', 25); }, 'sub');
-    $builder->where('key', '=', 'val')->having('email', '!=', 'me@email.com');
-    $this->assertEquals($expectedSql, $builder->toSql());
-    $this->assertEquals($expectedBindings, $builder->getBindings());
-  }
+		$builder = $this->getBuilder();
+		$builder->from('one')->select(['foo', 'bar'])->where('key', '=', 'val')->orderByRaw('"age" ? desc', array('fuzz'));
+		$builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->orderByRaw('"age" ? desc', array('buzz')); }, 'sub');
+		$this->assertEquals($expectedSql, $builder->toSql());
+		$this->assertEquals($expectedBindings, $builder->getBindings());
+	}
 
 
-  public function testSubSelectWithJoins()
-  {
-    $expectedSql = 'select "foo", "bar", (select "baz" from "two" inner join "photos" on "users"."id" != ? where "subkey" = ?) as "sub" from "one" inner join "photos" on "users"."id" = ? where "key" = ?';
-    $expectedBindings = ['bar', 'subval', 'foo', 'val'];
+	public function testSubSelectWithHavings()
+	{
+		$expectedSql = 'select "foo", "bar", (select "baz" from "two" where "subkey" = ? having "age" > ?) as "sub" from "one" where "key" = ? having "email" != ?';
+		$expectedBindings = ['subval', 25, 'val', 'me@email.com'];
 
-    $builder = $this->getBuilder();
-    $builder->from('one')->select(['foo', 'bar']);
-    $builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->joinWhere('photos', 'users.id', '!=', 'bar'); }, 'sub');
-    $builder->where('key', '=', 'val')->joinWhere('photos', 'users.id', '=', 'foo');
-    $this->assertEquals($expectedSql, $builder->toSql());
-    $this->assertEquals($expectedBindings, $builder->getBindings());
-  }
+		$builder = $this->getBuilder();
+		$builder->from('one')->select(['foo', 'bar']);
+		$builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->having('age', '>', 25); }, 'sub');
+		$builder->where('key', '=', 'val')->having('email', '!=', 'me@email.com');
+		$this->assertEquals($expectedSql, $builder->toSql());
+		$this->assertEquals($expectedBindings, $builder->getBindings());
+	}
 
 
-  public function testSubSelectWithRawSelect()
-  {
-    $expectedSql = 'select (select ? from "two" where "subkey" = ?) as "sub", "foo", "bar", ? from "one" where "key" = ?';
-    $expectedBindings = ['baz', 'subval', 'buzz', 'val'];
+	public function testSubSelectWithJoins()
+	{
+		$expectedSql = 'select "foo", "bar", (select "baz" from "two" inner join "photos" on "users"."id" != ? where "subkey" = ?) as "sub" from "one" inner join "photos" on "users"."id" = ? where "key" = ?';
+		$expectedBindings = ['bar', 'subval', 'foo', 'val'];
 
-    $builder = $this->getBuilder();
-    $builder->from('one');
-    $builder->selectSub(function($query) { $query->from('two')->selectRaw('?', ['baz'])->where('subkey', '=', 'subval'); }, 'sub');
-    $builder->addSelect(['foo', 'bar'])->selectRaw('?', ['buzz'])->where('key', '=', 'val');
-    $this->assertEquals($expectedSql, $builder->toSql());
-    $this->assertEquals($expectedBindings, $builder->getBindings());
-  }
+		$builder = $this->getBuilder();
+		$builder->from('one')->select(['foo', 'bar']);
+		$builder->selectSub(function($query) { $query->from('two')->select('baz')->where('subkey', '=', 'subval')->joinWhere('photos', 'users.id', '!=', 'bar'); }, 'sub');
+		$builder->where('key', '=', 'val')->joinWhere('photos', 'users.id', '=', 'foo');
+		$this->assertEquals($expectedSql, $builder->toSql());
+		$this->assertEquals($expectedBindings, $builder->getBindings());
+	}
+
+
+	public function testSubSelectWithRawSelect()
+	{
+		$expectedSql = 'select (select ? from "two" where "subkey" = ?) as "sub", "foo", "bar", ? from "one" where "key" = ?';
+		$expectedBindings = ['baz', 'subval', 'buzz', 'val'];
+
+		$builder = $this->getBuilder();
+		$builder->from('one');
+		$builder->selectSub(function($query) { $query->from('two')->selectRaw('?', ['baz'])->where('subkey', '=', 'subval'); }, 'sub');
+		$builder->addSelect(['foo', 'bar'])->selectRaw('?', ['buzz'])->where('key', '=', 'val');
+		$this->assertEquals($expectedSql, $builder->toSql());
+		$this->assertEquals($expectedBindings, $builder->getBindings());
+	}
 
 
 	protected function getBuilder()

--- a/tests/Database/DatabaseQueryCompiledQueryTest.php
+++ b/tests/Database/DatabaseQueryCompiledQueryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use \Illuminate\Database\Query\CompiledQuery;
+
+class DatabaseQueryCompiledQueryTest extends PHPUnit_Framework_TestCase {
+
+	public function testConstruction()
+	{
+		$compiled = new CompiledQuery('select *', [1]);
+		$this->assertEquals('select *', $compiled->sql);
+		$this->assertEquals([1], $compiled->bindings);
+	}
+
+
+	public function testSimpleConcatenation()
+	{
+		$compiled = new CompiledQuery('select *');
+		$compiled->concatenate(new CompiledQuery('from users'));
+		$this->assertEquals('select * from users', $compiled->sql);
+	}
+
+
+	public function testConcatenationHandlesEmptyAndNullStrings()
+	{
+		$select = new CompiledQuery('select *');
+		$select->concatenate(new CompiledQuery);
+		$this->assertEquals('select *', $select->sql);
+
+		$select->concatenate(new CompiledQuery(''));
+		$this->assertEquals('select *', $select->sql);
+
+		$null = new CompiledQuery;
+		$null->concatenate($select);
+		$this->assertEquals('select *', $null->sql);
+
+		$empty = new CompiledQuery('');
+		$empty->concatenate($select);
+		$this->assertEquals('select *', $empty->sql);
+
+		$null = new CompiledQuery;
+		$null->concatenate(new CompiledQuery());
+		$this->assertEquals('', $null->sql);
+	}
+
+
+	public function testGluedConcatenation()
+	{
+		$compiled = new CompiledQuery('order by name');
+		$compiled->concatenate(new CompiledQuery('age'), ', ');
+		$this->assertEquals('order by name, age', $compiled->sql);
+	}
+
+
+	public function testConcatenationTrims()
+	{
+		$compiled = new CompiledQuery(' select * ');
+		$compiled->concatenate(new CompiledQuery(' from users '));
+		$this->assertEquals('select * from users', $compiled->sql);
+	}
+
+
+	public function testSimpleBindingMerge()
+	{
+		$compiled = new CompiledQuery('', [1]);
+		$compiled->concatenate(new CompiledQuery('', [2]));
+		$this->assertEquals([1,2], $compiled->bindings);
+	}
+
+	public function testConcatenationHandlesEmptyAndNullBindings()
+	{
+		$select = new CompiledQuery('', [1]);
+		$select->concatenate(new CompiledQuery);
+		$this->assertEquals([1], $select->bindings);
+
+		$select->concatenate(new CompiledQuery('', null));
+		$this->assertEquals([1], $select->bindings);
+
+		$null = new CompiledQuery;
+		$null->concatenate($select);
+		$this->assertEquals([1], $select->bindings);
+
+		$empty = new CompiledQuery('', []);
+		$empty->concatenate($select);
+		$this->assertEquals([1], $select->bindings);
+
+		$null = new CompiledQuery;
+		$null->concatenate(new CompiledQuery);
+		$this->assertEquals([], $null->bindings);
+	}
+
+	public function testFullConcatenate()
+	{
+		$select = new CompiledQuery('select ?', ['*']);
+		$from = new CompiledQuery('from users');
+		$where = new CompiledQuery('where email = ?', ['you@email.com']);
+		$select->concatenate($from)->concatenate($where);
+		$this->assertEquals('select ? from users where email = ?', $select->sql);
+		$this->assertEquals(['*', 'you@email.com'], $select->bindings);
+	}
+
+	public function testConcatenateReturnsSelf()
+	{
+		$select = new CompiledQuery('select *');
+		$return = $select->concatenate(new CompiledQuery);
+		$this->assertEquals($select, $return);
+	}
+
+	public function testConcatenateDoesNotMutatePassedInCompiledQuery()
+	{
+		$select = new CompiledQuery('select *');
+		$from = new CompiledQuery('from users', [1]);
+		$select->concatenate($from);
+		$this->assertEquals('from users', $from->sql);
+		$this->assertEquals([1], $from->bindings);
+	}
+
+} 


### PR DESCRIPTION
Followup PR from #5974. Much of the code is from that PR.

What is new here is that compiling a Builder not only returns the sql string but also the array of bindings which were previously stored as side effects on the builder. We introduce a CompiledQuery class that holds the sql string and the bindings array. It also takes care of a lot of the complexity of the concatenating and trimming sql string so the Grammar doesn't have to care about those details or imploding arrays of strings.

All unit tests pass as is with only a minor refactoring to allow us to assert the sql string and bindings in one helper method.
