### PR TITLE
[5.0] Bugfix to properly set request instance for console

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/SetRequestForConsole.php
+++ b/src/Illuminate/Foundation/Bootstrap/SetRequestForConsole.php
@@ -1,0 +1,21 @@
+<?php namespace Illuminate\Foundation\Bootstrap;
+
+use Illuminate\Http\Request;
+use Illuminate\Contracts\Foundation\Application;
+
+class SetRequestForConsole {
+
+	/**
+	 * Bootstrap the given application.
+	 *
+	 * @param  \Illuminate\Contracts\Foundation\Application  $app
+	 * @return void
+	 */
+	public function bootstrap(Application $app)
+	{
+		$url = $app['config']->get('app.url', 'http://localhost');
+
+		$app->instance('request', Request::create($url, 'GET', [], [], [], $_SERVER));
+	}
+
+}

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -30,6 +30,7 @@ class Kernel implements KernelContract {
 		'Illuminate\Foundation\Bootstrap\DetectEnvironment',
 		'Illuminate\Foundation\Bootstrap\LoadConfiguration',
 		'Illuminate\Foundation\Bootstrap\RegisterFacades',
+		'Illuminate\Foundation\Bootstrap\SetRequestForConsole',
 		'Illuminate\Foundation\Bootstrap\RegisterProviders',
 		'Illuminate\Foundation\Bootstrap\BootProviders',
 	];


### PR DESCRIPTION
> Catchable fatal error: Argument 2 passed to Illuminate\Routing\UrlGenerator::__construct() must be an instance of Illuminate\Http\Request, null given, called in /Users/crynobone/Projects/orchestra/orchestraplatform.com/vendor/laravel/framework/src/Illuminate/Routing/RoutingServiceProvider.php on line 56 and defined in /Users/crynobone/Projects/orchestra/orchestraplatform.com/vendor/laravel/framework/src/Illuminate/Routing/UrlGenerator.php on line 70

While most of the time `"url"` is not needed on artisan command, you might still use it when using queue to send email (password resets etc), or include `illuminate/html` which currently break all artisan command.
## How to reproduce the bug
1. `$ composer create-project laravel/laravel test dev-develop`
2. `$ cd test && composer require "illuminate/html=~5.0"`
3. `$ php artisan`

Signed-off-by: crynobone crynobone@gmail.com
