### PR TITLE
[5.0] Add resources method to router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -300,6 +300,20 @@ class Router implements RegistrarContract {
 	}
 
 	/**
+	 * Register an array of resource controllers.
+	 *
+	 * @param  array  $resources
+	 * @return void
+	 */
+	public function resources(array $resources)
+	{
+		foreach ($resources as $name => $controller)
+		{
+			$this->resource($name, $controller);
+		}
+	}
+
+	/**
 	 * Route a resource to a controller.
 	 *
 	 * @param  string  $name


### PR DESCRIPTION
I noticed a `controllers()` method had been added to the router and is used in Laravel to register the two auth controllers. Added a similar `resources()` method, that allows the registering of multiple resources in one go.
