### PR TITLE
[5.1] [Should be 5.0] Added Back "--path" For Migration Command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -58,7 +58,17 @@ class MigrateCommand extends BaseCommand {
 		// a database for real, which is helpful for double checking migrations.
 		$pretend = $this->input->getOption('pretend');
 
-		$path = $this->getMigrationPath();
+		// Next, we will check to see if a path option has been defined. If it has
+		// we will use the path relative to the root of this installation folder
+		// so that migrations may be run for any path within the applications.
+		if( ! is_null($path = $this->input->getOption('path')))
+		{
+			$path = $this->laravel['path.base'].'/'.$path;
+		}
+		else
+		{
+			$path = $this->getMigrationPath();
+		}
 
 		$this->migrator->run($path, $pretend);
 
@@ -105,6 +115,8 @@ class MigrateCommand extends BaseCommand {
 	{
 		return array(
 			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+
+			array('path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed. If not provided, it will use the default migrations path.'),
 
 			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
 


### PR DESCRIPTION
Hi, I just noticed that in Laravel 5, the --path option is removed in migration console command. In our team, we heavily used the --path command in migrating processes, especially our application components are segregated together with its respective migration files. By using --path also, we painlessly execute migrations in orders, like for example we separated migrations that performs relations to databases, rather than manually editing the migration file name to alter the order.

I would like to suggest to bring the --path back, if it's okay, this pull request does it. Thank you for your time.
