### PR TITLE
[4.2] Ignore parent global scopes when relation grabs its parent's query builder in order to avoid loop

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -266,7 +266,7 @@ abstract class Relation {
 	 */
 	public function wrap($value)
 	{
-		return $this->parent->getQuery()->getGrammar()->wrap($value);
+		return $this->parent->newQueryWithoutScopes()->getQuery()->getGrammar()->wrap($value);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -102,7 +102,7 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('select')->once()->with(m::type('Illuminate\Database\Query\Expression'));
 		$relation->getParent()->shouldReceive('getTable')->andReturn('table');
 		$query->shouldReceive('where')->once()->with('table.foreign_key', '=', m::type('Illuminate\Database\Query\Expression'));
-		$relation->getParent()->shouldReceive('getQuery')->andReturn($parentQuery = m::mock('StdClass'));
+		$relation->getQuery()->shouldReceive('getQuery')->andReturn($parentQuery = m::mock('StdClass'));
 		$parentQuery->shouldReceive('getGrammar')->once()->andReturn($grammar = m::mock('StdClass'));
 		$grammar->shouldReceive('wrap')->once()->with('table.id');
 
@@ -120,6 +120,7 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 		$parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 		$parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
 		$parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+        $parent->shouldReceive('newQueryWithoutScopes')->andReturn($builder);
 		return new HasOne($builder, $parent, 'table.foreign_key', 'id');
 	}
 

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -120,7 +120,7 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 		$parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 		$parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
 		$parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-        $parent->shouldReceive('newQueryWithoutScopes')->andReturn($builder);
+		$parent->shouldReceive('newQueryWithoutScopes')->andReturn($builder);
 		return new HasOne($builder, $parent, 'table.foreign_key', 'id');
 	}
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -37,9 +37,40 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
 		$relation->touch();
 	}
 
+    /**
+     * Executing parent model's global scopes could result in an infinite loop when the parent model's
+     * global scope utilizes a relation in a query like has or whereHas
+     */
+    public function testDonNotRunParentModelGlobalScopes()
+    {
+        /** @var Mockery\MockInterface $parent */
+        $eloquentBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $queryBuilder = m::mock('Illuminate\Database\Query\Builder');
+        $parent = m::mock('EloquentRelationResetModelStub')->makePartial();
+        $grammar = m::mock('\Illuminate\Database\Grammar');
+
+        $eloquentBuilder->shouldReceive('getModel')->andReturn($related = m::mock('StdClass'));
+        $eloquentBuilder->shouldReceive('getQuery')->andReturn($queryBuilder);
+        $queryBuilder->shouldReceive('getGrammar')->andReturn($grammar);
+        $grammar->shouldReceive('wrap');
+        $parent->shouldReceive('newQueryWithoutScopes')->andReturn($eloquentBuilder);
+
+        //Test Condition
+        $parent->shouldReceive('applyGlobalScopes')->andReturn($eloquentBuilder)->never();
+
+        $relation = new EloquentRelationStub($eloquentBuilder, $parent);
+        $relation->wrap('test');
+    }
+
 }
 
-class EloquentRelationResetModelStub extends Illuminate\Database\Eloquent\Model {}
+class EloquentRelationResetModelStub extends Illuminate\Database\Eloquent\Model {
+    //Override method call which would normally go through __call()
+    public function getQuery()
+    {
+        return $this->newQuery()->getQuery();
+    }
+}
 
 
 class EloquentRelationResetStub extends Illuminate\Database\Eloquent\Builder {
@@ -50,4 +81,12 @@ class EloquentRelationResetStub extends Illuminate\Database\Eloquent\Builder {
 
 class EloquentRelationQueryStub extends Illuminate\Database\Query\Builder {
 	public function __construct() {}
+}
+
+class EloquentRelationStub extends \Illuminate\Database\Eloquent\Relations\Relation {
+    public function addConstraints() {}
+    public function addEagerConstraints(array $models) {}
+    public function initRelation(array $models, $relation) {}
+    public function match(array $models, \Illuminate\Database\Eloquent\Collection $results, $relation) {}
+    public function getResults() {}
 }

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -37,39 +37,41 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
 		$relation->touch();
 	}
 
-    /**
-     * Executing parent model's global scopes could result in an infinite loop when the parent model's
-     * global scope utilizes a relation in a query like has or whereHas
-     */
-    public function testDonNotRunParentModelGlobalScopes()
-    {
-        /** @var Mockery\MockInterface $parent */
-        $eloquentBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $queryBuilder = m::mock('Illuminate\Database\Query\Builder');
-        $parent = m::mock('EloquentRelationResetModelStub')->makePartial();
-        $grammar = m::mock('\Illuminate\Database\Grammar');
+	/**
+	 * Testing to ensure loop does not occur during relational queries in global scopes
+	 *
+	 * Executing parent model's global scopes could result in an infinite loop when the
+	 * parent model's global scope utilizes a relation in a query like has or whereHas
+	 */
+	public function testDonNotRunParentModelGlobalScopes()
+	{
+		/** @var Mockery\MockInterface $parent */
+		$eloquentBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$queryBuilder = m::mock('Illuminate\Database\Query\Builder');
+		$parent = m::mock('EloquentRelationResetModelStub')->makePartial();
+		$grammar = m::mock('\Illuminate\Database\Grammar');
 
-        $eloquentBuilder->shouldReceive('getModel')->andReturn($related = m::mock('StdClass'));
-        $eloquentBuilder->shouldReceive('getQuery')->andReturn($queryBuilder);
-        $queryBuilder->shouldReceive('getGrammar')->andReturn($grammar);
-        $grammar->shouldReceive('wrap');
-        $parent->shouldReceive('newQueryWithoutScopes')->andReturn($eloquentBuilder);
+		$eloquentBuilder->shouldReceive('getModel')->andReturn($related = m::mock('StdClass'));
+		$eloquentBuilder->shouldReceive('getQuery')->andReturn($queryBuilder);
+		$queryBuilder->shouldReceive('getGrammar')->andReturn($grammar);
+		$grammar->shouldReceive('wrap');
+		$parent->shouldReceive('newQueryWithoutScopes')->andReturn($eloquentBuilder);
 
-        //Test Condition
-        $parent->shouldReceive('applyGlobalScopes')->andReturn($eloquentBuilder)->never();
+		//Test Condition
+		$parent->shouldReceive('applyGlobalScopes')->andReturn($eloquentBuilder)->never();
 
-        $relation = new EloquentRelationStub($eloquentBuilder, $parent);
-        $relation->wrap('test');
-    }
+		$relation = new EloquentRelationStub($eloquentBuilder, $parent);
+		$relation->wrap('test');
+	}
 
 }
 
 class EloquentRelationResetModelStub extends Illuminate\Database\Eloquent\Model {
-    //Override method call which would normally go through __call()
-    public function getQuery()
-    {
-        return $this->newQuery()->getQuery();
-    }
+	//Override method call which would normally go through __call()
+	public function getQuery()
+	{
+		return $this->newQuery()->getQuery();
+	}
 }
 
 
@@ -84,9 +86,9 @@ class EloquentRelationQueryStub extends Illuminate\Database\Query\Builder {
 }
 
 class EloquentRelationStub extends \Illuminate\Database\Eloquent\Relations\Relation {
-    public function addConstraints() {}
-    public function addEagerConstraints(array $models) {}
-    public function initRelation(array $models, $relation) {}
-    public function match(array $models, \Illuminate\Database\Eloquent\Collection $results, $relation) {}
-    public function getResults() {}
+	public function addConstraints() {}
+	public function addEagerConstraints(array $models) {}
+	public function initRelation(array $models, $relation) {}
+	public function match(array $models, \Illuminate\Database\Eloquent\Collection $results, $relation) {}
+	public function getResults() {}
 }


### PR DESCRIPTION
Resubmitting pull request on branch 4.2 and with updated tests.  I am far from a testing expert so please advise if the test needs improvement.

Encountered an issue when using whereHas inside a globalScope. When the global scope runs on the parent it calls whereHas which gets the related object which then gets the parents query object and runs the scope again. This results in a loop. Fixing this involves getting a scopeless query object from the parent when adding the relation in the whereHas. The global scope will still be applied to the parent object in its own right, just not apart of the relation building mechanism.
