### PR TITLE
[5.0] Correct PHPDoc type hint for Facade class

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -9,7 +9,7 @@ abstract class Facade {
 	/**
 	 * The application instance being facaded.
 	 *
-	 * @var \Illuminate\Foundation\Application
+	 * @var \Illuminate\Contracts\Foundation\Application
 	 */
 	protected static $app;
 
@@ -172,7 +172,7 @@ abstract class Facade {
 	/**
 	 * Get the application instance behind the facade.
 	 *
-	 * @return \Illuminate\Foundation\Application
+	 * @return \Illuminate\Contracts\Foundation\Application
 	 */
 	public static function getFacadeApplication()
 	{
@@ -182,7 +182,7 @@ abstract class Facade {
 	/**
 	 * Set the application instance.
 	 *
-	 * @param  \Illuminate\Foundation\Application  $app
+	 * @param  \Illuminate\Contracts\Foundation\Application  $app
 	 * @return void
 	 */
 	public static function setFacadeApplication($app)


### PR DESCRIPTION
When creating custom applications with several illuminate packages (without Foundation), IDE marks setFacadeApplication() call as error.

Replace for #7342
