### PR TITLE
[4.2] Filling Date Value Attributes And Validation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2671,7 +2671,13 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		// can return back the finally formatted DateTime instances to the devs.
 		else
 		{
-			$value = Carbon::createFromFormat($format, $value);
+			$parsed = date_parse_from_format($format, $value);
+			$errors = ( $parsed['error_count'] === 0 || $parsed['warning_count'] === 0);
+
+			if (!$errors)
+				throw new \Exception("Format of date could not be detected: ". $value);
+			else
+				$value = Carbon::createFromFormat($format, $value);
 		}
 
 		return $value->format($format);


### PR DESCRIPTION
I noted that when there are errors in formatting attributes as a date when using a models $dates / Carbon.  Eloquent assume the date is in the format used by the database connection. I've added a check to test if the value matches the format instead of assuming it is already in that format to prevent errors. For instance `Data missing`, `Unexpected data found. Data missing`, or `Unexpected data found. Trailing data`. 

I'm guessing throwing an exception would be acceptable, however I could see returning null also being possibly acceptable.

This stems from an issue with validating date values. Using the 'date' field validation from Illuminate\Validation can pass for a date like `2015-03-18T17:36:33.416Z`, however will fail when filling a Model attribute that is identified to be a Carbon date since the various options in fromDateTime() does not accommodate that format.

Naturally the DB date format could be set to match my example format, but it is possible that input formats may be different coming from the UI or from faked requests which could cause issues.

I find it strange that Validation and filling a date attribute on a model are not in sync in their methods using/validating date values. I feel that these two should better match so that the validation of attributes can be trusted. As it is dates would need to be manually validated outside of the Validator since their is no guarantee that it can be filled into the model without erroring.
