### PR TITLE
[4.2] Mutator Fixes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -212,7 +212,7 @@ class Builder {
 		// If the model has a mutator for the requested column, we will spin through
 		// the results and mutate the values so that the mutated version of these
 		// columns are returned as you would expect from these Eloquent models.
-		if ($this->model->hasGetMutator($column))
+		if ($this->model->getMutatorMethod($column))
 		{
 			foreach ($results as $key => &$value)
 			{

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2527,14 +2527,14 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function hasGetMutator($key)
 	{
-		return $this->getMutatorMethod($key);
+		return $this->getMutatorMethod($key) !== null;
 	}
 
 	/**
 	 * Get the method name if a get mutator exists for an attribute.
 	 *
 	 * @param  string  $key
-	 * @return bool
+	 * @return string|null
 	 */
 	public function getMutatorMethod($key)
 	{

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2518,6 +2518,19 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
+	 * Determine if a get mutator exists for an attribute.
+	 *
+	 * @deprecated Deprecated since version 4.2.13, to be removed in 5.0.0.
+	 *
+	 * @param  string  $key
+	 * @return bool
+	 */
+	public function hasGetMutator($key)
+	{
+		return $this->getMutatorMethod($key);
+	}
+
+	/**
 	 * Get the method name if a get mutator exists for an attribute.
 	 *
 	 * @param  string  $key

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -175,7 +175,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->getQuery()->shouldReceive('lists')->with('name', '')->andReturn(array('bar', 'baz'));
 		$builder->setModel($this->getMockModel());
-		$builder->getModel()->shouldReceive('hasGetMutator')->with('name')->andReturn(true);
+		$builder->getModel()->shouldReceive('getMutatorMethod')->with('name')->andReturn(true);
 		$builder->getModel()->shouldReceive('newFromBuilder')->with(array('name' => 'bar'))->andReturn(new EloquentBuilderTestListsStub(array('name' => 'bar')));
 		$builder->getModel()->shouldReceive('newFromBuilder')->with(array('name' => 'baz'))->andReturn(new EloquentBuilderTestListsStub(array('name' => 'baz')));
 
@@ -188,7 +188,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = $this->getBuilder();
 		$builder->getQuery()->shouldReceive('lists')->with('name', '')->andReturn(array('bar', 'baz'));
 		$builder->setModel($this->getMockModel());
-		$builder->getModel()->shouldReceive('hasGetMutator')->with('name')->andReturn(false);
+		$builder->getModel()->shouldReceive('getMutatorMethod')->with('name')->andReturn(false);
 
 		$this->assertEquals(array('bar', 'baz'), $builder->lists('name'));
 	}


### PR DESCRIPTION
This updates the code to use the new `getMutatorMethod` method, and restores the `hasGetMutator` method since we can't remove it in a patch release.

---

// cc @taylorotwell, @KossShtukert, @xAockd, @arcanedev-maroc, @bostanio.
