### PR TITLE
[5.0] Add ArrayAccess support to data_get

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -402,6 +402,15 @@ if ( ! function_exists('data_get'))
 
 				$target = $target[$segment];
 			}
+			elseif ($target instanceof ArrayAccess)
+			{
+				if ( ! isset($target[$segment]))
+				{
+					return value($default);
+				}
+
+				$target = $target[$segment];
+			}
 			elseif (is_object($target))
 			{
 				if ( ! isset($target->{$segment}))

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -230,12 +230,19 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	{
 		$object = (object) array('users' => array('name' => array('Taylor', 'Otwell')));
 		$array = array((object) array('users' => array((object) array('name' => 'Taylor'))));
+		$arrayAccess = new SupportTestArrayAccess(['price' => 56, 'user' => new SupportTestArrayAccess(['name' => 'John'])]);
 
 		$this->assertEquals('Taylor', data_get($object, 'users.name.0'));
 		$this->assertEquals('Taylor', data_get($array, '0.users.0.name'));
 		$this->assertNull(data_get($array, '0.users.3'));
 		$this->assertEquals('Not found', data_get($array, '0.users.3', 'Not found'));
 		$this->assertEquals('Not found', data_get($array, '0.users.3', function (){ return 'Not found'; }));
+		$this->assertEquals(56, data_get($arrayAccess, 'price'));
+		$this->assertEquals('John', data_get($arrayAccess, 'user.name'));
+		$this->assertEquals('void', data_get($arrayAccess, 'foo', 'void'));
+		$this->assertEquals('void', data_get($arrayAccess, 'user.foo', 'void'));
+		$this->assertNull(data_get($arrayAccess, 'foo'));
+		$this->assertNull(data_get($arrayAccess, 'user.foo'));
 	}
 
 
@@ -292,3 +299,19 @@ class SupportTestClassOne {
 }
 
 class SupportTestClassTwo extends SupportTestClassOne {}
+
+class SupportTestArrayAccess implements ArrayAccess {
+
+	protected $attributes = [];
+
+	public function __construct ($attributes = []){ $this->attributes = $attributes; }
+
+	public function offsetExists ($offset){ return isset($this->attributes[$offset]); }
+
+	public function offsetGet ($offset){ return $this->attributes[$offset]; }
+
+	public function offsetSet ($offset, $value){ $this->attributes[$offset] = $value; }
+
+	public function offsetUnset ($offset){ unset($this->attributes[$offset]); }
+
+}


### PR DESCRIPTION
Mainly so that we can use it with `Eloquent` models and `Collection` objects:

``` php
$comment = Comment::with('post.user')->find(1);

$author = data_get($comment, 'post.user');
```

This also goes nicely with the [recently added](https://github.com/laravel/framework/pull/6553) `where` and `contains` functionality to the collection class:

``` php
if ($orders->contains('user_id', Auth::id())) {
    //
}
```
