### PR TITLE
[4.2] Added Customizable Expiration Time To Redis Queue Jobs

### DIFF
--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -40,7 +40,11 @@ class RedisConnector implements ConnectorInterface {
 	 */
 	public function connect(array $config)
 	{
-		return new RedisQueue($this->redis, $config['queue'], $this->connection);
+		$queue = new RedisQueue($this->redis, $config['queue'], $this->connection);
+
+		$queue->setExpire(array_get($config, 'expire', 60));
+
+		return $queue;
 	}
 
 }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -27,6 +27,13 @@ class RedisQueue extends Queue implements QueueInterface {
 	protected $default;
 
 	/**
+	 * The expiration time of a job.
+	 *
+	 * @var int|null
+	 */
+	protected $expire = 60;
+
+	/**
 	 * Create a new Redis queue instance.
 	 *
 	 * @param  \Illuminate\Redis\Database  $redis
@@ -115,13 +122,18 @@ class RedisQueue extends Queue implements QueueInterface {
 	{
 		$original = $queue ?: $this->default;
 
-		$this->migrateAllExpiredJobs($queue = $this->getQueue($queue));
+		$queue = $this->getQueue($queue);
+
+		if ( ! is_null($this->expire))
+		{
+			$this->migrateAllExpiredJobs($queue);
+		}
 
 		$job = $this->redis->lpop($queue);
 
 		if ( ! is_null($job))
 		{
-			$this->redis->zadd($queue.':reserved', $this->getTime() + 60, $job);
+			$this->redis->zadd($queue.':reserved', $this->getTime() + $this->expire, $job);
 
 			return new RedisJob($this->container, $this, $job, $original);
 		}
@@ -271,6 +283,26 @@ class RedisQueue extends Queue implements QueueInterface {
 	public function getRedis()
 	{
 		return $this->redis;
+	}
+
+	/**
+	 * Get the expiration time in seconds.
+	 *
+	 * @return int|null
+	 */
+	public function getExpire()
+	{
+		return $this->expire;
+	}
+
+	/**
+	 * Set the expiration time in seconds.
+	 *
+	 * @param int|null $seconds
+	 */
+	public function setExpire($seconds)
+	{
+		$this->expire = $seconds;
 	}
 
 }

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -99,4 +99,32 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 		$queue->migrateExpiredJobs('from', 'to');
 	}
 
+
+	public function testNotExpireJobsWhenExpireNull()
+	{
+		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime', 'migrateAllExpiredJobs'), array($redis = m::mock('Illuminate\Redis\Database'), 'default', null));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$queue->setExpire(null);
+		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
+		$queue->expects($this->never())->method('migrateAllExpiredJobs');
+		$redis->shouldReceive('lpop')->once()->with('queues:default')->andReturn('foo');
+		$redis->shouldReceive('zadd')->once()->with('queues:default:reserved', 1, 'foo');
+
+		$result = $queue->pop();
+	}
+
+
+	public function testExpireJobsWhenExpireSet()
+	{
+		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime', 'migrateAllExpiredJobs'), array($redis = m::mock('Illuminate\Redis\Database'), 'default', null));
+		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$queue->setExpire(30);
+		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
+		$queue->expects($this->once())->method('migrateAllExpiredJobs')->with($this->equalTo('queues:default'));
+		$redis->shouldReceive('lpop')->once()->with('queues:default')->andReturn('foo');
+		$redis->shouldReceive('zadd')->once()->with('queues:default:reserved', 31, 'foo');
+
+		$result = $queue->pop();
+	}
+
 }


### PR DESCRIPTION
This is a resubmission of #6141 with removal of constructor changes so we can get this into 4.2.

When using a Redis queue, it used to expire jobs if they lasted more than 60 seconds by default. This created some issues where a job could be processing for longer than 60 seconds, but it would add it back to the delayed queue so later you'd get multiple instances of the same job running in parallel.

I've added an expire option that could be added to config/queue.php. This value should be null if you don't want to expire jobs, or an integer expiration time.
