### PR TITLE
[5.0] BCC Addresses Not Supported By MandrillTransport

### DIFF
--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -52,18 +52,41 @@ class MandrillTransport implements Swift_Transport {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function send(Swift_Mime_Message $message, &$failedRecipients = null)
-	{
-		$client = $this->getHttpClient();
+    public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+    {
+        $client = $this->getHttpClient();
 
-		$client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', [
-			'body' => [
-				'key' => $this->key,
-				'raw_message' => (string) $message,
-				'async' => false,
-			],
-		]);
-	}
+        $client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', [
+            'body' => [
+                'key' => $this->key,
+                'raw_message' => (string) $message,
+                'async' => false,
+                'to' => $this->getToAddresses($message)
+            ],
+        ]);
+    }
+
+    /**
+     * Get all the addresses this email should be sent to,
+     * including "to", "cc" and "bcc" addresses
+     *
+     * @param Swift_Mime_Message $message
+     * @return array
+     */
+    protected function getToAddresses(Swift_Mime_Message $message)
+    {
+        $to = [];
+        if ($message->getTo()) {
+            $to = array_merge($to, array_keys($message->getTo()));
+        }
+        if ($message->getCc()) {
+            $to = array_merge($to, array_keys($message->getCc()));
+        }
+        if ($message->getBcc()) {
+            $to = array_merge($to, array_keys($message->getBcc()));
+        }
+        return $to;
+    }
 
 	/**
 	 * {@inheritdoc}

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -52,19 +52,19 @@ class MandrillTransport implements Swift_Transport {
 	/**
 	 * {@inheritdoc}
 	 */
-    public function send(Swift_Mime_Message $message, &$failedRecipients = null)
-    {
-        $client = $this->getHttpClient();
+	public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+	{
+		$client = $this->getHttpClient();
 
-        $client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', [
-            'body' => [
-                'key' => $this->key,
-                'raw_message' => (string) $message,
-                'async' => false,
-                'to' => $this->getToAddresses($message)
-            ],
-        ]);
-    }
+		$client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', [
+			'body' => [
+				'key' => $this->key,
+				'raw_message' => (string) $message,
+				'async' => false,
+				'to' => $this->getToAddresses($message)
+			],
+		]);
+	}
 
     /**
      * Get all the addresses this email should be sent to,
@@ -73,20 +73,20 @@ class MandrillTransport implements Swift_Transport {
      * @param Swift_Mime_Message $message
      * @return array
      */
-    protected function getToAddresses(Swift_Mime_Message $message)
-    {
-        $to = [];
-        if ($message->getTo()) {
-            $to = array_merge($to, array_keys($message->getTo()));
-        }
-        if ($message->getCc()) {
-            $to = array_merge($to, array_keys($message->getCc()));
-        }
-        if ($message->getBcc()) {
-            $to = array_merge($to, array_keys($message->getBcc()));
-        }
-        return $to;
-    }
+	protected function getToAddresses(Swift_Mime_Message $message)
+	{
+		$to = [];
+		if ($message->getTo()) {
+			$to = array_merge($to, array_keys($message->getTo()));
+		}
+		if ($message->getCc()) {
+			$to = array_merge($to, array_keys($message->getCc()));
+		}
+		if ($message->getBcc()) {
+			$to = array_merge($to, array_keys($message->getBcc()));
+		}
+		return $to;
+	}
 
 	/**
 	 * {@inheritdoc}

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -66,13 +66,13 @@ class MandrillTransport implements Swift_Transport {
 		]);
 	}
 
-    /**
-     * Get all the addresses this email should be sent to,
-     * including "to", "cc" and "bcc" addresses
-     *
-     * @param Swift_Mime_Message $message
-     * @return array
-     */
+	/**
+	 * Get all the addresses this email should be sent to,
+	 * including "to", "cc" and "bcc" addresses
+	 *
+	 * @param Swift_Mime_Message $message
+	 * @return array
+	 */
 	protected function getToAddresses(Swift_Mime_Message $message)
 	{
 		$to = [];

--- a/tests/Mail/MailMandrillTransportTest.php
+++ b/tests/Mail/MailMandrillTransportTest.php
@@ -1,0 +1,45 @@
+<?php
+
+class MailMandrillTransportTest extends PHPUnit_Framework_TestCase {
+
+    public function testSend()
+    {
+        $message = new Swift_Message('Foo subject', 'Bar body');
+        $message->setTo('me@example.com');
+        $message->setBcc('you@example.com');
+
+        $transport = new MandrillTransportStub('testkey');
+        $client = $this->getMock('GuzzleHttp\Client', array('post'));
+        $transport->setHttpClient($client);
+
+        $client->expects($this->once())
+            ->method('post')
+            ->with($this->equalTo('https://mandrillapp.com/api/1.0/messages/send-raw.json'),
+                $this->equalTo([
+                    'body' => [
+                        'key' => 'testkey',
+                        'raw_message' => $message->toString(),
+                        'async' => false,
+                        'to' => ['me@example.com', 'you@example.com']
+                    ]
+                ])
+            );
+
+        $transport->send($message);
+    }
+}
+
+class MandrillTransportStub extends \Illuminate\Mail\Transport\MandrillTransport
+{
+    protected $client;
+
+    protected function getHttpClient()
+    {
+        return $this->client;
+    }
+
+    public function setHttpClient($client)
+    {
+        $this->client = $client;
+    }
+}


### PR DESCRIPTION
Mandrill's `messages/send-raw` API currently doesn't support sending to BCC addresses by simply adding them to the raw message header, which is what's currently used by the Laravel `MandrillTransport`class.

This change includes all addresses that should receive the email (TO, CC and BCC) in the API call via a "to" argument which is supported by their API.

From a member of the Mandrill support team:

> If you want to include a BCC recipient while generating a send-raw call manually, you'll need to include the recipient in the to: array for your API call, while not including them in any headers within the raw message. The send-raw call is intended primarily as a way to convert SMTP conversations (which include a RCPT TO portion) to API calls, so if you're making the call directly you will need to include the address manually rather than just in the header of the raw message.

Also added a basic unit test for the `MandrillTransport` to test the `send()` method
