### PR TITLE
upgraded pheanstalk from ~2.1 to ~3.0 to fix memory leak

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
     "require-dev": {
         "aws/aws-sdk-php": "~2.6",
         "iron-io/iron_mq": "~1.5",
-        "pda/pheanstalk": "~2.1",
+        "pda/pheanstalk": "~3.0",
         "mockery/mockery": "~0.9",
         "phpunit/phpunit": "~4.0"
     },


### PR DESCRIPTION
3.0.2 contains a memory leak fix
see: https://github.com/pda/pheanstalk/pull/85
