### PR TITLE
[5.0] Tinker/PsySH Improvements

### DIFF
--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentModelPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/EloquentModelPresenter.php
@@ -1,0 +1,73 @@
+<?php namespace Illuminate\Foundation\Console\Tinker\Presenters;
+
+use ReflectionClass;
+use ReflectionProperty;
+use Psy\Presenter\ObjectPresenter;
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelPresenter extends ObjectPresenter {
+
+	/**
+	 * Can the presenter present the given value?
+	 *
+	 * @param  mixed  $value
+	 * @return bool
+	 */
+	public function canPresent($value)
+	{
+		return $value instanceof Model;
+	}
+
+	/**
+	 * Get an array of Model object properties.
+	 *
+	 * ReflectionProperty constants may be passed as $propertyFilter, and should
+	 * be used to toggle visibility of private and protected properties.
+	 *
+	 * @param  object  $value
+	 * @param  ReflectionClass  $class
+	 * @param  int  $propertyFilter
+	 * @return array
+	 */
+	public function getProperties($value, ReflectionClass $class, $propertyFilter)
+	{
+		$attributes = $value->getAttributes();
+		$visible = $value->getVisible();
+
+		if (count($visible) === 0)
+		{
+			$visible = array_diff(array_keys($attributes), $value->getHidden());
+		}
+
+		if ( ! $this->showHidden($propertyFilter))
+		{
+			return array_intersect_key($attributes, array_flip($visible));
+		}
+
+		$properties = [];
+
+		foreach ($attributes as $key => $value)
+		{
+			if ( ! in_array($key, $visible))
+			{
+				$key = sprintf('<protected>%s</protected>', $key);
+			}
+
+			$properties[$key] = $value;
+		}
+
+		return $properties;
+	}
+
+	/**
+	 * Decide whether to show hidden properties, based on a ReflectionProperty filter.
+	 *
+	 * @param  int  $propertyFilter
+	 * @return bool
+	 */
+	protected function showHidden($propertyFilter)
+	{
+		return $propertyFilter & (ReflectionProperty::IS_PROTECTED | ReflectionProperty::IS_PRIVATE);
+	}
+
+}

--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/IlluminateApplicationPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/IlluminateApplicationPresenter.php
@@ -1,0 +1,74 @@
+<?php namespace Illuminate\Foundation\Console\Tinker\Presenters;
+
+use Exception;
+use ReflectionClass;
+use Psy\Presenter\ObjectPresenter;
+use Illuminate\Foundation\Application;
+
+class IlluminateApplicationPresenter extends ObjectPresenter {
+
+	/**
+	 * Illuminate Application methods to include in the presenter.
+	 *
+	 * @var array
+	 */
+	protected static $appProperties = [
+		'configurationIsCached',
+		'environment',
+		'environmentFile',
+		'isLocal',
+		'routesAreCached',
+		'runningUnitTests',
+		'version',
+		'path',
+		'basePath',
+		'configPath',
+		'databasePath',
+		'langPath',
+		'publicPath',
+		'storagePath',
+	];
+
+	/**
+	 * Can the presenter present the given value?
+	 *
+	 * @param  mixed  $value
+	 * @return bool
+	 */
+	public function canPresent($value)
+	{
+		return $value instanceof Application;
+	}
+
+	/**
+	 * Get an array of Application object properties.
+	 *
+	 * ReflectionProperty constants may be passed as $propertyFilter, and should
+	 * be used to toggle visibility of private and protected properties.
+	 *
+	 * @param  object  $value
+	 * @param  ReflectionClass  $class
+	 * @param  int  $propertyFilter
+	 * @return array
+	 */
+	public function getProperties($value, ReflectionClass $class, $propertyFilter)
+	{
+		$properties = [];
+
+		foreach (self::$appProperties as $property)
+		{
+			try
+			{
+				$val = $value->$property();
+				if ( ! is_null($val)) $properties[$property] = $val;
+			}
+			catch (Exception $e)
+			{
+				// Ignore exceptions
+			}
+		}
+
+		return $properties;
+	}
+
+}

--- a/src/Illuminate/Foundation/Console/Tinker/Presenters/IlluminateCollectionPresenter.php
+++ b/src/Illuminate/Foundation/Console/Tinker/Presenters/IlluminateCollectionPresenter.php
@@ -1,0 +1,41 @@
+<?php namespace Illuminate\Foundation\Console\Tinker\Presenters;
+
+use Psy\Presenter\ArrayPresenter;
+use Illuminate\Support\Collection;
+
+class IlluminateCollectionPresenter extends ArrayPresenter {
+
+	/**
+	 * Can the presenter present the given value?
+	 *
+	 * @param  mixed  $value
+	 * @return bool
+	 */
+	public function canPresent($value)
+	{
+		return $value instanceof Collection;
+	}
+
+	/**
+	 * Collections should be treated as ArrayObjects.
+	 *
+	 * @param  object  $value
+	 * @return boolean
+	 */
+	protected function isArrayObject($value)
+	{
+		return $value instanceof Collection;
+	}
+
+	/**
+	 * Get an array of Collection values.
+	 *
+	 * @param  object  $value
+	 * @return array
+	 */
+	protected function getArrayObjectValue($value)
+	{
+		return $value->all();
+	}
+
+}

--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -1,9 +1,23 @@
 <?php namespace Illuminate\Foundation\Console;
 
 use Psy\Shell;
+use Psy\Configuration;
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Illuminate\Foundation\Console\Tinker\Presenters\EloquentModelPresenter;
+use Illuminate\Foundation\Console\Tinker\Presenters\IlluminateCollectionPresenter;
+use Illuminate\Foundation\Console\Tinker\Presenters\IlluminateApplicationPresenter;
 
 class TinkerCommand extends Command {
+
+	/**
+	 * artisan commands to include in the tinker shell.
+	 *
+	 * @var array
+	 */
+	protected static $commandWhitelist = [
+		'clear-compiled', 'down', 'env', 'inspire', 'migrate', 'optimize', 'up',
+	];
 
 	/**
 	 * The console command name.
@@ -28,9 +42,58 @@ class TinkerCommand extends Command {
 	{
 		$this->getApplication()->setCatchExceptions(false);
 
-		$shell = new Shell();
+		$config = new Configuration();
+
+		$pm = $config->getPresenterManager();
+		$pm->addPresenters($this->getPresenters());
+
+		$shell = new Shell($config);
+		$shell->addCommands($this->getCommands());
+		$shell->setIncludes($this->argument('include'));
 
 		$shell->run();
 	}
 
+	/**
+	 * Get the console command arguments.
+	 *
+	 * @return array
+	 */
+	protected function getArguments()
+	{
+		return [
+			['include', InputArgument::IS_ARRAY, 'Include file(s) before starting tinker'],
+		];
+	}
+
+	/**
+	 * Get artisan commands to pass through to PsySH.
+	 *
+	 * @return array
+	 */
+	protected function getCommands()
+	{
+		$commands = [];
+
+		foreach ($this->getApplication()->all() as $name => $command)
+		{
+			if (in_array($name, self::$commandWhitelist)) $commands[] = $command;
+		}
+
+		return $commands;
+	}
+
+	/**
+	 * Get an array of Laravel-specific Presenters.
+	 *
+	 * @return array
+	 */
+	protected function getPresenters()
+	{
+		return [
+			new EloquentModelPresenter(),
+			new IlluminateCollectionPresenter(),
+			new IlluminateApplicationPresenter(),
+		];
+	}
 }


### PR DESCRIPTION
- Support includes — run `php artisan tinker foo.php` to include `foo.php` before starting the shell.
- Add custom presenters for Illuminate Applications, and Eloquent Models and Collections.

---

See #7152. Replaces #7182.
