### PR TITLE
Make getDriver method public.

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -265,6 +265,16 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract {
 	}
 
 	/**
+	 * Get the Flysystem driver.
+	 *
+	 * @return \League\Flysystem\FilesystemInterface
+	 */
+	public function getDriver()
+	{
+		return $this->driver;
+	}
+
+	/**
 	 * Filter directory contents by type.
 	 *
 	 * @param  array  $contents
@@ -300,16 +310,6 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract {
 		}
 
 		throw new InvalidArgumentException('Unknown visibility: '.$visibility);
-	}
-
-	/**
-	 * Get the Flysystem driver.
-	 *
-	 * @return \League\Flysystem\FilesystemInterface
-	 */
-	protected function getDriver()
-	{
-		return $this->driver;
 	}
 
 }


### PR DESCRIPTION
As noted in #7005 I was dumb and didn't make the new `getDriver()` public. This fixes that. I've also moved the method up in the class with all the other `public` methods.
