### PR TITLE
[5.0] Added missing methods in Application Contract.

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -89,4 +89,5 @@ interface Application extends Container {
          * @return void
          */
         public function bootstrapWith($bootstrappers);
+        
 }

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -88,7 +88,7 @@ interface Application extends Container {
          * @param  array  $bootstrappers
 	 * @return void
          */
-        public function bootstrapWith();
+        public function bootstrapWith($bootstrappers);
      
         
 

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -91,5 +91,4 @@ interface Application extends Container {
         public function bootstrapWith($bootstrappers);
      
         
-
 }

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -74,21 +74,19 @@ interface Application extends Container {
 	 * @return void
 	 */
 	public function booted($callback);
-        
+
         /**
          * Determine if the Application has been booted.
-         * 
+         *
          * @return bool
          */
         public function hasBeenBootstrapped();
-        
+
         /**
          * Run the given array of bootstrap classes.
-         * 
+         *
          * @param  array  $bootstrappers
-	 * @return void
+         * @return void
          */
         public function bootstrapWith($bootstrappers);
-     
-        
 }

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -74,5 +74,22 @@ interface Application extends Container {
 	 * @return void
 	 */
 	public function booted($callback);
+        
+        /**
+         * Determine if the Application has been booted.
+         * 
+         * @return bool
+         */
+        public function hasBeenBootstrapped();
+        
+        /**
+         * Run the given array of bootstrap classes.
+         * 
+         * @param  array  $bootstrappers
+	 * @return void
+         */
+        public function bootstrapWith();
+     
+        
 
 }


### PR DESCRIPTION
**hasBeenBootstrapped** and **bootstrapWith** method is missing in the application contract. 

It's used in Illuminate\Foundation\Http\Kernal bootstrap method.
    /**
     \* Bootstrap the application for HTTP requests.
     *
     \* @return void
     */
    public function bootstrap()
    {
        if ( ! $this->app->hasBeenBootstrapped())
        {
            $this->app->bootstrapWith($this->bootstrappers());
        }
    }
