### PR TITLE
[5.0] Session Data Before Start Session Middleware Is Wiped

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -98,7 +98,7 @@ class Store implements SessionInterface {
 	 */
 	protected function loadSession()
 	{
-		$this->attributes = $this->readFromHandler();
+		$this->attributes = $this->attributes + $this->readFromHandler();
 
 		foreach (array_merge($this->bags, array($this->metaBag)) as $bag)
 		{


### PR DESCRIPTION
Since the http kernel is exposed on the application level the session is not started at the same place it was back in 4.x. Therefore adding things to the session before the middleware (StartSession) is hit will be wiped. If this is intended it should be noted in documentation that any session data set before the kernel will be wiped. 
