### PR TITLE
[5.0] Fixed Commands On HHVM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "nesbot/carbon": "~1.0",
         "patchwork/utf8": "~1.1",
         "predis/predis": "~1.0",
+        "sebastian/environment": "~1.0",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/console": "2.6.*",
         "symfony/debug": "2.6.*",

--- a/src/Illuminate/Foundation/Composer.php
+++ b/src/Illuminate/Foundation/Composer.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
+use SebastianBergmann\Environment\Runtime;
 
 class Composer {
 
@@ -11,6 +12,13 @@ class Composer {
 	 * @var \Illuminate\Filesystem\Filesystem
 	 */
 	protected $files;
+
+	/**
+	 * The runtime instance.
+	 *
+	 * @var \SebastianBergmann\Environment\Runtime
+	 */
+	protected $runtime;
 
 	/**
 	 * The working path to regenerate from.
@@ -23,12 +31,14 @@ class Composer {
 	 * Create a new Composer manager instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \SebastianBergmann\Environment\Runtime  $runtime
 	 * @param  string  $workingPath
 	 * @return void
 	 */
-	public function __construct(Filesystem $files, $workingPath = null)
+	public function __construct(Filesystem $files, Runtime $runtime, $workingPath = null)
 	{
 		$this->files = $files;
+		$this->runtime = $runtime;
 		$this->workingPath = $workingPath;
 	}
 
@@ -66,7 +76,7 @@ class Composer {
 	{
 		if ($this->files->exists($this->workingPath.'/composer.phar'))
 		{
-			return '"'.PHP_BINARY.'" composer.phar';
+			return $this->runtime->getBinary().' composer.phar';
 		}
 
 		return 'composer';

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use SebastianBergmann\Environment\Runtime;
 use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\ServeCommand;
@@ -276,7 +277,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	{
 		$this->app->singleton('command.serve', function()
 		{
-			return new ServeCommand;
+			return new ServeCommand(new Runtime);
 		});
 	}
 

--- a/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Foundation\Composer;
 use Illuminate\Support\ServiceProvider;
+use SebastianBergmann\Environment\Runtime;
 use Illuminate\Foundation\Console\AutoloadCommand;
 
 class ComposerServiceProvider extends ServiceProvider {
@@ -22,7 +23,7 @@ class ComposerServiceProvider extends ServiceProvider {
 	{
 		$this->app->singleton('composer', function($app)
 		{
-			return new Composer($app['files'], $app['path.base']);
+			return new Composer($app['files'], new Runtime, $app['path.base']);
 		});
 
 		$this->app->singleton('command.dump-autoload', function($app)

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -27,7 +27,6 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase {
 	public function testDumpAutoloadRunsTheCorrectCommandWhenComposerIsntPresent()
 	{
 		$composer = $this->getMock('Illuminate\Foundation\Composer', array('getProcess'), array($files = m::mock('Illuminate\Filesystem\Filesystem'), new Runtime, __DIR__));
-
 		$files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(false);
 		$process = m::mock('stdClass');
 		$composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use SebastianBergmann\Environment\Runtime;
 
 class FoundationComposerTest extends PHPUnit_Framework_TestCase {
 
@@ -12,11 +13,11 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase {
 
 	public function testDumpAutoloadRunsTheCorrectCommand()
 	{
-		$composer = $this->getMock('Illuminate\Foundation\Composer', array('getProcess'), array($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__));
+		$composer = $this->getMock('Illuminate\Foundation\Composer', array('getProcess'), array($files = m::mock('Illuminate\Filesystem\Filesystem'), $runtime = new Runtime, __DIR__));
 		$files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
 		$process = m::mock('stdClass');
 		$composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
-		$process->shouldReceive('setCommandLine')->once()->with('"'.PHP_BINARY.'" composer.phar dump-autoload');
+		$process->shouldReceive('setCommandLine')->once()->with($runtime->getBinary().' composer.phar dump-autoload');
 		$process->shouldReceive('run')->once();
 
 		$composer->dumpAutoloads();
@@ -25,7 +26,8 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase {
 
 	public function testDumpAutoloadRunsTheCorrectCommandWhenComposerIsntPresent()
 	{
-		$composer = $this->getMock('Illuminate\Foundation\Composer', array('getProcess'), array($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__));
+		$composer = $this->getMock('Illuminate\Foundation\Composer', array('getProcess'), array($files = m::mock('Illuminate\Filesystem\Filesystem'), new Runtime, __DIR__));
+
 		$files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(false);
 		$process = m::mock('stdClass');
 		$composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));


### PR DESCRIPTION
This fixes running artisan serve and a few other commands on hhvm. In particular, in the artisan serve command, I've removed the old redundant "are we php 5.4?" check, and replaced it with an "are we hhvm" check? This also provides a more robust way of getting the php binary path.
