### PR TITLE
[5.0] Updated controller stubs for make:controller

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/controller.plain.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.plain.stub
@@ -1,8 +1,6 @@
 <?php namespace {{namespace}};
 
-use Illuminate\Routing\Controller;
-
-class {{class}} extends Controller {
+class {{class}} {
 
 	//
 

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -1,8 +1,6 @@
 <?php namespace {{namespace}};
 
-use Illuminate\Routing\Controller;
-
-class {{class}} extends Controller {
+class {{class}} {
 
 	/**
 	 * Display a listing of the resource.


### PR DESCRIPTION
no more have Illuminate\Routing\Controller - no more use
