### PR TITLE
[5.0] Allow To Extend Validator Factory In FormRequests

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -77,6 +77,11 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 			return $this->container->call([$this, 'validator'], compact('factory'));
 		}
 
+		if (method_exists($this, 'extend'))
+		{
+			$this->container->call([$this, 'extend'], compact('factory'));
+		}
+
 		return $factory->make(
 			$this->all(), $this->container->call([$this, 'rules']), $this->messages()
 		);


### PR DESCRIPTION
I've noticed that quite often I need to extend Validator with custom rules. And FormRequest does have a handy method `validator` where that is indeed possible. But not without some unnecessary code. 

So, this PR adds another helper method called `extend` which allows simple extension of the factory.

As an example. Here's code you had to write previously:

``` php
public function validator(Factory $factory)
{
    $factory->extend('foo', function($attribute, $value, $parameters, $validator) {
        // Rule code
    });
    return $factory->make(
        $this->all(), $this->rules(), $this->messages()
    );
}
```

And here's new code with `extend`:

``` php
public function extend(Factory $factory)
{
    $factory->extend('foo', function($attribute, $value, $parameters, $validator) {
        // Rule code
    });
}
```

I know, difference is only 3 lines. But when you have multiple FormRequests - that gets old fast. Plus, DRY.

I've also renamed and fixed test file so that phpunit would pick it up when running tests.
