### PR TITLE
[5.0] Fix isEmpty() Bug With Paginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -339,7 +339,7 @@ abstract class AbstractPaginator {
 	 */
 	public function isEmpty()
 	{
-		return empty($this->items);
+		return $this->items->isEmpty();
 	}
 
 	/**
@@ -349,7 +349,7 @@ abstract class AbstractPaginator {
 	 */
 	public function count()
 	{
-		return count($this->items);
+		return $this->items->count();
 	}
 
 	/**


### PR DESCRIPTION
This fixes #6284.

Two PRs attempted to fix this (#6266, #6353) but we both made the same mistake. I (embarassingly) didn't bother to check why the tests failed.

Line 352 was changed for consistency.
