### PR TITLE
Don't show empty brackets in log files

### DIFF
--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -132,7 +132,7 @@ class Writer {
 	 */
 	protected function getDefaultFormatter()
 	{
-		return new LineFormatter(null, null, true);
+		return new LineFormatter(null, null, true, true);
 	}
 
 	/**


### PR DESCRIPTION
The current log files generated by Laravel all show empty brackets at the end of log files. We can remove these by using the $ignoreEmptyContextAndExtra parameter in the default Monolog LineFormatter.

@seldaek I was wondering why this isn't set to true by default?

http://stackoverflow.com/questions/13968967/how-not-to-show-last-bracket-in-a-monolog-log-line
