### PR TITLE
[5.0] Casting Of Eloquent Attributes To Native Types

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2593,7 +2593,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	/**
 	 * Get the type of cast for a model attribute.
 	 *
-	 * @param  string $key
+	 * @param  string  $key
 	 * @return string
 	 */
 	protected function getCastType($key)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -130,6 +130,13 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	protected $dates = array();
 
 	/**
+	 * The attributes that should be casted to native types.
+	 *
+	 * @var array
+	 */
+	protected $casts = array();
+
+	/**
 	 * The relationships that should be touched on save.
 	 *
 	 * @var array
@@ -2276,16 +2283,26 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			$attributes[$key] = (string) $this->asDateTime($attributes[$key]);
 		}
 
+		$mutatedAttributes = $this->getMutatedAttributes();
+
 		// We want to spin through all the mutated attributes for this model and call
 		// the mutator for the attribute. We cache off every mutated attributes so
 		// we don't have to constantly check on attributes that actually change.
-		foreach ($this->getMutatedAttributes() as $key)
+		foreach ($mutatedAttributes as $key)
 		{
 			if ( ! array_key_exists($key, $attributes)) continue;
 
 			$attributes[$key] = $this->mutateAttributeForArray(
 				$key, $attributes[$key]
 			);
+		}
+
+		foreach ($this->casts as $key => $value)
+		{
+			if ( ! array_key_exists($key, $attributes)) continue;
+			if (in_array($key, $mutatedAttributes)) continue;
+
+			$attributes[$key] = $this->castAttribute($key, $attributes[$key]);
 		}
 
 		// Here we will grab all of the appended, calculated attributes to this model
@@ -2455,6 +2472,14 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 			return $this->mutateAttribute($key, $value);
 		}
 
+		// If the attribute exists within the cast array, we will convert it to
+		// an appropriate native PHP type dependant upon the associated value
+		// given with the key in the pair. Dayle made this comment line up.
+		if ($this->hasCast($key))
+		{
+			$value = $this->castAttribute($key, $value);
+		}
+
 		// If the attribute is listed as a date, we will convert it to a DateTime
 		// instance on retrieval, which makes it quite convenient to work with
 		// date fields without having to create a mutator for each property.
@@ -2540,6 +2565,89 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	}
 
 	/**
+	 * Determine whether an attribute should be casted to a native type.
+	 *
+	 * @param  string  $key
+	 * @return boolean
+	 */
+	protected function hasCast($key)
+	{
+		return array_key_exists($key, $this->casts);
+	}
+
+	/**
+	 * Determine whether a value is JSON castable for inbound manipulation.
+	 *
+	 * @param  string  $key
+	 * @return boolean
+	 */
+	protected function isJsonCastable($key)
+	{
+		if ($this->hasCast($key))
+		{
+			return $this->getCastType($key) === 'json';
+		}
+		return false;
+	}
+
+	/**
+	 * Get the type of cast for a model attribute.
+	 *
+	 * @param  string $key
+	 * @return string
+	 */
+	protected function getCastType($key)
+	{
+		return trim(strtolower($this->casts[$key]));
+	}
+
+	/**
+	 * Cast an attribute to a native PHP type.
+	 *
+	 * @param  string  $key
+	 * @param  mixed   $value
+	 * @return mixed
+	 */
+	protected function castAttribute($key, $value)
+	{
+		$type = $this->getCastType($key);
+		switch ($type)
+		{
+			case 'int':
+			case 'integer':
+				return (int) $value;
+			case 'real':
+			case 'float':
+			case 'double':
+				return (float) $value;
+			case 'string':
+				return (string) $value;
+			case 'bool':
+			case 'boolean':
+				return (bool) $value;
+			case 'array':
+				return (array) $value;
+			case 'object':
+				return (object) $value;
+			case 'json':
+				return json_decode($value, true);
+		}
+		return $value;
+	}
+
+	/**
+	 * Get the value of an attribute using its casting for array conversion.
+	 *
+	 * @param  string  $key
+	 * @param  mixed   $value
+	 * @return mixed
+	 */
+	protected function castAttributeForArray($key, $value)
+	{
+		return $value;
+	}
+
+	/**
 	 * Set a given attribute on the model.
 	 *
 	 * @param  string  $key
@@ -2564,6 +2672,11 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		elseif (in_array($key, $this->getDates()) && $value)
 		{
 			$value = $this->fromDateTime($value);
+		}
+
+		if ($this->isJsonCastable($key))
+		{
+			$value = json_encode($value, true);
 		}
 
 		$this->attributes[$key] = $value;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -973,6 +973,51 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertNull($model->updated_at);
 	}
 
+	public function testModelAttributesAreCastedWhenPresentInCastsArray()
+	{
+		$model = new EloquentModelCastingStub;
+		$model->first = '3';
+		$model->second = '4.0';
+		$model->third = 2.5;
+		$model->fourth = 1;
+		$model->fifth = 0;
+		$model->sixth = array('foo' => 'bar');
+		$obj = new StdClass;
+		$obj->foo = 'bar';
+		$model->seventh = $obj;
+		$model->eighth = array('foo' => 'bar');
+
+		$this->assertInternalType('int', $model->first);
+		$this->assertInternalType('float', $model->second);
+		$this->assertInternalType('string', $model->third);
+		$this->assertInternalType('boolean', $model->fourth);
+		$this->assertInternalType('boolean', $model->fifth);
+		$this->assertInternalType('object', $model->sixth);
+		$this->assertInternalType('array', $model->seventh);
+		$this->assertInternalType('array', $model->eighth);
+		$this->assertTrue($model->fourth);
+		$this->assertFalse($model->fifth);
+		$this->assertEquals($obj, $model->sixth);
+		$this->assertEquals(array('foo' => 'bar'), $model->seventh);
+		$this->assertEquals(array('foo' => 'bar'), $model->eighth);
+		$this->assertEquals('{"foo":"bar"}', $model->eighthAttributeValue());
+
+		$arr = $model->toArray();
+		$this->assertInternalType('int', $arr['first']);
+		$this->assertInternalType('float', $arr['second']);
+		$this->assertInternalType('string', $arr['third']);
+		$this->assertInternalType('boolean', $arr['fourth']);
+		$this->assertInternalType('boolean', $arr['fifth']);
+		$this->assertInternalType('object', $arr['sixth']);
+		$this->assertInternalType('array', $arr['seventh']);
+		$this->assertInternalType('array', $arr['eighth']);
+		$this->assertTrue($arr['fourth']);
+		$this->assertFalse($arr['fifth']);
+		$this->assertEquals($obj, $arr['sixth']);
+		$this->assertEquals(array('foo' => 'bar'), $arr['seventh']);
+		$this->assertEquals(array('foo' => 'bar'), $arr['eighth']);
+	}
+
 
 	protected function addMockConnection($model)
 	{
@@ -1154,5 +1199,22 @@ class EloquentModelAppendsStub extends Illuminate\Database\Eloquent\Model {
 	public function getStudlyCasedAttribute()
 	{
 		return 'StudlyCased';
+	}
+}
+
+class EloquentModelCastingStub extends Illuminate\Database\Eloquent\Model {
+	protected $casts = array(
+		'first' => 'int',
+		'second' => 'float',
+		'third' => 'string',
+		'fourth' => 'bool',
+		'fifth' => 'boolean',
+		'sixth' => 'object',
+		'seventh' => 'array',
+		'eighth' => 'json'
+	);
+	public function eighthAttributeValue()
+	{
+		return $this->attributes['eighth'];
 	}
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -973,6 +973,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertNull($model->updated_at);
 	}
 
+
 	public function testModelAttributesAreCastedWhenPresentInCastsArray()
 	{
 		$model = new EloquentModelCastingStub;


### PR DESCRIPTION
This was a feature I tried a while back, but this should be a better implementation.

Models can now have a `$casts` array of PHP native type casts that will be respected upon accessing attributes or exporting array/json. For example:

``` php
protected $casts = [
    'username'   => 'string',
    'age'             => 'int',
    'settings'       => 'json'
];
```

Possibly casts are `int`, `integer`, `float`, `double`, `real`, `bool`, `boolean`, `string`, `json`.

Binary / Unset types were removed by request of @taylorotwell .

Feature request by @taylorotwell implemented:

Attributes with the `json` cast are stored within the model and database as a JSON string, however, setting and accessing / exporting these attributes will result in an `array` representing the JSON string. Useful for storing JSON in the database.

Tests provided.
