### PR TITLE
[5.0] Override defaults for artisan serve

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -47,9 +47,9 @@ class ServeCommand extends Command {
 	protected function getOptions()
 	{
 		return array(
-			array('host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', 'localhost'),
+			array('host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', env('SERVE_HOST', 'localhost')),
 
-			array('port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', 8000),
+			array('port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', env('SERVE_PORT', 8000)),
 		);
 	}
 


### PR DESCRIPTION
In my work I must rely only with PHP built-in server in my develop machine to comply with IT policies, I can't use Apache, Ngnix, VMs or Vagrant.

While working with multiple projects at time, I found boring typing over and over a different host/port (`php artisan serve --host xpto --port 8088`), so override `php artisan serve` defaults into a `.env` file sounded a good idea for me.

I don't know if this is the best approach, maybe extract this to a config file.
