### PR TITLE
Note that Repository#Flush ignores cache prefix

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -108,6 +108,8 @@ class ApcStore extends TaggableStore implements StoreInterface {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush()

--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -81,6 +81,8 @@ class ApcWrapper {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush()

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -90,6 +90,8 @@ class ArrayStore extends TaggableStore implements StoreInterface {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush()

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -47,6 +47,12 @@ class ClearCommand extends Command {
 
 		$this->cache = $cache;
 		$this->files = $files;
+		$this->setHelp(wordwrap(
+			"The entire cache repository is flushed, ignoring any configured cache key prefix. "
+			. "If this application is using a shared repository "
+			. "(for example a single Redis store shared by multiple websites), "
+			. "the data cleared may not only be that set by this application."
+		));
 	}
 
 	/**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -176,6 +176,8 @@ class DatabaseStore implements StoreInterface {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush()

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -187,6 +187,8 @@ class FileStore implements StoreInterface {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush()

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -108,6 +108,8 @@ class MemcachedStore extends TaggableStore implements StoreInterface {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush()

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -83,6 +83,8 @@ class NullStore extends TaggableStore implements StoreInterface {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush()

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -123,6 +123,8 @@ class RedisStore extends TaggableStore implements StoreInterface {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush()

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -19,6 +19,8 @@ class RedisTaggedCache extends TaggedCache {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush()

--- a/src/Illuminate/Cache/StoreInterface.php
+++ b/src/Illuminate/Cache/StoreInterface.php
@@ -58,6 +58,8 @@ interface StoreInterface {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush();

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -144,6 +144,8 @@ class TaggedCache implements StoreInterface {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush()

--- a/src/Illuminate/Cache/WinCacheStore.php
+++ b/src/Illuminate/Cache/WinCacheStore.php
@@ -99,6 +99,8 @@ class WinCacheStore extends TaggableStore implements StoreInterface {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush()

--- a/src/Illuminate/Cache/XCacheStore.php
+++ b/src/Illuminate/Cache/XCacheStore.php
@@ -99,6 +99,8 @@ class XCacheStore extends TaggableStore implements StoreInterface {
 	/**
 	 * Remove all items from the cache.
 	 *
+	 * This ignores any configured cache key prefix.
+	 *
 	 * @return void
 	 */
 	public function flush()


### PR DESCRIPTION
As discussed in https://github.com/laravel/framework/issues/5034

This patch adds a warning in the docstring for the flush method and also in the help text of the `artisan cache:flush` command.

If you would prefer this to be against a different branch I can rebase.

Sister pull request to https://github.com/laravel/laravel/pull/3199
