### PR TITLE
[5.0] Limit the depth of the config file finder

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -65,7 +65,7 @@ class LoadConfiguration {
 	{
 		$files = [];
 
-		foreach (Finder::create()->files()->name('*.php')->in($app->configPath()) as $file)
+		foreach (Finder::create()->files()->name('*.php')->in($app->configPath())->depth('== 0') as $file)
 		{
 			$files[basename($file->getRealPath(), '.php')] = $file->getRealPath();
 		}


### PR DESCRIPTION
Currently, it is possible to break a Laravel 5 application by placing subdirectories inside `/config`, which could potentially be confusing for people coming from Laravel 4 expecting that the config system will work the same way.

One simple example:

Create the following file inside a Laravel app: `config/testing/app.php`:

``` php
<?php

return [];
```

This will cause the app to break since the Finder inside `Illuminate\Foundation\Bootstrap\LoadConfiguration` will recursively traverse directories, which causes files with the same name to replace those in upper directories.

This pull request just tells the finder to limit the search to the root level of `/config`
