### PR TITLE
[4.2] Remove % From filenameFallback In Response::download

### DIFF
--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -103,7 +103,7 @@ class Response {
 
 		if ( ! is_null($name))
 		{
-			return $response->setContentDisposition($disposition, $name, Str::ascii($name));
+			return $response->setContentDisposition($disposition, $name, str_replace('%', '', Str::ascii($name)));
 		}
 
 		return $response;


### PR DESCRIPTION
The filename fallback is turned to ASCII, because only ASCII is allowed. But there are 2 more checks:
- check for `%` in the fallback
- check for slashes in the filename and the fallback.

(See https://github.com/symfony/symfony/blob/v2.5.5/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php#L264-L277)

I think we can skip the slashes, because they are also checked in the filename itself. But we should probably remove the % sign. Downloads work when files have a `%` in them, just the fallback doesn't.

I propose removing the % from the fallback.
