### PR TITLE
Fix bug in AppNameCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -134,7 +134,7 @@ class AppNameCommand extends Command {
 		$search = [
 			$this->currentRoot.'\\Http',
 			$this->currentRoot.'\\Console',
-			$this->currentRoot.'\\Exception',
+			$this->currentRoot.'\\Exceptions',
 		];
 
 		$replace = [


### PR DESCRIPTION
where it would rename App\Exceptions* to Acme\Exceptionss*
