### PR TITLE
[proposal] Make Eloquent\Collection::first not force passing key in callback

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Database\Eloquent;
 
+use Closure;
 use Illuminate\Support\Collection as BaseCollection;
 
 class Collection extends BaseCollection {
@@ -23,6 +24,26 @@ class Collection extends BaseCollection {
 			return $model->getKey() == $key;
 
 		}, $default);
+	}
+
+	/**
+	 * Get the first item from the collection.
+	 *
+	 * @param  \Closure   $callback
+	 * @param  mixed      $default
+	 * @return mixed|null
+	 */
+	public function first(Closure $callback = null, $default = null)
+	{
+		if (is_null($callback))
+		{
+			return count($this->items) > 0 ? reset($this->items) : null;
+		}
+
+		foreach ($this->items as $item)
+		{
+			if (call_user_func($callback, $item)) return $item;
+		}
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -217,4 +217,21 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(new Collection(array($one)), $c->except(array(2, 3)));
 	}
 
+	public function testFirstWithCallback()
+	{
+		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one->shouldReceive('getAttribute')->andReturn('foo');
+
+		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two->shouldReceive('getAttribute')->andReturn('bar');
+
+		$c = new Collection([$one, $two]);
+
+		$result = $c->first(function ($item) {
+			return $item->getAttribute('baz') == 'bar';
+		});
+
+		$this->assertEquals($two, $result);
+	}
+
 }


### PR DESCRIPTION
When using `Eloquent\Collection::first` with callback we are forced to pass 2 params: `$key` and `$value`, since it inherits `Arr::first` method:

```
$users = User::get();
$users->first(function ($key, $user) {
  return $user->email == 'some@email.com';
});
```

Obviously it is the way to go with `Support\Collection`, however when working with `Eloquent` you'd rather not use `$key` ever. Instead more convenient way would be passing only the item:

```
$users = User::get();
$users->first(function ($user) {
  return $user->email == 'some@email.com';
});
```

and this PR does it.
