### PR TITLE
Modified groupBy() method on Collection Class to return Collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -213,12 +213,12 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 
 		foreach ($this->items as $key => $value)
 		{
-            $groupByKey = $this->getGroupbyKey($groupBy, $key, $value);
+			$groupByKey = $this->getGroupbyKey($groupBy, $key, $value);
 
-            if( ! array_key_exists($groupByKey, $results))
-            {
-                $results[$groupByKey] = new static();
-            }
+			if( ! array_key_exists($groupByKey, $results))
+			{
+			    $results[$groupByKey] = new static();
+			}
 
 			$results[$groupByKey]->push($value);
 		}

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -213,7 +213,14 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 
 		foreach ($this->items as $key => $value)
 		{
-			$results[$this->getGroupbyKey($groupBy, $key, $value)][] = $value;
+            $groupByKey = $this->getGroupbyKey($groupBy, $key, $value);
+
+            if( ! array_key_exists($groupByKey, $results))
+            {
+                $results[$groupByKey] = new static();
+            }
+
+			$results[$groupByKey]->push($value);
 		}
 
 		return new static($results);


### PR DESCRIPTION
Allows users to do things like this

``` php
$users = User::all();
foreach ($users->groupBy('group_id') as $userGroup)
{
    //Show how many users in group
    echo $userGroup->count();

    //Get first user in group
    dd($userGroup->first());
}
```
