### PR TITLE
Fix "different" validator to accept input given in dot notation.

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -725,9 +725,9 @@ class Validator implements MessageProviderInterface {
 	{
 		$this->requireParameterCount(1, $parameters, 'different');
 
-		$other = $parameters[0];
+		$other = array_get($this->data, $parameters[0]);
 
-		return isset($this->data[$other]) && $value != $this->data[$other];
+		return (isset($other) && $value != $other);
 	}
 
 	/**


### PR DESCRIPTION
Right now, this validator always fails input that's given as dot notation.

I have altered it to be much more similar to the (correctly-behaving) "same" validator; it now matches the "same" validator exactly, except that it tests for inequality instead of equality. Using `array_get` fixes the issue with dot notation and the remainder of the change just brings the style in-line with the other validator.
