### PR TITLE
[5.0] Updated Form Validation Fail HTTP Response Code

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -143,7 +143,7 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	{
 		if ($this->ajax())
 		{
-			return new JsonResponse($errors, 422);
+			return new JsonResponse($errors, 400);
 		}
 		else
 		{


### PR DESCRIPTION
Updated form validation fail http response code to 400 instead of 422
looking at [the description of 422](https://tools.ietf.org/html/rfc4918#section-11.2)
