### PR TITLE
[5.0] Added "required_unless" Validator

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -143,7 +143,7 @@ class Validator implements ValidatorContract {
 	 * @var array
 	 */
 	protected $implicitRules = array(
-		'Required', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll', 'RequiredIf', 'Accepted'
+		'Required', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll', 'RequiredIf', 'RequiredUnless', 'Accepted'
 	);
 
 	/**
@@ -699,6 +699,30 @@ class Validator implements ValidatorContract {
 		$values = array_slice($parameters, 1);
 
 		if (in_array($data, $values))
+		{
+			return $this->validateRequired($attribute, $value);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate that an attribute exists when another attribute is not a given value.
+	 *
+	 * @param  string  $attribute
+	 * @param  mixed   $value
+	 * @param  mixed   $parameters
+	 * @return bool
+	 */
+	protected function validateRequiredUnless($attribute, $value, $parameters)
+	{
+		$this->requireParameterCount(2, $parameters, 'required_unless');
+
+		$data = array_get($this->data, $parameters[0]);
+
+		$values = array_slice($parameters, 1);
+
+		if (!in_array($data, $values))
 		{
 			return $this->validateRequired($attribute, $value);
 		}
@@ -1899,6 +1923,32 @@ class Validator implements ValidatorContract {
 		$parameters[0] = $this->getAttribute($parameters[0]);
 
 		return str_replace(array(':other', ':value'), $parameters, $message);
+	}
+
+	/**
+	 * Replace all place-holders for the required_unless rule.
+	 *
+	 * @param  string  $message
+	 * @param  string  $attribute
+	 * @param  string  $rule
+	 * @param  array   $parameters
+	 * @return string
+	 */
+	protected function replaceRequiredUnless($message, $attribute, $rule, $parameters)
+	{
+		$parameters[0] = $this->getAttribute($parameters[0]);
+
+		foreach ($parameters as $index => $parameter) {
+			if ($index == 0) continue;
+
+			$exceptions[] = $this->getDisplayableValue($parameters[0], $parameter);
+		}
+
+		$last = count($exceptions) > 1 ? ' or '.array_pop($exceptions) : '';
+
+		$parameters[1] = implode(', ', $exceptions).$last;
+
+		return str_replace(array(':other', ':parameters'), $parameters, $message);
 	}
 
 	/**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -471,6 +471,36 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRequiredUnless()
+	{
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('first' => 'taylor'), array('last' => 'required_unless:first,dayle'));
+		$this->assertTrue($v->fails());
+
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('first' => 'taylor', 'last' => 'otwell'), array('last' => 'required_unless:first,dayle'));
+		$this->assertTrue($v->passes());
+
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('first' => 'taylor', 'last' => 'otwell'), array('last' => 'required_unless:first,dayle,taylor'));
+		$this->assertTrue($v->passes());
+
+		$trans = $this->getRealTranslator();
+		$v = new Validator($trans, array('first' => 'dayle', 'last' => 'rees'), array('last' => 'required_unless:first,dayle,taylor'));
+		$this->assertTrue($v->passes());
+
+		// error message when passed multiple values (required_unless:foo,bar,baz)
+		$trans = $this->getRealTranslator();
+		$trans->addResource('array', array('validation.required_unless' => 'The :attribute field is required when :other is not :parameters.'), 'en', 'messages');
+		$v = new Validator($trans, array('first' => 'dayle', 'last' => ''), array('last' => 'RequiredUnless:first,taylor'));
+		$this->assertFalse($v->passes());
+		$this->assertEquals('The last field is required when first is not taylor.', $v->messages()->first('last'));
+		$v = new Validator($trans, array('first' => 'dayle', 'last' => ''), array('last' => 'RequiredUnless:first,taylor,jim,bob'));
+		$this->assertFalse($v->passes());
+		$this->assertEquals('The last field is required when first is not taylor, jim or bob.', $v->messages()->first('last'));
+	}
+
+
 	public function testValidateConfirmed()
 	{
 		$trans = $this->getRealTranslator();


### PR DESCRIPTION
required_with has required_without, so it only seems fair that required_if has required_unless. Mentioned this in #laravel-dev, but didn't get much response. The scenario I needed it for was selecting delivery methods in an app - a postal address field was required unless "collection" was the chosen delivery method.
