### PR TITLE
Fix Str::length return errors value when dealing with multi-byte length string

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -106,7 +106,7 @@ class Str {
 	 */
 	public static function length($value)
 	{
-		return mb_strlen($value);
+		return mb_strlen($value, 'UTF-8');
 	}
 
 	/**
@@ -119,7 +119,7 @@ class Str {
 	 */
 	public static function limit($value, $limit = 100, $end = '...')
 	{
-		if (mb_strlen($value) <= $limit) return $value;
+		if (self::length($value) <= $limit) return $value;
 
 		return rtrim(mb_substr($value, 0, $limit, 'UTF-8')).$end;
 	}

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -119,7 +119,7 @@ class Str {
 	 */
 	public static function limit($value, $limit = 100, $end = '...')
 	{
-		if (self::length($value) <= $limit) return $value;
+		if (static::length($value) <= $limit) return $value;
 
 		return rtrim(mb_substr($value, 0, $limit, 'UTF-8')).$end;
 	}


### PR DESCRIPTION
examle:

``` php
$str = '这是一个长度47个字符的中文字符串';

echo mb_strlen($str, 'UTF-8');  // 17

echo Illuminate\Support\Str::length($str);// 47
```
