### PR TITLE
[5.0] Removed Dead Code

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -536,17 +536,6 @@ class Router implements HttpKernelInterface, RegistrarContract {
 	}
 
 	/**
-	 * Dispatch the request to the application. Do not run any middleware.
-	 *
-	 * @param  \Illuminate\Http\Request  $request
-	 * @return \Illuminate\Http\Response
-	 */
-	public function dispatchWithoutMiddleware(Request $request)
-	{
-		return $this->dispatch($request, false);
-	}
-
-	/**
 	 * Dispatch the request to a route and return the response.
 	 *
 	 * @param  \Illuminate\Http\Request  $request


### PR DESCRIPTION
Router::dispatchWithoutMiddleware() as it's no longer an available option.
