### PR TITLE
[5.0] Fixed Resource Method Name Generator

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -212,7 +212,7 @@ class ResourceRegistrar {
 	 */
 	protected function getGroupResourceName($prefix, $resource, $method)
 	{
-		$group = str_replace('/', '.', $this->router->getLastGroupPrefix());
+		$group = trim(str_replace('/', '.', $this->router->getLastGroupPrefix()), '.');
 
 		return trim("{$prefix}{$group}.{$resource}.{$method}", '.');
 	}


### PR DESCRIPTION
Fixed invalid resources names if 'as' parameter defined and parent group has autoprefixed

For example 

```
  $router->group(['namespace' => 'ApiControllers\v1'], function($router) {
    $router->group(['middleware' => ['oauth']], function($router) {
            $router->resource('/v1/user', 'UserController', [
                'as' => 'api',
            ]);
            $router->resource('/v1/user.webSite', 'WebSiteController', [
                'as' => 'api',
            ]);
    });
  });
```

Before trimming the dots this code produce route names like this "api..v1.user.index"
