### PR TITLE
[5.0] Fixing Eloquent Model isset() to see relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3311,7 +3311,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	public function __isset($key)
 	{
 		return ((isset($this->attributes[$key]) || isset($this->relations[$key])) ||
-				($this->hasGetMutator($key) && ! is_null($this->getAttributeValue($key))));
+				($this->hasGetMutator($key) && ! is_null($this->getAttributeValue($key))) ||
++				(method_exists($this, camel_case($key))));
 	}
 
 	/**


### PR DESCRIPTION
If we have a User Model that Has One Address, isset doesn't work with relationships if the relation haven't being initialised, this happens:

``` php
$user = User::find(1);
var_dump(isset($user->address)); // false
$address = $user->address; // only to initialise the relation
var_dump(isset($user->address)); // true
```
