### PR TITLE
Change method for merging environment config for packages

### DIFF
--- a/src/Illuminate/Config/FileLoader.php
+++ b/src/Illuminate/Config/FileLoader.php
@@ -171,9 +171,7 @@ class FileLoader implements LoaderInterface {
 
 		if ($this->files->exists($path))
 		{
-			$items = array_merge(
-				$items, $this->getRequire($path)
-			);
+			$items = $this->mergeEnvironment($items, $path);
 		}
 
 		return $items;


### PR DESCRIPTION
Right now packages' configurations are merged using `array_merge` instead of `mergeEnvironment`. This is not what I would expect.

If there is a specific reason for this, I would love the discussion, but this does not break any unit tests (perhaps that is a separate issue).
