### PR TITLE
Update FormBuilder.php

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -648,6 +648,8 @@ class FormBuilder {
 	 */
 	protected function getCheckboxCheckedState($name, $value, $checked)
 	{
+		if (is_bool($checked)) return $checked;
+		
 		if (isset($this->session) && ! $this->oldInputIsEmpty() && is_null($this->old($name))) return false;
 
 		if ($this->missingOldAndModel($name)) return $checked;
@@ -667,6 +669,8 @@ class FormBuilder {
 	 */
 	protected function getRadioCheckedState($name, $value, $checked)
 	{
+		if (is_bool($checked)) return $checked;
+		
 		if ($this->missingOldAndModel($name)) return $checked;
 
 		return $this->getValueAttribute($name) == $value;


### PR DESCRIPTION
The priority for getCheckboxCheckedState and getRadioCheckedState should be to first check if an explicitly set $checked value was given by the user. Only if no acceptable $checked value was given should they try to logically determine the state.

Ref: https://github.com/laravel/framework/issues/5078
