### PR TITLE
[L5] Feature/automagically pull in env vars

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -51,7 +51,7 @@ class LoadConfiguration {
 	{
 		foreach ($this->getConfigurationFiles($app) as $key => $path)
 		{
-			$config->set($key, require $path);
+			$config->set($key, $this->pullInEnvVariables($key, require $path));
 		}
 	}
 
@@ -71,6 +71,22 @@ class LoadConfiguration {
 		}
 
 		return $files;
+	}
+
+	/**
+	 * Pull in any set environment variables that overwirtes the config values
+	 *
+	 * @param  string $key
+	 * @param  array  $config
+	 * @return array
+	 */
+	protected function pullInEnvVariables($key, Array $config)
+	{
+		foreach (array_dot($config) as $dot_notation_index => $default_value) {
+			array_set($config, $dot_notation_index, env("$key.$dot_notation_index", $default_value));
+		}
+
+		return $config;
 	}
 
 }

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -74,7 +74,7 @@ class LoadConfiguration {
 	}
 
 	/**
-	 * Pull in any set environment variables that overwirtes the config values
+	 * Pull in any set environment variables that overwrites the config values
 	 *
 	 * @param  string $key
 	 * @param  array  $config


### PR DESCRIPTION
As more & more variables in the configs are going to need to be replaceable with environment specific variables, the configs are going to end up with env() for every value.  This change looks for dot notation environment variables and pulls them in over the configuration value, so all of the env() calls can be removed from the config files.
