### PR TITLE
[5.0] Use singleton method in events service provider

### DIFF
--- a/src/Illuminate/Events/EventServiceProvider.php
+++ b/src/Illuminate/Events/EventServiceProvider.php
@@ -11,7 +11,7 @@ class EventServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app['events'] = $this->app->share(function($app)
+		$this->app->singleton('events', function($app)
 		{
 			return new Dispatcher($app);
 		});


### PR DESCRIPTION
We've had this before, the `share()` method isn't even part of the contract.
