### PR TITLE
[4.2] Don't Perform Update Query After Force Delete

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingTrait.php
@@ -42,7 +42,7 @@ trait SoftDeletingTrait {
 	{
 		if ($this->forceDeleting)
 		{
-			$this->withTrashed()->where($this->getKeyName(), $this->getKey())->forceDelete();
+			return $this->withTrashed()->where($this->getKeyName(), $this->getKey())->forceDelete();
 		}
 
 		return $this->runSoftDelete();


### PR DESCRIPTION
In reference to #6548, this will prevent a redundant `UPDATE` query being run after a force delete is performed on a soft deleting model.
