### PR TITLE
Add full UTF8 support to the Str::slug method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -254,24 +254,39 @@ class Str {
 	 *
 	 * @param  string  $title
 	 * @param  string  $separator
+	 * @param  bool	   $utf8
 	 * @return string
 	 */
-	public static function slug($title, $separator = '-')
+	public static function slug($title, $separator = '-', $utf8 = false)
 	{
-		$title = static::ascii($title);
+		$title = $utf8 ? $title : static::ascii($title);
 
 		// Convert all dashes/underscores into separator
 		$flip = $separator == '-' ? '_' : '-';
 
 		$title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
 
+		$title = $utf8 ? strtolower($title) : mb_strtolower($title);
+
 		// Remove all characters that are not the separator, letters, numbers, or whitespace.
-		$title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', mb_strtolower($title));
+		$title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', $title);
 
 		// Replace all separator characters and whitespace by a single separator
 		$title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
 
 		return trim($title, $separator);
+	}
+
+	/**
+	 * Generate a utf8-compatible URL friendly "slug" from a given string.
+	 *
+	 * @param $title
+	 * @param string $separator
+	 * @return string
+	 */
+	public static function lightSlug($title, $separator = '-')
+	{
+		return static::slug($title, $separator, true);
 	}
 
 	/**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -280,8 +280,8 @@ class Str {
 	/**
 	 * Generate a utf8-compatible URL friendly "slug" from a given string.
 	 *
-	 * @param $title
-	 * @param string $separator
+	 * @param  string $title
+	 * @param  string $separator
 	 * @return string
 	 */
 	public static function lightSlug($title, $separator = '-')

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -85,6 +85,10 @@ class SupportStrTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('hello-world', Str::slug('hello-world'));
 		$this->assertEquals('hello-world', Str::slug('hello_world'));
 		$this->assertEquals('hello_world', Str::slug('hello_world', '_'));
+		$this->assertEquals('سلام-دنیا', Str::slug('سلام دنیا', '-', true));
+		$this->assertEquals('سلام-دنیا', Str::slug('سلام-دنیا', '-', true));
+		$this->assertEquals('سلام_دنیا', Str::slug('سلام_دنیا', '_', true));
+		$this->assertEquals('سلام-دنیا', Str::slug('سلام_دنیا', '-', true));
 	}
 
 


### PR DESCRIPTION
I have made a request to this problem before in [Pull request #6204](https://github.com/laravel/framework/pull/6204) .
The current `Str::slug()` method returns an empty string for strings like `سلام دنیا`, this is due to converting the string to `ASCII` and also using `mb_strtolower` function.
