### PR TITLE
[4.2] Update getQualifiedParentKeyName() visibility on all relations and remove overrides

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1033,16 +1033,6 @@ class BelongsToMany extends Relation {
 	}
 
 	/**
-	 * Get the fully qualified parent key name.
-	 *
-	 * @return string
-	 */
-	protected function getQualifiedParentKeyName()
-	{
-		return $this->parent->getQualifiedKeyName();
-	}
-
-	/**
 	 * Get the intermediate table for the relationship.
 	 *
 	 * @return string

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -251,16 +251,6 @@ class HasManyThrough extends Relation {
 	}
 
 	/**
-	 * Get the key name of the parent model.
-	 *
-	 * @return string
-	 */
-	protected function getQualifiedParentKeyName()
-	{
-		return $this->parent->getQualifiedKeyName();
-	}
-
-	/**
 	 * Get the key for comparing against the parent key in "has" query.
 	 *
 	 * @return string

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -213,7 +213,7 @@ abstract class Relation {
 	 *
 	 * @return string
 	 */
-	protected function getQualifiedParentKeyName()
+	public function getQualifiedParentKeyName()
 	{
 		return $this->parent->getQualifiedKeyName();
 	}


### PR DESCRIPTION
As described in issue #7035, the visibility of the `getQualifiedParentKeyName()` method on relations was different for HasOneOrMany vs. all the rest.  This pull request sets the visibility of this method for all relations to public.

In contrast to PR #7071, this pull request also removes the function override from the `BelongsToMany` and `HasManyThrough` classes because it is the same logic as the base `Relation` class. If PR #7071 is merged, this PR can be closed.
