### PR TITLE
[5.0] Dispatch commands through a pipeline

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -2,10 +2,9 @@
 
 use Closure;
 use ArrayAccess;
-use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
-use Illuminate\Pipeline\Pipeline;
 use ReflectionClass;
 use ReflectionParameter;
+use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Bus\SelfHandling;
@@ -14,6 +13,7 @@ use Illuminate\Contracts\Bus\HandlerResolver;
 use Illuminate\Contracts\Queue\ShouldBeQueued;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
 
 class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResolver {
 
@@ -46,14 +46,14 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
 	protected $mapper;
 
 	/**
-	 * The pipeline
+	 * The pipeline implementation.
 	 *
 	 * @var Pipeline
 	 */
 	protected $pipeline;
 
 	/**
-	 * The pipes which the pipeline will send commands through
+	 * The pipes which the pipeline will send commands through.
 	 *
 	 * @var array
 	 */
@@ -63,15 +63,15 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
 	 * Create a new command dispatcher instance.
 	 *
 	 * @param  \Illuminate\Contracts\Container\Container  $container
-	 * @param  \Closure|null $queueResolver
 	 * @param  \Illuminate\Contracts\Pipeline\Pipeline|null  $pipeline
+	 * @param  \Closure|null $queueResolver
 	 * @return void
 	 */
-	public function __construct(Container $container, Closure $queueResolver = null, PipelineContract $pipeline = null)
+	public function __construct(Container $container, PipelineContract $pipeline, Closure $queueResolver = null)
 	{
 		$this->container = $container;
 		$this->queueResolver = $queueResolver;
-		$this->pipeline = $pipeline ?: new Pipeline($container);
+		$this->pipeline = $pipeline;
 	}
 
 	/**
@@ -383,9 +383,9 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
 	}
 
 	/**
-	 * Set the pipes which the pipeline will use when dispatching commands
+	 * Set the pipes which the pipeline will use when dispatching commands.
 	 *
-	 * @param array $pipes
+	 * @param  array  $pipes
 	 * @return void
 	 */
 	public function setPipes(array $pipes)

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -63,15 +63,15 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
 	 * Create a new command dispatcher instance.
 	 *
 	 * @param  \Illuminate\Contracts\Container\Container  $container
-	 * @param  \Illuminate\Contracts\Pipeline\Pipeline|null  $pipeline
+	 * @param  \Illuminate\Contracts\Pipeline\Pipeline  $pipeline
 	 * @param  \Closure|null $queueResolver
 	 * @return void
 	 */
 	public function __construct(Container $container, PipelineContract $pipeline, Closure $queueResolver = null)
 	{
 		$this->container = $container;
-		$this->queueResolver = $queueResolver;
 		$this->pipeline = $pipeline;
+		$this->queueResolver = $queueResolver;
 	}
 
 	/**

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -107,6 +107,25 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 		$result = $instance->dispatchFromArray('BusDispatcherTestArgumentMapping', ['flag' => false, 'emptyString' => '']);
 		$this->assertTrue($result);
 	}
+
+
+	public function testDispatchingSentThroughPipes()
+	{
+		$container = new Container;
+
+		$pipeDispatcher = m::mock('BusDispatcherPipelineDispatcher');
+		$pipeDispatcher->shouldReceive('dispatch')->once();
+		$container->instance('BusDispatcherPipelineDispatcher', $pipeDispatcher);
+
+		$handler = m::mock('StdClass')->shouldIgnoreMissing();
+		$container->instance('Handler', $handler);
+
+		$dispatcher = new Dispatcher($container);
+		$dispatcher->mapUsing(function() { return 'Handler@handle'; });
+		$dispatcher->setPipes(['BusDispatcherPipelineDispatcher']);
+		$dispatcher->dispatch(new BusDispatcherTestBasicCommand);
+	}
+
 }
 
 class BusDispatcherTestBasicCommand {
@@ -157,3 +176,9 @@ class BusDispatcherTestCustomQueueCommand implements Illuminate\Contracts\Queue\
 		$queue->push($command);
 	}
 }
+
+
+class BusDispatcherPipelineDispatcher {
+	public function dispatch($command) {}
+}
+

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Pipeline\Pipeline;
 use Mockery as m;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Container\Container;
@@ -15,10 +16,11 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 	public function testBasicDispatchingOfCommandsToHandlers()
 	{
 		$container = new Container;
+		$pipeline = new Pipeline($container);
 		$handler = m::mock('StdClass');
 		$handler->shouldReceive('handle')->once()->andReturn('foo');
 		$container->instance('Handler', $handler);
-		$dispatcher = new Dispatcher($container);
+		$dispatcher = new Dispatcher($container, $pipeline);
 		$dispatcher->mapUsing(function() { return 'Handler@handle'; });
 
 		$result = $dispatcher->dispatch(new BusDispatcherTestBasicCommand);
@@ -29,7 +31,8 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 	public function testCommandsThatShouldBeQueuedAreQueued()
 	{
 		$container = new Container;
-		$dispatcher = new Dispatcher($container, function() {
+		$pipeline = new Pipeline($container);
+		$dispatcher = new Dispatcher($container, $pipeline, function() {
 			$mock = m::mock('Illuminate\Contracts\Queue\Queue');
 			$mock->shouldReceive('push')->once();
 			return $mock;
@@ -42,7 +45,8 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 	public function testCommandsThatShouldBeQueuedAreQueuedUsingCustomHandler()
 	{
 		$container = new Container;
-		$dispatcher = new Dispatcher($container, function() {
+		$pipeline = new Pipeline($container);
+		$dispatcher = new Dispatcher($container, $pipeline, function() {
 			$mock = m::mock('Illuminate\Contracts\Queue\Queue');
 			$mock->shouldReceive('push')->once();
 			return $mock;
@@ -55,7 +59,8 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 	public function testHandlersThatShouldBeQueuedAreQueued()
 	{
 		$container = new Container;
-		$dispatcher = new Dispatcher($container, function() {
+		$pipeline = new Pipeline($container);
+		$dispatcher = new Dispatcher($container, $pipeline, function() {
 			$mock = m::mock('Illuminate\Contracts\Queue\Queue');
 			$mock->shouldReceive('push')->once();
 			return $mock;
@@ -69,10 +74,11 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 	public function testDispatchNowShouldNeverQueue()
 	{
 		$container = new Container;
+		$pipeline = new Pipeline($container);
 		$handler = m::mock('StdClass');
 		$handler->shouldReceive('handle')->once()->andReturn('foo');
 		$container->instance('Handler', $handler);
-		$dispatcher = new Dispatcher($container);
+		$dispatcher = new Dispatcher($container, $pipeline);
 		$dispatcher->mapUsing(function() { return 'Handler@handle'; });
 
 		$result = $dispatcher->dispatch(m::mock('Illuminate\Contracts\Queue\ShouldBeQueued'));
@@ -83,10 +89,11 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 	public function testDispatchShouldCallAfterResolvingIfCommandNotQueued()
 	{
 		$container = new Container;
+		$pipeline = new Pipeline($container);
 		$handler = m::mock('StdClass')->shouldIgnoreMissing();
 		$handler->shouldReceive('after')->once();
 		$container->instance('Handler', $handler);
-		$dispatcher = new Dispatcher($container);
+		$dispatcher = new Dispatcher($container, $pipeline);
 		$dispatcher->mapUsing(function() { return 'Handler@handle'; });
 
 		$dispatcher->dispatch(new BusDispatcherTestBasicCommand, function($handler) { $handler->after(); });
@@ -95,7 +102,9 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 
 	public function testDispatchingFromArray()
 	{
-		$instance = new Dispatcher(new Container);
+		$container = new Container();
+		$pipeline = new Pipeline($container);
+		$instance = new Dispatcher($container, $pipeline);
 		$result = $instance->dispatchFromArray('BusDispatcherTestSelfHandlingCommand', ['firstName' => 'taylor', 'lastName' => 'otwell']);
 		$this->assertEquals('taylor otwell', $result);
 	}
@@ -103,7 +112,9 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 
 	public function testMarshallArguments()
 	{
-		$instance = new Dispatcher(new Container);
+		$container = new Container();
+		$pipeline = new Pipeline($container);
+		$instance = new Dispatcher($container, $pipeline);
 		$result = $instance->dispatchFromArray('BusDispatcherTestArgumentMapping', ['flag' => false, 'emptyString' => '']);
 		$this->assertTrue($result);
 	}
@@ -111,7 +122,8 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 
 	public function testDispatchingSentThroughPipes()
 	{
-		$container = new Container;
+		$container = new Container();
+		$pipeline = new Pipeline($container);
 
 		$pipeDispatcher = m::mock('BusDispatcherPipelineDispatcher');
 		$pipeDispatcher->shouldReceive('dispatch')->once();
@@ -120,7 +132,7 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 		$handler = m::mock('StdClass')->shouldIgnoreMissing();
 		$container->instance('Handler', $handler);
 
-		$dispatcher = new Dispatcher($container);
+		$dispatcher = new Dispatcher($container, $pipeline);
 		$dispatcher->mapUsing(function() { return 'Handler@handle'; });
 		$dispatcher->setPipes(['BusDispatcherPipelineDispatcher']);
 		$dispatcher->dispatch(new BusDispatcherTestBasicCommand);


### PR DESCRIPTION
Sending commands through a pipeline will allow for easier decoration of the command bus.  Additional dispatchers can be used as pipes and can independently handle resolving handlers and firing handle method.
