### PR TITLE
[5.0] Fix "php artisan app:name" Crash

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -111,13 +111,11 @@ class AppNameCommand extends Command {
 	{
 		$search = [
 			'namespace '.$this->currentRoot.';',
-			'namespace '.$this->currentRoot.'\\',
 			$this->currentRoot.'\\',
 		];
 
 		$replace = [
 			'namespace '.$this->argument('name').';',
-			'namespace '.$this->argument('name').'\\',
 			$this->argument('name').'\\',
 		];
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Fixed tickets | https://github.com/laravel/framework/issues/7192 |

We should not replace `namespace App\` with `namespace TestApp\` if we also replace `App\` with `TestApp\` because the second replacement does the first as well and things crash
