### PR TITLE
[5.0] Missing class Illuminate\Mail\Transport\SesTransport

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -54,7 +54,7 @@ class SesTransport implements Swift_Transport {
 	 */
 	public function send(Swift_Mime_Message $message, &$failedRecipients = null)
 	{
-		$this->ses->sendRawEmail([
+		return $this->ses->sendRawEmail([
 			'Source' => $message->getSender(),
 			'Destinations' => $this->getTo($message),
 			'RawMessage' => [

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -7,6 +7,7 @@ use Swift_MailTransport as MailTransport;
 use Illuminate\Mail\Transport\LogTransport;
 use Illuminate\Mail\Transport\MailgunTransport;
 use Illuminate\Mail\Transport\MandrillTransport;
+use Illuminate\Mail\Transport\SesTransport;
 use Swift_SendmailTransport as SendmailTransport;
 
 class TransportManager extends Manager {


### PR DESCRIPTION
There is a missing class SesTransport, and I think we should return the result from sendRawEmail so we could get the message Id and process it.
