### PR TITLE
[4.2] Amazon SES Mail Driver

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -1,0 +1,96 @@
+<?php namespace Illuminate\Mail\Transport;
+
+use Swift_Transport;
+use Aws\Ses\SesClient;
+use Swift_Mime_Message;
+use Swift_Events_EventListener;
+
+class SesTransport implements Swift_Transport {
+
+	/**
+	 * The Amazon SES instance.
+	 *
+	 * @var \Aws\Ses\SesClient
+	 */
+	protected $ses;
+
+	/**
+	 * Create a new Mailgun transport instance.
+	 *
+	 * @param  \Aws\Ses\SesClient  $ses
+	 * @return void
+	 */
+	public function __construct(SesClient $ses)
+	{
+		$this->ses = $ses;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isStarted()
+	{
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function start()
+	{
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function stop()
+	{
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+	{
+		$this->ses->sendRawEmail([
+			'Source' => $message->getSender(),
+			'Destinations' => $this->getTo($message),
+			'RawMessage' => [
+				'Data' => base64_encode((string) $message)
+			]
+		]);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function registerPlugin(Swift_Events_EventListener $plugin)
+	{
+		//
+	}
+
+	/**
+	 * Get the "to" payload field for the API request.
+	 *
+	 * @param  \Swift_Mime_Message  $message
+	 * @return array
+	 */
+	protected function getTo(Swift_Mime_Message $message)
+	{
+		$destinations = [];
+
+		$contacts = array_merge(
+			(array) $message->getTo(), (array) $message->getCc(), (array) $message->getBcc()
+		);
+
+		foreach ($contacts as $address => $display)
+		{
+			$destinations[] = $address;
+		}
+
+		return $destinations;
+	}
+
+}


### PR DESCRIPTION
As per the proposal in #5349 here is an implementation of AWS SES as a mail transport driver.

It requires three configuration keys places in the `services.php` file for SES; `key`, `secret` and `region`, similar to SQS queues configuration.

I'm not sure if the instantiation of the `SesClient` should be moved from the `MailServiceProvider` to somewhere else - the `SqsClient` for queues is instantiated in a queue connector, but mail transports don't have connectors.
