### PR TITLE
[4.2] Change Mailer::setLogger To Accept PSR LoggerInterface

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -72,9 +72,9 @@ class MailServiceProvider extends ServiceProvider {
 	{
 		$mailer->setContainer($app);
 
-		if ($app->bound('log'))
+		if ($app->bound('Psr\Log\LoggerInterface'))
 		{
-			$mailer->setLogger($app['log']);
+			$mailer->setLogger($app->make('Psr\Log\LoggerInterface'));
 		}
 
 		if ($app->bound('queue'))

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -3,7 +3,7 @@
 use Closure;
 use Swift_Mailer;
 use Swift_Message;
-use Illuminate\Log\Writer;
+use Psr\Log\LoggerInterface;
 use Illuminate\View\Factory;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\QueueManager;
@@ -43,7 +43,7 @@ class Mailer {
 	/**
 	 * The log writer instance.
 	 *
-	 * @var \Illuminate\Log\Writer
+	 * @var \Psr\Log\LoggerInterface
 	 */
 	protected $logger;
 
@@ -467,10 +467,10 @@ class Mailer {
 	/**
 	 * Set the log writer instance.
 	 *
-	 * @param  \Illuminate\Log\Writer  $logger
+	 * @param  \Psr\Log\LoggerInterface  $logger
 	 * @return $this
 	 */
-	public function setLogger(Writer $logger)
+	public function setLogger(LoggerInterface $logger)
 	{
 		$this->logger = $logger;
 

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -141,7 +141,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase {
 		$message->shouldReceive('getTo')->once()->andReturn(array('taylor@userscape.com' => 'Taylor'));
 		$message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
 		$mailer->getSwiftMailer()->shouldReceive('send')->never();
-		$logger = m::mock('Illuminate\Log\Writer');
+		$logger = m::mock('Psr\Log\LoggerInterface');
 		$logger->shouldReceive('info')->once()->with('Pretending to mail message to: taylor@userscape.com');
 		$mailer->setLogger($logger);
 		$mailer->pretend();


### PR DESCRIPTION
Makes it easier to use outside the framework or with a custom logger.

Related: https://github.com/laravel/framework/pull/5816
