### PR TITLE
[4,2] add getMorphType method in MorphTo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -195,6 +195,16 @@ class MorphTo extends BelongsTo {
 	}
 
 	/**
+	 * Get the foreign key "type" name.
+	 *
+	 * @return string
+	 */
+	public function getMorphType()
+	{
+		return $this->morphType;
+	}
+
+	/**
 	 * Get the dictionary used by the relationship.
 	 *
 	 * @return array


### PR DESCRIPTION
getMorphType exist in
Illuminate\Database\Eloquent\Relations\MorphToMany.php:
Illuminate\Database\Eloquent\Relations\MorphOneOrMany.php:

but not exist in
Illuminate\Database\Eloquent\Relations\MorphTophp:
