### PR TITLE
Fixed compilation error while parsing contentTags with tailing ;

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -291,7 +291,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	protected function compileRegularEchos($value)
 	{
-		$pattern = sprintf('/(@)?%s\s*(.+?)\s*%s(\r?\n)?/s', $this->contentTags[0], $this->contentTags[1]);
+		$pattern = sprintf('/(@)?%s\s*(.+?)[\s;]*%s(\r?\n)?/s', $this->contentTags[0], $this->contentTags[1]);
 
 		$callback = function($matches)
 		{

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -134,6 +134,18 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('<?php echo e(myfunc(\'foo or bar\')); ?>', $compiler->compileString('{{ myfunc(\'foo or bar\') }}'));
 		$this->assertEquals('<?php echo e(myfunc("foo or bar")); ?>', $compiler->compileString('{{ myfunc("foo or bar") }}'));
 		$this->assertEquals('<?php echo e(myfunc("$name or \'foo\'")); ?>', $compiler->compileString('{{ myfunc("$name or \'foo\'") }}'));
+
+		$this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{$name;}}'));
+		$this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{ $name; }}'));
+		$this->assertEquals('<?php echo e("$name"); ?>', $compiler->compileString('{{"$name" ;}}'));
+		$this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{$name ;; }}'));
+		$this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{
+			$name ;;
+		}}'));
+		$this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{
+			$name
+		;}}'));
+
 	}
 
 


### PR DESCRIPTION
If you have statement like this in blade file:

```
    {{ $abc; }}
```

it will create parse error when blade compiles the view file:
<?php echo e($abc;); ?>

I have changed the regex so it neglects the tailing ';'
