### PR TITLE
[4.2] Fixed A Security Issue With The Encrypter

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -41,7 +41,7 @@ class Encrypter {
 	 */
 	public function __construct($key)
 	{
-		$this->key = $key;
+		$this->setKey($key);
 	}
 
 	/**
@@ -136,12 +136,12 @@ class Encrypter {
 		// to decrypt the given value. We'll also check the MAC for this encryption.
 		if ( ! $payload || $this->invalidPayload($payload))
 		{
-			throw new DecryptException("Invalid data.");
+			throw new DecryptException('Invalid data.');
 		}
 
 		if ( ! $this->validMac($payload))
 		{
-			throw new DecryptException("MAC is invalid.");
+			throw new DecryptException('MAC is invalid.');
 		}
 
 		return $payload;
@@ -263,9 +263,26 @@ class Encrypter {
 	 *
 	 * @param  string  $key
 	 * @return void
+	 *
+	 * @throws \Illuminate\Encryption\InvalidKeyException
 	 */
 	public function setKey($key)
 	{
+		if ( ! is_string($key))
+		{
+			throw new InvalidKeyException('The encryption key must be a string.');
+		}
+
+		if ($key === '')
+		{
+			throw new InvalidKeyException('The encryption key must be not be empty.');
+		}
+
+		if ($key === 'YourSecretKey!!!')
+		{
+			throw new InvalidKeyException('The encryption key must be a random string.');
+		}
+
 		$this->key = $key;
 	}
 

--- a/src/Illuminate/Encryption/InvalidKeyException.php
+++ b/src/Illuminate/Encryption/InvalidKeyException.php
@@ -1,0 +1,3 @@
+<?php namespace Illuminate\Encryption;
+
+class InvalidKeyException extends \InvalidArgumentException {}

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -24,6 +24,7 @@ class EncrypterTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @expectedException Illuminate\Encryption\DecryptException
+	 * @expectedExceptionMessage Invalid data.
 	 */
 	public function testExceptionThrownWhenPayloadIsInvalid()
 	{
@@ -31,6 +32,36 @@ class EncrypterTest extends PHPUnit_Framework_TestCase {
 		$payload = $e->encrypt('foo');
 		$payload = str_shuffle($payload);
 		$e->decrypt($payload);
+	}
+
+
+	/**
+	 * @expectedException Illuminate\Encryption\InvalidKeyException
+	 * @expectedExceptionMessage The encryption key must be a string.
+	 */
+	public function testConstuctWithNonString()
+	{
+		return new Encrypter(123);
+	}
+
+
+	/**
+	 * @expectedException Illuminate\Encryption\InvalidKeyException
+	 * @expectedExceptionMessage The encryption key must be not be empty.
+	 */
+	public function testConstuctWithEmptyString()
+	{
+		return new Encrypter('');
+	}
+
+
+	/**
+	 * @expectedException Illuminate\Encryption\InvalidKeyException
+	 * @expectedExceptionMessage The encryption key must be a random string.
+	 */
+	public function testConstuctWithDefaultString()
+	{
+		return new Encrypter('YourSecretKey!!!');
 	}
 
 


### PR DESCRIPTION
Recently, the issue of incorrect key length in the encrypted came up in the issues on GitHub. While this is not a security risk as such, it did bring something else to my attention. **An attacker may assume that a Laravel application still has the default key set**, thus allowing them to decrypt potentially sensitive data.

There is one application of this vulnerability in particular that could be very damaging. Knowing the encryption key would allow an attacker to **run any code on the system** in question if the user has an ironmq endpoint setup, because of course, then can not only decrypt information, but encrypt information too.

Obviously, if someone creates a laravel project via composer, we run "php artisan key:generate" for them, but if they clone a repo with git, or download a zip, they will never execute that command, and thus could potentially forget to set a key.

I propose that we actually implement a check in the encrypter class to check if the default key is still set, and throw an exception if it is. This pull request provides this implementation and tests.
