### PR TITLE
Allow setting Last-Modified header for file downloads

### DIFF
--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -95,6 +95,8 @@ class Response {
 	 * @param  string  $name
 	 * @param  array   $headers
 	 * @param  null|string  $disposition
+	 * @param  boolean $autoEtag
+	 * @param  boolean $autoLastModified
 	 * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
 	 */
 	public static function download($file, $name = null, array $headers = array(), $disposition = 'attachment', $autoEtag = false, $autoLastModified = true)

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -97,9 +97,9 @@ class Response {
 	 * @param  null|string  $disposition
 	 * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
 	 */
-	public static function download($file, $name = null, array $headers = array(), $disposition = 'attachment')
+	public static function download($file, $name = null, array $headers = array(), $disposition = 'attachment', $autoEtag = false, $autoLastModified = true)
 	{
-		$response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
+		$response = new BinaryFileResponse($file, 200, $headers, true, $disposition, $autoEtag, $autoLastModified);
 
 		if ( ! is_null($name))
 		{


### PR DESCRIPTION
The Response Facade does not allow configuring the autoEtag or autoLastModified parameters of a Symfony BinaryFileResponse.  This simply accepts them as parameters and passes them to the Symfony class.
