### PR TITLE
Fixing assignment bug in Eloquent model isset method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3116,7 +3116,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	public function __isset($key)
 	{
 		return ((isset($this->attributes[$key]) || isset($this->relations[$key])) ||
-				($method = $this->getMutatorMethod($key) && ! is_null($this->getMutatedAttributeValue($key, $method))));
+				(($method = $this->getMutatorMethod($key)) && ! is_null($this->getMutatedAttributeValue($key, $method))));
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -872,6 +872,11 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	public function testAppendingOfAttributes()
 	{
 		$model = new EloquentModelAppendsStub;
+
+		$this->assertTrue(isset($model->is_admin));
+		$this->assertTrue(isset($model->camelCased));
+		$this->assertTrue(isset($model->StudlyCased));
+
 		$this->assertEquals('admin', $model->is_admin);
 		$this->assertEquals('camelCased', $model->camelCased);
 		$this->assertEquals('StudlyCased', $model->StudlyCased);


### PR DESCRIPTION
After submitting #6702 last night I ran into another bug that has apparently been around [since October](https://github.com/laravel/framework/commit/7a87c07e1ba55035987760f7bb2625ab170b2bb2). It's just a minor syntax bug, but it surprisingly throws a pretty major exception in all cases where `getMutatorMethod()` returns something truthy. I added a test to make sure this doesn't happen again.
