### PR TITLE
[5.0] Fixed Typo

### DIFF
--- a/src/Illuminate/Contracts/Bus/HandlerResolver.php
+++ b/src/Illuminate/Contracts/Bus/HandlerResolver.php
@@ -5,7 +5,7 @@ use Closure;
 interface HandlerResolver {
 
 	/**
-	 * Get the handler instnace for the given command.
+	 * Get the handler instance for the given command.
 	 *
 	 * @param  mixed  $command
 	 * @return mixed


### PR DESCRIPTION
fixes misspelling of instnace to instance.
