### PR TITLE
[4.2] Select From Write Pdo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -644,6 +644,13 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		return $instance->newQuery()->find($id, $columns);
 	}
 
+	public static function onWrite()
+	{
+		$instance = new static;
+
+		return $instance->newQuery()->useWritePdo();
+	}
+
 	/**
 	 * Find a model by its primary key or return new static.
 	 *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -644,6 +644,11 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		return $instance->newQuery()->find($id, $columns);
 	}
 
+	/**
+	 * Begin querying the model on the write connection.
+	 *
+	 * @return \Illuminate\Database\Query\Builder
+	 */
 	public static function onWrite()
 	{
 		$instance = new static;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2104,6 +2104,11 @@ class Builder {
 		return $this->grammar;
 	}
 
+	/**
+	 * Use the write pdo for query.
+	 *
+	 * @return $this
+	 */
 	public function useWritePdo()
 	{
 		$this->useWritePdo = true;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1363,7 +1363,8 @@ class Builder {
 	 */
 	protected function runSelect()
 	{
-		if ($this->useWritePdo) {
+		if ($this->useWritePdo)
+		{
 			return $this->connection->select($this->toSql(), $this->getBindings(), false);
 		}
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -181,6 +181,13 @@ class Builder {
 	);
 
 	/**
+	 * Whether use write pdo for select.
+	 *
+	 * @var bool
+	 */
+	protected $useWritePdo = false;
+
+	/**
 	 * Create a new query builder instance.
 	 *
 	 * @param  \Illuminate\Database\ConnectionInterface  $connection
@@ -1356,6 +1363,10 @@ class Builder {
 	 */
 	protected function runSelect()
 	{
+		if ($this->useWritePdo) {
+			return $this->connection->select($this->toSql(), $this->getBindings(), false);
+		}
+
 		return $this->connection->select($this->toSql(), $this->getBindings());
 	}
 
@@ -2090,6 +2101,13 @@ class Builder {
 	public function getGrammar()
 	{
 		return $this->grammar;
+	}
+
+	public function useWritePdo()
+	{
+		$this->useWritePdo = true;
+
+		return $this;
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -105,6 +105,11 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo', $result);
 	}
 
+	public function testFindMethodUseWritePdo()
+	{
+		$result =  EloquentModelFindWithWritePdoStub::onWrite()->find(1);
+	}
+
 	/**
 	 * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
 	 */
@@ -1045,6 +1050,17 @@ class EloquentModelFindStub extends Illuminate\Database\Eloquent\Model {
 	{
 		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
 		$mock->shouldReceive('find')->once()->with(1, array('*'))->andReturn('foo');
+		return $mock;
+	}
+}
+
+class EloquentModelFindWithWritePdoStub extends Illuminate\Database\Eloquent\Model {
+	public function newQuery()
+	{
+		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
+		$mock->shouldReceive('useWritePdo')->once()->andReturnSelf();
+		$mock->shouldReceive('find')->once()->with(1)->andReturn('foo');
+
 		return $mock;
 	}
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1267,6 +1267,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
 	}
 
+
 	protected function getMySqlBuilderWithProcessor()
 	{
 		$grammar = new Illuminate\Database\Query\Grammars\MySqlGrammar;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -20,6 +20,20 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testBasicSelectUseWritePdo()
+	{
+		$builder = $this->getMySqlBuilderWithProcessor();
+		$builder->getConnection()->shouldReceive('select')->once()
+			->with('select * from `users`', array(), false);
+		$builder->useWritePdo()->select('*')->from('users')->get();
+
+		$builder = $this->getMySqlBuilderWithProcessor();
+		$builder->getConnection()->shouldReceive('select')->once()
+			->with('select * from `users`', array());
+		$builder->select('*')->from('users')->get();
+	}
+
+
 	public function testBasicTableWrappingProtectsQuotationMarks()
 	{
 		$builder = $this->getBuilder();
@@ -1250,6 +1264,13 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$grammar = new Illuminate\Database\Query\Grammars\SqlServerGrammar;
 		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+		return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+	}
+
+	protected function getMySqlBuilderWithProcessor()
+	{
+		$grammar = new Illuminate\Database\Query\Grammars\MySqlGrammar;
+		$processor = new Illuminate\Database\Query\Processors\MySqlProcessor;
 		return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
 	}
 


### PR DESCRIPTION
Eloquent use the read pdo for select query. 

However, in some scenes, it needs to query data just from the write pdo(master db), because of the _delay_ of database syncing.

As @crynobone says(#6599), the demand can be satisfied by the use of `User::on('mysql::write')->find(1);`. But, in my opinion, using the `on` method is not a natural way. Because every Eloquent model knows which db connection they will use. There should be no need to use the `on` method to set a concrete connection name.

Here is my solution. I add a new `onWrite` method to the Eloquent. We could do:

``` php
$user = User::onWrite()->find(1);
```
