### PR TITLE
[5.0] Replace bindShared() With singleton() In Service Providers

### DIFF
--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -25,7 +25,7 @@ class AuthServiceProvider extends ServiceProvider {
 	 */
 	protected function registerAuthenticator()
 	{
-		$this->app->bindShared('auth', function($app)
+		$this->app->singleton('auth', function($app)
 		{
 			// Once the authentication service has actually been requested by the developer
 			// we will set a variable in the application indicating such. This helps us
@@ -35,7 +35,7 @@ class AuthServiceProvider extends ServiceProvider {
 			return new AuthManager($app);
 		});
 
-		$this->app->bindShared('auth.driver', function($app)
+		$this->app->singleton('auth.driver', function($app)
 		{
 			return $app['auth']->driver();
 		});

--- a/src/Illuminate/Auth/GeneratorServiceProvider.php
+++ b/src/Illuminate/Auth/GeneratorServiceProvider.php
@@ -45,7 +45,7 @@ class GeneratorServiceProvider extends ServiceProvider {
 	 */
 	protected function registerClearRemindersCommand()
 	{
-		$this->app->bindShared('command.auth.reminders.clear', function()
+		$this->app->singleton('command.auth.reminders.clear', function()
 		{
 			return new ClearRemindersCommand;
 		});

--- a/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
+++ b/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
@@ -31,7 +31,7 @@ class PasswordResetServiceProvider extends ServiceProvider {
 	 */
 	protected function registerPasswordBroker()
 	{
-		$this->app->bindShared('auth.password', function($app)
+		$this->app->singleton('auth.password', function($app)
 		{
 			// The password token repository is responsible for storing the email addresses
 			// and password reset tokens. It will be used to verify the tokens are valid
@@ -58,7 +58,7 @@ class PasswordResetServiceProvider extends ServiceProvider {
 	 */
 	protected function registerTokenRepository()
 	{
-		$this->app->bindShared('auth.password.tokens', function($app)
+		$this->app->singleton('auth.password.tokens', function($app)
 		{
 			$connection = $app['db']->connection();
 

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -18,17 +18,17 @@ class CacheServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->bindShared('cache', function($app)
+		$this->app->singleton('cache', function($app)
 		{
 			return new CacheManager($app);
 		});
 
-		$this->app->bindShared('cache.store', function($app)
+		$this->app->singleton('cache.store', function($app)
 		{
 			return $app['cache']->driver();
 		});
 
-		$this->app->bindShared('memcached.connector', function()
+		$this->app->singleton('memcached.connector', function()
 		{
 			return new MemcachedConnector;
 		});
@@ -43,12 +43,12 @@ class CacheServiceProvider extends ServiceProvider {
 	 */
 	public function registerCommands()
 	{
-		$this->app->bindShared('command.cache.clear', function($app)
+		$this->app->singleton('command.cache.clear', function($app)
 		{
 			return new Console\ClearCommand($app['cache'], $app['files']);
 		});
 
-		$this->app->bindShared('command.cache.table', function($app)
+		$this->app->singleton('command.cache.table', function($app)
 		{
 			return new Console\CacheTableCommand($app['files']);
 		});

--- a/src/Illuminate/Cookie/CookieServiceProvider.php
+++ b/src/Illuminate/Cookie/CookieServiceProvider.php
@@ -11,7 +11,7 @@ class CookieServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->bindShared('cookie', function($app)
+		$this->app->singleton('cookie', function($app)
 		{
 			$config = $app['config']['session'];
 

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -30,7 +30,7 @@ class DatabaseServiceProvider extends ServiceProvider {
 		// The connection factory is used to create the actual connection instances on
 		// the database. We will inject the factory into the manager so that it may
 		// make the connections while they are actually needed and not of before.
-		$this->app->bindShared('db.factory', function($app)
+		$this->app->singleton('db.factory', function($app)
 		{
 			return new ConnectionFactory($app);
 		});
@@ -38,7 +38,7 @@ class DatabaseServiceProvider extends ServiceProvider {
 		// The database manager is used to resolve various connections, since multiple
 		// connections might be managed. It also implements the connection resolver
 		// interface which may be used by other components requiring connections.
-		$this->app->bindShared('db', function($app)
+		$this->app->singleton('db', function($app)
 		{
 			return new DatabaseManager($app, $app['db.factory']);
 		});
@@ -51,7 +51,7 @@ class DatabaseServiceProvider extends ServiceProvider {
 	 */
 	protected function registerQueueableEntityResolver()
 	{
-		$this->app->bindShared('Illuminate\Contracts\Queue\EntityResolver', function()
+		$this->app->singleton('Illuminate\Contracts\Queue\EntityResolver', function()
 		{
 			return new Eloquent\QueueEntityResolver;
 		});

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -45,7 +45,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRepository()
 	{
-		$this->app->bindShared('migration.repository', function($app)
+		$this->app->singleton('migration.repository', function($app)
 		{
 			$table = $app['config']['database.migrations'];
 
@@ -63,7 +63,7 @@ class MigrationServiceProvider extends ServiceProvider {
 		// The migrator is responsible for actually running and rollback the migration
 		// files in the application. We'll pass in our database connection resolver
 		// so the migrator can resolve any of these connections when it needs to.
-		$this->app->bindShared('migrator', function($app)
+		$this->app->singleton('migrator', function($app)
 		{
 			$repository = $app['migration.repository'];
 
@@ -106,7 +106,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerMigrateCommand()
 	{
-		$this->app->bindShared('command.migrate', function($app)
+		$this->app->singleton('command.migrate', function($app)
 		{
 			$packagePath = $app['path.base'].'/vendor';
 
@@ -121,7 +121,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRollbackCommand()
 	{
-		$this->app->bindShared('command.migrate.rollback', function($app)
+		$this->app->singleton('command.migrate.rollback', function($app)
 		{
 			return new RollbackCommand($app['migrator']);
 		});
@@ -134,7 +134,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerResetCommand()
 	{
-		$this->app->bindShared('command.migrate.reset', function($app)
+		$this->app->singleton('command.migrate.reset', function($app)
 		{
 			return new ResetCommand($app['migrator']);
 		});
@@ -147,7 +147,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRefreshCommand()
 	{
-		$this->app->bindShared('command.migrate.refresh', function()
+		$this->app->singleton('command.migrate.refresh', function()
 		{
 			return new RefreshCommand;
 		});
@@ -155,7 +155,7 @@ class MigrationServiceProvider extends ServiceProvider {
 
 	protected function registerStatusCommand()
 	{
-		$this->app->bindShared('command.migrate.status', function($app)
+		$this->app->singleton('command.migrate.status', function($app)
 		{
 			return new StatusCommand($app['migrator']);
 		});
@@ -168,7 +168,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerInstallCommand()
 	{
-		$this->app->bindShared('command.migrate.install', function($app)
+		$this->app->singleton('command.migrate.install', function($app)
 		{
 			return new InstallCommand($app['migration.repository']);
 		});
@@ -183,7 +183,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	{
 		$this->registerCreator();
 
-		$this->app->bindShared('command.migrate.make', function($app)
+		$this->app->singleton('command.migrate.make', function($app)
 		{
 			// Once we have the migration creator registered, we will create the command
 			// and inject the creator. The creator is responsible for the actual file
@@ -203,7 +203,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerCreator()
 	{
-		$this->app->bindShared('migration.creator', function($app)
+		$this->app->singleton('migration.creator', function($app)
 		{
 			return new MigrationCreator($app['files']);
 		});

--- a/src/Illuminate/Database/SeedServiceProvider.php
+++ b/src/Illuminate/Database/SeedServiceProvider.php
@@ -21,7 +21,7 @@ class SeedServiceProvider extends ServiceProvider {
 	{
 		$this->registerSeedCommand();
 
-		$this->app->bindShared('seeder', function()
+		$this->app->singleton('seeder', function()
 		{
 			return new Seeder;
 		});
@@ -36,7 +36,7 @@ class SeedServiceProvider extends ServiceProvider {
 	 */
 	protected function registerSeedCommand()
 	{
-		$this->app->bindShared('command.seed', function($app)
+		$this->app->singleton('command.seed', function($app)
 		{
 			return new SeedCommand($app['db']);
 		});

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -11,7 +11,7 @@ class EncryptionServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->bindShared('encrypter', function($app)
+		$this->app->singleton('encrypter', function($app)
 		{
 			$encrypter =  new Encrypter($app['config']['app.key']);
 

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -23,7 +23,7 @@ class FilesystemServiceProvider extends ServiceProvider {
 	 */
 	protected function registerNativeFilesystem()
 	{
-		$this->app->bindShared('files', function() { return new Filesystem; });
+		$this->app->singleton('files', function() { return new Filesystem; });
 	}
 
 	/**
@@ -35,12 +35,12 @@ class FilesystemServiceProvider extends ServiceProvider {
 	{
 		$this->registerManager();
 
-		$this->app->bindShared('filesystem.disk', function()
+		$this->app->singleton('filesystem.disk', function()
 		{
 			return $this->app['filesystem']->disk($this->getDefaultDriver());
 		});
 
-		$this->app->bindShared('filesystem.cloud', function()
+		$this->app->singleton('filesystem.cloud', function()
 		{
 			return $this->app['filesystem']->disk($this->getCloudDriver());
 		});
@@ -53,7 +53,7 @@ class FilesystemServiceProvider extends ServiceProvider {
 	 */
 	protected function registerManager()
 	{
-		$this->app->bindShared('filesystem', function()
+		$this->app->singleton('filesystem', function()
 		{
 			return new FilesystemManager($this->app);
 		});

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -79,7 +79,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerAppNameCommand()
 	{
-		$this->app->bindShared('command.app.name', function($app)
+		$this->app->singleton('command.app.name', function($app)
 		{
 			return new AppNameCommand($app['composer'], $app['files']);
 		});
@@ -92,7 +92,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerChangesCommand()
 	{
-		$this->app->bindShared('command.changes', function()
+		$this->app->singleton('command.changes', function()
 		{
 			return new ChangesCommand;
 		});
@@ -105,7 +105,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerClearCompiledCommand()
 	{
-		$this->app->bindShared('command.clear-compiled', function()
+		$this->app->singleton('command.clear-compiled', function()
 		{
 			return new ClearCompiledCommand;
 		});
@@ -118,7 +118,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerConsoleMakeCommand()
 	{
-		$this->app->bindShared('command.console.make', function($app)
+		$this->app->singleton('command.console.make', function($app)
 		{
 			return new ConsoleMakeCommand($app['files']);
 		});
@@ -131,7 +131,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerDownCommand()
 	{
-		$this->app->bindShared('command.down', function()
+		$this->app->singleton('command.down', function()
 		{
 			return new DownCommand;
 		});
@@ -144,7 +144,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerEnvironmentCommand()
 	{
-		$this->app->bindShared('command.environment', function()
+		$this->app->singleton('command.environment', function()
 		{
 			return new EnvironmentCommand;
 		});
@@ -157,7 +157,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerEventScanCommand()
 	{
-		$this->app->bindShared('command.event.scan', function()
+		$this->app->singleton('command.event.scan', function()
 		{
 			return new EventScanCommand;
 		});
@@ -170,7 +170,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerKeyGenerateCommand()
 	{
-		$this->app->bindShared('command.key.generate', function($app)
+		$this->app->singleton('command.key.generate', function($app)
 		{
 			return new KeyGenerateCommand($app['files']);
 		});
@@ -183,7 +183,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerOptimizeCommand()
 	{
-		$this->app->bindShared('command.optimize', function($app)
+		$this->app->singleton('command.optimize', function($app)
 		{
 			return new OptimizeCommand($app['composer']);
 		});
@@ -196,7 +196,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerProviderMakeCommand()
 	{
-		$this->app->bindShared('command.provider.make', function($app)
+		$this->app->singleton('command.provider.make', function($app)
 		{
 			return new ProviderMakeCommand($app['files']);
 		});
@@ -209,7 +209,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRequestMakeCommand()
 	{
-		$this->app->bindShared('command.request.make', function($app)
+		$this->app->singleton('command.request.make', function($app)
 		{
 			return new RequestMakeCommand($app['files']);
 		});
@@ -222,7 +222,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRouteCacheCommand()
 	{
-		$this->app->bindShared('command.route.cache', function($app)
+		$this->app->singleton('command.route.cache', function($app)
 		{
 			return new RouteCacheCommand($app['files']);
 		});
@@ -235,7 +235,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRouteClearCommand()
 	{
-		$this->app->bindShared('command.route.clear', function($app)
+		$this->app->singleton('command.route.clear', function($app)
 		{
 			return new RouteClearCommand($app['files']);
 		});
@@ -248,7 +248,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRouteListCommand()
 	{
-		$this->app->bindShared('command.route.list', function($app)
+		$this->app->singleton('command.route.list', function($app)
 		{
 			return new RouteListCommand($app['router']);
 		});
@@ -261,7 +261,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRouteScanCommand()
 	{
-		$this->app->bindShared('command.route.scan', function()
+		$this->app->singleton('command.route.scan', function()
 		{
 			return new RouteScanCommand;
 		});
@@ -274,7 +274,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerServeCommand()
 	{
-		$this->app->bindShared('command.serve', function()
+		$this->app->singleton('command.serve', function()
 		{
 			return new ServeCommand;
 		});
@@ -287,7 +287,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerTinkerCommand()
 	{
-		$this->app->bindShared('command.tinker', function()
+		$this->app->singleton('command.tinker', function()
 		{
 			return new TinkerCommand;
 		});
@@ -300,7 +300,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerUpCommand()
 	{
-		$this->app->bindShared('command.up', function()
+		$this->app->singleton('command.up', function()
 		{
 			return new UpCommand;
 		});

--- a/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
@@ -20,12 +20,12 @@ class ComposerServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->bindShared('composer', function($app)
+		$this->app->singleton('composer', function($app)
 		{
 			return new Composer($app['files'], $app['path.base']);
 		});
 
-		$this->app->bindShared('command.dump-autoload', function($app)
+		$this->app->singleton('command.dump-autoload', function($app)
 		{
 			return new AutoloadCommand($app['composer']);
 		});

--- a/src/Illuminate/Foundation/Providers/PublisherServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/PublisherServiceProvider.php
@@ -49,7 +49,7 @@ class PublisherServiceProvider extends ServiceProvider {
 	{
 		$this->registerAssetPublishCommand();
 
-		$this->app->bindShared('asset.publisher', function($app)
+		$this->app->singleton('asset.publisher', function($app)
 		{
 			$publicPath = $app['path.public'];
 
@@ -71,7 +71,7 @@ class PublisherServiceProvider extends ServiceProvider {
 	 */
 	protected function registerAssetPublishCommand()
 	{
-		$this->app->bindShared('command.asset.publish', function($app)
+		$this->app->singleton('command.asset.publish', function($app)
 		{
 			return new AssetPublishCommand($app['asset.publisher']);
 		});
@@ -86,7 +86,7 @@ class PublisherServiceProvider extends ServiceProvider {
 	{
 		$this->registerConfigPublishCommand();
 
-		$this->app->bindShared('config.publisher', function($app)
+		$this->app->singleton('config.publisher', function($app)
 		{
 			$path = $app['path.config'];
 
@@ -108,7 +108,7 @@ class PublisherServiceProvider extends ServiceProvider {
 	 */
 	protected function registerConfigPublishCommand()
 	{
-		$this->app->bindShared('command.config.publish', function($app)
+		$this->app->singleton('command.config.publish', function($app)
 		{
 			return new ConfigPublishCommand($app['config.publisher']);
 		});
@@ -123,7 +123,7 @@ class PublisherServiceProvider extends ServiceProvider {
 	{
 		$this->registerViewPublishCommand();
 
-		$this->app->bindShared('view.publisher', function($app)
+		$this->app->singleton('view.publisher', function($app)
 		{
 			$viewPath = $app['path.base'].'/resources/views';
 
@@ -145,7 +145,7 @@ class PublisherServiceProvider extends ServiceProvider {
 	 */
 	protected function registerViewPublishCommand()
 	{
-		$this->app->bindShared('command.view.publish', function($app)
+		$this->app->singleton('command.view.publish', function($app)
 		{
 			return new ViewPublishCommand($app['view.publisher']);
 		});
@@ -160,7 +160,7 @@ class PublisherServiceProvider extends ServiceProvider {
 	{
 		$this->registerMigratePublishCommand();
 
-		$this->app->bindShared('migration.publisher', function($app)
+		$this->app->singleton('migration.publisher', function($app)
 		{
 			return new MigrationPublisher($app['files']);
 		});
@@ -173,7 +173,7 @@ class PublisherServiceProvider extends ServiceProvider {
 	 */
 	protected function registerMigratePublishCommand()
 	{
-		$this->app->bindShared('command.migrate.publish', function()
+		$this->app->singleton('command.migrate.publish', function()
 		{
 			return new MigratePublishCommand;
 		});

--- a/src/Illuminate/Hashing/HashServiceProvider.php
+++ b/src/Illuminate/Hashing/HashServiceProvider.php
@@ -18,7 +18,7 @@ class HashServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->bindShared('hash', function() { return new BcryptHasher; });
+		$this->app->singleton('hash', function() { return new BcryptHasher; });
 	}
 
 	/**

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -19,7 +19,7 @@ class MailServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->bindShared('mailer', function($app)
+		$this->app->singleton('mailer', function($app)
 		{
 			$this->registerSwiftMailer();
 

--- a/src/Illuminate/Queue/FailConsoleServiceProvider.php
+++ b/src/Illuminate/Queue/FailConsoleServiceProvider.php
@@ -23,27 +23,27 @@ class FailConsoleServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->bindShared('command.queue.failed', function()
+		$this->app->singleton('command.queue.failed', function()
 		{
 			return new ListFailedCommand;
 		});
 
-		$this->app->bindShared('command.queue.retry', function()
+		$this->app->singleton('command.queue.retry', function()
 		{
 			return new RetryCommand;
 		});
 
-		$this->app->bindShared('command.queue.forget', function()
+		$this->app->singleton('command.queue.forget', function()
 		{
 			return new ForgetFailedCommand;
 		});
 
-		$this->app->bindShared('command.queue.flush', function()
+		$this->app->singleton('command.queue.flush', function()
 		{
 			return new FlushFailedCommand;
 		});
 
-		$this->app->bindShared('command.queue.failed-table', function($app)
+		$this->app->singleton('command.queue.failed-table', function($app)
 		{
 			return new FailedTableCommand($app['files']);
 		});

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -49,7 +49,7 @@ class QueueServiceProvider extends ServiceProvider {
 	 */
 	protected function registerManager()
 	{
-		$this->app->bindShared('queue', function($app)
+		$this->app->singleton('queue', function($app)
 		{
 			// Once we have an instance of the queue manager, we will register the various
 			// resolvers for the queue connectors. These connectors are responsible for
@@ -61,7 +61,7 @@ class QueueServiceProvider extends ServiceProvider {
 			return $manager;
 		});
 
-		$this->app->bindShared('queue.connection', function($app)
+		$this->app->singleton('queue.connection', function($app)
 		{
 			return $app['queue']->connection();
 		});
@@ -78,7 +78,7 @@ class QueueServiceProvider extends ServiceProvider {
 
 		$this->registerRestartCommand();
 
-		$this->app->bindShared('queue.worker', function($app)
+		$this->app->singleton('queue.worker', function($app)
 		{
 			return new Worker($app['queue'], $app['queue.failer'], $app['events']);
 		});
@@ -91,7 +91,7 @@ class QueueServiceProvider extends ServiceProvider {
 	 */
 	protected function registerWorkCommand()
 	{
-		$this->app->bindShared('command.queue.work', function($app)
+		$this->app->singleton('command.queue.work', function($app)
 		{
 			return new WorkCommand($app['queue.worker']);
 		});
@@ -108,7 +108,7 @@ class QueueServiceProvider extends ServiceProvider {
 	{
 		$this->registerListenCommand();
 
-		$this->app->bindShared('queue.listener', function($app)
+		$this->app->singleton('queue.listener', function($app)
 		{
 			return new Listener($app['path.base']);
 		});
@@ -121,7 +121,7 @@ class QueueServiceProvider extends ServiceProvider {
 	 */
 	protected function registerListenCommand()
 	{
-		$this->app->bindShared('command.queue.listen', function($app)
+		$this->app->singleton('command.queue.listen', function($app)
 		{
 			return new ListenCommand($app['queue.listener']);
 		});
@@ -136,7 +136,7 @@ class QueueServiceProvider extends ServiceProvider {
 	 */
 	public function registerRestartCommand()
 	{
-		$this->app->bindShared('command.queue.restart', function()
+		$this->app->singleton('command.queue.restart', function()
 		{
 			return new RestartCommand;
 		});
@@ -151,7 +151,7 @@ class QueueServiceProvider extends ServiceProvider {
 	 */
 	protected function registerSubscriber()
 	{
-		$this->app->bindShared('command.queue.subscribe', function()
+		$this->app->singleton('command.queue.subscribe', function()
 		{
 			return new SubscribeCommand;
 		});
@@ -272,7 +272,7 @@ class QueueServiceProvider extends ServiceProvider {
 	 */
 	protected function registerFailedJobServices()
 	{
-		$this->app->bindShared('queue.failer', function($app)
+		$this->app->singleton('queue.failer', function($app)
 		{
 			$config = $app['config']['queue.failed'];
 
@@ -287,7 +287,7 @@ class QueueServiceProvider extends ServiceProvider {
 	 */
 	protected function registerQueueClosure()
 	{
-		$this->app->bindShared('IlluminateQueueClosure', function($app)
+		$this->app->singleton('IlluminateQueueClosure', function($app)
 		{
 			return new IlluminateQueueClosure($app['encrypter']);
 		});

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -18,7 +18,7 @@ class RedisServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->bindShared('redis', function($app)
+		$this->app->singleton('redis', function($app)
 		{
 			return new Database($app['config']['database.redis']);
 		});

--- a/src/Illuminate/Routing/GeneratorServiceProvider.php
+++ b/src/Illuminate/Routing/GeneratorServiceProvider.php
@@ -34,7 +34,7 @@ class GeneratorServiceProvider extends ServiceProvider {
 	 */
 	protected function registerControllerGenerator()
 	{
-		$this->app->bindShared('command.controller.make', function($app)
+		$this->app->singleton('command.controller.make', function($app)
 		{
 			return new ControllerMakeCommand($app['files']);
 		});
@@ -47,7 +47,7 @@ class GeneratorServiceProvider extends ServiceProvider {
 	 */
 	protected function registerMiddlewareGenerator()
 	{
-		$this->app->bindShared('command.middleware.make', function($app)
+		$this->app->singleton('command.middleware.make', function($app)
 		{
 			return new MiddlewareMakeCommand($app['files']);
 		});

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -110,7 +110,7 @@ class RoutingServiceProvider extends ServiceProvider {
 	 */
 	protected function registerResponseFactory()
 	{
-		$this->app->bindShared('Illuminate\Contracts\Routing\ResponseFactory', function($app)
+		$this->app->singleton('Illuminate\Contracts\Routing\ResponseFactory', function($app)
 		{
 			return new ResponseFactory($app['Illuminate\Contracts\View\Factory'], $app['redirect']);
 		});

--- a/src/Illuminate/Session/CommandsServiceProvider.php
+++ b/src/Illuminate/Session/CommandsServiceProvider.php
@@ -18,7 +18,7 @@ class CommandsServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->bindShared('command.session.database', function($app)
+		$this->app->singleton('command.session.database', function($app)
 		{
 			return new Console\SessionTableCommand($app['files']);
 		});

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -38,7 +38,7 @@ class SessionServiceProvider extends ServiceProvider {
 	 */
 	protected function registerSessionManager()
 	{
-		$this->app->bindShared('session', function($app)
+		$this->app->singleton('session', function($app)
 		{
 			return new SessionManager($app);
 		});
@@ -51,7 +51,7 @@ class SessionServiceProvider extends ServiceProvider {
 	 */
 	protected function registerSessionDriver()
 	{
-		$this->app->bindShared('session.store', function($app)
+		$this->app->singleton('session.store', function($app)
 		{
 			// First, we will create the session manager which is responsible for the
 			// creation of the various session drivers when they are needed by the

--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -20,7 +20,7 @@ class TranslationServiceProvider extends ServiceProvider {
 	{
 		$this->registerLoader();
 
-		$this->app->bindShared('translator', function($app)
+		$this->app->singleton('translator', function($app)
 		{
 			$loader = $app['translation.loader'];
 
@@ -44,7 +44,7 @@ class TranslationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerLoader()
 	{
-		$this->app->bindShared('translation.loader', function($app)
+		$this->app->singleton('translation.loader', function($app)
 		{
 			return new FileLoader($app['files'], $app['path.lang']);
 		});

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -42,7 +42,7 @@ class ValidationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerValidationFactory()
 	{
-		$this->app->bindShared('validator', function($app)
+		$this->app->singleton('validator', function($app)
 		{
 			$validator = new Factory($app['translator'], $app);
 
@@ -65,7 +65,7 @@ class ValidationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerPresenceVerifier()
 	{
-		$this->app->bindShared('validation.presence', function($app)
+		$this->app->singleton('validation.presence', function($app)
 		{
 			return new DatabasePresenceVerifier($app['db']);
 		});

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -30,7 +30,7 @@ class ViewServiceProvider extends ServiceProvider {
 	 */
 	public function registerEngineResolver()
 	{
-		$this->app->bindShared('view.engine.resolver', function()
+		$this->app->singleton('view.engine.resolver', function()
 		{
 			$resolver = new EngineResolver;
 
@@ -70,7 +70,7 @@ class ViewServiceProvider extends ServiceProvider {
 		// The Compiler engine requires an instance of the CompilerInterface, which in
 		// this case will be the Blade compiler, so we'll first create the compiler
 		// instance to pass into the engine so it can compile the views properly.
-		$app->bindShared('blade.compiler', function($app)
+		$app->singleton('blade.compiler', function($app)
 		{
 			$cache = $app['config']['view.compiled'];
 
@@ -90,7 +90,7 @@ class ViewServiceProvider extends ServiceProvider {
 	 */
 	public function registerViewFinder()
 	{
-		$this->app->bindShared('view.finder', function($app)
+		$this->app->singleton('view.finder', function($app)
 		{
 			$paths = $app['config']['view.paths'];
 
@@ -105,7 +105,7 @@ class ViewServiceProvider extends ServiceProvider {
 	 */
 	public function registerFactory()
 	{
-		$this->app->bindShared('view', function($app)
+		$this->app->singleton('view', function($app)
 		{
 			// Next we need to grab the engine resolver instance that will be used by the
 			// environment. The resolver will be used by an environment to get each of

--- a/src/Illuminate/Workbench/WorkbenchServiceProvider.php
+++ b/src/Illuminate/Workbench/WorkbenchServiceProvider.php
@@ -19,12 +19,12 @@ class WorkbenchServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->bindShared('package.creator', function($app)
+		$this->app->singleton('package.creator', function($app)
 		{
 			return new PackageCreator($app['files']);
 		});
 
-		$this->app->bindShared('command.workbench', function($app)
+		$this->app->singleton('command.workbench', function($app)
 		{
 			return new WorkbenchMakeCommand($app['package.creator']);
 		});

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -147,7 +147,7 @@ class ApplicationDeferredSharedServiceProviderStub extends Illuminate\Support\Se
 	protected $defer = true;
 	public function register()
 	{
-		$this->app->bindShared('foo', function() {
+		$this->app->singleton('foo', function() {
 			return new StdClass;
 		});
 	}
@@ -188,7 +188,7 @@ class ApplicationMultiProviderStub extends Illuminate\Support\ServiceProvider {
 	protected $defer = true;
 	public function register()
 	{
-		$this->app->bindShared('foo', function() { return 'foo'; });
-		$this->app->bindShared('bar', function($app) { return $app['foo'].'bar'; });
+		$this->app->singleton('foo', function() { return 'foo'; });
+		$this->app->singleton('bar', function($app) { return $app['foo'].'bar'; });
 	}
 }


### PR DESCRIPTION
Since service providers have access to an instance of the container _contract_, we should use the method from the contract. This also seems to be the preferred way of binding shared instances anyway (and Taylor does not want to add `bindShared()` to the contract), so we might as well use the preferred way throughout the framework.
