### PR TITLE
[5.0] Improve ext-mbstring Requirements In composer.json Files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-mcrypt": "*",
         "ext-mbstring": "*",
         "classpreloader/classpreloader": "~1.0.2",
-        "danielstjules/stringy": "~1.5",
+        "danielstjules/stringy": "~1.8",
         "d11wtq/boris": "~1.0",
         "doctrine/inflector": "~1.0",
         "ircmaxell/password-compat": "~1.0",

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-mbstring": "*",
         "illuminate/contracts": "5.0.*",
         "illuminate/http": "5.0.*",
         "illuminate/session": "5.0.*",

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -15,6 +15,9 @@
         "symfony/finder": "2.6.*",
         "league/flysystem": "~1.0"
     },
+    "require-dev": {
+        "ext-mbstring": "*",
+    },
     "autoload": {
         "psr-4": {
             "Illuminate\\Filesystem\\": ""

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -13,7 +13,7 @@
         "ext-mbstring": "*",
         "illuminate/contracts": "5.0.*",
         "doctrine/inflector": "~1.0",
-        "danielstjules/stringy": "~1.5"
+        "danielstjules/stringy": "~1.8"
     },
     "require-dev": {
         "jeremeamia/superclosure": "~1.0.1"

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-mbstring": "*",
         "illuminate/filesystem": "5.0.*",
         "illuminate/support": "5.0.*",
         "symfony/translation": "2.6.*"

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-mbstring": "*",
         "illuminate/container": "5.0.*",
         "illuminate/contracts": "5.0.*",
         "illuminate/support": "5.0.*",


### PR DESCRIPTION
Thankfully, a simple search for "mb_" in files does the job.

By the way, Stringy compatibility has been improved (refs https://github.com/danielstjules/Stringy/pull/57).
