### PR TITLE
[5.0] Fix ConfigureLogging Closure

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -21,7 +21,7 @@ class ConfigureLogging {
 		// Next we will bind the a Closure to resolve the PSR logger implementation
 		// as this will grant us the ability to be interoperable with many other
 		// libraries which are able to utilize the PSR standardized interface.
-		$app->bind('Psr\Log\LoggerInterface', function() use ($app)
+		$app->bind('Psr\Log\LoggerInterface', function($app)
 		{
 			return $app['log']->getMonolog();
 		});

--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -21,7 +21,7 @@ class ConfigureLogging {
 		// Next we will bind the a Closure to resolve the PSR logger implementation
 		// as this will grant us the ability to be interoperable with many other
 		// libraries which are able to utilize the PSR standardized interface.
-		$app->bind('Psr\Log\LoggerInterface', function()
+		$app->bind('Psr\Log\LoggerInterface', function() use ($app)
 		{
 			return $app['log']->getMonolog();
 		});


### PR DESCRIPTION
Just added a `use ($app)` to avoid the PHP Notice
