### PR TITLE
[4.2] Addition of dynamic properties on Eloquent collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -269,7 +269,7 @@ class Collection extends BaseCollection {
 		// If it is not the case, we'll load the relationship.
 		if(method_exists($first, $key))
 		{
-			if (!isset($first[snake_case($key)]))
+			if(!array_key_exists($key, $first->relations))
 			{
 				$this->load($key);
 			}

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -162,7 +162,7 @@ class Collection extends BaseCollection {
 	/**
 	 * Intersect the collection with the given items.
 	 *
- 	 * @param  \ArrayAccess|array  $items
+	 * @param  \ArrayAccess|array  $items
 	 * @return static
 	 */
 	public function intersect($items)
@@ -249,11 +249,10 @@ class Collection extends BaseCollection {
 	{
 		return new BaseCollection($this->items);
 	}
-
 	/**
 	 * Get an array with the attribute values of given key.
 	 *
-	 * @param  string  $key
+	 * @param  string $key
 	 * @return array
 	 */
 	public function listsAttributeArray($key)
@@ -267,11 +266,14 @@ class Collection extends BaseCollection {
 		// Therefore we check if we're trying to list
 		// a relationship and if it's already loaded.
 		// If it is not the case, we'll load the relationship.
-		if(method_exists($first, $key))
+		if ($first instanceof Model)
 		{
-			if(!array_key_exists($key, $first->relations))
+			if (method_exists($first, $key))
 			{
-				$this->load($key);
+				if ( ! array_key_exists($key, $first->relations))
+				{
+					$this->load($key);
+				}
 			}
 		}
 
@@ -287,7 +289,7 @@ class Collection extends BaseCollection {
 	/**
 	 * Get a collection with the values of a given key.
 	 *
-	 * @param  string  $key
+	 * @param  string $key
 	 * @return mixed
 	 */
 	public function listsAttribute($key)
@@ -311,7 +313,10 @@ class Collection extends BaseCollection {
 
 		foreach ($this->items as $values)
 		{
-			if ($values instanceof Collection) $values = $values->all();
+			if ($values instanceof Collection)
+			{
+				$values = $values->all();
+			}
 
 			$results = array_merge($results, $values);
 		}
@@ -330,9 +335,12 @@ class Collection extends BaseCollection {
 	 */
 	public function newCollection(array $items = null)
 	{
-		if(is_null($items)) $items = $this->items;
+		if (is_null($items))
+		{
+			$items = $this->items;
+		}
 
-		if(($first = reset($items)) instanceof Model)
+		if (($first = reset($items)) instanceof Model)
 		{
 			$result = $first->newCollection($items);
 		}
@@ -347,7 +355,7 @@ class Collection extends BaseCollection {
 	/**
 	 * Dynamically retrieve attributes on the models.
 	 *
-	 * @param  string  $key
+	 * @param  string $key
 	 * @return mixed
 	 */
 	public function __get($key)

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -225,9 +225,9 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 		$two = m::mock('Illuminate\Database\Eloquent\Model');
 		$two->shouldReceive('getAttribute')->with('name')->once()->andReturn('dayle');
 
-		$data = new Collection(array($one, $two));
+		$c = new Collection(array($one, $two));
 
-		$this->assertEquals(array('taylor', 'dayle'), $data->name->all());
+		$this->assertEquals(array('taylor', 'dayle'), $c->name->all());
 	}
 
 	public function testMagicEagerLoadsRelationshipListsAttributesMethod()

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -217,4 +217,56 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(new Collection(array($one)), $c->except(array(2, 3)));
 	}
 
+	public function testMagicListsAttributesMethod()
+	{
+		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one->shouldReceive('getAttribute')->with('name')->once()->andReturn('taylor');
+
+		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two->shouldReceive('getAttribute')->with('name')->once()->andReturn('dayle');
+
+		$data = new Collection(array($one, $two));
+
+		$this->assertEquals(array('taylor', 'dayle'), $data->name->all());
+	}
+
+	public function testMagicEagerLoadsRelationshipListsAttributesMethod()
+	{
+		$mockItem = m::mock('EloquentModelCollectionMagicLoadStub');
+		$mockItem->shouldReceive('getAttribute')->with('workerType')->once()->andReturn('results');
+		$mockItem->shouldReceive('newQuery')->once()->andReturn($mockItem);
+		$mockItem->shouldReceive('with')->andReturn($mockItem);
+		$mockItem->shouldReceive('eagerLoadRelations')->once()->andReturn(array($mockItem));
+		$mockItem->shouldReceive('offsetExists')->andReturn(false);
+		$c = $this->getMock('Illuminate\Database\Eloquent\Collection', array('first'), array(array($mockItem)));
+		$c->expects($this->any())->method('first')->will($this->returnValue($mockItem));
+
+		$this->assertEquals(array('results'), $c->workerType->all());
+	}
+
+	public function testMagicRelationshipListsAttributesMethod()
+	{
+		$mockItem = m::mock('EloquentModelCollectionMagicLoadStub');
+		$mockItem->shouldReceive('getAttribute')->with('workerType')->once()->andReturn('results');
+		$mockItem->shouldReceive('newQuery')->never()->andReturn($mockItem);
+		$mockItem->shouldReceive('with')->never()->andReturn($mockItem);
+		$mockItem->shouldReceive('eagerLoadRelations')->never()->andReturn(array($mockItem));
+		$mockItem->shouldReceive('offsetExists')->andReturn(true);
+		$c = $this->getMock('Illuminate\Database\Eloquent\Collection', array('first'), array(array($mockItem)));
+		$c->expects($this->any())->method('first')->will($this->returnValue($mockItem));
+
+		$this->assertEquals(array('results'), $c->workerType->all());
+	}
+}
+
+class EloquentModelCollectionMagicLoadStub extends Illuminate\Database\Eloquent\Model {
+
+	protected $table = 'stub';
+
+	protected $guarded = array();
+
+	public function workerType()
+	{
+		return $this->belongsTo('EloquentModelSaveStub');
+	}
 }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -247,6 +247,7 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 	public function testMagicRelationshipListsAttributesMethod()
 	{
 		$mockItem = m::mock('EloquentModelCollectionMagicLoadStub');
+		$mockItem->relations = ['workerType'=>'results'];
 		$mockItem->shouldReceive('getAttribute')->with('workerType')->once()->andReturn('results');
 		$mockItem->shouldReceive('newQuery')->never()->andReturn($mockItem);
 		$mockItem->shouldReceive('with')->never()->andReturn($mockItem);
@@ -264,6 +265,8 @@ class EloquentModelCollectionMagicLoadStub extends Illuminate\Database\Eloquent\
 	protected $table = 'stub';
 
 	protected $guarded = array();
+
+	public $relations = array();
 
 	public function workerType()
 	{


### PR DESCRIPTION
This would allow the same type of dynamic properties on a Eloquent collection as currently available on the model.

``` php
$registrations = Car::all()->registration;

$names = Car::all()->users->collapse()->unique()->name;
```
