### PR TITLE
[5.0] Added Active Helper To The Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1125,6 +1125,17 @@ class Builder {
 	{
 		return $this->orderBy($column, 'asc');
 	}
+	
+	/**
+	 * Add an "where active" clause to the query.
+	 *
+	 * @param  string  $column
+	 * @return \Illuminate\Database\Query\Builder|static
+	 */
+	public function active($column = 'active', $value = '1')
+	{
+		return $this->where($column, $value);
+	}
 
 	/**
 	 * Add a raw "order by" clause to the query.


### PR DESCRIPTION
Added a simple helper to the query builder which would allow to return all active items:

``` php
return $this->model->active()->all();
```
