### PR TITLE
[5.0] Make validateNewPassword() public

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -190,7 +190,7 @@ class PasswordBroker implements PasswordBrokerContract {
 	 * @param  array  $credentials
 	 * @return bool
 	 */
-	protected function validateNewPassword(array $credentials)
+	public function validateNewPassword(array $credentials)
 	{
 		list($password, $confirm) = [
 			$credentials['password'], $credentials['password_confirmation']

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -65,4 +65,12 @@ interface PasswordBroker {
 	 */
 	public function validator(Closure $callback);
 
+	/**
+	 * Determine if the passwords match for the request.
+	 *
+	 * @param  array  $credentials
+	 * @return bool
+	 */
+	public function validateNewPassword(array $credentials);
+
 }


### PR DESCRIPTION
When implementing a change password behavior it would be nice to use the same method that is used in the reset forgotten password behavior to check if the new password is valid and if present call another custom validator set by `PasswordBroker::validator`.

To do this the `PasswordBroker::validateNewPassword` method needs to be made `public`.
