### PR TITLE
[5.0] Overriding Raw Tags

### DIFF
--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -169,6 +169,17 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testShortRawEchosAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$compiler->setRawTags('{{', '}}');
+		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{$name}}'));
+		$this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{ $name }}'));
+		$this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{{$name}}}'));
+		$this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{{ $name }}}'));
+	}
+
+
 	public function testExtendsAreCompiled()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
Since the switch to escaping content in double braces I've seen it suggested that `Blade::setRawTags("{{", "}}");` will restore previous functionality.
However this isn't the case as rawTags are compiled first, meaning that a triple brace now leaves dangling braces (`<?php echo { $name; ?>}`)

This pr handles this by sorting all 3 echo compiles by their length. Then in cases where the length is equal, priority is still given to rawTags.

Giving priority to rawTags over escaped feels a little off, but I guess the only time this would matter is if a developer writes:

``` php
Blade::setRawTags("{{", "}}");
Blade::setEscapedContentTags("{{", "}}");
```
