### PR TITLE
[5.0] Console : remove useless (array) cast

### DIFF
--- a/src/Illuminate/Console/AppNamespaceDetectorTrait.php
+++ b/src/Illuminate/Console/AppNamespaceDetectorTrait.php
@@ -13,7 +13,7 @@ trait AppNamespaceDetectorTrait {
 	 */
 	protected function getAppNamespace()
 	{
-		$composer = json_decode(file_get_contents(base_path().'/composer.json', true), true);
+		$composer = json_decode(file_get_contents(base_path().'/composer.json'), true);
 
 		foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path)
 		{

--- a/src/Illuminate/Console/AppNamespaceDetectorTrait.php
+++ b/src/Illuminate/Console/AppNamespaceDetectorTrait.php
@@ -13,7 +13,7 @@ trait AppNamespaceDetectorTrait {
 	 */
 	protected function getAppNamespace()
 	{
-		$composer = (array) json_decode(file_get_contents(base_path().'/composer.json', true));
+		$composer = json_decode(file_get_contents(base_path().'/composer.json', true), true);
 
 		foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path)
 		{


### PR DESCRIPTION
As json_decode can have the $assoc = true argument
