### PR TITLE
[4.2] Updated To Be Able To Access All Bags

### DIFF
--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -32,6 +32,16 @@ class ViewErrorBag implements Countable {
 	{
 		return array_get($this->bags, $key, new MessageBag);
 	}
+	
+	/**
+	 * Get all the bags.
+	 * 
+	 * @return $this->bags
+	 */
+	public function getBags()
+	{
+		return $this->bags;	
+	}
 
 	/**
 	 * Add a new MessageBag instance to the bags.

--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -36,7 +36,7 @@ class ViewErrorBag implements Countable {
 	/**
 	 * Get all the bags.
 	 * 
-	 * @return $this->bags
+	 * @return array
 	 */
 	public function getBags()
 	{


### PR DESCRIPTION
For ability to have a generic error handler for all bags in case they are grouped like `register[email]`. It's not possible to know what the grouping is unless `$errors->register->getMessages()` is specifically called.
