### PR TITLE
[5.0] Use Symfony Session In Guard

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -2,11 +2,11 @@
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\HttpFoundation\Request;
-use Illuminate\Session\Store as SessionStore;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Contracts\Auth\User as UserContract;
 use Illuminate\Contracts\Auth\Guard as GuardContract;
 use Illuminate\Contracts\Cookie\QueueingFactory as CookieJar;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class Guard implements GuardContract {
 
@@ -39,9 +39,9 @@ class Guard implements GuardContract {
 	protected $provider;
 
 	/**
-	 * The session store used by the guard.
+	 * The session used by the guard.
 	 *
-	 * @var \Illuminate\Session\Store
+	 * @var \Symfony\Component\HttpFoundation\Session\SessionInterface
 	 */
 	protected $session;
 
@@ -84,12 +84,12 @@ class Guard implements GuardContract {
 	 * Create a new authentication guard.
 	 *
 	 * @param  \Illuminate\Auth\UserProviderInterface  $provider
-	 * @param  \Illuminate\Session\Store  $session
+	 * @param  \Symfony\Component\HttpFoundation\Session\SessionInterface  $session
 	 * @param  \Symfony\Component\HttpFoundation\Request  $request
 	 * @return void
 	 */
 	public function __construct(UserProviderInterface $provider,
-								SessionStore $session,
+								SessionInterface $session,
 								Request $request = null)
 	{
 		$this->session = $session;
@@ -439,7 +439,7 @@ class Guard implements GuardContract {
 	 */
 	protected function updateSession($id)
 	{
-		$this->session->put($this->getName(), $id);
+		$this->session->set($this->getName(), $id);
 
 		$this->session->migrate(true);
 	}
@@ -453,7 +453,7 @@ class Guard implements GuardContract {
 	 */
 	public function loginUsingId($id, $remember = false)
 	{
-		$this->session->put($this->getName(), $id);
+		$this->session->set($this->getName(), $id);
 
 		$this->login($user = $this->provider->retrieveById($id), $remember);
 
@@ -536,7 +536,7 @@ class Guard implements GuardContract {
 	 */
 	protected function clearUserDataFromStorage()
 	{
-		$this->session->forget($this->getName());
+		$this->session->remove($this->getName());
 
 		$recaller = $this->getRecallerName();
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -93,7 +93,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		$user = m::mock('Illuminate\Contracts\Auth\User');
 		$mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
 		$user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
-		$mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
+		$mock->getSession()->shouldReceive('set')->with('foo', 'bar')->once();
 		$session->shouldReceive('migrate')->once();
 		$mock->login($user);
 	}
@@ -108,7 +108,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		$events->shouldReceive('fire')->once()->with('auth.login', array($user, false));
 		$mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
 		$user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
-		$mock->getSession()->shouldReceive('put')->with('foo', 'bar')->once();
+		$mock->getSession()->shouldReceive('set')->with('foo', 'bar')->once();
 		$session->shouldReceive('migrate')->once();
 		$mock->login($user);
 	}
@@ -176,7 +176,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		$cookie = m::mock('Symfony\Component\HttpFoundation\Cookie');
 		$cookies->shouldReceive('forget')->once()->with('bar')->andReturn($cookie);
 		$cookies->shouldReceive('queue')->once()->with($cookie);
-		$mock->getSession()->shouldReceive('forget')->once()->with('foo');
+		$mock->getSession()->shouldReceive('remove')->once()->with('foo');
 		$mock->setUser($user);
 		$mock->logout();
 		$this->assertNull($mock->getUser());
@@ -206,7 +206,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		$foreverCookie = new Symfony\Component\HttpFoundation\Cookie($guard->getRecallerName(), 'foo');
 		$cookie->shouldReceive('forever')->once()->with($guard->getRecallerName(), 'foo|recaller')->andReturn($foreverCookie);
 		$cookie->shouldReceive('queue')->once()->with($foreverCookie);
-		$guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
+		$guard->getSession()->shouldReceive('set')->once()->with($guard->getName(), 'foo');
 		$session->shouldReceive('migrate')->once();
 		$user = m::mock('Illuminate\Contracts\Auth\User');
 		$user->shouldReceive('getAuthIdentifier')->andReturn('foo');
@@ -225,7 +225,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		$foreverCookie = new Symfony\Component\HttpFoundation\Cookie($guard->getRecallerName(), 'foo');
 		$cookie->shouldReceive('forever')->once()->andReturn($foreverCookie);
 		$cookie->shouldReceive('queue')->once()->with($foreverCookie);
-		$guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 'foo');
+		$guard->getSession()->shouldReceive('set')->once()->with($guard->getName(), 'foo');
 		$session->shouldReceive('migrate')->once();
 		$user = m::mock('Illuminate\Contracts\Auth\User');
 		$user->shouldReceive('getAuthIdentifier')->andReturn('foo');
@@ -240,7 +240,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	{
 		list($session, $provider, $request, $cookie) = $this->getMocks();
 		$guard = $this->getMock('Illuminate\Auth\Guard', array('login', 'user'), array($provider, $session, $request));
-		$guard->getSession()->shouldReceive('put')->once()->with($guard->getName(), 10);
+		$guard->getSession()->shouldReceive('set')->once()->with($guard->getName(), 10);
 		$guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user = m::mock('Illuminate\Contracts\Auth\User'));
 		$guard->expects($this->once())->method('login')->with($this->equalTo($user), $this->equalTo(false))->will($this->returnValue($user));
 
@@ -272,7 +272,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 	protected function getMocks()
 	{
 		return array(
-			m::mock('Illuminate\Session\Store'),
+			m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface'),
 			m::mock('Illuminate\Auth\UserProviderInterface'),
 			Symfony\Component\HttpFoundation\Request::create('/', 'GET'),
 			m::mock('Illuminate\Cookie\CookieJar'),


### PR DESCRIPTION
These small changes mean we can use any Symfony session driver, which makes this slightly more flexible.

We can use `set()` instead of `put()` and `remove()` instead of `forget()`, because the dot notation stuff in the latter methods is not needed (we only have a simple string as key).
