### PR TITLE
[5.0] Use Container Contract In Database Connection Factory

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Database\Connectors;
 
 use PDO;
-use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\PostgresConnection;
@@ -12,14 +12,14 @@ class ConnectionFactory {
 	/**
 	 * The IoC container instance.
 	 *
-	 * @var \Illuminate\Container\Container
+	 * @var \Illuminate\Contracts\Container\Container
 	 */
 	protected $container;
 
 	/**
 	 * Create a new connection factory instance.
 	 *
-	 * @param  \Illuminate\Container\Container  $container
+	 * @param  \Illuminate\Contracts\Container\Container  $container
 	 * @return void
 	 */
 	public function __construct(Container $container)

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -1,11 +1,11 @@
 <?php namespace Illuminate\Database\Connectors;
 
 use PDO;
-use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SqlServerConnection;
+use Illuminate\Contracts\Container\Container;
 
 class ConnectionFactory {
 


### PR DESCRIPTION
PhpStorm was screaming at me when I tried to pass an application instance into the connection factory.
