### PR TITLE
[4.2] set JSON_UNESCAPED_UNICODE for default json_encode option

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -11,7 +11,7 @@ class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {
 	 *
 	 * @var int
 	 */
-	protected $jsonOptions;
+	protected $jsonOptions = JSON_UNESCAPED_UNICODE;
 
 	/**
 	 * Constructor.
@@ -23,7 +23,7 @@ class JsonResponse extends \Symfony\Component\HttpFoundation\JsonResponse {
 	*/
 	public function __construct($data = null, $status = 200, $headers = array(), $options = 0)
 	{
-		$this->jsonOptions = $options;
+		$this->jsonOptions |= $options;
 
 		parent::__construct($data, $status, $headers);
 	}

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -18,4 +18,10 @@ class HttpJsonResponseTest extends PHPUnit_Framework_TestCase {
 		$this->assertSame(JSON_PRETTY_PRINT, $response->getJsonOptions());
 	}
 
+    public function testDefaultUnescapedUnicode()
+    {
+        $response = new Illuminate\Http\JsonResponse(['china' => '中国']);
+        $this->assertEquals('{"china":"中国"}', $response->getContent());
+    }
+
 }


### PR DESCRIPTION
According to [PSR-1](http://www.php-fig.org/psr/psr-1/), php code file must only use utf-8. Since the default encoding of JSON string is utf-8 too, it's time to set the `JSON_UNESCAPED_UNICODE` as the default option for json_encode method, which is a great convenient for developers come from East Asia.
