### PR TITLE
[4.2] Fix Docblocks Alignements

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -131,10 +131,10 @@ class Connection implements ConnectionInterface {
 	/**
 	 * Create a new database connection instance.
 	 *
-	 * @param  \PDO     $pdo
-	 * @param  string   $database
-	 * @param  string   $tablePrefix
-	 * @param  array    $config
+	 * @param  \PDO    $pdo
+	 * @param  string  $database
+	 * @param  string  $tablePrefix
+	 * @param  array   $config
 	 * @return void
 	 */
 	public function __construct(PDO $pdo, $database = '', $tablePrefix = '', array $config = array())
@@ -283,8 +283,8 @@ class Connection implements ConnectionInterface {
 	 * Run a select statement against the database.
 	 *
 	 * @param  string  $query
-	 * @param  array  $bindings
-	 * @param  bool  $useReadPdo
+	 * @param  array   $bindings
+	 * @param  bool    $useReadPdo
 	 * @return array
 	 */
 	public function select($query, $bindings = array(), $useReadPdo = true)
@@ -560,8 +560,8 @@ class Connection implements ConnectionInterface {
 	/**
 	 * Run a SQL statement and log its execution context.
 	 *
-	 * @param  string    $query
-	 * @param  array     $bindings
+	 * @param  string  $query
+	 * @param  array   $bindings
 	 * @param  \Closure  $callback
 	 * @return mixed
 	 *
@@ -600,8 +600,8 @@ class Connection implements ConnectionInterface {
 	/**
 	 * Run a SQL statement.
 	 *
-	 * @param  string    $query
-	 * @param  array     $bindings
+	 * @param  string  $query
+	 * @param  array   $bindings
 	 * @param  \Closure  $callback
 	 * @return mixed
 	 *
@@ -634,8 +634,8 @@ class Connection implements ConnectionInterface {
 	 * Handle a query exception that occurred during query execution.
 	 *
 	 * @param  \Illuminate\Database\QueryException  $e
-	 * @param  string    $query
-	 * @param  array     $bindings
+	 * @param  string  $query
+	 * @param  array   $bindings
 	 * @param  \Closure  $callback
 	 * @return mixed
 	 *
@@ -755,7 +755,7 @@ class Connection implements ConnectionInterface {
 	/**
 	 * Get the elapsed time since a given starting point.
 	 *
-	 * @param  int    $start
+	 * @param  int  $start
 	 * @return float
 	 */
 	protected function getElapsedTime($start)

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -193,11 +193,11 @@ class ConnectionFactory {
 	/**
 	 * Create a new connection instance.
 	 *
-	 * @param  string   $driver
-	 * @param  \PDO     $connection
-	 * @param  string   $database
-	 * @param  string   $prefix
-	 * @param  array    $config
+	 * @param  string  $driver
+	 * @param  \PDO    $connection
+	 * @param  string  $database
+	 * @param  string  $prefix
+	 * @param  array   $config
 	 * @return \Illuminate\Database\Connection
 	 *
 	 * @throws \InvalidArgumentException

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -51,7 +51,7 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 	 * Create a DSN string from a configuration. Chooses socket or host/port based on
 	 * the 'unix_socket' config value
 	 *
-	 * @param  array   $config
+	 * @param  array  $config
 	 * @return string
 	 */
 	protected function getDsn(array $config)

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -53,7 +53,7 @@ class PostgresConnector extends Connector implements ConnectorInterface {
 	/**
 	 * Create a DSN string from a configuration.
 	 *
-	 * @param  array   $config
+	 * @param  array  $config
 	 * @return string
 	 */
 	protected function getDsn(array $config)

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -32,7 +32,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface {
 	/**
 	 * Create a DSN string from a configuration.
 	 *
-	 * @param  array   $config
+	 * @param  array  $config
 	 * @return string
 	 */
 	protected function getDsn(array $config)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -452,8 +452,8 @@ class Builder {
 	/**
 	 * Eagerly load the relationship on a set of models.
 	 *
-	 * @param  array     $models
-	 * @param  string    $name
+	 * @param  array   $models
+	 * @param  string  $name
 	 * @param  \Closure  $constraints
 	 * @return array
 	 */
@@ -622,10 +622,10 @@ class Builder {
 	/**
 	 * Add a relationship count condition to the query with where clauses.
 	 *
-	 * @param  string    $relation
+	 * @param  string  $relation
 	 * @param  \Closure  $callback
-	 * @param  string    $operator
-	 * @param  int       $count
+	 * @param  string  $operator
+	 * @param  int     $count
 	 * @return \Illuminate\Database\Eloquent\Builder|static
 	 */
 	public function whereHas($relation, Closure $callback, $operator = '>=', $count = 1)
@@ -661,10 +661,10 @@ class Builder {
 	/**
 	 * Add a relationship count condition to the query with where clauses and an "or".
 	 *
-	 * @param  string    $relation
+	 * @param  string  $relation
 	 * @param  \Closure  $callback
-	 * @param  string    $operator
-	 * @param  int       $count
+	 * @param  string  $operator
+	 * @param  int     $count
 	 * @return \Illuminate\Database\Eloquent\Builder|static
 	 */
 	public function orWhereHas($relation, Closure $callback, $operator = '>=', $count = 1)
@@ -678,7 +678,7 @@ class Builder {
 	 * @param  \Illuminate\Database\Eloquent\Builder  $hasQuery
 	 * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
 	 * @param  string  $operator
-	 * @param  int  $count
+	 * @param  int     $count
 	 * @param  string  $boolean
 	 * @return \Illuminate\Database\Eloquent\Builder
 	 */
@@ -892,7 +892,7 @@ class Builder {
 	/**
 	 * Extend the builder with a given callback.
 	 *
-	 * @param  string    $name
+	 * @param  string  $name
 	 * @param  \Closure  $callback
 	 * @return void
 	 */

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -91,7 +91,7 @@ abstract class Grammar {
 	/**
 	 * Convert an array of column names into a delimited string.
 	 *
-	 * @param  array   $columns
+	 * @param  array  $columns
 	 * @return string
 	 */
 	public function columnize(array $columns)
@@ -102,7 +102,7 @@ abstract class Grammar {
 	/**
 	 * Create query parameter place-holders for an array.
 	 *
-	 * @param  array   $values
+	 * @param  array  $values
 	 * @return string
 	 */
 	public function parameterize(array $values)
@@ -113,7 +113,7 @@ abstract class Grammar {
 	/**
 	 * Get the appropriate query parameter place-holder for a value.
 	 *
-	 * @param  mixed   $value
+	 * @param  mixed  $value
 	 * @return string
 	 */
 	public function parameter($value)

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -22,7 +22,7 @@ class QueryException extends PDOException {
 	 * Create a new query exception instance.
 	 *
 	 * @param  string  $sql
-	 * @param  array  $bindings
+	 * @param  array   $bindings
 	 * @param  \Exception $previous
 	 * @return void
 	 */
@@ -46,7 +46,7 @@ class QueryException extends PDOException {
 	 * Format the SQL error message.
 	 *
 	 * @param  string  $sql
-	 * @param  array  $bindings
+	 * @param  array   $bindings
 	 * @param  \Exception $previous
 	 * @return string
 	 */


### PR DESCRIPTION
I'm not sure about some docblocks like this one:

``` php
* @param  array  $values
* @return string
```

Is it better to write 3 spaces to not align with the return type?
And with some `\Closure` when it's better to align or not.

If you want, I can do that on a lot of file and check if params is inside the docblock too.
