### PR TITLE
[4.2] Fixed "relationsToArray"

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2343,6 +2343,8 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			{
 				$attributes[$key] = $relation;
 			}
+
+			unset($relation);
 		}
 
 		return $attributes;

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -11,6 +11,15 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testSetRelationFail()
+	{
+		$parent = new EloquentRelationResetModelStub;
+		$relation =new EloquentRelationResetModelStub;
+		$parent->setRelation('test',$relation);
+		$parent->setRelation('foo','bar');
+		$this->assertTrue(!array_key_exists('foo', $parent->toArray()));
+	}
+
 	public function testTouchMethodUpdatesRelatedTimestamps()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');


### PR DESCRIPTION
Not unsetting the relations variable might lead to setting the next key with the previous value if the current value is not an instanceof the ArrayableInterface or null.
