### PR TITLE
[5.0] Improve "key:generate" Console Command

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -26,21 +26,23 @@ class KeyGenerateCommand extends Command {
 	 */
 	public function fire()
 	{
-		$key = $this->getRandomKey();
+		$original_key = $this->laravel['config']['app.key'];
 
-		foreach ([base_path('.env'), base_path('.env.example')] as $path)
+		$environment_key = $this->getRandomKey();
+
+		foreach(glob(base_path()."/.env*") as $path)
 		{
-			if (file_exists($path))
-			{
-				file_put_contents($path, str_replace(
-					$this->laravel['config']['app.key'], $key, file_get_contents($path)
-				));
-			}
+			$this->setEnvKey($environment_key, $path, $original_key);
+			$this->info("Environment application key [$environment_key] set successfully for $path.");
+			$this->laravel['config']['app.key'] = $environment_key;
 		}
 
-		$this->laravel['config']['app.key'] = $key;
-
-		$this->info("Application key [$key] set successfully.");
+		if ($original_key === 'SomeRandomString')
+		{
+			$default_key = $this->getRandomKey();
+			$this->setEnvKey($default_key, base_path($this->laravel['path.config'].'/app.php'), $original_key);
+			$this->info("Default application key [$default_key] set successfully for ".base_path($this->laravel['path.config'].'/app.php'));
+		}
 	}
 
 	/**
@@ -53,4 +55,23 @@ class KeyGenerateCommand extends Command {
 		return Str::random(32);
 	}
 
+	/**
+	 * Set random key for the application.
+	 *
+	 * @param  string  $key
+	 * @param  string  $path
+	 * @param  string  $original_key
+	 * @return boolean
+	 */
+	protected function setEnvKey($key, $path, $original_key)
+	{
+		if (file_exists($path))
+		{
+			file_put_contents($path, str_replace(
+				$original_key, $key, file_get_contents($path)
+			));
+		}
+
+		return true;
+	}
 }


### PR DESCRIPTION
This proposal fixes a couple of issues with the current `key:generate`
1. It sets a single key for any `.env*` files. This will include `.env.`, `.env.example`, `.env.behat` etc that people setup to use.
2. It sets a separate second default key for the `app.php` config on a new project (only). This ensures that people who dont use `.env` will still have some sort of secure key set

Note: this assumes that PR https://github.com/laravel/laravel/pull/3216 on laravel/laravel is also accepted (for the default key name in `app.php`)
