### PR TITLE
[4.2] Ability to pass '0' as label to Form::label

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -209,7 +209,8 @@ class FormBuilder {
 	 */
 	protected function formatLabel($name, $value)
 	{
-		return $value ?: ucwords(str_replace('_', ' ', $name));
+		// return $value ?: ucwords(str_replace('_', ' ', $name));
+		return (string)$value != '' ? $value : ucwords(str_replace('_', ' ', $name));
 	}
 
 	/**

--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -209,7 +209,6 @@ class FormBuilder {
 	 */
 	protected function formatLabel($name, $value)
 	{
-		// return $value ?: ucwords(str_replace('_', ' ', $name));
 		return (string)$value != '' ? $value : ucwords(str_replace('_', ' ', $name));
 	}
 

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -54,11 +54,17 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase {
 
 	public function testFormLabel()
 	{
-		$form1 = $this->formBuilder->label('foo', 'Foobar');
-		$form2 = $this->formBuilder->label('foo', 'Foobar', array('class' => 'control-label'));
+		$form1      = $this->formBuilder->label('foo', 'Foobar');
+		$form2      = $this->formBuilder->label('foo', 'Foobar', array('class' => 'control-label'));
+		$zeroString = $this->formBuilder->label('foo', '0');
+		$zeroInt    = $this->formBuilder->label('foo', 0);
+		$null       = $this->formBuilder->label('foo');
 
 		$this->assertEquals('<label for="foo">Foobar</label>', $form1);
 		$this->assertEquals('<label for="foo" class="control-label">Foobar</label>', $form2);
+		$this->assertEquals('<label for="foo">0</label>', $zeroString);
+		$this->assertEquals('<label for="foo">0</label>', $zeroInt);
+		$this->assertEquals('<label for="foo">Foo</label>', $null);
 	}
 
 


### PR DESCRIPTION
Resolves the issue of not being able to make labels with the text being a zero.
`{{ Form::label("nps","0") }}`
The code improves on this by casting the value to a string and checking if it is an empty string or not when deciding between showing the actual value or generating a string from the field name.

Would this work for you?
