### PR TITLE
[5.0] Only Flush The App If It Exists

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -33,7 +33,10 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	 */
 	public function tearDown()
 	{
-		$this->app->flush();
+		if ($this->app)
+		{
+			$this->app->flush();
+		}
 	}
 
 }


### PR DESCRIPTION
If something else screwed up earlier on, we may run into a case where we hit a fatal error trying to call flush on `null`. This makes sure we don't end up with a php fatal error so people can actually work outwhat went wrong.
