### PR TITLE
[5.0] Made The Http Kernel Class Abstract

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Routing\TerminableMiddleware;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
 
-class Kernel implements KernelContract {
+abstract class Kernel implements KernelContract {
 
 	/**
 	 * The application implementation.


### PR DESCRIPTION
Added Abstract to the Http default Kernel.php, because I was getting this error and adding abstract to it seemed to get the app working again:

Error Output: PHP Fatal error:  Class Illuminate\Foundation\Http\Kernel contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Illuminate\Contracts\Http\Kernel::terminate) in /var/www/laravel/storage/framework/compiled.php on line 1236
