### PR TITLE
[4.2] Unset Key From Resolved In Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -837,7 +837,7 @@ class Container implements ArrayAccess {
 	 */
 	public function offsetUnset($key)
 	{
-		unset($this->bindings[$key], $this->instances[$key]);
+		unset($this->bindings[$key], $this->instances[$key], $this->resolved[$key]);
 	}
 
 	/**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -329,6 +329,16 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$container->make('ContainerMixedPrimitiveStub', $parameters);
 	}
 
+
+	public function testUnsetAffectsResolved()
+	{
+		$container = new Container;
+		$container->make('ContainerConcreteStub');
+
+		unset($container['ContainerConcreteStub']);
+		$this->assertFalse($container->resolved('ContainerConcreteStub'));
+	}
+
 }
 
 class ContainerConcreteStub {}


### PR DESCRIPTION
When unsetting a key from the Container, after clearing it from `bindings` and `instances`, it seems strange to keep it in `resolved`.
