### PR TITLE
[5.0] Use Contracts in Console Classes

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -14,7 +14,7 @@ class Application extends SymfonyApplication implements ApplicationContract {
 	/**
 	 * The Laravel application instance.
 	 *
-	 * @var \Illuminate\Foundation\Application
+	 * @var \Illuminate\Contracts\Foundation\Application
 	 */
 	protected $laravel;
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -8,13 +8,14 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Illuminate\Contracts\Foundation\Application as LaravelApplication;
 
 class Command extends \Symfony\Component\Console\Command\Command {
 
 	/**
 	 * The Laravel application instance.
 	 *
-	 * @var \Illuminate\Foundation\Application
+	 * @var \Illuminate\Contracts\Foundation\Application
 	 */
 	protected $laravel;
 
@@ -365,7 +366,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	/**
 	 * Get the Laravel application instance.
 	 *
-	 * @return \Illuminate\Foundation\Application
+	 * @return \Illuminate\Contracts\Foundation\Application
 	 */
 	public function getLaravel()
 	{
@@ -375,10 +376,10 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	/**
 	 * Set the Laravel application instance.
 	 *
-	 * @param  \Illuminate\Foundation\Application  $laravel
+	 * @param  \Illuminate\Contracts\Foundation\Application  $laravel
 	 * @return void
 	 */
-	public function setLaravel($laravel)
+	public function setLaravel(LaravelApplication $laravel)
 	{
 		$this->laravel = $laravel;
 	}

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Mockery as m;
-use Illuminate\Container\Container;
+use Illuminate\Foundation\Application;
 use Illuminate\Cache\Console\CacheTableCommand;
 
 class CacheTableCommandTest extends PHPUnit_Framework_TestCase {
@@ -20,7 +20,7 @@ class CacheTableCommandTest extends PHPUnit_Framework_TestCase {
 		);
 		$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
 
-		$app = new Container();
+		$app = new Application();
 		$app['path.database'] = __DIR__;
 		$app['migration.creator'] = $creator;
 		$command->setLaravel($app);

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -13,7 +13,7 @@ class DatabaseMigrationInstallCommandTest extends PHPUnit_Framework_TestCase {
 	public function testFireCallsRepositoryToInstall()
 	{
 		$command = new Illuminate\Database\Console\Migrations\InstallCommand($repo = m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'));
-		$command->setLaravel(new Illuminate\Container\Container);
+		$command->setLaravel(new Illuminate\Foundation\Application);
 		$repo->shouldReceive('setSource')->once()->with('foo');
 		$repo->shouldReceive('createRepository')->once();
 

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -12,7 +12,7 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testBasicCreateDumpsAutoload()
 	{
-		$command = new DatabaseMigrationMakeCommandTestStub(
+		$command = new MigrateMakeCommand(
 			$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
 			$composer = m::mock('Illuminate\Foundation\Composer'),
 			__DIR__.'/vendor'
@@ -28,7 +28,7 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testBasicCreateGivesCreatorProperArguments()
 	{
-		$command = new DatabaseMigrationMakeCommandTestStub(
+		$command = new MigrateMakeCommand(
 			$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
 			m::mock('Illuminate\Foundation\Composer')->shouldIgnoreMissing(),
 			__DIR__.'/vendor'
@@ -44,7 +44,7 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testBasicCreateGivesCreatorProperArgumentsWhenTableIsSet()
 	{
-		$command = new DatabaseMigrationMakeCommandTestStub(
+		$command = new MigrateMakeCommand(
 			$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
 			m::mock('Illuminate\Foundation\Composer')->shouldIgnoreMissing(),
 			__DIR__.'/vendor'
@@ -63,14 +63,4 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
 	}
 
-}
-
-
-
-class DatabaseMigrationMakeCommandTestStub extends MigrateMakeCommand
-{
-	public function call($command, array $arguments = array())
-	{
-		//
-	}
 }

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -17,7 +17,7 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 			$composer = m::mock('Illuminate\Foundation\Composer'),
 			__DIR__.'/vendor'
 		);
-		$app = new Illuminate\Container\Container;
+		$app = new Illuminate\Foundation\Application;
 		$app['path.database'] = __DIR__;
 		$command->setLaravel($app);
 		$creator->shouldReceive('create')->once()->with('create_foo', __DIR__.'/migrations', null, false);
@@ -33,7 +33,7 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 			m::mock('Illuminate\Foundation\Composer')->shouldIgnoreMissing(),
 			__DIR__.'/vendor'
 		);
-		$app = new Illuminate\Container\Container;
+		$app = new Illuminate\Foundation\Application;
 		$app['path.database'] = __DIR__;
 		$command->setLaravel($app);
 		$creator->shouldReceive('create')->once()->with('create_foo', __DIR__.'/migrations', null, false);
@@ -49,7 +49,7 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 			m::mock('Illuminate\Foundation\Composer')->shouldIgnoreMissing(),
 			__DIR__.'/vendor'
 		);
-		$app = new Illuminate\Container\Container;
+		$app = new Illuminate\Foundation\Application;
 		$app['path.database'] = __DIR__;
 		$command->setLaravel($app);
 		$creator->shouldReceive('create')->once()->with('create_foo', __DIR__.'/migrations', 'users', true);

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Foundation\Application;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 
 class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase {
@@ -76,14 +77,11 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class ApplicationDatabaseMigrationStub implements ArrayAccess {
-	public $content = array();
-	public $env = 'development';
-	public function __construct(array $data = array()) { $this->content = $data; }
-	public function offsetExists($offset) { return isset($this->content[$offset]); }
-	public function offsetGet($offset) { return $this->content[$offset]; }
-	public function offsetSet($offset, $value) { $this->content[$offset] = $value; }
-	public function offsetUnset($offset) { unset($this->content[$offset]); }
-	public function environment() { return $this->env; }
-	public function call($method) { return call_user_func($method); }
+class ApplicationDatabaseMigrationStub extends Application {
+	public function __construct(array $data = array()) {
+		foreach ($data as $abstract => $instance) {
+			$this->instance($abstract, $instance);
+		}
+	}
+	public function environment() { return 'development'; }
 }

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -41,8 +41,6 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 	}
 }
 
-class AppDatabaseMigrationStub {
-	public $env = 'development';
-	public function environment() { return $this->env; }
-	public function call($method) { return call_user_func($method); }
+class AppDatabaseMigrationStub extends \Illuminate\Foundation\Application {
+	public function environment() { return 'development'; }
 }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Foundation\Application;
 use Illuminate\Database\Console\Migrations\RollbackCommand;
 
 class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase {
@@ -42,8 +43,6 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class AppDatabaseMigrationRollbackStub {
-	public $env = 'development';
-	public function environment() { return $this->env; }
-	public function call($method) { return call_user_func($method); }
+class AppDatabaseMigrationRollbackStub extends Application {
+	public function environment() { return 'development'; }
 }

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Session\Console\SessionTableCommand;
-use Illuminate\Container\Container;
+use Illuminate\Foundation\Application;
 use Mockery as m;
 
 class SessionTableCommandTest extends PHPUnit_Framework_TestCase {
@@ -20,7 +20,7 @@ class SessionTableCommandTest extends PHPUnit_Framework_TestCase {
 		);
 		$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
 
-		$app = new Container();
+		$app = new Application();
 		$app['path.database'] = __DIR__;
 		$app['migration.creator'] = $creator;
 		$command->setLaravel($app);


### PR DESCRIPTION
I needed to fix some tests, so I was able to simplify some of the stub classes.

This replaces #6974.

@taylorotwell Basically every core file should be reviewed before the release of 5.0 for referencing the proper contracts. Also, what methods all the contracts contain. Before you cannot break backwards compatibility anymore...
