### PR TITLE
[4.2] Fix bug with array filters and using before/after method on route.

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -557,9 +557,13 @@ class Route {
 	 */
 	protected function addFilters($type, $filters)
 	{
+		$filters = static::explodeFilters($filters);
+
 		if (isset($this->action[$type]))
 		{
-			$this->action[$type] .= '|'.$filters;
+			$existing = static::explodeFilters($this->action[$type]);
+
+			$this->action[$type] = array_merge($existing, $filters);
 		}
 		else
 		{

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -398,6 +398,19 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testGroupFiltersAndRouteFilters()
+	{
+		$router = $this->getRouter();
+		$router->group(['before' => ['foo']], function() use ($router)
+		{
+			$router->get('foo/bar', function() { return 'hello'; })->before('bar');
+		});
+		$router->filter('foo', function($route, $request) { return 'foo'; });
+		$router->filter('bar', function($route, $request) { return 'bar'; });
+		$this->assertEquals('foo', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+	}
+
+
 	public function testMatchesMethodAgainstRequests()
 	{
 		/**


### PR DESCRIPTION
This fixes a bug where if you define either an array of filters on a route group or have multiple groups with multiple string based filters and then try to use either the `before` or `after` method on a route you'll get an "Array to string conversion" error.

Have added a test as well.

Signed-off-by: Jason Lewis jason.lewis1991@gmail.com
