### PR TITLE
[5.0] Replace array_add So That Support Package Shall Not Be Required

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -388,7 +388,7 @@ class Container implements ArrayAccess, ContainerContract {
 
 		foreach ($tags as $tag)
 		{
-			array_add($this->tags, $tag, []);
+			if ( ! isset($this->tags[$tag])) $this->tags[$tag] = [];
 
 			foreach ((array) $abstracts as $abstract)
 			{


### PR DESCRIPTION
As `array_add` from `Support` is used, `illuminate/support` should be required in `composer.json`
https://github.com/laravel/framework/blob/master/src/Illuminate/Container/Container.php#L391
