### PR TITLE
[4.2] Join bindings multiply when a query is executed multiple times

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -142,8 +142,9 @@ class Grammar extends BaseGrammar {
 				$clauses[] = $this->compileJoinConstraint($clause);
 			}
 
-			foreach ($join->bindings as $binding)
+			foreach ($join->bindings as $index => $binding)
 			{
+				unset($join->bindings[$index]);
 				$query->addBinding($binding, 'join');
 			}
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -597,6 +597,10 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		});
 		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = ? or "users"."name" = ?', $builder->toSql());
 		$this->assertEquals(array('foo', 'bar'), $builder->getBindings());
+
+		// Run the assertions again
+		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = ? or "users"."name" = ?', $builder->toSql());
+		$this->assertEquals(array('foo', 'bar'), $builder->getBindings());
 	}
 
 	public function testJoinWhereNull()


### PR DESCRIPTION
I encountered this bug when a query using a complex join containing inner bindings was used with the Paginator. When the query grammar compiles the complex join, it adds its bindings to the main query without unsetting the bindings from the join. The result is running toSql() multiple times causes the number of bindings to increase.

This is actually a major bug because RDBMSes won't even execute the query when the binding count doesn't match the number of bindings in the prepared statement.

Please see failing unit test and fix below.
