### PR TITLE
Removed unused $options variables

### DIFF
--- a/tests/Config/ConfigRepositoryTest.php
+++ b/tests/Config/ConfigRepositoryTest.php
@@ -103,14 +103,12 @@ class ConfigRepositoryTest extends PHPUnit_Framework_TestCase {
 	public function testItemsCanBeSet()
 	{
 		$config = $this->getRepository();
-		$options = $this->getDummyOptions();
 		$config->getLoader()->shouldReceive('load')->once()->with('production', 'foo', null)->andReturn(array('name' => 'dayle'));
 
 		$config->set('foo.name', 'taylor');
 		$this->assertEquals('taylor', $config->get('foo.name'));
 
 		$config = $this->getRepository();
-		$options = $this->getDummyOptions();
 		$config->getLoader()->shouldReceive('load')->once()->with('production', 'foo', 'namespace')->andReturn(array('name' => 'dayle'));
 
 		$config->set('namespace::foo.name', 'taylor');


### PR DESCRIPTION
They are never called in the test, and it still returns green
