### PR TITLE
[5.0] Return collection from query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -495,11 +495,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	/**
 	 * Create a collection of models from plain arrays.
 	 *
-	 * @param  array  $items
-	 * @param  string  $connection
+	 * @param  array|\ArrayAccess  $items
+	 * @param  string|null  $connection
 	 * @return \Illuminate\Database\Eloquent\Collection
 	 */
-	public static function hydrate(array $items, $connection = null)
+	public static function hydrate($items, $connection = null)
 	{
 		$collection = with($instance = new static)->newCollection();
 
@@ -1909,10 +1909,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	/**
 	 * Create a new Eloquent Collection instance.
 	 *
-	 * @param  array  $models
+	 * @param  array|\ArrayAccess  $models
 	 * @return \Illuminate\Database\Eloquent\Collection
 	 */
-	public function newCollection(array $models = array())
+	public function newCollection($models = array())
 	{
 		return new Collection($models);
 	}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3,7 +3,6 @@
 use Closure;
 use BadMethodCallException;
 use InvalidArgumentException;
-use Illuminate\Support\Collection;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Query\Grammars\Grammar;
@@ -1334,16 +1333,14 @@ class Builder {
 	 */
 	public function first($columns = array('*'))
 	{
-		$results = $this->take(1)->get($columns);
-
-		return count($results) > 0 ? reset($results) : null;
+		return $this->take(1)->get($columns)->first();
 	}
 
 	/**
 	 * Execute the query as a "select" statement.
 	 *
 	 * @param  array  $columns
-	 * @return array|static[]
+	 * @return \Illuminate\Support\Collection
 	 */
 	public function get($columns = array('*'))
 	{
@@ -1354,13 +1351,15 @@ class Builder {
 	 * Execute the query as a fresh "select" statement.
 	 *
 	 * @param  array  $columns
-	 * @return array|static[]
+	 * @return \Illuminate\Support\Collection
 	 */
 	public function getFresh($columns = array('*'))
 	{
 		if (is_null($this->columns)) $this->columns = $columns;
 
-		return $this->processor->processSelect($this, $this->runSelect());
+		$results = $this->processor->processSelect($this, $this->runSelect());
+
+		return collect($results);
 	}
 
 	/**
@@ -1502,7 +1501,7 @@ class Builder {
 	{
 		$columns = $this->getListSelect($column, $key);
 
-		$results = new Collection($this->get($columns));
+		$results = $this->get($columns);
 
 		return $results->lists($columns[0], array_get($columns, 1));
 	}
@@ -1634,7 +1633,7 @@ class Builder {
 
 		$previousColumns = $this->columns;
 
-		$results = $this->get($columns);
+		$results = $this->get($columns)->all();
 
 		// Once we have executed the query, we will reset the aggregate property so
 		// that more select queries can be executed against the database without

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -63,7 +63,7 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface {
 	 */
 	public function all()
 	{
-		return $this->getTable()->orderBy('id', 'desc')->get();
+		return $this->getTable()->orderBy('id', 'desc')->get()->all();
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1266,7 +1266,7 @@ class EloquentModelDestroyStub extends Illuminate\Database\Eloquent\Model {
 }
 
 class EloquentModelHydrateRawStub extends Illuminate\Database\Eloquent\Model {
-	public static function hydrate(array $items, $connection = null) { return 'hydrated'; }
+	public static function hydrate($items, $connection = null) { return 'hydrated'; }
 	public function getConnection()
 	{
 		$mock = m::mock('Illuminate\Database\Connection');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -793,7 +793,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$sum = $builder->sum('id');
 		$this->assertEquals(2, $sum);
 		$result = $builder->get();
-		$this->assertEquals(array(array('column1' => 'foo', 'column2' => 'bar')), $result);
+		$this->assertEquals(array(array('column1' => 'foo', 'column2' => 'bar')), $result->all());
 	}
 
 
@@ -807,7 +807,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$count = $builder->count('column1');
 		$this->assertEquals(1, $count);
 		$result = $builder->select('column2', 'column3')->get();
-		$this->assertEquals(array(array('column2' => 'foo', 'column3' => 'bar')), $result);
+		$this->assertEquals(array(array('column2' => 'foo', 'column3' => 'bar')), $result->all());
 	}
 
 
@@ -821,7 +821,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$count = $builder->count('column1');
 		$this->assertEquals(1, $count);
 		$result = $builder->get(array('column2', 'column3'));
-		$this->assertEquals(array(array('column2' => 'foo', 'column3' => 'bar')), $result);
+		$this->assertEquals(array(array('column2' => 'foo', 'column3' => 'bar')), $result->all());
 	}
 
 


### PR DESCRIPTION
This is a really nice feature. The collection class is one of the best things in Laravel! It is also a boon for consistency.

This one does not touch the `getModels` method, or anything that has to do with relations or eager loading. In fact, it doesn't touch anything Eloquent related, so it's much safer.

We also now have the integration tests, which _really_ helps.
