### PR TITLE
[5.1] [Should be 5.0] Add symlink/copy command for assets

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorAssetsCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorAssetsCommand.php
@@ -58,10 +58,12 @@ class VendorAssetsCommand extends Command {
 			$to = $targetDir . '/' . basename($package);
 			$this->files->remove($to);
 
+			$relativeFrom = $this->files->makePathRelative(realpath($from), $targetDir);
+
 			try
 			{
 				// Try to symlink, otherwise mirror
-				$this->files->symlink($from, $to, true);
+				$this->files->symlink($relativeFrom, $to, true);
 				if ( ! file_exists($to))
 				{
 					throw new IOException('Symbolic link is broken');

--- a/src/Illuminate/Foundation/Console/VendorAssetsCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorAssetsCommand.php
@@ -1,0 +1,108 @@
+<?php namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\ServiceProvider;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Exception\IOException;
+
+class VendorAssetsCommand extends Command {
+
+	/**
+	 * The filesystem instance.
+	 *
+	 * @var \Symfony\Component\Filesystem\Filesystem
+	 */
+	protected $files;
+
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'vendor:assets';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = "Copy/symlink vendor assets to the public folder";
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @param  \Symfony\Component\Filesystem\Filesystem  $files
+	 * @return void
+	 */
+	public function __construct(Filesystem $files)
+	{
+		parent::__construct();
+
+		$this->files = $files;
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return void
+	 */
+	public function fire()
+	{
+		$targetDir = public_path('vendor');
+		$this->files->mkdir($targetDir, 0777);
+
+		$this->info('Starting to copy/symlink the assets to the public folder');
+
+		foreach (ServiceProvider::assetsToPublish() as $from => $package)
+		{
+			$to = $targetDir . '/' . basename($package);
+			$this->files->remove($to);
+
+			try
+			{
+				// Try to symlink, otherwise mirror
+				$this->files->symlink($from, $to, true);
+				if ( ! file_exists($to))
+				{
+					throw new IOException('Symbolic link is broken');
+				}
+			}
+			catch (IOException $e)
+			{
+				$this->files->mirror($from, $to);
+			}
+
+			if (file_exists($to))
+			{
+				$this->status($from, $to);
+			}
+		}
+
+		$this->info('Done publishing the assets!');
+	}
+
+	/**
+	 * Write a status message to the console.
+	 *
+	 * @param  string  $from
+	 * @param  string  $to
+	 * @return void
+	 */
+	protected function status($from, $to)
+	{
+		$from = str_replace(base_path(), '', realpath($from));
+
+		if (is_link($to))
+		{
+			$to = str_replace(base_path(), '', $to);
+			$this->line('<info>Symlinked directory</info> <comment>['.$from.']</comment> <info>To</info> <comment>['.$to.']</comment>');
+		}
+		else
+		{
+			$to = str_replace(base_path(), '', realpath($to));
+			$this->line('<info>Copied directory</info> <comment>['.$from.']</comment> <info>To</info> <comment>['.$to.']</comment>');
+		}
+
+	}
+
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -23,6 +23,7 @@ use Illuminate\Foundation\Console\ProviderMakeCommand;
 use Illuminate\Foundation\Console\HandlerEventCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
 use Illuminate\Foundation\Console\EventGenerateCommand;
+use Illuminate\Foundation\Console\VendorAssetsCommand;
 use Illuminate\Foundation\Console\VendorPublishCommand;
 use Illuminate\Foundation\Console\HandlerCommandCommand;
 
@@ -64,6 +65,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 		'Serve' => 'command.serve',
 		'Tinker' => 'command.tinker',
 		'Up' => 'command.up',
+		'VendorAssets' => 'command.vendor.assets',
 		'VendorPublish' => 'command.vendor.publish',
 	];
 
@@ -380,6 +382,19 @@ class ArtisanServiceProvider extends ServiceProvider {
 		$this->app->singleton('command.up', function()
 		{
 			return new UpCommand;
+		});
+	}
+
+	/**
+	 * Register the command.
+	 *
+	 * @return void
+	 */
+	protected function registerVendorAssetsCommand()
+	{
+		$this->app->singleton('command.vendor.assets', function($app)
+		{
+			return new VendorAssetsCommand($app['Symfony\Component\Filesystem\Filesystem']);
 		});
 	}
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -31,6 +31,13 @@ abstract class ServiceProvider {
 	 * @var array
 	 */
 	protected static $publishGroups = [];
+    
+	/**
+	 * The assets that should be published.
+	 *
+	 * @var array
+	 */
+	protected static $assets = [];
 
 	/**
 	 * Create a new service provider instance.
@@ -144,6 +151,27 @@ abstract class ServiceProvider {
 		}
 
 		return $paths;
+	}
+
+	/**
+	 * Register paths to be published by the publish command.
+	 *
+	 * @param  array  $paths
+	 * @return void
+	 */
+	protected function assets(array $paths)
+	{
+		static::$assets = array_merge(static::$assets, $paths);
+	}
+
+	/**
+	 * Get the paths to publish.
+	 *
+	 * @return array
+	 */
+	public static function assetsToPublish()
+	{
+		return static::$assets;
 	}
 
 	/**


### PR DESCRIPTION
This is a implementation of #7147 and a simplified version of [Symfony AssetsInstallCommand](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php), based on the VendorPublish command.

This add the possibility for packages to register directories that should be copied to the public folder, so that they are accessible from the web, like javascript/css files. When possible, the files are symlinked to preserve space. On windows the files are mirrored.

The main difference with the VendorPublisher is that this command always overwrites the existing folders (deletes them first). This command would be run on a new install to make sure that assets are always in sync with the vendor folder.

Difference with L4: packages are copied to `public/vendor/<package name>` instead of `public/vendor/<vendor name>/<package name>`, in line with the publisher.

Example usage in the register() method of a package provider:

```
   $this->assets([
        __DIR__.'/../resources/assets' => 'foobar',
    ]);
```

Would copy the folder to `public/vendor/foobar`. This is used instead of a full path for consistency and prevent accidental deleting of the wrong folder ;) (misusage)
