### PR TITLE
[5.0] Added a config_path() helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -164,6 +164,20 @@ if ( ! function_exists('config'))
 	}
 }
 
+if ( ! function_exists('config_path'))
+{
+	/**
+	 * Get the configuration path.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	function config_path($path = '')
+	{
+		return app()->make('path.config').($path ? '/'.$path : $path);
+	}
+}
+
 if ( ! function_exists('cookie'))
 {
 	/**


### PR DESCRIPTION
Added a `config_path(:path)` helper function, which i believe to make sense, it stays consistent with the `app_path(:path)` and `base_path(:path)` methods and will also help a bit when writing the Service Providers for the new publisher command.

> Will you consider a `database_path(:path)` as well? I find both helper functions to be useful when writing the Service Providers as config and migrations are the most common things on packages, language files is another thing, but, i rarely see them.
