### PR TITLE
[5.0] Remove Useless Foreach

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -455,10 +455,7 @@ class Store implements SessionInterface {
 	 */
 	public function replace(array $attributes)
 	{
-		foreach ($attributes as $key => $value)
-		{
-			$this->put($key, $value);
-		}
+		$this->put($attributes);
 	}
 
 	/**


### PR DESCRIPTION
As `put` functions already handles `$attributes` as a `$key => $value` array
