### PR TITLE
[5.1] Remove superfluous firstByAttributes method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -621,17 +621,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	}
 
 	/**
-	 * Get the first model for the given attributes.
-	 *
-	 * @param  array  $attributes
-	 * @return static|null
-	 */
-	protected static function firstByAttributes($attributes)
-	{
-		return static::where($attributes)->first();
-	}
-
-	/**
 	 * Begin querying the model.
 	 *
 	 * @return \Illuminate\Database\Eloquent\Builder


### PR DESCRIPTION
1. It is not used anywhere in the framework.
2. It was never a public method.
3. It's simply a more verbose way of saying what it actually does. Compare:

``` php
$user = User::where($attributes)->first();

$user = User::firstByAttributes($attributes);
```

For context, see [#7300](https://github.com/laravel/framework/pull/7300#issuecomment-73294009) and #4847.
