### PR TITLE
[4.2] Fixed A Pluralization Bug

### DIFF
--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -170,6 +170,8 @@ class Pluralizer {
 	{
 		if ($count == 1) return $value;
 
+		if (in_array($value, static::$irregular)) return $value;
+
 		// First we'll check the cache of inflected values. We cache each word that
 		// is inflected so we don't have to spin through the regular expressions
 		// on each subsequent method calls for this word by the app developer.

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -41,4 +41,11 @@ class SupportPluralizerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('VertexFields', str_plural('VertexField'));
 	}
 
+	public function testAlreadyPluralizedIrregularWords()
+	{
+		$this->assertEquals('children', str_plural('children'));
+		$this->assertEquals('radii', str_plural('radii'));
+		$this->assertEquals('teeth', str_plural('teeth'));
+	}
+
 }


### PR DESCRIPTION
Fix a bug which caused irregular plural words to have an S appended when passed to Pluralizer::plural. This bug occurs if one of the irregular words are passed to Pluralizer::plural. Example:

``` php
echo str_plural('children');
```

Would print _childrens_.
