### PR TITLE
Fix parameter type hint on docblock

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -23,9 +23,9 @@ class WorkCommand extends Command {
 	protected $description = 'Process the next job on a queue';
 
 	/**
-	 * The queue listener instance.
+	 * The queue worker instance.
 	 *
-	 * @var \Illuminate\Queue\Listener
+	 * @var \Illuminate\Queue\Worker
 	 */
 	protected $worker;
 


### PR DESCRIPTION
Fix parameter type hint on docblock
