### PR TITLE
[5.0] Added hasRegex() to Request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -264,7 +264,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	{
 		foreach ($this->all() as $key => $value)
 		{
-			if (preg_match($pattern, $key) && ! $this->isEmptyString($key)) return true;
+			if (! $this->isEmptyString($key) && preg_match($pattern, $key)) return true;
 		}
 
 		return false;

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -271,6 +271,22 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	}
 
 	/**
+	 * Determine if the request contains a non-empty value for an input item matching a given pattern.
+	 *
+	 * @param  string  $pattern
+	 * @return bool
+	 */
+	public function hasRegex($pattern)
+	{
+		foreach ($this->all() as $key => $value)
+		{
+			if (! $this->isEmptyString($key) && preg_match($pattern, $key)) return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Determine if the given input key is an empty string for "has".
 	 *
 	 * @param  string  $key

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -266,9 +266,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 
 		foreach ($input as $key => $value)
 		{
-			$has = preg_match($pattern, $key) && ! $this->isEmptyString($key);
-
-			if ($has) return true;
+			if (preg_match($pattern, $key) && ! $this->isEmptyString($key)) return true;
 		}
 
 		return false;

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -255,6 +255,26 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	}
 
 	/**
+	 * Determine if the request contains a non-empty value for an input item matching a given pattern.
+	 *
+	 * @param  string  $pattern
+	 * @return bool
+	 */
+	public function hasRegex($pattern)
+	{
+		$input = $this->all();
+
+		foreach ($input as $key => $value)
+		{
+			$has = preg_match($pattern, $key) && ! $this->isEmptyString($key);
+
+			if ($has) return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Determine if the given input key is an empty string for "has".
 	 *
 	 * @param  string  $key

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -262,9 +262,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function hasRegex($pattern)
 	{
-		$input = $this->all();
-
-		foreach ($input as $key => $value)
+		foreach ($this->all() as $key => $value)
 		{
 			if (preg_match($pattern, $key) && ! $this->isEmptyString($key)) return true;
 		}

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -171,6 +171,20 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testHasRegexMethod()
+	{
+		$request = Request::create('/', 'GET', array('name' => 'Taylor', 'foo' => 'bar'));
+		$this->assertFalse($request->hasRegex('/^utm_/'));
+		$this->assertTrue($request->hasRegex('/name/'));
+		$this->assertTrue($request->hasRegex('/^foo$/'));
+
+		$request = Request::create('/', 'GET', array('name' => '', 'utm_source' => 'laravel', 'foo' => null));
+		$this->assertTrue($request->hasRegex('/^utm_/'));
+		$this->assertFalse($request->hasRegex('/foo/'));
+		$this->assertFalse($request->hasRegex('/name/'));
+	}
+
+
 	public function testInputMethod()
 	{
 		$request = Request::create('/', 'GET', array('name' => 'Taylor'));

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -157,6 +157,20 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testHasRegexMethod()
+	{
+		$request = Request::create('/', 'GET', array('name' => 'Taylor', 'foo' => 'bar'));
+		$this->assertFalse($request->hasRegex('/^utm_/'));
+		$this->assertTrue($request->hasRegex('/name/'));
+		$this->assertTrue($request->hasRegex('/^foo$/'));
+
+		$request = Request::create('/', 'GET', array('name' => '', 'utm_source' => 'laravel', 'foo' => null));
+		$this->assertTrue($request->hasRegex('/^utm_/'));
+		$this->assertFalse($request->hasRegex('/foo/'));
+		$this->assertFalse($request->hasRegex('/name/'));
+	}
+
+
 	public function testInputMethod()
 	{
 		$request = Request::create('/', 'GET', array('name' => 'Taylor'));


### PR DESCRIPTION
This is just a proposal for something I use a lot.

**Example:**

```
http://domain.com/page?utm_source=foo&utm_campaign=bar&utm_name=foo
```

So I need to check if there is any item that begins with `utm_`. With this new method:

``` php
if(Input::hasRegex('/^utm_/')) {
  // --
}
```
