### PR TITLE
Add exception throwing, when controller action not found

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -518,6 +518,8 @@ class UrlGenerator implements UrlGeneratorContract {
 	 * @param  mixed   $parameters
 	 * @param  bool    $absolute
 	 * @return string
+	 * 
+	 * @throws \InvalidArgumentException
 	 */
 	public function action($action, $parameters = array(), $absolute = true)
 	{
@@ -529,8 +531,13 @@ class UrlGenerator implements UrlGeneratorContract {
 		{
 			$action = trim($action, '\\');
 		}
-
-		return $this->toRoute($this->routes->getByAction($action), $parameters, $absolute);
+	
+		if ( !is_null($route = $this->routes->getByAction($action)))
+		{
+			 return $this->toRoute($route, $parameters, $absolute);
+		}
+		throw new InvalidArgumentException("Action {$action} not defined.");
+	
 	}
 
 	/**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -532,12 +532,12 @@ class UrlGenerator implements UrlGeneratorContract {
 			$action = trim($action, '\\');
 		}
 	
-		if ( !is_null($route = $this->routes->getByAction($action)))
+		if ( ! is_null($route = $this->routes->getByAction($action)))
 		{
 			 return $this->toRoute($route, $parameters, $absolute);
 		}
+		
 		throw new InvalidArgumentException("Action {$action} not defined.");
-	
 	}
 
 	/**


### PR DESCRIPTION
If undefined action passed In UrlGenerator::action(), it's throw fatal exception

`Call to a member function domain() on a non-object`

with fully uninformative debug stack

because route, which was returned by `$this->routes->getByAction($action)` is not checked, before it passes to `$this->toRoute(...` and can be `null` instead of `Route`

So, it seems logical to add some check, as in UrlGenerator::route()
