### PR TITLE
[5.0] Execute artisan serve from the public dir

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -26,17 +26,17 @@ class ServeCommand extends Command {
 	 */
 	public function fire()
 	{
-		chdir($this->laravel->basePath());
+		chdir($this->laravel->publicPath());
 
 		$host = $this->input->getOption('host');
 
 		$port = $this->input->getOption('port');
 
-		$public = $this->laravel->publicPath();
+		$base = $this->laravel->basePath();
 
 		$this->info("Laravel development server started on http://{$host}:{$port}");
 
-		passthru('"'.PHP_BINARY.'"'." -S {$host}:{$port} -t \"{$public}\" server.php");
+		passthru('"'.PHP_BINARY.'"'." -S {$host}:{$port} \"{$base}\"/server.php");
 	}
 
 	/**


### PR DESCRIPTION
artisan serve executes the `php -S` command from the base dir causing `realpath` to return the base dir instead of the public dir.
- **Regular webserver** `echo realpath(null);` outputs the correct path to the public directory.
- **Built-in webserver** `echo realpath(null);` outputs the path to the base directory.

This PR changes that behavior by executing the command from the public dir ensuring the same output is generated on both web servers.

Signed-off-by: Suhayb Wardany me@suw.me
