### PR TITLE
[5.0] Implementation Of ExistanceAwareTrait In Sessions

### DIFF
--- a/src/Illuminate/Session/CacheBasedSessionHandler.php
+++ b/src/Illuminate/Session/CacheBasedSessionHandler.php
@@ -2,7 +2,8 @@
 
 use Illuminate\Contracts\Cache\Repository as CacheContract;
 
-class CacheBasedSessionHandler implements \SessionHandlerInterface {
+class CacheBasedSessionHandler implements \SessionHandlerInterface, ExpirationAwareInterface {
+	use ExpirationAwareTrait;
 
 	/**
 	 * The cache repository instance.
@@ -12,23 +13,14 @@ class CacheBasedSessionHandler implements \SessionHandlerInterface {
 	protected $cache;
 
 	/**
-	 * The number of minutes to store the data in the cache.
-	 *
-	 * @var int
-	 */
-	protected $minutes;
-
-	/**
 	 * Create a new cache driven handler instance.
 	 *
 	 * @param  \Illuminate\Contracts\Cache\Repository  $cache
-	 * @param  int  $minutes
 	 * @return void
 	 */
-	public function __construct(CacheContract $cache, $minutes)
+	public function __construct(CacheContract $cache)
 	{
 		$this->cache = $cache;
-		$this->minutes = $minutes;
 	}
 
 	/**
@@ -60,7 +52,7 @@ class CacheBasedSessionHandler implements \SessionHandlerInterface {
 	 */
 	public function write($sessionId, $data)
 	{
-		return $this->cache->put($sessionId, $data, $this->minutes);
+		return $this->cache->put($sessionId, $data, $this->lifetime);
 	}
 
 	/**

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -3,7 +3,8 @@
 use Symfony\Component\HttpFoundation\Request;
 use Illuminate\Contracts\Cookie\Factory as CookieJar;
 
-class CookieSessionHandler implements \SessionHandlerInterface {
+class CookieSessionHandler implements \SessionHandlerInterface, ExpirationAwareInterface {
+	use ExpirationAwareTrait;
 
 	/**
 	 * The cookie jar instance.
@@ -23,13 +24,11 @@ class CookieSessionHandler implements \SessionHandlerInterface {
 	 * Create a new cookie driven handler instance.
 	 *
 	 * @param  \Illuminate\Contracts\Cookie\Factory  $cookie
-	 * @param  int  $minutes
 	 * @return void
 	 */
-	public function __construct(CookieJar $cookie, $minutes)
+	public function __construct(CookieJar $cookie)
 	{
 		$this->cookie = $cookie;
-		$this->minutes = $minutes;
 	}
 
 	/**
@@ -61,7 +60,7 @@ class CookieSessionHandler implements \SessionHandlerInterface {
 	 */
 	public function write($sessionId, $data)
 	{
-		$this->cookie->queue($sessionId, $data, $this->minutes);
+		$this->cookie->queue($sessionId, $data, $this->lifetime);
 	}
 
 	/**

--- a/src/Illuminate/Session/ExpirationAwareInterface.php
+++ b/src/Illuminate/Session/ExpirationAwareInterface.php
@@ -1,0 +1,27 @@
+<?php namespace Illuminate\Session;
+
+interface ExpirationAwareInterface {
+
+	/**
+	 * Get the expiration time of session data in minutes.
+	 *
+	 * @return int
+	 */
+	public function getLifetime();
+
+	/**
+	 * Set the expiration time of session data in minutes.
+	 *
+	 * @param  int  $lifetime
+	 * @return int
+	 */
+	public function setLifetime($lifetime);
+
+	/**
+	 * Runs the garbage collector using the minutes set in the lifetime.
+	 *
+	 * @return bool
+	 */
+	public function garbageCollect();
+
+}

--- a/src/Illuminate/Session/ExpirationAwareTrait.php
+++ b/src/Illuminate/Session/ExpirationAwareTrait.php
@@ -5,12 +5,14 @@ trait ExpirationAwareTrait {
 	/**
 	 * The total number of minutes that a session is valid for.
 	 *
-	 * @var int
+	 * @var int|null
 	 */
 	protected $lifetime = null;
 
 	/**
-	 * {@inheritDoc}
+	 * Sets the number of minutes that a session is valid for.
+	 *
+	 * @param $lifetime  int
 	 */
 	public function setLifetime($lifetime)
 	{
@@ -28,7 +30,9 @@ trait ExpirationAwareTrait {
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * Gets the number of minutes that a session is valid for.
+	 *
+	 * @return int|null
 	 */
 	public function getLifetime()
 	{
@@ -36,7 +40,9 @@ trait ExpirationAwareTrait {
 	}
 
 	/**
-	 * Runs the garbage collection (gc) method using $lifetime.
+	 * Runs the garbage collection (gc) method using $this->lifetime.
+	 *
+	 * @return bool
 	 */
 	public function garbageCollect()
 	{

--- a/src/Illuminate/Session/ExpirationAwareTrait.php
+++ b/src/Illuminate/Session/ExpirationAwareTrait.php
@@ -1,0 +1,46 @@
+<?php namespace Illuminate\Session;
+
+trait ExpirationAwareTrait {
+	
+	/**
+	 * The total number of minutes that a session is valid for.
+	 *
+	 * @var int
+	 */
+	protected $lifetime = null;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setLifetime($lifetime)
+	{
+		if (!is_numeric($lifetime))
+		{
+			throw new \InvalidArgumentException('setLifetime expects a number');
+		}
+
+		if ($lifetime < 0)
+		{
+			throw new \InvalidArgumentException('setLifetime expects a number');
+		}
+
+		$this->lifetime = $lifetime;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getLifetime()
+	{
+		return $this->lifetime;
+	}
+
+	/**
+	 * Runs the garbage collection (gc) method using $lifetime.
+	 */
+	public function garbageCollect()
+	{
+		return $this->gc($this->lifetime * 60);
+	}
+
+}

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -23,7 +23,7 @@ class SessionManager extends Manager {
 	 */
 	protected function createArrayDriver()
 	{
-		return new Store($this->app['config']['session.cookie'], new NullSessionHandler);
+		return $this->buildSession(new NullSessionHandler);
 	}
 
 	/**
@@ -33,9 +33,7 @@ class SessionManager extends Manager {
 	 */
 	protected function createCookieDriver()
 	{
-		$lifetime = $this->app['config']['session.lifetime'];
-
-		return $this->buildSession(new CookieSessionHandler($this->app['cookie'], $lifetime));
+		return $this->buildSession(new CookieSessionHandler($this->app['cookie']));
 	}
 
 	/**
@@ -149,9 +147,7 @@ class SessionManager extends Manager {
 	 */
 	protected function createCacheHandler($driver)
 	{
-		$minutes = $this->app['config']['session.lifetime'];
-
-		return new CacheBasedSessionHandler($this->app['cache']->driver($driver), $minutes);
+		return new CacheBasedSessionHandler($this->app['cache']->driver($driver));
 	}
 
 	/**
@@ -162,6 +158,11 @@ class SessionManager extends Manager {
 	 */
 	protected function buildSession($handler)
 	{
+		if ($handler instanceof ExpirationAwareInterface)
+		{
+			$handler->setLifetime($this->app['config']['session.lifetime']);
+		}
+
 		return new Store($this->app['config']['session.cookie'], $handler);
 	}
 

--- a/tests/Session/ExpirationAwareTraitTest.php
+++ b/tests/Session/ExpirationAwareTraitTest.php
@@ -1,0 +1,36 @@
+<?php
+
+class ExpirationAwareTraitTest extends PHPUnit_Framework_TestCase {
+	
+	public function testSetLifetime()
+	{
+		$handler = new Illuminate\Session\CookieSessionHandler(new \Illuminate\Cookie\CookieJar);
+		$this->assertNull($handler->getLifetime());
+
+		$handler->setLifetime(100);
+		$this->assertEquals(100, $handler->getLifetime());
+
+		$handler->setLifetime(120);
+		$this->assertEquals(120, $handler->getLifetime());
+	}
+
+	public function testSetLifetimeString()
+	{
+		$handler = new Illuminate\Session\CookieSessionHandler(new \Illuminate\Cookie\CookieJar);
+		$this->assertNull($handler->getLifetime());
+
+		$this->setExpectedException('InvalidArgumentException');
+		$handler->setLifetime('asdf');
+		$this->assertEquals(120, $handler->getLifetime());
+	}
+
+	public function testSetLifetimeNegative()
+	{
+		$handler = new Illuminate\Session\CookieSessionHandler(new \Illuminate\Cookie\CookieJar);
+
+		$this->setExpectedException('InvalidArgumentException');
+		$handler->setLifetime(-1);
+		$this->assertEquals(120, $handler->getLifetime());
+	}
+
+}

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -249,7 +249,10 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($session->handlerNeedsRequest());
 		$session->getHandler()->shouldReceive('setRequest')->never();
 
-		$session = new \Illuminate\Session\Store('test', m::mock(new \Illuminate\Session\CookieSessionHandler(new \Illuminate\Cookie\CookieJar(), 60)));
+		$handler = new \Illuminate\Session\CookieSessionHandler(new \Illuminate\Cookie\CookieJar);
+		$handler->setLifetime(60);
+
+		$session = new \Illuminate\Session\Store('test', m::mock($handler));
 		$this->assertTrue($session->handlerNeedsRequest());
 		$session->getHandler()->shouldReceive('setRequest')->once();
 		$request = new \Symfony\Component\HttpFoundation\Request();


### PR DESCRIPTION
See #6122 

**Adding session expiration to the DatabaseSessionHandler**

BUGFIX - By default each request has a 2% chance of running the garbage collector. The database is also agnostic of any expiration, so if a session ID is spoofed in a cookie, and the garbage collector has not been run, the session can be hijacked regardless of whether the session has expired or not. This means that the majority of the onus is put on the cookie to expire in order to check the session validity.

This fix addresses this issue by ensuring the session is still valid before it is used, even if the garbage collector has not been run.

**Abstracting session expiration**

The session expiration has repeated code amongst many of the handlers, so this introduces the interface ExpirationAwareInterface which contains three method: getLifetime, setLifetime and garbageCollect.

The methods getLifetime and setLifetime provide accessors and mutators in the same workings as the interface ExistenceAwareInterface. It provides a universal way to passthrough the term in which a session is expected to exist in its handling endpoint.

The garbageCollect method is a simple courtesy, it calls the gc method (part of PHP's SessionHandlerInterface interface) with the maxLifetime parameter pre-filled.
