### PR TITLE
Fix ArrayAccess bug on Request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -744,7 +744,8 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function offsetGet($offset)
 	{
-		return $this->input($offset);
+		$all = $this->all();
+		return $all[$offset];
 	}
 
 	/**


### PR DESCRIPTION
Because the offsetExists method uses all parameters you can  see that a file exists, but when you try to get it, you get a null value.

I am using Controller->dispatchFrom("App\Commands\" . ucfirst($this->resource->getName()) . '\CreateCommand', $request); so that the current Request is sent to the Command Bus to be mapped on the command. The Command::__construct(..., $file); which arrives null because of this bug.
