### PR TITLE
[5.0] Paginator : do not check for collection

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -37,7 +37,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
 		$this->perPage = $perPage;
 		$this->currentPage = $this->setCurrentPage($currentPage);
 		$this->path = $this->path != '/' ? rtrim($this->path, '/').'/' : $this->path;
-		$this->items = $items instanceof Collection ? $items : Collection::make($items);
+		$this->items = new Collection($items);
 
 		$this->checkForMorePages();
 	}


### PR DESCRIPTION
As `getArrayableItems` already do this check
https://github.com/laravel/framework/blob/master/src/Illuminate/Support/Collection.php#L873
