### PR TITLE
[4.2] Add getDefaultDatabaseDriver() To DatabaseManager

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -249,9 +249,9 @@ class DatabaseManager implements ConnectionResolverInterface {
 	 *
 	 * @throws \InvalidArgumentException
 	 */
-	protected function getConfig($name)
+	protected function getConfig($name = null)
 	{
-		$name = $name ?: $this->getDefaultConnection();
+		$name = !is_null($name) ? $name : $this->getDefaultConnection();
 
 		// To get the database connection configuration, we will just pull each of the
 		// connection configurations and get the configurations for the given name.
@@ -275,6 +275,17 @@ class DatabaseManager implements ConnectionResolverInterface {
 	{
 		return $this->app['config']['database.default'];
 	}
+
+	/**
+	 * Get the default connection's driver name.
+	 *
+	 * @return string
+	 */
+	public function getDefaultDriver()
+	{
+		return array_get($this->getConfig(), 'driver');
+	}
+
 
 	/**
 	 * Set the default connection name.

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -281,7 +281,7 @@ class DatabaseManager implements ConnectionResolverInterface {
 	 *
 	 * @return string
 	 */
-	public function getDefaultDriver()
+	public function getDefaultDatabaseDriver()
 	{
 		return array_get($this->getConfig(), 'driver');
 	}


### PR DESCRIPTION
Currently, naming database connections anything but their driver name sometimes fails (for instance when using OctoberCMS) because it's easy to use getDefaultConnection() to get the connection name but harder to drill down to the default connection's driver, so this shortcut is often used.

This change makes it much simpler and more realistic for database config files to be named semantically going forward, for instance:

``` php
return array( 
    'fetch' => PDO::FETCH_CLASS, 
    'default' => 'production', 
    'connections' => array( 
        ...
        'production' => array( 
            'driver'   => 'pgsql', 
        ...
```

instead of being confined to:

``` php
return array(
    'fetch' => PDO::FETCH_CLASS,
    'default' => 'pgsql',
    'connections' => array(
        ...
        'pgsql' => array(
            'driver'   => 'pgsql',
        ...
```
