### PR TITLE
[4.2] Only Prepending Root For Path Fragments

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -119,7 +119,9 @@ class UrlGenerator {
 		// Once we have the scheme we will compile the "tail" by collapsing the values
 		// into a single string delimited by slashes. This just makes it convenient
 		// for passing the array of parameters to this URL as a list of segments.
-		$root = $this->getRootUrl($scheme);
+		// The root should only be calculated for paths without a leading domain (in this case
+		// looking for http presence)
+		$root = (substr($path, 0, 4) !== 'http' ? $this->getRootUrl($scheme) : '');
 
 		return $this->trimUrl($root, $path, $tail);
 	}

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -13,6 +13,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals('http://www.foo.com/foo/bar', $url->to('foo/bar'));
 		$this->assertEquals('https://www.foo.com/foo/bar', $url->to('foo/bar', array(), true));
+		$this->assertEquals('http://www.foo.com/foo baz/bar', $url->to('http://www.foo.com/foo baz/bar'));
 		$this->assertEquals('https://www.foo.com/foo/bar/baz/boom', $url->to('foo/bar', array('baz', 'boom'), true));
 
 		/**


### PR DESCRIPTION
When a url is passed in that contains spaces the validate function fails and falls through further down the code, however at this point the root is always pre-pended, even when one already exists.

This patch checks the passed in path to make sure it's not a full url:

Example:
http://foo.com/bar baz/file -> http://foo.com/http://foo.com/bar%20baz/file

This is an invalid url, granted, but the behavior currently will convert it to an even less valid one.

I updated the code to check if the $path starts with an 'http' string, if it does then root will be set to an empty string and $path will be left alone in the next step.
