### PR TITLE
[5.0] Fix isEmpty bug with paginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -339,7 +339,7 @@ abstract class AbstractPaginator {
 	 */
 	public function isEmpty()
 	{
-		return empty($this->items);
+		return empty($this->items());
 	}
 
 	/**
@@ -349,7 +349,7 @@ abstract class AbstractPaginator {
 	 */
 	public function count()
 	{
-		return count($this->items);
+		return count($this->items());
 	}
 
 	/**


### PR DESCRIPTION
`$paginated->isEmpty()` returns `false` regardless of its emptiness.

Line 352 was changed for consistency.
