### PR TITLE
[5.1] [Should be 5.0] MySqlGrammar supports limit on DELETE statements

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -108,10 +108,24 @@ class MySqlGrammar extends Grammar {
 		{
 			$joins = ' '.$this->compileJoins($query, $query->joins);
 
-			return trim("delete $table from {$table}{$joins} $where");
+			$sql = trim("delete $table from {$table}{$joins} $where");
+		}
+		else
+		{
+			$sql = trim("delete from $table $where");
 		}
 
-		return trim("delete from $table $where");
+		if (isset($query->orders))
+		{
+			$sql .= ' '.$this->compileOrders($query, $query->orders);
+		}
+
+		if (isset($query->limit))
+		{
+			$sql .= ' '.$this->compileLimit($query, $query->limit);
+		}
+
+		return $sql;
 	}
 
 	/**


### PR DESCRIPTION
Had to delete duplicate rows from a pivot table that somehow didn't get a primary key. Hopefully someone else finds this useful.
