### PR TITLE
[5.0] Allow setting Last-Modified header for file downloads

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -122,11 +122,13 @@ class ResponseFactory implements FactoryContract {
 	 * @param  string  $name
 	 * @param  array   $headers
 	 * @param  null|string  $disposition
+	 * @param  boolean $autoEtag
+	 * @param  boolean $autoLastModified
 	 * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
 	 */
-	public function download($file, $name = null, array $headers = array(), $disposition = 'attachment')
+	public function download($file, $name = null, array $headers = array(), $disposition = 'attachment', $autoEtag = false, $autoLastModified = true)
 	{
-		$response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
+		$response = new BinaryFileResponse($file, 200, $headers, true, $disposition, $autoEtag, $autoLastModified);
 
 		if ( ! is_null($name))
 		{

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -122,8 +122,8 @@ class ResponseFactory implements FactoryContract {
 	 * @param  string  $name
 	 * @param  array   $headers
 	 * @param  null|string  $disposition
-	 * @param  boolean $autoEtag
-	 * @param  boolean $autoLastModified
+	 * @param  bool  $autoEtag
+	 * @param  bool  $autoLastModified
 	 * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
 	 */
 	public function download($file, $name = null, array $headers = array(), $disposition = 'attachment', $autoEtag = false, $autoLastModified = true)


### PR DESCRIPTION
Illuminate\Routing\ResponseFactory does not allow configuring the `autoEtag` or `autoLastModified` parameters of a Symfony BinaryFileResponse. This simply accepts them as parameters and passes them to the Symfony class using the same defaults used in a BinaryFileResponse.
