### PR TITLE
[5.0] Artisan Scheduler: Checking for /dev/null output in emailOutputTo()

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -631,7 +631,7 @@ class Event {
 	 */
 	public function emailOutputTo($addresses)
 	{
-		if (is_null($this->output))
+		if (is_null($this->output) || $this->output == '/dev/null')
 		{
 			throw new LogicException("Must direct output to a file in order to e-mail results.");
 		}


### PR DESCRIPTION
As part of the artisan scheduler, the emailOutputTo() option only works
when the sendOutputTo() option has been passed a file, and it does so by
checking if the output string is null. Given the default output is
actually '/dev/null' and not null, this check never fails and the
exception is not thrown.

This fix checks for '/dev/null' so the exception is thrown correctly.
