### PR TITLE
[5.0] Use Doctrine Inflector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "classpreloader/classpreloader": "~1.0.2",
         "d11wtq/boris": "~1.0",
         "doctrine/annotations": "~1.0",
+        "doctrine/inflector": "~1.0",
         "ircmaxell/password-compat": "~1.0",
         "jeremeamia/superclosure": "~1.0.1",
         "league/flysystem": "~1.0",

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -1,102 +1,8 @@
 <?php namespace Illuminate\Support;
 
+use Doctrine\Common\Inflector\Inflector;
+
 class Pluralizer {
-
-	/**
-	 * Plural word form rules.
-	 *
-	 * @var array
-	 */
-	public static $plural = array(
-		'/(quiz)$/i' => "$1zes",
-		'/^(ox)$/i' => "$1en",
-		'/([m|l])ouse$/i' => "$1ice",
-		'/(matr|vert|ind)ix$|ex$/i' => "$1ices",
-		'/(stoma|epo|monar|matriar|patriar|oligar|eunu)ch$/i' => "$1chs",
-		'/(x|ch|ss|sh)$/i' => "$1es",
-		'/([^aeiouy]|qu)y$/i' => "$1ies",
-		'/(hive)$/i' => "$1s",
-		'/(?:([^f])fe|([lr])f)$/i' => "$1$2ves",
-		'/(shea|lea|loa|thie)f$/i' => "$1ves",
-		'/sis$/i' => "ses",
-		'/([ti])um$/i' => "$1a",
-		'/(torped|embarg|tomat|potat|ech|her|vet)o$/i' => "$1oes",
-		'/(bu)s$/i' => "$1ses",
-		'/(alias)$/i' => "$1es",
-		'/(fung)us$/i' => "$1i",
-		'/(ax|test)is$/i' => "$1es",
-		'/(us)$/i' => "$1es",
-		'/s$/i' => "s",
-		'/$/' => "s",
-	);
-
-	/**
-	 * Singular word form rules.
-	 *
-	 * @var array
-	 */
-	public static $singular = array(
-		'/(quiz)zes$/i' => "$1",
-		'/(matr)ices$/i' => "$1ix",
-		'/(vert|vort|ind)ices$/i' => "$1ex",
-		'/^(ox)en$/i' => "$1",
-		'/(alias)es$/i' => "$1",
-		'/(octop|vir|fung)i$/i' => "$1us",
-		'/(cris|ax|test)es$/i' => "$1is",
-		'/(shoe)s$/i' => "$1",
-		'/(o)es$/i' => "$1",
-		'/(bus)es$/i' => "$1",
-		'/([m|l])ice$/i' => "$1ouse",
-		'/(x|ch|ss|sh)es$/i' => "$1",
-		'/(m)ovies$/i' => "$1ovie",
-		'/(s)eries$/i' => "$1eries",
-		'/([^aeiouy]|qu)ies$/i' => "$1y",
-		'/([lr])ves$/i' => "$1f",
-		'/(tive)s$/i' => "$1",
-		'/(hive)s$/i' => "$1",
-		'/(li|wi|kni)ves$/i' => "$1fe",
-		'/(shea|loa|lea|thie)ves$/i' => "$1f",
-		'/(^analy)ses$/i' => "$1sis",
-		'/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$/i' => "$1$2sis",
-		'/([ti])a$/i' => "$1um",
-		'/(n)ews$/i' => "$1ews",
-		'/(h|bl)ouses$/i' => "$1ouse",
-		'/(corpse)s$/i' => "$1",
-		'/(gallows|headquarters)$/i' => "$1",
-		'/(us)es$/i' => "$1",
-		'/(us|ss)$/i' => "$1",
-		'/s$/i' => "",
-	);
-
-	/**
-	 * Irregular word forms.
-	 *
-	 * @var array
-	 */
-	public static $irregular = array(
-		'child' => 'children',
-		'corpus' => 'corpora',
-		'criterion' => 'criteria',
-		'foot' => 'feet',
-		'freshman' => 'freshmen',
-		'goose' => 'geese',
-		'genus' => 'genera',
-		'human' => 'humans',
-		'man' => 'men',
-		'move' => 'moves',
-		'nucleus' => 'nuclei',
-		'ovum' => 'ova',
-		'person' => 'people',
-		'phenomenon' => 'phenomena',
-		'radius' => 'radii',
-		'sex' => 'sexes',
-		'stimulus' => 'stimuli',
-		'syllabus' => 'syllabi',
-		'tax' => 'taxes',
-		'tech' => 'techs',
-		'tooth' => 'teeth',
-		'viscus' => 'viscera',
-	);
 
 	/**
 	 * Uncountable word forms.
@@ -130,39 +36,7 @@ class Pluralizer {
 	);
 
 	/**
-	 * The cached copies of the plural inflections.
-	 *
-	 * @var array
-	 */
-	protected static $pluralCache = array();
-
-	/**
-	 * The cached copies of the singular inflections.
-	 *
-	 * @var array
-	 */
-	protected static $singularCache = array();
-
-	/**
-	 * Get the singular form of the given word.
-	 *
-	 * @param  string  $value
-	 * @return string
-	 */
-	public static function singular($value)
-	{
-		if (isset(static::$singularCache[$value]))
-		{
-			return static::$singularCache[$value];
-		}
-
-		$result = static::inflect($value, static::$singular, static::$irregular);
-
-		return static::$singularCache[$value] = $result ?: $value;
-	}
-
-	/**
-	 * Get the plural form of the given word.
+	 * Get the plural form of an English word.
 	 *
 	 * @param  string  $value
 	 * @param  int     $count
@@ -170,67 +44,27 @@ class Pluralizer {
 	 */
 	public static function plural($value, $count = 2)
 	{
-		if ($count == 1) return $value;
-
-		if (in_array($value, static::$irregular)) return $value;
-
-		// First we'll check the cache of inflected values. We cache each word that
-		// is inflected so we don't have to spin through the regular expressions
-		// on each subsequent method calls for this word by the app developer.
-		if (isset(static::$pluralCache[$value]))
+		if ($count === 1 || static::uncountable($value))
 		{
-			return static::$pluralCache[$value];
+			return $value;
 		}
 
-		$irregular = array_flip(static::$irregular);
+		$plural = Inflector::pluralize($value);
 
-		// When doing the singular to plural transformation, we'll flip the irregular
-		// array since we need to swap sides on the keys and values. After we have
-		// the transformed value we will cache it in memory for faster look-ups.
-		$plural = static::$plural;
-
-		$result = static::inflect($value, $plural, $irregular);
-
-		return static::$pluralCache[$value] = $result;
+		return static::matchCase($plural, $value);
 	}
 
 	/**
-	 * Perform auto inflection on an English word.
+	 * Get the singular form of an English word.
 	 *
 	 * @param  string  $value
-	 * @param  array   $source
-	 * @param  array   $irregular
 	 * @return string
 	 */
-	protected static function inflect($value, $source, $irregular)
+	public static function singular($value)
 	{
-		if (static::uncountable($value)) return $value;
+		$singular = Inflector::singularize($value);
 
-		// Next, we will check the "irregular" patterns which contain words that are
-		// not easily summarized in regular expression rules, like "children" and
-		// "teeth", both of which cannot get inflected using our typical rules.
-		foreach ($irregular as $irregular => $pattern)
-		{
-			if (preg_match($pattern = '/'.$pattern.'$/i', $value))
-			{
-				$irregular = static::matchCase($irregular, $value);
-
-				return preg_replace($pattern, $irregular, $value);
-			}
-		}
-
-		// Finally, we'll spin through the array of regular expressions and look for
-		// matches for the word. If we find a match, we will cache and return the
-		// transformed value so we will quickly look it up on subsequent calls.
-		foreach ($source as $pattern => $inflected)
-		{
-			if (preg_match($pattern, $value))
-			{
-				$inflected = preg_replace($pattern, $inflected, $value);
-
-				return static::matchCase($inflected, $value);
-			}
-		}
+		return static::matchCase($singular, $value);
 	}
 
 	/**

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/contracts": "5.0.*",
+        "doctrine/inflector": "~1.0",
         "patchwork/utf8": "~1.1"
     },
     "require-dev": {

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -2,19 +2,38 @@
 
 class SupportPluralizerTest extends PHPUnit_Framework_TestCase {
 
-	public function testBasicUsage()
+
+	public function testBasicSingular()
+	{
+		$this->assertEquals('child', str_singular('children'));
+		$this->assertEquals('test', str_singular('tests'));
+		$this->assertEquals('deer', str_singular('deer'));
+		$this->assertEquals('criterium', str_singular('criteria'));
+	}
+
+
+	public function testBasicPlural()
 	{
 		$this->assertEquals('children', str_plural('child'));
 		$this->assertEquals('tests', str_plural('test'));
 		$this->assertEquals('deer', str_plural('deer'));
-		$this->assertEquals('child', str_singular('children'));
-		$this->assertEquals('test', str_singular('tests'));
-		$this->assertEquals('deer', str_singular('deer'));
-		$this->assertEquals('criterion', str_singular('criteria'));
 	}
 
 
-	public function testCaseSensitiveUsage()
+	public function testCaseSensitiveSingularUsage()
+	{
+		$this->assertEquals('Child', str_singular('Children'));
+		$this->assertEquals('CHILD', str_singular('CHILDREN'));
+		$this->assertEquals('Test', str_singular('Tests'));
+		$this->assertEquals('TEST', str_singular('TESTS'));
+		$this->assertEquals('Deer', str_singular('Deer'));
+		$this->assertEquals('DEER', str_singular('DEER'));
+		$this->assertEquals('Criterium', str_singular('Criteria'));
+		$this->assertEquals('CRITERIUM', str_singular('CRITERIA'));
+	}
+
+
+	public function testCaseSensitiveSingularPlural()
 	{
 		$this->assertEquals('Children', str_plural('Child'));
 		$this->assertEquals('CHILDREN', str_plural('CHILD'));
@@ -23,30 +42,15 @@ class SupportPluralizerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('tests', str_plural('test'));
 		$this->assertEquals('Deer', str_plural('Deer'));
 		$this->assertEquals('DEER', str_plural('DEER'));
-		$this->assertEquals('Child', str_singular('Children'));
-		$this->assertEquals('CHILD', str_singular('CHILDREN'));
-		$this->assertEquals('Test', str_singular('Tests'));
-		$this->assertEquals('TEST', str_singular('TESTS'));
-		$this->assertEquals('Deer', str_singular('Deer'));
-		$this->assertEquals('DEER', str_singular('DEER'));
-		$this->assertEquals('Criterion', str_singular('Criteria'));
-		$this->assertEquals('CRITERION', str_singular('CRITERIA'));
 	}
 
 
-	public function testIfEndOfWord()
+	public function testIfEndOfWordPlural()
 	{
 		$this->assertEquals('VortexFields', str_plural('VortexField'));
 		$this->assertEquals('MatrixFields', str_plural('MatrixField'));
 		$this->assertEquals('IndexFields', str_plural('IndexField'));
 		$this->assertEquals('VertexFields', str_plural('VertexField'));
-	}
-
-	public function testAlreadyPluralizedIrregularWords()
-	{
-		$this->assertEquals('children', str_plural('children'));
-		$this->assertEquals('radii', str_plural('radii'));
-		$this->assertEquals('teeth', str_plural('teeth'));
 	}
 
 }


### PR DESCRIPTION
We actually already require people to download this package with laravel anyway because it is a dependency of the doctrine annotations package, so we might as well start using it. This can only be an advantage as far as I can see. It's a really small package, and takes the weight of maintaining the pluraliser off laravel.

~~NB, we used to have a second parameter in the pluralise function in laravel - I checked, and the laravel core doesn't use that parameter at all. As Laravel 5.0 is breaking, I don't see an issue with removing that param.~~ I've restored this functionality.
