### PR TITLE
[5.0] Allow For Per-Deploy Environment Config Overrides

### DIFF
--- a/src/Illuminate/Config/FileLoader.php
+++ b/src/Illuminate/Config/FileLoader.php
@@ -80,11 +80,15 @@ class FileLoader implements LoaderInterface {
 		// Finally we're ready to check for the environment specific configuration
 		// file which will be merged on top of the main arrays so that they get
 		// precedence over them if we are currently in an environments setup.
-		$file = "{$path}/{$environment}/{$group}.php";
+		$file = "{$path}/{$environment}/{$group}";
 
-		if ($this->files->exists($file))
+		if ($this->files->exists("{$file}.local.php"))
 		{
-			$items = $this->mergeEnvironment($items, $file);
+			$items = $this->mergeEnvironment($items, "{$file}.local.php");
+		}
+		else if ($this->files->exists("{$file}.php"))
+		{
+			$items = $this->mergeEnvironment($items, "{$file}.php");
 		}
 
 		return $items;


### PR DESCRIPTION
This is my suggestion to solve #5951.

For local / per-developer / per-installation / per-deploy configs, this allows for adding e.g. a config/developers/mail.local.php. This would not be added to version control. The file would probably contain some mailer API credentials for the current developer. It would only be loaded on his machine if Laravel runs in the "developers" environment.

This is super-simple and it would be a nice built-in workflow for the problems described in #5951.

Thoughts?

---

I realize tests are probably failing, this is just meant to start a discussion. I will fix the tests (and add new ones) and clean up the code a bit once this gets some support.

This will also be accompanied by another PR to laravel/laravel that would add `*.local.php` to a `.gitignore` file in the config directory.
