### PR TITLE
[4.2] Allow Custom Column Name When Adding or Removing Soft Deletes

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -272,11 +272,12 @@ class Blueprint {
 	/**
 	* Indicate that the soft delete column should be dropped.
 	*
+	* @param  string  $column
 	* @return void
 	*/
-	public function dropSoftDeletes()
+	public function dropSoftDeletes($column = 'deleted_at')
 	{
-		$this->dropColumn('deleted_at');
+		$this->dropColumn($column);
 	}
 
 	/**
@@ -639,11 +640,12 @@ class Blueprint {
 	/**
 	 * Add a "deleted at" timestamp for the table.
 	 *
+	 * @param  string  $column
 	 * @return \Illuminate\Support\Fluent
 	 */
-	public function softDeletes()
+	public function softDeletes($column = 'deleted_at')
 	{
-		return $this->timestamp('deleted_at')->nullable();
+		return $this->timestamp($column)->nullable();
 	}
 
 	/**


### PR DESCRIPTION
Advantages:
- When creating, the developer doesn’t have to remember that the column needs to be a nullable timestamp.
- When removing, keeps the migration file clear by still communicating the intent of the column deletion (i.e., removal of soft deletes) instead of having to use a vague `dropColumn()` that says nothing about the column’s special role.
