### PR TITLE
[4.2] Fixed Coverage Config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,6 +21,11 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
+            <exclude>
+                <file>./src/Illuminate/Foundation/start.php</file>
+                <file>./src/Illuminate/Foundation/Console/Optimize/config.php</file>
+                <directory>./src/Illuminate/Pagination/views</directory>
+            </exclude>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
Running phpunit, enabling the coverage reports, is broken without these fixes.
