### PR TITLE
Added FIRST column modifier to put a column in first position

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -565,6 +565,21 @@ class MySqlGrammar extends Grammar {
 	}
 
 	/**
+	 * Get the SQL for an "first" column modifier.
+	 *
+	 * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+	 * @param  \Illuminate\Support\Fluent  $column
+	 * @return string|null
+	 */
+	protected function modifyAfter(Blueprint $blueprint, Fluent $column)
+	{
+		if ( ! is_null($column->first))
+		{
+			return ' first '.$this->wrap($column->after);
+		}
+	}
+
+	/**
 	 * Get the SQL for an "comment" column modifier.
 	 *
 	 * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -575,7 +575,7 @@ class MySqlGrammar extends Grammar {
 	{
 		if ( ! is_null($column->first))
 		{
-			return ' first '.$this->wrap($column->after);
+			return ' first '.$this->wrap($column->first);
 		}
 	}
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -571,7 +571,7 @@ class MySqlGrammar extends Grammar {
 	 * @param  \Illuminate\Support\Fluent  $column
 	 * @return string|null
 	 */
-	protected function modifyAfter(Blueprint $blueprint, Fluent $column)
+	protected function modifyFirst(Blueprint $blueprint, Fluent $column)
 	{
 		if ( ! is_null($column->first))
 		{


### PR DESCRIPTION
MySQL reference: http://dev.mysql.com/doc/refman/5.1/en/alter-table.html

For example, if adding an auto incrementing PK to a pivot table, you'd normally have to do the following in a migration:

Schema::table('TABLE_NAME', function ($table)
{
    $table->increments('id');
});
DB::unprepared('ALTER TABLE table_name MODIFY COLUMN id int(10) unsigned NOT NULL AUTO_INCREMENT FIRST');

It would be ideal to do:
Schema::table('TABLE_NAME', function ($table)
{
    $table->increments('id')->first();
});
