### PR TITLE
[5.0] Added A Getter For The Defined Commands

### DIFF
--- a/src/Illuminate/Contracts/Console/Kernel.php
+++ b/src/Illuminate/Contracts/Console/Kernel.php
@@ -27,4 +27,11 @@ interface Kernel {
 	 */
 	public function output();
 
+	/**
+	 * Get all defined artisan commands
+	 *
+	 * @return array
+	 */
+	public function all();
+
 }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -114,6 +114,16 @@ class Kernel implements KernelContract {
 	}
 
 	/**
+	 * Get all defined artisan commands
+	 *
+	 * @return array
+	 */
+	public function all()
+	{
+		return $this->commands;
+	}
+
+	/**
 	 * Get the Artisan application instance.
 	 *
 	 * @return \Illuminate\Console\Application


### PR DESCRIPTION
Before we used to do Artisan::all(). It would be useful for package developers to have access to the array of commands defined in app/Console/Kernel.php
