### PR TITLE
[5.0] Fix event:scan command

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -41,6 +41,13 @@ class Dispatcher implements DispatcherContract {
 	protected $firing = array();
 
 	/**
+	 * The classes that should be scanned.
+	 *
+	 * @var array
+	 */
+	protected $classesToScan = array();
+
+	/**
 	 * Create a new event dispatcher instance.
 	 *
 	 * @param  \Illuminate\Container\Container  $container
@@ -347,6 +354,27 @@ class Dispatcher implements DispatcherContract {
 		{
 			if (ends_with($key, '_queue')) $this->forget($key);
 		}
+	}
+
+	/**
+	 * Get the classes to scan.
+	 *
+	 * @return array
+	 */
+	public function getClassesToScan()
+	{
+		return $this->classesToScan;
+	}
+
+	/**
+	 * Set the classes that should be scanned.
+	 *
+	 * @param  array  $classes
+	 * @return void
+	 */
+	public function setClassesToScan(array $classes)
+	{
+		$this->classesToScan = $classes;
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/EventScanCommand.php
+++ b/src/Illuminate/Foundation/Console/EventScanCommand.php
@@ -43,7 +43,7 @@ class EventScanCommand extends Command {
 	protected function getEventDefinitions()
 	{
 		return '<?php '.PHP_EOL.PHP_EOL.Scanner::create(
-			rtrim($this->laravel['path'].'/'.$this->option('path'), '/'), $this->getAppNamespace()
+			$this->laravel['events']->getClassesToScan()
 		)->getEventDefinitions().PHP_EOL;
 	}
 

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -21,6 +21,8 @@ class EventServiceProvider extends ServiceProvider {
 	 */
 	public function boot(DispatcherContract $events)
 	{
+		$this->app['events']->setClassesToScan($this->scan ?: []);
+
 		if ($this->app->environment('local') && $this->scanWhenLocal)
 		{
 			$this->scanEvents();


### PR DESCRIPTION
Fixes error with the event:scan command. Changes made in this https://github.com/laravel/framework/commit/21a48520e5777acb88f66f9ed5f9628b5e45d070 did not update event scanning

```
[ErrorException]
  Argument 1 passed to Illuminate\Events\Annotations\Scanner::create() must be of the type array, string given, called in /home/vagrant/Code/behat_v2_laravel/vendor/laravel/framework/src/Illuminate/Foundation/Console/EventScanCommand.php on line 47 and defined
```
