### PR TITLE
Added abstract method getJobId()

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -66,6 +66,13 @@ abstract class Job {
 	 * @return void
 	 */
 	abstract public function release($delay = 0);
+	
+	/**
+	 * Get the ID of the job
+	 * 
+	 * @return mixed
+	 */
+	abstract public function getJobId();
 
 	/**
 	 * Get the number of times the job has been attempted.


### PR DESCRIPTION
The `getJobId()` method appears in each of the queue drivers but not in the abstract class. This commit adds the the abstract definition to the parent class.
