### PR TITLE
[4.2] Update getQualifiedParentKeyName() visibility on all relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1037,7 +1037,7 @@ class BelongsToMany extends Relation {
 	 *
 	 * @return string
 	 */
-	protected function getQualifiedParentKeyName()
+	public function getQualifiedParentKeyName()
 	{
 		return $this->parent->getQualifiedKeyName();
 	}

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -255,7 +255,7 @@ class HasManyThrough extends Relation {
 	 *
 	 * @return string
 	 */
-	protected function getQualifiedParentKeyName()
+	public function getQualifiedParentKeyName()
 	{
 		return $this->parent->getQualifiedKeyName();
 	}

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -213,7 +213,7 @@ abstract class Relation {
 	 *
 	 * @return string
 	 */
-	protected function getQualifiedParentKeyName()
+	public function getQualifiedParentKeyName()
 	{
 		return $this->parent->getQualifiedKeyName();
 	}


### PR DESCRIPTION
As described in issue #7035, the visibility of the getQualifiedParentKeyName() method on relations was different for HasOneOrMany vs. all the rest. This pull request sets the visibility of this method for all relations to public.

In contrast to PR #7069, this pull request does not remove the overridden methods, and only updates the visibility.  If PR #7069 is merged, this PR can be closed.
