### PR TITLE
[4.2] Correctly identify the end of a custom blade function

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -639,7 +639,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function createMatcher($function)
 	{
-		return '/(?<!\w)(\s*)@'.$function.'(\s*\(.*\))/';
+		return '/(?<!\w)(\s*)@'.$function.'(\s*\([^)]*\))/';
 	}
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -421,6 +421,7 @@ empty
 		$this->assertEquals('bar', $compiler->compileString('foo'));
 	}
 
+	
 	public function testCustomBladeFunctionIsUsable()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
@@ -429,6 +430,7 @@ empty
 		$this->assertEquals('biz(bar)', preg_replace($pattern, "biz$2", $compiler->compileString('@foo(bar)')));
 	}
 
+
 	public function testCustomBladeFunctionIsUsableMultipleTimes()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
@@ -436,6 +438,7 @@ empty
 
 		$this->assertEquals('biz(bar)biz(bar)', preg_replace($pattern, "biz$2", $compiler->compileString('@foo(bar)@foo(bar)')));
 	}
+
 
 	public function testConfiguringContentTags()
 	{

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -421,6 +421,21 @@ empty
 		$this->assertEquals('bar', $compiler->compileString('foo'));
 	}
 
+	public function testCustomBladeFunctionIsUsable()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$pattern = $compiler->createMatcher('foo');
+
+		$this->assertEquals('biz(bar)', preg_replace($pattern, "biz$2", $compiler->compileString('@foo(bar)')));
+	}
+
+	public function testCustomBladeFunctionIsUsableMultipleTimes()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$pattern = $compiler->createMatcher('foo');
+
+		$this->assertEquals('biz(bar)biz(bar)', preg_replace($pattern, "biz$2", $compiler->compileString('@foo(bar)@foo(bar)')));
+	}
 
 	public function testConfiguringContentTags()
 	{


### PR DESCRIPTION
The current regex returned from `BladeCompiler::createMatcher` finds the last `)` in the file. It should find the first one so we know when the function call ends.
