### PR TITLE
[5.0] Return Collection From The Query Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -487,11 +487,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	/**
 	 * Create a collection of models from plain arrays.
 	 *
-	 * @param  array  $items
+	 * @param  array|\ArrayAccess  $items
 	 * @param  string  $connection
 	 * @return \Illuminate\Database\Eloquent\Collection
 	 */
-	public static function hydrate(array $items, $connection = null)
+	public static function hydrate($items, $connection = null)
 	{
 		$collection = with($instance = new static)->newCollection();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1287,20 +1287,18 @@ class Builder {
 	 * Execute the query and get the first result.
 	 *
 	 * @param  array   $columns
-	 * @return mixed|static
+	 * @return mixed
 	 */
 	public function first($columns = array('*'))
 	{
-		$results = $this->take(1)->get($columns);
-
-		return count($results) > 0 ? reset($results) : null;
+		return $this->take(1)->get($columns)->first();
 	}
 
 	/**
 	 * Execute the query as a "select" statement.
 	 *
 	 * @param  array  $columns
-	 * @return array|static[]
+	 * @return \Illuminate\Support\Collection
 	 */
 	public function get($columns = array('*'))
 	{
@@ -1311,13 +1309,15 @@ class Builder {
 	 * Execute the query as a fresh "select" statement.
 	 *
 	 * @param  array  $columns
-	 * @return array|static[]
+	 * @return \Illuminate\Support\Collection
 	 */
 	public function getFresh($columns = array('*'))
 	{
 		if (is_null($this->columns)) $this->columns = $columns;
 
-		return $this->processor->processSelect($this, $this->runSelect());
+		$results = $this->processor->processSelect($this, $this->runSelect());
+
+		return new Collection($results);
 	}
 
 	/**
@@ -1462,7 +1462,7 @@ class Builder {
 		// First we will just get all of the column values for the record result set
 		// then we can associate those values with the column if it was specified
 		// otherwise we can just give these values back without a specific key.
-		$results = new Collection($this->get($columns));
+		$results = $this->get($columns);
 
 		$values = $results->fetch($columns[0])->all();
 
@@ -1600,7 +1600,7 @@ class Builder {
 
 		$previousColumns = $this->columns;
 
-		$results = $this->get($columns);
+		$results = $this->get($columns)->all();
 
 		// Once we have executed the query, we will reset the aggregate property so
 		// that more select queries can be executed against the database without

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -63,7 +63,7 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface {
 	 */
 	public function all()
 	{
-		return $this->getTable()->orderBy('id', 'desc')->get();
+		return $this->getTable()->orderBy('id', 'desc')->get()->all();
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -106,7 +106,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testGetMethodLoadsModelsAndHydratesEagerRelations()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[getModels,eagerLoadRelations]', array($this->getMockQueryBuilder()));
-		$builder->shouldReceive('getModels')->with(array('foo'))->andReturn(array('bar'));
+		$builder->shouldReceive('getModels')->with(array('foo'))->andReturn(new Collection(array('bar')));
 		$builder->shouldReceive('eagerLoadRelations')->with(array('bar'))->andReturn(array('bar', 'baz'));
 		$builder->setModel($this->getMockModel());
 		$builder->getModel()->shouldReceive('newCollection')->with(array('bar', 'baz'))->andReturn(new Collection(array('bar', 'baz')));
@@ -119,7 +119,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testGetMethodDoesntHydrateEagerRelationsWhenNoResultsAreReturned()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[getModels,eagerLoadRelations]', array($this->getMockQueryBuilder()));
-		$builder->shouldReceive('getModels')->with(array('foo'))->andReturn(array());
+		$builder->shouldReceive('getModels')->with(array('foo'))->andReturn(new Collection);
 		$builder->shouldReceive('eagerLoadRelations')->never();
 		$builder->setModel($this->getMockModel());
 		$builder->getModel()->shouldReceive('newCollection')->with(array())->andReturn(new Collection(array()));
@@ -221,13 +221,13 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', array($this->getMockQueryBuilder()));
 		$records[] = array('name' => 'taylor', 'age' => 26);
 		$records[] = array('name' => 'dayle', 'age' => 28);
-		$builder->getQuery()->shouldReceive('get')->once()->with(array('foo'))->andReturn($records);
+		$builder->getQuery()->shouldReceive('get')->once()->with(array('foo'))->andReturn(new Collection($records));
 		$model = m::mock('Illuminate\Database\Eloquent\Model[getTable,getConnectionName,newInstance]');
 		$model->shouldReceive('getTable')->once()->andReturn('foo_table');
 		$builder->setModel($model);
 		$model->shouldReceive('getConnectionName')->once()->andReturn('foo_connection');
 		$model->shouldReceive('newInstance')->andReturnUsing(function() { return new EloquentBuilderTestModelStub; });
-		$models = $builder->getModels(array('foo'));
+		$models = $builder->getModels(['foo']);
 
 		$this->assertEquals('taylor', $models[0]->name);
 		$this->assertEquals($models[0]->getAttributes(), $models[0]->getOriginal());

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1101,7 +1101,7 @@ class EloquentModelDestroyStub extends Illuminate\Database\Eloquent\Model {
 }
 
 class EloquentModelHydrateRawStub extends Illuminate\Database\Eloquent\Model {
-	public static function hydrate(array $items, $connection = null) { return 'hydrated'; }
+	public static function hydrate($items, $connection = null) { return 'hydrated'; }
 	public function getConnection()
 	{
 		$mock = m::mock('Illuminate\Database\Connection');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -699,7 +699,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$sum = $builder->sum('id');
 		$this->assertEquals(2, $sum);
 		$result = $builder->get();
-		$this->assertEquals(array(array('column1' => 'foo', 'column2' => 'bar')), $result);
+		$this->assertEquals(array(array('column1' => 'foo', 'column2' => 'bar')), $result->all());
 	}
 
 
@@ -713,7 +713,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$count = $builder->count('column1');
 		$this->assertEquals(1, $count);
 		$result = $builder->select('column2', 'column3')->get();
-		$this->assertEquals(array(array('column2' => 'foo', 'column3' => 'bar')), $result);
+		$this->assertEquals(array(array('column2' => 'foo', 'column3' => 'bar')), $result->all());
 	}
 
 
@@ -727,7 +727,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$count = $builder->count('column1');
 		$this->assertEquals(1, $count);
 		$result = $builder->get(array('column2', 'column3'));
-		$this->assertEquals(array(array('column2' => 'foo', 'column3' => 'bar')), $result);
+		$this->assertEquals(array(array('column2' => 'foo', 'column3' => 'bar')), $result->all());
 	}
 
 


### PR DESCRIPTION
Eloquent's query builder already returns an Eloquent collection.

This change has the query builder itself return an instance of `Illuminate\Support\Collection`, so that you can get all of the collection's goodness when doing simple DB queries. Example:

``` php
DB::table('user')->all()->groupBy('age');
```

The next step would be to pass around the collection object in eloquent's eager loading and relation matching. Right now a simple array is being passed around all over the place, which is extremely inefficient (since arrays are passed by value).
