### PR TITLE
[5.0] Use FileNotFoundException

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -50,22 +50,16 @@ class FileStore implements StoreInterface {
 	 */
 	protected function getPayload($key)
 	{
-		$path = $this->path($key);
-
 		// If the file doesn't exists, we obviously can't return the cache so we will
 		// just return null. Otherwise, we'll get the contents of the file and get
 		// the expiration UNIX timestamps from the start of the file's contents.
-		if ( ! $this->files->exists($path))
-		{
-			return array('data' => null, 'time' => null);
-		}
-
 		try
 		{
-			$expire = substr($contents = $this->files->get($path), 0, 10);
+			$expire = substr($contents = $this->files->get($this->path($key)), 0, 10);
 		}
 		catch (\Exception $e)
 		{
+			// Also occurs when a FileNotFoundException is thrown.
 			return array('data' => null, 'time' => null);
 		}
 

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Foundation;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FileNotFoundException;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
 class ProviderRepository {
@@ -180,11 +181,15 @@ class ProviderRepository {
 		// The service manifest is a file containing a JSON representation of every
 		// service provided by the application and whether its provider is using
 		// deferred loading or should be eagerly loaded on each request to us.
-		if ($this->files->exists($this->manifestPath))
+		try
 		{
 			$manifest = json_decode($this->files->get($this->manifestPath), true);
 
 			return array_merge(['when' => []], $manifest);
+		}
+		catch (FileNotFoundException $e)
+		{
+			return;
 		}
 	}
 

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -2,6 +2,7 @@
 
 use Symfony\Component\Finder\Finder;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FileNotFoundException;
 
 class FileSessionHandler implements \SessionHandlerInterface {
 
@@ -53,12 +54,14 @@ class FileSessionHandler implements \SessionHandlerInterface {
 	 */
 	public function read($sessionId)
 	{
-		if ($this->files->exists($path = $this->path.'/'.$sessionId))
+		try
 		{
-			return $this->files->get($path);
+			return $this->files->get($this->path.'/'.$sessionId);
 		}
-
-		return '';
+		catch (FileNotFoundException $e)
+		{
+			return '';
+		}
 	}
 
 	/**

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Translation;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FileNotFoundException;
 
 class FileLoader implements LoaderInterface {
 
@@ -87,14 +88,16 @@ class FileLoader implements LoaderInterface {
 	 */
 	protected function loadNamespaceOverrides(array $lines, $locale, $group, $namespace)
 	{
-		$file = "{$this->path}/packages/{$locale}/{$namespace}/{$group}.php";
-
-		if ($this->files->exists($file))
+		try
 		{
+			$file = "{$this->path}/packages/{$locale}/{$namespace}/{$group}.php";
+
 			return array_replace_recursive($lines, $this->files->getRequire($file));
 		}
-
-		return $lines;
+		catch (FileNotFoundException $e)
+		{
+			return $lines;
+		}
 	}
 
 	/**
@@ -107,12 +110,16 @@ class FileLoader implements LoaderInterface {
 	 */
 	protected function loadPath($path, $locale, $group)
 	{
-		if ($this->files->exists($full = "{$path}/{$locale}/{$group}.php"))
+		try
 		{
+			$full = "{$path}/{$locale}/{$group}.php";
+
 			return $this->files->getRequire($full);
 		}
-
-		return array();
+		catch (FileNotFoundException $e)
+		{
+			return [];
+		}
 	}
 
 	/**

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -7,7 +7,7 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 	public function testNullIsReturnedIfFileDoesntExist()
 	{
 		$files = $this->mockFilesystem();
-		$files->expects($this->once())->method('exists')->will($this->returnValue(false));
+		$files->expects($this->once())->method('get')->willThrowException(new Exception());
 		$store = new FileStore($files, __DIR__);
 		$value = $store->get('foo');
 		$this->assertNull($value);
@@ -29,7 +29,6 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 	public function testExpiredItemsReturnNull()
 	{
 		$files = $this->mockFilesystem();
-		$files->expects($this->once())->method('exists')->will($this->returnValue(true));
 		$contents = '0000000000';
 		$files->expects($this->once())->method('get')->will($this->returnValue($contents));
 		$store = $this->getMock('Illuminate\Cache\FileStore', array('forget'), array($files, __DIR__));
@@ -42,7 +41,6 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 	public function testValidItemReturnsContents()
 	{
 		$files = $this->mockFilesystem();
-		$files->expects($this->once())->method('exists')->will($this->returnValue(true));
 		$contents = '9999999999'.serialize('Hello World');
 		$files->expects($this->once())->method('get')->will($this->returnValue($contents));
 		$store = new FileStore($files, __DIR__);

--- a/tests/Foundation/ProviderRepositoryTest.php
+++ b/tests/Foundation/ProviderRepositoryTest.php
@@ -89,7 +89,6 @@ class ProviderRepositoryTest extends PHPUnit_Framework_TestCase {
 	public function testLoadManifestReturnsParsedJSON()
 	{
 		$repo = new Illuminate\Foundation\ProviderRepository(m::mock('Illuminate\Contracts\Foundation\Application'), $files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__.'/services.json');
-		$files->shouldReceive('exists')->once()->with(__DIR__.'/services.json')->andReturn(true);
 		$files->shouldReceive('get')->once()->with(__DIR__.'/services.json')->andReturn(json_encode($array = array('users' => array('dayle' => true), 'when' => array())));
 
 		$this->assertEquals($array, $repo->loadManifest());

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Mockery as m;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\FileNotFoundException;
 use Illuminate\Translation\FileLoader;
 
 class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase {
@@ -15,7 +15,6 @@ class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase {
 	public function testLoadMethodWithoutNamespacesProperlyCallsLoader()
 	{
 		$loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
-		$files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(true);
 		$files->shouldReceive('getRequire')->once()->with(__DIR__.'/en/foo.php')->andReturn(array('messages'));
 
 		$this->assertEquals(array('messages'), $loader->load('en', 'foo', null));
@@ -25,8 +24,7 @@ class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase {
 	public function testLoadMethodWithNamespacesProperlyCallsLoader()
 	{
 		$loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
-		$files->shouldReceive('exists')->once()->with('bar/en/foo.php')->andReturn(true);
-		$files->shouldReceive('exists')->once()->with(__DIR__.'/packages/en/namespace/foo.php')->andReturn(false);
+		$files->shouldReceive('getRequire')->once()->with(__DIR__.'/packages/en/namespace/foo.php')->andThrow(new FileNotFoundException);
 		$files->shouldReceive('getRequire')->once()->with('bar/en/foo.php')->andReturn(array('foo' => 'bar'));
 		$loader->addNamespace('namespace', 'bar');
 
@@ -37,8 +35,6 @@ class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase {
 	public function testLoadMethodWithNamespacesProperlyCallsLoaderAndLoadsLocalOverrides()
 	{
 		$loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
-		$files->shouldReceive('exists')->once()->with('bar/en/foo.php')->andReturn(true);
-		$files->shouldReceive('exists')->once()->with(__DIR__.'/packages/en/namespace/foo.php')->andReturn(true);
 		$files->shouldReceive('getRequire')->once()->with('bar/en/foo.php')->andReturn(array('foo' => 'bar'));
 		$files->shouldReceive('getRequire')->once()->with(__DIR__.'/packages/en/namespace/foo.php')->andReturn(array('foo' => 'override', 'baz' => 'boom'));
 		$loader->addNamespace('namespace', 'bar');
@@ -50,8 +46,7 @@ class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase {
 	public function testEmptyArraysReturnedWhenFilesDontExist()
 	{
 		$loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
-		$files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(false);
-		$files->shouldReceive('getRequire')->never();
+		$files->shouldReceive('getRequire')->andThrow(new FileNotFoundException);
 
 		$this->assertEquals(array(), $loader->load('en', 'foo', null));
 	}


### PR DESCRIPTION
`get` or `getRequire` functions both check that the file exists and throw a `FileNotFoundException` if this not the case. So using `files->exists(...)` and thus checking twice that the file exists is useless.
Instead a `FileNotFoundException` can simply be caught.

References https://github.com/laravel/framework/pull/5814 (4.2)
