### PR TITLE
[4.2]: Query\Builder::lists("table.name") passes through full column identifier to query

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1484,6 +1484,14 @@ class Builder {
 		// otherwise we can just give these values back without a specific key.
 		$results = new Collection($this->get($columns));
 
+		// If the selected column contains a "dot", we will remove it so that the list
+		// operation can run normally. Specifying the table is not needed, since we
+		// really want the names of the columns as it is in this resulting array.
+		if (($dot = strpos($columns[0], '.')) !== false)
+		{
+			$columns[0] = substr($columns[0], $dot + 1);
+		}
+
 		$values = $results->fetch($columns[0])->all();
 
 		// If a key was specified and we have results, we will go ahead and combine
@@ -1509,14 +1517,6 @@ class Builder {
 	protected function getListSelect($column, $key)
 	{
 		$select = is_null($key) ? array($column) : array($column, $key);
-
-		// If the selected column contains a "dot", we will remove it so that the list
-		// operation can run normally. Specifying the table is not needed, since we
-		// really want the names of the columns as it is in this resulting array.
-		if (($dot = strpos($select[0], '.')) !== false)
-		{
-			$select[0] = substr($select[0], $dot + 1);
-		}
 
 		return $select;
 	}

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -653,6 +653,15 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('bar', 'baz'), $results);
 
 		$builder = $this->getBuilder();
+		$builder->getConnection()->shouldReceive('select')->once()->with('select "users"."foo" from "users" where "id" = ?', array(1))->andReturn(array(array('foo' => 'bar'), array('foo' => 'baz')));
+		$builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, array(array('foo' => 'bar'), array('foo' => 'baz')))->andReturnUsing(function($query, $results)
+		{
+			return $results;
+		});
+		$results = $builder->from('users')->where('id', '=', 1)->lists('users.foo');
+		$this->assertEquals(array('bar', 'baz'), $results);
+
+		$builder = $this->getBuilder();
 		$builder->getConnection()->shouldReceive('select')->once()->andReturn(array(array('id' => 1, 'foo' => 'bar'), array('id' => 10, 'foo' => 'baz')));
 		$builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, array(array('id' => 1, 'foo' => 'bar'), array('id' => 10, 'foo' => 'baz')))->andReturnUsing(function($query, $results)
 		{


### PR DESCRIPTION
In the case of multiple joins, where a specific field is required (e.g. id), the current implementation causes an 'ambiguous field' error, because 'id' is common to all tables.

This fix allows for the table name to be passed through to the select query, but other functionality to remain unchanged.
