### PR TITLE
[5.0] Allow to inject dependencies in closure resolution

### DIFF
--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -25,19 +25,19 @@ class AuthServiceProvider extends ServiceProvider {
 	 */
 	protected function registerAuthenticator()
 	{
-		$this->app->singleton('auth', function($app)
+		$this->app->singleton('auth', function()
 		{
 			// Once the authentication service has actually been requested by the developer
 			// we will set a variable in the application indicating such. This helps us
 			// know that we need to set any queued cookies in the after event later.
-			$app['auth.loaded'] = true;
+			$this->app['auth.loaded'] = true;
 
-			return new AuthManager($app);
+			return new AuthManager($this->app);
 		});
 
-		$this->app->singleton('auth.driver', function($app)
+		$this->app->singleton('auth.driver', function()
 		{
-			return $app['auth']->driver();
+			return $this->app['auth']->driver();
 		});
 	}
 
@@ -48,9 +48,9 @@ class AuthServiceProvider extends ServiceProvider {
 	 */
 	protected function registerUserResolver()
 	{
-		$this->app->bind('Illuminate\Contracts\Auth\Authenticatable', function($app)
+		$this->app->bind('Illuminate\Contracts\Auth\Authenticatable', function()
 		{
-			return $app['auth']->user();
+			return $this->app['auth']->user();
 		});
 	}
 
@@ -61,11 +61,11 @@ class AuthServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRequestRebindHandler()
 	{
-		$this->app->rebinding('request', function($app, $request)
+		$this->app->rebinding('request', function($request)
 		{
-			$request->setUserResolver(function() use ($app)
+			$request->setUserResolver(function()
 			{
-				return $app['auth']->user();
+				return $this->app['auth']->user();
 			});
 		});
 	}

--- a/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
+++ b/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
@@ -31,22 +31,22 @@ class PasswordResetServiceProvider extends ServiceProvider {
 	 */
 	protected function registerPasswordBroker()
 	{
-		$this->app->singleton('auth.password', function($app)
+		$this->app->singleton('auth.password', function()
 		{
 			// The password token repository is responsible for storing the email addresses
 			// and password reset tokens. It will be used to verify the tokens are valid
 			// for the given e-mail addresses. We will resolve an implementation here.
-			$tokens = $app['auth.password.tokens'];
+			$tokens = $this->app['auth.password.tokens'];
 
-			$users = $app['auth']->driver()->getProvider();
+			$users = $this->app['auth']->driver()->getProvider();
 
-			$view = $app['config']['auth.password.email'];
+			$view = $this->app['config']['auth.password.email'];
 
 			// The password broker uses a token repository to validate tokens and send user
 			// password e-mails, as well as validating that password reset process as an
 			// aggregate service of sorts providing a convenient interface for resets.
 			return new PasswordBroker(
-				$tokens, $users, $app['mailer'], $view
+				$tokens, $users, $this->app['mailer'], $view
 			);
 		});
 	}
@@ -58,18 +58,18 @@ class PasswordResetServiceProvider extends ServiceProvider {
 	 */
 	protected function registerTokenRepository()
 	{
-		$this->app->singleton('auth.password.tokens', function($app)
+		$this->app->singleton('auth.password.tokens', function()
 		{
-			$connection = $app['db']->connection();
+			$connection = $this->app['db']->connection();
 
 			// The database token repository is an implementation of the token repository
 			// interface, and is responsible for the actual storing of auth tokens and
 			// their e-mail addresses. We will inject this table and hash key to it.
-			$table = $app['config']['auth.password.table'];
+			$table = $this->app['config']['auth.password.table'];
 
-			$key = $app['config']['app.key'];
+			$key = $this->app['config']['app.key'];
 
-			$expire = $app['config']->get('auth.password.expire', 60);
+			$expire = $this->app['config']->get('auth.password.expire', 60);
 
 			return new DbRepository($connection, $table, $key, $expire);
 		});

--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -18,11 +18,11 @@ class BusServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton('Illuminate\Bus\Dispatcher', function($app)
+		$this->app->singleton('Illuminate\Bus\Dispatcher', function()
 		{
-			return new Dispatcher($app, function() use ($app)
+			return new Dispatcher($this->app, function()
 			{
-				return $app['Illuminate\Contracts\Queue\Queue'];
+				return $this->app['queue.connection'];
 			});
 		});
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -10,7 +10,7 @@ class CacheManager implements FactoryContract {
 	/**
 	 * The application instance.
 	 *
-	 * @var \Illuminate\Foundation\Application
+	 * @var \Illuminate\Contracts\Foundation\Application
 	 */
 	protected $app;
 
@@ -31,7 +31,7 @@ class CacheManager implements FactoryContract {
 	/**
 	 * Create a new Cache manager instance.
 	 *
-	 * @param  \Illuminate\Foundation\Application  $app
+	 * @param  \Illuminate\Contracts\Foundation\Application  $app
 	 * @return void
 	 */
 	public function __construct($app)

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -18,14 +18,14 @@ class CacheServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton('cache', function($app)
+		$this->app->singleton('cache', function()
 		{
-			return new CacheManager($app);
+			return new CacheManager($this->app);
 		});
 
-		$this->app->singleton('cache.store', function($app)
+		$this->app->singleton('cache.store', function()
 		{
-			return $app['cache']->driver();
+			return $this->app['cache']->driver();
 		});
 
 		$this->app->singleton('memcached.connector', function()
@@ -43,14 +43,14 @@ class CacheServiceProvider extends ServiceProvider {
 	 */
 	public function registerCommands()
 	{
-		$this->app->singleton('command.cache.clear', function($app)
+		$this->app->singleton('command.cache.clear', function()
 		{
-			return new Console\ClearCommand($app['cache']);
+			return new Console\ClearCommand($this->app['cache']);
 		});
 
-		$this->app->singleton('command.cache.table', function($app)
+		$this->app->singleton('command.cache.table', function()
 		{
-			return new Console\CacheTableCommand($app['files'], $app['composer']);
+			return new Console\CacheTableCommand($this->app['files'], $this->app['composer']);
 		});
 
 		$this->commands('command.cache.clear', 'command.cache.table');

--- a/src/Illuminate/Cookie/CookieServiceProvider.php
+++ b/src/Illuminate/Cookie/CookieServiceProvider.php
@@ -11,9 +11,9 @@ class CookieServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton('cookie', function($app)
+		$this->app->singleton('cookie', function()
 		{
-			$config = $app['config']['session'];
+			$config = $this->app['config']['session'];
 
 			return (new CookieJar)->setDefaultPathAndDomain($config['path'], $config['domain']);
 		});

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -37,7 +37,7 @@ class DatabaseManager implements ConnectionResolverInterface {
 	/**
 	 * Create a new database manager instance.
 	 *
-	 * @param  \Illuminate\Foundation\Application  $app
+	 * @param  \Illuminate\Contracts\Foundation\Application  $app
 	 * @param  \Illuminate\Database\Connectors\ConnectionFactory  $factory
 	 * @return void
 	 */

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -30,17 +30,17 @@ class DatabaseServiceProvider extends ServiceProvider {
 		// The connection factory is used to create the actual connection instances on
 		// the database. We will inject the factory into the manager so that it may
 		// make the connections while they are actually needed and not of before.
-		$this->app->singleton('db.factory', function($app)
+		$this->app->singleton('db.factory', function()
 		{
-			return new ConnectionFactory($app);
+			return new ConnectionFactory($this->app);
 		});
 
 		// The database manager is used to resolve various connections, since multiple
 		// connections might be managed. It also implements the connection resolver
 		// interface which may be used by other components requiring connections.
-		$this->app->singleton('db', function($app)
+		$this->app->singleton('db', function()
 		{
-			return new DatabaseManager($app, $app['db.factory']);
+			return new DatabaseManager($this->app, $this->app['db.factory']);
 		});
 	}
 

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -45,11 +45,11 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRepository()
 	{
-		$this->app->singleton('migration.repository', function($app)
+		$this->app->singleton('migration.repository', function()
 		{
-			$table = $app['config']['database.migrations'];
+			$table = $this->app['config']['database.migrations'];
 
-			return new DatabaseMigrationRepository($app['db'], $table);
+			return new DatabaseMigrationRepository($this->app['db'], $table);
 		});
 	}
 
@@ -63,11 +63,11 @@ class MigrationServiceProvider extends ServiceProvider {
 		// The migrator is responsible for actually running and rollback the migration
 		// files in the application. We'll pass in our database connection resolver
 		// so the migrator can resolve any of these connections when it needs to.
-		$this->app->singleton('migrator', function($app)
+		$this->app->singleton('migrator', function()
 		{
-			$repository = $app['migration.repository'];
+			$repository = $this->app['migration.repository'];
 
-			return new Migrator($repository, $app['db'], $app['files']);
+			return new Migrator($repository, $this->app['db'], $this->app['files']);
 		});
 	}
 
@@ -106,9 +106,9 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerMigrateCommand()
 	{
-		$this->app->singleton('command.migrate', function($app)
+		$this->app->singleton('command.migrate', function()
 		{
-			return new MigrateCommand($app['migrator']);
+			return new MigrateCommand($this->app['migrator']);
 		});
 	}
 
@@ -119,9 +119,9 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRollbackCommand()
 	{
-		$this->app->singleton('command.migrate.rollback', function($app)
+		$this->app->singleton('command.migrate.rollback', function()
 		{
-			return new RollbackCommand($app['migrator']);
+			return new RollbackCommand($this->app['migrator']);
 		});
 	}
 
@@ -132,9 +132,9 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerResetCommand()
 	{
-		$this->app->singleton('command.migrate.reset', function($app)
+		$this->app->singleton('command.migrate.reset', function()
 		{
-			return new ResetCommand($app['migrator']);
+			return new ResetCommand($this->app['migrator']);
 		});
 	}
 
@@ -153,9 +153,9 @@ class MigrationServiceProvider extends ServiceProvider {
 
 	protected function registerStatusCommand()
 	{
-		$this->app->singleton('command.migrate.status', function($app)
+		$this->app->singleton('command.migrate.status', function()
 		{
-			return new StatusCommand($app['migrator']);
+			return new StatusCommand($this->app['migrator']);
 		});
 	}
 
@@ -166,9 +166,9 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerInstallCommand()
 	{
-		$this->app->singleton('command.migrate.install', function($app)
+		$this->app->singleton('command.migrate.install', function()
 		{
-			return new InstallCommand($app['migration.repository']);
+			return new InstallCommand($this->app['migration.repository']);
 		});
 	}
 
@@ -181,14 +181,14 @@ class MigrationServiceProvider extends ServiceProvider {
 	{
 		$this->registerCreator();
 
-		$this->app->singleton('command.migrate.make', function($app)
+		$this->app->singleton('command.migrate.make', function()
 		{
 			// Once we have the migration creator registered, we will create the command
 			// and inject the creator. The creator is responsible for the actual file
 			// creation of the migrations, and may be extended by these developers.
-			$creator = $app['migration.creator'];
+			$creator = $this->app['migration.creator'];
 
-			$composer = $app['composer'];
+			$composer = $this->app['composer'];
 
 			return new MigrateMakeCommand($creator, $composer);
 		});
@@ -201,9 +201,9 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerCreator()
 	{
-		$this->app->singleton('migration.creator', function($app)
+		$this->app->singleton('migration.creator', function()
 		{
-			return new MigrationCreator($app['files']);
+			return new MigrationCreator($this->app['files']);
 		});
 	}
 

--- a/src/Illuminate/Database/SeedServiceProvider.php
+++ b/src/Illuminate/Database/SeedServiceProvider.php
@@ -36,9 +36,9 @@ class SeedServiceProvider extends ServiceProvider {
 	 */
 	protected function registerSeedCommand()
 	{
-		$this->app->singleton('command.seed', function($app)
+		$this->app->singleton('command.seed', function()
 		{
-			return new SeedCommand($app['db']);
+			return new SeedCommand($this->app['db']);
 		});
 	}
 

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -11,13 +11,13 @@ class EncryptionServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton('encrypter', function($app)
+		$this->app->singleton('encrypter', function()
 		{
-			$encrypter =  new Encrypter($app['config']['app.key']);
+			$encrypter =  new Encrypter($this->app['config']['app.key']);
 
-			if ($app['config']->has('app.cipher'))
+			if ($this->app['config']->has('app.cipher'))
 			{
-				$encrypter->setCipher($app['config']['app.cipher']);
+				$encrypter->setCipher($this->app['config']['app.cipher']);
 			}
 
 			return $encrypter;

--- a/src/Illuminate/Events/EventServiceProvider.php
+++ b/src/Illuminate/Events/EventServiceProvider.php
@@ -11,11 +11,11 @@ class EventServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton('events', function($app)
+		$this->app->singleton('events', function()
 		{
-			return (new Dispatcher($app))->setQueueResolver(function() use ($app)
+			return (new Dispatcher($this->app))->setQueueResolver(function()
 			{
-				return $app->make('Illuminate\Contracts\Queue\Queue');
+				return $this->app['queue.connection'];
 			});
 		});
 	}

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -4,11 +4,11 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Redirector;
-use Illuminate\Container\Container;
 use Illuminate\Validation\Validator;
 use Illuminate\Http\Exception\HttpResponseException;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use Illuminate\Contracts\Validation\ValidatesWhenResolved;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 
 class FormRequest extends Request implements ValidatesWhenResolved {
 
@@ -17,7 +17,7 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	/**
 	 * The container instance.
 	 *
-	 * @var \Illuminate\Container\Container
+	 * @var \Illuminate\Contracts\Container\Container
 	 */
 	protected $container;
 
@@ -200,10 +200,10 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	/**
 	 * Set the container implementation.
 	 *
-	 * @param  \Illuminate\Container\Container  $container
+	 * @param  \Illuminate\Contracts\Container\Container  $container
 	 * @return $this
 	 */
-	public function setContainer(Container $container)
+	public function setContainer(ContainerContract $container)
 	{
 		$this->container = $container;
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -87,9 +87,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerAppNameCommand()
 	{
-		$this->app->singleton('command.app.name', function($app)
+		$this->app->singleton('command.app.name', function()
 		{
-			return new AppNameCommand($app['composer'], $app['files']);
+			return new AppNameCommand($this->app['composer'], $this->app['files']);
 		});
 	}
 
@@ -113,9 +113,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerCommandMakeCommand()
 	{
-		$this->app->singleton('command.command.make', function($app)
+		$this->app->singleton('command.command.make', function()
 		{
-			return new CommandMakeCommand($app['files']);
+			return new CommandMakeCommand($this->app['files']);
 		});
 	}
 
@@ -126,9 +126,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerConfigCacheCommand()
 	{
-		$this->app->singleton('command.config.cache', function($app)
+		$this->app->singleton('command.config.cache', function()
 		{
-			return new ConfigCacheCommand($app['files']);
+			return new ConfigCacheCommand($this->app['files']);
 		});
 	}
 
@@ -139,9 +139,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerConfigClearCommand()
 	{
-		$this->app->singleton('command.config.clear', function($app)
+		$this->app->singleton('command.config.clear', function()
 		{
-			return new ConfigClearCommand($app['files']);
+			return new ConfigClearCommand($this->app['files']);
 		});
 	}
 
@@ -152,9 +152,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerConsoleMakeCommand()
 	{
-		$this->app->singleton('command.console.make', function($app)
+		$this->app->singleton('command.console.make', function()
 		{
-			return new ConsoleMakeCommand($app['files']);
+			return new ConsoleMakeCommand($this->app['files']);
 		});
 	}
 
@@ -165,9 +165,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerEventMakeCommand()
 	{
-		$this->app->singleton('command.event.make', function($app)
+		$this->app->singleton('command.event.make', function()
 		{
-			return new EventMakeCommand($app['files']);
+			return new EventMakeCommand($this->app['files']);
 		});
 	}
 
@@ -204,9 +204,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerHandlerCommandCommand()
 	{
-		$this->app->singleton('command.handler.command', function($app)
+		$this->app->singleton('command.handler.command', function()
 		{
-			return new HandlerCommandCommand($app['files']);
+			return new HandlerCommandCommand($this->app['files']);
 		});
 	}
 
@@ -217,9 +217,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerHandlerEventCommand()
 	{
-		$this->app->singleton('command.handler.event', function($app)
+		$this->app->singleton('command.handler.event', function()
 		{
-			return new HandlerEventCommand($app['files']);
+			return new HandlerEventCommand($this->app['files']);
 		});
 	}
 
@@ -230,7 +230,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerKeyGenerateCommand()
 	{
-		$this->app->singleton('command.key.generate', function($app)
+		$this->app->singleton('command.key.generate', function()
 		{
 			return new KeyGenerateCommand;
 		});
@@ -243,9 +243,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerModelMakeCommand()
 	{
-		$this->app->singleton('command.model.make', function($app)
+		$this->app->singleton('command.model.make', function()
 		{
-			return new ModelMakeCommand($app['files']);
+			return new ModelMakeCommand($this->app['files']);
 		});
 	}
 
@@ -256,9 +256,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerOptimizeCommand()
 	{
-		$this->app->singleton('command.optimize', function($app)
+		$this->app->singleton('command.optimize', function()
 		{
-			return new OptimizeCommand($app['composer']);
+			return new OptimizeCommand($this->app['composer']);
 		});
 	}
 
@@ -269,9 +269,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerProviderMakeCommand()
 	{
-		$this->app->singleton('command.provider.make', function($app)
+		$this->app->singleton('command.provider.make', function()
 		{
-			return new ProviderMakeCommand($app['files']);
+			return new ProviderMakeCommand($this->app['files']);
 		});
 	}
 
@@ -282,9 +282,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRequestMakeCommand()
 	{
-		$this->app->singleton('command.request.make', function($app)
+		$this->app->singleton('command.request.make', function()
 		{
-			return new RequestMakeCommand($app['files']);
+			return new RequestMakeCommand($this->app['files']);
 		});
 	}
 
@@ -295,9 +295,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRouteCacheCommand()
 	{
-		$this->app->singleton('command.route.cache', function($app)
+		$this->app->singleton('command.route.cache', function()
 		{
-			return new RouteCacheCommand($app['files']);
+			return new RouteCacheCommand($this->app['files']);
 		});
 	}
 
@@ -308,9 +308,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRouteClearCommand()
 	{
-		$this->app->singleton('command.route.clear', function($app)
+		$this->app->singleton('command.route.clear', function()
 		{
-			return new RouteClearCommand($app['files']);
+			return new RouteClearCommand($this->app['files']);
 		});
 	}
 
@@ -321,9 +321,9 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerRouteListCommand()
 	{
-		$this->app->singleton('command.route.list', function($app)
+		$this->app->singleton('command.route.list', function()
 		{
-			return new RouteListCommand($app['router']);
+			return new RouteListCommand($this->app['router']);
 		});
 	}
 
@@ -334,7 +334,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 	 */
 	protected function registerServeCommand()
 	{
-		$this->app->singleton('command.serve', function($app)
+		$this->app->singleton('command.serve', function()
 		{
 			return new ServeCommand;
 		});

--- a/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
@@ -19,9 +19,9 @@ class ComposerServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton('composer', function($app)
+		$this->app->singleton('composer', function()
 		{
-			return new Composer($app['files'], $app['path.base']);
+			return new Composer($this->app['files'], $this->app['path.base']);
 		});
 	}
 

--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -25,12 +25,12 @@ class FormRequestServiceProvider extends ServiceProvider {
 	{
 		$this->app['events']->listen('router.matched', function()
 		{
-			$this->app->resolving(function(FormRequest $request, $app)
+			$this->app->resolving(function(FormRequest $request)
 			{
-				$this->initializeRequest($request, $app['request']);
+				$this->initializeRequest($request, $this->app['request']);
 
-				$request->setContainer($app)
-                        ->setRedirector($app['Illuminate\Routing\Redirector']);
+				$request->setContainer($this->app)
+                        ->setRedirector($this->app['Illuminate\Routing\Redirector']);
 			});
 		});
 	}

--- a/src/Illuminate/Pipeline/PipelineServiceProvider.php
+++ b/src/Illuminate/Pipeline/PipelineServiceProvider.php
@@ -18,9 +18,9 @@ class PipelineServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton(
-			'Illuminate\Contracts\Pipeline\Hub', 'Illuminate\Pipeline\Hub'
-		);
+		$this->app->singleton('Illuminate\Contracts\Pipeline\Hub', function () {
+			return new Hub($this->app);
+		});
 	}
 
 	/**

--- a/src/Illuminate/Queue/ConsoleServiceProvider.php
+++ b/src/Illuminate/Queue/ConsoleServiceProvider.php
@@ -24,9 +24,9 @@ class ConsoleServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton('command.queue.table', function($app)
+		$this->app->singleton('command.queue.table', function()
 		{
-			return new TableCommand($app['files']);
+			return new TableCommand($this->app['files']);
 		});
 
 		$this->app->singleton('command.queue.failed', function()
@@ -49,9 +49,9 @@ class ConsoleServiceProvider extends ServiceProvider {
 			return new FlushFailedCommand;
 		});
 
-		$this->app->singleton('command.queue.failed-table', function($app)
+		$this->app->singleton('command.queue.failed-table', function()
 		{
-			return new FailedTableCommand($app['files']);
+			return new FailedTableCommand($this->app['files']);
 		});
 
 		$this->commands(

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -10,7 +10,7 @@ class QueueManager implements FactoryContract, MonitorContract {
 	/**
 	 * The application instance.
 	 *
-	 * @var \Illuminate\Foundation\Application
+	 * @var \Illuminate\Contracts\Foundation\Application
 	 */
 	protected $app;
 
@@ -24,7 +24,7 @@ class QueueManager implements FactoryContract, MonitorContract {
 	/**
 	 * Create a new queue manager instance.
 	 *
-	 * @param  \Illuminate\Foundation\Application  $app
+	 * @param  \Illuminate\Contracts\Foundation\Application  $app
 	 * @return void
 	 */
 	public function __construct($app)

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -18,9 +18,9 @@ class RedisServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton('redis', function($app)
+		$this->app->singleton('redis', function()
 		{
-			return new Database($app['config']['database.redis']);
+			return new Database($this->app['config']['database.redis']);
 		});
 	}
 

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -3,7 +3,7 @@
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Pipeline\Pipeline;
-use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 
 class ControllerDispatcher {
 
@@ -19,7 +19,7 @@ class ControllerDispatcher {
 	/**
 	 * The IoC container instance.
 	 *
-	 * @var \Illuminate\Container\Container
+	 * @var \Illuminate\Contracts\Container\Container
 	 */
 	protected $container;
 
@@ -27,11 +27,10 @@ class ControllerDispatcher {
 	 * Create a new controller dispatcher instance.
 	 *
 	 * @param  \Illuminate\Routing\Router  $router
-	 * @param  \Illuminate\Container\Container  $container
+	 * @param  \Illuminate\Contracts\Container\Container  $container
 	 * @return void
 	 */
-	public function __construct(Router $router,
-								Container $container = null)
+	public function __construct(Router $router, ContainerContract $container = null)
 	{
 		$this->router = $router;
 		$this->container = $container;

--- a/src/Illuminate/Routing/ControllerServiceProvider.php
+++ b/src/Illuminate/Routing/ControllerServiceProvider.php
@@ -11,9 +11,9 @@ class ControllerServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton('illuminate.route.dispatcher', function($app)
+		$this->app->singleton('illuminate.route.dispatcher', function()
 		{
-			return new ControllerDispatcher($app['router'], $app);
+			return new ControllerDispatcher($this->app['router'], $this->app);
 		});
 	}
 

--- a/src/Illuminate/Routing/GeneratorServiceProvider.php
+++ b/src/Illuminate/Routing/GeneratorServiceProvider.php
@@ -34,9 +34,9 @@ class GeneratorServiceProvider extends ServiceProvider {
 	 */
 	protected function registerControllerGenerator()
 	{
-		$this->app->singleton('command.controller.make', function($app)
+		$this->app->singleton('command.controller.make', function()
 		{
-			return new ControllerMakeCommand($app['files']);
+			return new ControllerMakeCommand($this->app['files']);
 		});
 	}
 
@@ -47,9 +47,9 @@ class GeneratorServiceProvider extends ServiceProvider {
 	 */
 	protected function registerMiddlewareGenerator()
 	{
-		$this->app->singleton('command.middleware.make', function($app)
+		$this->app->singleton('command.middleware.make', function()
 		{
-			return new MiddlewareMakeCommand($app['files']);
+			return new MiddlewareMakeCommand($this->app['files']);
 		});
 	}
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Routing\Registrar as RegistrarContract;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 
 class Router implements RegistrarContract {
 
@@ -26,7 +27,7 @@ class Router implements RegistrarContract {
 	/**
 	 * The IoC container instance.
 	 *
-	 * @var \Illuminate\Container\Container
+	 * @var \Illuminate\Contracts\Container\Container
 	 */
 	protected $container;
 
@@ -104,10 +105,10 @@ class Router implements RegistrarContract {
 	 * Create a new Router instance.
 	 *
 	 * @param  \Illuminate\Contracts\Events\Dispatcher  $events
-	 * @param  \Illuminate\Container\Container  $container
+	 * @param  \Illuminate\Contracts\Container\Container  $container
 	 * @return void
 	 */
-	public function __construct(Dispatcher $events, Container $container = null)
+	public function __construct(Dispatcher $events, ContainerContract $container = null)
 	{
 		$this->events = $events;
 		$this->routes = new RouteCollection;

--- a/src/Illuminate/Session/CommandsServiceProvider.php
+++ b/src/Illuminate/Session/CommandsServiceProvider.php
@@ -18,9 +18,9 @@ class CommandsServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton('command.session.database', function($app)
+		$this->app->singleton('command.session.database', function()
 		{
-			return new Console\SessionTableCommand($app['files'], $app['composer']);
+			return new Console\SessionTableCommand($this->app['files'], $this->app['composer']);
 		});
 
 		$this->commands('command.session.database');

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -40,9 +40,9 @@ class SessionServiceProvider extends ServiceProvider {
 	 */
 	protected function registerSessionManager()
 	{
-		$this->app->singleton('session', function($app)
+		$this->app->singleton('session', function()
 		{
-			return new SessionManager($app);
+			return new SessionManager($this->app);
 		});
 	}
 
@@ -53,12 +53,12 @@ class SessionServiceProvider extends ServiceProvider {
 	 */
 	protected function registerSessionDriver()
 	{
-		$this->app->singleton('session.store', function($app)
+		$this->app->singleton('session.store', function()
 		{
 			// First, we will create the session manager which is responsible for the
 			// creation of the various session drivers when they are needed by the
 			// application instance, and will resolve them on a lazy load basis.
-			$manager = $app['session'];
+			$manager = $this->app['session'];
 
 			return $manager->driver();
 		});

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -8,7 +8,7 @@ abstract class Manager {
 	/**
 	 * The application instance.
 	 *
-	 * @var \Illuminate\Foundation\Application
+	 * @var \Illuminate\Contracts\Foundation\Application
 	 */
 	protected $app;
 
@@ -29,7 +29,7 @@ abstract class Manager {
 	/**
 	 * Create a new manager instance.
 	 *
-	 * @param  \Illuminate\Foundation\Application  $app
+	 * @param  \Illuminate\Contracts\Foundation\Application  $app
 	 * @return void
 	 */
 	public function __construct($app)

--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -20,18 +20,18 @@ class TranslationServiceProvider extends ServiceProvider {
 	{
 		$this->registerLoader();
 
-		$this->app->singleton('translator', function($app)
+		$this->app->singleton('translator', function()
 		{
-			$loader = $app['translation.loader'];
+			$loader = $this->app['translation.loader'];
 
 			// When registering the translator component, we'll need to set the default
 			// locale as well as the fallback locale. So, we'll grab the application
 			// configuration so we can easily get both of these values from there.
-			$locale = $app['config']['app.locale'];
+			$locale = $this->app['config']['app.locale'];
 
 			$trans = new Translator($loader, $locale);
 
-			$trans->setFallback($app['config']['app.fallback_locale']);
+			$trans->setFallback($this->app['config']['app.fallback_locale']);
 
 			return $trans;
 		});
@@ -44,9 +44,9 @@ class TranslationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerLoader()
 	{
-		$this->app->singleton('translation.loader', function($app)
+		$this->app->singleton('translation.loader', function()
 		{
-			return new FileLoader($app['files'], $app['path.lang']);
+			return new FileLoader($this->app['files'], $this->app['path.lang']);
 		});
 	}
 

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -39,16 +39,16 @@ class ValidationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerValidationFactory()
 	{
-		$this->app->singleton('validator', function($app)
+		$this->app->singleton('validator', function()
 		{
-			$validator = new Factory($app['translator'], $app);
+			$validator = new Factory($this->app['translator'], $this->app);
 
 			// The validation presence verifier is responsible for determining the existence
 			// of values in a given data collection, typically a relational database or
 			// other persistent data stores. And it is used to check for uniqueness.
-			if (isset($app['validation.presence']))
+			if (isset($this->app['validation.presence']))
 			{
-				$validator->setPresenceVerifier($app['validation.presence']);
+				$validator->setPresenceVerifier($this->app['validation.presence']);
 			}
 
 			return $validator;
@@ -62,9 +62,9 @@ class ValidationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerPresenceVerifier()
 	{
-		$this->app->singleton('validation.presence', function($app)
+		$this->app->singleton('validation.presence', function()
 		{
-			return new DatabasePresenceVerifier($app['db']);
+			return new DatabasePresenceVerifier($this->app['db']);
 		});
 	}
 

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -64,21 +64,19 @@ class ViewServiceProvider extends ServiceProvider {
 	 */
 	public function registerBladeEngine($resolver)
 	{
-		$app = $this->app;
-
 		// The Compiler engine requires an instance of the CompilerInterface, which in
 		// this case will be the Blade compiler, so we'll first create the compiler
 		// instance to pass into the engine so it can compile the views properly.
-		$app->singleton('blade.compiler', function($app)
+		$this->app->singleton('blade.compiler', function()
 		{
-			$cache = $app['config']['view.compiled'];
+			$cache = $this->app['config']['view.compiled'];
 
-			return new BladeCompiler($app['files'], $cache);
+			return new BladeCompiler($this->app['files'], $cache);
 		});
 
-		$resolver->register('blade', function() use ($app)
+		$resolver->register('blade', function()
 		{
-			return new CompilerEngine($app['blade.compiler'], $app['files']);
+			return new CompilerEngine($this->app['blade.compiler'], $this->app['files']);
 		});
 	}
 
@@ -89,11 +87,11 @@ class ViewServiceProvider extends ServiceProvider {
 	 */
 	public function registerViewFinder()
 	{
-		$this->app->bind('view.finder', function($app)
+		$this->app->bind('view.finder', function()
 		{
-			$paths = $app['config']['view.paths'];
+			$paths = $this->app['config']['view.paths'];
 
-			return new FileViewFinder($app['files'], $paths);
+			return new FileViewFinder($this->app['files'], $paths);
 		});
 	}
 
@@ -104,23 +102,23 @@ class ViewServiceProvider extends ServiceProvider {
 	 */
 	public function registerFactory()
 	{
-		$this->app->singleton('view', function($app)
+		$this->app->singleton('view', function()
 		{
 			// Next we need to grab the engine resolver instance that will be used by the
 			// environment. The resolver will be used by an environment to get each of
 			// the various engine implementations such as plain PHP or Blade engine.
-			$resolver = $app['view.engine.resolver'];
+			$resolver = $this->app['view.engine.resolver'];
 
-			$finder = $app['view.finder'];
+			$finder = $this->app['view.finder'];
 
-			$env = new Factory($resolver, $finder, $app['events']);
+			$env = new Factory($resolver, $finder, $this->app['events']);
 
 			// We will also set the container instance on this view environment since the
 			// view composers may be classes registered in the container, which allows
 			// for great testable, flexible composers for the application developer.
-			$env->setContainer($app);
+			$env->setContainer($this->app);
 
-			$env->share('app', $app);
+			$env->share('app', $this->app);
 
 			return $env;
 		});

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -87,15 +87,6 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testContainerIsPassedToResolvers()
-	{
-		$container = new Container;
-		$container->bind('something', function($c) { return $c; });
-		$c = $container->make('something');
-		$this->assertSame($c, $container);
-	}
-
-
 	public function testArrayAccess()
 	{
 		$container = new Container;
@@ -147,7 +138,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	{
 		$container = new Container;
 		$container['foo'] = 'foo';
-		$container->extend('foo', function($old, $container)
+		$container->extend('foo', function($old)
 		{
 			return $old.'bar';
 		});
@@ -160,7 +151,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		{
 			return (object) array('name' => 'taylor');
 		});
-		$container->extend('foo', function($old, $container)
+		$container->extend('foo', function($old)
 		{
 			$old->age = 26;
 			return $old;
@@ -178,11 +169,11 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	{
 		$container = new Container;
 		$container['foo'] = 'foo';
-		$container->extend('foo', function($old, $container)
+		$container->extend('foo', function($old)
 		{
 			return $old.'bar';
 		});
-		$container->extend('foo', function($old, $container)
+		$container->extend('foo', function($old)
 		{
 			return $old.'baz';
 		});
@@ -197,8 +188,8 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$container->bind('foo', function() { $obj = new StdClass; $obj->foo = 'bar'; return $obj; });
 		$obj = new StdClass; $obj->foo = 'foo';
 		$container->instance('foo', $obj);
-		$container->extend('foo', function($obj, $container) { $obj->bar = 'baz'; return $obj; });
-		$container->extend('foo', function($obj, $container) { $obj->baz = 'foo'; return $obj; });
+		$container->extend('foo', function($obj) { $obj->bar = 'baz'; return $obj; });
+		$container->extend('foo', function($obj) { $obj->baz = 'foo'; return $obj; });
 		$this->assertEquals('foo', $container->make('foo')->foo);
 	}
 
@@ -207,7 +198,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	{
 		$container = new Container;
 		$container->bind('ContainerLazyExtendStub');
-		$container->extend('ContainerLazyExtendStub', function($obj, $container) { $obj->init(); return $obj; });
+		$container->extend('ContainerLazyExtendStub', function($obj) { $obj->init(); return $obj; });
 		$this->assertFalse(ContainerLazyExtendStub::$initialized);
 		$container->make('ContainerLazyExtendStub');
 		$this->assertTrue(ContainerLazyExtendStub::$initialized);
@@ -217,7 +208,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	public function testExtendCanBeCalledBeforeBind()
 	{
 		$container = new Container;
-		$container->extend('foo', function($old, $container)
+		$container->extend('foo', function($old)
 		{
 			return $old.'bar';
 		});
@@ -230,9 +221,9 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 	public function testParametersCanBePassedThroughToClosure()
 	{
 		$container = new Container;
-		$container->bind('foo', function($c, $parameters)
+		$container->bind('foo', function($param1, $param2, $param3)
 		{
-			return $parameters;
+			return [$param1, $param2, $param3];
 		});
 
 		$this->assertEquals(array(1, 2, 3), $container->make('foo', array(1, 2, 3)));
@@ -468,7 +459,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$container->bind('IContainerContractStub', 'ContainerImplementationStub');
 
 		$container->when('ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerImplementationStub');
-		$container->when('ContainerTestContextInjectTwo')->needs('IContainerContractStub')->give(function($container) {
+		$container->when('ContainerTestContextInjectTwo')->needs('IContainerContractStub')->give(function() use ($container) {
 			return $container->make('ContainerImplementationStubTwo');
 		});
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -62,7 +62,7 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 	{
 		$app = new Application;
 		$app->setDeferredServices(array('foo' => 'ApplicationDeferredServiceProviderStub'));
-		$app->extend('foo', function($instance, $container) { return $instance.'bar'; });
+		$app->extend('foo', function($instance) { return $instance.'bar'; });
 		$this->assertEquals('foobar', $app->make('foo'));
 	}
 
@@ -85,7 +85,7 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 		$app->setDeferredServices(array('foo' => 'ApplicationDeferredServiceProviderStub'));
 		$this->assertTrue($app->bound('foo'));
 		$this->assertFalse(ApplicationDeferredServiceProviderStub::$initialized);
-		$app->extend('foo', function($instance, $container) { return $instance.'bar'; });
+		$app->extend('foo', function($instance) { return $instance.'bar'; });
 		$this->assertFalse(ApplicationDeferredServiceProviderStub::$initialized);
 		$this->assertEquals('foobar', $app->make('foo'));
 		$this->assertTrue(ApplicationDeferredServiceProviderStub::$initialized);
@@ -208,6 +208,6 @@ class ApplicationMultiProviderStub extends Illuminate\Support\ServiceProvider {
 	public function register()
 	{
 		$this->app->singleton('foo', function() { return 'foo'; });
-		$this->app->singleton('bar', function($app) { return $app['foo'].'bar'; });
+		$this->app->singleton('bar', function() { return $this->app['foo'].'bar'; });
 	}
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -806,7 +806,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		{
 			$_SERVER['route.test.controller.after.filter'] = true;
 		});
-		$container->singleton('illuminate.route.dispatcher', function($container) use ($router)
+		$container->singleton('illuminate.route.dispatcher', function() use ($container, $router)
 		{
 			return new Illuminate\Routing\ControllerDispatcher($router, $container);
 		});


### PR DESCRIPTION
This allows to do the following in the ServiceProvider register methods:

``` php
public function register() {
    $this->app->bind('Acme\Namespace\Notifier', function (Repository $config) {
        return new Notifier($config->get('services.notification.token'));
    });
}
```

instead of

``` php
public function register() {
    $this->app->bind('Acme\Namespace\Notifier', function ($app) {
        return new Notifier($app['config']->get('services.notification.token'));
    });
}
```

This also keeps everything working, except when people type hinted the parameters.

These examples still work:

``` php
public function register() {
    $this->app->bind('Acme\Namespace\Notifier', function ($app) {
        return new Notifier($app['config']->get('services.notification.token'));
    });
}
```

``` php
public function register() {
    $this->app->bind('Acme\Namespace\Notifier', function ($app, $parameters) {
        return new Notifier($app['config']->get('services.notification.token'), $parameters);
    });
}
```

This will be broken, because Application would be resolved from the container and `$parameters` would become `$app`

``` php
public function register() {
    $this->app->bind('Acme\Namespace\Notifier', function (Application $app, $parameters) {
        return new Notifier($app['config']->get('services.notification.token'), $parameters);
    });
}
```

This would work as well:

``` php
public function register() {
    $this->app->bind('Acme\Namespace\Notifier', function ($app, $parameters, Repository $config) {
        return new Notifier($config->get('services.notification.token'));
    });
}
```
