### PR TITLE
[Proposal] Update model event names

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1694,7 +1694,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		// We will append the names of the class to the event to distinguish it from
 		// other model events that are fired, allowing us to listen on each model
 		// event set individually instead of catching event for all the models.
-		$event = "eloquent.{$event}: ".get_class($this);
+		$event = "eloquent.{$event}.".get_class($this);
 
 		$method = $halt ? 'until' : 'fire';
 


### PR DESCRIPTION
Model events are currently named like so:

`eloquent.{event}: {model}`

It doesn't really make any sense to me why it's not using the established dot syntax there. This PR changes it to this:

`eloquent.{event}.{model}`

This obviously breaks a bunch of stuff relying on the old syntax right now, but I'm happy to do that update work if this is something we want.
