### PR TITLE
[5.0] Added Cache Events

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -155,7 +155,14 @@ class CacheManager extends Manager implements FactoryContract {
 	 */
 	protected function repository(StoreInterface $store)
 	{
-		return new Repository($store);
+		$repository = new Repository($store);
+
+		if ($this->app->bound('events'))
+		{
+			$repository->setEventDispatcher($this->app['events']);
+		}
+
+		return $repository;
 	}
 
 	/**

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -85,7 +85,12 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	protected function getRepository()
 	{
-		return new Illuminate\Cache\Repository(m::mock('Illuminate\Cache\StoreInterface'));
+		$dispatcher = new \Illuminate\Events\Dispatcher(m::mock('Illuminate\Container\Container'));
+		$repository = new Illuminate\Cache\Repository(m::mock('Illuminate\Cache\StoreInterface'));
+
+		$repository->setEventDispatcher($dispatcher);
+
+		return $repository;
 	}
 
 }


### PR DESCRIPTION
Add cache events, so that the following events can now be listened:

``` php
// when a cache item is not found
Event::listen('cache.missed', function($key) { ... });

// when a cache item is successfully retrieved
// note : $duration = 0 when using Cache::forever()
Event::listen('cache.hit', function($key, $value) { ... });

// when a cache entry is written
Event::listen('cache.write', function($key, $value, $duration) { ... });

// when a cache entry is deleted
Event::listen('cache.delete', function($key) { ... });
```

Related to https://github.com/laravel/framework/issues/5581 and https://github.com/laravel/framework/pull/5935 (cache events for 4.2)
Closes https://github.com/laravel/framework/pull/5919
