### PR TITLE
Array check for invalid argument error

### DIFF
--- a/src/Illuminate/Config/FileEnvironmentVariablesLoader.php
+++ b/src/Illuminate/Config/FileEnvironmentVariablesLoader.php
@@ -46,6 +46,11 @@ class FileEnvironmentVariablesLoader implements EnvironmentVariablesLoaderInterf
 			return array();
 		}
 
+		if ( ! is_array($this->files->getRequire($path)))
+		{
+			return array();
+		}
+
 		return array_dot($this->files->getRequire($path));
 	}
 


### PR DESCRIPTION
If the .env file exists but is empty an error is thrown in
laravel/framework/src/Illuminate/Support/Arr.php on line 71 because an
array is expected but not given.
