### PR TITLE
[5.0] Add Customization Methods To The Validation Factory Contract

### DIFF
--- a/src/Illuminate/Contracts/Validation/Factory.php
+++ b/src/Illuminate/Contracts/Validation/Factory.php
@@ -13,4 +13,33 @@ interface Factory {
 	 */
 	public function make(array $data, array $rules, array $messages = array(), array $customAttributes = array());
 
+	/**
+	 * Register a custom validator extension.
+	 *
+	 * @param  string  $rule
+	 * @param  \Closure|string  $extension
+	 * @param  string  $message
+	 * @return void
+	 */
+	public function extend($rule, $extension, $message = null);
+
+	/**
+	 * Register a custom implicit validator extension.
+	 *
+	 * @param  string   $rule
+	 * @param  \Closure|string  $extension
+	 * @param  string  $message
+	 * @return void
+	 */
+	public function extendImplicit($rule, $extension, $message = null);
+
+	/**
+	 * Register a custom implicit validator message replacer.
+	 *
+	 * @param  string   $rule
+	 * @param  \Closure|string  $replacer
+	 * @return void
+	 */
+	public function replacer($rule, $replacer);
+
 }


### PR DESCRIPTION
This makes sense in my eyes. Similar methods are also in the view factory contract.

@taylorotwell There are other public methods in the factory, but I'd argue they're not as important to the actual factory contract, but rather implementation-specific? Your call... especially regarding the `resolver()` method...
