### PR TITLE
[4.2] Eloquent Relationship Query Builder Broken With Global Query Scope

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -672,8 +672,8 @@ class Builder {
 	/**
 	 * Merge the "wheres" from a relation query to a has query.
 	 *
-	 * @param  \Illuminate\Database\Eloquent\Builder  $hasQuery
-	 * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+	 * @param  \Illuminate\Database\Eloquent\Builder $hasQuery
+	 * @param  \Illuminate\Database\Eloquent\Relations\Relation $relation
 	 * @return void
 	 */
 	protected function mergeWheresToHas(Builder $hasQuery, Relation $relation)
@@ -683,10 +683,10 @@ class Builder {
 		// the has query, and then copy the bindings from the "has" query to the main.
 		$relationQuery = $relation->getBaseQuery();
 
-        // The relation query is going to have all the necessary global scope definitions
-        // If the global scopes aren't removed here then they will be duplicated in the final
-        // Query.  This is noticeable when a global scope includes where clauses.
-        $hasQuery = $hasQuery->getModel()->removeGlobalScopes($hasQuery);
+		// The relation query is going to have all the necessary global scope definitions
+		// If the global scopes aren't removed here then they will be duplicated in the final
+		// Query.  This is noticeable when a global scope includes where clauses.
+		$hasQuery = $hasQuery->getModel()->removeGlobalScopes($hasQuery);
 
 		$hasQuery->mergeWheres(
 			$relationQuery->wheres, $relationQuery->getBindings()

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -683,6 +683,11 @@ class Builder {
 		// the has query, and then copy the bindings from the "has" query to the main.
 		$relationQuery = $relation->getBaseQuery();
 
+        // The relation query is going to have all the necessary global scope definitions
+        // If the global scopes aren't removed here then they will be duplicated in the final
+        // Query.  This is noticeable when a global scope includes where clauses.
+        $hasQuery = $hasQuery->getModel()->removeGlobalScopes($hasQuery);
+
 		$hasQuery->mergeWheres(
 			$relationQuery->wheres, $relationQuery->getBindings()
 		);


### PR DESCRIPTION
In eloquent when including a sub-model via the eloquent method has (whereHas) 2 queries objects are built and then merged together.  The merge is done in an effort to preserve any where statements that a developer may have included prior to calling has.  The problem occurs when the subject of the 'has' method (the sub-model) is utilizing a global query scope.  
In my example, consider a global query scope which adds several where filters to every query.  When the 'has' method generates the 2 query objects each of them have the global query scope and as a result of the whereMerge the resulting query has duplicates of all the where filters.  This inconsistency causes several problems including complication of the remove query scope functionality.
My proposed change simply looks at one of the query objects prior to the merge and removes any global scope options that may have been added.  

I attempted to write a unit test for this, but i'm unfamiliar with Mockery and it was becoming quite the struggle to represent this scenario.  I'm positive it can be done, but may need some assistance on that front.
