### PR TITLE
[5.0] Make use of new resolvingType method

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -965,6 +965,8 @@ class Container implements ArrayAccess, ContainerContract {
 	}
 
 	/**
+	 * Register a new resolving callback for a given type or one of its subtypes.
+	 *
 	 * @param  $type
 	 * @param  callable  $callback
 	 */
@@ -974,6 +976,8 @@ class Container implements ArrayAccess, ContainerContract {
 	}
 
 	/**
+	 * Register a new after resolving callback for a given type or one of its subtypes.
+	 *
 	 * @param  $type
 	 * @param  callable  $callback
 	 */
@@ -1014,7 +1018,7 @@ class Container implements ArrayAccess, ContainerContract {
 	}
 
 	/**
-	 * Get all callbacks for a givne type.
+	 * Get all callbacks for a given type.
 	 *
 	 * @param  object  $object
 	 * @param  array  $callbacksPerType

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -139,4 +139,30 @@ interface Container {
 	 */
 	public function resolvingAny(Closure $callback);
 
+	/**
+	 * Register a new resolving callback for a given type or one of its subtypes.
+	 *
+	 * @param  string    $abstract
+	 * @param  \Closure  $callback
+	 * @return void
+	 */
+	public function resolvingType($abstract, Closure $callback);
+
+	/**
+	 * Register a new after resolving callback for all types.
+	 *
+	 * @param  \Closure  $callback
+	 * @return void
+	 */
+	public function afterResolvingAny(Closure $callback);
+
+	/**
+	 * Register a new after resolving callback for a given type or one of its subtypes.
+	 *
+	 * @param  string    $abstract
+	 * @param  \Closure  $callback
+	 * @return void
+	 */
+	public function afterResolvingType($abstract, Closure $callback);
+
 }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -237,7 +237,7 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	 * Set the container implementation.
 	 *
 	 * @param  \Illuminate\Container\Container  $container
-	 * @return $this
+	 * @return \Illuminate\Foundation\Http\FormRequest
 	 */
 	public function setContainer(Container $container)
 	{

--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -25,18 +25,14 @@ class FormRequestServiceProvider extends ServiceProvider {
 	{
 		$this->app['events']->listen('router.matched', function()
 		{
-			$this->app->resolvingAny(function($resolved, $app)
+			$this->app->resolvingType('Illuminate\Foundation\Http\FormRequest', function(FormRequest $resolved, $app)
 			{
-				// If the resolved instance is an instance of the FormRequest object, we will go
-				// ahead and initialize the request as well as set a few dependencies on this
+				// Initialize the request as well as set a few dependencies on this
 				// request instance. The "ValidatesWhenResolved" hook will fire "validate".
-				if ($resolved instanceof FormRequest)
-				{
-					$this->initializeRequest($resolved, $app['request']);
+				$this->initializeRequest($resolved, $app['request']);
 
-					$resolved->setContainer($app)
-                             ->setRedirector($app['Illuminate\Routing\Redirector']);
-				}
+				$resolved->setContainer($app)
+                         ->setRedirector($app['Illuminate\Routing\Redirector']);
 			});
 		});
 	}

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -26,12 +26,11 @@ class ValidationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerValidationResolverHook()
 	{
-		$this->app->afterResolvingAny(function($resolved)
+		$type = 'Illuminate\Contracts\Validation\ValidatesWhenResolved';
+
+		$this->app->afterResolvingType($type, function(ValidatesWhenResolved $resolved)
 		{
-			if ($resolved instanceof ValidatesWhenResolved)
-			{
-				$resolved->validate();
-			}
+			$resolved->validate();
 		});
 	}
 


### PR DESCRIPTION
Follow-up PR of #6724

Includes
- More method documentation for new methods
- Methods now also added to the `Container` contract
- Made use of the new `$container->resolvingType` method to clean up `ValidationServiceProvider` and `FormRequestServiceProvider`.
