### PR TITLE
[4.2] 'has' clause on 'hasMany' relationships with self relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -1,5 +1,7 @@
 <?php namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Collection;
 
 class HasMany extends HasOneOrMany {
@@ -42,6 +44,53 @@ class HasMany extends HasOneOrMany {
 	public function match(array $models, Collection $results, $relation)
 	{
 		return $this->matchMany($models, $results, $relation);
+	}
+
+	/**
+	 * Add the constraints for a relationship count query.
+	 *
+	 * @param  \Illuminate\Database\Eloquent\Builder  $query
+	 * @param  \Illuminate\Database\Eloquent\Builder  $parent
+	 * @return \Illuminate\Database\Eloquent\Builder
+	 */
+	public function getRelationCountQuery(Builder $query, Builder $parent)
+	{
+		if ($parent->getQuery()->from == $query->getQuery()->from)
+		{
+			return $this->getRelationCountQueryForSelfRelation($query, $parent);
+		}
+
+		return parent::getRelationCountQuery($query, $parent);
+	}
+
+	/**
+	 * Add the constraints for a relationship count query on the same table.
+	 *
+	 * @param  \Illuminate\Database\Eloquent\Builder  $query
+	 * @param  \Illuminate\Database\Eloquent\Builder  $parent
+	 * @return \Illuminate\Database\Eloquent\Builder
+	 */
+	public function getRelationCountQueryForSelfRelation(Builder $query, Builder $parent)
+	{
+		$query->select(new Expression('count(*)'));
+
+		$tablePrefix = $this->query->getQuery()->getConnection()->getTablePrefix();
+
+		$query->from($query->getQuery()->from.' as '.$tablePrefix.$hash = $this->getRelationCountHash());
+
+		$key = $this->wrap($this->getQualifiedParentKeyName());
+
+		return $query->where($tablePrefix.$hash.'.'.$this->getPlainForeignKey(), '=', new Expression($key));
+	}
+
+	/**
+	 * Get a relationship join table hash.
+	 *
+	 * @return string
+	 */
+	public function getRelationCountHash()
+	{
+		return 'self_'.md5(microtime(true));
 	}
 
 }


### PR DESCRIPTION
"_Eloquent does not alias tables in a self join relationship_" is the title of this Liferaft issue: https://github.com/laravel/laravel/pull/3127 (brought randomly by a `liferaft grab`).

This PR seems to solve the OP issue, which uses a "hasMany" relationship.

Implementation based on https://github.com/laravel/framework/commit/16f099e0bc17d89f1e11aff6343b2999230560a3
