### PR TITLE
[4.2] Fix PDO::FETCH_ASSOC Support In Schema::hasColumn()

### DIFF
--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -10,7 +10,7 @@ class MySqlProcessor extends Processor {
 	 */
 	public function processColumnListing($results)
 	{
-		return array_map(function($r) { return $r->column_name; }, $results);
+		return array_map(function($r) { $r = (object) $r; return $r->column_name; }, $results);
 	}
 
 }

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -34,7 +34,7 @@ class PostgresProcessor extends Processor {
 	 */
 	public function processColumnListing($results)
 	{
-		return array_values(array_map(function($r) { return $r->column_name; }, $results));
+		return array_values(array_map(function($r) { $r = (object) $r; return $r->column_name; }, $results));
 	}
 
 }

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -10,7 +10,7 @@ class SQLiteProcessor extends Processor {
 	 */
 	public function processColumnListing($results)
 	{
-		return array_values(array_map(function($r) { return $r->name; }, $results));
+		return array_values(array_map(function($r) { $r = (object) $r; return $r->name; }, $results));
 	}
 
 }

--- a/tests/Database/DatabaseMySqlProcessorTest.php
+++ b/tests/Database/DatabaseMySqlProcessorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class DatabaseMySqlProcessorTest extends PHPUnit_Framework_TestCase {
+
+	public function testProcessColumnListing()
+	{
+		$processor = new Illuminate\Database\Query\Processors\MySqlProcessor;
+		$listing = [['column_name' => 'id'], ['column_name' => 'name'], ['column_name' => 'email']];
+		$expected = ['id', 'name', 'email'];
+		$this->assertEquals($expected, $processor->processColumnListing($listing));
+
+		// convert listing to objects to simulate PDO::FETCH_CLASS
+		foreach($listing as &$row) {
+			$row = (object) $row;
+		}
+
+		$this->assertEquals($expected, $processor->processColumnListing($listing));
+	}
+
+}

--- a/tests/Database/DatabasePostgresProcessorTest.php
+++ b/tests/Database/DatabasePostgresProcessorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class DatabasePostgresProcessorTest extends PHPUnit_Framework_TestCase {
+
+  public function testProcessColumnListing()
+  {
+    $processor = new Illuminate\Database\Query\Processors\PostgresProcessor;
+    $listing = [['column_name' => 'id'], ['column_name' => 'name'], ['column_name' => 'email']];
+    $expected = ['id', 'name', 'email'];
+    $this->assertEquals($expected, $processor->processColumnListing($listing));
+
+    // convert listing to objects to simulate PDO::FETCH_CLASS
+    foreach($listing as &$row) {
+      $row = (object) $row;
+    }
+
+    $this->assertEquals($expected, $processor->processColumnListing($listing));
+  }
+
+}

--- a/tests/Database/DatabaseSQLiteProcessorTest.php
+++ b/tests/Database/DatabaseSQLiteProcessorTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class DatabaseSQLiteProcessorTest extends PHPUnit_Framework_TestCase {
+
+  public function testProcessColumnListing()
+  {
+    $processor = new Illuminate\Database\Query\Processors\SQLiteProcessor;
+    $listing = [['name' => 'id'], ['name' => 'name'], ['name' => 'email']];
+    $expected = ['id', 'name', 'email'];
+    $this->assertEquals($expected, $processor->processColumnListing($listing));
+
+    // convert listing to objects to simulate PDO::FETCH_CLASS
+    foreach($listing as &$row) {
+      $row = (object) $row;
+    }
+
+    $this->assertEquals($expected, $processor->processColumnListing($listing));
+  }
+
+}


### PR DESCRIPTION
Consider this a continuation of #3512. When fetch mode is set to `PDO::FETCH_ASSOC`, `Schema::hasColumn()` fails because the processors under `Illuminate\Database\Query\Processors` expect an array of objects. This PR casts results to objects before trying to use them. I've also added tests for each changed processor to ensure that both `PDO::FETCH_ASSOC` and `PDO::FETCH_CLASS` are supported.
