### PR TITLE
[4.2] Use The File Loading Method In FileLoader

### DIFF
--- a/src/Illuminate/Config/FileLoader.php
+++ b/src/Illuminate/Config/FileLoader.php
@@ -74,7 +74,7 @@ class FileLoader implements LoaderInterface {
 
 		if ($this->files->exists($file))
 		{
-			$items = $this->files->getRequire($file);
+			$items = $this->getRequire($file);
 		}
 
 		// Finally we're ready to check for the environment specific configuration
@@ -99,7 +99,7 @@ class FileLoader implements LoaderInterface {
 	 */
 	protected function mergeEnvironment(array $items, $file)
 	{
-		return array_replace_recursive($items, $this->files->getRequire($file));
+		return array_replace_recursive($items, $this->getRequire($file));
 	}
 
 	/**


### PR DESCRIPTION
Before, to switch formats you had to extend and override a bunch of methods:
- `\Illuminate\Config\FileLoader::load`
- `\Illuminate\Config\FileLoader::mergeEnvironment`
- `\Illuminate\Config\FileLoader::getRequire`

This is a pain for obvious reasons, I may want to use json format, but I might want the Load method to work as it does in the framework. with this change, the only method that needs overriding is `\Illuminate\Config\FileLoader::getRequire`.
