### PR TITLE
[5.0] Make Openssl And Mcrypt Required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-openssl": "*",
+        "ext-mcrypt": "*",
         "classpreloader/classpreloader": "~1.0.2",
         "d11wtq/boris": "~1.0",
         "doctrine/annotations": "~1.0",

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -159,11 +159,6 @@ class Encrypter implements EncrypterContract {
 	 */
 	protected function validMac(array $payload)
 	{
-		if ( ! function_exists('openssl_random_pseudo_bytes'))
-		{
-			throw new \RuntimeException('OpenSSL extension is required.');
-		}
-
 		$bytes = (new SecureRandom)->nextBytes(16);
 
 		$calcMac = hash_hmac('sha256', $this->hash($payload['iv'], $payload['value']), $bytes, true);

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -9,6 +9,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-openssl": "*",
         "illuminate/contracts": "5.0.*",
         "illuminate/support": "5.0.*",
         "symfony/security-core": "2.6.*"


### PR DESCRIPTION
This is a perfect time to make this change because composer won't be able to go an install and older version of laravel 5 because this would be included in the first 5.0.0 tag.
