### PR TITLE
Version mismatch of thephpleague/flysystem-aws-s3

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -7,7 +7,7 @@ use League\Flysystem\FilesystemInterface;
 use League\Flysystem\Filesystem as Flysystem;
 use League\Flysystem\Rackspace\RackspaceAdapter;
 use League\Flysystem\Adapter\Local as LocalAdapter;
-use League\Flysystem\AwsS3v3\AwsS3Adapter as S3Adapter;
+use League\Flysystem\AwsS3V2\AwsS3Adapter as S3Adapter;
 use Illuminate\Contracts\Filesystem\Factory as FactoryContract;
 
 class FilesystemManager implements FactoryContract {


### PR DESCRIPTION
There is a version mismatch in the use of thephpleague/flysystem-aws-s3. laravel/framework requires v2 (league/flysystem-aws-s3-v2).
