### PR TITLE
[4.2] Abstraction Of Session Expiration

### DIFF
--- a/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Cache\Repository;
 
-class CacheBasedSessionHandler implements \SessionHandlerInterface {
+class CacheBasedSessionHandler extends ExpirationAwareSessionHandler {
 
 	/**
 	 * The cache repository instance.
@@ -12,23 +12,14 @@ class CacheBasedSessionHandler implements \SessionHandlerInterface {
 	protected $cache;
 
 	/**
-	 * The number of minutes to store the data in the cache.
-	 *
-	 * @var int
-	 */
-	protected $minutes;
-
-	/**
 	 * Create a new cache driven handler instance.
 	 *
 	 * @param  \Illuminate\Cache\Repository  $cache
-	 * @param  int  $minutes
 	 * @return void
 	 */
-	public function __construct(Repository $cache, $minutes)
+	public function __construct(Repository $cache)
 	{
 		$this->cache = $cache;
-		$this->minutes = $minutes;
 	}
 
 	/**
@@ -60,7 +51,7 @@ class CacheBasedSessionHandler implements \SessionHandlerInterface {
 	 */
 	public function write($sessionId, $data)
 	{
-		return $this->cache->put($sessionId, $data, $this->minutes);
+		return $this->cache->put($sessionId, $data, $this->lifetime);
 	}
 
 	/**

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -3,7 +3,7 @@
 use Illuminate\Cookie\CookieJar;
 use Symfony\Component\HttpFoundation\Request;
 
-class CookieSessionHandler implements \SessionHandlerInterface {
+class CookieSessionHandler extends ExpirationAwareSessionHandler {
 
 	/**
 	 * The cookie jar instance.
@@ -23,13 +23,11 @@ class CookieSessionHandler implements \SessionHandlerInterface {
 	 * Create a new cookie driven handler instance.
 	 *
 	 * @param  \Illuminate\Cookie\CookieJar  $cookie
-	 * @param  int  $minutes
 	 * @return void
 	 */
-	public function __construct(CookieJar $cookie, $minutes)
+	public function __construct(CookieJar $cookie)
 	{
 		$this->cookie = $cookie;
-		$this->minutes = $minutes;
 	}
 
 	/**
@@ -61,7 +59,7 @@ class CookieSessionHandler implements \SessionHandlerInterface {
 	 */
 	public function write($sessionId, $data)
 	{
-		$this->cookie->queue($sessionId, $data, $this->minutes);
+		$this->cookie->queue($sessionId, $data, $this->lifetime);
 	}
 
 	/**

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Database\Connection;
 
-class DatabaseSessionHandler implements \SessionHandlerInterface, ExistenceAwareInterface {
+class DatabaseSessionHandler extends ExpirationAwareSessionHandler implements ExistenceAwareInterface {
 
 	/**
 	 * The database connection instance.
@@ -59,14 +59,27 @@ class DatabaseSessionHandler implements \SessionHandlerInterface, ExistenceAware
 	 */
 	public function read($sessionId)
 	{
-		$session = (object) $this->getQuery()->find($sessionId);
+        // Unless we identify otherwise, this is a new session
+        $this->exists = false;
 
-		if (isset($session->payload))
-		{
-			$this->exists = true;
+        // Get the session from the database
+        $session = $this->getQuery()->find($sessionId);
 
-			return base64_decode($session->payload);
-		}
+        // If the session is null, no data
+        if (is_null($session)) {
+            return;
+        }
+
+        // Delete the session if it's still in the database but it has expired
+        if ($session->last_activity <= time() - ($this->lifetime * 60)) {
+            $this->destroy($sessionId);
+            return;
+        }
+
+        // This is a new session
+        $this->exists = true;
+
+        return base64_decode($session->payload);
 	}
 
 	/**

--- a/src/Illuminate/Session/ExpirationAwareInterface.php
+++ b/src/Illuminate/Session/ExpirationAwareInterface.php
@@ -1,0 +1,26 @@
+<?php namespace Illuminate\Session;
+
+interface ExpirationAwareInterface {
+
+    /**
+     * Get the expiration time of session data in minutes
+     *
+     * @return int
+     */
+    public function getLifetime();
+
+    /**
+     * Set the expiration time of session data in minutes
+     *
+     * @param  int   $lifetime
+     * @return int
+     */
+    public function setLifetime($lifetime);
+
+    /**
+     * Runs the garbage collector using the minutes set in the lifetime
+     *
+     * @return bool
+     */
+    public function garbageCollect();
+}

--- a/src/Illuminate/Session/ExpirationAwareSessionHandler.php
+++ b/src/Illuminate/Session/ExpirationAwareSessionHandler.php
@@ -1,0 +1,34 @@
+<?php namespace Illuminate\Session;
+
+use SessionHandlerInterface;
+
+abstract class ExpirationAwareSessionHandler implements SessionHandlerInterface, ExpirationAwareInterface {
+    
+    /**
+     * The total number of minutes that a session is valid for
+     *
+     * @var int
+     */
+    protected $lifetime;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setLifetime($lifetime) {
+        $this->lifetime = $lifetime;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getLifetime() {
+        return $this->lifetime;
+    }
+
+    /**
+     * Runs the garbage collection (gc) method using $lifetime
+     */
+    public function garbageCollect() {
+        return $this->gc($this->lifetime * 60);
+    }
+}

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -23,7 +23,7 @@ class SessionManager extends Manager {
 	 */
 	protected function createArrayDriver()
 	{
-		return new Store($this->app['config']['session.cookie'], new NullSessionHandler);
+		return $this->buildSession(new NullSessionHandler);
 	}
 
 	/**
@@ -33,9 +33,7 @@ class SessionManager extends Manager {
 	 */
 	protected function createCookieDriver()
 	{
-		$lifetime = $this->app['config']['session.lifetime'];
-
-		return $this->buildSession(new CookieSessionHandler($this->app['cookie'], $lifetime));
+		return $this->buildSession(new CookieSessionHandler($this->app['cookie']));
 	}
 
 	/**
@@ -149,9 +147,7 @@ class SessionManager extends Manager {
 	 */
 	protected function createCacheHandler($driver)
 	{
-		$minutes = $this->app['config']['session.lifetime'];
-
-		return new CacheBasedSessionHandler($this->app['cache']->driver($driver), $minutes);
+		return new CacheBasedSessionHandler($this->app['cache']->driver($driver));
 	}
 
 	/**
@@ -162,6 +158,10 @@ class SessionManager extends Manager {
 	 */
 	protected function buildSession($handler)
 	{
+		if ($handler instanceof ExpirationAwareInterface) {
+			$handler->setLifetime($this->app['config']['session.lifetime']);
+		}
+
 		return new Store($this->app['config']['session.cookie'], $handler);
 	}
 

--- a/tests/Session/ExpirationAwareSessionHandlerTest.php
+++ b/tests/Session/ExpirationAwareSessionHandlerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Mockery as m;
+
+class ExpirationAwareSessionHandlerTest extends PHPUnit_Framework_TestCase {
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testNoDefaultLifetime()
+    {
+        $handler = m::mock(
+            new \Illuminate\Session\CookieSessionHandler(
+                new \Illuminate\Cookie\CookieJar()
+            )
+        );
+
+        $this->assertEquals(0, $handler->getLifetime());
+    }
+
+    public function testLifetimeAccessorMutator()
+    {
+        $handler = m::mock(
+            new \Illuminate\Session\CookieSessionHandler(
+                new \Illuminate\Cookie\CookieJar()
+            )
+        );
+
+        $handler->setLifetime(100);
+        $this->assertEquals(100, $handler->getLifetime());
+
+        $handler->setLifetime(200);
+        $this->assertEquals(200, $handler->getLifetime());
+    }
+}

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -249,7 +249,10 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($session->handlerNeedsRequest());
 		$session->getHandler()->shouldReceive('setRequest')->never();
 
-		$session = new \Illuminate\Session\Store('test', m::mock(new \Illuminate\Session\CookieSessionHandler(new \Illuminate\Cookie\CookieJar(), 60)));
+		$handler = m::mock(new \Illuminate\Session\CookieSessionHandler(new \Illuminate\Cookie\CookieJar()));
+		$handler->setLifetime(60);
+		$session = new \Illuminate\Session\Store('test', $handler);
+
 		$this->assertTrue($session->handlerNeedsRequest());
 		$session->getHandler()->shouldReceive('setRequest')->once();
 		$request = new \Symfony\Component\HttpFoundation\Request();


### PR DESCRIPTION
This pull request stems from two related issues …

**Adding session expiration to the DatabaseSessionHandler**

Important: by default each request has a 2% chance of running the garbage collector. The database is also agnostic of any expiration, so if a session ID is spoofed in a cookie, and the garbage collector has not been run, the session can be hijacked regardless of whether the session has expired or not. This means that the majority of the onus is put on the cookie to expire in order to check the session validity.

This fix addresses this issue by ensuring the session is still valid before it is used, even if the garbage collector has not been run.

**Abstracting session expiration**

The session expiration has repeated code amongst many of the handlers, so this introduces the interface ExpirationAwareInterface which contains three method: getLifetime, setLifetime and garbageCollect.

The methods getLifetime and setLifetime provide accessors and mutators in the same workings as the interface ExistenceAwareInterface. It provides a universal way to passthrough the term in which a session is expected to exist in its handling endpoint.

The garbageCollect method is a simple courtesy, it calls the gc method (part of PHP's SessionHandlerInterface interface) with the maxLifetime parameter pre-filled.
