### PR TITLE
[5.0] Automatically Resolve Migrations Dependencies

### DIFF
--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -67,7 +67,7 @@ class MigrationServiceProvider extends ServiceProvider {
 		{
 			$repository = $app['migration.repository'];
 
-			return new Migrator($repository, $app['db'], $app['files']);
+			return new Migrator($repository, $app, $app['db'], $app['files']);
 		});
 	}
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Database\Migrations;
 
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 class Migrator {
@@ -51,21 +51,21 @@ class Migrator {
 	/**
 	 * Create a new migrator instance.
 	 *
-	 * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface $repository
-	 * @param  \Illuminate\Contracts\Container\Container $container
-	 * @param  \Illuminate\Database\ConnectionResolverInterface $resolver
-	 * @param  \Illuminate\Filesystem\Filesystem $files
+	 * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
+	 * @param  \Illuminate\Contracts\Container\Container  $container
+	 * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
+	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @return void
 	 */
 	public function __construct(MigrationRepositoryInterface $repository,
-								Container $container,
-								Resolver $resolver,
-								Filesystem $files)
+	                            ContainerContract $container,
+	                            Resolver $resolver,
+	                            Filesystem $files)
 	{
-		$this->files = $files;
-		$this->resolver = $resolver;
-		$this->container = $container;
 		$this->repository = $repository;
+		$this->container = $container;
+		$this->resolver = $resolver;
+		$this->files = $files;
 	}
 
 	/**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -1,9 +1,17 @@
 <?php namespace Illuminate\Database\Migrations;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 class Migrator {
+
+	/**
+	 * The container instance.
+	 *
+	 * @var \Illuminate\Contracts\Container\Container
+	 */
+	protected $container;
 
 	/**
 	 * The migration repository implementation.
@@ -43,17 +51,20 @@ class Migrator {
 	/**
 	 * Create a new migrator instance.
 	 *
-	 * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
-	 * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
-	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface $repository
+	 * @param  \Illuminate\Contracts\Container\Container $container
+	 * @param  \Illuminate\Database\ConnectionResolverInterface $resolver
+	 * @param  \Illuminate\Filesystem\Filesystem $files
 	 * @return void
 	 */
 	public function __construct(MigrationRepositoryInterface $repository,
+								Container $container,
 								Resolver $resolver,
-                                Filesystem $files)
+								Filesystem $files)
 	{
 		$this->files = $files;
 		$this->resolver = $resolver;
+		$this->container = $container;
 		$this->repository = $repository;
 	}
 
@@ -298,7 +309,7 @@ class Migrator {
 
 		$class = studly_case($file);
 
-		return new $class;
+		return $this->container->make($class);
 	}
 
 	/**

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -14,6 +14,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
+			m::mock('Illuminate\Container\Container'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
 		));
@@ -48,6 +49,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
+			m::mock('Illuminate\Container\Container'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
 		));
@@ -96,6 +98,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
+			m::mock('Illuminate\Container\Container'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
 		));
@@ -115,6 +118,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
+			m::mock('Illuminate\Container\Container'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
 		));
@@ -143,6 +147,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
+			m::mock('Illuminate\Container\Container'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
 		));
@@ -183,6 +188,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 	{
 		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
 			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
+			m::mock('Illuminate\Container\Container'),
 			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
 			m::mock('Illuminate\Filesystem\Filesystem'),
 		));


### PR DESCRIPTION
This one is to automatically resolve:

```
class CreateUsersTable extends Migration {

    public function __construct(ClasName $class)
    {
        $this->class = $class;
    }

    ...
}
```

@GrahamCampbell, before you say anything, there was a bunch of spaces before Filesystem:

```
public function __construct(MigrationRepositoryInterface $repository,
                            Container $container,
                            Resolver $resolver,
                            Filesystem $files)
```

So I replaced them all with tabs.
