### PR TITLE
[5.0] Config logging file name ['app.logfile']

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -40,7 +40,8 @@ class ConfigureLogging {
 		// Next, we will bind a Closure that resolves the PSR logger implementation
 		// as this will grant us the ability to be interoperable with many other
 		// libraries which are able to utilize the PSR standardized interface.
-		$app->bind('Psr\Log\LoggerInterface', function ($app) {
+		$app->bind('Psr\Log\LoggerInterface', function ($app)
+		{
 			return $app['log']->getMonolog();
 		});
 	}
@@ -73,7 +74,8 @@ class ConfigureLogging {
 		$this->log = $log;
 		$this->logfile = $app->storagePath() . '/logs/laravel.log';
 
-		if (!empty($app['config']['app.logfile'])) {
+		if (!empty($app['config']['app.logfile']))
+		{
 			$this->logfile = $app['config']['app.logfile'];
 		}
 


### PR DESCRIPTION
Laravel 5.0
Is now possible to set a specific name for logging.

config/app.php

``` php
return [
...
    'log' => 'daily',

    'logfile' => storage_path('logs/laravel-' . php_sapi_name(). '.log'),
...
]
```

The default log file name is "storage/logs/laravel.log"

This can solves the problem access to the logs for apache2handler and cli. As files are created daily with permissions 0644
