### PR TITLE
[5.0] Fix app:name command by changing the order of searches/replaces

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -112,15 +112,15 @@ class AppNameCommand extends Command {
 	protected function replaceNamespace($path)
 	{
 		$search = [
+			$this->currentRoot.'\\',
 			'namespace '.$this->currentRoot.';',
 			'namespace '.$this->currentRoot.'\\',
-			$this->currentRoot.'\\',
 		];
 
 		$replace = [
+			$this->argument('name').'\\',
 			'namespace '.$this->argument('name').';',
 			'namespace '.$this->argument('name').'\\',
-			$this->argument('name').'\\',
 		];
 
 		$this->replaceIn($path, $search, $replace);


### PR DESCRIPTION
This PR fix an issue with the `app:name` command.
When you use it with a name that contains the old name, the namespaces get messed up.

Example:

```
# Fresh laravel installation
$ php artisan app:name SomeApp
Application namespace set!
$ head app/Commands/Command.php -n1
<?php namespace SomeSomeApp\Commands;
```
