### PR TITLE
[5.0] Allow S3 region in config/filesystems.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "illuminate/workbench": "self.version"
     },
     "require-dev": {
-        "aws/aws-sdk-php": "~2.6",
+        "aws/aws-sdk-php": ">=2.7.5",
         "iron-io/iron_mq": "~1.5",
         "pda/pheanstalk": "~3.0",
         "mockery/mockery": "~0.9",

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -93,9 +93,12 @@ class FilesystemManager implements FactoryContract {
 	 */
 	public function createS3Driver(array $config)
 	{
-		$client = S3Client::factory([
-			'key' => $config['key'], 'secret' => $config['secret'],
-		]);
+		$s3Config = ['key' => $config['key'], 'secret' => $config['secret']];
+		
+		if(isset($config['region']))
+			$s3Config['region'] = $config['region'];
+		
+		$client = S3Client::factory($s3Config);
 
 		return $this->adapt(
 			new Flysystem(new S3Adapter($client, $config['bucket']))


### PR DESCRIPTION
Some AWS regions, such as eu-central-1 (Frankfurt) do not support the default "v2" authentication signature. Setting the region when creating the client enables the correct signature to be used. Requires aws-sdk-php >= 2.7.5
AWS SDK issue: https://github.com/aws/aws-sdk-php/issues/393
