### PR TITLE
[5.0] Remove Type Hinting In toRoute

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -241,11 +241,11 @@ class UrlGenerator implements UrlGeneratorContract {
 	 * Get the URL for a given route instance.
 	 *
 	 * @param  \Illuminate\Routing\Route  $route
-	 * @param  array  $parameters
-	 * @param  bool  $absolute
+	 * @param  mixed  $parameters
+	 * @param  bool   $absolute
 	 * @return string
 	 */
-	protected function toRoute($route, array $parameters, $absolute)
+	protected function toRoute($route, $parameters, $absolute)
 	{
 		$parameters = $this->formatParameters($parameters);
 


### PR DESCRIPTION
`toRoute()` used in `action()` and `route()` which can accept simple value **or** array. Thus the

``` php
link_to_route('resource.edit', 'Edit', 1);
```

will throw an exception `Argument 2 passed to Illuminate\Routing\UrlGenerator::toRoute() must be of the type array, integer given`.
