### PR TITLE
[4.2] Fix updated_at Being Updated Twice

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -313,7 +313,7 @@ class Builder {
 	 */
 	public function update(array $values)
 	{
-		return $this->query->update($this->addUpdatedAtColumn($values));
+		return $this->query->update($values);
 	}
 
 	/**


### PR DESCRIPTION
Column updated_at is already updated in Model::performUpdate(), it is not necessary to be updated again in Eloquent\Builder::update()
