### PR TITLE
Make it possible to use `artisan make:controller Foo/Bar/Baz`

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -90,6 +90,11 @@ abstract class GeneratorCommand extends Command {
 			return $name;
 		}
 
+		if (str_contains($name, '/'))
+		{
+			$name = str_replace('/', '\\', $name);
+		}
+
 		return $this->parseName($this->getDefaultNamespace(trim($rootNamespace, '\\')).'\\'.$name);
 	}
 


### PR DESCRIPTION
We can use `php artisan make:controller Foo\\Bar\\Baz` to generate a new controller. This PR will make it possible to use `php artisan make:controller Foo/Bar/Baz`.

This will affects to another generator like `make:request`, `make:model`, `make:command`, etc.
