### PR TITLE
[5.0] Do not call terminate method if handle method not called in StartSession middleware

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -21,6 +21,12 @@ class StartSession implements MiddlewareContract, TerminableMiddleware {
 	protected $manager;
 
 	/**
+	 * True if handle method called
+	 * @var bool
+	 */
+	protected $sessionHandled = false;
+
+	/**
 	 * Create a new session middleware.
 	 *
 	 * @param  \Illuminate\Session\SessionManager  $manager
@@ -40,6 +46,7 @@ class StartSession implements MiddlewareContract, TerminableMiddleware {
 	 */
 	public function handle($request, Closure $next)
 	{
+		$this->sessionHandled = true;
 		// If a session driver has been configured, we will need to start the session here
 		// so that the data is ready for an application. Note that the Laravel sessions
 		// do not make use of PHP "native" sessions in any way since they are crappy.
@@ -76,7 +83,7 @@ class StartSession implements MiddlewareContract, TerminableMiddleware {
 	 */
 	public function terminate($request, $response)
 	{
-		if ($this->sessionConfigured() && ! $this->usingCookieSessions())
+		if ($this->sessionHandled && $this->sessionConfigured() && ! $this->usingCookieSessions())
 		{
 			$this->manager->driver()->save();
 		}


### PR DESCRIPTION
Getting fatal error for application maintenance mode
ErrorException: Undefined index: _sf2_meta at /var/www/vendor/laravel/framework/src/Illuminate/Session/Store.php:280

If application in maintenance mode
Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode throw new HttpException(503);
and StartSession::handle method not called, but at the end of the request Laravel call terminate function in StartSession middleware to save session data and that why getting error "Undefined index: _sf2_meta at "

My change is checking if handle method not called, than not saving session data
