### PR TITLE
[5.0] Check url as 'A' type record in DNS instead 'MX'

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1165,7 +1165,7 @@ class Validator implements ValidatorContract {
 	{
 		$url = str_replace(array('http://', 'https://', 'ftp://'), '', strtolower($value));
 
-		return checkdnsrr($url);
+		return checkdnsrr($url, 'A');
 	}
 
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -948,6 +948,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 
 		$v = new Validator($trans, array('x' => 'http://google.com'), array('x' => 'active_url'));
 		$this->assertTrue($v->passes());
+		
+		$v = new Validator($trans, array('x' => 'http://www.google.com'), array('x' => 'active_url'));
+		$this->assertTrue($v->passes());		
 	}
 
 


### PR DESCRIPTION
Example,

```
checkdnsrr('www.laravel.com'); // false
but
checkdnsrr('www.laravel.com', 'A'); //true
```
