### PR TITLE
Grammar correction

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -272,7 +272,7 @@ class Encrypter implements EncrypterContract {
 
 		if ($key === '')
 		{
-			throw new InvalidKeyException('The encryption key must be not be empty.');
+			throw new InvalidKeyException('The encryption key must not be empty.');
 		}
 
 		if ($key === 'YourSecretKey!!!')

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -46,7 +46,7 @@ class EncrypterTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @expectedException Illuminate\Encryption\InvalidKeyException
-	 * @expectedExceptionMessage The encryption key must be not be empty.
+	 * @expectedExceptionMessage The encryption key must not be empty.
 	 */
 	public function testConstuctWithEmptyString()
 	{


### PR DESCRIPTION
[5.0] Changed `'The encryption key must be not be empty.'` to `'The encryption key must not be empty.'`
