### PR TITLE
[5.0] Add type-hint to Manager constructor

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -2,13 +2,14 @@
 
 use Closure;
 use InvalidArgumentException;
+use Illuminate\Contracts\Foundation\Application;
 
 abstract class Manager {
 
 	/**
 	 * The application instance.
 	 *
-	 * @var \Illuminate\Foundation\Application
+	 * @var \Illuminate\Contracts\Foundation\Application
 	 */
 	protected $app;
 
@@ -17,22 +18,22 @@ abstract class Manager {
 	 *
 	 * @var array
 	 */
-	protected $customCreators = array();
+	protected $customCreators = [];
 
 	/**
 	 * The array of created "drivers".
 	 *
 	 * @var array
 	 */
-	protected $drivers = array();
+	protected $drivers = [];
 
 	/**
 	 * Create a new manager instance.
 	 *
-	 * @param  \Illuminate\Foundation\Application  $app
+	 * @param  \Illuminate\Contracts\Foundation\Application  $app
 	 * @return void
 	 */
-	public function __construct($app)
+	public function __construct(Application $app)
 	{
 		$this->app = $app;
 	}


### PR DESCRIPTION
Added `Application` type-hint to `Manager` constructor, so extending classes can be resolved by the service container.
