### PR TITLE
[5.0] Add \Illuminate\Support\Collection::getDot Like array_get()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -445,5 +445,10 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	{
 		return $this->toJson();
 	}
+	
+	public function getDot($key, $default = null)
+	{
+		return \Illuminate\Support\Arr::get($this->items, $key, $default);
+	}
 
 }


### PR DESCRIPTION
Add \Illuminate\Support\Collection::getDot() like array_get(). So pity, we havnt method to get value of nested array in Collection.
