### PR TITLE
[5.0] Moved "patchwork/utf8" To Require

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -10,11 +10,11 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/contracts": "5.0.*"
+        "illuminate/contracts": "5.0.*",
+        "patchwork/utf8": "~1.1"
     },
     "require-dev": {
-        "jeremeamia/superclosure": "~1.0.1",
-        "patchwork/utf8": "~1.1"
+        "jeremeamia/superclosure": "~1.0.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Moving `patchwork/utf8` to the require block as suggested in #6547.
