### PR TITLE
Add toSentence() method to the Collection class

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -739,10 +739,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 *
 	 * @param  string  $key
 	 * @param  string  $wordsConnector
+	 * @param  string  $twoWordsConnector
 	 * @param  string  $lastWordConnector
 	 * @return string
 	 */
-	public function toSentence($key, $wordsConnector = ', ', $lastWordConnector = ' and ')
+	public function toSentence($key, $wordsConnector = ', ', $twoWordsConnector = ' and ', $lastWordConnector = ', and ')
 	{
 		switch ($this->count()) 
 		{
@@ -753,7 +754,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 				return array_get($this->first(), $key);
 
 			case 2:
-				return $this->implode($key, $lastWordConnector);
+				return $this->implode($key, $twoWordsConnector);
 
 			default:
 				$lastWord = $this->pop();

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -735,6 +735,33 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	}
 
 	/**
+	 * Get a collection of items as a sentence.
+	 *
+	 * @param  string  $key
+	 * @param  string  $wordsConnector
+	 * @param  string  $lastWordConnector
+	 * @return string
+	 */
+	public function toSentence($key, $wordsConnector = ', ', $lastWordConnector = ' and ')
+	{
+		switch ($this->count()) 
+		{
+			case 0:
+				return '';
+
+			case 1:
+				return array_get($this->first(), $key);
+
+			case 2:
+				return $this->implode($key, $lastWordConnector);
+
+			default:
+				$lastWord = $this->pop();
+				return $this->implode($key, $wordsConnector) . $lastWordConnector . array_get($lastWord, $key);
+		}
+	}
+
+	/**
 	 * Get the collection of items as a plain array.
 	 *
 	 * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -46,6 +46,22 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testToSentence()
+	{
+		$c = new Collection;
+		$this->assertEquals('', $c->toSentence('key'));
+
+		$c = new Collection([['key' => 'foo']]);
+		$this->assertEquals('foo', $c->toSentence('key'));
+
+		$c = new Collection([['key' => 'foo'], ['key' => 'bar']]);
+		$this->assertEquals('foo and bar', $c->toSentence('key'));
+
+		$c = new Collection([['key' => 'foo'], ['key' => 'bar'], ['key' => 'bat']]);
+		$this->assertEquals('foo, bar and bat', $c->toSentence('key'));
+	}
+
+
 	public function testToArrayCallsToArrayOnEachItemInCollection()
 	{
 		$item1 = m::mock('Illuminate\Contracts\Support\Arrayable');

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -58,7 +58,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo and bar', $c->toSentence('key'));
 
 		$c = new Collection([['key' => 'foo'], ['key' => 'bar'], ['key' => 'bat']]);
-		$this->assertEquals('foo, bar and bat', $c->toSentence('key'));
+		$this->assertEquals('foo, bar, and bat', $c->toSentence('key'));
 	}
 
 


### PR DESCRIPTION
As described in #6889, this adds a helper method to the base Collection class that makes it easy to build a sentence.

Ideally I'd imagine the default connectors should come from a translation file, but would appreciate some feedback on this (especially as though it would require the addition of the default connectors to the `laravel/laravel` language files).
