### PR TITLE
[5.0] Added base_url to allow connections to S3 compatible clouds

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -134,7 +134,7 @@ class FilesystemManager implements FactoryContract {
 	 */
 	public function createS3Driver(array $config)
 	{
-		$s3Config = array_only($config, ['key', 'region', 'secret', 'signature']);
+		$s3Config = array_only($config, ['key', 'region', 'secret', 'signature', 'base_url']);
 
 		return $this->adapt(
 			new Flysystem(new S3Adapter(S3Client::factory($s3Config), $config['bucket']))


### PR DESCRIPTION
This small change will allow connections to S3 compatible clouds like [Google Cloud Storage](https://cloud.google.com/storage/docs/migrating) or [Constant](https://www.constant.com/cloud/storage/).

Example `filesystems.php` config file:

``` php
<?php

return [

    'default' => env('DEFAULT_STORAGE', 'local'),

    'cloud' => env('CLOUD_STORAGE', 'gcs'),

    'disks' => [
        'local' => [
            'driver' => 'local',
            'root'   => storage_path().'/app',
        ],
        'gcs' => [
            'driver' => 's3',
            'key'    => env('GCS_KEY'),
            'secret' => env('GCS_SECRET'),
            'base_url' => 'https://storage.googleapis.com',
            'bucket' => env('GCS_BUCKET')
        ],
    ],
];
```

I've tested it with Google Cloud Storage and it works.
