### PR TITLE
[5.0] [Bug] Remove incorrect decrypt of header during CSRF check

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -59,7 +59,7 @@ class VerifyCsrfToken implements Middleware {
 		$header = $request->header('X-XSRF-TOKEN');
 
 		return StringUtils::equals($token, $request->input('_token')) ||
-		       ($header && StringUtils::equals($token, $this->encrypter->decrypt($header)));
+		       ($header && StringUtils::equals($token, $header));
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -3,29 +3,10 @@
 use Closure;
 use Illuminate\Contracts\Routing\Middleware;
 use Symfony\Component\HttpFoundation\Cookie;
-use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Session\TokenMismatchException;
 use Symfony\Component\Security\Core\Util\StringUtils;
 
 class VerifyCsrfToken implements Middleware {
-
-	/**
-	 * The encrypter implementation.
-	 *
-	 * @var \Illuminate\Contracts\Encryption\Encrypter
-	 */
-	protected $encrypter;
-
-	/**
-	 * Create a new middleware instance.
-	 *
-	 * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
-	 * @return void
-	 */
-	public function __construct(Encrypter $encrypter)
-	{
-		$this->encrypter = $encrypter;
-	}
 
 	/**
 	 * Handle an incoming request.


### PR DESCRIPTION
So I'm using the default CSRF middleware - using a `X-XSRF-TOKEN` in my ajax call.

I kept getting `DecryptException in Encrypter.php line 142: Invalid data.` errors when I tried to use it.

Looking at the code - `$header = $request->header('X-XSRF-TOKEN');` - the request header containing `X-XSRF-TOKEN` is just a raw string containing the CSRF token - there is nothing to decrypt?

So with this PR I was able to get everything working correctly with `X-XSRF-TOKEN` headers.
