### PR TITLE
Fixes fragment encoding and closes #6455

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -49,6 +49,10 @@ class UrlGenerator {
 		'%21' => '!',
 		'%2A' => '*',
 		'%7C' => '|',
+		'%23' => '#',
+		'%3F' => '?',
+		'%26' => '&',
+		'%25' => '%',
 	);
 
 	/**
@@ -243,10 +247,10 @@ class UrlGenerator {
 	{
 		$domain = $this->getRouteDomain($route, $parameters);
 
-		$uri = strtr(rawurlencode($this->trimUrl(
+		$uri = strtr(rawurlencode($this->addQueryString($this->trimUrl(
 			$root = $this->replaceRoot($route, $domain, $parameters),
 			$this->replaceRouteParameters($route->uri(), $parameters)
-		)), $this->dontEncode).$this->getRouteQueryString($parameters);
+		), $parameters)), $this->dontEncode);
 
 		return $absolute ? $uri : '/'.ltrim(str_replace($root, '', $uri), '/');
 	}
@@ -297,6 +301,30 @@ class UrlGenerator {
 			return isset($parameters[$m[1]]) ? array_pull($parameters, $m[1]) : $m[0];
 
 		}, $path);
+	}
+
+	/**
+	 * Add a query string to the URI.
+	 *
+	 * @param  string  $uri
+	 * @param  array  $parameters
+	 * @return mixed|string
+	 */
+	protected function addQueryString($uri, array $parameters)
+	{
+		$fragment = parse_url($uri, PHP_URL_FRAGMENT);
+		if (!is_null($fragment))
+		{
+			$uri = preg_replace('/#.*/', '', $uri);
+		}
+
+		$uri .= $this->getRouteQueryString($parameters);
+		if (!is_null($fragment))
+		{
+			$uri .= "#$fragment";
+		}
+
+		return $uri;
 	}
 
 	/**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -81,6 +81,12 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$route = new Illuminate\Routing\Route(array('GET'), 'foo/bar/åαф/{baz}', array('as' => 'foobarbaz'));
 		$routes->add($route);
 
+		/**
+		 * Fragments
+		 */
+		$route = new Illuminate\Routing\Route(array('GET'), 'foo/bar#derp', array('as' => 'fragment'));
+		$routes->add($route);
+
 		$this->assertEquals('/', $url->route('plain', array(), false));
 		$this->assertEquals('/?foo=bar', $url->route('plain', array('foo' => 'bar'), false));
 		$this->assertEquals('http://www.foo.com/foo/bar', $url->route('foo'));
@@ -94,6 +100,9 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', array('wall', 'woz', 'boom' => 'otwell', 'baz' => 'taylor')));
 		$this->assertEquals('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', array('taylor', 'otwell', 'wall', 'woz')));
 		$this->assertEquals('http://www.foo.com/foo/bar/%C3%A5%CE%B1%D1%84/%C3%A5%CE%B1%D1%84', $url->route('foobarbaz', array('baz' => 'åαф')));
+		$this->assertEquals('/foo/bar#derp', $url->route('fragment', array(), false));
+		$this->assertEquals('/foo/bar?foo=bar#derp', $url->route('fragment', array('foo' => 'bar'), false));
+		$this->assertEquals('/foo/bar?baz=%C3%A5%CE%B1%D1%84#derp', $url->route('fragment', array('baz' => 'åαф'), false));
 
 	}
 


### PR DESCRIPTION
I added some tests for #6455 and fixed an issue that involved incorrectly building URLs that have both a fragment and a query.
