### PR TITLE
[5.0] Get migration path from parent

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -76,7 +76,7 @@ class StatusCommand extends BaseCommand {
 	 */
 	protected function getAllMigrationFiles()
 	{
-		return $this->migrator->getMigrationFiles($this->laravel['path.database'].'/migrations');
+		return $this->migrator->getMigrationFiles($this->getMigrationPath());
 	}
 
 }


### PR DESCRIPTION
On Illuminate\Database\Console\Migrations:

StatusCommand.php is using `$this->laravel['path.database'].'/migrations'` to get the migrations path

However, its parent class (BaseCommand.php) already has a function that does the exact same thing: `$this->getMigrationPath()`
