### PR TITLE
[4.2] Added A File::name() Function

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -138,6 +138,17 @@ class Filesystem {
 	{
 		return copy($path, $target);
 	}
+	
+	/**
+	 * Extract the file name from a file path.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	public function name($path)
+	{
+		return pathinfo($path, PATHINFO_FILENAME);
+	}
 
 	/**
 	 * Extract the file extension from a file path.


### PR DESCRIPTION
This would be handy I think.
This retrieve the name of the file without the extension as we already have File::extension().
