### PR TITLE
Update CacheServiceProvider.php

### DIFF
--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -18,6 +18,11 @@ class CacheServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
+		$this->app->bindShared('memcached.connector', function()
+		{
+			return new MemcachedConnector;
+		});
+		
 		$this->app->bindShared('cache', function($app)
 		{
 			return new CacheManager($app);
@@ -26,11 +31,6 @@ class CacheServiceProvider extends ServiceProvider {
 		$this->app->bindShared('cache.store', function($app)
 		{
 			return $app['cache']->driver();
-		});
-
-		$this->app->bindShared('memcached.connector', function()
-		{
-			return new MemcachedConnector;
 		});
 
 		$this->registerCommands();


### PR DESCRIPTION
when use 'memcached' driver, cache.store depends on 'memcached.connector', so 'memcached.connector' should bind before 'cache.store'
