### PR TITLE
[5.0] Accomodate Multiple Autoloaded Folders

### DIFF
--- a/src/Illuminate/Console/AppNamespaceDetectorTrait.php
+++ b/src/Illuminate/Console/AppNamespaceDetectorTrait.php
@@ -15,7 +15,10 @@ trait AppNamespaceDetectorTrait {
 
 		foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path)
 		{
-			if (realpath(app_path()) == realpath(base_path().'/'.$path)) return $namespace;
+			foreach ((array) $path as $pathChoice)
+			{
+				if (realpath(app_path()) == realpath(base_path().'/'.$pathChoice)) return $namespace;
+			}
 		}
 
 		throw new \RuntimeException("Unable to detect application namespace.");


### PR DESCRIPTION
At the moment `getAppNamespace()` breaks if you have multiple source folders set in composers PSR-4 setting as it expects a string but is an array. This just first checks if its an array first then handles accordingly.
ie
This works fine

```
"psr-4": {
    "Ntech\\": "app/"
}
```

But this breaks

```
"psr-4": {
    "Ntech\\": [ "app/" , "src/" ]
}
```
