### PR TITLE
[4.2] Don't Double Escape In Form::option()

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -543,7 +543,7 @@ class FormBuilder {
 	{
 		$selected = $this->getSelectedValue($value, $selected);
 
-		$options = array('value' => e($value), 'selected' => $selected);
+		$options = array('value' => $value, 'selected' => $selected);
 
 		return '<option'.$this->html->attributes($options).'>'.e($display).'</option>';
 	}


### PR DESCRIPTION
The html->attributes() below already does the escaping.

Let us not depend on the double escaping protection mechanism.
