### PR TITLE
[5.0] Add Subject To Password Email

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -110,6 +110,8 @@ class PasswordBroker implements PasswordBrokerContract {
 		return $this->mailer->send($view, compact('token', 'user'), function($m) use ($user, $token, $callback)
 		{
 			$m->to($user->getEmailForPasswordReset());
+			
+			$m->subject('Password Reset');
 
 			if ( ! is_null($callback)) call_user_func($callback, $m, $user, $token);
 		});


### PR DESCRIPTION
On Laravel5 there is no password email subject set when the email is sent.

This will set an email subject header.
