### PR TITLE
[5.0] Moved Form Request ToThe Http Package

### DIFF
--- a/src/Illuminate/Foundation/Console/Optimize/config.php
+++ b/src/Illuminate/Foundation/Console/Optimize/config.php
@@ -54,7 +54,7 @@ return array_map('realpath', array(
     $basePath.'/vendor/laravel/framework/src/Illuminate/Validation/ValidationServiceProvider.php',
     $basePath.'/vendor/laravel/framework/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php',
     $basePath.'/vendor/laravel/framework/src/Illuminate/Foundation/Providers/EventServiceProvider.php',
-    $basePath.'/vendor/laravel/framework/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php',
+    $basePath.'/vendor/laravel/framework/src/Illuminate/Http/FormRequestServiceProvider.php',
     $basePath.'/vendor/laravel/framework/src/Illuminate/Routing/RouteServiceProvider.php',
     $basePath.'/vendor/laravel/framework/src/Illuminate/Auth/AuthServiceProvider.php',
     $basePath.'/vendor/laravel/framework/src/Illuminate/Pagination/PaginationServiceProvider.php',

--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -1,6 +1,6 @@
 <?php namespace {{namespace}};
 
-use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\FormRequest;
 
 class {{class}} extends FormRequest {
 

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -10,7 +10,7 @@ class FoundationServiceProvider extends AggregateServiceProvider {
 	 * @var array
 	 */
 	protected $providers = [
-		'Illuminate\Foundation\Providers\FormRequestServiceProvider',
+		'Illuminate\Http\FormRequestServiceProvider',
 	];
 
 }

--- a/src/Illuminate/Http/FormRequest.php
+++ b/src/Illuminate/Http/FormRequest.php
@@ -1,9 +1,6 @@
-<?php namespace Illuminate\Foundation\Http;
+<?php namespace Illuminate\Http;
 
-use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
-use Illuminate\Http\Response;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Redirector;
 use Illuminate\Container\Container;
 use Illuminate\Validation\Validator;
@@ -205,7 +202,7 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	 * Set the route handling the request.
 	 *
 	 * @param  \Illuminate\Routing\Route  $route
-	 * @return \Illuminate\Foundation\Http\FormRequest
+	 * @return \Illuminate\Http\FormRequest
 	 */
 	public function setRoute(Route $route)
 	{
@@ -218,7 +215,7 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	 * Set the Redirector instance.
 	 *
 	 * @param  \Illuminate\Routing\Redirector  $redirector
-	 * @return \Illuminate\Foundation\Http\FormRequest
+	 * @return \Illuminate\Http\FormRequest
 	 */
 	public function setRedirector(Redirector $redirector)
 	{

--- a/src/Illuminate/Http/FormRequestServiceProvider.php
+++ b/src/Illuminate/Http/FormRequestServiceProvider.php
@@ -1,7 +1,6 @@
-<?php namespace Illuminate\Foundation\Providers;
+<?php namespace Illuminate\Http;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Foundation\Http\FormRequest;
 use Symfony\Component\HttpFoundation\Request;
 
 class FormRequestServiceProvider extends ServiceProvider {
@@ -45,7 +44,7 @@ class FormRequestServiceProvider extends ServiceProvider {
 	/**
 	 * Initialize the form request with data from the given request.
 	 *
-	 * @param  \Illuminate\Foundation\Http\FormRequest  $form
+	 * @param  \Illuminate\Http\FormRequest  $form
 	 * @param  \Symfony\Component\HttpFoundation\Request  $request
 	 * @return void
 	 */

--- a/tests/Foundation/FoundationFormRequestTestCase.php
+++ b/tests/Foundation/FoundationFormRequestTestCase.php
@@ -86,7 +86,7 @@ class FoundationFormRequestTestCase extends PHPUnit_Framework_TestCase {
 
 }
 
-class FoundationTestFormRequestStub extends Illuminate\Foundation\Http\FormRequest {
+class FoundationTestFormRequestStub extends Illuminate\Http\FormRequest {
 	public function rules(StdClass $dep) {
 		return ['name' => 'required'];
 	}
@@ -98,7 +98,7 @@ class FoundationTestFormRequestStub extends Illuminate\Foundation\Http\FormReque
 	}
 }
 
-class FoundationTestFormRequestForbiddenStub extends Illuminate\Foundation\Http\FormRequest {
+class FoundationTestFormRequestForbiddenStub extends Illuminate\Http\FormRequest {
 	public function rules() {
 		return ['name' => 'required'];
 	}


### PR DESCRIPTION
The issue is that laravel 5 packages can't use the form request class unless they depend on the entire laravel/framework, but that's not an idea situation. I propose we move this class into illuminate/http.
