### PR TITLE
[4.2] Make "findClosure" Actually Find Closures

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Routing;
 
+use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Matching\UriValidator;
 use Illuminate\Routing\Matching\HostValidator;
@@ -504,7 +505,7 @@ class Route {
 	{
 		return array_first($action, function($key, $value)
 		{
-			return is_callable($value);
+			return $value instanceOf Closure;
 		});
 	}
 


### PR DESCRIPTION
Return of method findClosure() is Closure Object that is callable and must be an object. So only using is_callable() function isn't enough. A string could be callable, example when you adding alias 'app' in your route. 
Route::get('apps', array('as' => 'app', function()
{
//
})); will make an error.

![screenshot from 2014-12-03 23 16 49](https://cloud.githubusercontent.com/assets/7432391/5283824/8d8de5f6-7b42-11e4-9d91-df07599cc8e9.png)
