### PR TITLE
[4.2] Setting Up Order, Limit, And Offset For Union Queries

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -127,6 +127,27 @@ class Builder {
 	public $unions;
 
 	/**
+	 * The maximum number of union records to return.
+	 *
+	 * @var int
+	 */
+	public $unionLimit;
+
+	/**
+	 * The number of union records to skip.
+	 *
+	 * @var int
+	 */
+	public $unionOffset;
+
+	/**
+	 * The orderings for the union query.
+	 *
+	 * @var array
+	 */
+	public $unionOrders;
+
+	/**
 	 * Indicates whether row locking is being used.
 	 *
 	 * @var string|bool
@@ -1054,9 +1075,10 @@ class Builder {
 	 */
 	public function orderBy($column, $direction = 'asc')
 	{
+		$property = $this->unions ? 'unionOrders' : 'orders';
 		$direction = strtolower($direction) == 'asc' ? 'asc' : 'desc';
 
-		$this->orders[] = compact('column', 'direction');
+		$this->{$property}[] = compact('column', 'direction');
 
 		return $this;
 	}
@@ -1109,7 +1131,9 @@ class Builder {
 	 */
 	public function offset($value)
 	{
-		$this->offset = max(0, $value);
+		$property = $this->unions ? 'unionOffset' : 'offset';
+
+		$this->$property = max(0, $value);
 
 		return $this;
 	}
@@ -1133,7 +1157,9 @@ class Builder {
 	 */
 	public function limit($value)
 	{
-		if ($value > 0) $this->limit = $value;
+		$property = $this->unions ? 'unionLimit' : 'limit';
+
+		if ($value > 0) $this->$property = $value;
 
 		return $this;
 	}

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -555,6 +555,21 @@ class Grammar extends BaseGrammar {
 			$sql .= $this->compileUnion($union);
 		}
 
+		if (isset($query->unionOrders))
+		{
+			$sql .= ' '.$this->compileOrders($query, $query->unionOrders);
+		}
+
+		if (isset($query->unionLimit))
+		{
+			$sql .= ' '.$this->compileLimit($query, $query->unionLimit);
+		}
+
+		if (isset($query->unionOffset))
+		{
+			$sql .= ' '.$this->compileOffset($query, $query->unionOffset);
+		}
+
 		return ltrim($sql);
 	}
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -376,6 +376,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(0 => 1, 1 => 2, 2 => 3), $builder->getBindings());
 	}
 
+
 	public function testUnionOrderBys()
 	{
 		$builder = $this->getBuilder();
@@ -386,6 +387,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(0 => 1, 1 => 2), $builder->getBindings());
 	}
 
+
 	public function testUnionLimitsAndOffsets()
 	{
 		$builder = $this->getBuilder();
@@ -394,6 +396,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->skip(5)->take(10);
 		$this->assertEquals('select * from "users" union select * from "dogs" limit 10 offset 5', $builder->toSql());
 	}
+
 
 	public function testMySqlUnionOrderBys()
 	{
@@ -405,6 +408,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(0 => 1, 1 => 2), $builder->getBindings());
 	}
 
+
 	public function testMySqlUnionLimitsAndOffsets()
 	{
 		$builder = $this->getMySqlBuilder();
@@ -413,6 +417,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->skip(5)->take(10);
 		$this->assertEquals('(select * from `users`) union (select * from `dogs`) limit 10 offset 5', $builder->toSql());
 	}
+
 
 	public function testSubSelectWhereIns()
 	{

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -376,6 +376,43 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array(0 => 1, 1 => 2, 2 => 3), $builder->getBindings());
 	}
 
+	public function testUnionOrderBys()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->where('id', '=', 1);
+		$builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
+		$builder->orderBy('id', 'desc');
+		$this->assertEquals('select * from "users" where "id" = ? union select * from "users" where "id" = ? order by "id" desc', $builder->toSql());
+		$this->assertEquals(array(0 => 1, 1 => 2), $builder->getBindings());
+	}
+
+	public function testUnionLimitsAndOffsets()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users');
+		$builder->union($this->getBuilder()->select('*')->from('dogs'));
+		$builder->skip(5)->take(10);
+		$this->assertEquals('select * from "users" union select * from "dogs" limit 10 offset 5', $builder->toSql());
+	}
+
+	public function testMySqlUnionOrderBys()
+	{
+		$builder = $this->getMySqlBuilder();
+		$builder->select('*')->from('users')->where('id', '=', 1);
+		$builder->union($this->getMySqlBuilder()->select('*')->from('users')->where('id', '=', 2));
+		$builder->orderBy('id', 'desc');
+		$this->assertEquals('(select * from `users` where `id` = ?) union (select * from `users` where `id` = ?) order by `id` desc', $builder->toSql());
+		$this->assertEquals(array(0 => 1, 1 => 2), $builder->getBindings());
+	}
+
+	public function testMySqlUnionLimitsAndOffsets()
+	{
+		$builder = $this->getMySqlBuilder();
+		$builder->select('*')->from('users');
+		$builder->union($this->getMySqlBuilder()->select('*')->from('dogs'));
+		$builder->skip(5)->take(10);
+		$this->assertEquals('(select * from `users`) union (select * from `dogs`) limit 10 offset 5', $builder->toSql());
+	}
 
 	public function testSubSelectWhereIns()
 	{


### PR DESCRIPTION
This is the follow-up to #4758. The goal is to allow ordering, limiting, and offsetting for union queries. I'm really only familiar with MySQL's application of this, but I did some research to see how this is done in all the different SQL flavors. It seems that MySQL is the deviant here, but [this commit](https://github.com/laravel/framework/commit/ea1d3c89311e763d6c78d17325d21f2ad4614c1c) from a year ago seems to aggressively put parentheses around all the things (and rightfully so).

The resources that I found regarding the other languages:
- SQL Server: http://technet.microsoft.com/en-us/library/ms173288(v=sql.110).aspx
- SQLite: http://stackoverflow.com/a/16913355/385950
- Postgres: http://stackoverflow.com/questions/4232626/posgresql-how-to-union-3-tables-sorted-by-date

All of these would seem to suggest that the normal order by syntax is (using the example from the unit test):

``` sql
select * from "users" where "id" = ? union select * from "users" where "id" = ? order by "id" desc
```

In MySQL, of course, this would only order the union select, not the combined result of the two tables. So in MySQL, that would be:

``` sql
(select * from `users` where `id` = ?) union (select * from `users` where `id` = ?) order by `id` desc
```

The four new unit tests reflect this syntax. Please let me know if one of these grammars is incorrect and I'll be sure to write some new tests.
