### PR TITLE
fixed expired XSRF-TOKEN cookie.

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -72,7 +72,7 @@ class VerifyCsrfToken implements Middleware {
 	protected function addCookieToResponse($request, $response)
 	{
 		$response->headers->setCookie(
-			new Cookie('XSRF-TOKEN', $request->session()->token(), 120)
+			new Cookie('XSRF-TOKEN', $request->session()->token(), time() + 60 * 120)
 		);
 
 		return $response;


### PR DESCRIPTION
It seems that `VerifyCsrfToken` middleware adds an expired cookie i.e., `XSRF-TOKEN` to the response:

``` bash
$ curl -I localhost:8000
HTTP/1.1 200 OK
Host: localhost:8000
Connection: close
X-Powered-By: PHP/5.4.33-2+deb.sury.org~precise+1
Cache-Control: no-cache
Date: Fri, 28 Nov 2014 04:32:27 GMT
Content-Type: text/html; charset=UTF-8
Set-Cookie: XSRF-TOKEN=eyJpdiI6IlViTHlMYWVDcGxpRjZKdWNpaDBFUmc9PSIsInZhbHVlIjoiamJSbDZRd3MxRm5ZbkM3SWtWMFZlYlJJRTlIcjBYdzd2NHc3U1JqVHBPRGJ1VGdaNjA5Sk11NmdSSzBLZHVEN1lBK3lcL3JQZkV1aDFlT055MExWY3l3PT0iLCJtYWMiOiIxMWE4YzI3ZmMxNThkNWZjZWRhMGUxMmQyNDUwYTI5ZDUxOTFhOWYxNjMxZTczZjJjNmE0Y2IzMTU3MjIwYzc5In0%3D; expires=Thu, 01-Jan-1970 00:02:00 GMT; path=/; httponly
Set-Cookie: laravel_session=eyJpdiI6Ikpta2g4KzJBSHAzNFlmY25OS3FTd2c9PSIsInZhbHVlIjoiMzFveHFDaGNNV2FBQUFtdG50VnF4NFFwZUV4XC9KOEEwTG5xRHNodHhCTG0xY1pWSkJxU1FqMGt0MENXdWtsWjVNUjh0VHU0TWNEZjROR3pqQklDRXVRPT0iLCJtYWMiOiIyNjgxNjRkZGM5OTZkZmI0OTdkNDZkYWU5MjEzNWU0MDU4ODg3MzExZmI5MmIyMjM2ZjM0ZDQ2NjdhNDQxODUwIn0%3D; expires=Fri, 28-Nov-2014 06:32:27 GMT; path=/; httponly
```

However, adding the current timestamp in the `expire` argument for the `Cookie` constructor solves the issue:

``` bash
curl -I localhost:8000
HTTP/1.1 200 OK
Host: localhost:8000
Connection: close
X-Powered-By: PHP/5.4.33-2+deb.sury.org~precise+1
Cache-Control: no-cache
Date: Fri, 28 Nov 2014 04:36:34 GMT
Content-Type: text/html; charset=UTF-8
Set-Cookie: XSRF-TOKEN=eyJpdiI6IllvM1k1cXhBNUxyNm9uSkFhXC9jbUNBPT0iLCJ2YWx1ZSI6IkUyTlFhajlLejF2V1NrcDF6UU5aNm93dHZQQ2NNYXVuTXRsSHZPOHg3WTkrYnp2cnREMHJcL2NoOFlJWUR5NHIyTEFXXC9wSmYzN21OT3dTTUVoOVNQNnc9PSIsIm1hYyI6IjNiYmY4MjZmYTg2MmJkNDVhYzJjOTk4MjNmN2UyNjRlYjY1ZThhODJmN2YxNTRlYjZmYmQ3YWE3ODZkNmVjYjcifQ%3D%3D; expires=Fri, 28-Nov-2014 06:36:34 GMT; path=/; httponly
Set-Cookie: laravel_session=eyJpdiI6Ik15eGR0ZzBpSzM0aFNHTmJ1ZUxIaXc9PSIsInZhbHVlIjoiRlRQSEhrRnJVY3dvbmltUnl2NlNFclhvWVN5M2NIUUsrTFlmZGlEMUN5VFFWMG1JejdncWVnVDFEMldzc0NTMmZ0ZjFUZ0xyTHVsTlVHWnA0amF6UlE9PSIsIm1hYyI6IjA3OTg4NzFjZTY2ODc4MGI0YWRmNzk0MTdiZjkyYWQwYTk2OTJmOTZmZDBkNTgyZjgyYWJmMzU1ZTVkNGIxYjcifQ%3D%3D; expires=Fri, 28-Nov-2014 06:36:34 GMT; path=/; httponly
```
