### PR TITLE
Extending UrlGenerator with url alter method

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -76,6 +76,20 @@ class UrlGenerator {
 	}
 
 	/**
+	 * Get the current URL with one or more replaced parameters
+	 *
+	 * @param  array   $parameters
+	 * @param  bool    $absolute
+	 * @return string
+	 */
+	public function alter(array $parameters = array(), $absolute = true)
+	{
+		$replaced_parameters = array_merge($_GET, $this->request->route()->parameters(), $parameters);
+
+		return $this->toRoute($this->request->route(), $replaced_parameters, $absolute);
+	}
+
+	/**
 	 * Get the current URL for the request.
 	 *
 	 * @return string


### PR DESCRIPTION
This method basically conveniently changes parameters of the current url.

Example URL:

``` php
Route::get('/{lang}/users/profile/{id}/article/{slug}', function($lang, $id, $slug) {
 // ...
});

# http://laravel/en/users/profile/12/article/super-awesome-article
```

Case 1 — single parameter:

``` php
URL::alter(['lang' => 'uk'])
# http://laravel/uk/users/profile/12/article/super-awesome-article
```

Case 2 — multiple parameters:

``` php
URL::alter(['lang' => 'uk', 'slug' => 'best-of-the-best-of-the-best'])
# http://laravel/uk/users/profile/12/article/best-of-the-best-of-the-best
```

Case 3 — multiple parameters with GET params:

``` php
URL::alter(['lang' => 'uk', 'slug' => 'best-of-the-best-of-the-best', 'page' => 7, 'order' => 'desc'])
# http://laravel/uk/users/profile/12/article/best-of-the-best-of-the-best?page=7&order=desc
```
