### PR TITLE
[5.0] Remove use of unused `php artisan migrate --path` option, and remove `$packagePath`.

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -30,23 +30,16 @@ class MigrateCommand extends BaseCommand {
 	protected $migrator;
 
 	/**
-	 * The path to the packages directory (vendor).
-	 */
-	protected $packagePath;
-
-	/**
 	 * Create a new migration command instance.
 	 *
 	 * @param  \Illuminate\Database\Migrations\Migrator  $migrator
-	 * @param  string  $packagePath
 	 * @return void
 	 */
-	public function __construct(Migrator $migrator, $packagePath)
+	public function __construct(Migrator $migrator)
 	{
 		parent::__construct();
 
 		$this->migrator = $migrator;
-		$this->packagePath = $packagePath;
 	}
 
 	/**
@@ -114,8 +107,6 @@ class MigrateCommand extends BaseCommand {
 			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
 
 			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
-
-			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to migration files.', null),
 
 			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -29,13 +29,6 @@ class MigrateMakeCommand extends BaseCommand {
 	protected $creator;
 
 	/**
-	 * The path to the packages directory (vendor).
-	 *
-	 * @var string
-	 */
-	protected $packagePath;
-
-	/**
 	 * @var \Illuminate\Foundation\Composer
 	 */
 	protected $composer;
@@ -45,16 +38,14 @@ class MigrateMakeCommand extends BaseCommand {
 	 *
 	 * @param  \Illuminate\Database\Migrations\MigrationCreator  $creator
 	 * @param  \Illuminate\Foundation\Composer  $composer
-	 * @param  string  $packagePath
 	 * @return void
 	 */
-	public function __construct(MigrationCreator $creator, Composer $composer, $packagePath)
+	public function __construct(MigrationCreator $creator, Composer $composer)
 	{
 		parent::__construct();
 
 		$this->creator = $creator;
 		$this->composer = $composer;
-		$this->packagePath = $packagePath;
 	}
 
 	/**
@@ -121,8 +112,6 @@ class MigrateMakeCommand extends BaseCommand {
 	{
 		return array(
 			array('create', null, InputOption::VALUE_OPTIONAL, 'The table to be created.'),
-
-			array('path', null, InputOption::VALUE_OPTIONAL, 'Where to store the migration.', null),
 
 			array('table', null, InputOption::VALUE_OPTIONAL, 'The table to migrate.'),
 		);

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -108,9 +108,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	{
 		$this->app->singleton('command.migrate', function($app)
 		{
-			$packagePath = $app['path.base'].'/vendor';
-
-			return new MigrateCommand($app['migrator'], $packagePath);
+			return new MigrateCommand($app['migrator']);
 		});
 	}
 
@@ -190,11 +188,9 @@ class MigrationServiceProvider extends ServiceProvider {
 			// creation of the migrations, and may be extended by these developers.
 			$creator = $app['migration.creator'];
 
-			$packagePath = $app['path.base'].'/vendor';
-
 			$composer = $app['composer'];
 
-			return new MigrateMakeCommand($creator, $composer, $packagePath);
+			return new MigrateMakeCommand($creator, $composer);
 		});
 	}
 


### PR DESCRIPTION
No reason to keep this when it been decided not to support package migration natively,

Reference: https://github.com/laravel/framework/issues/6911#issuecomment-68728037

Signed-off-by: crynobone crynobone@gmail.com
