### PR TITLE
Add sub-directories to config keys

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ao/framework",
+    "name": "laravel/framework",
     "description": "The Laravel Framework.",
     "keywords": ["framework", "laravel"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel/framework",
+    "name": "ao/framework",
     "description": "The Laravel Framework.",
     "keywords": ["framework", "laravel"],
     "license": "MIT",
@@ -7,6 +7,10 @@
         {
             "name": "Taylor Otwell",
             "email": "taylorotwell@gmail.com"
+        },
+        {
+            "name": "Tom de Goede",
+            "email": "tom@allesonline.eu"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,6 @@
         {
             "name": "Taylor Otwell",
             "email": "taylorotwell@gmail.com"
-        },
-        {
-            "name": "Tom de Goede",
-            "email": "tom@allesonline.eu"
         }
     ],
     "require": {

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -69,7 +69,8 @@ class LoadConfiguration {
 
 		foreach (Finder::create()->files()->name('*.php')->in($app->configPath()) as $file)
 		{
-			$files[basename($file->getRealPath(), '.php')] = $file->getRealPath();
+			$key = str_replace('\\','/',substr($file->getRealPath(), strlen($app->configPath()) + 1, -4));
+			$files[/*basename($file->getRealPath(), '.php')*/$key] = $file->getRealPath();
 		}
 
 		return $files;

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Support;
 
 use BadMethodCallException;
+use Symfony\Component\Finder\Finder;
 
 abstract class ServiceProvider {
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -59,6 +59,23 @@ abstract class ServiceProvider {
 	 */
 	protected function mergeConfigFrom($path, $key)
 	{
+		if(is_dir($path))
+			$this->mergeConfigFromDir($path,$key);
+		else
+			$this->mergeConfigFromFile($path,$key);
+	}
+
+	protected function mergeConfigFromDir($path, $key)
+	{
+		foreach (Finder::create()->files()->name('*.php')->in(realpath($path)) as $file)
+		{
+			$subKey = str_replace('\\','/',substr($file->getRealPath(), strlen(realpath($path)) + 1, -4));
+			$this->mergeConfigFromFile($file->getRealPath(), $key.'/'.$subKey);
+		}
+	}
+
+	protected function mergeConfigFromFile($path, $key)
+	{
 		$config = $this->app['config']->get($key, []);
 
 		$this->app['config']->set($key, array_merge(require $path, $config));


### PR DESCRIPTION
Previously config files placed inside a sub directory of config were keyed only by the file name. So config/subdir/file.php is accessible trough Config::get('file.*')). With these edits it puts the sub directory in the key making it easier to group lots of config files and avoid overwriting config files with the same name. So config/subdir/file.php is accessible trough Config::get('subdir/file.*')).
