### PR TITLE
Add basePath() method to application contract

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -10,6 +10,13 @@ interface Application extends Container {
 	 * @return string
 	 */
 	public function version();
+	
+	/**
+	 * Get the base path of the Laravel installation.
+	 *
+	 * @return string
+	 */
+	public function basePath()
 
 	/**
 	 * Get or check the current application environment.

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -16,7 +16,7 @@ interface Application extends Container {
 	 *
 	 * @return string
 	 */
-	public function basePath()
+	public function basePath();
 
 	/**
 	 * Get or check the current application environment.


### PR DESCRIPTION
This method is used in the `ServiceProvider` class (method `loadViewsFrom()`).

Since I'm using a custom application class (implementing the interface), I would expect this to work, thus I added the method to the interface.
