### PR TITLE
[4.2] Fix Eloquent\Builder::where() malfunctioning inside a ScopeInterface

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1746,14 +1746,7 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function newQuery()
 	{
-		$builder = $this->newEloquentBuilder(
-			$this->newBaseQueryBuilder()
-		);
-
-		// Once we have the query builders, we will set the model instances so the
-		// builder can easily access any information it may need from the model
-		// while it is constructing and executing various queries against it.
-		$builder->setModel($this)->with($this->with);
+		$builder = $this->newQueryWithoutScopes();
 
 		return $this->applyGlobalScopes($builder);
 	}
@@ -1778,7 +1771,14 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	 */
 	public function newQueryWithoutScopes()
 	{
-		return $this->removeGlobalScopes($this->newQuery());
+		$builder = $this->newEloquentBuilder(
+			$this->newBaseQueryBuilder()
+		);
+
+		// Once we have the query builders, we will set the model instances so the
+		// builder can easily access any information it may need from the model
+		// while it is constructing and executing various queries against it.
+		return $builder->setModel($this)->with($this->with);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -143,11 +143,11 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	public function testUpdateProcess()
 	{
-		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
+		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes', 'updateTimestamps'));
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$query->shouldReceive('where')->once()->with('id', '=', 1);
 		$query->shouldReceive('update')->once()->with(array('name' => 'taylor'));
-		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 		$model->expects($this->once())->method('updateTimestamps');
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
 		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
@@ -167,11 +167,11 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	public function testUpdateProcessDoesntOverrideTimestamps()
 	{
-		$model = $this->getMock('EloquentModelStub', array('newQuery'));
+		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes'));
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$query->shouldReceive('where')->once()->with('id', '=', 1);
 		$query->shouldReceive('update')->once()->with(array('created_at' => 'foo', 'updated_at' => 'bar'));
-		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
 		$events->shouldReceive('until');
 		$events->shouldReceive('fire');
@@ -187,9 +187,9 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	public function testSaveIsCancelledIfSavingEventReturnsFalse()
 	{
-		$model = $this->getMock('EloquentModelStub', array('newQuery'));
+		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes'));
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
-		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
 		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(false);
 		$model->exists = true;
@@ -200,9 +200,9 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	public function testUpdateIsCancelledIfUpdatingEventReturnsFalse()
 	{
-		$model = $this->getMock('EloquentModelStub', array('newQuery'));
+		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes'));
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
-		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
 		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
 		$events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
@@ -215,12 +215,12 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	public function testUpdateProcessWithoutTimestamps()
 	{
-		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps', 'fireModelEvent'));
+		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes', 'updateTimestamps', 'fireModelEvent'));
 		$model->timestamps = false;
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$query->shouldReceive('where')->once()->with('id', '=', 1);
 		$query->shouldReceive('update')->once()->with(array('name' => 'taylor'));
-		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 		$model->expects($this->never())->method('updateTimestamps');
 		$model->expects($this->any())->method('fireModelEvent')->will($this->returnValue(true));
 
@@ -234,11 +234,11 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	public function testUpdateUsesOldPrimaryKey()
 	{
-		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
+		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes', 'updateTimestamps'));
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$query->shouldReceive('where')->once()->with('id', '=', 1);
 		$query->shouldReceive('update')->once()->with(array('id' => 2, 'foo' => 'bar'));
-		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 		$model->expects($this->once())->method('updateTimestamps');
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
 		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
@@ -337,10 +337,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	public function testInsertProcess()
 	{
-		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
+		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes', 'updateTimestamps'));
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$query->shouldReceive('insertGetId')->once()->with(array('name' => 'taylor'), 'id')->andReturn(1);
-		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 		$model->expects($this->once())->method('updateTimestamps');
 
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
@@ -355,10 +355,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, $model->id);
 		$this->assertTrue($model->exists);
 
-		$model = $this->getMock('EloquentModelStub', array('newQuery', 'updateTimestamps'));
+		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes', 'updateTimestamps'));
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$query->shouldReceive('insert')->once()->with(array('name' => 'taylor'));
-		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 		$model->expects($this->once())->method('updateTimestamps');
 		$model->setIncrementing(false);
 
@@ -378,9 +378,9 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	public function testInsertIsCancelledIfCreatingEventReturnsFalse()
 	{
-		$model = $this->getMock('EloquentModelStub', array('newQuery'));
+		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes'));
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
-		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 		$model->setEventDispatcher($events = m::mock('Illuminate\Events\Dispatcher'));
 		$events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
 		$events->shouldReceive('until')->once()->with('eloquent.creating: '.get_class($model), $model)->andReturn(false);
@@ -392,11 +392,11 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	public function testDeleteProperlyDeletesModel()
 	{
-		$model = $this->getMock('Illuminate\Database\Eloquent\Model', array('newQuery', 'updateTimestamps', 'touchOwners'));
+		$model = $this->getMock('Illuminate\Database\Eloquent\Model', array('newQueryWithoutScopes', 'updateTimestamps', 'touchOwners'));
 		$query = m::mock('stdClass');
 		$query->shouldReceive('where')->once()->with('id', 1)->andReturn($query);
 		$query->shouldReceive('delete')->once();
-		$model->expects($this->once())->method('newQuery')->will($this->returnValue($query));
+		$model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 		$model->expects($this->once())->method('touchOwners');
 		$model->exists = true;
 		$model->id = 1;
@@ -939,11 +939,11 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
 	public function testTimestampsAreNotUpdatedWithTimestampsFalseSaveOption()
 	{
-		$model = m::mock('EloquentModelStub[newQuery]');
+		$model = m::mock('EloquentModelStub[newQueryWithoutScopes]');
 		$query = m::mock('Illuminate\Database\Eloquent\Builder');
 		$query->shouldReceive('where')->once()->with('id', '=', 1);
 		$query->shouldReceive('update')->once()->with(array('name' => 'taylor'));
-		$model->shouldReceive('newQuery')->once()->andReturn($query);
+		$model->shouldReceive('newQueryWithoutScopes')->once()->andReturn($query);
 
 		$model->id = 1;
 		$model->syncOriginal();


### PR DESCRIPTION
Fix for issue #6116.
Currently using an advanced where inside a GlobalScope apply() method creates an enless loop because of the `->applyGlobalScopes()->removeGlobalScopes()` produced with `newQueryWithoutScopes()`.

I've moved some code to prevent this. Nothing new is added, just made sure of calling `->applyGlobalScopes()` only when needed...
