### PR TITLE
[5.0] Generate Key Without Having To Update The Config

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -29,6 +29,26 @@ class KeyGenerateCommand extends Command {
 	{
 		$key = $this->getRandomKey();
 
+		if ( ! $this->input->getOption('pretend'))
+		{
+			$this->updateAppKey($key);
+
+			$this->info("Application key [$key] set successfully.");
+		}
+		else
+		{
+			$this->comment($key);
+		}
+	}
+
+	/**
+	 * Update environment file with new key.
+	 *
+	 * @param  string  $key
+	 * @return void
+	 */
+	protected function updateAppKey($key)
+	{
 		foreach ([base_path('.env'), base_path('.env.example')] as $path)
 		{
 			if (file_exists($path))
@@ -40,15 +60,6 @@ class KeyGenerateCommand extends Command {
 		}
 
 		$this->laravel['config']['app.key'] = $key;
-
-		if ( ! $this->input->getOption('pretend'))
-		{
-			$this->info("Application key [$key] set successfully.");
-		}
-		else
-		{
-			$this->comment($key);
-		}
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
 
 class KeyGenerateCommand extends Command {
 
@@ -40,7 +41,14 @@ class KeyGenerateCommand extends Command {
 
 		$this->laravel['config']['app.key'] = $key;
 
-		$this->info("Application key [$key] set successfully.");
+		if ( ! $this->input->getOption('pretend'))
+		{
+			$this->info("Application key [$key] set successfully.");
+		}
+		else
+		{
+			$this->comment($key);
+		}
 	}
 
 	/**
@@ -51,6 +59,18 @@ class KeyGenerateCommand extends Command {
 	protected function getRandomKey()
 	{
 		return Str::random(32);
+	}
+
+	/**
+	 * Get the console command options.
+	 *
+	 * @return array
+	 */
+	protected function getOptions()
+	{
+		return array(
+			array('pretend', null, InputOption::VALUE_NONE, 'Generate key without updating the config file.'),
+		);
 	}
 
 }


### PR DESCRIPTION
So you can do `php artisan key:generate --pretend | pbcopy` and pipe the output to clipboard, useful when generating new key for production environment.

Signed-off-by: crynobone crynobone@gmail.com
