### PR TITLE
Decryption of the $header token, is causing a DecryptException

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -59,7 +59,7 @@ class VerifyCsrfToken implements Middleware {
 		$header = $request->header('X-XSRF-TOKEN');
 
 		return StringUtils::equals($token, $request->input('_token')) ||
-		       ($header && StringUtils::equals($token, $this->encrypter->decrypt($header)));
+		       ($header && StringUtils::equals($token, $header));
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -59,7 +59,9 @@ class VerifyCsrfToken implements Middleware {
 		$header = $request->header('X-XSRF-TOKEN');
 
 		return StringUtils::equals($token, $request->input('_token')) ||
+		       ($header && StringUtils::equals($token, $this->encrypter->decrypt($header))) ||
 		       ($header && StringUtils::equals($token, $header));
+
 	}
 
 	/**


### PR DESCRIPTION
This fixes the $header toke decryption bug:

When passing the token through the header for AJAX requests eg:

``` javascript
headers: {
  'X-XSRF-TOKEN': '{{ csrf_token() }}
 }
```

Since we are using the same principle as the hidden form input, decrypting the token in VerifyCsrfToken throws an exception, 
DecryptException in Encrypter.php line 142: Invalid data

So a new term was addedd, eg:

``` php
protected function tokensMatch($request)
{
    $token = $request->session()->token();

    $header = $request->header('X-XSRF-TOKEN');

    return StringUtils::equals($token, $request->input('_token')) ||
           ($header && StringUtils::equals($token, $this->encrypter->decrypt($header))) ||
           ($header && StringUtils::equals($token, $header));
}
```
