### PR TITLE
[5.0] Translate column type correctly when changing

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -359,7 +359,7 @@ abstract class Grammar extends BaseGrammar {
 	 */
 	protected function getDoctrineColumnChangeOptions(Fluent $fluent)
 	{
-		$options = ['type' => Type::getType($fluent['type'])];
+		$options = ['type' => Type::getType($this->getType($fluent))];
 
 		if (in_array($fluent['type'], ['text', 'mediumText', 'longText']))
 		{


### PR DESCRIPTION
This change fixes an issue where un-translated column types were
getting passed to DBAL causing a crash.

For example, trying to change a `dateTime` column in MySQL would pass
'dateTime' to `Type::getType`, when it is expecting `datetime`.
