### PR TITLE
[5.0] Added 'resetLocations()' in ViewFinder

### DIFF
--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -176,15 +176,6 @@ class FileViewFinder implements ViewFinderInterface {
 	}
 
 	/**
-	* Empty locations list.
-	*
-	* @return void
-	*/
-	public function resetLocations(){
-		$this->paths = [];
-	}
-	
-	/**
 	 * Add a namespace hint to the finder.
 	 *
 	 * @param  string  $namespace

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -166,6 +166,15 @@ class FileViewFinder implements ViewFinderInterface {
 	}
 
 	/**
+	* Empty locations list.
+	*
+	* @return void
+	*/
+	public function resetLocations(){
+		$this->paths = [];
+	}
+	
+	/**
 	 * Add a namespace hint to the finder.
 	 *
 	 * @param  string  $namespace

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -166,6 +166,16 @@ class FileViewFinder implements ViewFinderInterface {
 	}
 
 	/**
+	 * Initialize locations list to empty.
+	 *
+	 * @return void
+	 */
+	public function resetLocations()
+	{
+		$this->paths = [];
+	}
+
+	/**
 	* Empty locations list.
 	*
 	* @return void

--- a/src/Illuminate/View/ViewFinderInterface.php
+++ b/src/Illuminate/View/ViewFinderInterface.php
@@ -26,6 +26,13 @@ interface ViewFinderInterface {
 	public function addLocation($location);
 
 	/**
+	 * Initialize locations list to empty.
+	 *
+	 * @return void
+	 */
+	public function resetLocations();
+
+	/**
 	 * Add a namespace hint to the finder.
 	 *
 	 * @param  string  $namespace

--- a/src/Illuminate/View/ViewFinderInterface.php
+++ b/src/Illuminate/View/ViewFinderInterface.php
@@ -40,13 +40,6 @@ interface ViewFinderInterface {
 	 * @return void
 	 */	
 	public function addNamespace($namespace, $hints);
-	
-    /**
-     * Add a valid view extension to the finder.
-     *
-     * @return void
-     */
-    public function resetLocations();
 
 	/**
 	 * Prepend a namespace hint to the finder.

--- a/src/Illuminate/View/ViewFinderInterface.php
+++ b/src/Illuminate/View/ViewFinderInterface.php
@@ -38,7 +38,7 @@ interface ViewFinderInterface {
 	 * @param  string  $namespace
 	 * @param  string|array  $hints
 	 * @return void
-	 */	
+	 */
 	public function addNamespace($namespace, $hints);
 
 	/**

--- a/src/Illuminate/View/ViewFinderInterface.php
+++ b/src/Illuminate/View/ViewFinderInterface.php
@@ -31,8 +31,15 @@ interface ViewFinderInterface {
 	 * @param  string  $namespace
 	 * @param  string|array  $hints
 	 * @return void
-	 */
+	 */	
 	public function addNamespace($namespace, $hints);
+	
+    /**
+     * Add a valid view extension to the finder.
+     *
+     * @return void
+     */
+    public function resetLocations();
 
 	/**
 	 * Prepend a namespace hint to the finder.


### PR DESCRIPTION
since ViewFinder is a singleton, its $path array is initated at bootstrap (from `'view.paths'` configuration), and can not be altered at runtime. (although new paths can be added with `addLocation()`).

To enable dynamic relocation of the views folder (eg for Themes) we need a method to edit the (protected) $paths array. I added a `resetLocations()` method in `ViewFinder` and the `ViewFinderInterface` to keep consistency with the other methods. (a setLocations() method might also be more appropriate)

thanks for reviewing...

Giannis Gasteratos
