### PR TITLE
Fix Str caching.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -310,9 +310,11 @@ class Str {
 	 */
 	public static function snake($value, $delimiter = '_')
 	{
-		if (isset(static::$snakeCache[$value.$delimiter]))
+		$key = $value.$delimiter;
+		
+		if (isset(static::$snakeCache[$key]))
 		{
-			return static::$snakeCache[$value.$delimiter];
+			return static::$snakeCache[$key];
 		}
 
 		if ( ! ctype_lower($value))
@@ -320,7 +322,7 @@ class Str {
 			$value = strtolower(preg_replace('/(.)(?=[A-Z])/', '$1'.$delimiter, $value));
 		}
 
-		return static::$snakeCache[$value.$delimiter] = $value;
+		return static::$snakeCache[$key] = $value;
 	}
 
 	/**
@@ -348,14 +350,16 @@ class Str {
 	 */
 	public static function studly($value)
 	{
-		if (isset(static::$studlyCache[$value]))
+		$key = $value;
+		
+		if (isset(static::$studlyCache[$key]))
 		{
-			return static::$studlyCache[$value];
+			return static::$studlyCache[$key];
 		}
 
 		$value = ucwords(str_replace(array('-', '_'), ' ', $value));
 
-		return static::$studlyCache[$value] = str_replace(' ', '', $value);
+		return static::$studlyCache[$key] = str_replace(' ', '', $value);
 	}
 
 }


### PR DESCRIPTION
Both `Str::studly` and `Str::snake` change the cache key before storing it, and as a result the cache lookup doesn't match when it's supposed to.
