### PR TITLE
[5.0] fix wrong @param namespace comment - Router

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -56,7 +56,7 @@ class Kernel implements KernelContract {
 	 * Create a new HTTP kernel instance.
 	 *
 	 * @param  \Illuminate\Contracts\Foundation\Application  $app
-	 * @param  \Illuminate\Contracts\Routing\Registrar  $router
+	 * @param  \Illuminate\Routing\Router  $router
 	 * @return void
 	 */
 	public function __construct(Application $app, Router $router)


### PR DESCRIPTION
wrong namespace comment on __construct function.
In Illuminate\Foundation\Http\Kernel.php file
Router namespace was wrong. 

I fix it.
