### PR TITLE
[5.0] Allow collections of primitives to be imploded

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -316,7 +316,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 */
 	public function implode($value, $glue = null)
 	{
-		return implode($glue, $this->lists($value));
+		$first = $this->first();
+
+		if (is_array($first) || is_object($first))
+		{
+			return implode($glue, $this->lists($value));
+		}
+
+		return implode($value, $this->items);
 	}
 
 	/**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -289,9 +289,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testImplode()
 	{
-		$data = new Collection(array(array('name' => 'taylor', 'email' => 'foo'), array('name' => 'dayle', 'email' => 'bar')));
+		$data = new Collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
 		$this->assertEquals('foobar', $data->implode('email'));
 		$this->assertEquals('foo,bar', $data->implode('email', ','));
+
+		$data = new Collection(['taylor', 'dayle']);
+		$this->assertEquals('taylordayle', $data->implode(''));
+		$this->assertEquals('taylor,dayle', $data->implode(','));
 	}
 
 


### PR DESCRIPTION
So that we can do this:

``` php
collect([1, 2, 3])->implode('-'); // 1-2-3
```
