### PR TITLE
[5.0] Return a response object for routeMiddleware

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -659,6 +659,8 @@ class Router implements RegistrarContract {
 			);
 		}
 
+		$response = $this->prepareResponse($request, $response);
+
 		// After we have a prepared response from the route or filter we will call to
 		// the "after" filters to do any last minute processing on this request or
 		// response object before the response is returned back to the consumer.

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -247,8 +247,7 @@ class Router implements RegistrarContract {
 			$prepended = $this->prependGroupUses($controller);
 		}
 
-		$routable = (new ControllerInspector)
-							->getRoutable($prepended, $uri);
+		$routable = (new ControllerInspector)->getRoutable($prepended, $uri);
 
 		// When a controller is routed using this method, we use Reflection to parse
 		// out all of the routable methods for the controller, then register each

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -247,7 +247,8 @@ class Router implements RegistrarContract {
 			$prepended = $this->prependGroupUses($controller);
 		}
 
-		$routable = (new ControllerInspector)->getRoutable($prepended, $uri);
+		$routable = (new ControllerInspector)
+		                    ->getRoutable($prepended, $uri);
 
 		// When a controller is routed using this method, we use Reflection to parse
 		// out all of the routable methods for the controller, then register each
@@ -681,9 +682,9 @@ class Router implements RegistrarContract {
 		$middleware = $this->gatherRouteMiddlewares($route);
 
 		return (new Pipeline($this->container))
-						->send($request)
-						->through($middleware)
-						->then(function($request) use ($route)
+		                ->send($request)
+		                ->through($middleware)
+		                ->then(function($request) use ($route)
 						{
 							return $this->prepareResponse(
 								$request,

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -248,7 +248,7 @@ class Router implements RegistrarContract {
 		}
 
 		$routable = (new ControllerInspector)
-		                    ->getRoutable($prepended, $uri);
+							->getRoutable($prepended, $uri);
 
 		// When a controller is routed using this method, we use Reflection to parse
 		// out all of the routable methods for the controller, then register each
@@ -660,8 +660,6 @@ class Router implements RegistrarContract {
 			);
 		}
 
-		$response = $this->prepareResponse($request, $response);
-
 		// After we have a prepared response from the route or filter we will call to
 		// the "after" filters to do any last minute processing on this request or
 		// response object before the response is returned back to the consumer.
@@ -682,11 +680,14 @@ class Router implements RegistrarContract {
 		$middleware = $this->gatherRouteMiddlewares($route);
 
 		return (new Pipeline($this->container))
-		                ->send($request)
-		                ->through($middleware)
-		                ->then(function($request) use ($route)
+						->send($request)
+						->through($middleware)
+						->then(function($request) use ($route)
 						{
-							return $route->run($request);
+							return $this->prepareResponse(
+								$request,
+								$route->run($request)
+							);
 						});
 	}
 


### PR DESCRIPTION
While I was trying to get the VerifyCsrfToken middleware to work optionally using `$routeMiddleware`, I noticed that middleware declared in `$routeMiddleware` instead of `$middleware` does not get a response object when `$next($response)` is called (at least not every time), instead it gets whatever the controller or route handler returned (a View object in most cases).

The proposed change below makes sure the response is prepared before it goes back through the route middleware pipeline

Also, some spaces to tabs conversion
