### PR TITLE
[5.0] Restores exception and error handlers when application gets flushed

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -905,6 +905,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 		parent::flush();
 
 		$this->loadedProviders = [];
+        restore_exception_handler();
+        restore_error_handler();
 	}
 
 }


### PR DESCRIPTION
This fixes a bug where the exception handler bound in the IOC container is flushed, but Laravel is still registered to handle errors resulting in a BindingResolutionError being thrown when the handler is being resolved , obfuscating the underlying exception..  
