### PR TITLE
[4.2] Correctly fill the $request->request parameter bag on creation

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -572,12 +572,20 @@ class Request extends SymfonyRequest {
 	{
 		if ($request instanceof static) return $request;
 
-		return (new static)->duplicate(
+		$content = $request->content;
+
+		$request = (new static)->duplicate(
 
 			$request->query->all(), $request->request->all(), $request->attributes->all(),
 
 			$request->cookies->all(), $request->files->all(), $request->server->all()
 		);
+
+		$request->content = $content;
+
+		$request->request = $request->getInputSource();
+
+		return $request;
 	}
 
 	/**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class HttpRequestTest extends PHPUnit_Framework_TestCase {
 
@@ -390,6 +391,25 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$this->setExpectedException('RuntimeException');
 		$request = Request::create('/', 'GET');
 		$request->session();
+	}
+
+
+	public function testCreateFromBase()
+	{
+		$body = [
+			'foo' => 'bar',
+			'baz' => ['qux'],
+		];
+
+		$server = array(
+			'CONTENT_TYPE' => 'application/json',
+		);
+
+		$base = SymfonyRequest::create('/', 'GET', array(), array(), array(), $server, json_encode($body));
+
+		$request = Request::createFromBase($base);
+
+		$this->assertEquals($request->request->all(), $body);
 	}
 
 }


### PR DESCRIPTION
The `Illuminate\Http\Request` class extends the `Symfony\Component\HttpFoundation\Request`. But the SymfonyRequest does not fill the property `->request` (which should hold the [POST parameters](https://github.com/symfony/HttpFoundation/blob/2.5/Request.php#L210)), except when the `Content-Type` header is equal to `application/x-www-form-urlencoded` (see [source](https://github.com/symfony/HttpFoundation/blob/2.5/Request.php#L286-L287)).

`IlluminateRequest` parses the request body if the `Content-Type` header is set to `application/json`, but only when the `getInputSource()` method is called. In Laravel you can request the `IlluminateRequest` and pass it on, but when the `IlluminateRequest` is used using the `SymfonyRequest` interface, and they access the `->request` `ParameterBag`, it will not be loaded with the request body data if it's json formatted.
