### PR TITLE
Use array_merge instead of config_merge in mergeConfigFrom

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -54,7 +54,7 @@ abstract class ServiceProvider {
 	{
 		$config = $this->app['config']->get($key, []);
 
-		$this->app['config']->set($key, config_merge(require $path, $config));
+		$this->app['config']->set($key, array_merge(require $path, $config));
 	}
 
 	/**


### PR DESCRIPTION
For simpler merging of default config, as proposed in #7138 

Simple examle would be:

```
$defaults = [
    'files' => ['a', 'b'],
    'config' => ['a' => 'b'],
];
$config = [
    'files' => ['c'],
    'config' => ['c' => 'd'],
];

print_r(config_merge($defaults, $config));
print_r(array_merge($defaults, $config));
```

The first example would have the files/config merged, instead of replaced. So that makes it harder to remove default values from deeper arrays.
