### PR TITLE
Added --prefer-lowest tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,9 @@ matrix:
       env: dependencies=lowest  
 
 sudo: false
-
-before_script:
-  - travis retry composer self-update
   
 install:
+  - travis retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,16 @@ php:
   - 5.5
   - 5.6
   - hhvm
-  
+
 matrix:
   include:
     - php: 5.4
-      env: dependencies=lowest  
+      env: dependencies=lowest
 
 sudo: false
-  
-install:
+
+before_script:
+	- composer self-update
   - travis_retry composer install --no-interaction --prefer-source
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,19 @@ php:
   - 5.5
   - 5.6
   - hhvm
+  
+matrix:
+  include:
+    - php: 5.4
+      env: dependencies=lowest  
 
 sudo: false
 
-install: travis_retry composer install --no-interaction --prefer-source
+before_script:
+  - travis retry composer self-update
+  
+install:
+  - travis_retry composer install --no-interaction --prefer-source
+  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
 
 script: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
 sudo: false
   
 install:
-  - travis retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
 


### PR DESCRIPTION
This ensures that the dependencies constraints are not only valid for the latest versions specified but also for the lowest versions allowed. Only running on 5.4 since that is the "main" version of Laravel, at least the oldest you can have.

(Will squash when it passes – or fails on lowest at least)
