### PR TITLE
Fix: Preventing Divide by zero when $value->getSize() is called

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -889,7 +889,7 @@ class Validator implements MessageProviderInterface {
 		{
 			return count($value);
 		}
-		elseif ($value instanceof File)
+		elseif ($value instanceof UploadedFile)
 		{
 			return ($value->isValid()) ? $value->getSize() / 1024 : false;
 		}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -891,7 +891,7 @@ class Validator implements MessageProviderInterface {
 		}
 		elseif ($value instanceof UploadedFile)
 		{
-			return ($value->isValid()) ? $value->getSize() / 1024 : (int)false;
+			return ($value->isValid()) ? $value->getSize() / 1024 : 0;
 		}
 
 		return $this->getStringSize($value);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -891,7 +891,7 @@ class Validator implements MessageProviderInterface {
 		}
 		elseif ($value instanceof File)
 		{
-			return $value->getSize() / 1024;
+			return ($value->isValid()) ? $value->getSize() / 1024 : false;
 		}
 
 		return $this->getStringSize($value);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -891,7 +891,7 @@ class Validator implements MessageProviderInterface {
 		}
 		elseif ($value instanceof UploadedFile)
 		{
-			return ($value->isValid()) ? $value->getSize() / 1024 : false;
+			return ($value->isValid()) ? $value->getSize() / 1024 : (int)false;
 		}
 
 		return $this->getStringSize($value);


### PR DESCRIPTION
When using min:0 in validation rule, Laravel throws an Exception SplFileInfo::getSize():  stat failed for [filename]. 

It would be ideal to ensure that the Validator getSize function prevents the scenario from taking place, by checking that a valid file exists and that no empty file is evaluated to trigger the above exception.
