### PR TITLE
[5.0] Allow Passing Wildcards To App::environment()

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -265,14 +265,9 @@ class Application extends Container implements ApplicationContract {
 	{
 		if (func_num_args() > 0)
 		{
-			if (is_array(func_get_arg(0)))
-			{
-				return in_array($this['env'], func_get_arg(0));
-			}
-			else
-			{
-				return in_array($this['env'], func_get_args());
-			}
+			$patterns = is_array(func_get_arg(0)) ? func_get_arg(0) : func_get_args();
+
+			return in_array($this['env'], $patterns);
 		}
 
 		return $this['env'];

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -267,7 +267,15 @@ class Application extends Container implements ApplicationContract {
 		{
 			$patterns = is_array(func_get_arg(0)) ? func_get_arg(0) : func_get_args();
 
-			return in_array($this['env'], $patterns);
+			foreach ($patterns as $pattern)
+			{
+				if (str_is($pattern, $this['env']))
+				{
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 		return $this['env'];

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -123,10 +123,12 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo', $app->environment());
 
 		$this->assertTrue($app->environment('foo'));
+		$this->assertTrue($app->environment('f*'));
 		$this->assertTrue($app->environment('foo', 'bar'));
 		$this->assertTrue($app->environment(['foo', 'bar']));
 
 		$this->assertFalse($app->environment('qux'));
+		$this->assertFalse($app->environment('q*'));
 		$this->assertFalse($app->environment('qux', 'bar'));
 		$this->assertFalse($app->environment(['qux', 'bar']));
 	}


### PR DESCRIPTION
Makes use of `str_is()`, so we can specify patterns like `App::environment('production-*')`.
