### PR TITLE
[4.2] Set morphs directly

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -101,14 +101,12 @@ abstract class MorphOneOrMany extends HasOneOrMany {
 	 */
 	public function create(array $attributes)
 	{
-		$foreign = $this->getForeignAttributesForCreate();
+		$instance = $this->related->newInstance($attributes);
 
 		// When saving a polymorphic relationship, we need to set not only the foreign
 		// key, but also the foreign key type, which is typically the class name of
 		// the parent model. This makes the polymorphic item unique in the table.
-		$attributes = array_merge($attributes, $foreign);
-
-		$instance = $this->related->newInstance($attributes);
+		$this->setForeignAttributesForCreate($instance);
 
 		$instance->save();
 
@@ -116,17 +114,16 @@ abstract class MorphOneOrMany extends HasOneOrMany {
 	}
 
 	/**
-	 * Get the foreign ID and type for creating a related model.
+	 * Set the foreign ID and type for creating a related model.
 	 *
-	 * @return array
+	 * @param  \Illuminate\Database\Eloquent\Model  $model
+	 * @return void
 	 */
-	protected function getForeignAttributesForCreate()
+	protected function setForeignAttributesForCreate(Model $model)
 	{
-		$foreign = array($this->getPlainForeignKey() => $this->getParentKey());
+		$model->{$this->getPlainForeignKey()} = $this->getParentKey();
 
-		$foreign[last(explode('.', $this->morphType))] = $this->morphClass;
-
-		return $foreign;
+		$model->{last(explode('.', $this->morphType))} = $this->morphClass;
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -60,8 +60,10 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 	{
 		// Doesn't matter which relation type we use since they share the code...
 		$relation = $this->getOneRelation();
-		$created = m::mock('stdClass');
-		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('name' => 'taylor', 'morph_id' => 1, 'morph_type' => get_class($relation->getParent())))->andReturn($created);
+		$created = m::mock('Illuminate\Database\Eloquent\Model');
+		$created->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+		$created->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('name' => 'taylor'))->andReturn($created);
 		$created->shouldReceive('save')->once()->andReturn(true);
 
 		$this->assertEquals($created, $relation->create(array('name' => 'taylor')));


### PR DESCRIPTION
``` php
$post->images()->create(['path' => 'some/path.jpg']);
```

Currently, creating a new model off a morph relationship does not correctly set the foreign keys unless they're fillable - which I don't think they should be.

This change sets the foreign keys directly on the model, bypassing the fillable filter.

---

I've been bitten by this pretty harshly. I now have a whole list of records in my morph table that have no foreign key data (much thanks to MySQL "helpfully" filling them in with `0` and `''`).
