### PR TITLE
[5.0] Allow Stability To Be Passed To Workbench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 .DS_Store
 Thumbs.db
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ composer.phar
 composer.lock
 .DS_Store
 Thumbs.db
-/.idea

--- a/src/Illuminate/Workbench/Console/WorkbenchMakeCommand.php
+++ b/src/Illuminate/Workbench/Console/WorkbenchMakeCommand.php
@@ -102,7 +102,7 @@ class WorkbenchMakeCommand extends Command {
 			throw new \UnexpectedValueException("Please set the author's email in the workbench configuration file.");
 		}
 
-		return new Package($vendor, $name, $config['name'], $config['email']);
+		return new Package($vendor, $name, $config['name'], $config['email'], $config['stability']);
 	}
 
 	/**

--- a/src/Illuminate/Workbench/Package.php
+++ b/src/Illuminate/Workbench/Package.php
@@ -44,24 +44,32 @@ class Package {
 	 */
 	public $email;
 
-	/**
-	 * Create a new package instance.
-	 *
-	 * @param  string  $vendor
-	 * @param  string  $name
-	 * @param  string  $author
-	 * @param  string  $email
-	 * @return void
-	 */
-	public function __construct($vendor, $name, $author, $email)
-	{
-		$this->name = $name;
-		$this->email = $email;
-		$this->vendor = $vendor;
-		$this->author = $author;
-		$this->lowerName = snake_case($name, '-');
-		$this->lowerVendor = snake_case($vendor, '-');
-	}
+    /**
+     * The stability choice.
+     *
+     * @var string
+     */
+    public $stability;
+
+    /**
+     * Create a new package instance.
+     *
+     * @param  string $vendor
+     * @param  string $name
+     * @param  string $author
+     * @param  string $email
+     * @param  string $stability
+     */
+    public function __construct($vendor, $name, $author, $email, $stability = 'stable')
+    {
+        $this->name = $name;
+        $this->email = $email;
+        $this->vendor = $vendor;
+        $this->author = $author;
+        $this->stability = $stability;
+        $this->lowerName = snake_case($name, '-');
+        $this->lowerVendor = snake_case($vendor, '-');
+    }
 
 	/**
 	 * Get the full package name.

--- a/src/Illuminate/Workbench/stubs/composer.json
+++ b/src/Illuminate/Workbench/stubs/composer.json
@@ -19,5 +19,5 @@
             "{{vendor}}\\{{name}}\\": "src/"
         }
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "{{stability}}"
 }

--- a/src/Illuminate/Workbench/stubs/plain.composer.json
+++ b/src/Illuminate/Workbench/stubs/plain.composer.json
@@ -16,5 +16,5 @@
             "{{vendor}}\\{{name}}": "src/"
         }
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "{{stability}}"
 }


### PR DESCRIPTION
As a Developer
When working on a dev version of Laravel and making a Laravel Package using workbench 
I would like to still use php artisan workbench without getting the error that matching stability level not found so I can continue making Laravel packages for a project even when using a dev version of Laravel

---

This way Workbench allows the stability option and more importantly continues to work when 
in transitions like L4 to L5.
