### PR TITLE
Add method to get Flysystem driver.

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -302,4 +302,14 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract {
 		throw new InvalidArgumentException('Unknown visibility: '.$visibility);
 	}
 
+	/**
+	 * Get the Flysystem driver.
+	 *
+	 * @return \League\Flysystem\FilesystemInterface
+	 */
+	protected function getDriver()
+	{
+		return $this->driver;
+	}
+
 }


### PR DESCRIPTION
A very simple addition to the new `FilesystemAdapter` which allows access to underlying `Flysystem` driver. This is especially helpful when working with libraries that implement the `League\Flysystem\FilesystemInterface` interface. A simple example:

``` php
$this->app->singleton('League\Glide\Server', function ($app) {

    $filesystem = $this->app->make('Illuminate\Contracts\Filesystem\Filesystem');

    return League\Glide\Factories\Server::create([
        'source' => $filesystem->getDriver()
        // etc
    ]);
});
```
