### PR TITLE
[5.0] Fail with an error if key:generate fails.

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -36,16 +36,31 @@ class KeyGenerateCommand extends Command {
 
 		$path = base_path('.env');
 
+		if ( ! file_exists($path))
+		{
+			copy(base_path('.env.example'), $path);
+		}
+
+		$success = false;
+
 		if (file_exists($path))
 		{
-			file_put_contents($path, str_replace(
+			$success = file_put_contents($path, str_replace(
 				$this->laravel['config']['app.key'], $key, file_get_contents($path)
 			));
 		}
 
 		$this->laravel['config']['app.key'] = $key;
 
-		$this->info("Application key [$key] set successfully.");
+		if ($success)
+		{
+			$this->info("Application key [$key] set successfully.");
+		}
+		else
+		{
+			$this->error("Application key was not set. Try creating a .env file.");
+		}
+
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -38,29 +38,17 @@ class KeyGenerateCommand extends Command {
 
 		if ( ! file_exists($path))
 		{
-			copy(base_path('.env.example'), $path);
+			$this->error("A .env file needs to be created first.");
+			exit(1);
 		}
 
-		$success = false;
-
-		if (file_exists($path))
-		{
-			$success = file_put_contents($path, str_replace(
-				$this->laravel['config']['app.key'], $key, file_get_contents($path)
-			));
-		}
+		file_put_contents($path, str_replace(
+			$this->laravel['config']['app.key'], $key, file_get_contents($path)
+		));
 
 		$this->laravel['config']['app.key'] = $key;
 
-		if ($success)
-		{
-			$this->info("Application key [$key] set successfully.");
-		}
-		else
-		{
-			$this->error("Application key was not set. Try creating a .env file.");
-		}
-
+		$this->info("Application key [$key] set successfully.");
 	}
 
 	/**


### PR DESCRIPTION
First, attempt to copy .env.example to avoid failing.

Fix for issue #7356.
