### PR TITLE
[4.2] Fixed The Encrypter

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -41,7 +41,7 @@ class Encrypter {
 	 */
 	public function __construct($key)
 	{
-		$this->setKey($key);
+		$this->key = (string) $key;
 	}
 
 	/**
@@ -52,6 +52,8 @@ class Encrypter {
 	 */
 	public function encrypt($value)
 	{
+		$this->checkKey();
+
 		$iv = mcrypt_create_iv($this->getIvSize(), $this->getRandomizer());
 
 		$value = base64_encode($this->padAndMcrypt($value, $iv));
@@ -86,6 +88,8 @@ class Encrypter {
 	 */
 	public function decrypt($payload)
 	{
+		$this->checkKey();
+
 		$payload = $this->getJsonPayload($payload);
 
 		// We'll go ahead and remove the PKCS7 padding from the encrypted value before
@@ -263,27 +267,10 @@ class Encrypter {
 	 *
 	 * @param  string  $key
 	 * @return void
-	 *
-	 * @throws \Illuminate\Encryption\InvalidKeyException
 	 */
 	public function setKey($key)
 	{
-		if ( ! is_string($key))
-		{
-			throw new InvalidKeyException('The encryption key must be a string.');
-		}
-
-		if ($key === '')
-		{
-			throw new InvalidKeyException('The encryption key must be not be empty.');
-		}
-
-		if ($key === 'YourSecretKey!!!')
-		{
-			throw new InvalidKeyException('The encryption key must be a random string.');
-		}
-
-		$this->key = $key;
+		$this->key = (string) $key;
 	}
 
 	/**
@@ -320,6 +307,26 @@ class Encrypter {
 	protected function updateBlockSize()
 	{
 		$this->block = mcrypt_get_iv_size($this->cipher, $this->mode);
+	}
+
+	/**
+	 * Check the current key is usable to perform cryptographic operations.
+	 *
+	 * @return void
+	 *
+	 * @throws \Illuminate\Encryption\InvalidKeyException
+	 */
+	protected function checkKey()
+	{
+		if ($this->key === '')
+		{
+			throw new InvalidKeyException('The encryption key must not be empty.');
+		}
+
+		if ($this->key === 'YourSecretKey!!!')
+		{
+			throw new InvalidKeyException('The encryption key must be a random string.');
+		}
 	}
 
 }

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -35,23 +35,35 @@ class EncrypterTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	/**
-	 * @expectedException Illuminate\Encryption\InvalidKeyException
-	 * @expectedExceptionMessage The encryption key must be a string.
-	 */
-	public function testConstuctWithNonString()
+	public function testCanStillBeConstructedWithInvalidKeys()
 	{
-		return new Encrypter(123);
+		$e = new Encrypter(''); // should not throw an exception
+
+		$e = new Encrypter('YourSecretKey!!!'); // should not throw an exception
 	}
 
 
 	/**
 	 * @expectedException Illuminate\Encryption\InvalidKeyException
-	 * @expectedExceptionMessage The encryption key must be not be empty.
+	 * @expectedExceptionMessage The encryption key must not be empty.
 	 */
-	public function testConstuctWithEmptyString()
+	public function testEncryptWithEmptyStringAsKey()
 	{
-		return new Encrypter('');
+		$e = new Encrypter('');
+
+		$e->encrypt('bar'); // throw the exception now that we tried to use the encrypter
+	}
+
+
+	/**
+	 * @expectedException Illuminate\Encryption\InvalidKeyException
+	 * @expectedExceptionMessage The encryption key must not be empty.
+	 */
+	public function testDecryptWithEmptyStringAsKey()
+	{
+		$e = new Encrypter('');
+
+		$e->decrypt('bar'); // throw the exception now that we tried to use the encrypter
 	}
 
 
@@ -59,9 +71,23 @@ class EncrypterTest extends PHPUnit_Framework_TestCase {
 	 * @expectedException Illuminate\Encryption\InvalidKeyException
 	 * @expectedExceptionMessage The encryption key must be a random string.
 	 */
-	public function testConstuctWithDefaultString()
+	public function testEncryptWithDefaultStringAsKey()
 	{
-		return new Encrypter('YourSecretKey!!!');
+		$e = new Encrypter('YourSecretKey!!!');
+
+		$e->encrypt('bar'); // throw the exception now that we tried to use the encrypter
+	}
+
+
+	/**
+	 * @expectedException Illuminate\Encryption\InvalidKeyException
+	 * @expectedExceptionMessage The encryption key must be a random string.
+	 */
+	public function testDecryptWithDefaultStringAsKey()
+	{
+		$e = new Encrypter('YourSecretKey!!!');
+
+		$e->decrypt('bar'); // throw the exception now that we tried to use the encrypter
 	}
 
 


### PR DESCRIPTION
The previous security patch was causing laravel to crash, even when the user was trying to generate an encryption key from the console. Instead, we should only throw an exception if they actually try to use the encrypter, not just if they instantiate it.
