### PR TITLE
[4.2] Fixed An Issue With The Form Builder

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -233,11 +233,7 @@ class FormBuilder {
 		if ( ! in_array($type, $this->skipValueTypes))
 		{
 			$value = $this->getValueAttribute($name, $value);
-			if (is_array($value))
-			{
-				$value = reset($value);
-			}
-
+			if (is_array($value)) $value = reset($value);
 		}
 
 		// Once we have the type, value, and ID we can merge them into the rest of the

--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -233,6 +233,11 @@ class FormBuilder {
 		if ( ! in_array($type, $this->skipValueTypes))
 		{
 			$value = $this->getValueAttribute($name, $value);
+			if (is_array($value))
+			{
+				$value = reset($value);
+			}
+
 		}
 
 		// Once we have the type, value, and ID we can merge them into the rest of the


### PR DESCRIPTION
Add check if old input is an array and grab the first value before passing it as an attribute.

A potential fix for the issue with using square brackets in the name of a non-checkable field.

---

Issue #6401.
