### PR TITLE
[5.0] Revert "FormRequests Check Auth Before Validating"

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -17,13 +17,13 @@ trait ValidatesWhenResolvedTrait {
 	{
 		$instance = $this->getValidatorInstance();
 
-		if ( ! $this->passesAuthorization())
-		{
-			$this->failedAuthorization();
-		}
-		elseif ( ! $instance->passes())
+		if ( ! $instance->passes())
 		{
 			$this->failedValidation($instance);
+		}
+		elseif ( ! $this->passesAuthorization())
+		{
+			$this->failedAuthorization();
 		}
 	}
 


### PR DESCRIPTION
this is revert about https://github.com/laravel/framework/pull/6407 @fnwbr @GrahamCampbell 

when db access is needed for authority check
i think that the first thing to do is parameter check

example
to check whether login user is board author or not. 
i think that the first thing to do is to check board id parameter existence.

below code throw error exception ( undefined variable ) when no parameter exist 
but proper exception is HttpResponseException

``` php
public function authorize()
{
    $params = Input::all();

    $board = Board::find($params['board']['author_id']);

    if ( $board->author_id !== Auth::id() )
    {
        return false;
    }

    return true;
}
```
