### PR TITLE
[5.0] Improved The Str::snake Function

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -279,17 +279,13 @@ class Str {
 	 *
 	 * @param  string  $value
 	 * @param  string  $delimiter
-	 * @param  bool    $each
 	 * @return string
 	 */
-	public static function snake($value, $delimiter = '_', $each = true)
+	public static function snake($value, $delimiter = '_')
 	{
 		if (ctype_lower($value)) return $value;
 
-		$replace = $each ? '$1'.$delimiter : '$1'.$delimiter.'$2';
-		$pattern = $each ? '/(.)(?=[A-Z])/' : '/(.)([A-Z]+)/';
-
-		return strtolower(preg_replace($pattern, $replace, $value));
+		return strtolower(preg_replace('/(.)(?=[A-Z])/', '$1'.$delimiter, $value));
 	}
 
 	/**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -279,15 +279,17 @@ class Str {
 	 *
 	 * @param  string  $value
 	 * @param  string  $delimiter
+	 * @param  bool    $each
 	 * @return string
 	 */
-	public static function snake($value, $delimiter = '_')
+	public static function snake($value, $delimiter = '_', $each = true)
 	{
 		if (ctype_lower($value)) return $value;
 
-		$replace = '$1'.$delimiter.'$2';
+		$replace = $each ? '$1'.$delimiter : '$1'.$delimiter.'$2';
+		$pattern = $each ? '/(.)(?=[A-Z])/' : '/(.)([A-Z]+)/';
 
-		return strtolower(preg_replace('/(.)([A-Z])/', $replace, $value));
+		return strtolower(preg_replace($pattern, $replace, $value));
 	}
 
 	/**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -152,7 +152,7 @@ class SupportStrTest extends PHPUnit_Framework_TestCase {
 	public function testSnake()
 	{
 		$this->assertEquals('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));
-		$this->assertEquals('laravel-phpframework', Str::snake('LaravelPHPFramework', '-', false));
+		$this->assertEquals('laravel_php_framework', Str::snake('LaravelPhpFramework'));
 	}
 
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -149,4 +149,10 @@ class SupportStrTest extends PHPUnit_Framework_TestCase {
 		$this->assertInternalType('string', Str::random());
 	}
 
+	public function testSnake()
+	{
+		$this->assertEquals('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));
+		$this->assertEquals('laravel-phpframework', Str::snake('LaravelPHPFramework', '-', false));
+	}
+
 }


### PR DESCRIPTION
The old way of snake function dealing with continuous capital letters is wrong:

``` php
$string = 'LaravelPHPFramework';
echo Str::snake($string);  // Output content: "laravel_ph_pframework"
```

After repair:

``` php
$string = 'LaravelPHPFramework';
echo Str::snake($string);  // Output content: "laravel_p_h_p_framework"
echo Str::snake($string, '_', false);  // Output content: "laravel_phpframework"
``
I think it can make the "LaravelPHPFramework" converted to "laravel_php_framework", But will make this function is not so simple.
```
