### PR TITLE
Removed repetition of documentation word

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/routes.stub
+++ b/src/Illuminate/Foundation/Console/stubs/routes.stub
@@ -7,7 +7,7 @@
 |
 | Here we will decode and unserialize the RouteCollection instance that
 | holds all of the route information for an application. This allows
-| us to quickly load the entire route map into the router quickly.
+| us to quickly load the entire route map into the router.
 |
 */
 


### PR DESCRIPTION
"Quickly" was mentioned twice in the same sentence. It slightly bothered me.
