### PR TITLE
[5.0] Fix composer dump-autoload command after make:migration

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Database\Console\Migrations;
 
+use Illuminate\Foundation\Composer;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Illuminate\Database\Migrations\MigrationCreator;
@@ -35,17 +36,24 @@ class MigrateMakeCommand extends BaseCommand {
 	protected $packagePath;
 
 	/**
+	 * @var \Illuminate\Foundation\Composer
+	 */
+	protected $composer;
+
+	/**
 	 * Create a new migration install command instance.
 	 *
 	 * @param  \Illuminate\Database\Migrations\MigrationCreator  $creator
+	 * @param  \Illuminate\Foundation\Composer  $composer
 	 * @param  string  $packagePath
 	 * @return void
 	 */
-	public function __construct(MigrationCreator $creator, $packagePath)
+	public function __construct(MigrationCreator $creator, Composer $composer, $packagePath)
 	{
 		parent::__construct();
 
 		$this->creator = $creator;
+		$this->composer = $composer;
 		$this->packagePath = $packagePath;
 	}
 
@@ -72,7 +80,7 @@ class MigrateMakeCommand extends BaseCommand {
 		// make sure that the migrations are registered by the class loaders.
 		$this->writeMigration($name, $table, $create);
 
-		$this->call('dump-autoload');
+		$this->composer->dumpAutoloads();
 	}
 
 	/**

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -192,7 +192,9 @@ class MigrationServiceProvider extends ServiceProvider {
 
 			$packagePath = $app['path.base'].'/vendor';
 
-			return new MigrateMakeCommand($creator, $packagePath);
+			$composer = $app['composer'];
+
+			return new MigrateMakeCommand($creator, $composer, $packagePath);
 		});
 	}
 

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -10,10 +10,29 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 		m::close();
 	}
 
+	public function testBasicCreateDumpsAutoload()
+	{
+		$command = new DatabaseMigrationMakeCommandTestStub(
+			$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
+			$composer = m::mock('Illuminate\Foundation\Composer'),
+			__DIR__.'/vendor'
+		);
+		$app = new Illuminate\Container\Container;
+		$app['path.database'] = __DIR__;
+		$command->setLaravel($app);
+		$creator->shouldReceive('create')->once()->with('create_foo', __DIR__.'/migrations', null, false);
+		$composer->shouldReceive('dumpAutoloads')->once();
+
+		$this->runCommand($command, array('name' => 'create_foo'));
+	}
 
 	public function testBasicCreateGivesCreatorProperArguments()
 	{
-		$command = new DatabaseMigrationMakeCommandTestStub($creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'), __DIR__.'/vendor');
+		$command = new DatabaseMigrationMakeCommandTestStub(
+			$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
+			m::mock('Illuminate\Foundation\Composer')->shouldIgnoreMissing(),
+			__DIR__.'/vendor'
+		);
 		$app = new Illuminate\Container\Container;
 		$app['path.database'] = __DIR__;
 		$command->setLaravel($app);
@@ -25,7 +44,11 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testBasicCreateGivesCreatorProperArgumentsWhenTableIsSet()
 	{
-		$command = new DatabaseMigrationMakeCommandTestStub($creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'), __DIR__.'/vendor');
+		$command = new DatabaseMigrationMakeCommandTestStub(
+			$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
+			m::mock('Illuminate\Foundation\Composer')->shouldIgnoreMissing(),
+			__DIR__.'/vendor'
+		);
 		$app = new Illuminate\Container\Container;
 		$app['path.database'] = __DIR__;
 		$command->setLaravel($app);


### PR DESCRIPTION
Currently, the attempt to call `dump-autoload` fails because there is no artisan command by that name.
