### PR TITLE
[5.0] Route Cache Improvements

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -56,10 +56,8 @@ class RouteCacheCommand extends Command {
 			return $this->error("Your application doesn't have any routes.");
 		}
 
-		foreach ($routes as $route)
-		{
-			$route->prepareForSerialization();
-		}
+
+		$routes->prepareForSerialization();
 
 		$this->files->put(
 			$this->laravel->getCachedRoutesPath(), $this->buildRouteCacheFile($routes)

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -111,6 +111,36 @@ class RouteCollection implements Countable, IteratorAggregate {
 	}
 
 	/**
+	 * Prepare the route collection instance for serialization.
+	 *
+	 * @return void
+	 */
+	public function prepareForSerialization()
+	{
+		foreach ($this->routes as $routes)
+		{
+			$this->prepareRoutesForSerialization($routes);
+		}
+
+		$this->prepareRoutesForSerialization($this->allRoutes);
+		$this->prepareRoutesForSerialization($this->nameList);
+		$this->prepareRoutesForSerialization($this->actionList);
+	}
+
+	/**
+	 * @param array $routes Array of routes
+	 *
+	 * @return void
+	 */
+	protected function prepareRoutesForSerialization($routes)
+	{
+		foreach ($routes as $route)
+		{
+			$route->prepareForSerialization();
+		}
+	}
+
+	/**
 	 * Find the first route matching a given request.
 	 *
 	 * @param  \Illuminate\Http\Request  $request

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Illuminate\Routing\Route;
+use Illuminate\Container\Container;
+use Illuminate\Routing\RouteCollection;
+
+class RouteCollectionTest extends PHPUnit_Framework_TestCase {
+
+	/** @var Illuminate\Routing\RouteCollection */
+	protected $collection;
+
+	/** @var Illuminate\Container\Container */
+	protected $container;
+
+	public function setUp()
+	{
+		$this->collection = new RouteCollection();
+		$this->container = new Container();
+		$this->container['foo'] = function () {};
+	}
+
+	public function testRouteSerializationWithDuplicatePathAndDifferingName()
+	{
+		// Create two routes with the same path and method
+		$routeA = new Route('GET', 'product', ['uses' => 'View@view', 'as' => 'routeA']);
+		$routeB = new Route('GET', 'product', ['uses' => 'View@view', 'as' => 'routeB']);
+
+		// Add Routes to the collection, add the container to the routes
+		foreach (compact('routeA', 'routeB') as $route)
+		{
+			$route->setContainer($this->container);
+			$this->collection->add($route);
+		}
+
+		// Prepare the routes for serialization
+		$this->collection->prepareForSerialization();
+
+		// Serialize the Routes
+		serialize($this->collection);
+	}
+
+	public function testRouteSerializationWithDuplicatePathAndDifferingMethod()
+	{
+		// Create two routes with the same path and method
+		$routeA = new Route('GET', 'product', ['uses' => 'View@view']);
+		$routeB = new Route('HEAD', 'product', ['uses' => 'View@view']);
+
+		// Add Routes to the collection, add the container to the routes
+		foreach (compact('routeA', 'routeB') as $route)
+		{
+			$route->setContainer($this->container);
+			$this->collection->add($route);
+		}
+
+		// Prepare the routes for serialization
+		$this->collection->prepareForSerialization();
+
+		// Serialize the Routes
+		serialize($this->collection);
+	}
+
+	public function testRouteSerializationWithDuplicatePathAndDifferingAction()
+	{
+		// Create two routes with the same path and method
+		$routeA = new Route('GET', 'product', ['controller' => 'foo']);
+		$routeB = new Route('GET', 'product', ['controller' => 'bar']);
+
+		// Add Routes to the collection, add the container to the routes
+		foreach (compact('routeA', 'routeB') as $route)
+		{
+			$route->setContainer($this->container);
+			$this->collection->add($route);
+		}
+
+		// Prepare the routes for serialization
+		$this->collection->prepareForSerialization();
+
+		// Serialize the Routes
+		serialize($this->collection);
+	}
+
+}


### PR DESCRIPTION
# My Issue

I had two routes with the same URI and method but different names. When I tried to cache the routes the command would fail with a serialization error.
# Solution

I dug into the code and figured out that when routes were prepared for serialization only one of the arrays of routes was iterated over. There were other routes in the collection in other arrays that would not be prepare for serialization. Following tell don't ask, rather than asking for all the routes in the collection and prepare the routes for serialization, I added a method to tell the collection to prepare it for serialization.
# Side Notes

I feel like this seems rather awkward so I feel I should explain why I have two routes with the same URi and method but with different names. My site is a blog and has both permalink pages as well as blog posts. Both can be access from _.tld/{slug}_. If there was no post that could match `{slug}` then the app would check for a matching page. I wanted to keep the route generation separate for the 2 objects in case I decided to change the uris later. This was the original issue, I found it also applied to action as well as header differences and included a solution that solved all three issues.
