### PR TITLE
allow configuring of url type for Rackspace Cloud Files

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -167,7 +167,9 @@ class FilesystemManager implements FactoryContract {
 	 */
 	protected function getRackspaceContainer(Rackspace $client, array $config)
 	{
-		$store = $client->objectStoreService('cloudFiles', $config['region']);
+		$urlType = array_key_exists('url_type', $config) ? $config['url_type'] : null;
+			
+		$store = $client->objectStoreService('cloudFiles', $config['region'], $urlType);
 
 		return $store->getContainer($config['container']);
 	}


### PR DESCRIPTION
Cloud files have an option that lets the user specify whether to use a public network or an internal network. If you have a server in the same region as your container, you can use the internal network, which is free and is faster,

It looks like the underlying League filesystem objects support setting the url type, so it's just a simple matter of passing the config value through if it's set.
