### PR TITLE
[5.0] Improve the middleware generated by make:middleware.

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/middleware.stub
+++ b/src/Illuminate/Routing/Console/stubs/middleware.stub
@@ -13,7 +13,7 @@ class {{class}} {
 	 */
 	public function handle($request, Closure $next)
 	{
-		//
+		return $next($request);
 	}
 
 }


### PR DESCRIPTION
Just a quick addition to the middleware stub with `return $next($request);` as this line is (and will be) present in most middlewares.

(PR #7236 sent to the wrong branch)
