### PR TITLE
Adding errorlog handler

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -90,4 +90,16 @@ class ConfigureLogging {
 		$log->useSyslog('laravel');
 	}
 
+	/**
+	 * Configure the Monolog handlers for the application.
+	 *
+	 * @param  \Illuminate\Contracts\Foundation\Application  $app
+	 * @param  \Illuminate\Log\Writer  $log
+	 * @return void
+	 */
+	protected function configureStdoutHandler(Application $app, Writer $log)
+	{
+		$log->useErrorLog();
+	}
+	
 }

--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -97,7 +97,7 @@ class ConfigureLogging {
 	 * @param  \Illuminate\Log\Writer  $log
 	 * @return void
 	 */
-	protected function configureStdoutHandler(Application $app, Writer $log)
+	protected function configureErrorlogHandler(Application $app, Writer $log)
 	{
 		$log->useErrorLog();
 	}


### PR DESCRIPTION
In some situations could be useful “echoing” logs so that the logs become “visible”, more info http://www.jmilan.net/posts/laravel-logs-in-heroku-and-more

It would let us set log in \config\app.php as 'errorlog'

Hope this change makes sense.
