### PR TITLE
[5.0] Fix incorrect parameter order for Paginator object

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1413,7 +1413,7 @@ class Builder {
 
 		$this->skip(($page - 1) * $perPage)->take($perPage + 1);
 
-		return new Paginator($this->get($columns), $page, $perPage, [
+		return new Paginator($this->get($columns), $perPage, $page, [
 			'path' => Paginator::resolveCurrentPath()
 		]);
 	}


### PR DESCRIPTION
Paginator constructor parameters ($page and $currentPage) were interchanged, so I reordered them.
