### PR TITLE
[5.0] Added Callable Wheres On Route

### DIFF
--- a/src/Illuminate/Contracts/Routing/CallableWhere.php
+++ b/src/Illuminate/Contracts/Routing/CallableWhere.php
@@ -1,0 +1,14 @@
+<?php namespace Illuminate\Contracts\Routing;
+
+interface CallableWhere {
+
+	/**
+	 * Validate a given rule against a route and request.
+	 *
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @param  \Illuminate\Http\Request  $request
+	 * @return bool
+	 */
+	public function check($route, $request);
+
+}

--- a/src/Illuminate/Routing/Matching/CallableWheresValidator.php
+++ b/src/Illuminate/Routing/Matching/CallableWheresValidator.php
@@ -1,0 +1,49 @@
+<?php namespace Illuminate\Routing\Matching;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use \Closure;
+
+class CallableWheresValidator implements ValidatorInterface {
+
+	/**
+	 * Validate a given rule against a route and request.
+	 *
+	 * @param  \Illuminate\Routing\Route  $route
+	 * @param  \Illuminate\Http\Request   $request
+	 * @return bool
+	 */
+	public function matches(Route $route, Request $request){
+		foreach($route->getCallableWheres() as $condition){
+			$route->bindParameters($request);
+
+			$result = $this->callCondition($route, $request, $condition);
+
+			if( ! $result) return $result;
+		}
+
+
+		return true;
+	}
+
+	/**
+	 * @param  Route          $route
+	 * @param  Request        $request
+	 * @param  string|Closure $condition
+	 * @return bool
+	 */
+	protected function callCondition(Route $route, Request $request, $condition)
+	{
+		if (is_string($condition)) {
+			// condition is a class name with, ex callable:PageExistsWhere
+			$className = ltrim($condition, 'callable:');
+			$result    = (new $className)->check($route, $request);
+
+			return $result;
+		}
+
+		// condition is a closure
+		$result = $condition($route, $request);
+		return $result;
+	}
+}


### PR DESCRIPTION
Example of usage:

``` php
$router
    ->get('/{page}', function(){
        return 'a page';
    })
    ->where(function($route, $request){
        $slugs = ['about', 'tos'];
        return in_array($route->page, $slugs);
    });

$router
    ->get('/{post}', function(){
        return 'a post';
    })
    ->where(function($route, $request){
        $slugs = ['hello-world'];
        return in_array($route->post, $slugs);
    });
```

A huge number of projects needs this feature. Before callable wheres we used some regex "hacks" with slugs separated by |, or a ugly foreach. Ex:

``` php
$slugs = Page::lists('slug');
foreach($slugs as $slug){
    Route::get('/'.$slug, function() use($slug){
        return View::make('page')->with('slug', $slug);
    });
}
```
