### PR TITLE
[4.2] Fix Bug In Named Resource Within Domain Grouping

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -503,6 +503,11 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	{
 		$group = str_replace('/', '.', $this->getLastGroupPrefix());
 
+        if (empty($group))
+        {
+		    return trim("{$prefix}{$resource}.{$method}", '.');
+        }
+
 		return trim("{$prefix}{$group}.{$resource}.{$method}", '.');
 	}
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -503,10 +503,10 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 	{
 		$group = str_replace('/', '.', $this->getLastGroupPrefix());
 
-        if (empty($group))
-        {
-		    return trim("{$prefix}{$resource}.{$method}", '.');
-        }
+		if (empty($group))
+		{
+			return trim("{$prefix}{$resource}.{$method}", '.');
+		}
 
 		return trim("{$prefix}{$group}.{$resource}.{$method}", '.');
 	}


### PR DESCRIPTION
The original bug is #6984.
Because the `$group` variable can be a empty string, so we need to check it first in order to make sure that the group resource name is right.
