### PR TITLE
[5.0] Swap arguments of resource loading methods

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -46,11 +46,11 @@ abstract class ServiceProvider {
 	/**
 	 * Merge the given configuration with the existing configuration.
 	 *
-	 * @param  string  $key
 	 * @param  string  $path
+	 * @param  string  $key
 	 * @return void
 	 */
-	protected function mergeConfigFrom($key, $path)
+	protected function mergeConfigFrom($path, $key)
 	{
 		$config = $this->app['config']->get($key, []);
 
@@ -60,11 +60,11 @@ abstract class ServiceProvider {
 	/**
 	 * Register a view file namespace.
 	 *
-	 * @param  string  $namespace
 	 * @param  string  $path
+	 * @param  string  $namespace
 	 * @return void
 	 */
-	protected function loadViewsFrom($namespace, $path)
+	protected function loadViewsFrom($path, $namespace)
 	{
 		if (is_dir($appPath = $this->app->basePath().'/resources/views/vendor/'.$namespace))
 		{
@@ -77,11 +77,11 @@ abstract class ServiceProvider {
 	/**
 	 * Register a translation file namespace.
 	 *
-	 * @param  string  $namespace
 	 * @param  string  $path
+	 * @param  string  $namespace
 	 * @return void
 	 */
-	protected function loadTranslationsFrom($namespace, $path)
+	protected function loadTranslationsFrom($path, $namespace)
 	{
 		$this->app['translator']->addNamespace($namespace, $path);
 	}


### PR DESCRIPTION
This is just a suggestion, maybe @taylorotwell doesn't like it:

Resources such as views, config, etc. from packages are currently loaded like this:

``` php
$this->loadViewsFrom('courier', __DIR__.'/path/to/views');
```

I'd argue it would read more naturally if it looked like this:

``` php
$this->loadViewsFrom(__DIR__.'/path/to/views', 'courier');
```

After all, I'm loading the views from the given path and also give them a name.

Anyway, that's what this PR does.
