### PR TITLE
Use static $verbs property when adding "any" route

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -195,9 +195,7 @@ class Router implements RegistrarContract {
 	 */
 	public function any($uri, $action)
 	{
-		$verbs = array('GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE');
-
-		return $this->addRoute($verbs, $uri, $action);
+		return $this->addRoute(static::$verbs, $uri, $action);
 	}
 
 	/**


### PR DESCRIPTION
Not sure if this is intentional or not, but shouldn't the static $verbs property be used when adding a route that runs on any HTTP verb?

This PR simply uses the $verbs property when adding a route using the `any()` method.
