### PR TITLE
[4.2] change paginate mode's last_page to be 1 when the items is empty.

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -144,6 +144,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 		else
 		{
 			$this->lastPage = (int) ceil($this->total / $this->perPage);
+			$this->lastPage = ($this->lastPage > 0) ? $this->lastPage : 1;
 
 			$this->currentPage = $this->calculateCurrentPage($this->lastPage);
 		}

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -143,8 +143,7 @@ class Paginator implements ArrayableInterface, ArrayAccess, Countable, IteratorA
 		}
 		else
 		{
-			$this->lastPage = (int) ceil($this->total / $this->perPage);
-			$this->lastPage = ($this->lastPage > 0) ? $this->lastPage : 1;
+			$this->lastPage = max((int) ceil($this->total / $this->perPage), 1);
 
 			$this->currentPage = $this->calculateCurrentPage($this->lastPage);
 		}

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -21,6 +21,7 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, $p->getCurrentPage());
 	}
 
+
 	public function testPaginationContextIsSetupCorrectlyWithEmptyItems()
 	{
 		$p = new Paginator($factory = m::mock('Illuminate\Pagination\Factory'), array(), 0, 2);

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -21,6 +21,16 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, $p->getCurrentPage());
 	}
 
+	public function testPaginationContextIsSetupCorrectlyWithEmptyItems()
+	{
+		$p = new Paginator($factory = m::mock('Illuminate\Pagination\Factory'), array(), 0, 2);
+		$factory->shouldReceive('getCurrentPage')->once()->andReturn(1);
+		$p->setupPaginationContext();
+
+		$this->assertEquals(1, $p->getLastPage());
+		$this->assertEquals(1, $p->getCurrentPage());
+	}
+
 
 	public function testSimplePagination()
 	{


### PR DESCRIPTION
When the items is empty, both `current_page` and `last_page` will be `1` with simple paginate mode.
But in paginate mode, the `current_page` will be `1` and the `last_page` is `0`, this a little puzzled me.
I just change the `last_page` to be `1`, just list simple paginate does.
