### PR TITLE
[5.0] The findOrFail method should throw an error when any model is missing

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -105,13 +105,22 @@ class Builder {
 	 *
 	 * @param  mixed  $id
 	 * @param  array  $columns
-	 * @return \Illuminate\Database\Eloquent\Model|static
+	 * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
 	 *
 	 * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
 	 */
 	public function findOrFail($id, $columns = array('*'))
 	{
-		if ( ! is_null($model = $this->find($id, $columns))) return $model;
+		$result = $this->find($id, $columns);
+
+		if (is_array($id))
+		{
+			if (count($result) == count(array_unique($id))) return $result;
+		}
+		elseif ( ! is_null($result))
+		{
+			return $result;
+		}
 
 		throw (new ModelNotFoundException)->setModel(get_class($this->model));
 	}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -725,9 +725,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public static function findOrFail($id, $columns = array('*'))
 	{
-		if ( ! is_null($model = static::find($id, $columns))) return $model;
-
-		throw (new ModelNotFoundException)->setModel(get_called_class());
+		return static::query()->findOrFail($id, $columns);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -71,6 +71,18 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
 	 */
+	public function testFindOrFailMethodWithManyThrowsModelNotFoundException()
+	{
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder[get]', array($this->getMockQueryBuilder()));
+		$builder->setModel($this->getMockModel());
+		$builder->getQuery()->shouldReceive('whereIn')->once()->with('foo_table.foo', [1, 2]);
+		$builder->shouldReceive('get')->with(array('column'))->andReturn(new Collection([1]));
+		$result = $builder->findOrFail([1, 2], array('column'));
+	}
+
+	/**
+	 * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
+	 */
 	public function testFirstOrFailMethodThrowsModelNotFoundException()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', array($this->getMockQueryBuilder()));
@@ -437,7 +449,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($builder, $result);
 	}
 
-	
+
 	public function testHasNested()
 	{
 		$model = new EloquentBuilderTestModelParentStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 
@@ -1263,10 +1264,10 @@ class EloquentModelFindWithWritePdoStub extends Illuminate\Database\Eloquent\Mod
 }
 
 class EloquentModelFindNotFoundStub extends Illuminate\Database\Eloquent\Model {
-	public function newQuery()
+	public static function query()
 	{
 		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
-		$mock->shouldReceive('find')->once()->with(1, array('*'))->andReturn(null);
+		$mock->shouldReceive('findOrFail')->once()->with(1, array('*'))->andThrow(new ModelNotFoundException);
 		return $mock;
 	}
 }


### PR DESCRIPTION
https://github.com/laravel/framework/issues/7043

``` php
Model::findOrFail([1, 2]);
```

will now throw a `ModelNotFoundException` if _any_ of the requested IDs don't exist.
