### PR TITLE
[5.0] Allow ResponseFactory To Redirect Back

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -68,6 +68,15 @@ interface ResponseFactory {
 	public function download($file, $name = null, array $headers = array(), $disposition = 'attachment');
 
 	/**
+	 * Create a new redirect response to the previous location.
+	 *
+	 * @param  int    $status
+	 * @param  array  $headers
+	 * @return \Symfony\Component\HttpFoundation\Response
+	 */
+	public function redirectBack($status = 302, $headers = array());
+
+	/**
 	 * Create a new redirect response to the given path.
 	 *
 	 * @param  string  $path

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -137,6 +137,18 @@ class ResponseFactory implements FactoryContract {
 	}
 
 	/**
+	 * Create a new redirect response to the previous location.
+	 *
+	 * @param  int    $status
+	 * @param  array  $headers
+	 * @return \Symfony\Component\HttpFoundation\Response
+	 */
+	public function redirectBack($status = 302, $headers = array())
+	{
+		return $this->redirector->back($status, $headers);
+	}
+
+	/**
 	 * Create a new redirect response to the given path.
 	 *
 	 * @param  string  $path


### PR DESCRIPTION
This adds the same kind of shortcut to
Illuminate\Routing\Redirector::back() that is already available for
some other redirect types.
