### PR TITLE
[5.0] Fix Incorrect DateTime Format

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -228,11 +228,6 @@ abstract class HasOneOrMany extends Relation {
 	 */
 	public function update(array $attributes)
 	{
-		if ($this->related->usesTimestamps())
-		{
-			$attributes[$this->relatedUpdatedAt()] = $this->related->freshTimestamp();
-		}
-
 		return $this->query->update($attributes);
 	}
 

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -38,13 +38,26 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
 	public function testUpdateMethodUpdatesModelsWithTimestamps()
 	{
-		$relation = $this->getRelation();
-		$relation->getRelated()->shouldReceive('usesTimestamps')->once()->andReturn(true);
-		$relation->getRelated()->shouldReceive('freshTimestamp')->once()->andReturn(100);
-		$relation->getRelated()->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-		$relation->getQuery()->shouldReceive('update')->once()->with(array('foo' => 'bar', 'updated_at' => 100))->andReturn('results');
+		$query_builder = m::mock('Illuminate\Database\Query\Builder');
+		$query_builder->shouldReceive('update')->andReturn(array('foo' => 'bar', 'updated_at' => 100));
+		$query_builder->shouldReceive('from')->once();
+		$query_builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
 
-		$this->assertEquals('results', $relation->update(array('foo' => 'bar')));
+		$related = m::mock('Illuminate\Database\Eloquent\Model');
+		$related->shouldReceive('getTable')->once();
+		$related->shouldReceive('usesTimestamps')->once()->andReturn(true);
+		$related->shouldReceive('freshTimestampString')->once()->andReturn("100");
+		$related->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+
+		$builder = new \Illuminate\Database\Eloquent\Builder($query_builder);
+		$builder->setModel($related);
+
+		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+
+		$relation = new HasOne($builder, $parent, 'table.foreign_key', 'id');
+
+		$this->assertEquals(array('foo' => 'bar', 'updated_at' => "100"), $relation->update(array('foo' => 'bar')));
 	}
 
 


### PR DESCRIPTION
The problem is, The update of relation will refresh timestamp in two place,
The first one is in `Relations\HasOneOrMany::update`, Another is in
`Eloquent\Builder::addUpdatedAtColumn`.

Eloquent timestamp does not respect date format return by Model::getDateFormat()
if we update relation through model.

We can override getDateFormat() to return 'U' in model to
store datetime as unix timestamp. For example:

``` php
use Illuminate\Database\Eloquent\Model;

class A extends Model
{
    public function b()
    {
        return $this->hasOne('B');
    }
}

class B extends Model
{
    public function getDateFormat()
    {
        return 'U';
    }
}

$a = A::find(9);
$a->b->update(array('foo' => 'bar')); // Invalid date format
```
