### PR TITLE
[5.0] Fix data_get() With ArrayAccess And Null Values

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -404,7 +404,7 @@ if ( ! function_exists('data_get'))
 			}
 			elseif ($target instanceof ArrayAccess)
 			{
-				if ( ! isset($target[$segment]))
+				if ( ! $target->offsetExists($segment))
 				{
 					return value($default);
 				}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -306,7 +306,7 @@ class SupportTestArrayAccess implements ArrayAccess {
 
 	public function __construct ($attributes = []){ $this->attributes = $attributes; }
 
-	public function offsetExists ($offset){ return isset($this->attributes[$offset]); }
+	public function offsetExists ($offset){ return array_key_exists($offset, $this->attributes); }
 
 	public function offsetGet ($offset){ return $this->attributes[$offset]; }
 


### PR DESCRIPTION
Follow-up to #6571 (see comments on commit 39db9e14d3235a29eb7751b12959d2b76fa82af4).

Also, tests with null values should be added, I leave it up to you as I'm afraid cluttering `testDataGet()` :sweat_smile:

**edit:** wrong, see notes below
