### PR TITLE
[5.0] Fixed The Flysystem Version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "doctrine/annotations": "~1.0",
         "ircmaxell/password-compat": "~1.0",
         "jeremeamia/superclosure": "~1.0.1",
-        "league/flysystem": "0.6.*",
+        "league/flysystem": "~1.0",
         "monolog/monolog": "~1.6",
         "mtdowling/cron-expression": "~1.0",
         "nesbot/carbon": "~1.0",

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -13,7 +13,7 @@
         "illuminate/contracts": "5.0.*",
         "illuminate/support": "5.0.*",
         "symfony/finder": "2.6.*",
-        "league/flysystem": "0.6.*"
+        "league/flysystem": "~1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`0.6.x` doesn't exist anymore. The next version will be `1.0.x`. I have updated the version constraint accordingly.
