### PR TITLE
[5.0] Push Visible And Hidden Attributes To Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2077,7 +2077,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function addHidden($attributes = null)
 	{
-		if ( ! is_array($attributes)) $attributes = func_get_args();
+		$attributes = is_array($attributes) ? $attributes : func_get_args();
 		
 		$this->hidden = array_merge($this->hidden, $attributes);
 	}
@@ -2111,7 +2111,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function addVisible($attributes = null)
 	{
-		if ( ! is_array($attributes)) $attributes = func_get_args();
+		$attributes = is_array($attributes) ? $attributes : func_get_args();
 		
 		$this->visible = array_merge($this->visible, $attributes);
 	}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2068,6 +2068,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	{
 		$this->hidden = $hidden;
 	}
+	
+	/**
+	 * Add hidden attributes for the model.
+	 *
+	 * @param  array|string|null  $attributes
+	 * @return void
+	 */
+	public function addHidden($attributes = null)
+	{
+		if ( ! is_array($attributes)) $attributes = func_get_args();
+		
+		$this->hidden = array_merge($this->hidden, $attributes);
+	}
 
 	/**
 	 * Set the visible attributes for the model.
@@ -2078,6 +2091,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	public function setVisible(array $visible)
 	{
 		$this->visible = $visible;
+	}
+	
+	/**
+	 * Add visible attributes for the model.
+	 *
+	 * @param  array|string|null  $attributes
+	 * @return void
+	 */
+	public function addVisible($attributes = null)
+	{
+		if ( ! is_array($attributes)) $attributes = func_get_args();
+		
+		$this->visible = array_merge($this->visible, $attributes);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2081,6 +2081,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		
 		$this->hidden = array_merge($this->hidden, $attributes);
 	}
+	
+	/**
+	 * Get the visible attributes for the model.
+	 *
+	 * @return array
+	 */
+	public function getVisible()
+	{
+		return $this->visible;
+	}
 
 	/**
 	 * Set the visible attributes for the model.


### PR DESCRIPTION
Add two methods to push visible and hidden attributes to model. Instead of `setHidden` and `setVisible`, methods `addHidden` and `addVisible` push to the hidden and visible model arrays instead of replacing them entirely.
This makes hiding/showing attributes from controllers easier and avoids having to use `getHidden/getVisible`, merge attributes and then call `setHidden/setVisible`, by just using one method.
