### PR TITLE
[5.0] Fixed An Extra Period In Generated Route Names

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -213,7 +213,7 @@ class ResourceRegistrar {
 	{
 		$group = str_replace('/', '.', $this->router->getLastGroupPrefix());
 
-		return trim("{$prefix}{$group}.{$resource}.{$method}", '.');
+		return trim("{$prefix}{$group}{$resource}.{$method}", '.');
 	}
 
 	/**


### PR DESCRIPTION
When creating a resource controller with a name prefix (via the `as` option), an extra period is sometimes added to the route names (e.g., `bar..foo.create` instead of `bar.foo.create`).

``` php
// Should generate named routes 'bar.foo.index', 'bar.foo.create', etc.
// but it gives 'bar..foo.index', etc. instead.
$router->resource('foo', 'FooController', [
    'as' => 'bar'
]);
```

This PR simply removes a period from the `getGroupResourceName()` method because one is already added in `getResourceName()`.
