### PR TITLE
[5.0] Add The Ability To Register Subscribers

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -12,6 +12,13 @@ class EventServiceProvider extends ServiceProvider {
 	 * @var array
 	 */
 	protected $scan = [];
+	
+	/**
+	 * The subscriber classes to register.
+	 * 
+	 * @var array
+	 */
+	protected $subscribe = [];
 
 	/**
 	 * Determines if we will auto-scan in the local environment.
@@ -44,6 +51,11 @@ class EventServiceProvider extends ServiceProvider {
 			{
 				$events->listen($event, $listener);
 			}
+		}
+		
+		foreach ($this->subscribe as $subscriber)
+		{
+			$events->subscribe($subscriber);
 		}
 	}
 


### PR DESCRIPTION
To use this you would simply add the class names you wish to register in the `$subscribe` property in the `App\Providers\EventServiceProvider` class. I've added the property to the class itself because I didn't want to make laravel/laravel dependent on this change. I also kept `$subscribe` singular to remain consistent with `$listen`.
