### PR TITLE
[4.2] Fix Handling Of CamelCase Relation Attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2397,19 +2397,19 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// If the key already exists in the relationships array, it just means the
 		// relationship has already been loaded, so we'll just return it out of
 		// here because there is no need to query within the relations twice.
-		if (array_key_exists($key, $this->relations))
+		$camelKey = camel_case($key);
+
+		if (array_key_exists($camelKey, $this->relations))
 		{
-			return $this->relations[$key];
+			return $this->relations[$camelKey];
 		}
 
 		// If the "attribute" exists as a method on the model, we will just assume
 		// it is a relationship and will load and return results from the query
 		// and hydrate the relationship's value on the "relationships" array.
-		$camelKey = camel_case($key);
-
 		if (method_exists($this, $camelKey))
 		{
-			return $this->getRelationshipFromMethod($key, $camelKey);
+			return $this->getRelationshipFromMethod($camelKey);
 		}
 	}
 
@@ -2460,14 +2460,13 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 * Get a relationship value from a method.
 	 *
 	 * @param  string  $key
-	 * @param  string  $camelKey
 	 * @return mixed
 	 *
 	 * @throws \LogicException
 	 */
-	protected function getRelationshipFromMethod($key, $camelKey)
+	protected function getRelationshipFromMethod($key)
 	{
-		$relations = $this->$camelKey();
+		$relations = $this->$key();
 
 		if ( ! $relations instanceof Relation)
 		{

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -842,6 +842,30 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testGetRelationAttributeReturnsSameCollectionEachTime()
+	{
+		$model = new EloquentModelWithHasManyRelation;
+
+		$data = array(array('name' => 'Taylor'), array('name' => 'Otwell'));
+		$collection = EloquentModelStub::hydrate($data);
+
+		$model->setRelation('testRelation', $collection);
+		$this->assertSame($collection, $model->testRelation);
+	}
+
+
+	public function testGetRelationAttributeReturnsSameCollectionEachTimeWithCamelCase()
+	{
+		$model = new EloquentModelWithHasManyRelation;
+
+		$data = array(array('name' => 'Taylor'), array('name' => 'Otwell'));
+		$collection = EloquentModelStub::hydrate($data);
+
+		$model->setRelation('testRelation', $collection);
+		$this->assertSame($collection, $model->test_relation);
+	}
+
+
 	public function testModelIsBootedOnUnserialize()
 	{
 		$model = new EloquentModelBootingTestStub;
@@ -1115,5 +1139,12 @@ class EloquentModelAppendsStub extends Illuminate\Database\Eloquent\Model {
 	public function getIsAdminAttribute()
 	{
 		return 'admin';
+	}
+}
+
+class EloquentModelWithHasManyRelation extends Illuminate\Database\Eloquent\Model {
+	public function testRelation()
+	{
+		return $this->hasMany('EloquentModelStub');
 	}
 }


### PR DESCRIPTION
Currently this code, with snake-casing, doesn't use the eager-loaded data - it runs the database query again:

``` php
$contacts = Contact::with('emailAddresses')->get();
$email_addresses = $contact[0]->email_addresses;
```

Whereas this code, with camel-casing, correctly uses it:

``` php
$contacts = Contact::with('emailAddresses')->get();
$email_addresses = $contact[0]->emailAddresses;
```

This PR fixes it so it will always use the camel cased version in the array key, so that both spellings will return the same object.
