### PR TITLE
[5.0] Add Illuminate\Pagination\Paginator::isEmpty()

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -337,6 +337,16 @@ abstract class AbstractPaginator {
 	}
 
 	/**
+	 * Determine if the list of items is empty or not.
+	 *
+	 * @return bool
+	 */
+	public function isEmpty()
+	{
+		return empty($this->items);
+	}
+
+	/**
 	 * Get the number of items for the current page.
 	 *
 	 * @return int


### PR DESCRIPTION
Make it easier to iterate since `Illuminate\Support\Collection` has the same method. Same method was also available in 4.x

Signed-off-by: crynobone crynobone@gmail.com
