### PR TITLE
[5.0] Fixed FileStore::flush If The Cache Root Directory Doesn't Exist

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -189,9 +189,12 @@ class FileStore implements StoreInterface {
 	 */
 	public function flush()
 	{
-		foreach ($this->files->directories($this->directory) as $directory)
+		if ($this->files->isDirectory($this->directory))
 		{
-			$this->files->deleteDirectory($directory);
+			foreach ($this->files->directories($this->directory) as $directory)
+			{
+				$this->files->deleteDirectory($directory);
+			}
 		}
 	}
 

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -102,10 +102,21 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 	public function testFlushCleansDirectory()
 	{
 		$files = $this->mockFilesystem();
+		$files->expects($this->once())->method('isDirectory')->with($this->equalTo(__DIR__))->will($this->returnValue(true));
 		$files->expects($this->once())->method('directories')->with($this->equalTo(__DIR__))->will($this->returnValue(array('foo')));
 		$files->expects($this->once())->method('deleteDirectory')->with($this->equalTo('foo'));
 
 		$store = new FileStore($files, __DIR__);
+		$store->flush();
+	}
+
+
+	public function testFlushIgnoreNonExistingDirectory()
+	{
+		$files = $this->mockFilesystem();
+		$files->expects($this->once())->method('isDirectory')->with($this->equalTo(__DIR__ . '--wrong'))->will($this->returnValue(false));
+
+		$store = new FileStore($files, __DIR__ . '--wrong');
 		$store->flush();
 	}
 


### PR DESCRIPTION
Trying to list the content of a non-existing directory raises an exception, with this patch calling flush doesn't fail even if the cache is completely empty.
