### PR TITLE
[5.0] updated_at timestamp is already updated in Model::performUpdate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -276,7 +276,7 @@ class Builder {
 	 */
 	public function update(array $values)
 	{
-		return $this->query->update($this->addUpdatedAtColumn($values));
+		return $this->query->update($values);
 	}
 
 	/**


### PR DESCRIPTION
updated_at column is updated twice, first time in Model::performUpdate and second time in Eloquent\Builder::update. 

Next, this pull request #5840 doesn't make a sense because column will be however updated in Eloquent\Builder.
