### PR TITLE
[5.0] Fixed The SES Transport Constructor Docblock

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -15,7 +15,7 @@ class SesTransport implements Swift_Transport {
 	protected $ses;
 
 	/**
-	 * Create a new Mailgun transport instance.
+	 * Create a new SES transport instance.
 	 *
 	 * @param  \Aws\Ses\SesClient  $ses
 	 * @return void


### PR DESCRIPTION
This should read as:

```
Create a new SES transport instance.
```

not:

```
Create a new Mailgun transport instance.
```
