### PR TITLE
[5.0] Paginator isEmpty method fix

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -339,7 +339,7 @@ abstract class AbstractPaginator {
 	 */
 	public function isEmpty()
 	{
-		return empty($this->items);
+		return empty($this->items());
 	}
 
 	/**


### PR DESCRIPTION
Test this->items() (array) instead of $this->items (instance of \Illuminate\Support\Collection)
