### PR TITLE
[5.0] Remove Unnecessary Check

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -76,7 +76,7 @@ class StartSession implements MiddlewareContract, TerminableMiddleware {
 	 */
 	public function terminate($request, $response)
 	{
-		if ($this->sessionConfigured() && ! $this->usingCookieSessions())
+		if ( ! $this->usingCookieSessions())
 		{
 			$this->manager->driver()->save();
 		}


### PR DESCRIPTION
The `usingCookieSessions()` method is already taking care of calling this check.
