### PR TITLE
Update naming convention for helpers.php

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -559,11 +559,11 @@ if ( ! function_exists('env'))
 			case '(false)':
 				return false;
 
-                        case 'null':
+			case 'null':
 			case '(null)':
 				return null;
 
-                        case 'empty':
+			case 'empty':
 			case '(empty)':
 				return '';
 		}

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -559,9 +559,11 @@ if ( ! function_exists('env'))
 			case '(false)':
 				return false;
 
+                        case 'null':
 			case '(null)':
 				return null;
 
+                        case 'empty':
 			case '(empty)':
 				return '';
 		}


### PR DESCRIPTION
Provide same naming convention to `null` and `empty` as already exists for `false` and `true`
