### PR TITLE
[5.0] Application developer might want to include additional classes for as bootstrappers

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -107,7 +107,7 @@ class Kernel implements KernelContract {
 	{
 		if ( ! $this->app->hasBeenBootstrapped())
 		{
-			$this->app->bootstrapWith($this->bootstrappers);
+			$this->app->bootstrapWith($this->getBootstrappers());
 		}
 
 		$this->app->loadDeferredProviders();
@@ -127,6 +127,16 @@ class Kernel implements KernelContract {
 		}
 
 		return $this->artisan;
+	}
+
+	/**
+	 * Get the bootstrap classes for the application.
+	 *
+	 * @return array
+	 */
+	protected function getBootstrappers()
+	{
+		return $this->bootstrappers;
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -104,7 +104,7 @@ class Kernel implements KernelContract {
 	{
 		if ( ! $this->app->hasBeenBootstrapped())
 		{
-			$this->app->bootstrapWith($this->bootstrappers);
+			$this->app->bootstrapWith($this->getBootstrappers());
 		}
 	}
 
@@ -121,6 +121,16 @@ class Kernel implements KernelContract {
 
 			return $this->router->dispatch($request);
 		};
+	}
+
+	/**
+	 * Get the bootstrap classes for the application.
+	 *
+	 * @return array
+	 */
+	protected function getBootstrappers()
+	{
+		return $this->bootstrappers;
 	}
 
 	/**


### PR DESCRIPTION
This give them an easier way to do that without overriding the default options. E.g:

``` php
    protected function getBootstrappers()
    {
         return parent::getBootstrapper() + ['FooBoostrap']:
    }
```

Signed-off-by: crynobone crynobone@gmail.com
