### PR TITLE
[5.0] Update app:name command

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -134,6 +134,10 @@ class AppNameCommand extends Command {
 		$this->replaceIn(
 			$this->getBootstrapPath(), $this->currentRoot.'\\Console', $this->argument('name').'\\Console'
 		);
+		
+		$this->replaceIn(
+			$this->getBootstrapPath(), $this->currentRoot.'\\Exceptions', $this->argument('name').'\\Exceptions'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Allow php artisan app:name to set the correct namespace for the application exception handler
