### PR TITLE
Get parameters from the request if none are specified

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -244,12 +244,17 @@ class UrlGenerator implements UrlGeneratorContract {
 	 */
 	public function route($name, $parameters = array(), $absolute = true)
 	{
-		if ( ! is_null($route = $this->routes->getByName($name)))
-		{
-			return $this->toRoute($route, $parameters, $absolute);
-		}
-
-		throw new InvalidArgumentException("Route [{$name}] not defined.");
+	    if ( ! is_null($route = $this->routes->getByName($name)))
+	    {
+	        if (count($parameters)) {
+	            return $this->toRoute($route, $parameters, $absolute);
+	        } else {
+	            //If no parameters are specified grab them from the current request...
+	            $parameters = $route->bind($this->getRequest())->parameters();
+	            return $this->toRoute($route, $parameters, $absolute);
+	        }
+	    }
+	    throw new InvalidArgumentException("Route [{$name}] not defined.");
 	}
 
 	/**


### PR DESCRIPTION
When using route('name') with no explicit parameters specified maybe we could grab them from the request... Issue #7366
