### PR TITLE
[4.2] Fixed port separator in DSN when using dblib with PDO in sql server connector

### DIFF
--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -42,12 +42,14 @@ class SqlServerConnector extends Connector implements ConnectorInterface {
 		// First we will create the basic DSN setup as well as the port if it is in
 		// in the configuration options. This will give us the basic DSN we will
 		// need to establish the PDO connections and return them back for use.
-		$port = isset($config['port']) ? ','.$port : '';
-
 		if (in_array('dblib', $this->getAvailableDrivers()))
 		{
+			$port = isset($config['port']) ? ':'.$port : '';
+
 			return "dblib:host={$host}{$port};dbname={$database}";
 		}
+
+		$port = isset($config['port']) ? ','.$port : '';
 
 		$dbName = $database != '' ? ";Database={$database}" : '';
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -124,14 +124,14 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 	{
 		extract($config);
 
-		$port = isset($config['port']) ? ','.$port : '';
-
 		if (in_array('dblib', PDO::getAvailableDrivers()))
 		{
+			$port = isset($config['port']) ? ':'.$port : '';
 			return "dblib:host={$host}{$port};dbname={$database}";
 		}
 		else
 		{
+			$port = isset($config['port']) ? ','.$port : '';
 			return "sqlsrv:Server={$host}{$port};Database={$database}";
 		}
 	}


### PR DESCRIPTION
I've been playing with Laravel and SQL server the past few days.

Without this I get a `PDOException` with `SQLSTATE[HY000] Unknown host machine name (severity 2)` on my Mac connecting to SQL server.

I believe it's because dblib is Unix it is expecting a Unix style port separator `:` and the `sqlsrv` option is expecting `,` as it is the Windows style. The `sqlsrv` option works fine when I'm on Windows running Laravel.

Propel ORM has some dblib DSN examples that match too:
http://propelorm.org/Propel/cookbook/using-mssql-server.html#pdodblib
