### PR TITLE
[5.0] Extending UrlGenerator With Url Alter Method

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -95,6 +95,23 @@ class UrlGenerator implements UrlGeneratorContract {
 	}
 
 	/**
+	 * Get the current URL with one or more replaced parameters
+	 *
+	 * @param  array  $routeParameters
+	 * @param  array  $getParameters
+	 * @param  bool   $absolute
+	 * @return string
+	 */
+	public function alter(array $routeParameters = array(), array $getParameters = array(), $absolute = true)
+	{
+		$replacedRouteParameters = $routeParameters + $this->request->route()->parameters();
+		$replacedGetParameters = $getParameters + $this->request->query->all();
+
+		return $this->toRoute($this->request->route(), $replacedRouteParameters, $absolute)
+			. $this->getRouteQueryString($replacedGetParameters);
+	}
+
+	/**
 	 * Get the URL for the previous request.
 	 *
 	 * @return string


### PR DESCRIPTION
This method basically conveniently changes parameters of the current url.

Example URL:

``` php
Route::get('/{lang}/users/profile/{id}/article/{slug}', function($lang, $id, $slug) {
 // ...
});

# http://laravel/en/users/profile/12/article/super-awesome-article?page=12
```

Case 1 — single parameter:

``` php
URL::alter(['lang' => 'uk'])
# http://laravel/uk/users/profile/12/article/super-awesome-article?page=12
```

Case 2 — multiple parameters:

``` php
URL::alter(['lang' => 'uk', 'slug' => 'best-of-the-best-of-the-best'])
# http://laravel/uk/users/profile/12/article/best-of-the-best-of-the-best?page=12
```

Case 3 — multiple parameters with GET params:

``` php
URL::alter(
  ['lang' => 'uk', 'slug' => 'best-of-the-best-of-the-best'],
  ['page' => 7, 'order' => 'desc']
)
# http://laravel/uk/users/profile/12/article/best-of-the-best-of-the-best?page=7&order=desc
```
