### PR TITLE
Better results for merging config

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -61,7 +61,7 @@ abstract class ServiceProvider {
 	{
 		$config = $this->app['config']->get($key, []);
 
-		$this->app['config']->set($key, array_merge(require $path, $config));
+		$this->app['config']->set($key, recursive_merge(require $path, $config));
 	}
 
 	/**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -308,6 +308,32 @@ if ( ! function_exists('array_where'))
 	}
 }
 
+if ( ! function_exists('recursive_merge'))
+{
+	/**
+	 * Array merge recursive
+	 * 
+	 * @param array $arr1
+	 * @param array $arr2
+	 * @return array
+	 */
+	function recursive_merge($arr1, $arr2)
+	{
+		if ( ! is_array($arr1) || ! is_array($arr2)) return $arr2;
+	
+		foreach ($arr2 as $key => $val2)
+		{
+		
+			$val1 = isset($arr1[$key]) ? $arr1[$key] : [];
+			
+			$arr1[$key] = recursive_merge($val1, $val2);
+		
+		}
+		
+		return $arr1;
+	}
+}
+
 if ( ! function_exists('camel_case'))
 {
 	/**


### PR DESCRIPTION
The ServiceProvider::mergeConfigFrom() method uses array_merge which doesn't have desirable results, this PR attempts to improve this feature for a future release and encourage discussion.

please see this pure php example: https://gist.github.com/ryaan-anthony/3dacdf3a722217eb66f0
