### PR TITLE
Return given value from Cache::put()

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -130,7 +130,7 @@ class Repository implements CacheContract, ArrayAccess {
 	 * @param  string  $key
 	 * @param  mixed   $value
 	 * @param  \DateTime|int  $minutes
-	 * @return void
+	 * @return mixed
 	 */
 	public function put($key, $value, $minutes)
 	{
@@ -142,6 +142,8 @@ class Repository implements CacheContract, ArrayAccess {
 
 			$this->fireCacheEvent('write', [$key, $value, $minutes]);
 		}
+
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
This allows saving 2 of 3 steps in the best case scenario.

Say you have a function doing some stuff and want to cache your return value. Currently this will look like this:

```
function example($data)
{
    $data = doSomeStuff($data);
    Cache::put('key', $data, 60);
    return $data;
}
```

With this change it might look like this:

```
function example($data)
{
    return Cache::put('key', doSomeStuff($data), 60);
}
```
