### PR TITLE
[5.0] Marshalling arguments to commands failed if the argument evaluated to fa...

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -131,8 +131,11 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
 	protected function getParameterValueForCommand($command, ArrayAccess $source,
                                                    ReflectionParameter $parameter, array $extras = array())
 	{
-		$value = $this->extractValueFromExtras($parameter, $extras)
-								?: $this->extractValueFromSource($source, $parameter);
+		$value = $this->extractValueFromExtras($parameter, $extras);
+		if (is_null($value))
+		{
+			$value = $this->extractValueFromSource($source, $parameter);
+		}
 
 		if (is_null($value) && $parameter->isDefaultValueAvailable())
 		{

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -132,12 +132,12 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
                                                    ReflectionParameter $parameter, array $extras = array())
 	{
 		$value = $this->extractValueFromExtras($parameter, $extras);
+		
 		if (is_null($value))
 		{
 			$value = $this->extractValueFromSource($source, $parameter);
 		}
-
-		if (is_null($value) && $parameter->isDefaultValueAvailable())
+		elseif (is_null($value) && $parameter->isDefaultValueAvailable())
 		{
 			$value = $parameter->getDefaultValue();
 		}

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -100,10 +100,30 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('taylor otwell', $result);
 	}
 
+
+	public function testMarshallArguments()
+	{
+		$instance = new Dispatcher(new Container);
+		$result = $instance->dispatchFromArray('BusDispatcherTestArgumentMapping', ['flag' => false, 'emptyString' => '']);
+		$this->assertTrue($result);
+	}
 }
 
 class BusDispatcherTestBasicCommand {
 
+}
+
+class BusDispatcherTestArgumentMapping implements Illuminate\Contracts\Bus\SelfHandling {
+	public $flag, $emptyString;
+	public function __construct($flag, $emptyString)
+	{
+		$this->flag = $flag;
+		$this->emptyString = $emptyString;
+	}
+	public function handle()
+	{
+		return true;
+	}
 }
 
 class BusDispatcherTestSelfHandlingCommand implements Illuminate\Contracts\Bus\SelfHandling {


### PR DESCRIPTION
When trying to marshall arguments to command constructors in getParameterValueForCommand(), empty strings, integer 0, bool false etc would all cause an exception to be thrown, suggesting the argument was missing.

Fixed the problem and added a test to verify the behaviour.
