### PR TITLE
[5.0] Resolve Artisan Custom Commands

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -43,6 +43,13 @@ class Kernel implements KernelContract {
 	];
 
 	/**
+	 * The Artisan commands to resolve.
+	 *
+	 * @var array
+	 */
+	protected $commands =[];
+
+	/**
 	 * Create a new console kernel instance.
 	 *
 	 * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -66,7 +73,9 @@ class Kernel implements KernelContract {
 	{
 		$this->bootstrap();
 
-		return $this->getArtisan()->run($input, $output);
+		return $this->getArtisan()
+			->resolveCommands($this->commands)
+			->run($input, $output);
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -47,7 +47,7 @@ class Kernel implements KernelContract {
 	 *
 	 * @var array
 	 */
-	protected $commands =[];
+	protected $commands = [];
 
 	/**
 	 * Create a new console kernel instance.


### PR DESCRIPTION
Custom commands in the laravel application don't work without it, even the default command "inspire".
