### PR TITLE
Allow config to be stored in subdirs

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Config\Repository;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Config\Repository as RepositoryContract;
 
@@ -69,10 +70,26 @@ class LoadConfiguration {
 
 		foreach (Finder::create()->files()->name('*.php')->in($app->configPath()) as $file)
 		{
-			$files[basename($file->getRealPath(), '.php')] = $file->getRealPath();
+			$files[$this->getConfigurationSubtree($file).basename($file->getRealPath(), '.php')] = $file->getRealPath();
 		}
 
 		return $files;
+	}
+
+	/**
+	 * Get the configuration file subtree.
+	 *
+	 * @param  \Symfony\Component\Finder\SplFileInfo $file
+	 * @return string
+	 */
+	private function getConfigurationSubtree(SplFileInfo $file)
+	{
+		if ($tree = ltrim(dirname($file->getRealPath()), config_path()))
+		{
+			$tree = str_replace(DIRECTORY_SEPARATOR, '.', $tree) . '.';
+		}
+
+		return $tree;
 	}
 
 }


### PR DESCRIPTION
Is not currently possible to store configuration in subdirs, so if we do 

```
$this->publishes([
    __DIR__.'/path/to/config/courier.php' => config_path('vendorname/courier/rules.php'),
]);
```

We will have to access configuration for the package doing:

```
$rulesAreEnabled = $this->app['config']->get('rules.enabled');
```

And NOT as it should be:

```
$rulesAreEnabled = $this->app['config']->get('vendorname.courier.rules.enabled');
```

This PR fix this.
