### PR TITLE
[5.0] Update the Passwords Facade Constants

### DIFF
--- a/src/Illuminate/Support/Facades/Password.php
+++ b/src/Illuminate/Support/Facades/Password.php
@@ -10,35 +10,35 @@ class Password extends Facade {
 	 *
 	 * @var int
 	 */
-	const REMINDER_SENT = 'reminders.sent';
+	const REMINDER_SENT = 'passwords.sent';
 
 	/**
 	 * Constant representing a successfully reset password.
 	 *
 	 * @var int
 	 */
-	const PASSWORD_RESET = 'reminders.reset';
+	const PASSWORD_RESET = 'passwords.reset';
 
 	/**
 	 * Constant representing the user not found response.
 	 *
 	 * @var int
 	 */
-	const INVALID_USER = 'reminders.user';
+	const INVALID_USER = 'passwords.user';
 
 	/**
 	 * Constant representing an invalid password.
 	 *
 	 * @var int
 	 */
-	const INVALID_PASSWORD = 'reminders.password';
+	const INVALID_PASSWORD = 'passwords.password';
 
 	/**
 	 * Constant representing an invalid token.
 	 *
 	 * @var int
 	 */
-	const INVALID_TOKEN = 'reminders.token';
+	const INVALID_TOKEN = 'passwords.token';
 
 	/**
 	 * Get the registered name of the component.


### PR DESCRIPTION
Laravel 5 updated the constant values for PasswordBroker in framework/src/Illuminate/Contracts/Auth/PasswordBroker.php, the PasswordBroker facade was not updated however. I updated them here to be consistent.

This is my first time making a Laravel PR, let me know if there's anything I need to do.
