### PR TITLE
[5.0] Config Closures

### DIFF
--- a/src/Illuminate/Config/FileLoader.php
+++ b/src/Illuminate/Config/FileLoader.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Config;
 
+use Closure;
 use Illuminate\Filesystem\Filesystem;
 
 class FileLoader implements LoaderInterface {
@@ -99,7 +100,13 @@ class FileLoader implements LoaderInterface {
 	 */
 	protected function mergeEnvironment(array $items, $file)
 	{
-		return config_merge($items, $this->files->getRequire($file));
+		$fileItems = $this->files->getRequire($file);
+		if ($fileItems instanceof Closure)
+		{
+			return call_user_func($fileItems, $items);
+		}
+
+		return array_replace_recursive($items, $fileItems);
 	}
 
 	/**
@@ -159,7 +166,7 @@ class FileLoader implements LoaderInterface {
 
 		if ($this->files->exists($path = $this->defaultPath.'/'.$file))
 		{
-			$items = config_merge(
+			$items = array_merge(
 				$items, $this->getRequire($path)
 			);
 		}
@@ -171,7 +178,7 @@ class FileLoader implements LoaderInterface {
 
 		if ($this->files->exists($path))
 		{
-			$items = config_merge(
+			$items = array_merge(
 				$items, $this->getRequire($path)
 			);
 		}

--- a/tests/Config/ConfigFileLoaderTest.php
+++ b/tests/Config/ConfigFileLoaderTest.php
@@ -38,9 +38,21 @@ class ConfigFileLoaderTest extends PHPUnit_Framework_TestCase {
 		$loader->getFilesystem()->shouldReceive('getRequire')->once()->with(__DIR__.'/local/app.php')->andReturn(array('foo' => 'blah', 'baz' => 'boom', 'providers' => ['SomeProvider']));
 		$array = $loader->load('local', 'app', null);
 
-		$this->assertEquals(array('foo' => 'blah', 'baz' => 'boom', 'providers' => ['AppProvider', 'SomeProvider']), $array);
+		$this->assertEquals(array('foo' => 'blah', 'baz' => 'boom', 'providers' => ['SomeProvider']), $array);
 	}
 
+	public function testEnvironmentClosureIsMerged()
+	{
+		$closure = function ($base) { return array('foo' => 'blah', 'baz' => 'boom'); };
+		$loader = $this->getLoader();
+		$loader->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/app.php')->andReturn(true);
+		$loader->getFilesystem()->shouldReceive('exists')->once()->with(__DIR__.'/local/app.php')->andReturn(true);
+		$loader->getFilesystem()->shouldReceive('getRequire')->once()->with(__DIR__.'/app.php')->andReturn(array('foo' => 'bar'));
+		$loader->getFilesystem()->shouldReceive('getRequire')->once()->with(__DIR__.'/local/app.php')->andReturn($closure);
+		$array = $loader->load('local', 'app', null);
+
+		$this->assertEquals(array('foo' => 'blah', 'baz' => 'boom'), $array);
+	}
 
 	public function testGroupExistsReturnsTrueWhenTheGroupExists()
 	{


### PR DESCRIPTION
Recent changes in the way config arrays are merged causes problems for some packages and raises other issues, such as making it impossible to override some package settings (reported here: https://github.com/laravel/framework/issues/6398 & https://github.com/laravel/framework/issues/6088 )

This proposed solution for Laravel 5 does the following...
1. Reverts the default behaviour to be the same as 4.2 for better compatibility with existing code.
2. Adds support for config php files returning **either an array or a closure**. When a closure is returned, it is used to perform the array merge, allowing any arbitrary config merging strategy (such as appending) to be supported if required. The closure is expected to take a single argument (the existing config array) and return a new array containing the merged result.
