### PR TITLE
[5.0] Only Load PHP Configuration Files

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -64,7 +64,7 @@ class LoadConfiguration {
 	{
 		$files = [];
 
-		foreach (Finder::create()->files()->in($app->configPath()) as $file)
+		foreach (Finder::create()->files()->name('*.php')->in($app->configPath()) as $file)
 		{
 			$files[basename($file->getRealPath(), '.php')] = $file->getRealPath();
 		}


### PR DESCRIPTION
Helps if you have other files in this directory (for example Capistrano deploy.rb)
