### PR TITLE
[5.0] Made Openssl Required For Str:random()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -186,19 +186,17 @@ class Str {
 	 */
 	public static function random($length = 16)
 	{
-		if (function_exists('openssl_random_pseudo_bytes'))
+		if ( ! function_exists('openssl_random_pseudo_bytes'))
 		{
-			$bytes = openssl_random_pseudo_bytes($length * 2);
-
-			if ($bytes === false)
-			{
-				throw new \RuntimeException('Unable to generate random string.');
-			}
-
-			return substr(str_replace(array('/', '+', '='), '', base64_encode($bytes)), 0, $length);
+			throw new \RuntimeException('OpenSSL extension is required.');
 		}
 
-		return static::quickRandom($length);
+		if ($bytes = openssl_random_pseudo_bytes($length * 2) === false)
+		{
+			throw new \RuntimeException('Unable to generate random string.');
+		}
+
+		return substr(str_replace(array('/', '+', '='), '', base64_encode($bytes)), 0, $length);
 	}
 
 	/**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -191,7 +191,9 @@ class Str {
 			throw new \RuntimeException('OpenSSL extension is required.');
 		}
 
-		if ($bytes = openssl_random_pseudo_bytes($length * 2) === false)
+		$bytes = openssl_random_pseudo_bytes($length * 2);
+
+		if ($bytes === false)
 		{
 			throw new \RuntimeException('Unable to generate random string.');
 		}


### PR DESCRIPTION
Since `ext-openssl` is now a hard requirement in laravel 5, I suggest we tighten up the Str::random() function in laravel 5, and make if fail if we don't have the extension (ie, if someone is using illuminate/support as a stand alone package), rather than falling back to a very poor alternative random function.
