### PR TITLE
[5.0] Ditched Unused Method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -665,17 +665,6 @@ class Application extends Container implements ApplicationContract {
 	}
 
 	/**
-	 * Handle the given request and get the response.
-	 *
-	 * @param  \Symfony\Component\HttpFoundation\Request  $request
-	 * @return \Symfony\Component\HttpFoundation\Response
-	 */
-	protected function run(SymfonyRequest $request)
-	{
-		return $this->make('Illuminate\Contracts\Http\Kernel')->run(Request::createFromBase($request));
-	}
-
-	/**
 	 * Call the booting callbacks for the application.
 	 *
 	 * @param  array  $callbacks


### PR DESCRIPTION
No code calls the `run` method in the Application. It must have been left over from the previous refactor.
