### PR TITLE
[4.2] Added customizable expiration time to Redis queue jobs

### DIFF
--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -40,7 +40,9 @@ class RedisConnector implements ConnectorInterface {
 	 */
 	public function connect(array $config)
 	{
-		return new RedisQueue($this->redis, $config['queue'], $this->connection);
+		$config['expire'] = isset($config['expire']) ? $config['expire'] : 60;
+
+		return new RedisQueue($this->redis, $config['queue'], $this->connection, $config['expire']);
 	}
 
 }

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -99,4 +99,28 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 		$queue->migrateExpiredJobs('from', 'to');
 	}
 
+
+	public function testNotExpireJobsWhenExpireNull()
+	{
+		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime', 'migrateAllExpiredJobs'), array($redis = m::mock('Illuminate\Redis\Database'), 'default', null, null));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
+		$redis->shouldReceive('lpop')->once()->with('queues:default')->andReturn('foo');
+		$redis->shouldReceive('zadd')->once()->with('queues:default:reserved', 1, 'foo');
+
+		$result = $queue->pop();
+	}
+
+
+	public function testExpireJobsWhenExpireSet()
+	{
+		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime', 'migrateAllExpiredJobs'), array($redis = m::mock('Illuminate\Redis\Database'), 'default', null, 30));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
+		$redis->shouldReceive('lpop')->once()->with('queues:default')->andReturn('foo');
+		$redis->shouldReceive('zadd')->once()->with('queues:default:reserved', 31, 'foo');
+
+		$result = $queue->pop();
+	}
+
 }


### PR DESCRIPTION
When using a Redis queue, it used to expire jobs if they lasted more than 60 seconds by default. This created some issues where a job could be processing for longer than 60 seconds, but it would add it back to the delayed queue so later you'd get multiple instances of the same job running in parallel. 

I've added an expire option that could be added to `config/queue.php`. This value should be null if you don't want to expire jobs, or an integer expiration time.
