### PR TITLE
[4.2] Extending UrlGenerator With Url Alter Method

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -86,6 +86,23 @@ class UrlGenerator {
 	}
 
 	/**
+	 * Get the current URL with one or more replaced parameters
+	 *
+	 * @param  array   $route_parameters
+	 * @param  array   $get_parameters
+	 * @param  bool    $absolute
+	 * @return string
+	 */
+	public function alter(array $route_parameters = array(), array $get_parameters = array(), $absolute = true)
+	{
+		$replaced_route_parameters = $route_parameters + $this->request->route()->parameters();
+		$replaced_get_parameters   = $get_parameters   + $this->request->query->all();
+
+		return $this->toRoute($this->request->route(), $replaced_route_parameters, $absolute)
+			. $this->getRouteQueryString($replaced_get_parameters);
+	}
+
+	/**
 	 * Get the URL for the previous request.
 	 *
 	 * @return string

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -88,18 +88,18 @@ class UrlGenerator {
 	/**
 	 * Get the current URL with one or more replaced parameters
 	 *
-	 * @param  array   $route_parameters
-	 * @param  array   $get_parameters
-	 * @param  bool    $absolute
+	 * @param  array  $routeParameters
+	 * @param  array  $getParameters
+	 * @param  bool  $absolute
 	 * @return string
 	 */
-	public function alter(array $route_parameters = array(), array $get_parameters = array(), $absolute = true)
+	public function alter(array $routeParameters = array(), array $getParameters = array(), $absolute = true)
 	{
-		$replaced_route_parameters = $route_parameters + $this->request->route()->parameters();
-		$replaced_get_parameters   = $get_parameters   + $this->request->query->all();
+		$replacedRouteParameters = $routeParameters + $this->request->route()->parameters();
+		$replacedGetParameters = $getParameters + $this->request->query->all();
 
-		return $this->toRoute($this->request->route(), $replaced_route_parameters, $absolute)
-			. $this->getRouteQueryString($replaced_get_parameters);
+		return $this->toRoute($this->request->route(), $replacedRouteParameters, $absolute)
+			. $this->getRouteQueryString($replacedGetParameters);
 	}
 
 	/**


### PR DESCRIPTION
This method basically conveniently changes parameters of the current url.

Example URL:

``` php
Route::get('/{lang}/users/profile/{id}/article/{slug}', function($lang, $id, $slug) {
 // ...
});

# http://laravel/en/users/profile/12/article/super-awesome-article?page=12
```

Case 1 — single parameter:

``` php
URL::alter(['lang' => 'uk'])
# http://laravel/uk/users/profile/12/article/super-awesome-article?page=12
```

Case 2 — multiple parameters:

``` php
URL::alter(['lang' => 'uk', 'slug' => 'best-of-the-best-of-the-best'])
# http://laravel/uk/users/profile/12/article/best-of-the-best-of-the-best?page=12
```

Case 3 — multiple parameters with GET params:

``` php
URL::alter(
  ['lang' => 'uk', 'slug' => 'best-of-the-best-of-the-best'],
  ['page' => 7, 'order' => 'desc']
)
# http://laravel/uk/users/profile/12/article/best-of-the-best-of-the-best?page=7&order=desc
```
