### PR TITLE
[4.2] Fix A Bug That Validator Bypasses Array Checking

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -368,7 +368,7 @@ class Validator implements MessageProviderInterface {
 	protected function isValidatable($rule, $attribute, $value)
 	{
 		return $this->presentOrRuleIsImplicit($rule, $attribute, $value) &&
-			   $this->passesOptionalCheck($attribute);
+				$this->passesOptionalCheck($attribute);
 	}
 
 	/**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -395,6 +395,7 @@ class Validator implements MessageProviderInterface {
 		if ($this->hasRule($attribute, array('Sometimes')))
 		{
 			return array_key_exists($attribute, array_dot($this->data))
+				|| in_array($attribute, array_keys($this->data))
                 || array_key_exists($attribute, $this->files);
 		}
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -395,7 +395,7 @@ class Validator implements MessageProviderInterface {
 		if ($this->hasRule($attribute, array('Sometimes')))
 		{
 			return array_key_exists($attribute, array_dot($this->data))
-				|| in_array($attribute, array_keys($this->data))
+                || in_array($attribute, array_keys($this->data))
                 || array_key_exists($attribute, $this->files);
 		}
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -368,7 +368,7 @@ class Validator implements MessageProviderInterface {
 	protected function isValidatable($rule, $attribute, $value)
 	{
 		return $this->presentOrRuleIsImplicit($rule, $attribute, $value) &&
-				$this->passesOptionalCheck($attribute);
+			$this->passesOptionalCheck($attribute);
 	}
 
 	/**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -316,27 +316,27 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
- 	 * Returns the data which was valid.
- 	 *
+	 * Returns the data which was valid.
+	 *
 	 * @return array
 	 */
 	public function valid()
 	{
 		if ( ! $this->messages) $this->passes();
 
- 		return array_diff_key($this->data, $this->messages()->toArray());
+		return array_diff_key($this->data, $this->messages()->toArray());
 	}
 
 	/**
- 	 * Returns the data which was invalid.
- 	 *
+	 * Returns the data which was invalid.
+	 *
 	 * @return array
 	 */
 	public function invalid()
 	{
 		if ( ! $this->messages) $this->passes();
 
- 		return array_intersect_key($this->data, $this->messages()->toArray());
+		return array_intersect_key($this->data, $this->messages()->toArray());
 	}
 
 	/**
@@ -368,7 +368,7 @@ class Validator implements MessageProviderInterface {
 	protected function isValidatable($rule, $attribute, $value)
 	{
 		return $this->presentOrRuleIsImplicit($rule, $attribute, $value) &&
-               $this->passesOptionalCheck($attribute);
+			   $this->passesOptionalCheck($attribute);
 	}
 
 	/**
@@ -395,8 +395,8 @@ class Validator implements MessageProviderInterface {
 		if ($this->hasRule($attribute, array('Sometimes')))
 		{
 			return array_key_exists($attribute, array_dot($this->data))
-                || in_array($attribute, array_keys($this->data))
-                || array_key_exists($attribute, $this->files);
+				|| in_array($attribute, array_keys($this->data))
+				|| array_key_exists($attribute, $this->files);
 		}
 
 		return true;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -24,6 +24,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 	}
 
+
 	public function testSometimesWorksOnArrays()
 	{
 		$trans = $this->getRealTranslator();
@@ -35,6 +36,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('foo' => array('bar', 'baz', 'moo', 'pew', 'boom')), array('foo' => 'sometimes|required|between:5,10'));
 		$this->assertTrue($v->passes());
 	}
+
 
 	public function testHasFailedValidationRules()
 	{

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -24,6 +24,17 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 	}
 
+	public function testSometimesWorksOnArrays()
+	{
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('foo' => array('bar', 'baz', 'moo')), array('foo' => 'sometimes|required|between:5,10'));
+		$this->assertFalse($v->passes());
+		$this->assertNotEmpty($v->failed());
+
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('foo' => array('bar', 'baz', 'moo', 'pew', 'boom')), array('foo' => 'sometimes|required|between:5,10'));
+		$this->assertTrue($v->passes());
+	}
 
 	public function testHasFailedValidationRules()
 	{


### PR DESCRIPTION
For checking array with “sometimes”
Validator calls function passesOptionalCheck to check if attribute key is set.
“passesOptionalCheck” uses array_dot to flatten the input data, so for input like “items”: [“good1”, “good2”, “good3”] become array(“items.0”
=> “good1”, “items.1” => “good2”, “items.2” => “good3”). Checking attribute with array_key_exists here will always return false and
validation is skipped
