### PR TITLE
[4.2] Skip Database Validation If Attribute Has Already Failed

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -415,7 +415,8 @@ class Validator implements MessageProviderInterface {
 
 	/**
 	 * Determine if it's a necessary presence validation.
-	 * It's unneccesary if any validation for the attribute has already failed
+	 *
+	 * It's unneccesary if any validation for the attribute has already failed.
 	 *
 	 * @param  string  $rule
 	 * @param  string  $attribute
@@ -431,6 +432,7 @@ class Validator implements MessageProviderInterface {
 			// in the database to avoid exceptions
 			return ! $this->messages->has($attribute);
 		}
+
 		return true;
 	}
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -368,7 +368,8 @@ class Validator implements MessageProviderInterface {
 	protected function isValidatable($rule, $attribute, $value)
 	{
 		return $this->presentOrRuleIsImplicit($rule, $attribute, $value) &&
-               $this->passesOptionalCheck($attribute);
+               $this->passesOptionalCheck($attribute) &&
+               $this->presenceValidationAndRequired($rule, $attribute);
 	}
 
 	/**
@@ -410,6 +411,27 @@ class Validator implements MessageProviderInterface {
 	protected function isImplicit($rule)
 	{
 		return in_array($rule, $this->implicitRules);
+	}
+
+	/**
+	 * Determine if it's a necessary presence validation.
+	 * It's unneccesary if any validation for the attribute has already failed
+	 *
+	 * @param  string  $rule
+	 * @param  string  $attribute
+	 * @return bool
+	 */
+	protected function presenceValidationAndRequired($rule, $attribute)
+	{
+		$presenceValidations = array('Unique', 'Exists');
+
+		if (in_array($rule, $presenceValidations))
+		{
+			// if validation has already failed for the attribute we'll skip the validation
+			// in the database to avoid exceptions
+			return ! $this->messages->has($attribute);
+		}
+		return true;
 	}
 
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -876,6 +876,23 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($v->passes());
 	}
 
+	public function testValidationExistsIsNotCalledUnnecessarily()
+	{
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('id' => 'foo'), array('id' => 'Integer|Exists:users,id'));
+		$mock2 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+		$mock2->shouldReceive('getCount')->never();
+		$v->setPresenceVerifier($mock2);
+		$this->assertFalse($v->passes());
+
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('id' => '1'), array('id' => 'Integer|Exists:users,id'));
+		$mock2 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+		$mock2->shouldReceive('getCount')->once()->with('users', 'id', '1', null, null, array())->andReturn(true);
+		$v->setPresenceVerifier($mock2);
+		$this->assertTrue($v->passes());
+	}
+
 
 	public function testValidateIp()
 	{


### PR DESCRIPTION
Related to [#6048](https://github.com/laravel/framework/issues/6048)

In Postgres the existence validation raises an exception when comparing a string agains an integer column. This commits skips the database validator when the attribute has already failed, avoiding the exception.
