### PR TITLE
Added PSR-4 autoloader methods in workbench command.

### DIFF
--- a/src/Illuminate/Workbench/PackageCreator.php
+++ b/src/Illuminate/Workbench/PackageCreator.php
@@ -320,7 +320,7 @@ class PackageCreator {
 	 */
 	protected function createClassDirectory(Package $package, $directory)
 	{
-		$path = $directory.'/src/'.$package->vendor.'/'.$package->name;
+		$path = $directory.'/src/';
 
 		if ( ! $this->files->isDirectory($path))
 		{

--- a/src/Illuminate/Workbench/stubs/composer.json
+++ b/src/Illuminate/Workbench/stubs/composer.json
@@ -15,7 +15,7 @@
         "classmap": [
             "src/migrations"
         ],
-        "psr-0": {
+        "psr-4": {
             "{{vendor}}\\{{name}}\\": "src/"
         }
     },

--- a/src/Illuminate/Workbench/stubs/plain.composer.json
+++ b/src/Illuminate/Workbench/stubs/plain.composer.json
@@ -12,8 +12,8 @@
         "illuminate/support": "5.0.*"
     },
     "autoload": {
-        "psr-0": {
-            "{{vendor}}\\{{name}}": "src/"
+        "psr-4": {
+            "{{vendor}}\\{{name}}\\": "src/"
         }
     },
     "minimum-stability": "stable"


### PR DESCRIPTION
PSR-0 is now deprecated(http://www.php-fig.org/psr/psr-0/).
So by default, we should be using PSR-4 autoloading, and this PR adds it.

I've tested it from console. There are two things coming ahead:
- Ability to create PSR-0 packages.
- Automated testing for workbench command.

BTW, why are tests not written for workbench commands?
