### PR TITLE
[5.0] Fixing DB::beginTransaction() And DB::rollBack()

### DIFF
--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -154,6 +154,20 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRollbackDoesNotAcquireNegativeTransactions()
+	{
+		$pdo = $this->getMock('DatabaseConnectionTestMockPDO');
+		$connection = $this->getMockConnection(array('getName'), $pdo);
+		$connection->expects($this->any())->method('getName')->will($this->returnValue('name'));
+		$connection->rollBack();
+		$connection->rollBack();
+		$connection->rollBack();
+
+		// regression bug fix, calling multiple times caused negative level
+		$this->assertEquals(0, $connection->transactionLevel());
+	}
+
+
 	public function testTransactionMethodRunsSuccessfully()
 	{
 		$pdo = $this->getMock('DatabaseConnectionTestMockPDO', array('beginTransaction', 'commit'));


### PR DESCRIPTION
Examine regression bug fix in tests/Database/DatabaseConnectionTest.php.

---

If you execute this you can see that transactions don't behave like one might think they should. In the following code, you can see how this can cause problems for a developer using transactions.

```
    DB::rollBack();  // nothing keeps this from happening

        print DB::transactionLevel() . PHP_EOL; // -1

    DB::beginTransaction(); // transaction does not start here... 

        DB::table('some_table')->insert([...]); // change to some table

    print DB::transactionLevel() . PHP_EOL; // 0

    DB::rollBack();  // rollback is not applied here

    print DB::transactionLevel() . PHP_EOL; // -1
```

---

Related issue: #6360.
