### PR TITLE
[5.0] Add loadConfigFrom SP Helper

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -54,7 +54,7 @@ abstract class ServiceProvider {
 	{
 		$defaults = $this->app['files']->getRequire($path);
 		$config = $this->app['config']->get($key, []);
-		$this->app['config']->set($key, array_merge($defaults, $config));
+		$this->app['config']->set($key, config_merge($defaults, $config));
 	}
 
 	/**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -44,6 +44,20 @@ abstract class ServiceProvider {
 	abstract public function register();
 
 	/**
+	 * Register the package defaults.
+	 *
+	 * @param  string  $key
+	 * @param  string  $path
+	 * @return void
+	 */
+	protected function loadConfigFrom($key, $path)
+	{
+		$defaults = $this->app['files']->getRequire($path);
+		$config = $this->app['config']->get($key, []);
+		$this->app['config']->set($key, array_merge($defaults, $config));
+	}
+
+	/**
 	 * Register a view file namespace.
 	 *
 	 * @param  string  $namespace


### PR DESCRIPTION
The config files in the app config folder are loaded on bootstrap, additional config could be set by a ServiceProvider. It isn't really clear whether the ConfigServiceProvider is run before or after a package config.

This adds a simple method to load the config (if set) and merge it with the default config from the package. Usage would be something like this, similar to other load*From() methods:

```
$configPath = __DIR__ . '/../config/dompdf.php';
$this->loadConfigFrom('dompdf', $configPath);
$this->publishes([$configPath => config_path('dompdf.php')]);
```

This is the simplest solution I came up with, but perhaps it would be useful to be able to recursively load a directory, but we could leave that up to the package developer (for performance)
