### PR TITLE
[4.2] Multiple Composer Registrations Were Not Merged Correctly

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -325,7 +325,7 @@ class Factory {
 
 		foreach ($composers as $callback => $views)
 		{
-			$registered += $this->composer($views, $callback);
+			$registered = array_merge($registered, $this->composer($views, $callback));
 		}
 
 		return $registered;

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -176,6 +176,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 			'baz@baz' => array('qux', 'foo'),
 		));
 
+		$this->assertCount(3, $composers);
 		$reflections = array(
 			new ReflectionFunction($composers[0]),
 			new ReflectionFunction($composers[1]),


### PR DESCRIPTION
The use of the `+` operator over `array_merge()` resulted in the loss of some composers, because `+` replaces duplicate numeric keys, while `array_merge()` appends.

This is the failing unit test. I will push the fix in a little bit to prove this fixes the problem.
