### PR TITLE
[4.2] Arr Method To Convert Dot-Notation Keys...

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -357,29 +357,34 @@ class Arr {
 	}
 
 	/**
-	 * Converts a one-dimensional array with keys that are written in dot notation
-	 * into a multidimensional associative array
+	 * Expand a flattened array with dots keys to a multi-dimensional
+	 * associative array.
 	 *
-	 * @param array $array
+	 * @param  array  $array
 	 * @return array
 	 */
 	public static function associativeFromDotKeys(array $array)
 	{
 		$results = array();
+
 		while (list($keys, $value) = each($array))
 		{
 			self::assignArrayByPath($results, $keys, $value);
 		}
+
 		return $results;
 	}
 
 	/**
-	 * In a couple of [key => value] assigned value to the key in the form of multi-dimensional array
-	 * formed from a string key with dot notation
+	 * Assigns value to the transformed from string with dots key
 	 *
-	 * @param array $array
-	 * @param string $path
-	 * @param mixed  $value
+	 * In a couple of [key => value] assigned value to the key in the form of
+	 * multi-dimensional array formed from a string key with dot notation
+	 *
+	 * @param  array   $array
+	 * @param  string  $path
+	 * @param  mixed   $value
+	 * @return void
 	 */
 	protected static function assignArrayByPath(array &$array, $path, $value)
 	{

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -356,4 +356,39 @@ class Arr {
 		return $filtered;
 	}
 
+	/**
+	 * Converts a one-dimensional array with keys that are written in dot notation
+	 * into a multidimensional associative array
+	 *
+	 * @param array $array
+	 * @return array
+	 */
+	public static function associativeFromDotKeys(array $array)
+	{
+		$results = array();
+		while (list($keys, $value) = each($array))
+		{
+			self::assignArrayByPath($results, $keys, $value);
+		}
+		return $results;
+	}
+
+	/**
+	 * In a couple of [key => value] assigned value to the key in the form of multi-dimensional array
+	 * formed from a string key with dot notation
+	 *
+	 * @param array $array
+	 * @param string $path
+	 * @param mixed  $value
+	 */
+	protected static function assignArrayByPath(array &$array, $path, $value)
+	{
+		$keys = explode('.', $path);
+
+		while ($key = array_shift($keys)) {
+			$array = &$array[$key];
+		}
+
+		$array = $value;
+	}
 }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -376,10 +376,10 @@ class Arr {
 	}
 
 	/**
-	 * Assigns value to the transformed from string with dots key
+	 * Assigns value to the transformed from string with dots key.
 	 *
 	 * In a couple of [key => value] assigned value to the key in the form of
-	 * multi-dimensional array formed from a string key with dot notation
+	 * multi-dimensional array formed from a string key with dot notation.
 	 *
 	 * @param  array   $array
 	 * @param  string  $path

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Arr;
+
+class SupportArrTest extends PHPUnit_Framework_TestCase {
+
+	public function testAssociativeFromDotKeys()
+	{
+		$testArray = array(
+			'levelOne' => 1,
+			'levelTwo.someKey' => 2,
+			'levelTwo.anotherKey' => 3,
+			'levelThree.moreKey.withMoreDepth' => 4,
+			'levelThree.moreKey.andAssigningToSameDepthKey' => 5,
+		);
+
+		$resultArray = Arr::associativeFromDotKeys($testArray);
+
+		$this->assertEquals(array(
+			'levelOne' => 1,
+			'levelTwo' => array(
+				'someKey' => 2,
+				'anotherKey' => 3,
+			),
+			'levelThree' => array(
+				'moreKey' => array(
+					'withMoreDepth' => 4,
+					'andAssigningToSameDepthKey' => 5,
+				)
+			)
+		), $resultArray);
+	}
+
+}


### PR DESCRIPTION
Adding method to Arr Helper that converts a one-dimensional array with keys that are written in dot notation into a multidimensional associative array.

From:

```
array(
    'levelOne' => 1,
    'levelTwo.someKey' => 2,
    'levelTwo.anotherKey' => 3,
    'levelThree.moreKey.withMoreDepth' => 4,
    'levelThree.moreKey.andAssigningToSameDepthKey' => 5,
)
```

to:

```
array(
    'levelOne' => 1,
    'levelTwo' => array(
        'someKey' => 2,
        'anotherKey' => 3,
    ),
    'levelThree' => array(
        'moreKey' => array(
            'withMoreDepth' => 4,
            'andAssigningToSameDepthKey' => 5,
        )
    )
)
```
