### PR TITLE
Rename header token?

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -56,7 +56,7 @@ class VerifyCsrfToken implements Middleware {
 	{
 		$token = $request->session()->token();
 
-		$header = $request->header('X-XSRF-TOKEN');
+		$header = $request->header('X-CSRF-TOKEN');
 
 		return StringUtils::equals($token, $request->input('_token')) ||
 		       ($header && StringUtils::equals($token, $this->encrypter->decrypt($header)));
@@ -72,7 +72,7 @@ class VerifyCsrfToken implements Middleware {
 	protected function addCookieToResponse($request, $response)
 	{
 		$response->headers->setCookie(
-			new Cookie('XSRF-TOKEN', $request->session()->token(), time() + 60 * 120, '/', null, false, false)
+			new Cookie('CSRF-TOKEN', $request->session()->token(), time() + 60 * 120, '/', null, false, false)
 		);
 
 		return $response;


### PR DESCRIPTION
`XSRF` is less well known than the convention `CSRF` - so I'm not sure if this was intentional or just a typo?

The filename is VerifyCsrfToken - so it makes sense that the header name itself should follow the same convention and also be called `CSRF`?

The only thing is this PR might be a breaking change - since some people might be already using the `xsrf` headers in there app?

Happy either way...
