### PR TITLE
[5.0] [Filesystem] Fixed PHP Fatal Error

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -30,7 +30,7 @@ interface Filesystem {
 	 * @param  string  $path
 	 * @return string
 	 *
-	 * @throws FileNotFoundException
+	 * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
 	 */
 	public function get($path);
 

--- a/src/Illuminate/Filesystem/FileNotFoundException.php
+++ b/src/Illuminate/Filesystem/FileNotFoundException.php
@@ -1,3 +1,0 @@
-<?php namespace Illuminate\Filesystem;
-
-class FileNotFoundException extends \Exception {}

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -2,6 +2,7 @@
 
 use FilesystemIterator;
 use Symfony\Component\Finder\Finder;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class Filesystem {
 
@@ -22,7 +23,7 @@ class Filesystem {
 	 * @param  string  $path
 	 * @return string
 	 *
-	 * @throws FileNotFoundException
+	 * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
 	 */
 	public function get($path)
 	{
@@ -37,7 +38,7 @@ class Filesystem {
 	 * @param  string  $path
 	 * @return mixed
 	 *
-	 * @throws FileNotFoundException
+	 * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
 	 */
 	public function getRequire($path)
 	{
@@ -138,7 +139,7 @@ class Filesystem {
 	{
 		return copy($path, $target);
 	}
-	
+
 	/**
 	 * Extract the file name from a file path.
 	 *


### PR DESCRIPTION
Cannot use League\Flysystem\FileNotFoundException as FileNotFoundException because the name is already in use

---

I assume you forgot to remove the old exception class when you moved it over to the contracts component.
