### PR TITLE
[5.0] Fix Multi-Row Insert For SQLite

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -56,7 +56,7 @@ class SQLiteGrammar extends Grammar {
 
 		$columns = array_fill(0, count($values), implode(', ', $columns));
 
-		return "insert into $table ($names) select ".implode(' union select ', $columns);
+		return "insert into $table ($names) select ".implode(' union all select ', $columns);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -242,6 +242,32 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('First Post', $photos[3]->imageable->name);
 	}
 
+
+	public function testMultiInsertsWithDifferentValues()
+	{
+		$date = '1970-01-01';
+		$result = EloquentTestPost::insert([
+			['user_id' => 1, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date],
+			['user_id' => 2, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date],
+		]);
+
+		$this->assertTrue($result);
+		$this->assertEquals(2, EloquentTestPost::count());
+	}
+
+
+	public function testMultiInsertsWithSameValues()
+	{
+		$date = '1970-01-01';
+		$result = EloquentTestPost::insert([
+			['user_id' => 1, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date],
+			['user_id' => 1, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date],
+		]);
+
+		$this->assertTrue($result);
+		$this->assertEquals(2, EloquentTestPost::count());
+	}
+
 	/**
 	 * Helpers...
 	 */

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -837,7 +837,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testSQLiteMultipleInserts()
 	{
 		$builder = $this->getSQLiteBuilder();
-		$builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email", "name") select ? as "email", ? as "name" union select ? as "email", ? as "name"', array('foo', 'taylor', 'bar', 'dayle'))->andReturn(true);
+		$builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email", "name") select ? as "email", ? as "name" union all select ? as "email", ? as "name"', array('foo', 'taylor', 'bar', 'dayle'))->andReturn(true);
 		$result = $builder->from('users')->insert(array(array('email' => 'foo', 'name' => 'taylor'), array('email' => 'bar', 'name' => 'dayle')));
 		$this->assertTrue($result);
 	}


### PR DESCRIPTION
Multi-row insert does not work with same data.
Use `UNION ALL` instead `UNION`.

``` php
// DB connection
'sqlite' => [
    'driver'   => 'sqlite',
    'database' => ':memory:',
    'prefix'   => '',
];

class Post extends \Eloquent {}

// 3 insertion
Post::insert([
    ['test' => 1],
    ['test' => 1],
    ['test' => 1]
]);

// Result
Post::all()->count(); // => 1
```

``` bash
$ sqlite3
```

``` sql
create table test (column integer);

-- different data, 3 records inserted
insert into "test" ("column") select 1 as "column" union all select 2 as "column" union all select 3 as "column";


-- same data with `UNION ALL`, 3 records inserted
insert into "test" ("column") select 4 as "column" union all select 4 as "column" union all select 4 as "column";

-- same data with `UNION`, only one record inserted
insert into "test" ("column") select 5 as "column" union select 5 as "column" union select 5 as "column";

-- result
select * from test;
1
2
3
4
4
4
5
```
