### PR TITLE
[4.2] Fixed UrlGenerator::previous() When There's No Referer

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -92,9 +92,9 @@ class UrlGenerator {
 	 */
 	public function previous()
 	{
-        $referer = $this->request->headers->get('referer');
+		$referer = $this->request->headers->get('referer');
 
-        return is_null($referer) ? null : $this->to($referer);
+		return is_null($referer) ? null : $this->to($referer);
 	}
 
 	/**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -92,7 +92,9 @@ class UrlGenerator {
 	 */
 	public function previous()
 	{
-		return $this->to($this->request->headers->get('referer'));
+        $referer = $this->request->headers->get('referer');
+
+        return is_null($referer) ? null : $this->to($referer);
 	}
 
 	/**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -235,4 +235,22 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('https://www.bar.com/foo', $url->route('plain'));
 	}
 
+    public function testPrevious()
+    {
+		$url = new UrlGenerator(
+			$routes = new Illuminate\Routing\RouteCollection,
+			$request = Illuminate\Http\Request::create('http://www.foo.com/', 'GET', array(), array(), array(), array('HTTP_REFERER' => 'http://bar.com'))
+		);
+
+        $this->assertEquals('http://bar.com', $url->previous());
+
+        
+		$url = new UrlGenerator(
+			$routes = new Illuminate\Routing\RouteCollection,
+			$request = Illuminate\Http\Request::create('http://www.foo.com/') 
+		);
+
+        $this->assertNull($url->previous());
+    }
+
 }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -244,7 +244,6 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals('http://bar.com', $url->previous());
 
-
         $url = new UrlGenerator(
             $routes = new Illuminate\Routing\RouteCollection,
             $request = Illuminate\Http\Request::create('http://www.foo.com/') 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -237,18 +237,18 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
     public function testPrevious()
     {
-		$url = new UrlGenerator(
-			$routes = new Illuminate\Routing\RouteCollection,
-			$request = Illuminate\Http\Request::create('http://www.foo.com/', 'GET', array(), array(), array(), array('HTTP_REFERER' => 'http://bar.com'))
-		);
+        $url = new UrlGenerator(
+            $routes = new Illuminate\Routing\RouteCollection,
+            $request = Illuminate\Http\Request::create('http://www.foo.com/', 'GET', array(), array(), array(), array('HTTP_REFERER' => 'http://bar.com'))
+        );
 
         $this->assertEquals('http://bar.com', $url->previous());
 
-        
-		$url = new UrlGenerator(
-			$routes = new Illuminate\Routing\RouteCollection,
-			$request = Illuminate\Http\Request::create('http://www.foo.com/') 
-		);
+
+        $url = new UrlGenerator(
+            $routes = new Illuminate\Routing\RouteCollection,
+            $request = Illuminate\Http\Request::create('http://www.foo.com/') 
+        );
 
         $this->assertNull($url->previous());
     }


### PR DESCRIPTION
Found this behavior on our application. Whenever there was no referer header, the UrlGenerator::previous() method was returning the project's root URL (which was causing a small bug on our 404 page).

The code wasn't explicit enough for me to understand whether this behavior was intended, or not. I've ended up going directly to the request's HeaderBag instance to probe for the referer header and depending its value conditionally invoking the previous() method - I found no "clean" way to distinguish if the client did arrive from our homepage, or if there was simply no referer.

I've exposed the problem through an unit test. I'd appreciate if someone gave it a look and tell me if this is being done on purpose, or if there's really a problem (I'll address if that's the case).

The culprit source code can be found [here](/laravel/framework/blob/4.2/src/Illuminate/Routing/UrlGenerator.php#L95).
