### PR TITLE
[5.0] Add where method to collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -62,11 +62,17 @@ class Collection extends BaseCollection {
 	 * Determine if a key exists in the collection.
 	 *
 	 * @param  mixed  $key
+	 * @param  mixed  $value
 	 * @return bool
 	 */
-	public function contains($key)
+	public function contains($key, $value = null)
 	{
-		return ! is_null($this->find($key));
+		if (func_num_args() == 1)
+		{
+			return ! is_null($this->find($key));
+		}
+
+		return parent::contains($key, $value);
 	}
 
 	/**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -75,17 +75,26 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	/**
 	 * Determine if an item exists in the collection.
 	 *
+	 * @param  mixed  $key
 	 * @param  mixed  $value
 	 * @return bool
 	 */
-	public function contains($value)
+	public function contains($key, $value = null)
 	{
-		if ($value instanceof Closure)
+		if (func_num_args() == 2)
 		{
-			return ! is_null($this->first($value));
+			return $this->contains(function($k, $item) use ($key, $value)
+			{
+				return data_get($item, $key) == $value;
+			});
 		}
 
-		return in_array($value, $this->items);
+		if ($key instanceof Closure)
+		{
+			return ! is_null($this->first($key));
+		}
+
+		return in_array($key, $this->items);
 	}
 
 	/**
@@ -132,6 +141,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	public function filter(Closure $callback)
 	{
 		return new static(array_filter($this->items, $callback));
+	}
+
+	/**
+	 * Filter items by the given key value pair.
+	 *
+	 * @param  string  $key
+	 * @param  mixed  $value
+	 * @return static
+	 */
+	public function where($key, $value)
+	{
+		return $this->filter(function($item) use ($key, $value)
+		{
+			return data_get($item, $key) == $value;
+		});
 	}
 
 	/**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -124,6 +124,14 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testWhere()
+	{
+		$c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
+
+		$this->assertEquals([['v' => 3], ['v' => '3']], $c->where('v', 3)->values()->all());
+	}
+
+
 	public function testValues()
 	{
 		$c = new Collection(array(array('id' => 1, 'name' => 'Hello'), array('id' => 2, 'name' => 'World')));
@@ -477,6 +485,11 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($c->contains(2));
 		$this->assertTrue($c->contains(function($value) { return $value < 5; }));
 		$this->assertFalse($c->contains(function($value) { return $value > 5; }));
+
+		$c = new Collection([['v' => 1], ['v' => 3], ['v' => 5]]);
+
+		$this->assertTrue($c->contains('v', 1));
+		$this->assertFalse($c->contains('v', 2));
 	}
 
 


### PR DESCRIPTION
This PR replaces #6502 and now only support simple match filtering. No more operator checking.

Usage is still roughly the same:

``` php
$collection = new Collection(['v' => 1], ['v' => 2], ['v' => 3]);

$two = $collection->where('v', 2);
```

---

This is quite useful as is. If we add Eloquent support to `data_get` (which we should anyhow do, for many other reasons) this would become way more useful:

``` php
if ($orders->contains('user_id', Auth::id())) {
    // 
}
```
