### PR TITLE
[4.2] Fixed Carbon InvalidArgumentException When Using toArray or toJson On Unset Timestamps

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2247,7 +2247,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// formatting while accessing attributes vs. arraying / JSONing a model.
 		foreach ($this->getDates() as $key)
 		{
-			if ( ! isset($attributes[$key])) continue;
+			if ( ! isset($attributes[$key]) || ! strtotime($attributes[$key])) continue;
 
 			$attributes[$key] = (string) $this->asDateTime($attributes[$key]);
 		}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -482,8 +482,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	{
 		$model = new EloquentDateModelStub;
 		$model->setRawAttributes(array(
-			'created_at'	=> '0000-00-00',
-			'updated_at'	=> '0000-00-00',
+			'created_at'	=> '0000-00-00 00:00:00',
+			'updated_at'	=> '0000-00-00 00:00:00',
 		));
 
 		$array = $model->toArray();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -491,8 +491,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('0000-00-00 00:00:00', $array['created_at']);
 		$this->assertEquals('0000-00-00 00:00:00', $array['updated_at']);
 	}
-	
-	
+
+
 	public function testToArrayIncludesDefaultFormattedTimestamps()
 	{
 		$model = new EloquentDateModelStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -478,6 +478,21 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testToArrayIncludesNulledMysqlTimestamps()
+	{
+		$model = new EloquentDateModelStub;
+		$model->setRawAttributes(array(
+			'created_at'	=> '0000-00-00',
+			'updated_at'	=> '0000-00-00',
+		));
+
+		$array = $model->toArray();
+
+		$this->assertEquals('0000-00-00 00:00:00', $array['created_at']);
+		$this->assertEquals('0000-00-00 00:00:00', $array['updated_at']);
+	}
+	
+	
 	public function testToArrayIncludesDefaultFormattedTimestamps()
 	{
 		$model = new EloquentDateModelStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -478,7 +478,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testToArrayIncludesNulledMysqlTimestamps()
+	public function testToArrayIncludesUnsetMysqlTimestamps()
 	{
 		$model = new EloquentDateModelStub;
 		$model->setRawAttributes(array(


### PR DESCRIPTION
An unset Timestamp in database would sometimes cause Carbon to fail:
InvalidArgumentException in Carbon.php line 385: Unexpected data found.

Proposed changes fix issue.
