### PR TITLE
[5.1] return original value when calling preset property

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2571,6 +2571,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		{
 			return $this->getRelationshipFromMethod($key);
 		}
+
+		if( property_exists($this, $key))
+		{
+			return $this->$key;
+		}
 	}
 
 	/**


### PR DESCRIPTION
The current issue is that when you add a custom property to your model and try to call it from an instance you'll get null if the property doesn't match a relationship method or value on the model. This makes calling `(new Model)->presetProperty`  & `Model::find(1)->presetProperty` always return null rather than what might have been set in `presetProperty`.

Anyway, this simple line fixes this issue.
