### PR TITLE
Removing the call to array_only(...) as it breaks the new AWS S3 v3 LIbs...

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -127,10 +127,8 @@ class FilesystemManager implements FactoryContract {
 	 */
 	public function createS3Driver(array $config)
 	{
-		$s3Config = array_only($config, ['key', 'region', 'secret', 'signature']);
-
 		return $this->adapt(
-			new Flysystem(new S3Adapter(S3Client::factory($s3Config), $config['bucket']))
+			new Flysystem(new S3Adapter(S3Client::factory($config), $config['bucket']))
 		);
 	}
 


### PR DESCRIPTION
.... Passing entire array should keep v2 working as well as allow for v3 to work. 

Alternatively we could add the new 'credentials' and 'version' fields to the array_only(...).
