### PR TITLE
[5.0] Rework of the resolving and resolvingAny method on container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -676,7 +676,7 @@ class Container implements ArrayAccess, ContainerContract {
 			$this->instances[$abstract] = $object;
 		}
 
-		$this->fireResolvingCallbacks($object);
+		$this->fireResolvingCallbacks($abstract, $object);
 
 		$this->resolved[$abstract] = true;
 
@@ -1029,16 +1029,17 @@ class Container implements ArrayAccess, ContainerContract {
 	/**
 	 * Fire all of the resolving callbacks.
 	 *
+	 * @param  string  $abstract
 	 * @param  mixed   $object
 	 * @return void
 	 */
-	protected function fireResolvingCallbacks($object)
+	protected function fireResolvingCallbacks($abstract, $object)
 	{
 		$this->fireCallbackArray($object, $this->globalResolvingCallbacks);
 
 		$this->fireCallbackArray(
 			$object, $this->getCallbacksForType(
-				$object, $this->resolvingCallbacks
+				$abstract, $object, $this->resolvingCallbacks
 			)
 		);
 
@@ -1046,7 +1047,7 @@ class Container implements ArrayAccess, ContainerContract {
 
 		$this->fireCallbackArray(
 			$object, $this->getCallbacksForType(
-				$object, $this->afterResolvingCallbacks
+				$abstract, $object, $this->afterResolvingCallbacks
 			)
 		);
 	}
@@ -1054,18 +1055,19 @@ class Container implements ArrayAccess, ContainerContract {
 	/**
 	 * Get all callbacks for a given type.
 	 *
+	 * @param  string  $abstract
 	 * @param  object  $object
 	 * @param  array   $callbacksPerType
 	 *
 	 * @return array
 	 */
-	protected function getCallbacksForType($object, array $callbacksPerType)
+	protected function getCallbacksForType($abstract, $object, array $callbacksPerType)
 	{
 		$results = [];
 
 		foreach ($callbacksPerType as $type => $callbacks)
 		{
-			if ($object instanceof $type)
+			if ($type === $abstract || $object instanceof $type)
 			{
 				$results = array_merge($results, $callbacks);
 			}

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -129,14 +129,6 @@ interface Container {
 	 * @param  \Closure  $callback
 	 * @return void
 	 */
-	public function resolving($abstract, Closure $callback);
-
-	/**
-	 * Register a new resolving callback for all types.
-	 *
-	 * @param  \Closure  $callback
-	 * @return void
-	 */
-	public function resolvingAny(Closure $callback);
+	public function resolving($abstract, Closure $callback = null);
 
 }

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -131,4 +131,13 @@ interface Container {
 	 */
 	public function resolving($abstract, Closure $callback = null);
 
+	/**
+	 * Register a new after resolving callback.
+	 *
+	 * @param  string    $abstract
+	 * @param  \Closure  $callback
+	 * @return void
+	 */
+	public function afterResolving($abstract, Closure $callback = null);
+
 }

--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -25,18 +25,14 @@ class FormRequestServiceProvider extends ServiceProvider {
 	{
 		$this->app['events']->listen('router.matched', function()
 		{
-			$this->app->resolvingAny(function($resolved, $app)
+			$this->app->resolving(function(FormRequest $request, $app)
 			{
-				// If the resolved instance is an instance of the FormRequest object, we will go
-				// ahead and initialize the request as well as set a few dependencies on this
-				// request instance. The "ValidatesWhenResolved" hook will fire "validate".
-				if ($resolved instanceof FormRequest)
-				{
-					$this->initializeRequest($resolved, $app['request']);
+				// We will go ahead and initialize the request as well as set a few dependencies
+				// on this request instance. The "ValidatesWhenResolved" hook will fire "validate".
+				$this->initializeRequest($request, $app['request']);
 
-					$resolved->setContainer($app)
-                             ->setRedirector($app['Illuminate\Routing\Redirector']);
-				}
+				$request->setContainer($app)
+                        ->setRedirector($app['Illuminate\Routing\Redirector']);
 			});
 		});
 	}

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -26,12 +26,9 @@ class ValidationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerValidationResolverHook()
 	{
-		$this->app->afterResolvingAny(function($resolved)
+		$this->app->afterResolving(function(ValidatesWhenResolved $resolved)
 		{
-			if ($resolved instanceof ValidatesWhenResolved)
-			{
-				$resolved->validate();
-			}
+			$resolved->validate();
 		});
 	}
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -262,7 +262,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	public function testResolvingCallbacksAreCalled()
 	{
 		$container = new Container;
-		$container->resolvingAny(function($object) { return $object->name = 'taylor'; });
+		$container->resolving(function($object) { return $object->name = 'taylor'; });
 		$container->bind('foo', function() { return new StdClass; });
 		$instance = $container->make('foo');
 
@@ -273,7 +273,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	public function testResolvingCallbacksAreCalledForType()
 	{
 		$container = new Container;
-		$container->resolvingType('StdClass', function($object) { return $object->name = 'taylor'; });
+		$container->resolving('StdClass', function($object) { return $object->name = 'taylor'; });
 		$container->bind('foo', function() { return new StdClass; });
 		$instance = $container->make('foo');
 


### PR DESCRIPTION
- The basic usage of `$app->resolving('Vendor\Class', function ($object) {...})` still works.
- The first parameter of `$app->resolving` is now optional. If it is left out it will look at the type hint of the first argument of the callable. `$app->resolving(function (\Vendor\Class $object) {...})` equals `$app->resolving('Vendor\Class', function ($object) {...})`, except the latter doesn't use the Reflection API.
- `$app->resolvingAny(function ($object) {...})` is removed and replaced with `$app->resolving(function ($object) {...})` (mind that no type hint is used).

The same is true for `afterResolving` and `afterResolvingAny` (the latter is also removed).

So the interface now looks like this:

``` php
interface Container
{
    ...
    public function resolving($abstract, Closure $callback = null);
    public function afterResolving($abstract, Closure $callback = null);
}
```

Some examples.

``` php
// Register a callback for executing on every resolve
$container->afterResolving(function ($object)
{
    // Called for every resolved object.
});

// Register a callback to be called when an object of a specific type is resolved.
$container->afterResolving(GuzzleHttp\Client::class, function ($guzzle)
{
    // Called when a GuzzleHttp\Client is resolved from the container.
});

// Also works for subtypes.
$container->afterResolving(Illuminate\Contracts\Filesystem\Filesystem::class, function ($fs)
{
    // Called when an object of type Illuminate\Contracts\Filesystem\Filesystem is resolved.
});

// Also works with type hinting.
$container->afterResolving(function (Illuminate\Contracts\Filesystem\Filesystem $fs)
{
    // Called when an object of type Illuminate\Contracts\Filesystem\Filesystem is resolved.
});
```
