### PR TITLE
[5.1] Mysql table and columns can have separate charset and collations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -36,6 +36,16 @@ class Blueprint {
 	public $engine;
 
 	/**
+	 * The default character set that should be used for the table
+	 */
+	public $charset;
+
+	/**
+	 * The collation that should be used for the table;
+	 */
+	public $collation;
+
+	/**
 	 * Create a new schema blueprint.
 	 *
 	 * @param  string  $table


### PR DESCRIPTION
Currently the default character set for a table is what is configured in `config/database.php`. There is no flexibility in changing this for a single table, or even a specific column. 

```
        Schema::create('fun_table', function(Blueprint $table)
        {
            $table->bigIncrements('id');
            $table->string('some_column')->charset('utf8')->collation('utf8_unicode_ci');
            $table->charset = 'utf8mb4';
            $table->collation = 'utf8mb4_unicode_ci';
        });
```
