### PR TITLE
[5.0] Redirect User to Intended Url After Login

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesAndRegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesAndRegistersUsers.php
@@ -93,7 +93,7 @@ trait AuthenticatesAndRegistersUsers {
 
 		if ($this->auth->attempt($credentials, $request->has('remember')))
 		{
-			return redirect($this->redirectPath());
+			return redirect()->intended($this->redirectPath());
 		}
 
 		return redirect('/auth/login')


### PR DESCRIPTION
Redirect the logged in user to the intended URL if one exists instead of forcing her to go to the defined redirect path.

This nicely complements the `redirect()->guest('auth/login')` in the built-in [Authenticate middleware](https://github.com/laravel/laravel/blob/develop/app/Http/Middleware/Authenticate.php#L44).
