### PR TITLE
[5.0] Added the ability to change the `$pageName` property

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -52,7 +52,7 @@ abstract class AbstractPaginator {
 	 *
 	 * @var string
 	 */
-	protected $pageName = 'page';
+	public static $pageName = 'page';
 
 	/**
 	 * The current page resolver callback.
@@ -111,7 +111,7 @@ abstract class AbstractPaginator {
 		// If we have any extra query string key / value pairs that need to be added
 		// onto the URL, we will put them in query string form and then attach it
 		// to the URL. This allows for extra information like sortings storage.
-		$parameters = [$this->pageName => $page];
+		$parameters = [static::$pageName => $page];
 
 		if (count($this->query) > 0)
 		{
@@ -190,7 +190,7 @@ abstract class AbstractPaginator {
 	 */
 	public function addQuery($key, $value)
 	{
-		if ($key !== $this->pageName)
+		if ($key !== static::$pageName)
 		{
 			$this->query[$key] = $value;
 		}


### PR DESCRIPTION
Changed the `$pageName` property to be static. There was no way to change the `$pageName` to another value without having is static when using the Paginator with the query builder.

This allows the application to set another `$pageName`.

I am aware you with this change can't have separate `$pageName` per Paginator, but when does an application have that? I've never ever seen that.

With this change, you can change the `$pageName` to another value by using

```
\Illuminate\Pagination\Paginator::$pageName = 'sida';
```

just like you would with the static method `currentPageResolver`

```
\Illuminate\Pagination\Paginator::currentPageResolver(function() {
    return $this->app['request']->input('sida');
});
```

_For those who don't know, `$pageName` sets `?pageName=N` in the views while `currentPageResolver` looks for `?pageName=N` in the url._

The ability to be able to do this is very important for websites not using English urls.
