### PR TITLE
[5.0] Eloquent foreign key getter

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2090,7 +2090,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function getForeignKey()
 	{
-		return snake_case(class_basename($this)).'_id';
+		return snake_case(str_singular($this->getTable())).'_id';
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -547,6 +547,12 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo', $model->getTable());
 	}
 
+	public function testGetForeignKey()
+	{
+		$model = new EloquentModelStub;
+		$this->assertEquals('stub', $model->getForeignKey());
+	}
+
 
 	public function testGetKeyReturnsValueOfPrimaryKey()
 	{

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -550,7 +550,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	public function testGetForeignKey()
 	{
 		$model = new EloquentModelStub;
-		$this->assertEquals('stub', $model->getForeignKey());
+		$this->assertEquals('stub_id', $model->getForeignKey());
 	}
 
 
@@ -761,7 +761,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model = new EloquentModelStub;
 		$this->addMockConnection($model);
 		$relation = $model->hasOne('EloquentModelSaveStub');
-		$this->assertEquals('save_stub.eloquent_model_stub_id', $relation->getForeignKey());
+		$this->assertEquals('save_stub.stub_id', $relation->getForeignKey());
 
 		$model = new EloquentModelStub;
 		$this->addMockConnection($model);
@@ -788,7 +788,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model = new EloquentModelStub;
 		$this->addMockConnection($model);
 		$relation = $model->hasMany('EloquentModelSaveStub');
-		$this->assertEquals('save_stub.eloquent_model_stub_id', $relation->getForeignKey());
+		$this->assertEquals('save_stub.stub_id', $relation->getForeignKey());
 
 		$model = new EloquentModelStub;
 		$this->addMockConnection($model);
@@ -842,8 +842,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model = new EloquentModelStub;
 		$this->addMockConnection($model);
 		$relation = $model->belongsToMany('EloquentModelSaveStub');
-		$this->assertEquals('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_stub_id', $relation->getForeignKey());
-		$this->assertEquals('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_save_stub_id', $relation->getOtherKey());
+		$this->assertEquals('eloquent_model_save_stub_eloquent_model_stub.stub_id', $relation->getForeignKey());
+		$this->assertEquals('eloquent_model_save_stub_eloquent_model_stub.save_stub_id', $relation->getOtherKey());
 		$this->assertSame($model, $relation->getParent());
 		$this->assertInstanceOf('EloquentModelSaveStub', $relation->getQuery()->getModel());
 		$this->assertEquals(__FUNCTION__, $relation->getRelationName());


### PR DESCRIPTION
As described in #7162.

In my experience, whenever i've overridden the `$table` property, it has always made more sense for foreign keys pointing to that model to reflect the specified table name, rather than the class name.

(i've put this as 5.0, because although it could be implemented in 4.*, it would break b/c)
