### PR TITLE
[5.0] Return empty array when provider/group doesn't match

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -136,6 +136,11 @@ abstract class ServiceProvider {
 			return static::$publishes[$provider];
 		}
 
+		if ($group || $provider)
+		{
+			return [];	
+		}
+
 		$paths = [];
 
 		foreach (static::$publishes as $class => $publish)


### PR DESCRIPTION
Instead of returning all files.

For example, when you want to force publish a tag/provider and make a typo, you overwrite _all_  assets.. Propbably not desirable.
