### PR TITLE
[5.0] Package Config : Update mergeConfigFrom use array_replace_recursive

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -61,7 +61,7 @@ abstract class ServiceProvider {
 	{
 		$config = $this->app['config']->get($key, []);
 
-		$this->app['config']->set($key, array_merge(require $path, $config));
+		$this->app['config']->set($key, array_replace_recursive(require $path, $config));
 	}
 
 	/**


### PR DESCRIPTION
using array_merge will only merge the first dimension array and not take default value from second level of dimension array, I think using array_replace_recursive is better so that user can only override certain value from multidimensional array.

Example :

``` php
Default config :
return [
     'first' => [
             'second' => [
                     'param1' => 'value1',
                     'param2' => 'value2'
             ]
     ]
];
```

User Config :

``` php
return [
     'first' => [
          'second' => [
               'param1' => 'value3'
          ]
     ]
];
```

array_merge result :

``` php
return [
     'first' => [
          'second' => [
               'param1' => 'value3'
          ]
     ]
];
```

array_replace_recursive result :

``` php
return [
     'first' => [
          'second' => [
               'param1' => 'value3',
               'param2' => 'value2',
          ]
     ]
];
```

If using array_merge, param 2 won't included, if using array_replace_recursive it will be included.
