### PR TITLE
[5.0] Allowing for resolved engines to be re-registered

### DIFF
--- a/src/Illuminate/View/Engines/EngineResolver.php
+++ b/src/Illuminate/View/Engines/EngineResolver.php
@@ -30,6 +30,7 @@ class EngineResolver {
 	 */
 	public function register($engine, Closure $resolver)
 	{
+		unset($this->resolved[$engine]);
 		$this->resolvers[$engine] = $resolver;
 	}
 


### PR DESCRIPTION
Currently if you want to override or decorate the blade compiler there doesn't seem to be a way. This is because once a engine is resolved it is used (so that we no longer have to keep making calls to resolve the registered engine). Imagine a service provider like below. The following will work after the merge but currently does not work)

```
      $app = $this->app;

        $resolver = $this->app['view']->getEngineResolver();

        $compiler = $resolver->resolve('blade')->getCompiler();

        $resolver->register('blade', function() use ($app, $compiler)
        {
            $extended = new ExtendedBladeCompiler($compiler);

            return new CompilerEngine($compiler, $app['files']);
        });
```

(fixed to be branch 5.0 Taylor)
