### PR TITLE
[5.0] Fix CLI Dependencies

### DIFF
--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -49,11 +49,7 @@ class RoutingServiceProvider extends ServiceProvider {
 			// and all the registered routes will be available to the generator.
 			$app->instance('routes', $routes);
 
-			$url = new UrlGenerator(
-				$routes, $app->rebinding(
-					'request', $this->requestRebinder()
-				)
-			);
+			$url = new UrlGenerator($routes, $this->getRequestInstance());
 
 			// If the route collection is "rebound", for example, when the routes stay
 			// cached for the application, we will need to rebind the routes on the
@@ -65,6 +61,25 @@ class RoutingServiceProvider extends ServiceProvider {
 
 			return $url;
 		});
+	}
+
+	/**
+	 * Resolve/rebind or create a Request object.
+	 *
+	 * @return \Illuminate\Http\Request
+	 */
+	public function getRequestInstance()
+	{
+		$request = $this->app->rebinding('request', $this->requestRebinder());
+
+		if (is_null($request))
+		{
+			$request = \Illuminate\Http\Request::capture();
+
+			$this->app->instance('request', $request);
+		}
+
+		return $request;
 	}
 
 	/**

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Routing;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
 
 class RoutingServiceProvider extends ServiceProvider {
@@ -72,9 +73,9 @@ class RoutingServiceProvider extends ServiceProvider {
 	{
 		$request = $this->app->rebinding('request', $this->requestRebinder());
 
-		if (is_null($request))
+		if ($request === null)
 		{
-			$request = \Illuminate\Http\Request::capture();
+			$request = Request::capture();
 
 			$this->app->instance('request', $request);
 		}


### PR DESCRIPTION
Automatically instantiate a Request object if it's required. (Useful when running from the CLI where it would not already be instantiated.)

ServiceProviders using objects (eg. URLGenerator) which depend on a Request object were squaking due to receiving NULL instead of a Request object.

[See here.](https://laracasts.com/discuss/channels/general-discussion/laravel-5-service-provider)
