### PR TITLE
[5.0] Recreate compiled things in "app:name" command

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -83,6 +83,10 @@ class AppNameCommand extends Command {
 		$this->info('Application namespace set!');
 
 		$this->composer->dumpAutoloads();
+		
+		$this->call('clear-compiled');
+
+		$this->call('optimize');
 	}
 
 	/**


### PR DESCRIPTION
Another issue with `php artisan app:name` command:

Step 1: Fresh L5 is installed in Homested
`composer create-project laravel/laravel l5 dev-develop --prefer-dist && sudo chmod -R 777 l5 && cd l5`

Step2 (optional):  `php artisan app:name Acme`. Everything is fine at this moment.

Step3 (): `php artisan app:name APP` (the name is strange but why not).

After the last command was executed, we get the error http://gyazo.com/6ba944e9c15e5da092803582f9c41c04
We can't even clear everything with `php artisan clear-compied` because it causes the same error.

I'm not completely sure whether it is the best solution or not, but it works and seems right to me.

if `app.debug` is false the `optimize` command produces compiled files with new namespaces.
