### PR TITLE
[5.0] Added A Setter For `$pageName` In The Paginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -267,7 +267,20 @@ abstract class AbstractPaginator {
 	{
 		return ! ($this->currentPage() == 1 && ! $this->hasMorePages());
 	}
+	
+	/**
+	 * Set the query string variable used to store the page.
+	 *
+	 * @param string $name
+	 * @return $this
+	 */
+	public function setPageName($name)
+	{
+		$this->pageName = $name;
 
+		return $this;
+	}
+	
 	/**
 	 * Resolve the current request path or return the default value.
 	 *

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -271,7 +271,7 @@ abstract class AbstractPaginator {
 	/**
 	 * Set the query string variable used to store the page.
 	 *
-	 * @param string $name
+	 * @param  string  $name
 	 * @return $this
 	 */
 	public function setPageName($name)


### PR DESCRIPTION
Continuing on pull https://github.com/laravel/framework/pull/6384.

This allows you to change the `$pageName` property fluently.

```
Model::paginate(20)->setPageName('sida');
```

Still not really fond of this, as you need to have

```
\Illuminate\Pagination\Paginator::currentPageResolver(function() {
    return $this->app['request']->input('sida');
});
```

somewhere else (in a new service provider etc). Would have been better if you could change it in only one place, but at least it's better then not being able to change it at all.
