### PR TITLE
[4.2] Added Test To Demonstate A Date Validation With Big Dates

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1110,6 +1110,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array('x' => '2000-01-01'), array('x' => 'date'));
 		$this->assertTrue($v->passes());
 
+		$v = new Validator($trans, array('x' => '22000-01-01'), array('x' => 'date'));
+		$this->assertTrue($v->fails());
+
 		$v = new Validator($trans, array('x' => 'Not a date'), array('x' => 'date'));
 		$this->assertTrue($v->fails());
 


### PR DESCRIPTION
PHP has some difficult handling dates with a year over 9999 for example if you pass a date like "11972-04-01" into DateTime it will return "2004-08-13" which is clearly not correct. However, the date validator considers this date to be valid.

My specific problem comes from pushing that date (which has been validated) into a model which uses the method Carbon::createFromFormat('Y-m-d H:i:s', '11972-04-01') which will throw an InvalidArgumentException.

The problem with the validateDate is that it is making use of the PHP function date_parse() which is changing the years 11972 to 2002 and 22014 to 2014 which is then being pumped into checkdate() which will validate because date_parse() has "corrected" it.

This is loosely related to issue #329 validateDate could be better.
