### PR TITLE
[5.0] Move collect helper from foundation to support

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -126,20 +126,6 @@ if ( ! function_exists('bcrypt'))
 	}
 }
 
-if ( ! function_exists('collect'))
-{
-	/**
-	 * Create a collection from the given value.
-	 *
-	 * @param  mixed  $value
-	 * @return \Illuminate\Support\Collection
-	 */
-	function collect($value)
-	{
-		return Illuminate\Support\Collection::make($value);
-	}
-}
-
 if ( ! function_exists('config'))
 {
 	/**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Debug\Dumper;
 
 if ( ! function_exists('append_config'))
@@ -355,6 +356,20 @@ if ( ! function_exists('class_uses_recursive'))
 		}
 
 		return array_unique($results);
+	}
+}
+
+if ( ! function_exists('collect'))
+{
+	/**
+	 * Create a collection from the given value.
+	 *
+	 * @param  mixed  $value
+	 * @return \Illuminate\Support\Collection
+	 */
+	function collect($value = null)
+	{
+		return new Collection($value);
 	}
 }
 


### PR DESCRIPTION
On a side note: wouldn't it be great if we used this helper function throughout the codebase instead of just `new`ing up a collection? That way you can extend the base collection class, override this function, and all the collections returned from core will be your own extended implementation.

Thoughts?
