### PR TITLE
If a queue is defined, it is not transfered to connection.

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -215,7 +215,7 @@ class QueueManager {
 	 */
 	public function __call($method, $parameters)
 	{
-		$callable = array($this->connection(), $method);
+		$callable = array($this->connection(isset($parameters[2]) ? $parameters[2] : null), $method);
 
 		return call_user_func_array($callable, $parameters);
 	}


### PR DESCRIPTION
If a queue were defined, the queue name were not transfered to connection, and therefor using the default queue instead.
