### PR TITLE
[4.2] Improved Workbench Email Validation

### DIFF
--- a/src/Illuminate/Workbench/Console/WorkbenchMakeCommand.php
+++ b/src/Illuminate/Workbench/Console/WorkbenchMakeCommand.php
@@ -97,7 +97,7 @@ class WorkbenchMakeCommand extends Command {
 
 		$config = $this->laravel['config']['workbench'];
 
-		if (is_null($config['email']))
+		if ( ! filter_var($config['email'], FILTER_VALIDATE_EMAIL))
 		{
 			throw new \UnexpectedValueException("Please set the author's email in the workbench configuration file.");
 		}


### PR DESCRIPTION
Fixed issue where validation passed if email was `''`, causing composer to throw:

```
[Composer\Json\JsonValidationException]
"./composer.json" does not match the expected JSON schema:
 - authors[0].email : Invalid email
```

Now using `filter_var`
