### PR TITLE
[4.2] Addition of findOrNew, firstOrNew, firstOrCreate, updateOrCreate to relevant relations.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -514,6 +514,80 @@ class BelongsToMany extends Relation {
 	}
 
 	/**
+	 * Find a related model by its primary key or return new instance of the related model.
+	 *
+	 * @param  mixed  $id
+	 * @param  array  $columns
+	 * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
+	 */
+	public function findOrNew($id, $columns = array('*'))
+	{
+		if(is_null($instance = $this->find($id, $columns)))
+		{
+			$instance = $this->related->newInstance();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get the first related record matching the attributes or create it.
+	 *
+	 * @param  array  $attributes
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function firstOrCreate(array $attributes, array $joining = array(), $touch = true)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->create($attributes, $joining, $touch);
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get the first related model record matching the attributes or instantiate it.
+	 *
+	 * @param  array  $attributes
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function firstOrNew(array $attributes)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->related->newInstance();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Create or update a related record matching the attributes, and fill it with values.
+	 *
+	 * @param  array  $attributes
+	 * @param  array  $values
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function updateOrCreate(array $attributes, array $values = array(), array $joining = array(), $touch = true)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->related->newInstance();
+
+			$new = true;
+		}
+
+		$instance->fill($values);
+
+		$instance->save(array('touch' => false));
+
+		if ($new) $this->attach($instance->getKey(), $joining, $touch);
+
+		return $instance;
+	}
+
+	/**
 	 * Create a new instance of the related model.
 	 *
 	 * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -183,6 +183,82 @@ abstract class HasOneOrMany extends Relation {
 	}
 
 	/**
+	 * Find a model by its primary key or return new instance of the related model.
+	 *
+	 * @param  mixed  $id
+	 * @param  array  $columns
+	 * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
+	 */
+	public function findOrNew($id, $columns = array('*'))
+	{
+		if(is_null($instance = $this->find($id, $columns)))
+		{
+			$instance = $this->related->newInstance();
+		}
+
+		if( ! $instance instanceof Collection)
+		{
+			$instance->setAttribute($this->getPlainForeignKey(), $this->getParentKey());
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get the first related record matching the attributes or create it.
+	 *
+	 * @param  array  $attributes
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function firstOrCreate(array $attributes)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->create($attributes);
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get the first related model record matching the attributes or instantiate it.
+	 *
+	 * @param  array  $attributes
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function firstOrNew(array $attributes)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->related->newInstance();
+
+			$instance->setAttribute($this->getPlainForeignKey(), $this->getParentKey());
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Create or update a related record matching the attributes, and fill it with values.
+	 *
+	 * @param  array  $attributes
+	 * @param  array  $values
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function updateOrCreate(array $attributes, array $values = array())
+	{
+		$instance = $this->firstOrNew($attributes);
+
+		$instance->fill($values);
+
+		$instance->setAttribute($this->getPlainForeignKey(), $this->getParentKey());
+
+		$instance->save();
+
+		return $instance;
+	}
+
+	/**
 	 * Create a new instance of the related model.
 	 *
 	 * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -94,6 +94,91 @@ abstract class MorphOneOrMany extends HasOneOrMany {
 	}
 
 	/**
+	 * Find a related model by its primary key or return new instance of the related model.
+	 *
+	 * @param  mixed  $id
+	 * @param  array  $columns
+	 * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
+	 */
+	public function findOrNew($id, $columns = array('*'))
+	{
+		if(is_null($instance = $this->find($id, $columns)))
+		{
+			$instance = $this->related->newInstance();
+		}
+
+		if( ! $instance instanceof Collection)
+		{
+			// When saving a polymorphic relationship, we need to set not only the foreign
+			// key, but also the foreign key type, which is typically the class name of
+			// the parent model. This makes the polymorphic item unique in the table.
+			$this->setForeignAttributesForCreate($instance);
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get the first related record matching the attributes or create it.
+	 *
+	 * @param  array  $attributes
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function firstOrCreate(array $attributes)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->create($attributes);
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get the first related model record matching the attributes or instantiate it.
+	 *
+	 * @param  array  $attributes
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function firstOrNew(array $attributes)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->related->newInstance();
+
+			// When saving a polymorphic relationship, we need to set not only the foreign
+			// key, but also the foreign key type, which is typically the class name of
+			// the parent model. This makes the polymorphic item unique in the table.
+			$this->setForeignAttributesForCreate($instance);
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Create or update a related record matching the attributes, and fill it with values.
+	 *
+	 * @param  array  $attributes
+	 * @param  array  $values
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function updateOrCreate(array $attributes, array $values = array())
+	{
+		$instance = $this->firstOrNew($attributes);
+
+		$instance->fill($values);
+
+		// When saving a polymorphic relationship, we need to set not only the foreign
+		// key, but also the foreign key type, which is typically the class name of
+		// the parent model. This makes the polymorphic item unique in the table.
+		$this->setForeignAttributesForCreate($instance);
+
+		$instance->save();
+
+		return $instance;
+	}
+
+	/**
 	 * Create a new instance of the related model.
 	 *
 	 * @param  array  $attributes


### PR DESCRIPTION
I make extensive use of the `findOrNew`, `firstOrNew`, `firstOrCreate`, `updateOrCreate` methods in the Eloquent model but am missing them in the `BelongsToMany`, `HasOneOrMany` and `MorphOneOrMany` relations. I've added them myself and will write the tests if there is interest in taking this on. Thank you for considering!
