### PR TITLE
[5.0] Adding missing GuzzleHttp dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "classpreloader/classpreloader": "~1.0.2",
         "d11wtq/boris": "~1.0",
         "doctrine/annotations": "~1.0",
+        "guzzlehttp/guzzle": "5.0.*",
         "ircmaxell/password-compat": "~1.0",
         "jeremeamia/superclosure": "~1.0.1",
         "league/flysystem": "~1.0",


### PR DESCRIPTION
Looks like the \Illuminate\Mail\Transport\MandrillTransport class needs the GuzzleHttp client which is not included right now.
