### PR TITLE
[5.0] Remove hardcoded cache filename

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -20,7 +20,7 @@ class LoadConfiguration {
 		// First we will see if we have a cache configuration file. If we do, we'll load
 		// the configuration items from that file so that it is very quick. Otherwise
 		// we will need to spin through every configuration file and load them all.
-		if (file_exists($cached = storage_path('framework/config.php')))
+		if (file_exists($cached = $app->getCachedConfigPath()))
 		{
 			$items = require $cached;
 


### PR DESCRIPTION
That filename is already hardcoded and exposed in the application class.
