### PR TITLE
[5.0] Long string support fix for dd()

### DIFF
--- a/src/Illuminate/Support/Debug/HtmlDumper.php
+++ b/src/Illuminate/Support/Debug/HtmlDumper.php
@@ -10,7 +10,7 @@ class HtmlDumper extends SymfonyHtmlDumper {
 	 * @var array
 	 */
 	protected $styles = array(
-		'default' => 'background-color:#fff; color:#222; line-height:1.2em; font-weight:normal; font:12px Monaco, Consolas, monospace',
+		'default' => 'background-color:#fff; color:#222; line-height:1.2em; font-weight:normal; font:12px Monaco, Consolas, monospace; word-wrap: break-word; white-space: pre-wrap',
 		'num' => 'color:#a71d5d',
 		'const' => 'color:#795da3',
 		'str' => 'color:#df5000',


### PR DESCRIPTION
There was a css bugfix in symfony/var-dumper component. 
(More info here https://github.com/symfony/symfony/pull/13487)

We need to manually repeat these changes because Laravel overrides those styles.
