### PR TITLE
[5.0] More status messages for publish command

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -66,6 +66,10 @@ class VendorPublishCommand extends Command {
 			{
 				$this->publishDirectory($from, $to);
 			}
+			else
+			{
+				$this->error("Cannot find path '$from'");
+			}
 		}
 
 		$this->info('Publishing Complete!');
@@ -113,6 +117,8 @@ class VendorPublishCommand extends Command {
 				$manager->put('to://'.$file['path'], $manager->read('from://'.$file['path']));
 			}
 		}
+
+		$this->status($from, $to, 'Directory');
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -56,6 +56,12 @@ class VendorPublishCommand extends Command {
 			$this->option('provider'), $this->option('tag')
 		);
 
+		if (empty($paths))
+		{
+			$this->error("There are no paths to publish");
+			return;
+		}
+
 		foreach ($paths as $from => $to)
 		{
 			if ($this->files->isFile($from))


### PR DESCRIPTION
Makes it clear if a path cannot be found (indication for the package developer mainly) and that a directory has been copied.
We don't know for sure that the contents are copied if the force option isn't set, but at least it gives us an idea that the directory is found and copied if possible.
