### PR TITLE
Fixing relation queries to ignore the parent scope in order to avoid inf...

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -266,7 +266,7 @@ abstract class Relation {
 	 */
 	public function wrap($value)
 	{
-		return $this->parent->getQuery()->getGrammar()->wrap($value);
+		return $this->parent->newQueryWithoutScopes()->getQuery()->getGrammar()->wrap($value);
 	}
 
 	/**


### PR DESCRIPTION
Encountered an issue when using whereHas inside a globalScope.  When the global scope runs on the parent it calls whereHas which gets the related object which then gets the parents query object and runs the scope again.  This results in a loop.  Fixing this involves getting a scopeless query object from the parent when adding the relation in the whereHas.  The global scope will still be applied to the parent object in its own right, just not apart of the relation building mechanism.
