### PR TITLE
Require symfony/var-dumper package in Illuminate/Support

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -13,7 +13,8 @@
         "ext-mbstring": "*",
         "illuminate/contracts": "5.0.*",
         "doctrine/inflector": "~1.0",
-        "danielstjules/stringy": "~1.5"
+        "danielstjules/stringy": "~1.5",
+        "symfony/var-dumper": "2.6.*"
     },
     "require-dev": {
         "jeremeamia/superclosure": "~1.0.1"


### PR DESCRIPTION
Fix 

```
Fatal error: Class 'Symfony\Component\VarDumper\Dumper\CliDumper' not found in /home/vagrant/Projects/todo_server/vendor/illuminate/support/Debug/Dumper.php on line 16
```

(or some others classes)
on separate use Illuminate/Support
