### PR TITLE
[4.2] Added A "getRepository" Method To The Cache Manager

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -158,6 +158,17 @@ class CacheManager extends Manager {
 	}
 
 	/**
+	 * Create a new cache repository with the given implementation.
+	 *
+	 * @param  \Illuminate\Cache\StoreInterface  $store
+	 * @return \Illuminate\Cache\Repository
+	 */
+	protected function getRepository(StoreInterface $store)
+	{
+		return $this->repository($store);
+	}
+
+	/**
 	 * Get the default cache driver name.
 	 *
 	 * @return string


### PR DESCRIPTION
Currently the repository creation within the CacheManager is protected. When adding new cache drivers the implementation requires creation of specific class. It appears to me that the CacheManager is responsible for controlling Repository implementation.

``` php
Cache::extend('elasticache', function() {
    $servers = Config::get('cache.memcached');
    $elasticache = new Illuminate\Cache\ElasticacheConnector();
    $memcached = $elasticache->connect($servers);
    return new Illuminate\Cache\Repository(new Illuminate\Cache\MemcachedStore($memcached, Config::get('cache.prefix')));
});
```

I propose that this Repository creation process be publicly accessible for extension, such that the above use case looks more like:

``` php
Cache::extend('elasticache', function() {
    $servers = Config::get('cache.memcached');
    $elasticache = new Illuminate\Cache\ElasticacheConnector();
    $memcached = $elasticache->connect($servers);
    return Cache::getRepository(new Illuminate\Cache\MemcachedStore($memcached, Config::get('cache.prefix')));
});
```

The proposed solution in this pull request adds a new public `getRepository` method to the CacheManager class that calls the protected `repository` method. 
