### PR TITLE
Update PHP dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "classpreloader/classpreloader": "~1.0.2",
         "d11wtq/boris": "~1.0",
         "ircmaxell/password-compat": "~1.0",


### PR DESCRIPTION
`password_hash` method is only available for PHP >= 5.5.0 according to related [PHP docs](http://php.net/manual/fr/function.password-hash.php)
