### PR TITLE
[5.1] saveMany receives collection OR array to hasOneOrMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -170,13 +170,15 @@ abstract class HasOneOrMany extends Relation {
 	}
 
 	/**
-	 * Attach an array of models to the parent instance.
+	 * Attach an array or collection of models to the parent instance.
 	 *
-	 * @param  array  $models
+	 * @param  mixed  $models
 	 * @return array
 	 */
-	public function saveMany(array $models)
+	public function saveMany($models)
 	{
+		if ($models instanceof Collection) $models = $models->all();
+
 		array_walk($models, array($this, 'save'));
 
 		return $models;


### PR DESCRIPTION
`saveMany()` receiving a collection OR array. In `Illuminate\Database\Eloquent\Relations\hasOneOrMany`. See [issue #7144](https://github.com/laravel/framework/issues/7144). Backwards Compatible no BCs.

---

The saveMany() method of the `Illuminate\Database\Eloquent\Relations\hasOneOrMany` relationship can only receive an array of models. The API across eloquent usually you can pass in collections or arrays. So this behaviour seems strange and not consistent with the rest of the API.
