### PR TITLE
[4.2] Fix MorphToMany Relation Not Using Eloquent\Model@getMorphClass()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -45,7 +45,7 @@ class MorphToMany extends BelongsToMany {
 	{
 		$this->inverse = $inverse;
 		$this->morphType = $name.'_type';
-		$this->morphClass = $inverse ? get_class($query->getModel()) : get_class($parent);
+		$this->morphClass = $inverse ? $query->getModel()->getMorphClass() : $parent->getMorphClass();
 
 		parent::__construct($query, $parent, $table, $foreignKey, $otherKey, $relationName);
 	}

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -83,6 +83,7 @@ class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
 	public function getRelationArguments()
 	{
 		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
 		$parent->shouldReceive('getKey')->andReturn(1);
 		$parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
 		$parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');


### PR DESCRIPTION
Eloquent\Relations\MorphTo uses getMorphClass() method on Eloquent\Model to determine a model's morphClass, but Eloquent\Relations\MorphToMany still uses PHP builtin get_class. 

getMorphClass() method on Eloquent\Model originally introduced in b41bf57f65f32572ba3113910213f4d1077a7578

Signed-off-by: Jason Urasky jurasky@gmail.com
