### PR TITLE
[5.0] Fixed Setting The Namespace In composer.json

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -154,7 +154,7 @@ class AppNameCommand extends Command {
 	protected function setComposerNamespace()
 	{
 		$this->replaceIn(
-			$this->getComposerPath(), $this->currentRoot.'\\\\', $this->argument('name').'\\\\'
+			$this->getComposerPath(), $this->currentRoot.'\\\\', str_replace('\\', '\\\\', $this->argument('name')).'\\\\'
 		);
 	}
 


### PR DESCRIPTION
`composer.json` was being incorrectly set with an invalid PSR-4 namespace when using not single namespaces.

Examples:

> php artisan app:name Vendor\\App

was setting "Vendor\App\\" inside composer.json instead of "Vendor\\App\\".

Single names was not affected and still not being.

P.S. if you want to type the namespace on the command without the `\\`, you will need to single quote it:

> php artisan app:name 'Vendor\App'
