### PR TITLE
Unnecessary environment detection.

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -67,9 +67,7 @@ class KeyGenerateCommand extends Command {
 	 */
 	protected function getKeyFile()
 	{
-		$env = $this->option('env') ? $this->option('env').'/' : '';
-
-		$contents = $this->files->get($path = $this->laravel['path.config']."/{$env}app.php");
+		$contents = $this->files->get($path = $this->laravel['path.config']."/app.php");
 
 		return array($path, $contents);
 	}

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -67,7 +67,7 @@ class KeyGenerateCommand extends Command {
 	 */
 	protected function getKeyFile()
 	{
-		$contents = $this->files->get($path = $this->laravel['path.config']."/app.php");
+		$contents = $this->files->get($path = $this->laravel['path.config'].'/app.php');
 
 		return array($path, $contents);
 	}


### PR DESCRIPTION
After the addition of `dotenv`, no need to detect the environment.
