### PR TITLE
Added queue name checking to dispatchers.

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -126,7 +126,21 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
 			throw new \RuntimeException("Queue resolver did not return a Queue implementation.");
 		}
 
-		$queue->push($command);
+		$queue->push($command, '', $this->getQueueName($command));
+	}
+
+	/**
+	 * Gets the queue name from a given class, if available.
+	 *
+	 * @param  string|object  $class
+	 *
+	 * @return null|string
+	 */
+	protected function getQueueName($class)
+	{
+		if ( ! is_string($class)) $class = get_class($class);
+
+		return defined($class.'::QUEUE') ? $class::QUEUE : null;
 	}
 
 	/**

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -395,8 +395,22 @@ class Dispatcher implements DispatcherContract {
 		{
 			$this->resolveQueue()->push('Illuminate\Events\CallQueuedHandler@call', [
 				'class' => $class, 'method' => $method, 'data' => serialize(func_get_args()),
-			]);
+			], $this->getQueueName($class));
 		};
+	}
+
+	/**
+	 * Gets the queue name from a given class, if available.
+	 *
+	 * @param  string|object  $class
+	 *
+	 * @return null|string
+	 */
+	protected function getQueueName($class)
+	{
+		if ( ! is_string($class)) $class = get_class($class);
+
+		return defined($class.'::QUEUE') ? $class::QUEUE : null;
 	}
 
 	/**


### PR DESCRIPTION
This adds the ability to send dispatched events or commands to a named queue by defining a QUEUE constant on the class that implements "ShouldBeQueued" like so:

``` php
class SendPaymentEmail implements  Illuminate\Contracts\Queue\ShouldBeQueued {
    const QUEUE = 'email';
    public function handle(PaymentProcessedEvent $event) {
        //do whatever
    }
}
```

If the constant is not provided, the default queue will be used.
