### PR TITLE
[5.0] Change Implementation Of Container::extend()

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -484,29 +484,6 @@ class Application extends Container implements HttpKernelInterface,
 	}
 
 	/**
-	 * "Extend" an abstract type in the container.
-	 *
-	 * (Overriding Container::extend)
-	 *
-	 * @param  string   $abstract
-	 * @param  \Closure  $closure
-	 * @return void
-	 *
-	 * @throws \InvalidArgumentException
-	 */
-	public function extend($abstract, Closure $closure)
-	{
-		$abstract = $this->getAlias($abstract);
-
-		if (isset($this->deferredServices[$abstract]))
-		{
-			$this->loadDeferredProvider($abstract);
-		}
-
-		return parent::extend($abstract, $closure);
-	}
-
-	/**
 	 * Register a "before" application filter.
 	 *
 	 * @param  \Closure|string  $callback

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -214,6 +214,19 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testExtendCanBeCalledBeforeBind()
+	{
+		$container = new Container;
+		$container->extend('foo', function($old, $container)
+		{
+			return $old.'bar';
+		});
+		$container['foo'] = 'foo';
+
+		$this->assertEquals('foobar', $container->make('foo'));
+	}
+
+
 	public function testParametersCanBePassedThroughToClosure()
 	{
 		$container = new Container;

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -95,7 +95,7 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($app->bound('foo'));
 		$this->assertFalse(ApplicationDeferredServiceProviderStub::$initialized);
 		$app->extend('foo', function($instance, $container) { return $instance.'bar'; });
-		$this->assertTrue(ApplicationDeferredServiceProviderStub::$initialized);
+		$this->assertFalse(ApplicationDeferredServiceProviderStub::$initialized);
 		$this->assertEquals('foobar', $app->make('foo'));
 		$this->assertTrue(ApplicationDeferredServiceProviderStub::$initialized);
 	}


### PR DESCRIPTION
I previously called `Container::extend()` nearly useless because calling it was dependent on `bind()` being called in advance.

It turned out, that's not quite true, as instead `extend()` checks whether services have already been instantiated and, if they do, simply applies the closures to the instances.

This means `extend()` would always have to be called in service providers' `boot()` method, though, because you could not sure the extended services exist when extended in `register()`, but the container took care of applying extensions to already instantiated services.

Well, this change makes sure `extend()` works even for services that have not been registered yet, which might be a point of discussion. All previously existing unit tests pass.

To me, this would make `extend()` the preferred solution (over binding a listener to `resolving()`) - it could safely be called in `register()` without any dependence on the order of service providers. Which is nice because `extend()` is more powerful for doing stuff like decorators etc.
