### PR TITLE
[5.0] Add primary key to migrations table

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -122,6 +122,8 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 			$table->string('migration');
 
 			$table->integer('batch');
+
+			$table->primary('migration');
 		});
 	}
 


### PR DESCRIPTION
MariaDB Galera Cluster requires that all tables have primary keys for cluster synchronisation to be fully supported.  To quote the documentation:

> All tables should have a primary key (multi-column primary keys are supported). DELETE operations are unsupported on tables without a primary key. Also, rows in tables without a primary key may appear in a different order on different nodes.

This PR makes the the `migration` column the primary key of the `migrations` table.
