### PR TITLE
[5.0] [Proposal] Allow snake_case when marshalling command

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -2,6 +2,7 @@
 
 use Closure;
 use ArrayAccess;
+use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionParameter;
 use Illuminate\Support\Collection;
@@ -166,7 +167,9 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
 	 */
 	protected function extractValueFromSource(ArrayAccess $source, ReflectionParameter $parameter)
 	{
-		return array_get($source, $parameter->name);
+		$name = $parameter->name;
+
+		return array_get($source, $name, array_get($source, Str::snake($name)));
 	}
 
 	/**

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -100,6 +100,26 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('taylor otwell', $result);
 	}
 
+
+	public function testDispatchingFromArrayAccess()
+	{
+		$instance = new Dispatcher(new Container);
+		$source = new Container();
+		$source->firstName = 'taylor';
+		$result = $instance->dispatchFrom('BusDispatcherTestSelfHandlingCommand', $source, ['lastName' => 'otwell']);
+		$this->assertEquals('taylor otwell', $result);
+	}
+
+
+	public function testDispatchingFromArrayAccessChecksSnakeCase()
+	{
+		$instance = new Dispatcher(new Container);
+		$source = new Container();
+		$source->first_name = 'taylor';
+		$result = $instance->dispatchFrom('BusDispatcherTestSelfHandlingCommand', $source, ['lastName' => 'otwell']);
+		$this->assertEquals('taylor otwell', $result);
+	}
+
 }
 
 class BusDispatcherTestBasicCommand {


### PR DESCRIPTION
When marshalling command, it would be beneficial to check for a version of the constructor parameter in snake_case within the source.  It is common for Request objects to contain snake_case variables.  I believe this was mentioned as a potential feature in a recent screencast by @taylorotwell 
