### PR TITLE
Fix duplicate queries for Cache::rememberForever

### DIFF
--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -195,7 +195,7 @@ class TaggedCache implements StoreInterface {
 		// If the item exists in the cache we will just return this immediately
 		// otherwise we will execute the given Closure and cache the result
 		// of that execution for the given number of minutes. It's easy.
-		if ($this->has($key)) return $this->get($key);
+		if ( ! is_null($value = $this->get($key))) return $value;
 
 		$this->forever($key, $value = $callback());
 


### PR DESCRIPTION
fix #6966 (#6981 didn't fix all of it)
