### PR TITLE
Allowing for camel and studly-cased mutator attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2537,6 +2537,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	public function getMutatorMethod($key)
 	{
 		$mutators = static::$mutatorCache[$this->klass];
+		$key = snake_case($key);
 
 		return isset($mutators[$key]) ? $mutators[$key] : null;
 	}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -871,8 +871,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	{
 		$model = new EloquentModelAppendsStub;
 		$this->assertEquals('admin', $model->is_admin);
+		$this->assertEquals('camelCased', $model->camelCased);
+		$this->assertEquals('StudlyCased', $model->StudlyCased);
 
-		$model->setHidden(['is_admin']);
+		$model->setHidden(['is_admin', 'camelCased', 'StudlyCased']);
 		$this->assertEquals([], $model->toArray());
 
 		$model->setVisible([]);
@@ -1133,9 +1135,17 @@ class EloquentModelBootingTestStub extends Illuminate\Database\Eloquent\Model {
 }
 
 class EloquentModelAppendsStub extends Illuminate\Database\Eloquent\Model {
-	protected $appends = array('is_admin');
+	protected $appends = array('is_admin', 'camelCased', 'StudlyCased');
 	public function getIsAdminAttribute()
 	{
 		return 'admin';
+	}
+	public function getCamelCasedAttribute()
+	{
+		return 'camelCased';
+	}
+	public function getStudlyCasedAttribute()
+	{
+		return 'StudlyCased';
 	}
 }


### PR DESCRIPTION
In [this commit](https://github.com/laravel/framework/commit/e5c3c1cb36021e351bee2b56f2bcbccacfa494eb#diff-d8e24a5815a26f7211e66db787be647f) a previously undocumented feature of the mutator attributes was removed. Prior to this commit, it was possible to reference accessors using snake, camel, and studly cases. For example:

``` php
protected $appends = ['first_name', 'lastName', 'FullName'];

public function getFirstNameAttribute() {...}
public function getLastNameAttribute() {...}
public function getFullNameAttribute() {...}
```

This would work and append the key that you specified into the resulting array:

``` php
[
    'first_name' => ...,
    'lastName' => ...,
    'FullName' => ...,
]
```

After this commit, it only accepts snake case. I imagine we aren't the only ones using this (and we are using it rather widely in our systems), so I put together a pull request that keeps all the current features and allows for this. I added a test to verify that it works as well. Let me know if you need anything else or if you have any comments/questions/concerns.
