### PR TITLE
[4.2] Execute artisan serve from the public dir

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -28,17 +28,17 @@ class ServeCommand extends Command {
 	{
 		$this->checkPhpVersion();
 
-		chdir($this->laravel['path.base']);
+		chdir($this->laravel['path.public']);
 
 		$host = $this->input->getOption('host');
 
 		$port = $this->input->getOption('port');
 
-		$public = $this->laravel['path.public'];
+		$base = $this->laravel['path.base'];
 
 		$this->info("Laravel development server started on http://{$host}:{$port}");
 
-		passthru('"'.PHP_BINARY.'"'." -S {$host}:{$port} -t \"{$public}\" server.php");
+		passthru('"'.PHP_BINARY.'"'." -S {$host}:{$port} \"{$base}\"/server.php");
 	}
 
 	/**


### PR DESCRIPTION
artisan serve executes the `php -S` command from the base dir causing `realpath` to return the base dir instead of the public dir.
- **Regular webserver** `echo realpath(null);` outputs the correct path to the public directory.
- **Built-in webserver** `echo realpath(null);` outputs the path to the base directory.

This PR changes that behavior by executing the command from the public dir ensuring the same output is generated on both web servers.

Signed-off-by: Suhayb Wardany me@suw.me
