### PR TITLE
[5.0] Add auto incrementing id column to migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -119,6 +119,8 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 			// The migrations table is responsible for keeping track of which of the
 			// migrations have actually run for the application. We'll create the
 			// table to hold the migration file's path as well as the batch ID.
+			$table->increments('id');
+
 			$table->string('migration');
 
 			$table->integer('batch');


### PR DESCRIPTION
As an alternative to #7244 this adds an auto incrementing id column to the migrations table.  This gives the table a primary key but doesn't have any issues around string index length.
