### PR TITLE
[5.0] Add closure helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -126,6 +126,30 @@ if ( ! function_exists('bcrypt'))
 	}
 }
 
+if ( ! function_exists('closure'))
+{
+	/**
+	 * Create a closure from the given callback.
+	 *
+	 * @param  callable|string  $callback
+	 * @return \Closure
+	 */
+	function closure($callback)
+	{
+		return function() use ($callback)
+		{
+			if (is_string($callback) && str_contains($callback, '@'))
+			{
+				$fragments = explode('@', $callback);
+
+				$callback = [app($fragments[0]), $fragments[1]];
+			}
+
+			return call_user_func_array($callback, func_get_args());
+		};
+	}
+}
+
 if ( ! function_exists('config'))
 {
 	/**

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -1,0 +1,35 @@
+<?php
+
+class FoundationHelpersTest extends PHPUnit_Framework_TestCase {
+
+	public function testClosure()
+	{
+		$closure1 = (new FoundationTestClosure)->foo();
+		$closure2 = closure('FoundationTestClosure@bar');
+		$closure3 = closure(['FoundationTestClosure', 'baz']);
+		$closure4 = closure('strtoupper');
+
+		$this->assertInstanceOf('\Closure', $closure1);
+		$this->assertInstanceOf('\Closure', $closure2);
+		$this->assertInstanceOf('\Closure', $closure3);
+		$this->assertInstanceOf('\Closure', $closure4);
+		$this->assertEquals(['baz', []], $closure1());
+		$this->assertEquals(['bar', []], $closure2());
+		$this->assertEquals(['baz', []], $closure3());
+		$this->assertEquals(['baz', [1, 2]], $closure1(1, 2));
+		$this->assertEquals(['bar', [1, 2]], $closure2(1, 2));
+		$this->assertEquals(['baz', [1, 2]], $closure3(1, 2));
+		$this->assertEquals('FOO', $closure4('foo'));
+	}
+
+}
+
+class FoundationTestClosure {
+
+	public function foo(){ return closure([$this, 'baz']); }
+
+	public function bar(){ return ['bar', func_get_args()]; }
+
+	public static function baz(){ return ['baz', func_get_args()]; }
+
+}


### PR DESCRIPTION
A lot, and I do mean _a lot_, of methods in core only accept an actual closure, either by type hinting it or doing `instanceof` in a conditional (sometimes because it also accepts a plain string).

Here's a quick sample of a couple of places:
- [View\Factory@addViewEvent](https://github.com/laravel/framework/blob/5.0/src/Illuminate/View/Factory.php#L409)
- Query Builder's [`selectSub`](https://github.com/laravel/framework/blob/5.0/src/Illuminate/Database/Query/Builder.php#L246), [`join`](https://github.com/laravel/framework/blob/5.0/src/Illuminate/Database/Query/Builder.php#L327), [`where`](https://github.com/laravel/framework/blob/5.0/src/Illuminate/Database/Query/Builder.php#L462), and more...
- Collection's [`keyBy`](https://github.com/laravel/framework/blob/5.0/src/Illuminate/Support/Collection.php#L284), [`reject`](https://github.com/laravel/framework/blob/5.0/src/Illuminate/Support/Collection.php#L500) and more...
- and in too many other places to list here...

---

Many times you might want to use a method in the class you're currently in, or a method from a different class altogether.

This helper would be immensely useful in a lot of places.

Contrast this:

``` php
public function foo()
{
    ...

    return $collection->keyBy(function($item)
    {
        return $this->complexKeyBy($item);
    });
}
```

vs. this:

``` php
public function foo()
{
    ...

    return $collection->keyBy(closure([$this, 'complexKeyBy']));
}
```

or contrast this:

``` php
$collection->map(function($item)
{
    return strtoupper($item);
});
```

vs. this:

``` php
$collection->map(closure('strtoupper'));
```

These are trivial examples, but I've been running into this way too many times, and in more complex situations.
