### PR TITLE
[5.0] Remove unnecessary findOrFail method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -715,20 +715,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	}
 
 	/**
-	 * Find a model by its primary key or throw an exception.
-	 *
-	 * @param  mixed  $id
-	 * @param  array  $columns
-	 * @return \Illuminate\Support\Collection|static
-	 *
-	 * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
-	 */
-	public static function findOrFail($id, $columns = array('*'))
-	{
-		return static::query()->findOrFail($id, $columns);
-	}
-
-	/**
 	 * Reload a fresh model instance from the database.
 	 *
 	 * @param  array  $with

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -106,6 +106,39 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testFindOrFail()
+	{
+		EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+		EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+		$single = EloquentTestUser::findOrFail(1);
+		$multiple = EloquentTestUser::findOrFail([1, 2]);
+
+		$this->assertInstanceOf('EloquentTestUser', $single);
+		$this->assertEquals('taylorotwell@gmail.com', $single->email);
+		$this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $multiple);
+		$this->assertInstanceOf('EloquentTestUser', $multiple[0]);
+		$this->assertInstanceOf('EloquentTestUser', $multiple[1]);
+	}
+
+	/**
+	 * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
+	 */
+	public function testFindOrFailWithSingleIdThrowsModelNotFoundException()
+	{
+		EloquentTestUser::findOrFail(1);
+	}
+
+	/**
+	 * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
+	 */
+	public function testFindOrFailWithMultipleIdsThrowsModelNotFoundException()
+	{
+		EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+		EloquentTestUser::findOrFail([1, 2]);
+	}
+
+
 	public function testHasOnSelfReferencingBelongsToManyRelationship()
 	{
 		$user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -113,15 +113,6 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	/**
-	 * @expectedException Illuminate\Database\Eloquent\ModelNotFoundException
-	 */
-	public function testFindOrFailMethodThrowsModelNotFoundException()
-	{
-		$result = EloquentModelFindNotFoundStub::findOrFail(1);
-	}
-
-
 	public function testFindMethodWithArrayCallsQueryBuilderCorrectly()
 	{
 		$result = EloquentModelFindManyStub::find(array(1, 2));
@@ -1259,15 +1250,6 @@ class EloquentModelFindWithWritePdoStub extends Illuminate\Database\Eloquent\Mod
 		$mock->shouldReceive('useWritePdo')->once()->andReturnSelf();
 		$mock->shouldReceive('find')->once()->with(1)->andReturn('foo');
 
-		return $mock;
-	}
-}
-
-class EloquentModelFindNotFoundStub extends Illuminate\Database\Eloquent\Model {
-	public static function query()
-	{
-		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
-		$mock->shouldReceive('findOrFail')->once()->with(1, array('*'))->andThrow(new ModelNotFoundException);
 		return $mock;
 	}
 }


### PR DESCRIPTION
There's no point in this method, since it will anyhow end up in the query builder.
