### PR TITLE
[4.2] morphClass property not applied when morphToMany Relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -45,7 +45,7 @@ class MorphToMany extends BelongsToMany {
 	{
 		$this->inverse = $inverse;
 		$this->morphType = $name.'_type';
-		$this->morphClass = $inverse ? get_class($query->getModel()) : get_class($parent);
+		$this->morphClass = $inverse ? $query->getModel()->getMorphClass() : $parent->getMorphClass();
 
 		parent::__construct($query, $parent, $table, $foreignKey, $otherKey, $relationName);
 	}

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -86,6 +86,7 @@ class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
 		$parent->shouldReceive('getKey')->andReturn(1);
 		$parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
 		$parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+		$parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
 
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
 		$related = m::mock('Illuminate\Database\Eloquent\Model');
@@ -93,6 +94,7 @@ class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
 
 		$related->shouldReceive('getTable')->andReturn('tags');
 		$related->shouldReceive('getKeyName')->andReturn('id');
+		$related->shouldReceive('getMorphClass')->andReturn(get_class($related));
 
 		$builder->shouldReceive('join')->once()->with('taggables', 'tags.id', '=', 'taggables.tag_id');
 		$builder->shouldReceive('where')->once()->with('taggables.taggable_id', '=', 1);


### PR DESCRIPTION
when Post class has own namespace like 'App\Models' and has **morphClass property like 'Post'**

morphToMany and morphedByMany Relationship where condition is **incorrect**  like **"where taggable_type='App\Models\Post'**

but **correct where condition is "where taggable_type='Post'"**
