### PR TITLE
[4.2] Addition of First to Schema MySql Grammar

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -11,7 +11,7 @@ class MySqlGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $modifiers = array('Unsigned', 'Nullable', 'Default', 'Increment', 'After', 'Comment');
+	protected $modifiers = array('Unsigned', 'Nullable', 'Default', 'Increment', 'After', 'First', 'Comment');
 
 	/**
 	 * The possible column serials
@@ -561,6 +561,21 @@ class MySqlGrammar extends Grammar {
 		if ( ! is_null($column->after))
 		{
 			return ' after '.$this->wrap($column->after);
+		}
+	}
+
+	/**
+	 * Get the SQL for an "first" column modifier.
+	 *
+	 * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+	 * @param  \Illuminate\Support\Fluent  $column
+	 * @return string|null
+	 */
+	protected function modifyFirst(Blueprint $blueprint, Fluent $column)
+	{
+		if ( ! is_null($column->first))
+		{
+			return ' first ';
 		}
 	}
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -250,6 +250,17 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAddingColumnAsFirstColumn()
+	{
+		$blueprint = new Blueprint('users');
+		$blueprint->string('name')->first();
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` add `name` varchar(255) not null first ', $statements[0]);
+	}
+
+
 	public function testAddingString()
 	{
 		$blueprint = new Blueprint('users');


### PR DESCRIPTION
For MySql Laravel already supported to add a column after another column but had to my knowledge no solution to create a new column as first column in an existing table.

This pull add's support for the FIRST MySql Alter table command and will allow this:

``` php
Schema::table('pancakes', function(Blueprint $table)
{
    $table->increments('id')->first();
});
```
