### PR TITLE
[5.1] Fix domain wildcard group in routes and url generation

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -244,15 +244,16 @@ class UrlGenerator implements UrlGeneratorContract {
 	 */
 	public function route($name, $parameters = array(), $absolute = true)
 	{
-		if ( ! is_null($route = $this->routes->getByName($name)))
+		if (is_null($route = $this->routes->getByName($name)))
 		{
-			if (count($parameters) >= 1) {
-					return $this->toRoute($route, $parameters, $absolute);
-			}
-
-			return $this->toRoute($route, $route->bind($this->getRequest())->parameters(), $absolute);
+		    throw new InvalidArgumentException("Route [{$name}] not defined.");
 		}
-		throw new InvalidArgumentException("Route [{$name}] not defined.");
+		
+		if (count($parameters) > 0) {
+		    return $this->toRoute($route, $parameters, $absolute);
+		}
+		
+		return $this->toRoute($route, $route->bind($this->getRequest())->parameters(), $absolute);
 	}
 
 	/**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -246,9 +246,13 @@ class UrlGenerator implements UrlGeneratorContract {
 	{
 		if ( ! is_null($route = $this->routes->getByName($name)))
 		{
-			return $this->toRoute($route, $parameters, $absolute);
+			if (count($parameters)) {
+				return $this->toRoute($route, $parameters, $absolute);
+			} else {
+				$parameters = $route->bind($this->getRequest())->parameters();
+				return $this->toRoute($route, $parameters, $absolute);
+			}
 		}
-
 		throw new InvalidArgumentException("Route [{$name}] not defined.");
 	}
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -246,12 +246,11 @@ class UrlGenerator implements UrlGeneratorContract {
 	{
 		if ( ! is_null($route = $this->routes->getByName($name)))
 		{
-			if (count($parameters)) {
-				return $this->toRoute($route, $parameters, $absolute);
-			} else {
-				$parameters = $route->bind($this->getRequest())->parameters();
-				return $this->toRoute($route, $parameters, $absolute);
+			if (count($parameters) >= 1) {
+					return $this->toRoute($route, $parameters, $absolute);
 			}
+
+			return $this->toRoute($route, $route->bind($this->getRequest())->parameters(), $absolute);
 		}
 		throw new InvalidArgumentException("Route [{$name}] not defined.");
 	}

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -248,6 +248,20 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://sub.taylor.com:8080/foo/bar/otwell', $url->route('bar', array('taylor', 'otwell')));
 	}
 
+	public function testRoutesWithDomainWildcard()
+	{
+		$url = new UrlGenerator(
+			$routes = new Illuminate\Routing\RouteCollection,
+			$request = Illuminate\Http\Request::create('http://sub.foo.com')
+		);
+
+		$route = new Illuminate\Routing\Route(array('GET'), '/', array('as' => 'bar', 'domain' => '{subdomain}.foo.com'));
+		$routes->add($route);
+
+		//Parameters filled by current request
+		$this->assertEquals('http://sub.foo.com', $url->route('bar'));
+	}
+
 
 	public function testHttpsRoutesWithDomains()
 	{


### PR DESCRIPTION
Allow the UrlGenerator `route(...)` function to get its parameters from the current request as suggested in issue #7366. With this you can either explicitly set the parameters or get them from the request.

Example:

```
Route::group(
    [
        'domain' => '{subdomain}.domain.com',
    ],
    function ($router) {
        Route::get(
            '/',
            [
                'uses' => function ($subdomain) use ($router) {
                    $route = $router->getCurrentRoute();
                    $action = $route->getAction();
                    $action['domain'] = $subdomain . '.domain.com';
                    $route->setAction($action);

                    return route('subhome');
                },
                'as' => 'subhome'
            ]
        );
    }
);
```

You can use `route('subhome')` with no other options and have it generate a correct URL.

Just a suggestion :)
