### PR TITLE
[4.2] Fixed Cloning Queries With Join Bindings Being Broken

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -128,6 +128,8 @@ class Grammar extends BaseGrammar {
 	{
 		$sql = array();
 
+		$query->setBindings(array(), 'join');
+
 		foreach ($joins as $join)
 		{
 			$table = $this->wrapTable($join->table);
@@ -144,8 +146,6 @@ class Grammar extends BaseGrammar {
 
 			foreach ($join->bindings as $index => $binding)
 			{
-				unset($join->bindings[$index]);
-
 				$query->addBinding($binding, 'join');
 			}
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -144,7 +144,7 @@ class Grammar extends BaseGrammar {
 				$clauses[] = $this->compileJoinConstraint($clause);
 			}
 
-			foreach ($join->bindings as $index => $binding)
+			foreach ($join->bindings as $binding)
 			{
 				$query->addBinding($binding, 'join');
 			}


### PR DESCRIPTION
Commit aedc6eb0 had the unfortunate side effect of breaking cloned queries which contained "join" bindings: executing one of the clones made all the other clones fail. This should fix the issue.
