### PR TITLE
[5.0] Pass Session To FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -60,6 +60,8 @@ class FormRequestServiceProvider extends ServiceProvider {
 			$current->cookies->all(), $files, $current->server->all(), $current->getContent()
 		);
 
+		$form->setSession($current->getSession());
+
 		$form->setUserResolver($current->getUserResolver());
 
 		$form->setRouteResolver($current->getRouteResolver());


### PR DESCRIPTION
Without this, the FormRequest does not have access to the session and cannot access things like url.intended in order to do redirects after login.
