### PR TITLE
[5.0] Remove getStringSize() on Validator class

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -964,20 +964,7 @@ class Validator implements ValidatorContract {
 			return $value->getSize() / 1024;
 		}
 
-		return $this->getStringSize($value);
-	}
-
-	/**
-	 * Get the size of a string.
-	 *
-	 * @param  string  $value
-	 * @return int
-	 */
-	protected function getStringSize($value)
-	{
-		if (function_exists('mb_strlen')) return mb_strlen($value);
-
-		return strlen($value);
+		return mb_strlen($value);
 	}
 
 	/**


### PR DESCRIPTION
Now mbstring is required: https://github.com/laravel/framework/blob/master/composer.json#L16
