### PR TITLE
[4.2] Improve "has" For Nested Relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -597,6 +597,11 @@ class Builder {
 	 */
 	public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
 	{
+		if (strpos($relation, '.') !== false)
+		{
+			return $this->hasNested($relation, $operator, $count, $boolean, $callback);
+		}
+
 		$relation = $this->getHasRelationQuery($relation);
 
 		$query = $relation->getRelationCountQuery($relation->getRelated()->newQuery(), $this);
@@ -604,6 +609,41 @@ class Builder {
 		if ($callback) call_user_func($callback, $query);
 
 		return $this->addHasWhere($query, $relation, $operator, $count, $boolean);
+	}
+
+	/**
+	 * Add nested relationship count conditions to the query.
+	 * 
+	 * @param  string  $relations
+	 * @param  string  $operator
+	 * @param  integer $count
+	 * @param  string  $boolean
+	 * @param  \Closure  $callback
+	 * @return \Illuminate\Database\Eloquent\Builder|static
+	 */
+	protected function hasNested($relations, $operator = '>=', $count = 1, $boolean = 'and', $callback = null)
+	{
+		$relations = explode('.', $relations);
+
+		// In order to nest "has", we need to add count relation constraints
+		// on the callback closure. We will do this by simply passing to
+		// closure its own reference, so it calls itself recursively.
+		$closure = function ($q) use (&$closure, &$relations, $operator, $count, $boolean, $callback)
+		{
+			// If the "relation" is specified using dot notation, we will assume
+			// that developer wants to check simple "has" on the intermediate
+			// relations and add constraints only on the furthermost query.
+			if (count($relations) > 1)
+			{
+				$q->whereHas(array_shift($relations), $closure);
+			}
+			else
+			{
+				$q->has(array_shift($relations), $operator, $count, $boolean, $callback);
+			}
+		};
+
+		return $this->whereHas(array_shift($relations), $closure);
 	}
 
 	/**


### PR DESCRIPTION
**Fixes lack of consistency when working with nested relations:**

```
// eager loading works with dot nested relations:
Model::with('closeRelation.farRelation.evenFurtherRelation')->get();

// but has filter does not:
Model::has('closeRelation.farRelation.evenFurtherRelation')->get();
// PHP Fatal error:  Uncaught exception 'BadMethodCallException' with message 'Call to undefined method Illuminate\Database\Query\Builder::closeRelation.farRelation.EvenFurtherRelation()'
```

This PR allows you to do the same with `has` (and whereHas, orHas etc):

```
Model::has('closeRelation.farRelation.evenFurtherRelation')->get();
```

The query will be **exactly the same** as when using this piece, which is required now, and it sucks:

```
Model::whereHas('closeRelation', function ($q) {
  $q->whereHas('farRelaton', function ($q) {
    $q->has('evenFurtherRelation');
  });
})->get();
```

In order to achieve this it is required to add `relation count query` constraints in reversed order. This is solved by using callback closure that gets its own reference and calls itself recursively.

There are tests added, but in fact they are simply comparing and proving, that the method result is identical to the query generated using currently available method, with nested `whereHas` calls.
