### PR TITLE
[4.2] Allows Redis Queue To Use User Defined Connections

### DIFF
--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -40,7 +40,9 @@ class RedisConnector implements ConnectorInterface {
 	 */
 	public function connect(array $config)
 	{
-		return new RedisQueue($this->redis, $config['queue'], $this->connection);
+		$connection = isset($config['connection']) ? $config['connection'] : $this->connection);
+
+		return new RedisQueue($this->redis, $config['queue'], $connection);
 	}
 
 }

--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -40,7 +40,7 @@ class RedisConnector implements ConnectorInterface {
 	 */
 	public function connect(array $config)
 	{
-		$connection = isset($config['connection']) ? $config['connection'] : $this->connection);
+		$connection = array_get($config, 'connection', $this->connection);
 
 		return new RedisQueue($this->redis, $config['queue'], $connection);
 	}

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -14,6 +14,7 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 	{
 		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getRandomId'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
 		$queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
+		$redis->shouldReceive('connection')->once()->andReturn($redis);
 		$redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(array('job' => 'foo', 'data' => array('data'), 'id' => 'foo', 'attempts' => 1)));
 
 		$id = $queue->push('foo', array('data'));
@@ -28,6 +29,7 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 		$queue->expects($this->once())->method('getSeconds')->with(1)->will($this->returnValue(1));
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
 
+		$redis->shouldReceive('connection')->once()->andReturn($redis);
 		$redis->shouldReceive('zadd')->once()->with(
 			'queues:default:delayed',
 			2,
@@ -47,6 +49,7 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 		$queue->expects($this->once())->method('getSeconds')->with($date)->will($this->returnValue(1));
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
 
+		$redis->shouldReceive('connection')->once()->andReturn($redis);
 		$redis->shouldReceive('zadd')->once()->with(
 			'queues:default:delayed',
 			2,
@@ -63,6 +66,8 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 		$queue->setContainer(m::mock('Illuminate\Container\Container'));
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
 		$queue->expects($this->once())->method('migrateAllExpiredJobs')->with($this->equalTo('queues:default'));
+
+		$redis->shouldReceive('connection')->andReturn($redis);
 		$redis->shouldReceive('lpop')->once()->with('queues:default')->andReturn('foo');
 		$redis->shouldReceive('zadd')->once()->with('queues:default:reserved', 61, 'foo');
 
@@ -76,6 +81,7 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 	{
 		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
+		$redis->shouldReceive('connection')->once()->andReturn($redis);
 		$redis->shouldReceive('zadd')->once()->with('queues:default:delayed', 2, json_encode(array('attempts' => 2)));
 
 		$queue->release('default', json_encode(array('attempts' => 1)), 1, 2);
@@ -87,6 +93,7 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
 		$transaction = m::mock('StdClass');
+		$redis->shouldReceive('connection')->once()->andReturn($redis);
 		$redis->shouldReceive('transaction')->with(m::any(), m::type('Closure'))->andReturnUsing(function($options, $callback) use ($transaction)
 		{
 			$callback($transaction);


### PR DESCRIPTION
Laravel has fantastic support for variety of queues out of the box. But in case of Redis queues, there was no support to use a connection other than the 'default' one (those defined in `database.php` config file).

In production, application of considerable size would prefer to use a totally separate box of Redis for queues (to keep the good performance of cache and queues). This pull request allows users to define which connection to use for Redis queue in the `queue.php` config file, like so:

``` php
'redis' => array(
    'driver' => 'redis',
    'connection' => 'default', // <------- new attribute here
    'queue'  => 'default',
),
```

Then, the `Illuminate/Queue/Connectors/RedisConnector.php` passes this new attribute in the constructor of `Illuminate\Queue\RedisQueue.php` (yes, we are first checking if the new attribute exists or not) . And instead of directly using `$this->redis` in the `RedisQueue.php`, we are now using `$this->getConnection()` method which has the following definition:

``` php
/**
 * Get the connection for the queue.
 *
 * @return \Predis\ClientInterface
 */
protected function getConnection()
{
    return $this->redis->connection($this->connection);
}
```

The test are also fixed and everything is working fine.
