### PR TITLE
Use timing safe string comparison in CSRF filter

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -5,6 +5,7 @@ use Illuminate\Contracts\Routing\Middleware;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Session\TokenMismatchException;
+use Symfony\Component\Security\Core\Util\StringUtils;
 
 class VerifyCsrfToken implements Middleware {
 
@@ -57,8 +58,8 @@ class VerifyCsrfToken implements Middleware {
 
 		$header = $request->header('X-XSRF-TOKEN');
 
-		return $token === $request->input('_token') ||
-		       ($header && $token === $this->encrypter->decrypt($header));
+		return StringUtils::equals($token, $request->input('_token')) ||
+		       ($header && StringUtils::equals($token, $this->encrypter->decrypt($header)));
 	}
 
 	/**


### PR DESCRIPTION
Use a timing safe comparison, as provided by the Symfony Security Component.

As proposed by by @lasselehtinen and @ircmaxell in ba0cf2a

See also https://github.com/laravel/laravel/pull/3126
