### PR TITLE
[4.2] Fix Problems When Soft-Deleting A JOIN Request

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -65,7 +65,7 @@ class SoftDeletingScope implements ScopeInterface {
 
 		$builder->onDelete(function(Builder $builder)
 		{
-			$column = $builder->getModel()->getDeletedAtColumn();
+			$column = $builder->getModel()->getQualifiedDeletedAtColumn();
 
 			return $builder->update(array(
 				$column => $builder->getModel()->freshTimestampString()


### PR DESCRIPTION
I had "SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'deleted_at' in field list is ambiguous"
cause I was deleting a request that contains JOIN(s) elements.
