### PR TITLE
[4.2] Fixed Query\Builder call to undefined method hasGetMutator

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -212,7 +212,7 @@ class Builder {
 		// If the model has a mutator for the requested column, we will spin through
 		// the results and mutate the values so that the mutated version of these
 		// columns are returned as you would expect from these Eloquent models.
-		if ($this->model->hasGetMutator($column))
+		if ($this->model->getMutatorMethod($column))
 		{
 			foreach ($results as $key => &$value)
 			{

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -175,7 +175,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->getQuery()->shouldReceive('lists')->with('name', '')->andReturn(array('bar', 'baz'));
 		$builder->setModel($this->getMockModel());
-		$builder->getModel()->shouldReceive('hasGetMutator')->with('name')->andReturn(true);
+		$builder->getModel()->shouldReceive('getMutatorMethod')->with('name')->andReturn(true);
 		$builder->getModel()->shouldReceive('newFromBuilder')->with(array('name' => 'bar'))->andReturn(new EloquentBuilderTestListsStub(array('name' => 'bar')));
 		$builder->getModel()->shouldReceive('newFromBuilder')->with(array('name' => 'baz'))->andReturn(new EloquentBuilderTestListsStub(array('name' => 'baz')));
 
@@ -188,7 +188,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->getQuery()->shouldReceive('lists')->with('name', '')->andReturn(array('bar', 'baz'));
 		$builder->setModel($this->getMockModel());
-		$builder->getModel()->shouldReceive('hasGetMutator')->with('name')->andReturn(false);
+		$builder->getModel()->shouldReceive('getMutatorMethod')->with('name')->andReturn(false);
 
 		$this->assertEquals(array('bar', 'baz'), $builder->lists('name'));
 	}


### PR DESCRIPTION
When using lists method in Query\Builder:
Call to undefined method Illuminate\Database\Query\Builder::hasGetMutator().
Need new method getMutatorMethod

Proposed changes fix issue.
