### PR TITLE
Use phpdotenv methods instead of getenv/putenv

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -16,6 +16,8 @@ class DetectEnvironment {
 	{
 		try
 		{
+			Dotenv::makeMutable();
+
 			Dotenv::load($app['path.base'], $app->environmentFile());
 		}
 		catch (InvalidArgumentException $e)

--- a/src/Illuminate/Foundation/Testing/ApplicationTrait.php
+++ b/src/Illuminate/Foundation/Testing/ApplicationTrait.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Foundation\Testing;
 
+use Dotenv;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
 
@@ -26,8 +27,8 @@ trait ApplicationTrait {
 	 */
 	protected function refreshApplication()
 	{
-		putenv('APP_ENV=testing');
-		
+		Dotenv::setEnvironmentVariable('APP_ENV', 'testing');
+
 		$this->app = $this->createApplication();
 	}
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -559,9 +559,9 @@ if ( ! function_exists('env'))
 	 */
 	function env($key, $default = null)
 	{
-		$value = getenv($key);
+		$value = Dotenv::findEnvironmentVariable($key);
 
-		if ($value === false) return value($default);
+		if ($value === null) return value($default);
 
 		switch (strtolower($value))
 		{


### PR DESCRIPTION
There is a bug with functions getenv() and putenv() if PHP is thread-safe. But phpdotenv has methods that don't only use these functions to retrieve and modify environment variables but also $_ENV and $_SERVER, which are not affected by this bug.

More details here : #7354 
