### PR TITLE
Create 'make:seed' command to speed up the workflow

### DIFF
--- a/src/Illuminate/Database/SeedServiceProvider.php
+++ b/src/Illuminate/Database/SeedServiceProvider.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Console\SeedCommand;
+use Illuminate\Database\Console\SeedMakeCommand;
+use Illuminate\Database\Seeder\SeedCreator;
 
 class SeedServiceProvider extends ServiceProvider {
 
@@ -19,14 +21,37 @@ class SeedServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->registerSeedCommand();
-
 		$this->app->singleton('seeder', function()
 		{
 			return new Seeder;
 		});
 
-		$this->commands('command.seed');
+		$this->registerCommands();
+	}
+
+	/**
+	 * Register all of the seed commands.
+	 *
+	 * @return void
+	 */
+	protected function registerCommands()
+	{
+		$commands = array('Seed', 'Make');
+
+		// We'll simply spin through the list of commands that are seed related
+		// and register each one of them with an application container. They will
+		// be resolved in the Artisan start file and registered on the console.
+		foreach ($commands as $command)
+		{
+			$this->{'register'.$command.'Command'}();
+		}
+
+		// Once the commands are registered in the application IoC container we will
+		// register them with the Artisan start event so that these are available
+		// when the Artisan application actually starts up and is getting used.
+		$this->commands(
+			'command.seed', 'command.seed.make'
+		);
 	}
 
 	/**
@@ -39,6 +64,41 @@ class SeedServiceProvider extends ServiceProvider {
 		$this->app->singleton('command.seed', function($app)
 		{
 			return new SeedCommand($app['db']);
+		});
+	}
+
+	/**
+	 * Register the "make" seed command.
+	 *
+	 * @return void
+	 */
+	protected function registerMakeCommand()
+	{
+		$this->registerCreator();
+
+		$this->app->singleton('command.seed.make', function($app)
+		{
+			// Once we have the seed creator registered, we will create the command
+			// and inject the creator. The creator is responsible for the actual file
+			// creation of the seeds, and may be extended by these developers.
+			$creator = $app['seed.creator'];
+
+			$composer = $app['composer'];
+
+			return new SeedMakeCommand($creator, $composer);
+		});
+	}
+
+	/**
+	 * Register the seed creator.
+	 *
+	 * @return void
+	 */
+	protected function registerCreator()
+	{
+		$this->app->singleton('seed.creator', function($app)
+		{
+			return new SeedCreator($app['files']);
 		});
 	}
 


### PR DESCRIPTION
This command creats a file on 'database/seeds' with the name
'{{name}}TableSeeder'. After file creation composer dump-autoload
command is executed.
