### PR TITLE
[5.0] Fix queries with whereIn and empty arrays

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -306,6 +306,8 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function whereIn(Builder $query, $where)
 	{
+		if (empty($where['values'])) return '0';
+
 		$values = $this->parameterize($where['values']);
 
 		return $this->wrap($where['column']).' in ('.$values.')';
@@ -320,6 +322,8 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function whereNotIn(Builder $query, $where)
 	{
+		if (empty($where['values'])) return '1';
+
 		$values = $this->parameterize($where['values']);
 
 		return $this->wrap($where['column']).' not in ('.$values.')';
@@ -376,7 +380,7 @@ class Grammar extends BaseGrammar {
 	{
 		return $this->wrap($where['column']).' is not null';
 	}
-	
+
 	/**
 	 * Compile a "where date" clause.
 	 *
@@ -388,7 +392,7 @@ class Grammar extends BaseGrammar {
 	{
 		return $this->dateBasedWhere('date', $query, $where);
 	}
-	
+
 	/**
 	 * Compile a "where day" clause.
 	 *

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -306,7 +306,7 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function whereIn(Builder $query, $where)
 	{
-		if (empty($where['values'])) return '0';
+		if (empty($where['values'])) return '0=1';
 
 		$values = $this->parameterize($where['values']);
 
@@ -322,7 +322,7 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function whereNotIn(Builder $query, $where)
 	{
-		if (empty($where['values'])) return '1';
+		if (empty($where['values'])) return '1=1';
 
 		$values = $this->parameterize($where['values']);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -306,12 +306,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereIn('id', array());
-		$this->assertEquals('select * from "users" where 0', $builder->toSql());
+		$this->assertEquals('select * from "users" where 0=1', $builder->toSql());
 		$this->assertEquals(array(), $builder->getBindings());
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', array());
-		$this->assertEquals('select * from "users" where "id" = ? or 0', $builder->toSql());
+		$this->assertEquals('select * from "users" where "id" = ? or 0=1', $builder->toSql());
 		$this->assertEquals(array(0 => 1), $builder->getBindings());
 	}
 
@@ -320,12 +320,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->whereNotIn('id', array());
-		$this->assertEquals('select * from "users" where 1', $builder->toSql());
+		$this->assertEquals('select * from "users" where 1=1', $builder->toSql());
 		$this->assertEquals(array(), $builder->getBindings());
 
 		$builder = $this->getBuilder();
 		$builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotIn('id', array());
-		$this->assertEquals('select * from "users" where "id" = ? or 1', $builder->toSql());
+		$this->assertEquals('select * from "users" where "id" = ? or 1=1', $builder->toSql());
 		$this->assertEquals(array(0 => 1), $builder->getBindings());
 	}
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -302,6 +302,34 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testEmptyWhereIns()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->whereIn('id', array());
+		$this->assertEquals('select * from "users" where 0', $builder->toSql());
+		$this->assertEquals(array(), $builder->getBindings());
+
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', array());
+		$this->assertEquals('select * from "users" where "id" = ? or 0', $builder->toSql());
+		$this->assertEquals(array(0 => 1), $builder->getBindings());
+	}
+
+
+	public function testEmptyWhereNotIns()
+	{
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->whereNotIn('id', array());
+		$this->assertEquals('select * from "users" where 1', $builder->toSql());
+		$this->assertEquals(array(), $builder->getBindings());
+
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotIn('id', array());
+		$this->assertEquals('select * from "users" where "id" = ? or 1', $builder->toSql());
+		$this->assertEquals(array(0 => 1), $builder->getBindings());
+	}
+
+
 	public function testUnions()
 	{
 		$builder = $this->getBuilder();


### PR DESCRIPTION
This fixes #5296 by compiling empty arrays to a simple boolean predicate.

`whereIn([])` is never true, thus compiled to `false`, whereas `whereNotIn([])` is always true.

If this should go into 4.2, let me know and I'll retarget.
