### PR TITLE
[5.0] Allow Getting The Response From The Mailer

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -150,7 +150,7 @@ class Mailer implements MailerContract, MailQueueContract {
 
 		$message = $message->getSwiftMessage();
 
-		$this->sendSwiftMessage($message);
+		return $this->sendSwiftMessage($message);
 	}
 
 	/**
@@ -328,7 +328,7 @@ class Mailer implements MailerContract, MailQueueContract {
 
 		if ( ! $this->pretending)
 		{
-			$this->swift->send($message, $this->failedRecipients);
+			return $this->swift->send($message, $this->failedRecipients);
 		}
 		elseif (isset($this->logger))
 		{

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -74,7 +74,7 @@ class MailgunTransport implements Swift_Transport {
 	{
 		$client = $this->getHttpClient();
 
-		$client->post($this->url, ['auth' => ['api', $this->key],
+		return $client->post($this->url, ['auth' => ['api', $this->key],
 			'body' => [
 				'to' => $this->getTo($message),
 				'message' => new PostFile('message', (string) $message),

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -56,7 +56,7 @@ class MandrillTransport implements Swift_Transport {
 	{
 		$client = $this->getHttpClient();
 
-		$client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', [
+		return $client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', [
 			'body' => [
 				'key' => $this->key,
 				'raw_message' => (string) $message,


### PR DESCRIPTION
When using the Mandrill and Mailgun transports the api response isn't being returned through the Laravel mailer class, the response is being return from the Swift mailer though so it is already half implemented.

This allows accessing the Guzzle response from using Mail::send in order to check status or get message id.
