### PR TITLE
Update VerifyCsrfToken.php

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -59,7 +59,7 @@ class VerifyCsrfToken implements Middleware {
 		$header = $request->header('X-XSRF-TOKEN');
 
 		return StringUtils::equals($token, $request->input('_token')) ||
-		       ($header && StringUtils::equals($token, $this->encrypter->decrypt($header)));
+		       ($header && StringUtils::equals($token, $header));
 	}
 
 	/**


### PR DESCRIPTION
Never sure :) but after I delete $this->encrypter->decrypt part from tokensMatch my global csrf middleware works fine..
is it ok??
(I am using 5.0.2)
