### PR TITLE
[5.0] Use raw array to load relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -153,7 +153,7 @@ class BelongsToMany extends Relation {
 
 		$select = $this->getSelectColumns($columns);
 
-		$models = $this->query->addSelect($select)->getModels();
+		$models = $this->query->addSelect($select)->getModels()->all();
 
 		$this->hydratePivotRelation($models);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -205,7 +205,7 @@ class HasManyThrough extends Relation {
 		// models with the result of those columns as a separate model relation.
 		$select = $this->getSelectColumns($columns);
 
-		$models = $this->query->addSelect($select)->getModels();
+		$models = $this->query->addSelect($select)->getModels()->all();
 
 		// If we actually found models we will also eager load any relationships that
 		// have been specified as needing to be eager loaded. This will solve the

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
@@ -25,7 +26,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getRelation();
 		$relation->getParent()->shouldReceive('getConnectionName')->andReturn('foo.connection');
 		$relation->getQuery()->shouldReceive('addSelect')->once()->with(array('roles.*', 'user_role.user_id as pivot_user_id', 'user_role.role_id as pivot_role_id'))->andReturn($relation->getQuery());
-		$relation->getQuery()->shouldReceive('getModels')->once()->andReturn($models);
+		$relation->getQuery()->shouldReceive('getModels')->once()->andReturn(new BaseCollection($models));
 		$relation->getQuery()->shouldReceive('eagerLoadRelations')->once()->with($models)->andReturn($models);
 		$relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function($array) { return new Collection($array); });
 		$relation->getQuery()->shouldReceive('getQuery')->once()->andReturn($baseBuilder);
@@ -69,7 +70,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 			'user_role.created_at as pivot_created_at',
 			'user_role.updated_at as pivot_updated_at',
 		))->andReturn($relation->getQuery());
-		$relation->getQuery()->shouldReceive('getModels')->once()->andReturn($models);
+		$relation->getQuery()->shouldReceive('getModels')->once()->andReturn(new BaseCollection($models));
 		$relation->getQuery()->shouldReceive('eagerLoadRelations')->once()->with($models)->andReturn($models);
 		$relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function($array) { return new Collection($array); });
 		$relation->getQuery()->shouldReceive('getQuery')->once()->andReturn($baseBuilder);


### PR DESCRIPTION
Since `getModels` [now returns a collection](https://github.com/laravel/framework/pull/6803), we need to get the raw array to pass to the hydration/eager loading methods.
