### PR TITLE
[4.2] Remove Unnecessary Style Attributes

### DIFF
--- a/src/Illuminate/Html/HtmlBuilder.php
+++ b/src/Illuminate/Html/HtmlBuilder.php
@@ -72,7 +72,7 @@ class HtmlBuilder {
 	 */
 	public function style($url, $attributes = array(), $secure = null)
 	{
-		$defaults = array('media' => 'all', 'type' => 'text/css', 'rel' => 'stylesheet');
+		$defaults = array('rel' => 'stylesheet');
 
 		$attributes = $attributes + $defaults;
 


### PR DESCRIPTION
In HTML5, it seems that only rel attribute is necessary.
