### PR TITLE
Testing ApplicationTrait should assign the env

### DIFF
--- a/src/Illuminate/Foundation/Testing/ApplicationTrait.php
+++ b/src/Illuminate/Foundation/Testing/ApplicationTrait.php
@@ -26,9 +26,9 @@ trait ApplicationTrait {
 	 */
 	protected function refreshApplication()
 	{
-		$this->app = $this->createApplication();
-
 		putenv('APP_ENV=testing');
+		
+		$this->app = $this->createApplication();
 	}
 
 	/**


### PR DESCRIPTION
Testing ApplicationTrait should assign the env before creating the application
