### PR TITLE
[5.0] Addition of findOrNew, firstOrNew, firstOrCreate, updateOrCreate to relevant relations.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -513,6 +513,78 @@ class BelongsToMany extends Relation {
 	}
 
 	/**
+	 * Find a related model by its primary key or return new instance of the related model.
+	 *
+	 * @param  mixed  $id
+	 * @param  array  $columns
+	 * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
+	 */
+	public function findOrNew($id, $columns = array('*'))
+	{
+		if (is_null($instance = $this->find($id, $columns)))
+		{
+			$instance = $this->getRelated()->newInstance();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get the first related model record matching the attributes or instantiate it.
+	 *
+	 * @param  array  $attributes
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function firstOrNew(array $attributes)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->related->newInstance();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get the first related record matching the attributes or create it.
+	 *
+	 * @param  array  $attributes
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function firstOrCreate(array $attributes, array $joining = array(), $touch = true)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->create($attributes, $joining, $touch);
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Create or update a related record matching the attributes, and fill it with values.
+	 *
+	 * @param  array  $attributes
+	 * @param  array  $values
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function updateOrCreate(array $attributes, array $values = array(), array $joining = array(), $touch = true)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->create($values, $joining, $touch);
+		}
+		else
+		{
+			$instance->fill($values);
+
+			$instance->save(array('touch' => false));
+		}
+
+		return $instance;
+	}
+
+	/**
 	 * Create a new instance of the related model.
 	 *
 	 * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -519,7 +519,7 @@ class BelongsToMany extends Relation {
 	 * @param  array  $columns
 	 * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
 	 */
-	public function findOrNew($id, $columns = array('*'))
+	public function findOrNew($id, $columns = ['*'])
 	{
 		if (is_null($instance = $this->find($id, $columns)))
 		{
@@ -551,7 +551,7 @@ class BelongsToMany extends Relation {
 	 * @param  array  $attributes
 	 * @return \Illuminate\Database\Eloquent\Model
 	 */
-	public function firstOrCreate(array $attributes, array $joining = array(), $touch = true)
+	public function firstOrCreate(array $attributes, array $joining = [], $touch = true)
 	{
 		if (is_null($instance = $this->where($attributes)->first()))
 		{
@@ -568,18 +568,16 @@ class BelongsToMany extends Relation {
 	 * @param  array  $values
 	 * @return \Illuminate\Database\Eloquent\Model
 	 */
-	public function updateOrCreate(array $attributes, array $values = array(), array $joining = array(), $touch = true)
+	public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
 	{
 		if (is_null($instance = $this->where($attributes)->first()))
 		{
-			$instance = $this->create($values, $joining, $touch);
+			return $this->create($values, $joining, $touch);
 		}
-		else
-		{
-			$instance->fill($values);
 
-			$instance->save(array('touch' => false));
-		}
+		$instance->fill($values);
+
+		$instance->save(['touch' => false]);
 
 		return $instance;
 	}

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -189,7 +189,7 @@ abstract class HasOneOrMany extends Relation {
 	 * @param  array  $columns
 	 * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
 	 */
-	public function findOrNew($id, $columns = array('*'))
+	public function findOrNew($id, $columns = ['*'])
 	{
 		if (is_null($instance = $this->find($id, $columns)))
 		{
@@ -242,7 +242,7 @@ abstract class HasOneOrMany extends Relation {
 	 * @param  array  $values
 	 * @return \Illuminate\Database\Eloquent\Model
 	 */
-	public function updateOrCreate(array $attributes, array $values = array())
+	public function updateOrCreate(array $attributes, array $values = [])
 	{
 		$instance = $this->firstOrNew($attributes);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -183,6 +183,77 @@ abstract class HasOneOrMany extends Relation {
 	}
 
 	/**
+	 * Find a model by its primary key or return new instance of the related model.
+	 *
+	 * @param  mixed  $id
+	 * @param  array  $columns
+	 * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
+	 */
+	public function findOrNew($id, $columns = array('*'))
+	{
+		if (is_null($instance = $this->find($id, $columns)))
+		{
+			$instance = $this->related->newInstance();
+
+			$instance->setAttribute($this->getPlainForeignKey(), $this->getParentKey());
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get the first related model record matching the attributes or instantiate it.
+	 *
+	 * @param  array  $attributes
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function firstOrNew(array $attributes)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->related->newInstance();
+
+			$instance->setAttribute($this->getPlainForeignKey(), $this->getParentKey());
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get the first related record matching the attributes or create it.
+	 *
+	 * @param  array  $attributes
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function firstOrCreate(array $attributes)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->create($attributes);
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Create or update a related record matching the attributes, and fill it with values.
+	 *
+	 * @param  array  $attributes
+	 * @param  array  $values
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function updateOrCreate(array $attributes, array $values = array())
+	{
+		$instance = $this->firstOrNew($attributes);
+
+		$instance->fill($values);
+
+		$instance->save();
+
+		return $instance;
+	}
+
+	/**
 	 * Create a new instance of the related model.
 	 *
 	 * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -94,6 +94,83 @@ abstract class MorphOneOrMany extends HasOneOrMany {
 	}
 
 	/**
+	 * Find a related model by its primary key or return new instance of the related model.
+	 *
+	 * @param  mixed  $id
+	 * @param  array  $columns
+	 * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
+	 */
+	public function findOrNew($id, $columns = array('*'))
+	{
+		if (is_null($instance = $this->find($id, $columns)))
+		{
+			$instance = $this->related->newInstance();
+
+			// When saving a polymorphic relationship, we need to set not only the foreign
+			// key, but also the foreign key type, which is typically the class name of
+			// the parent model. This makes the polymorphic item unique in the table.
+			$this->setForeignAttributesForCreate($instance);
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get the first related model record matching the attributes or instantiate it.
+	 *
+	 * @param  array  $attributes
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function firstOrNew(array $attributes)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->related->newInstance();
+
+			// When saving a polymorphic relationship, we need to set not only the foreign
+			// key, but also the foreign key type, which is typically the class name of
+			// the parent model. This makes the polymorphic item unique in the table.
+			$this->setForeignAttributesForCreate($instance);
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get the first related record matching the attributes or create it.
+	 *
+	 * @param  array  $attributes
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function firstOrCreate(array $attributes)
+	{
+		if (is_null($instance = $this->where($attributes)->first()))
+		{
+			$instance = $this->create($attributes);
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Create or update a related record matching the attributes, and fill it with values.
+	 *
+	 * @param  array  $attributes
+	 * @param  array  $values
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function updateOrCreate(array $attributes, array $values = array())
+	{
+		$instance = $this->firstOrNew($attributes);
+
+		$instance->fill($values);
+
+		$instance->save();
+
+		return $instance;
+	}
+
+	/**
 	 * Create a new instance of the related model.
 	 *
 	 * @param  array  $attributes

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -100,7 +100,7 @@ abstract class MorphOneOrMany extends HasOneOrMany {
 	 * @param  array  $columns
 	 * @return \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Model
 	 */
-	public function findOrNew($id, $columns = array('*'))
+	public function findOrNew($id, $columns = ['*'])
 	{
 		if (is_null($instance = $this->find($id, $columns)))
 		{
@@ -159,7 +159,7 @@ abstract class MorphOneOrMany extends HasOneOrMany {
 	 * @param  array  $values
 	 * @return \Illuminate\Database\Eloquent\Model
 	 */
-	public function updateOrCreate(array $attributes, array $values = array())
+	public function updateOrCreate(array $attributes, array $values = [])
 	{
 		$instance = $this->firstOrNew($attributes);
 

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -271,6 +271,85 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($model, $relation->create(array('attributes'), array('joining')));
 	}
 
+	public function testFindOrNewMethodFindsModel()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('find'), $this->getRelationArguments());
+		$relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue($model = m::mock('StdClass')));
+		$relation->getRelated()->shouldReceive('newInstance')->never();
+
+		$this->assertTrue($relation->findOrNew('foo') instanceof StdClass);
+	}
+
+	public function testFindOrNewMethodReturnsNewModel()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('find'), $this->getRelationArguments());
+		$relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue(null));
+		$relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'));
+
+		$this->assertTrue($relation->findOrNew('foo') instanceof StdClass);
+	}
+
+	public function testFirstOrNewMethodFindsFirstModel()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('where'), $this->getRelationArguments());
+		$relation->expects($this->once())->method('where')->with(array('foo'))->will($this->returnValue($relation->getQuery()));
+		$relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
+		$relation->getRelated()->shouldReceive('newInstance')->never();
+
+		$this->assertTrue($relation->firstOrNew(array('foo')) instanceof StdClass);
+	}
+
+	public function testFirstOrNewMethodReturnsNewModel()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('where'), $this->getRelationArguments());
+		$relation->expects($this->once())->method('where')->with(array('foo'))->will($this->returnValue($relation->getQuery()));
+		$relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
+		$relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'));
+
+		$this->assertTrue($relation->firstOrNew(array('foo')) instanceof StdClass);
+	}
+
+	public function testFirstOrCreateMethodFindsFirstModel()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('where','create'), $this->getRelationArguments());
+		$relation->expects($this->once())->method('where')->with(array('foo'))->will($this->returnValue($relation->getQuery()));
+		$relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
+		$relation->expects($this->never())->method('create')->with(array('foo'))->will($this->returnValue(null));
+
+		$this->assertTrue($relation->firstOrCreate(array('foo')) instanceof StdClass);
+	}
+
+	public function testFirstOrCreateMethodReturnsNewModel()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('where','create'), $this->getRelationArguments());
+		$relation->expects($this->once())->method('where')->with(array('foo'))->will($this->returnValue($relation->getQuery()));
+		$relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
+		$relation->expects($this->once())->method('create')->with(array('foo'))->will($this->returnValue($model = m::mock('StdClass')));
+
+		$this->assertTrue($relation->firstOrCreate(array('foo')) instanceof StdClass);
+	}
+
+	public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('where','create'), $this->getRelationArguments());
+		$relation->expects($this->once())->method('where')->with(array('foo'))->will($this->returnValue($relation->getQuery()));
+		$relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
+		$model->shouldReceive('fill')->once();
+		$model->shouldReceive('save')->once();
+		$relation->expects($this->never())->method('create')->with(array('foo'))->will($this->returnValue(null));
+
+		$this->assertTrue($relation->updateOrCreate(array('foo')) instanceof StdClass);
+	}
+
+	public function testUpdateOrCreateMethodReturnsNewModel()
+	{
+		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('where','create'), $this->getRelationArguments());
+		$relation->expects($this->once())->method('where')->with(array('bar'))->will($this->returnValue($relation->getQuery()));
+		$relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
+		$relation->expects($this->once())->method('create')->with(array('foo'))->will($this->returnValue($model = m::mock('StdClass')));
+
+		$this->assertTrue($relation->updateOrCreate(array('bar'),array('foo')) instanceof StdClass);
+	}
 
 	/**
 	 * @dataProvider syncMethodListProvider

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -23,6 +23,94 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($created, $relation->create(array('name' => 'taylor')));
 	}
 
+	public function testFindOrNewMethodFindsModel()
+	{
+		$relation = $this->getRelation();
+		$relation->getQuery()->shouldReceive('find')->once()->with('foo', array('*'))->andReturn($model = m::mock('StdClass'));
+		$model->shouldReceive('setAttribute')->never();
+
+		$this->assertTrue($relation->findOrNew('foo') instanceof StdClass);
+	}
+
+	public function testFindOrNewMethodReturnsNewModelWithForeignKeySet()
+	{
+		$relation = $this->getRelation();
+		$relation->getQuery()->shouldReceive('find')->once()->with('foo', array('*'))->andReturn(null);
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('StdClass'));
+		$model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
+
+		$this->assertTrue($relation->findOrNew('foo') instanceof StdClass);
+	}
+
+	public function testFirstOrNewMethodFindsFirstModel()
+	{
+		$relation = $this->getRelation();
+		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('StdClass'));
+		$model->shouldReceive('setAttribute')->never();
+
+		$this->assertTrue($relation->firstOrNew(array('foo')) instanceof StdClass);
+	}
+
+	public function testFirstOrNewMethodReturnsNewModelWithForeignKeySet()
+	{
+		$relation = $this->getRelation();
+		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('StdClass'));
+		$model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
+
+		$this->assertTrue($relation->firstOrNew(array('foo')) instanceof StdClass);
+	}
+
+	public function testFirstOrCreateMethodFindsFirstModel()
+	{
+		$relation = $this->getRelation();
+		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('StdClass'));
+		$relation->getRelated()->shouldReceive('newInstance')->never();
+		$model->shouldReceive('setAttribute')->never();
+		$model->shouldReceive('save')->never();
+
+		$this->assertTrue($relation->firstOrCreate(array('foo')) instanceof StdClass);
+	}
+
+	public function testFirstOrCreateMethodCreatesNewModelWithForeignKeySet()
+	{
+		$relation = $this->getRelation();
+		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('foo'))->andReturn($model = m::mock('StdClass'));
+		$model->shouldReceive('save')->once()->andReturn(true);
+		$model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
+
+		$this->assertTrue($relation->firstOrCreate(array('foo')) instanceof StdClass);
+	}
+
+	public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
+	{
+		$relation = $this->getRelation();
+		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('StdClass'));
+		$relation->getRelated()->shouldReceive('newInstance')->never();
+		$model->shouldReceive('fill')->once()->with(array('bar'));
+		$model->shouldReceive('save')->once();
+
+		$this->assertTrue($relation->updateOrCreate(array('foo'),array('bar')) instanceof StdClass);
+	}
+
+	public function testUpdateOrCreateMethodCreatesNewModelWithForeignKeySet()
+	{
+		$relation = $this->getRelation();
+		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('StdClass'));
+		$model->shouldReceive('save')->once()->andReturn(true);
+		$model->shouldReceive('fill')->once()->with(array('bar'));
+		$model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
+
+		$this->assertTrue($relation->updateOrCreate(array('foo'),array('bar')) instanceof StdClass);
+	}
 
 	public function testUpdateMethodUpdatesModelsWithTimestamps()
 	{

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
@@ -69,6 +70,105 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($created, $relation->create(array('name' => 'taylor')));
 	}
 
+	public function testFindOrNewMethodFindsModel()
+	{
+		$relation = $this->getOneRelation();
+		$relation->getQuery()->shouldReceive('find')->once()->with('foo', array('*'))->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getRelated()->shouldReceive('newInstance')->never();
+		$model->shouldReceive('setAttribute')->never();
+		$model->shouldReceive('save')->never();
+
+		$this->assertTrue($relation->findOrNew('foo') instanceof Model);
+	}
+
+	public function testFindOrNewMethodReturnsNewModelWithMorphKeysSet()
+	{
+		$relation = $this->getOneRelation();
+		$relation->getQuery()->shouldReceive('find')->once()->with('foo', array('*'))->andReturn(null);
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+		$model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+		$model->shouldReceive('save')->never();
+
+		$this->assertTrue($relation->findOrNew('foo') instanceof Model);
+	}
+
+	public function testFirstOrNewMethodFindsFirstModel()
+	{
+		$relation = $this->getOneRelation();
+		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getRelated()->shouldReceive('newInstance')->never();
+		$model->shouldReceive('setAttribute')->never();
+		$model->shouldReceive('save')->never();
+
+		$this->assertTrue($relation->firstOrNew(array('foo')) instanceof Model);
+	}
+
+	public function testFirstOrNewMethodReturnsNewModelWithMorphKeysSet()
+	{
+		$relation = $this->getOneRelation();
+		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+		$model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+		$model->shouldReceive('save')->never();
+
+		$this->assertTrue($relation->firstOrNew(array('foo')) instanceof Model);
+	}
+
+	public function testFirstOrCreateMethodFindsFirstModel()
+	{
+		$relation = $this->getOneRelation();
+		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getRelated()->shouldReceive('newInstance')->never();
+		$model->shouldReceive('setAttribute')->never();
+		$model->shouldReceive('save')->never();
+
+		$this->assertTrue($relation->firstOrCreate(array('foo')) instanceof Model);
+	}
+
+	public function testFirstOrCreateMethodCreatesNewMorphModel()
+	{
+		$relation = $this->getOneRelation();
+		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('foo'))->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+		$model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+		$model->shouldReceive('save')->once()->andReturn(true);
+
+		$this->assertTrue($relation->firstOrCreate(array('foo')) instanceof Model);
+	}
+
+	public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
+	{
+		$relation = $this->getOneRelation();
+		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getRelated()->shouldReceive('newInstance')->never();
+		$model->shouldReceive('setAttribute')->never();
+		$model->shouldReceive('fill')->once()->with(array('bar'));
+		$model->shouldReceive('save')->once();
+
+		$this->assertTrue($relation->updateOrCreate(array('foo'),array('bar')) instanceof Model);
+	}
+
+	public function testUpdateOrCreateMethodCreatesNewMorphModel()
+	{
+		$relation = $this->getOneRelation();
+		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+		$model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
+		$model->shouldReceive('save')->once()->andReturn(true);
+		$model->shouldReceive('fill')->once()->with(array('bar'));
+
+		$this->assertTrue($relation->updateOrCreate(array('foo'),array('bar')) instanceof Model);
+	}
 
 	protected function getOneRelation()
 	{


### PR DESCRIPTION
As discussed in [pull request 6658](https://github.com/laravel/framework/pull/6658) I've created the tests and pushed this to the master branch. I've also updated the initial request on the 4.2 branch with working tests.

This pull request adds the  `findOrNew`, `firstOrNew`, `firstOrCreate`, `updateOrCreate` functions to the `BelongsToMany`, `HasOneOrMany` and `MorphOneOrMany` eloquent relationships.

Thank you!
