### PR TITLE
[5.0] Add "redirector" Property On "FormRequest"

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -23,6 +23,13 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	protected $container;
 
 	/**
+	 * The redirector instance.
+	 *
+	 * @var Redirector
+	 */
+	protected $redirector;
+
+	/**
 	 * The route instance the request is dispatched to.
 	 *
 	 * @var \Illuminate\Routing\Route
@@ -102,7 +109,7 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	}
 
 	/**
-	 * Deteremine if the request passes the authorization check.
+	 * Determine if the request passes the authorization check.
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
Adding missing "redirector" property, that is accessed from "FormRequest::setRedirector" method. This would allow to have correct IDE auto-complete on that property within that class.

Also fixing small typo error while I'm at it.
