### PR TITLE
[5.0] Pretty Print By Default

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -57,7 +57,7 @@ class Response extends BaseResponse {
 	{
 		if ($content instanceof Jsonable) return $content->toJson();
 
-		return json_encode($content);
+		return json_encode($content, JSON_PRETTY_PRINT);
 	}
 
 	/**

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -21,7 +21,7 @@ class HttpResponseTest extends PHPUnit_Framework_TestCase {
 
 		$response = new Illuminate\Http\Response();
 		$response->setContent(array('foo' => 'bar'));
-		$this->assertEquals('{"foo":"bar"}', $response->getContent());
+		$this->assertEquals("{\n    \"foo\": \"bar\"\n}", $response->getContent());
 		$this->assertEquals('application/json', $response->headers->get('Content-Type'));
 	}
 


### PR DESCRIPTION
I think the morphToJson method should pretty print by default. This would mean people get readable output as a response when they do something like this in their controller:

``` php
    return User::all();
```

---

// cc @jbrooksuk
