### PR TITLE
Update hydrate and newFromBuilder with $exists

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -481,13 +481,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * Create a new model instance that is existing.
 	 *
 	 * @param  array  $attributes
+	 * @param  bool  $exists
 	 * @return static
 	 */
-	public function newFromBuilder($attributes = array())
+	public function newFromBuilder($attributes = array(), $exists = true)
 	{
 		$instance = $this->newInstance(array(), true);
 
-		$instance->setRawAttributes((array) $attributes, true);
+		$instance->setRawAttributes((array) $attributes, $exists);
 
 		return $instance;
 	}
@@ -497,15 +498,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 *
 	 * @param  array  $items
 	 * @param  string  $connection
+	 * @param  bool  $exists
 	 * @return \Illuminate\Database\Eloquent\Collection
 	 */
-	public static function hydrate(array $items, $connection = null)
+	public static function hydrate(array $items, $connection = null, $exists = true)
 	{
 		$collection = with($instance = new static)->newCollection();
 
 		foreach ($items as $item)
 		{
-			$model = $instance->newFromBuilder($item);
+			$model = $instance->newFromBuilder($item, $exists);
 
 			if ( ! is_null($connection))
 			{


### PR DESCRIPTION
Allows you to use Hydrate to new up an array of models

I ran across this and needed it, it basically allows for this:

```
$posts = Post::hydrate($data, null, false);

$user->posts()->saveMany($posts);
```

Instead of

```
foreach($posts as $post) {
  $user->posts()->save(new Post($post));
}
```

Might not be worth anything, but I thought I mine as well see.
