### PR TITLE
[5.0] Refactoring and fixing make:auth

### DIFF
--- a/src/Illuminate/Auth/Console/AuthControllerCommand.php
+++ b/src/Illuminate/Auth/Console/AuthControllerCommand.php
@@ -71,7 +71,7 @@ class AuthControllerCommand extends GeneratorCommand {
 	 */
 	protected function getArguments()
 	{
-		$default = $this->getAppNamespace().'Http\Controllers\Auth\AuthController';
+		$default = 'Auth\AuthController';
 
 		return array(
 			array('name', InputArgument::OPTIONAL, 'The name of the class', $default),

--- a/src/Illuminate/Auth/Console/AuthControllerCommand.php
+++ b/src/Illuminate/Auth/Console/AuthControllerCommand.php
@@ -35,7 +35,7 @@ class AuthControllerCommand extends GeneratorCommand {
 	{
 		parent::fire();
 
-		$this->comment('Route: $router->controller(\'auth\', \''.$this->argument('name')."');");
+		//$this->comment('Route: $router->controller(\'auth\', \''.$this->argument('name')."');");
 	}
 
 	/**

--- a/src/Illuminate/Auth/Console/AuthControllerCommand.php
+++ b/src/Illuminate/Auth/Console/AuthControllerCommand.php
@@ -34,8 +34,6 @@ class AuthControllerCommand extends GeneratorCommand {
 	public function fire()
 	{
 		parent::fire();
-
-		//$this->comment('Route: $router->controller(\'auth\', \''.$this->argument('name')."');");
 	}
 
 	/**

--- a/src/Illuminate/Auth/Console/RemindersControllerCommand.php
+++ b/src/Illuminate/Auth/Console/RemindersControllerCommand.php
@@ -55,7 +55,7 @@ class RemindersControllerCommand extends GeneratorCommand {
 	 */
 	protected function getArguments()
 	{
-		$default = $this->getAppNamespace().'Http\Controllers\Auth\RemindersController';
+		$default = 'Auth\RemindersController';
 
 		return array(
 			array('name', InputArgument::OPTIONAL, 'The name of the class', $default),

--- a/src/Illuminate/Auth/Console/RemindersControllerCommand.php
+++ b/src/Illuminate/Auth/Console/RemindersControllerCommand.php
@@ -35,7 +35,7 @@ class RemindersControllerCommand extends GeneratorCommand {
 	{
 		parent::fire();
 
-		$this->comment('Route: $router->controller(\'password\', \''.$this->argument('name')."');");
+		//$this->comment('Route: $router->controller(\'password\', \''.$this->argument('name')."');");
 	}
 
 	/**

--- a/src/Illuminate/Auth/Console/RemindersControllerCommand.php
+++ b/src/Illuminate/Auth/Console/RemindersControllerCommand.php
@@ -34,8 +34,6 @@ class RemindersControllerCommand extends GeneratorCommand {
 	public function fire()
 	{
 		parent::fire();
-
-		//$this->comment('Route: $router->controller(\'password\', \''.$this->argument('name')."');");
 	}
 
 	/**

--- a/src/Illuminate/Auth/Console/stubs/controller.stub
+++ b/src/Illuminate/Auth/Console/stubs/controller.stub
@@ -1,12 +1,11 @@
 <?php namespace {{namespace}};
 
-use Illuminate\Routing\Controller;
 use Illuminate\Contracts\Auth\Authenticator;
 
 use {{request.namespace}}Auth\LoginRequest;
 use {{request.namespace}}Auth\RegisterRequest;
 
-class AuthController extends Controller {
+class AuthController {
 
 	/**
 	 * The authenticator implementation.
@@ -25,8 +24,8 @@ class AuthController extends Controller {
 	{
 		$this->auth = $auth;
 
-		$this->beforeFilter('csrf', ['on' => ['post']]);
-		$this->beforeFilter('guest', ['except' => ['getLogout']]);
+		//$this->beforeFilter('csrf', ['on' => ['post']]);
+		//$this->beforeFilter('guest', ['except' => ['getLogout']]);
 	}
 
 	/**

--- a/src/Illuminate/Auth/Console/stubs/controller.stub
+++ b/src/Illuminate/Auth/Console/stubs/controller.stub
@@ -31,6 +31,7 @@ class AuthController {
 	/**
 	 * Show the application registration form.
 	 *
+	 * @Get("auth/register")
 	 * @return Response
 	 */
 	public function getRegister()
@@ -41,6 +42,7 @@ class AuthController {
 	/**
 	 * Handle a registration request for the application.
 	 *
+	 * @Post("auth/register")
 	 * @param  RegisterRequest  $request
 	 * @return Response
 	 */
@@ -56,6 +58,7 @@ class AuthController {
 	/**
 	 * Show the application login form.
 	 *
+	 * @Get("auth/login")
 	 * @return Response
 	 */
 	public function getLogin()
@@ -66,6 +69,7 @@ class AuthController {
 	/**
 	 * Handle a login request to the application.
 	 *
+	 * @Post("auth/login")
 	 * @param  LoginRequest  $request
 	 * @return Response
 	 */
@@ -84,6 +88,7 @@ class AuthController {
 	/**
 	 * Log the user out of the application.
 	 *
+	 * @Get("auth/logout")
 	 * @return Response
 	 */
 	public function getLogout()

--- a/src/Illuminate/Auth/Console/stubs/reminders.controller.stub
+++ b/src/Illuminate/Auth/Console/stubs/reminders.controller.stub
@@ -30,6 +30,7 @@ class {{class}} {
 	/**
 	 * Display the password reminder view.
 	 *
+	 * @Get("password/remind")
 	 * @return Response
 	 */
 	public function getRemind()
@@ -40,6 +41,7 @@ class {{class}} {
 	/**
 	 * Handle a POST request to remind a user of their password.
 	 *
+	 * @Post("password/remind")
 	 * @param  Request  $request
 	 * @return Response
 	 */
@@ -58,6 +60,7 @@ class {{class}} {
 	/**
 	 * Display the password reset view for the given token.
 	 *
+	 * @Get("password/reset")
 	 * @param  string  $token
 	 * @return Response
 	 */
@@ -74,6 +77,7 @@ class {{class}} {
 	/**
 	 * Handle a POST request to reset a user's password.
 	 *
+	 * @Post("password/reset")
 	 * @param  Request  $request
 	 * @return Response
 	 */

--- a/src/Illuminate/Auth/Console/stubs/reminders.controller.stub
+++ b/src/Illuminate/Auth/Console/stubs/reminders.controller.stub
@@ -1,11 +1,10 @@
 <?php namespace {{namespace}};
 
 use Illuminate\Http\Request;
-use Illuminate\Routing\Controller;
 use Illuminate\Contracts\Auth\PasswordBroker;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class {{class}} extends Controller {
+class {{class}} {
 
 	/**
 	 * The password reminder implementation.
@@ -24,8 +23,8 @@ class {{class}} extends Controller {
 	{
 		$this->passwords = $passwords;
 
-		$this->beforeFilter('guest');
-		$this->beforeFilter('csrf', ['on' => ['post']]);
+		//$this->beforeFilter('guest');
+		//$this->beforeFilter('csrf', ['on' => ['post']]);
 	}
 
 	/**


### PR DESCRIPTION
Renaming base branch from https://github.com/laravel/framework/pull/5961

---

The make:auth artisan command was retuning the entire namespace in routing instructions, which caused the application to not work after adding the suggested routes. I removed the $NAMESPACE\Http\Controllers part which was being duplicated.

---

I've commented out controller routing instructions since it does not work as of now.
