### PR TITLE
[5.0] Change "\n" to PHP_EOL in 3 tests to make them pass on windows.

### DIFF
--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -19,7 +19,7 @@ class ViewCompilerEngineTest extends PHPUnit_Framework_TestCase {
 		$engine->getCompiler()->shouldReceive('compile')->once()->with(__DIR__.'/fixtures/foo.php');
 		$results = $engine->get(__DIR__.'/fixtures/foo.php');
 
-		$this->assertEquals("Hello World\n", $results);
+		$this->assertEquals("Hello World" . PHP_EOL, $results);
 	}
 
 
@@ -31,7 +31,7 @@ class ViewCompilerEngineTest extends PHPUnit_Framework_TestCase {
 		$engine->getCompiler()->shouldReceive('compile')->never();
 		$results = $engine->get(__DIR__.'/fixtures/foo.php');
 
-		$this->assertEquals("Hello World\n", $results);
+		$this->assertEquals("Hello World" . PHP_EOL, $results);
 	}
 
 

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -14,7 +14,7 @@ class ViewPhpEngineTest extends PHPUnit_Framework_TestCase {
 	public function testViewsMayBeProperlyRendered()
 	{
 		$engine = new PhpEngine;
-		$this->assertEquals("Hello World\n", $engine->get(__DIR__.'/fixtures/basic.php'));
+		$this->assertEquals("Hello World" . PHP_EOL, $engine->get(__DIR__.'/fixtures/basic.php'));
 	}
 
 }


### PR DESCRIPTION
These 3 tests are not passing in windows. This commit fixes it.
