### PR TITLE
[5.0] Add A Service Provider Contract

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -22,10 +22,10 @@ interface Application extends Container {
 	/**
 	 * Register a service provider with the application.
 	 *
-	 * @param  \Illuminate\Support\ServiceProvider|string  $provider
+	 * @param  \Illuminate\Contracts\Support\ServiceProvider|string  $provider
 	 * @param  array  $options
 	 * @param  bool   $force
-	 * @return \Illuminate\Support\ServiceProvider
+	 * @return \Illuminate\Contracts\Support\ServiceProvider
 	 */
 	public function register($provider, $options = array(), $force = false);
 

--- a/src/Illuminate/Contracts/Support/ServiceProvider.php
+++ b/src/Illuminate/Contracts/Support/ServiceProvider.php
@@ -1,0 +1,12 @@
+<?php namespace Illuminate\Contracts\Support;
+
+interface ServiceProvider {
+
+	/**
+	 * Register the service provider.
+	 *
+	 * @return void
+	 */
+	public function register();
+
+}

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -8,9 +8,9 @@ use Illuminate\Config\FileLoader;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Events\EventServiceProvider;
 use Illuminate\Routing\RoutingServiceProvider;
+use Illuminate\Contracts\Support\ServiceProvider;
 use Illuminate\Contracts\Support\ResponsePreparer;
 use Illuminate\Exception\ExceptionServiceProvider;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -286,9 +286,9 @@ class Application extends Container implements HttpKernelInterface,
 	/**
 	 * Force register a service provider with the application.
 	 *
-	 * @param  \Illuminate\Support\ServiceProvider|string  $provider
+	 * @param  \Illuminate\Contracts\Support\ServiceProvider|string  $provider
 	 * @param  array  $options
-	 * @return \Illuminate\Support\ServiceProvider
+	 * @return \Illuminate\Contracts\Support\ServiceProvider
 	 */
 	public function forceRegister($provider, $options = array())
 	{
@@ -298,10 +298,10 @@ class Application extends Container implements HttpKernelInterface,
 	/**
 	 * Register a service provider with the application.
 	 *
-	 * @param  \Illuminate\Support\ServiceProvider|string  $provider
+	 * @param  \Illuminate\Contracts\Support\ServiceProvider|string  $provider
 	 * @param  array  $options
 	 * @param  bool   $force
-	 * @return \Illuminate\Support\ServiceProvider
+	 * @return \Illuminate\Contracts\Support\ServiceProvider
 	 */
 	public function register($provider, $options = array(), $force = false)
 	{
@@ -316,7 +316,7 @@ class Application extends Container implements HttpKernelInterface,
 			$provider = $this->resolveProviderClass($provider);
 		}
 
-		$provider->register();
+		$this->call([$provider, 'register']);
 
 		// Once we have registered the service we will iterate through the options
 		// and set each of them on the application so they will be available on
@@ -342,8 +342,8 @@ class Application extends Container implements HttpKernelInterface,
 	/**
 	 * Get the registered service provider instance if it exists.
 	 *
-	 * @param  \Illuminate\Support\ServiceProvider|string  $provider
-	 * @return \Illuminate\Support\ServiceProvider|null
+	 * @param  \Illuminate\Contracts\Support\ServiceProvider|string  $provider
+	 * @return \Illuminate\Contracts\Support\ServiceProvider|null
 	 */
 	public function getRegistered($provider)
 	{
@@ -362,7 +362,7 @@ class Application extends Container implements HttpKernelInterface,
 	 * Resolve a service provider instance from the class name.
 	 *
 	 * @param  string  $provider
-	 * @return \Illuminate\Support\ServiceProvider
+	 * @return \Illuminate\Contracts\Support\ServiceProvider
 	 */
 	public function resolveProviderClass($provider)
 	{
@@ -372,7 +372,7 @@ class Application extends Container implements HttpKernelInterface,
 	/**
 	 * Mark the given provider as registered.
 	 *
-	 * @param  \Illuminate\Support\ServiceProvider
+	 * @param  \Illuminate\Contracts\Support\ServiceProvider
 	 * @return void
 	 */
 	protected function markAsRegistered($provider)
@@ -614,7 +614,7 @@ class Application extends Container implements HttpKernelInterface,
 	/**
 	 * Boot the given service provider.
 	 *
-	 * @param  \Illuminate\Support\ServiceProvider  $provider
+	 * @param  \Illuminate\Contracts\Support\ServiceProvider  $provider
 	 * @return void
 	 */
 	protected function bootProvider(ServiceProvider $provider)

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -150,7 +150,7 @@ class ProviderRepository {
 	 *
 	 * @param  \Illuminate\Foundation\Application  $app
 	 * @param  string  $provider
-	 * @return \Illuminate\Support\ServiceProvider
+	 * @return \Illuminate\Contracts\Support\ServiceProvider
 	 */
 	public function createProvider(Application $app, $provider)
 	{

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -1,8 +1,9 @@
 <?php namespace Illuminate\Support;
 
+use Illuminate\Contracts\Support\ServiceProvider as ServiceProviderContract;
 use ReflectionClass;
 
-abstract class ServiceProvider {
+abstract class ServiceProvider implements ServiceProviderContract {
 
 	/**
 	 * The application instance.

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -30,10 +30,17 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 		$provider = m::mock('Illuminate\Support\ServiceProvider');
 		$class = get_class($provider);
 		$provider->shouldReceive('register')->once();
+
+		$contractProvider = m::mock('Illuminate\Contracts\Support\ServiceProvider');
+		$contractClass = get_class($contractProvider);
+		$contractProvider->shouldReceive('register')->once();
+
 		$app = new Application;
 		$app->register($provider);
+		$app->register($contractProvider);
 
 		$this->assertTrue(in_array($class, $app->getLoadedProviders()));
+		$this->assertTrue(in_array($contractClass, $app->getLoadedProviders()));
 	}
 
 


### PR DESCRIPTION
Allows service providers that do not extend `Support\ServiceProvider` but instead implement the contract, in the spirit of the new Contracts package.
- new ServiceProvider contract
- Foundation\Application typehints on the new contract
- call `$provider->register()` is now resolved using `->call()`
