### PR TITLE
Ensures that the response is an actual Response.

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -71,6 +71,10 @@ class VerifyCsrfToken implements Middleware {
 	 */
 	protected function addCookieToResponse($request, $response)
 	{
+		if (!is_a($response, 'Illuminate\Http\Response')) {
+			$response = new \Illuminate\Http\Response($response);
+		}
+
 		$response->headers->setCookie(
 			new Cookie('XSRF-TOKEN', $request->session()->token(), time() + 60 * 120, '/', null, false, false)
 		);


### PR DESCRIPTION
When using the CSRF protection as a routing middleware, not applied in `kernel.php` it breaks because the controller/route could return a `View` instead of a `Response`. This is one potential fix.

Another approach would be to have the `view` function wrap the view in a `Response` to avoid this too.

e.g.

``` php
class AuthController extends Controller {

    /**
     * Create a new authentication controller instance.
     *
     * @param  Guard  $auth
     * @return void
     */
    public function __construct(Guard $auth)
    {
        $this->middleware('csrf');
    }

    /**
     * Show the application registration form.
     *
     * @return Response
     */
    public function getRegister()
    {
        return view('auth.login');
    }
```

The above returns a view to the middleware, where a response is expected.
