### PR TITLE
[4.2] Relationships automatically populate parents

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -54,7 +54,23 @@ class BelongsTo extends Relation {
 	 */
 	public function getResults()
 	{
-		return $this->query->first();
+		return $this->initInverseRelation($this->query->first());
+	}
+
+	/**
+	 * Initialize the parent relationship on the model.
+	 *
+	 * @param  mixed  $model
+	 * @return mixed
+	 */
+	protected function initInverseRelation($model = null)
+	{
+		if ( ! empty($this->relationToParent) && $model)
+		{
+			$model->setRelation($this->relationToParent, $this->parent);
+		}
+
+		return $model;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -11,7 +11,29 @@ class HasMany extends HasOneOrMany {
 	 */
 	public function getResults()
 	{
-		return $this->query->get();
+		return $this->initInverseRelation($this->query->get());
+	}
+
+	/**
+	 * Initialize the parent relationship on a set of models.
+	 *
+	 * @param  \Illuminate\Database\Eloquent\Collection  $models
+	 * @return \Illuminate\Database\Eloquent\Collection
+	 */
+	protected function initInverseRelation(Collection $models)
+	{
+		if ( ! empty($this->relationToParent) && !$models->isEmpty())
+		{
+			$relation = $this->relationToParent;
+			$parent   = $this->parent;
+
+			foreach($models as $model)
+			{
+				$model->setRelation($relation, $parent);
+			}
+		}
+
+		return $models;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -11,7 +11,23 @@ class HasOne extends HasOneOrMany {
 	 */
 	public function getResults()
 	{
-		return $this->query->first();
+		return $this->initInverseRelation($this->query->first());
+	}
+
+	/**
+	 * Initialize the parent relationship on the model.
+	 *
+	 * @param  mixed  $model
+	 * @return mixed
+	 */
+	protected function initInverseRelation($model = null)
+	{
+		if ( ! empty($this->relationToParent) && $model)
+		{
+			$model->setRelation($this->relationToParent, $this->parent);
+		}
+
+		return $model;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -11,7 +11,29 @@ class MorphMany extends MorphOneOrMany {
 	 */
 	public function getResults()
 	{
-		return $this->query->get();
+		return $this->initInverseRelation($this->query->get());
+	}
+
+	/**
+	 * Initialize the parent relationship on a set of models.
+	 *
+	 * @param  \Illuminate\Database\Eloquent\Collection  $models
+	 * @return \Illuminate\Database\Eloquent\Collection
+	 */
+	protected function initInverseRelation(Collection $models)
+	{
+		if ( ! empty($this->relationToParent) && !$models->isEmpty())
+		{
+			$relation = $this->relationToParent;
+			$parent   = $this->parent;
+
+			foreach($models as $model)
+			{
+				$model->setRelation($relation, $parent);
+			}
+		}
+
+		return $models;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -11,7 +11,23 @@ class MorphOne extends MorphOneOrMany {
 	 */
 	public function getResults()
 	{
-		return $this->query->first();
+		return $this->initInverseRelation($this->query->first());
+	}
+
+	/**
+	 * Initialize the parent relationship on the model.
+	 *
+	 * @param  mixed  $model
+	 * @return mixed
+	 */
+	protected function initInverseRelation($model = null)
+	{
+		if ( ! empty($this->relationToParent) && $model)
+		{
+			$model->setRelation($this->relationToParent, $this->parent);
+		}
+
+		return $model;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -30,6 +30,11 @@ abstract class Relation {
 	protected $related;
 
 	/**
+	 * The relationship from child to parent.
+	 */
+	protected $relationToParent;
+
+	/**
 	 * Indicates if the relation is adding constraints.
 	 *
 	 * @var bool
@@ -92,6 +97,19 @@ abstract class Relation {
 	 * @return mixed
 	 */
 	abstract public function getResults();
+
+	/**
+	 * Define the relationship of child to parent.
+	 *
+	 * @param  string  $relationship
+	 * @return \Illuminate\Database\Eloquent\Relations\Relation
+	 */
+	public function relate($relationship)
+	{
+		$this->relationToParent = $relationship;
+
+		return $this;
+	}
 
 	/**
 	 * Get the relationship for eager loading.

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -76,6 +76,22 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRelateMethodDefinesRelationship()
+	{
+		$relationship = 'foo';
+		$child = new EloquentBelongsToModelStub;
+
+		$relation = $this->getRelation();
+		$relation->relate($relationship);
+
+		$builder = $relation->getQuery();
+		$builder->shouldReceive('first')->andReturn($child);
+
+		$relation->getParent()->bip = 'bap';
+		$this->assertEquals('bap', $relation->getResults()->$relationship->bip);
+	}
+
+
 	protected function getRelation($parent = null)
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -90,6 +90,25 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRelateMethodDefinesRelationship()
+	{
+		$relationship = 'foo';
+		$child = new EloquentHasManyModelStub;
+
+		$relation = $this->getRelation();
+		$relation->relate($relationship);
+
+		$builder = $relation->getQuery();
+		$builder->shouldReceive('get')->andReturn(new Collection([$child]));
+
+		$children = $relation->getResults();
+		$this->assertCount(1, $children);
+
+		$relation->getParent()->shouldReceive('getAttribute')->with('bip')->andReturn('bap');
+		$this->assertEquals('bap', $children->first()->$relationship->bip);
+	}
+
+
 	protected function getRelation()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -110,6 +110,22 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRelateMethodDefinesRelationship()
+	{
+		$relationship = 'foo';
+		$child = new EloquentHasOneModelStub;
+
+		$relation = $this->getRelation();
+		$relation->relate($relationship);
+
+		$builder = $relation->getQuery();
+		$builder->shouldReceive('first')->andReturn($child);
+
+		$relation->getParent()->shouldReceive('getAttribute')->with('bip')->andReturn('bap');
+		$this->assertEquals('bap', $relation->getResults()->$relationship->bip);
+	}
+
+
 	protected function getRelation()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -70,6 +70,41 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRelateMethodOnMorphOneDefinesRelationship()
+	{
+		$relationship = 'foo';
+		$child = new EloquentMorphResetModelStub;
+
+		$relation = $this->getOneRelation();
+		$relation->relate($relationship);
+
+		$builder = $relation->getQuery();
+		$builder->shouldReceive('first')->andReturn($child);
+
+		$relation->getParent()->shouldReceive('getAttribute')->with('bip')->andReturn('bap');
+		$this->assertEquals('bap', $relation->getResults()->$relationship->bip);
+	}
+
+
+	public function testRelateMethodOnMorphManyDefinesRelationship()
+	{
+		$relationship = 'foo';
+		$child = new EloquentMorphResetModelStub;
+
+		$relation = $this->getManyRelation();
+		$relation->relate($relationship);
+
+		$builder = $relation->getQuery();
+		$builder->shouldReceive('get')->andReturn(new Illuminate\Database\Eloquent\Collection([$child]));
+
+		$children = $relation->getResults();
+		$this->assertCount(1, $children);
+
+		$relation->getParent()->shouldReceive('getAttribute')->with('bip')->andReturn('bap');
+		$this->assertEquals('bap', $children->first()->$relationship->bip);
+	}
+
+
 	protected function getOneRelation()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');


### PR DESCRIPTION
Currently $parent->child->parent returns a new instance of 'Parent', as opposed to the original parent. This causes issues when a child process is updating something on the parent, because it retrieves a new instance rather than an existing one

Consider the following pseudo-code

```
class Booking extends Model {

    public function invoice() {
        return $this->hasOne('Invoice');
    }

    public function reservations() {
        return $this->hasMany('Reservation');
    }

}

class Reservation extends Model {

    public function onDelete() {
        $booking = $this->booking; // this is a new instance, unrelated to the original
        $booking->invoice->total -= $this->amount;
    }

}

$booking->reservations->first()->delete();
```

This won't actually update $booking->invoice->total properly because the reservation creates a new instance

This change allows you to write the following:

```
class Booking extends Model {

    public function invoice() {
        return $this->hasOne('Invoice')->relate('booking');
    }

    public function reservations() {
        return $this->hasMany('Reservation')->relate('booking');
    }

}

class Reservation extends Model {

    public function onDelete() {
        $booking = $this->booking; // this is now the original booking, so the original invoice will be correctly updated
        $booking->invoice->total -= $this->amount;
    }

}

$booking->reservations->first()->delete();
```

The inverse relations can be generated for
- BelongsTo / MorphTo (inheritied behaviour)
- HasOne
- HasMany
- MorphOne
- MorphMany
