### PR TITLE
[4.2] Add Status Message To Password Reset Redirect

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/controller.stub
+++ b/src/Illuminate/Auth/Console/stubs/controller.stub
@@ -68,7 +68,7 @@ class RemindersController extends Controller {
 				return Redirect::back()->with('error', Lang::get($response));
 
 			case Password::PASSWORD_RESET:
-				return Redirect::to('/');
+				return Redirect::to('/')->with('status', Lang::get($response));
 		}
 	}
 


### PR DESCRIPTION
When the password is successfully reset, this controller doesn't pass a status message in the redirect. When I was using this controller, it looked like there was a built-in "reminders.reset" string passed back to match the "reset" key in the app/lang/en/reminders.php language file. There was a commit in that project (https://github.com/laravel/laravel/commit/9f31eede299fdd2faee9399f03a4328a173ad3ae#diff-b11d5eaf80c1cd8208c018b48a1f9d74) that added that missing string to the language file.
