### PR TITLE
[5.0] Remove "@methodName" from class names

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -83,6 +83,8 @@ abstract class GeneratorCommand extends Command {
 	 */
 	protected function parseName($name)
 	{
+		$name = strtok($name, '@');
+		
 		$rootNamespace = $this->getAppNamespace();
 
 		if (starts_with($name, $rootNamespace))


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/7264

This function returns a class name which is used to build a stub.

Since the convention to pass "className@methodName" instead of class name is so widespread in Laravel, I think it's worth checking and automatically removing "method part" to prevent issues like https://github.com/laravel/framework/issues/7264

I can also propose handling "@methodName" to create this method for some types of generators but it requires some extra work and another PR
