### PR TITLE
[4.2] Allows Developer To Specify Connection To Use For Cache

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -89,7 +89,11 @@ class CacheManager extends Manager {
 	{
 		$redis = $this->app['redis'];
 
-		return $this->repository(new RedisStore($redis, $this->getPrefix()));
+		// We allow the developer to specify which connection should be used
+		// to store the cached items.
+		$connection = $this->app['config']['cache.connection'];
+
+		return $this->repository(new RedisStore($redis, $this->getPrefix(), $connection));
 	}
 
 	/**


### PR DESCRIPTION
Laravel allows developer to specify connection to be used by cache when using Database Driver. But, the same can be true for Redis Driver as well. In production, a good app will use a separate Redis server for cache from those used by some other things, say Queues (https://github.com/laravel/framework/pull/6035).

This pull request re-uses the `connection` option in `cache.php` config file (which was used by Database driver) to specify the connection for Redis driver as well.
