### PR TITLE
enhance the Database/Builder aggregate function to deal with group by sql.

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1693,6 +1693,13 @@ class Builder {
 
 		$this->columns = $previousColumns;
 
+		// Once we have used orderBy function,$result may have more than one record,
+		//and $results[0] is just the first group count,so we need to get the count 
+		//of $results's  elements.
+		if (count($results) > 1) {
+			return count($results);
+		}
+		
 		if (isset($results[0]))
 		{
 			$result = array_change_key_case((array) $results[0]);


### PR DESCRIPTION
I enhance the Database/Builder class.
Once we have used orderBy function,$result may have more than one record,and $results[0] is just the first group count,so we need to get the count of $results's  elements.
