### PR TITLE
[4.2] Fix str_snake way of working

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -285,9 +285,9 @@ class Str {
 	{
 		if (ctype_lower($value)) return $value;
 
-		$replace = '$1'.$delimiter.'$2';
+		$replace = '$1'.$delimiter;
 
-		return strtolower(preg_replace('/(.)([A-Z])/', $replace, $value));
+		return strtolower(preg_replace('/(.)(?=[A-Z])/', $replace, $value));
 	}
 
 	/**


### PR DESCRIPTION
Old method converts 'ABCool' to 'a-bcool', after repair will be converted to 'a-b-cool'
