### PR TITLE
[5.0] Replace last() with end() to remove Illuminate\Support requirement for Illuminate\Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -706,9 +706,9 @@ class Container implements ArrayAccess, ContainerContract {
 	 */
 	protected function getContextualConcrete($abstract)
 	{
-		if (isset($this->contextual[last($this->buildStack)][$abstract]))
+		if (isset($this->contextual[end($this->buildStack)][$abstract]))
 		{
-			return $this->contextual[last($this->buildStack)][$abstract];
+			return $this->contextual[end($this->buildStack)][$abstract];
 		}
 	}
 


### PR DESCRIPTION
Unless you have good reason for this I don't think `Illuminate/Container` should depend on a single function from `Illuminate\Support` which is essentially a proxy to the `end` function.
