### PR TITLE
[4.2] Allow morphTo to return many parents instead of just one

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -135,14 +135,28 @@ class MorphTo extends BelongsTo {
 	 */
 	protected function matchToMorphParents($type, Collection $results)
 	{
+		
+		$resultsMap = array();
 		foreach ($results as $result)
 		{
 			if (isset($this->dictionary[$type][$result->getKey()]))
 			{
 				foreach ($this->dictionary[$type][$result->getKey()] as $model)
 				{
-					$model->setRelation($this->relation, $result);
+					$resultsMap[$model->{$this->foreignKey}]['model'] = $model;
+					if (!array_key_exists('results', $resultsMap[$model->{$this->foreignKey}])) {
+						$resultsMap[$model->{$this->foreignKey}]['results'] = array();
+					}
+					array_push($resultsMap[$model->{$this->foreignKey}]['results'], $result);
 				}
+			}
+		}
+		foreach ($resultsMap as $map)
+		{
+			if (sizeof($map['results']) === 1) {
+				$map['model']->setRelation($this->relation, $map['results'][0]);
+			} else {
+				$map['model']->setRelation($this->relation, new Collection($map['results']));
 			}
 		}
 	}


### PR DESCRIPTION
What do you think of this ? For me it allowed to retrieve many parents, instead of just one, without breaking the standard way this was working (it used to return only the last fetched element).

I asked some days ago for a way to do this on stackoverflow, detailed description [here](http://stackoverflow.com/questions/26226124/laravel-straight-morphto-relationship).

If you have questions / ideas to improve, shoot !
