### PR TITLE
[5.0] Adding a default value to elixir() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -605,29 +605,34 @@ if ( ! function_exists('event'))
 if ( ! function_exists('elixir'))
 {
 	/**
-	* Get the path to a versioned Elixir file.
-	*
-	* @param  string  $file
-	* @return string
-	*/
-	function elixir($file)
+	 * Get the path to a versioned Elixir file.
+	 *
+	 * @param  string  $file
+	 * @param  string  $default
+	 * @return string
+	 */
+	function elixir($file, $default = null)
 	{
 		static $manifest = null;
+		static $manifest_exists = true;
 
-		if (is_null($manifest))
+		if (is_null($manifest) && $manifest_exists)
 		{
 
-			if(!file_exists(public_path().'/build/rev-manifest.json'))
+			if ($manifest_exists = file_exists(public_path().'/build/rev-manifest.json'))
 			{
-				return $file;
+				$manifest = json_decode(file_get_contents(public_path() . '/build/rev-manifest.json'), true);
 			}
 
-			$manifest = json_decode(file_get_contents(public_path().'/build/rev-manifest.json'), true);
 		}
 
 		if (isset($manifest[$file]))
 		{
 			return '/build/'.$manifest[$file];
+		}
+		elseif ($default !== null)
+		{
+			return $default;
 		}
 
 		throw new InvalidArgumentException("File {$file} not defined in asset manifest.");

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -616,6 +616,12 @@ if ( ! function_exists('elixir'))
 
 		if (is_null($manifest))
 		{
+
+			if(!file_exists(public_path().'/build/rev-manifest.json'))
+			{
+				return $file;
+			}
+
 			$manifest = json_decode(file_get_contents(public_path().'/build/rev-manifest.json'), true);
 		}
 


### PR DESCRIPTION
During development I find it convenient to turn off .version() in elixir to reduce the number of files tracked by git, the problem with this is that using the elixir() helper in a .blade.php file will throw an error if the rev-manifest.json is not found. I've added a second (optional) argument to the helper function to prevent this from happening.

I first thought to just output the $file variable as the default/fallback, but chose to go with a more explicit route of defining a default. using: {{ elixir("css/app.css","css/default.css") }} in a blade template will use default.css if the  rev-manifest.json file is not found (i.e. .version() is not used in elixir/gulp)
