### PR TITLE
[5.0] Change Auth to Use Short Array Syntax

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -89,7 +89,7 @@ class DatabaseUserProvider implements UserProviderInterface {
 	{
 		$this->conn->table($this->table)
                             ->where('id', $user->getAuthIdentifier())
-                            ->update(array('remember_token' => $token));
+                            ->update(['remember_token' => $token]);
 	}
 
 	/**

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -235,7 +235,7 @@ class Guard implements GuardContract {
 	 * @param  array  $credentials
 	 * @return bool
 	 */
-	public function once(array $credentials = array())
+	public function once(array $credentials = [])
 	{
 		if ($this->validate($credentials))
 		{
@@ -253,7 +253,7 @@ class Guard implements GuardContract {
 	 * @param  array  $credentials
 	 * @return bool
 	 */
-	public function validate(array $credentials = array())
+	public function validate(array $credentials = [])
 	{
 		return $this->attempt($credentials, false, false);
 	}
@@ -313,7 +313,7 @@ class Guard implements GuardContract {
 	 */
 	protected function getBasicCredentials(Request $request, $field)
 	{
-		return array($field => $request->getUser(), 'password' => $request->getPassword());
+		return [$field => $request->getUser(), 'password' => $request->getPassword()];
 	}
 
 	/**
@@ -323,7 +323,7 @@ class Guard implements GuardContract {
 	 */
 	protected function getBasicResponse()
 	{
-		$headers = array('WWW-Authenticate' => 'Basic');
+		$headers = ['WWW-Authenticate' => 'Basic'];
 
 		return new Response('Invalid credentials.', 401, $headers);
 	}
@@ -336,7 +336,7 @@ class Guard implements GuardContract {
 	 * @param  bool   $login
 	 * @return bool
 	 */
-	public function attempt(array $credentials = array(), $remember = false, $login = true)
+	public function attempt(array $credentials = [], $remember = false, $login = true)
 	{
 		$this->fireAttemptEvent($credentials, $remember, $login);
 
@@ -379,7 +379,7 @@ class Guard implements GuardContract {
 	{
 		if ($this->events)
 		{
-			$payload = array($credentials, $remember, $login);
+			$payload = [$credentials, $remember, $login];
 
 			$this->events->fire('auth.attempt', $payload);
 		}
@@ -425,7 +425,7 @@ class Guard implements GuardContract {
 		// based on the login and logout events fired from the guard instances.
 		if (isset($this->events))
 		{
-			$this->events->fire('auth.login', array($user, $remember));
+			$this->events->fire('auth.login', [$user, $remember]);
 		}
 
 		$this->setUser($user);
@@ -518,7 +518,7 @@ class Guard implements GuardContract {
 
 		if (isset($this->events))
 		{
-			$this->events->fire('auth.logout', array($user));
+			$this->events->fire('auth.logout', [$user]);
 		}
 
 		// Once we have fired the logout event we will clear the users out of memory

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -93,7 +93,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface {
 	 */
 	protected function getPayload($email, $token)
 	{
-		return array('email' => $email, 'token' => $token, 'created_at' => new Carbon);
+		return ['email' => $email, 'token' => $token, 'created_at' => new Carbon];
 	}
 
 	/**

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -230,7 +230,7 @@ class PasswordBroker implements PasswordBrokerContract {
 	 */
 	public function getUser(array $credentials)
 	{
-		$credentials = array_except($credentials, array('token'));
+		$credentials = array_except($credentials, ['token']);
 
 		$user = $this->users->retrieveByCredentials($credentials);
 

--- a/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
+++ b/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
@@ -82,7 +82,7 @@ class PasswordResetServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('auth.password', 'auth.password.tokens');
+		return ['auth.password', 'auth.password.tokens'];
 	}
 
 }


### PR DESCRIPTION
Update `Illuminate/Auth` to use `[]` instead of `array()`
