### PR TITLE
[5.0] Aliases In Service Providers

### DIFF
--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -35,10 +35,15 @@ class AuthServiceProvider extends ServiceProvider {
 			return new AuthManager($app);
 		});
 
+		$this->app->alias('auth', 'Illuminate\Auth\AuthManager');
+
 		$this->app->singleton('auth.driver', function($app)
 		{
 			return $app['auth']->driver();
 		});
+
+		$this->app->alias('auth.driver', 'Illuminate\Auth\Guard');
+		$this->app->alias('auth.driver', 'Illuminate\Contracts\Auth\Guard');
 	}
 
 	/**

--- a/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
+++ b/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
@@ -49,6 +49,9 @@ class PasswordResetServiceProvider extends ServiceProvider {
 				$tokens, $users, $app['mailer'], $view
 			);
 		});
+
+		$this->app->alias('auth.password', 'Illuminate\Auth\Passwords\PasswordBroker');
+		$this->app->alias('auth.password', 'Illuminate\Contracts\Auth\PasswordBroker');
 	}
 
 	/**
@@ -73,6 +76,8 @@ class PasswordResetServiceProvider extends ServiceProvider {
 
 			return new DbRepository($connection, $table, $key, $expire);
 		});
+
+		$this->app->alias('auth.password.tokens', 'Illuminate\Auth\Passwords\TokenRepositoryInterface');
 	}
 
 	/**

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -23,10 +23,16 @@ class CacheServiceProvider extends ServiceProvider {
 			return new CacheManager($app);
 		});
 
+		$this->app->alias('cache', 'Illuminate\Cache\CacheManager');
+		$this->app->alias('cache', 'Illuminate\Contracts\Cache\Factory');
+
 		$this->app->singleton('cache.store', function($app)
 		{
 			return $app['cache']->driver();
 		});
+
+		$this->app->alias('cache.store', 'Illuminate\Cache\Repository');
+		$this->app->alias('cache.store', 'Illuminate\Contracts\Cache\Repository');
 
 		$this->app->singleton('memcached.connector', function()
 		{

--- a/src/Illuminate/Cookie/CookieServiceProvider.php
+++ b/src/Illuminate/Cookie/CookieServiceProvider.php
@@ -17,6 +17,10 @@ class CookieServiceProvider extends ServiceProvider {
 
 			return (new CookieJar)->setDefaultPathAndDomain($config['path'], $config['domain']);
 		});
+
+		$this->app->alias('cookie', 'Illuminate\Cookie\CookieJar');
+		$this->app->alias('cookie', 'Illuminate\Contracts\Cookie\Factory');
+		$this->app->alias('cookie', 'Illuminate\Contracts\Cookie\QueueingFactory');
 	}
 
 }

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -42,6 +42,8 @@ class DatabaseServiceProvider extends ServiceProvider {
 		{
 			return new DatabaseManager($app, $app['db.factory']);
 		});
+
+		$this->app->alias('db', 'Illuminate\Database\DatabaseManager');
 	}
 
 	/**

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -22,6 +22,9 @@ class EncryptionServiceProvider extends ServiceProvider {
 
 			return $encrypter;
 		});
+
+		$this->app->alias('encrypter', 'Illuminate\Encryption\Encrypter');
+		$this->app->alias('encrypter', 'Illuminate\Contracts\Encryption\Encrypter');
 	}
 
 }

--- a/src/Illuminate/Events/EventServiceProvider.php
+++ b/src/Illuminate/Events/EventServiceProvider.php
@@ -15,6 +15,9 @@ class EventServiceProvider extends ServiceProvider {
 		{
 			return new Dispatcher($app);
 		});
+
+		$this->app->alias('events', 'Illuminate\Events\Dispatcher');
+		$this->app->alias('events', 'Illuminate\Contracts\Events\Dispatcher');
 	}
 
 }

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -24,6 +24,8 @@ class FilesystemServiceProvider extends ServiceProvider {
 	protected function registerNativeFilesystem()
 	{
 		$this->app->singleton('files', function() { return new Filesystem; });
+
+		$this->app->alias('files', 'Illuminate\Filesystem\Filesystem');
 	}
 
 	/**
@@ -40,10 +42,14 @@ class FilesystemServiceProvider extends ServiceProvider {
 			return $this->app['filesystem']->disk($this->getDefaultDriver());
 		});
 
+		$this->app->alias('filesystem.disk', 'Illuminate\Contracts\Filesystem\Filesystem');
+
 		$this->app->singleton('filesystem.cloud', function()
 		{
 			return $this->app['filesystem']->disk($this->getCloudDriver());
 		});
+
+		$this->app->alias('filesystem.cloud', 'Illuminate\Contracts\Filesystem\Cloud');
 	}
 
 	/**
@@ -57,6 +63,8 @@ class FilesystemServiceProvider extends ServiceProvider {
 		{
 			return new FilesystemManager($this->app);
 		});
+
+		$this->app->alias('filesystem', 'Illuminate\Contracts\Filesystem\Factory');
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1,14 +1,11 @@
 <?php namespace Illuminate\Foundation;
 
 use Closure;
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Events\EventServiceProvider;
 use Illuminate\Routing\RoutingServiceProvider;
-use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 class Application extends Container implements ApplicationContract {
@@ -88,8 +85,6 @@ class Application extends Container implements ApplicationContract {
 
 		$this->registerBaseServiceProviders();
 
-		$this->registerCoreContainerAliases();
-
 		if ($basePath) $this->setBasePath($basePath);
 	}
 
@@ -114,7 +109,10 @@ class Application extends Container implements ApplicationContract {
 
 		$this->instance('app', $this);
 
-		$this->instance('Illuminate\Container\Container', $this);
+		$this->alias('app', 'Illuminate\Container\Container');
+		$this->alias('app', 'Illuminate\Foundation\Application');
+		$this->alias('app', 'Illuminate\Contracts\Container\Container');
+		$this->alias('app', 'Illuminate\Contracts\Foundation\Application');
 	}
 
 	/**
@@ -753,59 +751,6 @@ class Application extends Container implements ApplicationContract {
 		$this['translator']->setLocale($locale);
 
 		$this['events']->fire('locale.changed', array($locale));
-	}
-
-	/**
-	 * Register the core class aliases in the container.
-	 *
-	 * @return void
-	 */
-	public function registerCoreContainerAliases()
-	{
-		$aliases = array(
-			'app'            => ['Illuminate\Foundation\Application', 'Illuminate\Contracts\Container\Container', 'Illuminate\Contracts\Foundation\Application'],
-			'artisan'        => ['Illuminate\Console\Application', 'Illuminate\Contracts\Console\Application'],
-			'auth'           => 'Illuminate\Auth\AuthManager',
-			'auth.driver'    => ['Illuminate\Auth\Guard', 'Illuminate\Contracts\Auth\Guard'],
-			'auth.password.tokens' => 'Illuminate\Auth\Passwords\TokenRepositoryInterface',
-			'blade.compiler' => 'Illuminate\View\Compilers\BladeCompiler',
-			'cache'          => ['Illuminate\Cache\CacheManager', 'Illuminate\Contracts\Cache\Factory'],
-			'cache.store'    => ['Illuminate\Cache\Repository', 'Illuminate\Contracts\Cache\Repository'],
-			'config'         => ['Illuminate\Config\Repository', 'Illuminate\Contracts\Config\Repository'],
-			'cookie'         => ['Illuminate\Cookie\CookieJar', 'Illuminate\Contracts\Cookie\Factory', 'Illuminate\Contracts\Cookie\QueueingFactory'],
-			'encrypter'      => ['Illuminate\Encryption\Encrypter', 'Illuminate\Contracts\Encryption\Encrypter'],
-			'db'             => 'Illuminate\Database\DatabaseManager',
-			'events'         => ['Illuminate\Events\Dispatcher', 'Illuminate\Contracts\Events\Dispatcher'],
-			'files'          => 'Illuminate\Filesystem\Filesystem',
-			'filesystem'     => 'Illuminate\Contracts\Filesystem\Factory',
-			'filesystem.disk' => 'Illuminate\Contracts\Filesystem\Filesystem',
-			'filesystem.cloud' => 'Illuminate\Contracts\Filesystem\Cloud',
-			'hash'           => 'Illuminate\Contracts\Hashing\Hasher',
-			'translator'     => ['Illuminate\Translation\Translator', 'Symfony\Component\Translation\TranslatorInterface'],
-			'log'            => ['Illuminate\Log\Writer', 'Illuminate\Contracts\Logging\Log', 'Psr\Log\LoggerInterface'],
-			'mailer'         => ['Illuminate\Mail\Mailer', 'Illuminate\Contracts\Mail\Mailer', 'Illuminate\Contracts\Mail\MailQueue'],
-			'paginator'      => 'Illuminate\Pagination\Factory',
-			'auth.password'  => ['Illuminate\Auth\Passwords\PasswordBroker', 'Illuminate\Contracts\Auth\PasswordBroker'],
-			'queue'          => ['Illuminate\Queue\QueueManager', 'Illuminate\Contracts\Queue\Factory', 'Illuminate\Contracts\Queue\Monitor'],
-			'queue.connection' => 'Illuminate\Contracts\Queue\Queue',
-			'redirect'       => 'Illuminate\Routing\Redirector',
-			'redis'          => ['Illuminate\Redis\Database', 'Illuminate\Contracts\Redis\Database'],
-			'request'        => 'Illuminate\Http\Request',
-			'router'         => ['Illuminate\Routing\Router', 'Illuminate\Contracts\Routing\Registrar'],
-			'session'        => 'Illuminate\Session\SessionManager',
-			'session.store'  => ['Illuminate\Session\Store', 'Symfony\Component\HttpFoundation\Session\SessionInterface'],
-			'url'            => ['Illuminate\Routing\UrlGenerator', 'Illuminate\Contracts\Routing\UrlGenerator'],
-			'validator'      => ['Illuminate\Validation\Factory', 'Illuminate\Contracts\Validation\Factory'],
-			'view'           => ['Illuminate\View\Factory', 'Illuminate\Contracts\View\Factory'],
-		);
-
-		foreach ($aliases as $key => $aliases)
-		{
-			foreach ((array) $aliases as $alias)
-			{
-				$this->alias($key, $alias);
-			}
-		}
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -38,6 +38,10 @@ class ConfigureLogging {
 			new Monolog($app->environment()), $app['events'])
 		);
 
+		$app->alias('log', 'Illuminate\Log\Writer');
+		$app->alias('log', 'Illuminate\Contracts\Logging\Log');
+		$app->alias('log', 'Psr\Log\LoggerInterface');
+
 		return $log;
 	}
 

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -19,6 +19,9 @@ class LoadConfiguration {
 			new FileLoader(new Filesystem, $app['path.config']), $app->environment()
 		));
 
+		$app->alias('config', 'Illuminate\Config\Repository');
+		$app->alias('config', 'Illuminate\Contracts\Config\Repository');
+
 		date_default_timezone_set($config['app.timezone']);
 	}
 

--- a/src/Illuminate/Foundation/Bootstrap/SetRequestForConsole.php
+++ b/src/Illuminate/Foundation/Bootstrap/SetRequestForConsole.php
@@ -16,6 +16,8 @@ class SetRequestForConsole {
 		$url = $app['config']->get('app.url', 'http://localhost');
 
 		$app->instance('request', Request::create($url, 'GET', [], [], [], $_SERVER));
+		$app->alias('request', 'Illuminate\Http\Request');
+		$app->alias('request', 'Symfony\Component\HttpFoundation\Request');
 	}
 
 }

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -66,6 +66,9 @@ class Kernel implements KernelContract {
 	{
 		$this->app->instance('request', $request);
 
+		$this->app->alias('request', 'Illuminate\Http\Request');
+		$this->app->alias('request', 'Symfony\Component\HttpFoundation\Request');
+
 		$this->bootstrap();
 
 		return (new Stack($this->app))

--- a/src/Illuminate/Hashing/HashServiceProvider.php
+++ b/src/Illuminate/Hashing/HashServiceProvider.php
@@ -19,6 +19,8 @@ class HashServiceProvider extends ServiceProvider {
 	public function register()
 	{
 		$this->app->singleton('hash', function() { return new BcryptHasher; });
+
+		$this->app->alias('hash', 'Illuminate\Contracts\Hashing\Hasher');
 	}
 
 	/**

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -51,6 +51,10 @@ class MailServiceProvider extends ServiceProvider {
 
 			return $mailer;
 		});
+
+		$this->app->alias('mailer', 'Illuminate\Mail\Mailer');
+		$this->app->alias('mailer', 'Illuminate\Contracts\Mail\Mailer');
+		$this->app->alias('mailer', 'Illuminate\Contracts\Mail\MailQueue');
 	}
 
 	/**

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -61,10 +61,16 @@ class QueueServiceProvider extends ServiceProvider {
 			return $manager;
 		});
 
+		$this->app->alias('queue', 'Illuminate\Queue\QueueManager');
+		$this->app->alias('queue', 'Illuminate\Contracts\Queue\Factory');
+		$this->app->alias('queue', 'Illuminate\Contracts\Queue\Monitor');
+
 		$this->app->singleton('queue.connection', function($app)
 		{
 			return $app['queue']->connection();
 		});
+
+		$this->app->alias('queue.connection', 'Illuminate\Contracts\Queue\Queue');
 	}
 
 	/**

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -22,6 +22,9 @@ class RedisServiceProvider extends ServiceProvider {
 		{
 			return new Database($app['config']['database.redis']);
 		});
+
+		$this->app->alias('redis', 'Illuminate\Redis\Database');
+		$this->app->alias('redis', 'Illuminate\Contracts\Redis\Database');
 	}
 
 	/**

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -31,6 +31,9 @@ class RoutingServiceProvider extends ServiceProvider {
 		{
 			return new Router($app['events'], $app);
 		});
+
+		$this->app->alias('router', 'Illuminate\Routing\Router');
+		$this->app->alias('router', 'Illuminate\Contracts\Routing\Registrar');
 	}
 
 	/**
@@ -65,6 +68,9 @@ class RoutingServiceProvider extends ServiceProvider {
 
 			return $url;
 		});
+
+		$this->app->alias('url', 'Illuminate\Routing\UrlGenerator');
+		$this->app->alias('url', 'Illuminate\Contracts\Routing\UrlGenerator');
 	}
 
 	/**
@@ -101,6 +107,8 @@ class RoutingServiceProvider extends ServiceProvider {
 
 			return $redirector;
 		});
+
+		$this->app->alias('redirect', 'Illuminate\Routing\Redirector');
 	}
 
 	/**

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -42,6 +42,8 @@ class SessionServiceProvider extends ServiceProvider {
 		{
 			return new SessionManager($app);
 		});
+
+		$this->app->alias('session', 'Illuminate\Session\SessionManager');
 	}
 
 	/**
@@ -60,6 +62,9 @@ class SessionServiceProvider extends ServiceProvider {
 
 			return $manager->driver();
 		});
+
+		$this->app->alias('session.store', 'Illuminate\Session\Store');
+		$this->app->alias('session.store', 'Symfony\Component\HttpFoundation\Session\SessionInterface');
 	}
 
 }

--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -35,6 +35,9 @@ class TranslationServiceProvider extends ServiceProvider {
 
 			return $trans;
 		});
+
+		$this->app->alias('translator', 'Illuminate\Translation\Translator');
+		$this->app->alias('translator', 'Symfony\Component\Translation\TranslatorInterface');
 	}
 
 	/**

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -56,6 +56,9 @@ class ValidationServiceProvider extends ServiceProvider {
 
 			return $validator;
 		});
+
+		$this->app->alias('validator', 'Illuminate\Validation\Factory');
+		$this->app->alias('validator', 'Illuminate\Contracts\Validation\Factory');
 	}
 
 	/**

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -77,6 +77,8 @@ class ViewServiceProvider extends ServiceProvider {
 			return new BladeCompiler($app['files'], $cache);
 		});
 
+		$app->alias('blade.compiler', 'Illuminate\View\Compilers\BladeCompiler');
+
 		$resolver->register('blade', function() use ($app)
 		{
 			return new CompilerEngine($app['blade.compiler'], $app['files']);
@@ -125,6 +127,9 @@ class ViewServiceProvider extends ServiceProvider {
 
 			return $env;
 		});
+
+		$this->app->alias('view', 'Illuminate\View\Factory');
+		$this->app->alias('view', 'Illuminate\Contracts\View\Factory');
 	}
 
 }


### PR DESCRIPTION
This gets rid of the `registerCoreContainerAliases()` method in the base application class.

The benefits:
- aliases are defined where the bindings are registered (easier to maintain),
- service providers can more easily be re-used in other projects that do not use the application class (especially now since `illuminate/foundation` is gone)

While I was at it, I removed the aliases for the bindings called `paginator` and `artisan`. I could trace the removal of the former, not quite sure about the latter. Please confirm, @taylorotwell.
#### Question

I'm a little bit unsure about the alias(es) for the `request` binding. As the instance is bound to the container once in the HTTP kernel, once in a console bootstrapper, I added them in both places. Any better idea?
#### Deferred providers

I assume this will cause problems with deferred providers, which are not yet solved. Until now, when somebody wants to resolve a constructor argument typehinted with e.g. `Illuminate\Contracts\Redis\Database`, this would be recognized as an alias for `redis`. The application would then notice that this is provided by a deferred service provider and subsequently load it. Now, the aliases will not be registered until the service provider is actually loaded. Therefore, typehinting interfaces or classes that are registered in deferred providers would not work.

This affects the following service providers:
- `Illuminate\Auth\Passwords\PasswordResetServiceProvider`
- `Illuminate\Cache\CacheServiceProvider`
- `Illuminate\Hashing\HashServiceProvider`
- `Illuminate\Mail\MailServiceProvider`
- `Illuminate\Queue\QueueServiceProvider`
- `Illuminate\Redis\RedisServiceProvider`
- `Illuminate\Translation\TranslationServiceProvider`

I see the following ways around this:
1. When building the service provider manifest, run the `register()` methods and take note of all registered aliases. This would work for all aliases, except the one for the Blade compiler, as that will only be registered once the view factory is actually resolved. (We can change that? Or do we even need that alias?)
2. Add the aliases to the `provides()` array. This is duplication that I would like to avoid.
3. Add some kind of wrapper for alias generation in service providers. Either another method or a property, that would automatically be combined with the results from `provides()` when generating the manifest.
