### PR TITLE
[5.0] Trim trailing slash from forced root URL

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -560,7 +560,7 @@ class UrlGenerator implements UrlGeneratorContract {
 	 */
 	public function forceRootUrl($root)
 	{
-		$this->forcedRoot = $root;
+		$this->forcedRoot = rtrim($root, '/');
 	}
 
 	/**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -290,9 +290,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$url->forceRootUrl('https://www.bar.com');
 		$this->assertEquals('http://www.bar.com/foo/bar', $url->to('foo/bar'));
 
-		/**
-		 * Ensure trailing / is trimmed from root URL as UrlGenerator already handles this
-		 */
+		// Ensure trailing slash is trimmed from root URL as UrlGenerator already handles this
 		$url->forceRootUrl('http://www.foo.com/');
 		$this->assertEquals('http://www.foo.com/bar', $url->to('/bar'));
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -290,6 +290,11 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$url->forceRootUrl('https://www.bar.com');
 		$this->assertEquals('http://www.bar.com/foo/bar', $url->to('foo/bar'));
 
+		/**
+		 * Ensure trailing / is trimmed from root URL as UrlGenerator already handles this
+		 */
+		$url->forceRootUrl('http://www.foo.com/');
+		$this->assertEquals('http://www.foo.com/bar', $url->to('/bar'));
 
 		/**
 		 * Route Based...
@@ -331,4 +336,3 @@ class RoutableInterfaceStub implements UrlRoutable {
 	public function getRouteKey() { return $this->{$this->getRouteKeyName()}; }
 	public function getRouteKeyName() { return 'key'; }
 }
-


### PR DESCRIPTION
Not sure if this goes against the idea of forcing a URL, but today I noticed when you force a root URL with a trailing slash invalid URLs are then generated. You would end up with something like http://www.bar.com//foo

On a side note, the schema is also not forced from the root URL, although I assume that should be the case because of the forceSchema() function?
