### PR TITLE
Collection::sum() just sums values when no parameter is supplied

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -623,7 +623,7 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	{
 		if (is_null($callback))
 		{
-			$callback = function($item) { return $item; };
+			return array_sum($this->items);
 		}
 
 		if (is_string($callback))

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -619,8 +619,13 @@ class Collection implements ArrayAccess, ArrayableInterface, Countable, Iterator
 	 * @param  \Closure  $callback
 	 * @return mixed
 	 */
-	public function sum($callback)
+	public function sum($callback = null)
 	{
+		if (is_null($callback))
+		{
+			$callback = function($item) { return $item; };
+		}
+
 		if (is_string($callback))
 		{
 			$callback = $this->valueRetriever($callback);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -425,6 +425,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testCanSumValuesWithoutACallback()
+	{
+		$c = new Collection(array(1, 2, 3, 4, 5));
+		$this->assertEquals(15, $c->sum());
+	}
+
+
 	public function testValueRetrieverAcceptsDotNotation()
 	{
 		$c = new Collection(array(


### PR DESCRIPTION
Calling `sum()` on a collection without passing a parameter will just
sum the values in the collection.
