### PR TITLE
Make the ConfirmableTrait confirm question a bit more clear

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -24,7 +24,7 @@ trait ConfirmableTrait {
 			$this->comment(str_repeat('*', strlen($warning) + 12));
 			$this->output->writeln('');
 
-			$confirmed = $this->confirm('Do you really wish to run this command?');
+			$confirmed = $this->confirm('Do you really wish to run this command [y/N]?');
 
 			if ( ! $confirmed)
 			{


### PR DESCRIPTION
Some people might find this a bit unclear what to do when they see this question. This PR adds a `[y/N]` to the end of the question, similar to the `Do you want to continue [Y/n]?` from apt.
