### PR TITLE
[5.0] Move Away From Deprecated Autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,8 +85,8 @@
             "src/Illuminate/Foundation/helpers.php",
             "src/Illuminate/Support/helpers.php"
         ],
-        "psr-0": {
-            "Illuminate": "src/"
+        "psr-4": {
+            "Illuminate\\": "src/Illuminate/"
         }
     },
     "extra": {


### PR DESCRIPTION
We've already applied PSR-4 autoloading to each component, but we haven't applied to to the main framework. This change **does not change the folder structure**, but simply moves to a current autoloading standard since PSR-0 is depreciated.
