### PR TITLE
Catch missing directories during "artisan optimize"

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -133,24 +133,31 @@ class OptimizeCommand extends Command {
 	 */
 	protected function compileViews()
 	{
-		foreach ($this->laravel['view']->getFinder()->getPaths() as $path)
+		try
 		{
-			foreach ($this->laravel['files']->allFiles($path) as $file)
+			foreach ($this->laravel['view']->getFinder()->getPaths() as $path)
 			{
-				try
+				foreach ($this->laravel['files']->allFiles($path) as $file)
 				{
-					$engine = $this->laravel['view']->getEngineFromPath($file);
-				}
-				catch (InvalidArgumentException $e)
-				{
-					continue;
-				}
+					try
+					{
+						$engine = $this->laravel['view']->getEngineFromPath($file);
+					}
+					catch (InvalidArgumentException $e)
+					{
+						continue;
+					}
 
-				if ($engine instanceof CompilerEngine)
-				{
-					$engine->getCompiler()->compile($file);
+					if ($engine instanceof CompilerEngine)
+					{
+						$engine->getCompiler()->compile($file);
+					}
 				}
 			}
+		}
+		catch (InvalidArgumentException $e)
+		{
+			//	Ignore missing directory error (The "" directory does not exist)
 		}
 	}
 


### PR DESCRIPTION
Because my package has no resources, I removed the `resources` folder. This led to `artisan optimize` failing with this cryptic error: 

```
exception 'InvalidArgumentException' with message 'The "" directory does not exist.' in /path/to/my/project/vendor/symfony/finder/Symfony/Component/Finder/Finder.php:677
```

After tracing the issue I discovered the root cause. It only occurs when compiling views, of which, I had none. Sadly, `artisan` felt I _should_ have views and decided to puke. 

To correct this, I placed a `try`/`catch` around the entire view compilation loop. This handler is exactly the same as the one inside the loop. A directory check is probably more thorough and to the point, but I opted for less change.
