### PR TITLE
[5.0] Added remaining Filesystem tests

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -137,32 +137,163 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testGetFiles()
+	/**
+	 * @expectedException Illuminate\Contracts\Filesystem\FileNotFoundException
+	 */
+	public function testGetThrowsExceptionNonexisitingFile()
 	{
-		mkdir(__DIR__.'/tmp', 0777, true);
-		file_put_contents(__DIR__.'/tmp/foo.txt', '');
-		file_put_contents(__DIR__.'/tmp/bar.txt', '');
-		mkdir(__DIR__.'/tmp/nested', 0777, true);
-		file_put_contents(__DIR__.'/tmp/nested/baz.txt', '');
-
-		$fileSystem = new Filesystem;
-
-		$directories = [
-			__DIR__.'/tmp/nested',
-		];
-		$this->assertSame($directories, $fileSystem->directories(__DIR__.'/tmp'));
-
-		$files = [
-			__DIR__.'/tmp/bar.txt',
-			__DIR__.'/tmp/foo.txt',
-		];
-		$this->assertSame($files, $fileSystem->files(__DIR__.'/tmp'));
-
-		unlink(__DIR__.'/tmp/nested/baz.txt');
-		rmdir(__DIR__.'/tmp/nested');
-		unlink(__DIR__.'/tmp/bar.txt');
-		unlink(__DIR__.'/tmp/foo.txt');
-		rmdir(__DIR__.'/tmp');
+		$files = new Filesystem;
+		$files->get(__DIR__.'/unknown-file.txt');
 	}
+
+
+	public function testGetRequireReturnsProperly()
+	{
+		file_put_contents(__DIR__.'/file.php', '<?php return "Howdy?"; ?>');
+		$files = new Filesystem;
+		$this->assertEquals('Howdy?',$files->getRequire(__DIR__.'/file.php'));
+		@unlink(__DIR__.'/file.php');
+	}
+
+
+	/**
+	 * @expectedException Illuminate\Contracts\Filesystem\FileNotFoundException
+	 */
+	public function testGetRequireThrowsExceptionNonexisitingFile()
+	{
+		$files = new Filesystem;
+		$files->getRequire(__DIR__.'/file.php');
+	}
+
+
+	public function testAppendAddsDataToFile()
+	{
+		file_put_contents(__DIR__.'/file.txt', 'foo');
+		$files = new Filesystem;
+		$bytesWritten = $files->append(__DIR__.'/file.txt','bar');
+		$this->assertEquals(mb_strlen('bar','8bit'),$bytesWritten);
+		$this->assertFileExists(__DIR__.'/file.txt');
+		$this->assertStringEqualsFile(__DIR__.'/file.txt','foobar');
+		@unlink(__DIR__.'/file.txt');
+	}
+
+
+	public function testMoveMovesFiles()
+	{
+		file_put_contents(__DIR__.'/foo.txt', 'foo');
+		$files = new Filesystem;
+		$files->move(__DIR__.'/foo.txt',__DIR__.'/bar.txt');
+		$this->assertFileExists(__DIR__.'/bar.txt');
+		$this->assertFileNotExists(__DIR__.'/foo.txt');
+		@unlink(__DIR__.'/bar.txt');
+	}
+
+
+	public function testExtensionReturnsExtension()
+	{
+		file_put_contents(__DIR__.'/foo.txt', 'foo');
+		$files = new Filesystem;
+		$this->assertEquals('txt',$files->extension(__DIR__.'/foo.txt'));
+		@unlink(__DIR__.'/foo.txt');
+	}
+
+
+	public function testTypeIndentifiesFile()
+	{
+		file_put_contents(__DIR__.'/foo.txt', 'foo');
+		$files = new Filesystem;
+		$this->assertEquals('file',$files->type(__DIR__.'/foo.txt'));
+		@unlink(__DIR__.'/foo.txt');
+	}
+
+
+	public function testTypeIndentifiesDirectory()
+	{
+		mkdir(__DIR__.'/foo');
+		$files = new Filesystem;
+		$this->assertEquals('dir',$files->type(__DIR__.'/foo'));
+		@rmdir(__DIR__.'/foo');
+	}
+
+
+	public function testSizeOutputsSize()
+	{
+		$size = file_put_contents(__DIR__.'/foo.txt', 'foo');
+		$files = new Filesystem;
+		$this->assertEquals($size,$files->size(__DIR__.'/foo.txt'));
+		@unlink(__DIR__.'/foo.txt');
+	}
+
+
+	public function testLastModified()
+	{
+		$time = time();
+		file_put_contents(__DIR__.'/foo.txt', 'foo');
+		$files = new Filesystem;
+		$this->assertEquals($time,$files->lastModified(__DIR__.'/foo.txt'));
+		@unlink(__DIR__.'/foo.txt');
+	}
+
+
+	public function testIsWritable()
+	{
+		file_put_contents(__DIR__.'/foo.txt', 'foo');
+		$files = new Filesystem;
+		@chmod(__DIR__.'/foo.txt', 0444);
+		$this->assertFalse($files->isWritable(__DIR__.'/foo.txt'));
+		@chmod(__DIR__.'/foo.txt', 0777);
+		$this->assertTrue($files->isWritable(__DIR__.'/foo.txt'));
+		@unlink(__DIR__.'/foo.txt');
+	}
+
+
+	public function testGlobFindsFiles()
+	{
+		file_put_contents(__DIR__.'/foo.txt', 'foo');
+		file_put_contents(__DIR__.'/bar.txt', 'bar');
+		$files = new Filesystem;
+		$glob = $files->glob(__DIR__.'/*.txt');
+		$this->assertContains(__DIR__.'/foo.txt',$glob);
+		$this->assertContains(__DIR__.'/bar.txt',$glob);
+		@unlink(__DIR__.'/foo.txt');
+		@unlink(__DIR__.'/bar.txt');
+	}
+
+
+	public function testAllFilesFindsFiles()
+	{
+		file_put_contents(__DIR__.'/foo.txt', 'foo');
+		file_put_contents(__DIR__.'/bar.txt', 'bar');
+		$files = new Filesystem;
+		$allFiles = [];
+		foreach($files->allFiles(__DIR__) as $file)
+			$allFiles[] = $file->getFilename();
+		$this->assertContains('foo.txt',$allFiles);
+		$this->assertContains('bar.txt',$allFiles);
+		@unlink(__DIR__.'/foo.txt');
+		@unlink(__DIR__.'/bar.txt');
+	}
+
+
+	public function testDirectoriesFindsDirectories()
+	{
+		mkdir(__DIR__.'/foo');
+		mkdir(__DIR__.'/bar');
+		$files = new Filesystem;
+		$directories = $files->directories(__DIR__);
+		$this->assertContains(__DIR__.DIRECTORY_SEPARATOR.'foo',$directories);
+		$this->assertContains(__DIR__.DIRECTORY_SEPARATOR.'bar',$directories);
+		@rmdir(__DIR__.'/foo');
+		@rmdir(__DIR__.'/bar');
+	}
+
+	public function testMakeDirectory()
+	{
+		$files = new Filesystem;
+		$this->assertTrue($files->makeDirectory(__DIR__.'/foo'));
+		$this->assertFileExists(__DIR__.'/foo');
+		@rmdir(__DIR__.'/foo');
+	}
+
 
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -151,7 +151,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 	{
 		file_put_contents(__DIR__.'/file.php', '<?php return "Howdy?"; ?>');
 		$files = new Filesystem;
-		$this->assertEquals('Howdy?',$files->getRequire(__DIR__.'/file.php'));
+		$this->assertEquals('Howdy?', $files->getRequire(__DIR__.'/file.php'));
 		@unlink(__DIR__.'/file.php');
 	}
 
@@ -170,10 +170,10 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 	{
 		file_put_contents(__DIR__.'/file.txt', 'foo');
 		$files = new Filesystem;
-		$bytesWritten = $files->append(__DIR__.'/file.txt','bar');
-		$this->assertEquals(mb_strlen('bar','8bit'),$bytesWritten);
+		$bytesWritten = $files->append(__DIR__.'/file.txt', 'bar');
+		$this->assertEquals(mb_strlen('bar', '8bit'), $bytesWritten);
 		$this->assertFileExists(__DIR__.'/file.txt');
-		$this->assertStringEqualsFile(__DIR__.'/file.txt','foobar');
+		$this->assertStringEqualsFile(__DIR__.'/file.txt', 'foobar');
 		@unlink(__DIR__.'/file.txt');
 	}
 
@@ -182,7 +182,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 	{
 		file_put_contents(__DIR__.'/foo.txt', 'foo');
 		$files = new Filesystem;
-		$files->move(__DIR__.'/foo.txt',__DIR__.'/bar.txt');
+		$files->move(__DIR__.'/foo.txt', __DIR__.'/bar.txt');
 		$this->assertFileExists(__DIR__.'/bar.txt');
 		$this->assertFileNotExists(__DIR__.'/foo.txt');
 		@unlink(__DIR__.'/bar.txt');
@@ -193,7 +193,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 	{
 		file_put_contents(__DIR__.'/foo.txt', 'foo');
 		$files = new Filesystem;
-		$this->assertEquals('txt',$files->extension(__DIR__.'/foo.txt'));
+		$this->assertEquals('txt', $files->extension(__DIR__.'/foo.txt'));
 		@unlink(__DIR__.'/foo.txt');
 	}
 
@@ -202,7 +202,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 	{
 		file_put_contents(__DIR__.'/foo.txt', 'foo');
 		$files = new Filesystem;
-		$this->assertEquals('file',$files->type(__DIR__.'/foo.txt'));
+		$this->assertEquals('file', $files->type(__DIR__.'/foo.txt'));
 		@unlink(__DIR__.'/foo.txt');
 	}
 
@@ -211,7 +211,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 	{
 		mkdir(__DIR__.'/foo');
 		$files = new Filesystem;
-		$this->assertEquals('dir',$files->type(__DIR__.'/foo'));
+		$this->assertEquals('dir', $files->type(__DIR__.'/foo'));
 		@rmdir(__DIR__.'/foo');
 	}
 
@@ -220,7 +220,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 	{
 		$size = file_put_contents(__DIR__.'/foo.txt', 'foo');
 		$files = new Filesystem;
-		$this->assertEquals($size,$files->size(__DIR__.'/foo.txt'));
+		$this->assertEquals($size, $files->size(__DIR__.'/foo.txt'));
 		@unlink(__DIR__.'/foo.txt');
 	}
 
@@ -230,7 +230,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 		$time = time();
 		file_put_contents(__DIR__.'/foo.txt', 'foo');
 		$files = new Filesystem;
-		$this->assertEquals($time,$files->lastModified(__DIR__.'/foo.txt'));
+		$this->assertEquals($time, $files->lastModified(__DIR__.'/foo.txt'));
 		@unlink(__DIR__.'/foo.txt');
 	}
 
@@ -253,8 +253,8 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 		file_put_contents(__DIR__.'/bar.txt', 'bar');
 		$files = new Filesystem;
 		$glob = $files->glob(__DIR__.'/*.txt');
-		$this->assertContains(__DIR__.'/foo.txt',$glob);
-		$this->assertContains(__DIR__.'/bar.txt',$glob);
+		$this->assertContains(__DIR__.'/foo.txt', $glob);
+		$this->assertContains(__DIR__.'/bar.txt', $glob);
 		@unlink(__DIR__.'/foo.txt');
 		@unlink(__DIR__.'/bar.txt');
 	}
@@ -266,10 +266,12 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 		file_put_contents(__DIR__.'/bar.txt', 'bar');
 		$files = new Filesystem;
 		$allFiles = [];
-		foreach($files->allFiles(__DIR__) as $file)
+		foreach ($files->allFiles(__DIR__) as $file)
+		{
 			$allFiles[] = $file->getFilename();
-		$this->assertContains('foo.txt',$allFiles);
-		$this->assertContains('bar.txt',$allFiles);
+		}
+		$this->assertContains('foo.txt', $allFiles);
+		$this->assertContains('bar.txt', $allFiles);
 		@unlink(__DIR__.'/foo.txt');
 		@unlink(__DIR__.'/bar.txt');
 	}
@@ -281,8 +283,8 @@ class FilesystemTest extends PHPUnit_Framework_TestCase {
 		mkdir(__DIR__.'/bar');
 		$files = new Filesystem;
 		$directories = $files->directories(__DIR__);
-		$this->assertContains(__DIR__.DIRECTORY_SEPARATOR.'foo',$directories);
-		$this->assertContains(__DIR__.DIRECTORY_SEPARATOR.'bar',$directories);
+		$this->assertContains(__DIR__.DIRECTORY_SEPARATOR.'foo', $directories);
+		$this->assertContains(__DIR__.DIRECTORY_SEPARATOR.'bar', $directories);
 		@rmdir(__DIR__.'/foo');
 		@rmdir(__DIR__.'/bar');
 	}


### PR DESCRIPTION
I've removed the `testGetFiles()` because the same logic is implemented in two different test cases, `testDirectoriesFindsDirectories()` and `testFilesMethod()`.
