### PR TITLE
[5.1] [Should be 5.0] Allow Setting Encoding In The "lower" and "upper" Str Functions

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -155,10 +155,16 @@ class Str {
 	 * Convert the given string to lower-case.
 	 *
 	 * @param  string  $value
+	 * @param  string|null  $encoding
 	 * @return string
 	 */
-	public static function lower($value)
+	public static function lower($value, $encoding = null)
 	{
+		if ( ! is_null($encoding))
+		{
+			return mb_strtolower($value, $encoding);
+		}
+
 		return mb_strtolower($value);
 	}
 
@@ -247,10 +253,16 @@ class Str {
 	 * Convert the given string to upper-case.
 	 *
 	 * @param  string  $value
+	 * @param  string|null  $encoding
 	 * @return string
 	 */
-	public static function upper($value)
+	public static function upper($value, $encoding = null)
 	{
+		if ( ! is_null($encoding))
+		{
+			return mb_strtoupper($value, $encoding);
+		}
+
 		return mb_strtoupper($value);
 	}
 


### PR DESCRIPTION
mb_strtoupper & mb_strtolower needs an enconding in order to correctly change accented chars case. So, doing

```
mb_strtoupper('Este é um cedilha: ç')
```

Gives us

```
ESTE é UM CEDILHA: ç
```

But doing:

```
mb_strtoupper('Este é um cedilha: ç', 'UTF-8')
```

We get

```
ESTE É UM CEDILHA: Ç
```
