### PR TITLE
[5.0] Use model@hydrate in builder@getModels

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -377,26 +377,11 @@ class Builder {
 	 */
 	public function getModels($columns = array('*'))
 	{
-		// First, we will simply get the raw results from the query builders which we
-		// can use to populate an array with Eloquent models. We will pass columns
-		// that should be selected as well, which are typically just everything.
 		$results = $this->query->get($columns);
 
 		$connection = $this->model->getConnectionName();
 
-		$models = array();
-
-		// Once we have the results, we can spin through them and instantiate a fresh
-		// model instance for each records we retrieved from the database. We will
-		// also set the proper connection name for the model after we create it.
-		foreach ($results as $result)
-		{
-			$models[] = $model = $this->model->newFromBuilder($result);
-
-			$model->setConnection($connection);
-		}
-
-		return $models;
+		return $this->model->hydrate($results, $connection)->all();
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -234,19 +234,14 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$records[] = array('name' => 'taylor', 'age' => 26);
 		$records[] = array('name' => 'dayle', 'age' => 28);
 		$builder->getQuery()->shouldReceive('get')->once()->with(array('foo'))->andReturn($records);
-		$model = m::mock('Illuminate\Database\Eloquent\Model[getTable,getConnectionName,newInstance]');
+		$model = m::mock('Illuminate\Database\Eloquent\Model[getTable,getConnectionName,hydrate]');
 		$model->shouldReceive('getTable')->once()->andReturn('foo_table');
 		$builder->setModel($model);
 		$model->shouldReceive('getConnectionName')->once()->andReturn('foo_connection');
-		$model->shouldReceive('newInstance')->andReturnUsing(function() { return new EloquentBuilderTestModelStub; });
+		$model->shouldReceive('hydrate')->once()->with($records, 'foo_connection')->andReturn(new Collection(['hydrated']));
 		$models = $builder->getModels(array('foo'));
 
-		$this->assertEquals('taylor', $models[0]->name);
-		$this->assertEquals($models[0]->getAttributes(), $models[0]->getOriginal());
-		$this->assertEquals('dayle', $models[1]->name);
-		$this->assertEquals($models[1]->getAttributes(), $models[1]->getOriginal());
-		$this->assertEquals('foo_connection', $models[0]->getConnectionName());
-		$this->assertEquals('foo_connection', $models[1]->getConnectionName());
+		$this->assertEquals($models, ['hydrated']);
 	}
 
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -187,6 +187,21 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testBasicModelHydration()
+	{
+		EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+		EloquentTestUser::create(['email' => 'abigailotwell@gmail.com']);
+
+		$models = EloquentTestUser::hydrateRaw('SELECT * FROM users WHERE email = ?', ['abigailotwell@gmail.com'], 'foo_connection');
+
+		$this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $models);
+		$this->assertInstanceOf('EloquentTestUser', $models[0]);
+		$this->assertEquals('abigailotwell@gmail.com', $models[0]->email);
+		$this->assertEquals('foo_connection', $models[0]->getConnectionName());
+		$this->assertEquals(1, $models->count());
+	}
+
+
 	public function testHasOnSelfReferencingBelongsToManyRelationship()
 	{
 		$user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -73,14 +73,18 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	public function testHydrateCreatesCollectionOfModels()
 	{
 		$data = array(array('name' => 'Taylor'), array('name' => 'Otwell'));
-		$collection = EloquentModelStub::hydrate($data);
+		$collection = EloquentModelStub::hydrate($data, 'foo_connection');
 
 		$this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $collection);
 		$this->assertCount(2, $collection);
 		$this->assertInstanceOf('EloquentModelStub', $collection[0]);
 		$this->assertInstanceOf('EloquentModelStub', $collection[1]);
+		$this->assertEquals($collection[0]->getAttributes(), $collection[0]->getOriginal());
+		$this->assertEquals($collection[1]->getAttributes(), $collection[1]->getOriginal());
 		$this->assertEquals('Taylor', $collection[0]->name);
 		$this->assertEquals('Otwell', $collection[1]->name);
+		$this->assertEquals('foo_connection', $collection[0]->getConnectionName());
+		$this->assertEquals('foo_connection', $collection[1]->getConnectionName());
 	}
 
 


### PR DESCRIPTION
Use the model's `hydrate` method in the builder's `getModels` method, since they both do essentially the same thing.

This also simplifies the `hydrate` and `hydrateRaw` methods on the `Model` class.
