### PR TITLE
[5.0] Add instance() to the container contract

### DIFF
--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -79,6 +79,15 @@ interface Container {
 	public function extend($abstract, Closure $closure);
 
 	/**
+	 * Register an existing instance as shared in the container.
+	 *
+	 * @param  string  $abstract
+	 * @param  mixed   $instance
+	 * @return void
+	 */
+	public function instance($abstract, $instance);
+
+	/**
 	 * Define a contextual binding.
 	 *
 	 * @param  string  $concrete


### PR DESCRIPTION
That is being used in many places where we only have an instance implementing the interface, so we should make sure this is part of the interface.
