### PR TITLE
[4.2] Remove no-op code in Eloquent constructor.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -244,8 +244,6 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 	{
 		$this->bootIfNotBooted();
 
-		$this->syncOriginal();
-
 		$this->fill($attributes);
 	}
 


### PR DESCRIPTION
I reviewed the Eloquent source code and found this line of code is no-op.

All the unit tests passed after removing this line of code.

This is my first time contribute to Laravel framework. If I missed anything, please tell me.

Thanks!
