### PR TITLE
[5.0] Use Dotenv exception

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Foundation\Bootstrap;
 
 use Dotenv;
+use InvalidArgumentException;
 use Illuminate\Contracts\Foundation\Application;
 
 class DetectEnvironment {
@@ -13,9 +14,13 @@ class DetectEnvironment {
 	 */
 	public function bootstrap(Application $app)
 	{
-		if (file_exists($app['path.base'].'/.env'))
+		try
 		{
 			Dotenv::load($app['path.base']);
+		}
+		catch (InvalidArgumentException $e)
+		{
+			//
 		}
 
 		$app->detectEnvironment(function()


### PR DESCRIPTION
Use Dotenv InvalidArgumentException when .env file does not exist.
This PR will also allow to use other config loaders on Dotenv v2
