### PR TITLE
[5.0] Remove Empty Brackets From Log Files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ircmaxell/password-compat": "~1.0",
         "jeremeamia/superclosure": "~1.0.1",
         "league/flysystem": "0.6.*",
-        "monolog/monolog": "~1.6",
+        "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",
         "nesbot/carbon": "~1.0",
         "patchwork/utf8": "~1.1",

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -354,7 +354,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 */
 	protected function getDefaultFormatter()
 	{
-		return new LineFormatter(null, null, true);
+		return new LineFormatter(null, null, true, true);
 	}
 
 	/**

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.4.0",
         "illuminate/contracts": "5.0.*",
         "illuminate/support": "5.0.*",
-        "monolog/monolog": "~1.6"
+        "monolog/monolog": "~1.11"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Replacement for #6549. I sent this to master because of the monolog version bump.

The current log files generated by Laravel all show empty brackets at the end of log files. We can remove these by using the `$ignoreEmptyContextAndExtra parameter` in the default Monolog LineFormatter.

http://stackoverflow.com/questions/13968967/how-not-to-show-last-bracket-in-a-monolog-log-line
