### PR TITLE
[5.0] Added A Space After Questions

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -197,7 +197,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	{
 		$helper = $this->getHelperSet()->get('question');
 
-		$question = new Question("<question>$question</question>", $default);
+		$question = new Question("<question>$question</question> ", $default);
 
 		return $helper->ask($this->input, $this->output, $question);
 	}
@@ -214,7 +214,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	{
 		$helper = $this->getHelperSet()->get('question');
 
-		$question = new Question("<question>$question</question>", $default);
+		$question = new Question("<question>$question</question> ", $default);
 
 		$question->setAutocompleterValues($choices);
 
@@ -232,7 +232,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	{
 		$helper = $this->getHelperSet()->get('question');
 
-		$question = new Question("<question>$question</question>");
+		$question = new Question("<question>$question</question> ");
 
 		$question->setHidden(true)->setHiddenFallback($fallback);
 
@@ -253,7 +253,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	{
 		$helper = $this->getHelperSet()->get('question');
 
-		$question = new ChoiceQuestion("<question>$question</question>", $choices, $default);
+		$question = new ChoiceQuestion("<question>$question</question> ", $choices, $default);
 
 		$question->setMaxAttempts($attempts)->setMultiselect($multiple);
 


### PR DESCRIPTION
Issuing this pull request to the master branch as requested by @taylorotwell 

This pull request relates to the Command class.

The commit here adds a space after a question so the input is more readable. This could have been missed as the `confirm()` method has a space in it to separate the input.

To clarify:

Running `$this->ask('What is your name?');`

Output before:
`What is your name?`input

Output now:
`What is your name?` input
