### PR TITLE
[5.0] Ability To Set errorsKey For An Error Response

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -63,6 +63,13 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	 * @var array
 	 */
 	protected $dontFlash = ['password', 'password_confirmation'];
+	
+	/**
+	 * The key to be used on the withErrors method.
+	 *
+	 * @var string
+	 */
+	protected $errorsKey = 'default';
 
 	/**
 	 * Get the validator instance for the request.
@@ -149,7 +156,7 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 		{
 			return $this->redirector->to($this->getRedirectUrl())
                                             ->withInput($this->except($this->dontFlash))
-                                            ->withErrors($errors);
+                                            ->withErrors($errors, $this->errorsKey);
 		}
 	}
 


### PR DESCRIPTION
This change allows you to set a `key` to the `withErrors` method when sending back a response. This is a small change to help a user if he has multiple errors on one page. So instead of duplicating the `response` method in our `FormRequest` class when we need to change the key we just set the `$errorsKey` property.
