### PR TITLE
[4.2] Add Non Latin Character Support For Str::slug

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -254,11 +254,12 @@ class Str {
 	 *
 	 * @param  string  $title
 	 * @param  string  $separator
+	 * @param  bool    $utf8
 	 * @return string
 	 */
-	public static function slug($title, $separator = '-')
+	public static function slug($title, $separator = '-', $utf8 = false)
 	{
-		$title = static::ascii($title);
+		$title = (!$utf8) ? static::ascii($title) : $title;
 
 		// Convert all dashes/underscores into separator
 		$flip = $separator == '-' ? '_' : '-';
@@ -272,6 +273,18 @@ class Str {
 		$title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
 
 		return trim($title, $separator);
+	}
+
+	/**
+	 * Generates a utf-8 supported url friendly slug from a given string
+	 *
+	 * @param $title
+	 * @param $separator
+	 * @return string
+	 */
+	public static function lightSlug($title, $separator = '-')
+	{
+		return self::slug($title, $separator, true);
 	}
 
 	/**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -85,6 +85,8 @@ class SupportStrTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('hello-world', Str::slug('hello-world'));
 		$this->assertEquals('hello-world', Str::slug('hello_world'));
 		$this->assertEquals('hello_world', Str::slug('hello_world', '_'));
+		$this->assertEquals('سلام دنیا', Str::slug('سلام-دنیا', null, true));
+		$this->assertEquals('سلام دنیاÇ', Str::lightSlug('سلام دنیاÇ'));
 	}
 
 


### PR DESCRIPTION
Add support for UTF-8 encoded slugging.  In case of slugging persian characters (like آ, ب, ژ) converting encoding to ASCII causes an empty string.

``` php
// سلام-دنیا
Str::lightSlug('سلام دنیا'); 

//empty string 
Str::slug('سلام دنیا');
```
