### PR TITLE
[5.0] Added 'signature' And 'region' To AWS S3 Config

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -93,9 +93,9 @@ class FilesystemManager implements FactoryContract {
 	 */
 	public function createS3Driver(array $config)
 	{
-		$client = S3Client::factory([
-			'key' => $config['key'], 'secret' => $config['secret'],
-		]);
+		$client = S3Client::factory(
+			array_only($config, ['key', 'region', 'secret', 'signature'])
+		);
 
 		return $this->adapt(
 			new Flysystem(new S3Adapter($client, $config['bucket']))


### PR DESCRIPTION
Fix for the next errors: 

> "The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256"

and

> "A region must be specified when using signature version 4"

The new Amazon regions support only Signature Version 4 in Request Authentication.
http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version

Of course, you need to set these fields in the config of your app. But I didn't commit it, because it is not required for the all regions.

Also, this fix includes changes from https://github.com/laravel/framework/pull/5773
