### PR TITLE
[5.0] Allow DI In Static Methods

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -525,7 +525,7 @@ class Container implements ArrayAccess, ContainerContract {
 	 */
 	public function call($callback, array $parameters = array(), $defaultMethod = null)
 	{
-		if (is_string($callback))
+		if ($this->isCallableWithAtSign($callback, $defaultMethod))
 		{
 			return $this->callClass($callback, $parameters, $defaultMethod);
 		}
@@ -538,7 +538,7 @@ class Container implements ArrayAccess, ContainerContract {
 	/**
 	 * Get all dependencies for a given method.
 	 *
-	 * @param  \Closure|array  $callback
+	 * @param  callable|string  $callback
 	 * @param  array  $parameters
 	 * @return array
 	 */
@@ -557,11 +557,16 @@ class Container implements ArrayAccess, ContainerContract {
 	/**
 	 * Get the proper reflection instance for the given callback.
 	 *
-	 * @param  \Closure|array  $callback
+	 * @param  callable|string  $callback
 	 * @return \ReflectionFunctionAbstract
 	 */
 	protected function getCallReflector($callback)
 	{
+		if (is_string($callback) && strpos($callback, '::') !== false)
+		{
+			$callback = explode('::', $callback);
+		}
+
 		if (is_array($callback))
 		{
 			return new ReflectionMethod($callback[0], $callback[1]);
@@ -1155,6 +1160,23 @@ class Container implements ArrayAccess, ContainerContract {
 	public function __set($key, $value)
 	{
 		$this[$key] = $value;
+	}
+
+	/**
+	 * Is the given string of the Class@method syntax or is defaultMethod filled.
+	 *
+	 * @param  mixed   $callback
+	 * @param  string  $defaultMethod
+	 * @return bool
+	 */
+	protected function isCallableWithAtSign($callback, $defaultMethod = null)
+	{
+		if ( ! is_string($callback))
+		{
+			return false;
+		}
+
+		return strpos($callback, '@') !== false || $defaultMethod;
 	}
 
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -363,7 +363,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 
 
 	/**
-	 * @expectedException InvalidArgumentException
+	 * @expectedException ReflectionException
 	 */
 	public function testCallWithAtSignBasedClassReferencesWithoutMethodThrowsException()
 	{
@@ -391,6 +391,33 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$container = new Container;
 		$result = $container->call('ContainerTestCallStub', ['foo', 'bar'], 'work');
 		$this->assertEquals(['foo', 'bar'], $result);
+	}
+
+
+	public function testCallWithCallableArray()
+	{
+		$container = new Container;
+		$stub = new ContainerTestCallStub();
+		$result = $container->call([$stub, 'work'], ['foo', 'bar']);
+		$this->assertEquals(['foo', 'bar'], $result);
+	}
+
+
+	public function testCallWithStaticMethodNameString()
+	{
+		$container = new Container;
+		$result = $container->call('ContainerStaticMethodStub::inject');
+		$this->assertInstanceOf('ContainerConcreteStub', $result[0]);
+		$this->assertEquals('taylor', $result[1]);
+	}
+
+
+	public function testCallWithGlobalMethodName()
+	{
+		$container = new Container;
+		$result = $container->call('containerTestInject');
+		$this->assertInstanceOf('ContainerConcreteStub', $result[0]);
+		$this->assertEquals('taylor', $result[1]);
 	}
 
 
@@ -531,4 +558,17 @@ class ContainerTestContextInjectTwo {
 	{
 		$this->impl = $impl;
 	}
+}
+
+class ContainerStaticMethodStub
+{
+	public static function inject(ContainerConcreteStub $stub, $default = 'taylor')
+	{
+		return func_get_args();
+	}
+}
+
+function containerTestInject(ContainerConcreteStub $stub, $default = 'taylor')
+{
+	return func_get_args();
 }


### PR DESCRIPTION
This allows you to do

``` php
class Classname {
    public static function staticMethod(Foo $foo, Bar $bar)
    {
        //
    }
}

function global_function(Baz $baz)
{
    //
}

namespace Vendor {
    function local_function(Qux $qux)
    {
        //
    }
}

$container->call('Classname::staticMethod');
$container->call('global_function');
$container->call('Vendor\local_function');
```

Which wasn't possible before because `new \ReflectionFunction($arg)` doesn't accept this kind of string, because the string describes a Method and not a Function.

Also note the `callable` Type Hint, which is available since PHP 5.4 ([first line](http://php.net/manual/en/language.types.callable.php)), and accepts everything like:
- `'Classname::staticMethod'`,
- `'\Vendor\function_name'`,
- `'global_function_name'`,
- `[$object, 'methodName']`,
- `function () {}`

Basically anything that responds `is_callable` accepts and is a possible first argument for `call_user_func` and `call_user_func_array`.
