### PR TITLE
Create new session when user authenticates via remember me cookie

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -156,8 +156,13 @@ class Guard implements GuardContract {
 		if (is_null($user) && ! is_null($recaller))
 		{
 			$user = $this->getUserByRecaller($recaller);
+			
+			if ($user)
+			{
+				$this->updateSession($user->getAuthIdentifier());
 
-			if ($user) $this->fireLoginEvent($user, true);
+				$this->fireLoginEvent($user, true);
+			}
 		}
 
 		return $this->user = $user;

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -257,6 +257,9 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 		$guard->getSession()->shouldReceive('get')->once()->with($guard->getName())->andReturn(null);
 		$user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
 		$guard->getProvider()->shouldReceive('retrieveByToken')->once()->with('id', 'recaller')->andReturn($user);
+		$user->shouldReceive('getAuthIdentifier')->once()->andReturn('bar');
+		$guard->getSession()->shouldReceive('set')->with($guard->getName(), 'bar')->once();
+		$session->shouldReceive('migrate')->once();
 		$this->assertEquals($user, $guard->user());
 		$this->assertTrue($guard->viaRemember());
 	}


### PR DESCRIPTION
After my PR #5900 Taylor added auth.login event on commit 03dcc0daa4742337497b7620bbc80eb9da93cb4f  and that works great!

Problem is that auth.login event fires on **every** next page load/request after user is logged in via remember me cookie.

In this PR, session is also updated and on next request, user is retrieved through session and auth.login event doesn't get fired on every next request.
