### PR TITLE
BUG? in LoadConfiguration.php

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -65,10 +65,18 @@ class LoadConfiguration {
 	{
 		$files = [];
 
-		foreach (Finder::create()->files()->name('*.php')->in($app->configPath()) as $file)
-		{
-			$files[basename($file->getRealPath(), '.php')] = $file->getRealPath();
-		}
+        	foreach (Finder::create()->files()->name('*.php')->in($app->configPath()) as $file)
+        	{
+            		if (dirname($file->getRealPath()) == $app->configPath()) {
+                		$files[basename($file->getRealPath(), '.php')] = $file->getRealPath();
+            		}
+        	}
+        	if ($app->environment() != 'production') {
+            	foreach (Finder::create()->files()->name('*.php')->in($app->configPath().'/'.$app->environment()) as $file)
+            	{
+	                $files[basename($file->getRealPath(), '.php')] = $file->getRealPath();
+        	    }
+        	}
 
 		return $files;
 	}


### PR DESCRIPTION
Think found a bug.

Since

```
Finder::create()->files()->name('*.php')->in($app->configPath())
```

goes deep in config/ folder, it will found all files named "X.php" bellow it.

For example if I have 3 environments (local, staging and testing) :
  [...]/config/X.php
  [...]/config/local/X.php
  [...]/config/staging/X.php
  [...]/config/testing/X.php
  etc.

But $files will contains just one winner : the last one (depending on the sort done by Finder), so $files will be in this case :

   $files["X"] == "[...]/config/testing/X.php"

And this will happen even if .env says APP_ENV=local.

I think that this is not what you really want.
