### PR TITLE
[5.0] Fix Vendor Publish Command

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Foundation\Console;
 
+use FilesystemIterator;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\ServiceProvider;
@@ -92,16 +93,14 @@ class VendorPublishCommand extends Command {
 	 */
 	protected function publishDirectory($from, $to)
 	{
-		if ($this->files->isDirectory($to))
+		$items = new FilesystemIterator($from);
+
+		foreach ($items as $item)
 		{
-			return;
+			$method = $item->isDir() ? 'publishDirectory' : 'publishFile';
+
+			$this->{$method}($item->getPathname(), $to.'/'.$item->getBasename());
 		}
-
-		$this->createParentDirectory($to);
-
-		$this->files->copyDirectory($from, $to);
-
-		$this->status($from, $to, 'Directory');
 	}
 
 	/**


### PR DESCRIPTION
Currently if we're publishing a directory from a package and this directory already exists on the application, even if the files don't, the package directory contents never gets published.

Example, publishing migrations of a package, these migrations would never be published because the `database/migrations` already exists therefore it gets ignored by this [line](https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Console/VendorPublishCommand.php#L95) 

This was the most simpler way i could find to make it work.

> **Note:** Went with a more cleaner way, without any if/else, but if required i can update to if/else.

Related: https://github.com/laravel/docs/pull/1047
