### PR TITLE
[5.0] Allow empty namespace in RouteServiceProvider

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -76,12 +76,19 @@ class RouteServiceProvider extends ServiceProvider {
 	 */
 	protected function loadRoutesFrom($path)
 	{
-		$router = $this->app['Illuminate\Routing\Router'];
-
-		$router->group(['namespace' => $this->namespace], function($router) use ($path)
+		if (empty($this->namespace))
 		{
 			require $path;
-		});
+		}
+		else
+		{
+			$router = $this->app['Illuminate\Routing\Router'];
+
+			$router->group(['namespace' => $this->namespace], function($router) use ($path)
+			{
+				require $path;
+			});
+		}
 	}
 
 	/**


### PR DESCRIPTION
Don't enclose routes file in a namespace group if it's empty. This allows to use fully qualified namespaces for the controllers in the routes file without the issues described in #7055
