### PR TITLE
[4.2] Cache The Method Name As Well As The Attribute For "getMutators"

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -747,7 +747,13 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	{
 		$class = new EloquentModelStub;
 
-		$this->assertEquals(array('list_items', 'password', 'appendable'), $class->getMutatedAttributes());
+		$expectedAttributes = [
+			'list_items' => 'getListItemsAttribute',
+			'password'   => 'getPasswordAttribute',
+			'appendable' => 'getAppendableAttribute'
+		];
+
+		$this->assertEquals($expectedAttributes, $class->getMutatedAttributes());
 	}
 
 


### PR DESCRIPTION
When serializing are large number of Model objects the repeated calls to study_case to the attributes get mutators really add up. We already cache the get mutator attribute keys and its simple enough to expand that to include the method names as well. Other than a small change to the test around the getMutator cache all the other unit tests pass without adjustment.
