### PR TITLE
[4.2] Allow full stop in database name when connecting through unix socket

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -21,7 +21,7 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 
 		if (isset($config['unix_socket']))
 		{
-			$connection->exec("use {$config['database']};");
+			$connection->exec("use `{$config['database']}`;");
 		}
 
 		$collation = $config['collation'];


### PR DESCRIPTION
Details: #7155

Can't provide a test cause PDO->exec() is never actually called during tests.
