### PR TITLE
[5.0] Specify custom error messages with controller validation

### DIFF
--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -12,11 +12,12 @@ trait ValidatesRequests {
 	 *
 	 * @param  \Illuminate\Http\Request  $request
 	 * @param  array  $rules
+	 * @param  array  $messages
 	 * @return void
 	 */
-	public function validate(Request $request, array $rules)
+	public function validate(Request $request, array $rules, array $messages = [])
 	{
-		$validator = $this->getValidationFactory()->make($request->all(), $rules);
+		$validator = $this->getValidationFactory()->make($request->all(), $rules, $messages);
 
 		if ($validator->fails())
 		{


### PR DESCRIPTION
When using controller validation, I would like to specific generic custom messages for the errors however when I took a look at the trait, the parameter is left out.

``` php
        $this->validate($request, [
            'user' => 'required',
            'password' => 'required'
        ], [
            'required' => 'Required',
        ]);
```

Does not work as expected. 
