### PR TITLE
[5.0] Tinker/PsySH Improvements

### DIFF
--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentCollectionPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentCollectionPresenter.php
@@ -1,0 +1,31 @@
+<?php namespace Illuminate\Foundation\Console\Tinker\Presenters;
+
+use Psy\Presenter\ObjectPresenter;
+use Illuminate\Database\Eloquent\Collection;
+
+class EloquentCollectionPresenter extends ObjectPresenter {
+
+	/**
+	 * EloquentCollectionPresenter can present Collections.
+	 *
+	 * @param mixed $value
+	 * @return boolean
+	 */
+	public function canPresent($value)
+	{
+		return $value instanceof Collection;
+	}
+
+	/**
+	 * Get an array of Collection object properties.
+	 *
+	 * @param object           $value
+	 * @param \ReflectionClass $class
+     * @param int              $propertyFilter One of \ReflectionProperty constants
+	 * @return array
+	 */
+	public function getProperties($value, \ReflectionClass $class, $propertyFilter)
+	{
+		return $value->toArray();
+	}
+}

--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentCollectionPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentCollectionPresenter.php
@@ -1,9 +1,9 @@
 <?php namespace Illuminate\Foundation\Console\Tinker\Presenters;
 
-use Psy\Presenter\ObjectPresenter;
+use Psy\Presenter\ArrayPresenter;
 use Illuminate\Database\Eloquent\Collection;
 
-class EloquentCollectionPresenter extends ObjectPresenter {
+class EloquentCollectionPresenter extends ArrayPresenter {
 
 	/**
 	 * EloquentCollectionPresenter can present Collections.
@@ -16,20 +16,26 @@ class EloquentCollectionPresenter extends ObjectPresenter {
 		return $value instanceof Collection;
 	}
 
-	/**
-	 * Get an array of Collection object properties.
-	 *
-	 * ReflectionProperty constants may be passed as $propertyFilter, and should
-	 * be used to toggle visibility of private and protected properties.
-	 *
+    /**
+     * Collections should be treated as ArrayObjects.
+     *
 	 * @param  object  $value
-	 * @param  \ReflectionClass  $class
-	 * @param  int  $propertyFilter
-	 * @return array
-	 */
-	public function getProperties($value, \ReflectionClass $class, $propertyFilter)
-	{
-		return $value->toArray();
-	}
+     * @return boolean
+     */
+    protected function isArrayObject($value)
+    {
+        return $value instanceof Collection;
+    }
+
+    /**
+     * Get an array of Collection values.
+     *
+	 * @param  object  $value
+     * @return array
+     */
+    protected function getArrayObjectValue($value)
+    {
+        return $value->all();
+    }
 
 }

--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentCollectionPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentCollectionPresenter.php
@@ -8,8 +8,8 @@ class EloquentCollectionPresenter extends ObjectPresenter {
 	/**
 	 * EloquentCollectionPresenter can present Collections.
 	 *
-	 * @param mixed $value
-	 * @return boolean
+	 * @param  mixed  $value
+	 * @return bool
 	 */
 	public function canPresent($value)
 	{
@@ -19,13 +19,17 @@ class EloquentCollectionPresenter extends ObjectPresenter {
 	/**
 	 * Get an array of Collection object properties.
 	 *
-	 * @param object           $value
-	 * @param \ReflectionClass $class
-     * @param int              $propertyFilter One of \ReflectionProperty constants
+	 * ReflectionProperty constants may be passed as $propertyFilter, and should
+	 * be used to toggle visibility of private and protected properties.
+	 *
+	 * @param  object  $value
+	 * @param  \ReflectionClass  $class
+	 * @param  int  $propertyFilter
 	 * @return array
 	 */
 	public function getProperties($value, \ReflectionClass $class, $propertyFilter)
 	{
 		return $value->toArray();
 	}
+
 }

--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentCollectionPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentCollectionPresenter.php
@@ -16,26 +16,26 @@ class EloquentCollectionPresenter extends ArrayPresenter {
 		return $value instanceof Collection;
 	}
 
-    /**
-     * Collections should be treated as ArrayObjects.
-     *
+	/**
+	 * Collections should be treated as ArrayObjects.
+	 *
 	 * @param  object  $value
-     * @return boolean
-     */
-    protected function isArrayObject($value)
-    {
-        return $value instanceof Collection;
-    }
+	 * @return boolean
+	 */
+	protected function isArrayObject($value)
+	{
+		return $value instanceof Collection;
+	}
 
-    /**
-     * Get an array of Collection values.
-     *
+	/**
+	 * Get an array of Collection values.
+	 *
 	 * @param  object  $value
-     * @return array
-     */
-    protected function getArrayObjectValue($value)
-    {
-        return $value->all();
-    }
+	 * @return array
+	 */
+	protected function getArrayObjectValue($value)
+	{
+		return $value->all();
+	}
 
 }

--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentModelPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentModelPresenter.php
@@ -8,8 +8,8 @@ class EloquentModelPresenter extends ObjectPresenter {
 	/**
 	 * EloquentModelPresenter can present Models.
 	 *
-	 * @param mixed $value
-	 * @return boolean
+	 * @param  mixed  $value
+	 * @return bool
 	 */
 	public function canPresent($value)
 	{
@@ -19,13 +19,17 @@ class EloquentModelPresenter extends ObjectPresenter {
 	/**
 	 * Get an array of Model object properties.
 	 *
-	 * @param object           $value
-	 * @param \ReflectionClass $class
-     * @param int              $propertyFilter One of \ReflectionProperty constants
+	 * ReflectionProperty constants may be passed as $propertyFilter, and should
+	 * be used to toggle visibility of private and protected properties.
+	 *
+	 * @param  object  $value
+	 * @param  \ReflectionClass  $class
+	 * @param  int  $propertyFilter
 	 * @return array
 	 */
 	public function getProperties($value, \ReflectionClass $class, $propertyFilter)
 	{
 		return $value->toArray();
 	}
+
 }

--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentModelPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentModelPresenter.php
@@ -32,9 +32,35 @@ class EloquentModelPresenter extends ObjectPresenter {
 		$attributes = $value->getAttributes();
 		$visible = $value->getVisible();
 
-		if (count($visible) > 0) return array_intersect_key($attributes, array_flip($visible));
+		if (count($visible) === 0)
+		{
+			$visible = array_diff(array_keys($attributes), $value->getHidden());
+		}
 
-		return array_diff_key($attributes, array_flip($value->getHidden()));
+		if (!$this->showHidden($propertyFilter))
+		{
+			return array_intersect_key($attributes, array_flip($visible));
+		}
+
+		$properties = [];
+		foreach ($attributes as $key => $value)
+		{
+			if (!in_array($key, $visible)) $key = sprintf('<protected>%s</protected>', $key);
+			$properties[$key] = $value;
+		}
+
+		return $properties;
+	}
+
+	/**
+	 * Decide whether to show hidden properties, based on a ReflectionProperty filter.
+	 *
+	 * @param  int  $propertyFilter
+	 * @return bool
+	 */
+	protected function showHidden($propertyFilter)
+	{
+		return $propertyFilter & (\ReflectionProperty::IS_PROTECTED | \ReflectionProperty::IS_PRIVATE);
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentModelPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentModelPresenter.php
@@ -1,0 +1,31 @@
+<?php namespace Illuminate\Foundation\Console\Tinker\Presenters;
+
+use Psy\Presenter\ObjectPresenter;
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelPresenter extends ObjectPresenter {
+
+	/**
+	 * EloquentModelPresenter can present Models.
+	 *
+	 * @param mixed $value
+	 * @return boolean
+	 */
+	public function canPresent($value)
+	{
+		return $value instanceof Model;
+	}
+
+	/**
+	 * Get an array of Model object properties.
+	 *
+	 * @param object           $value
+	 * @param \ReflectionClass $class
+     * @param int              $propertyFilter One of \ReflectionProperty constants
+	 * @return array
+	 */
+	public function getProperties($value, \ReflectionClass $class, $propertyFilter)
+	{
+		return $value->toArray();
+	}
+}

--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentModelPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentModelPresenter.php
@@ -29,7 +29,12 @@ class EloquentModelPresenter extends ObjectPresenter {
 	 */
 	public function getProperties($value, \ReflectionClass $class, $propertyFilter)
 	{
-		return $value->toArray();
+		$attributes = $value->getAttributes();
+		$visible = $value->getVisible();
+
+		if (count($visible) > 0) return array_intersect_key($attributes, array_flip($visible));
+
+		return array_diff_key($attributes, array_flip($value->getHidden()));
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/IlluminateApplicationPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/IlluminateApplicationPresenter.php
@@ -5,57 +5,68 @@ use Illuminate\Foundation\Application;
 
 class IlluminateApplicationPresenter extends ObjectPresenter {
 
-    protected static $appProps = [
-        'configurationIsCached',
-        'environment',
-        'environmentFile',
-        'isLocal',
-        'routesAreCached',
-        'runningUnitTests',
-        'version',
-        'path',
-        'basePath',
-        'configPath',
-        'databasePath',
-        'langPath',
-        'publicPath',
-        'storagePath',
-    ];
+	/**
+	 * Illuminate Application methods to include in the presenter.
+	 *
+	 * @var array
+	 */
+	protected static $appProperties = [
+		'configurationIsCached',
+		'environment',
+		'environmentFile',
+		'isLocal',
+		'routesAreCached',
+		'runningUnitTests',
+		'version',
+		'path',
+		'basePath',
+		'configPath',
+		'databasePath',
+		'langPath',
+		'publicPath',
+		'storagePath',
+	];
 
-    /**
-     * IlluminateApplicationPresenter can present Models.
-     *
-     * @param mixed $value
-     * @return boolean
-     */
-    public function canPresent($value)
-    {
-        return $value instanceof Application;
-    }
+	/**
+	 * IlluminateApplicationPresenter can present Applications.
+	 *
+	 * @param  mixed  $value
+	 * @return bool
+	 */
+	public function canPresent($value)
+	{
+		return $value instanceof Application;
+	}
 
-    /**
-     * Get an array of Application object properties.
-     *
-     * @param object           $value
-     * @param \ReflectionClass $class
-     * @param int              $propertyFilter One of \ReflectionProperty constants
-     * @return array
-     */
-    public function getProperties($value, \ReflectionClass $class, $propertyFilter)
-    {
-        $props = [];
+	/**
+	 * Get an array of Application object properties.
+	 *
+	 * ReflectionProperty constants may be passed as $propertyFilter, and should
+	 * be used to toggle visibility of private and protected properties.
+	 *
+	 * @param  object  $value
+	 * @param  \ReflectionClass  $class
+	 * @param  int  $propertyFilter
+	 * @return array
+	 */
+	public function getProperties($value, \ReflectionClass $class, $propertyFilter)
+	{
+		$properties = [];
 
-        foreach (self::$appProps as $prop) {
-            try {
-                $val = $value->$prop();
-                if ($val !== null) {
-                    $props[$prop] = $val;
-                }
-            } catch (\Exception $e) {
-                // Ignore exceptions
-            }
-        }
+		foreach (self::$appProperties as $property)
+		{
+			try
+			{
+				$val = $value->$property();
+				if ( ! is_null($val)) $properties[$property] = $val;
+			}
+			catch (\Exception $e)
+			{
+				// Ignore exceptions
+			}
+		}
 
-        return $props;
-    }
+		return $properties;
+	}
+
 }

--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/IlluminateApplicationPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/IlluminateApplicationPresenter.php
@@ -1,0 +1,61 @@
+<?php namespace Illuminate\Foundation\Console\Tinker\Presenters;
+
+use Psy\Presenter\ObjectPresenter;
+use Illuminate\Foundation\Application;
+
+class IlluminateApplicationPresenter extends ObjectPresenter {
+
+    protected static $appProps = [
+        'configurationIsCached',
+        'environment',
+        'environmentFile',
+        'isLocal',
+        'routesAreCached',
+        'runningUnitTests',
+        'version',
+        'path',
+        'basePath',
+        'configPath',
+        'databasePath',
+        'langPath',
+        'publicPath',
+        'storagePath',
+    ];
+
+    /**
+     * IlluminateApplicationPresenter can present Models.
+     *
+     * @param mixed $value
+     * @return boolean
+     */
+    public function canPresent($value)
+    {
+        return $value instanceof Application;
+    }
+
+    /**
+     * Get an array of Application object properties.
+     *
+     * @param object           $value
+     * @param \ReflectionClass $class
+     * @param int              $propertyFilter One of \ReflectionProperty constants
+     * @return array
+     */
+    public function getProperties($value, \ReflectionClass $class, $propertyFilter)
+    {
+        $props = [];
+
+        foreach (self::$appProps as $prop) {
+            try {
+                $val = $value->$prop();
+                if ($val !== null) {
+                    $props[$prop] = $val;
+                }
+            } catch (\Exception $e) {
+                // Ignore exceptions
+            }
+        }
+
+        return $props;
+    }
+}

--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -35,7 +35,8 @@ class TinkerCommand extends Command {
 	 */
 	public function fire()
 	{
-		$this->getApplication()->setCatchExceptions(false);
+		$app = $this->getApplication();
+		$app->setCatchExceptions(false);
 
 		$config = new Configuration();
 
@@ -45,6 +46,9 @@ class TinkerCommand extends Command {
 		$shell = new Shell($config);
 		$shell->addCommands($this->getCommands());
 		$shell->setIncludes($this->argument('include'));
+		$shell->setScopeVariables([
+			'app' => $app->getLaravel(),
+		]);
 
 		$shell->run();
 	}

--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -2,6 +2,7 @@
 
 use Psy\Shell;
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class TinkerCommand extends Command {
 
@@ -29,8 +30,21 @@ class TinkerCommand extends Command {
 		$this->getApplication()->setCatchExceptions(false);
 
 		$shell = new Shell();
+		$shell->setIncludes($this->argument('include'));
 
 		$shell->run();
+	}
+
+	/**
+	 * Get the console command arguments.
+	 *
+	 * @return array
+	 */
+	protected function getArguments()
+	{
+		return [
+			['include', InputArgument::IS_ARRAY, 'Include file(s) before starting tinker'],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -1,16 +1,21 @@
 <?php namespace Illuminate\Foundation\Console;
 
-use Illuminate\Console\Command;
-use Illuminate\Foundation\Console\Tinker\Presenters\EloquentCollectionPresenter;
-use Illuminate\Foundation\Console\Tinker\Presenters\EloquentModelPresenter;
-use Illuminate\Foundation\Console\Tinker\Presenters\IlluminateApplicationPresenter;
-use Psy\Configuration;
 use Psy\Shell;
+use Psy\Configuration;
+use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
+use Illuminate\Foundation\Console\Tinker\Presenters\EloquentModelPresenter;
+use Illuminate\Foundation\Console\Tinker\Presenters\EloquentCollectionPresenter;
+use Illuminate\Foundation\Console\Tinker\Presenters\IlluminateApplicationPresenter;
 
 class TinkerCommand extends Command {
 
-	private static $commandWhitelist = [
+	/**
+	 * artisan commands to include in the tinker shell.
+	 *
+	 * @var array
+	 */
+	protected static $commandWhitelist = [
 		'clear-compiled', 'down', 'env', 'inspire', 'migrate', 'optimize', 'up',
 	];
 
@@ -72,13 +77,11 @@ class TinkerCommand extends Command {
 	 */
 	protected function getCommands()
 	{
-		$app = $this->getApplication();
 		$commands = [];
 
-		foreach ($app->all() as $name => $command) {
-			if (in_array($name, self::$commandWhitelist)) {
-				$commands[] = $command;
-			}
+		foreach ($this->getApplication()->all() as $name => $command)
+		{
+			if (in_array($name, self::$commandWhitelist)) $commands[] = $command;
 		}
 
 		return $commands;

--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -1,7 +1,10 @@
 <?php namespace Illuminate\Foundation\Console;
 
-use Psy\Shell;
 use Illuminate\Console\Command;
+use Illuminate\Foundation\Console\Tinker\Presenters\EloquentCollectionPresenter;
+use Illuminate\Foundation\Console\Tinker\Presenters\EloquentModelPresenter;
+use Psy\Configuration;
+use Psy\Shell;
 use Symfony\Component\Console\Input\InputArgument;
 
 class TinkerCommand extends Command {
@@ -29,7 +32,12 @@ class TinkerCommand extends Command {
 	{
 		$this->getApplication()->setCatchExceptions(false);
 
-		$shell = new Shell();
+		$config = new Configuration();
+
+		$pm = $config->getPresenterManager();
+		$pm->addPresenters($this->getPresenters());
+
+		$shell = new Shell($config);
 		$shell->setIncludes($this->argument('include'));
 
 		$shell->run();
@@ -47,4 +55,17 @@ class TinkerCommand extends Command {
 		];
 	}
 
+
+	/**
+	 * Get an array of Laravel-specific Presenters.
+	 *
+	 * @return array
+	 */
+	protected function getPresenters()
+	{
+		return [
+			new EloquentModelPresenter(),
+			new EloquentCollectionPresenter(),
+		];
+	}
 }

--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -3,6 +3,7 @@
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Console\Tinker\Presenters\EloquentCollectionPresenter;
 use Illuminate\Foundation\Console\Tinker\Presenters\EloquentModelPresenter;
+use Illuminate\Foundation\Console\Tinker\Presenters\IlluminateApplicationPresenter;
 use Psy\Configuration;
 use Psy\Shell;
 use Symfony\Component\Console\Input\InputArgument;
@@ -89,6 +90,7 @@ class TinkerCommand extends Command {
 		return [
 			new EloquentModelPresenter(),
 			new EloquentCollectionPresenter(),
+			new IlluminateApplicationPresenter(),
 		];
 	}
 }

--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -9,6 +9,10 @@ use Symfony\Component\Console\Input\InputArgument;
 
 class TinkerCommand extends Command {
 
+	private static $commandWhitelist = [
+		'clear-compiled', 'down', 'env', 'inspire', 'migrate', 'optimize', 'up',
+	];
+
 	/**
 	 * The console command name.
 	 *
@@ -38,6 +42,7 @@ class TinkerCommand extends Command {
 		$pm->addPresenters($this->getPresenters());
 
 		$shell = new Shell($config);
+		$shell->addCommands($this->getCommands());
 		$shell->setIncludes($this->argument('include'));
 
 		$shell->run();
@@ -55,6 +60,24 @@ class TinkerCommand extends Command {
 		];
 	}
 
+	/**
+	 * Get artisan commands to pass through to PsySH.
+	 *
+	 * @return array
+	 */
+	protected function getCommands()
+	{
+		$app = $this->getApplication();
+		$commands = [];
+
+		foreach ($app->all() as $name => $command) {
+			if (in_array($name, self::$commandWhitelist)) {
+				$commands[] = $command;
+			}
+		}
+
+		return $commands;
+	}
 
 	/**
 	 * Get an array of Laravel-specific Presenters.

--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -40,8 +40,7 @@ class TinkerCommand extends Command {
 	 */
 	public function fire()
 	{
-		$app = $this->getApplication();
-		$app->setCatchExceptions(false);
+		$this->getApplication()->setCatchExceptions(false);
 
 		$config = new Configuration();
 
@@ -51,9 +50,6 @@ class TinkerCommand extends Command {
 		$shell = new Shell($config);
 		$shell->addCommands($this->getCommands());
 		$shell->setIncludes($this->argument('include'));
-		$shell->setScopeVariables([
-			'app' => $app->getLaravel(),
-		]);
 
 		$shell->run();
 	}


### PR DESCRIPTION
- Support includes — run `php artisan tinker foo.php` to include `foo.php` before starting the shell.
- Add custom presenters for Illuminate Applications, and Eloquent Models and Collections.
- Pass Laravel app to tinker as `$app`.

See #7152 

/cc @GrahamCampbell
