### PR TITLE
[5.0] Fix More Bugs With "push" In Eloquent Models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1471,7 +1471,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		// us to recurs into all of these nested relations for this model instance.
 		foreach ($this->relations as $models)
 		{
-			$models = is_array($models) ? $models : array($models);
+			// Models can be a collection of models (hasMany), an individual model (hasOne),
+			// or null (non-existing hasOne). Convert to an array.
+			$models = $models instanceof Collection ? $models->all() : array($models);
+
+			// Filter out any null entries from non-existing relationships.
+			$models = array_filter($models);
 
 			foreach ($models as $model)
 			{

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -411,6 +411,127 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testPushNoRelations()
+	{
+		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('insertGetId')->once()->with(array('name' => 'taylor'), 'id')->andReturn(1);
+		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('updateTimestamps');
+
+		$model->name = 'taylor';
+		$model->exists = false;
+
+		$this->assertTrue($model->push());
+		$this->assertEquals(1, $model->id);
+		$this->assertTrue($model->exists);
+	}
+
+
+	public function testPushEmptyOneRelation()
+	{
+		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('insertGetId')->once()->with(array('name' => 'taylor'), 'id')->andReturn(1);
+		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('updateTimestamps');
+
+		$model->name = 'taylor';
+		$model->exists = false;
+		$model->setRelation('relationOne', null);
+
+		$this->assertTrue($model->push());
+		$this->assertEquals(1, $model->id);
+		$this->assertTrue($model->exists);
+		$this->assertNull($model->relationOne);
+	}
+
+
+	public function testPushOneRelation()
+	{
+		$related1 = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('insertGetId')->once()->with(array('name' => 'related1'), 'id')->andReturn(2);
+		$related1->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$related1->expects($this->once())->method('updateTimestamps');
+		$related1->name = 'related1';
+		$related1->exists = false;
+
+		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('insertGetId')->once()->with(array('name' => 'taylor'), 'id')->andReturn(1);
+		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('updateTimestamps');
+
+		$model->name = 'taylor';
+		$model->exists = false;
+		$model->setRelation('relationOne', $related1);
+
+		$this->assertTrue($model->push());
+		$this->assertEquals(1, $model->id);
+		$this->assertTrue($model->exists);
+		$this->assertEquals(2, $model->relationOne->id);
+		$this->assertTrue($model->relationOne->exists);
+		$this->assertEquals(2, $related1->id);
+		$this->assertTrue($related1->exists);
+	}
+
+
+	public function testPushEmptyManyRelation()
+	{
+		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('insertGetId')->once()->with(array('name' => 'taylor'), 'id')->andReturn(1);
+		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('updateTimestamps');
+
+		$model->name = 'taylor';
+		$model->exists = false;
+		$model->setRelation('relationMany', new Illuminate\Database\Eloquent\Collection(array()));
+
+		$this->assertTrue($model->push());
+		$this->assertEquals(1, $model->id);
+		$this->assertTrue($model->exists);
+		$this->assertEquals(0, count($model->relationMany));
+	}
+
+
+	public function testPushManyRelation()
+	{
+		$related1 = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('insertGetId')->once()->with(array('name' => 'related1'), 'id')->andReturn(2);
+		$related1->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$related1->expects($this->once())->method('updateTimestamps');
+		$related1->name = 'related1';
+		$related1->exists = false;
+
+		$related2 = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('insertGetId')->once()->with(array('name' => 'related2'), 'id')->andReturn(3);
+		$related2->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$related2->expects($this->once())->method('updateTimestamps');
+		$related2->name = 'related2';
+		$related2->exists = false;
+
+		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('insertGetId')->once()->with(array('name' => 'taylor'), 'id')->andReturn(1);
+		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('updateTimestamps');
+
+		$model->name = 'taylor';
+		$model->exists = false;
+		$model->setRelation('relationMany', new Illuminate\Database\Eloquent\Collection(array($related1, $related2)));
+
+		$this->assertTrue($model->push());
+		$this->assertEquals(1, $model->id);
+		$this->assertTrue($model->exists);
+		$this->assertEquals(2, count($model->relationMany));
+		$this->assertEquals([2, 3], $model->relationMany->lists('id'));
+	}
+
+
 	public function testNewQueryReturnsEloquentQueryBuilder()
 	{
 		$conn = m::mock('Illuminate\Database\Connection');


### PR DESCRIPTION
For extra reference, bugs with the `push()` method have been mentioned in issues #6139, #6066, and PR #6067.  Issues still remain.

`Illuminate\Database\Eloquent\Model::push()` has the following code snippet:

``` php
foreach ($this->relations as $models)
{
    $models = is_array($models) ? $models : array($models);
    foreach ($models as $model)
    {
        if ( ! $model->push()) return false;
    }
}
```

As far as I can tell, a relationship can either be a Collection (with 0+ items), a Model, or NULL.  There are a couple issues with the current `push()` implementation:
##### Relationship is a Collection

If the relationship is a Collection, the `is_array($models)` check returns false, so the Collection is wrapped in an array.  Therefore, `$models` is now an array containing one entry: the Collection.  The code then iterates the array, and calls `push()` on the Collection, which is not what was intended.  This causes the following error: `Missing argument 1 for Illuminate\Support\Collection::push()`.
##### Relationship is NULL

If a `hasOne` relationship is loaded but the related object doesn't exist, the relationship will be set to NULL. In this case, in the `push()` method, `is_array(NULL)` returns false, and the NULL value is wrapped in an array. Therefore, `$models` is now an array containing one entry: NULL.  The code then iterates the array, and calls `push()` on the NULL value, generating the following error: `PHP Fatal error:  Call to a member function push() on null`.
##### Relationship is a Model

This looks to work fine.

This Pull Request attempts to correctly convert `$models` into an array of Models, filtering out NULL values as well.  Tests have been included as well, which seem to work, but I don't have much experience writing tests, so they should be scrutinized.
