### PR TITLE
[5.0] Env helper : get rid of symfony notation

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -504,7 +504,7 @@ if ( ! function_exists('env'))
 	{
 		$value = getenv($key);
 
-		if (false === $value) return value($default);
+		if ($value === false) return value($default);
 
 		switch (strtolower($value))
 		{


### PR DESCRIPTION
Because we all prefer Laravel notation
