### PR TITLE
[4.2] Allow Snake Cased Driver Names

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -74,7 +74,10 @@ abstract class Manager {
 	 */
 	protected function createDriver($driver)
 	{
-		$method = 'create'.ucfirst($driver).'Driver';
+		$methods = [
+			'create'.ucfirst($driver).'Driver',
+			'create'.snake_case($driver).'Driver'
+		];
 
 		// We'll check to see if a creator method exists for the given driver. If not we
 		// will check for a custom driver creator, which allows developers to create
@@ -83,9 +86,13 @@ abstract class Manager {
 		{
 			return $this->callCustomCreator($driver);
 		}
-		elseif (method_exists($this, $method))
+		
+		foreach($methods as $method)
 		{
-			return $this->$method();
+			if (method_exists($this, $method))
+			{
+				return $this->$method();
+			}	
 		}
 
 		throw new \InvalidArgumentException("Driver [$driver] not supported.");

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -76,7 +76,7 @@ abstract class Manager {
 	{
 		$methods = [
 			'create'.ucfirst($driver).'Driver',
-			'create'.snake_case($driver).'Driver'
+			'create'.studly_case($driver).'Driver'
 		];
 
 		// We'll check to see if a creator method exists for the given driver. If not we


### PR DESCRIPTION
This will allow for snaked cased driver names. When using drivers whose names are longer that just one word, people can now give then snake_cased names, ie. "google_analytics" will now become "createGoogleAnalyticsDriver" instead of "createGoogle_analyticsDriver.

If there's something wrong with the pull request or my alterations to the code, please let me know -- this is my first PR and I'd like to learn from it :-)
