### PR TITLE
[5.0] Add where method to collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -135,6 +135,26 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	}
 
 	/**
+	 * Filter items by the given operator.
+	 *
+	 * @param  string  $key
+	 * @param  string  $operator
+	 * @param  mixed  $value
+	 * @return static
+	 */
+	public function where($key, $operator, $value = null)
+	{
+		if (func_num_args() == 2)
+		{
+			$value = $operator;
+
+			$operator = null;
+		}
+
+		return $this->filter($this->operatorChecker($key, $operator, $value));
+	}
+
+	/**
 	 * Get the first item from the collection.
 	 *
 	 * @param  \Closure   $callback
@@ -704,6 +724,44 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 		return function($item) use ($value)
 		{
 			return data_get($item, $value);
+		};
+	}
+
+	/**
+	 * Get an operator checker callback.
+	 *
+	 * @param  string  $key
+	 * @param  string  $operator
+	 * @param  mixed  $value
+	 * @return \Closure
+	 */
+	protected function operatorChecker($key, $operator, $value)
+	{
+		return function($item) use ($key, $operator, $value)
+		{
+			$retrieved = data_get($item, $key);
+
+			switch ($operator)
+			{
+				default:
+				case '=':
+				case '==':  return $retrieved == $value;
+
+				case '===': return $retrieved === $value;
+
+				case '<=':  return $retrieved <= $value;
+
+				case '>=':  return $retrieved >= $value;
+
+				case '<':   return $retrieved < $value;
+
+				case '>':   return $retrieved > $value;
+
+				case '<>':
+				case '!=':  return $retrieved != $value;
+
+				case '!==': return $retrieved !== $value;
+			}
 		};
 	}
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -123,6 +123,26 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		})->all());
 	}
 
+	public function testWhere()
+	{
+		$c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
+
+		$this->assertEquals([['v' => 3], ['v' => '3']], $c->where('v', 3)->values()->all());
+		$this->assertEquals([['v' => 3], ['v' => '3']], $c->where('v', '=', 3)->values()->all());
+		$this->assertEquals([['v' => 3], ['v' => '3']], $c->where('v', '==', 3)->values()->all());
+		$this->assertEquals([['v' => 3], ['v' => '3']], $c->where('v', 'garbage', 3)->values()->all());
+		$this->assertEquals([['v' => 3]],               $c->where('v', '===', 3)->values()->all());
+
+		$this->assertEquals([['v' => 1], ['v' => 2], ['v' => 4]],               $c->where('v', '<>', 3)->values()->all());
+		$this->assertEquals([['v' => 1], ['v' => 2], ['v' => 4]],               $c->where('v', '!=', 3)->values()->all());
+		$this->assertEquals([['v' => 1], ['v' => 2], ['v' => '3'], ['v' => 4]], $c->where('v', '!==', 3)->values()->all());
+
+		$this->assertEquals([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3']], $c->where('v', '<=', 3)->values()->all());
+		$this->assertEquals([['v' => 3], ['v' => '3'], ['v' => 4]],             $c->where('v', '>=', 3)->values()->all());
+		$this->assertEquals([['v' => 1], ['v' => 2]],                           $c->where('v', '<', 3)->values()->all());
+		$this->assertEquals([['v' => 4]],                                       $c->where('v', '>', 3)->values()->all());
+	}
+
 
 	public function testValues()
 	{


### PR DESCRIPTION
Adds a `where` method to the `Collection` class, to be used similarly to the `where` method on the query builder:

``` php
$collection = new Collection(['v' => 1], ['v' => 2], ['v' => 3]);

$one = $collection->where('v', 1);
$underThree = $collection->where('v', '<', 3);
```

---

This is quite useful as is. If we add Eloquent support to `data_get` (which we should anyhow do, for many other reasons) this would become infinitely more useful:

``` php
$users = User::all();

$adults = $users->where('age', '>=', 18);

$kids = $users->where('age', '<', 18);
```

Where before this required either two separate queries, or 2 more-verbose `filter` calls.

---

PS Shout-out to the [Cartalyst](https://cartalyst.com/) team. I got the operator switch idea from their excellent [Conditions package](https://cartalyst.com/manual/conditions/).
