### PR TITLE
[5.0] Removed Leftover Variable

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -191,9 +191,6 @@ class DatabaseManager implements ConnectionResolverInterface {
 			$connection->setEventDispatcher($this->app['events']);
 		}
 
-		$app = $this->app;
-
-
 		// Here we'll set a reconnector callback. This reconnector can be any callable
 		// so we will set a Closure to reconnect from this manager with the name of
 		// the connection, which will allow us to reconnect from the connections.


### PR DESCRIPTION
This wasn't removed when its usages were removed in commit ea6b958.
