### PR TITLE
[5.0] Pagination removed from root and fixed the data

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -31,7 +31,7 @@ abstract class AbstractPaginator {
 	 *
 	 * @var string
 	 */
-	protected $path = '/';
+	protected $path = null;
 
 	/**
 	 * The query parameters to add to all URLs.

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -36,7 +36,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
 
 		$this->perPage = $perPage;
 		$this->currentPage = $this->setCurrentPage($currentPage);
-		$this->path = $this->path != '/' ? rtrim($this->path, '/').'/' : $this->path;
+		$this->path = $this->path != '/' ? rtrim($this->path, '/') : $this->path;
 		$this->items = $items instanceof Collection ? $items : Collection::make($items);
 
 		$this->checkForMorePages();
@@ -64,7 +64,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
 	{
 		$this->hasMore = count($this->items) > ($this->perPage);
 
-		$this->items = $this->items->slice(0, $this->perPage);
+		$this->items = $this->items->slice(($this->currentPage - 1) * $this->perPage, $this->perPage);
 	}
 
 	/**

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -140,11 +140,11 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(2, $p->currentPage());
 		$this->assertTrue($p->hasPages());
 		$this->assertTrue($p->hasMorePages());
-		$this->assertEquals(['item3', 'item4'], $p->items());
+		$this->assertEquals(['item5'], $p->items());
 
 		$this->assertEquals([
-			'per_page' => 2, 'current_page' => 2, 'next_page_url' => '/?page=3',
-			'prev_page_url' => '/?page=1', 'from' => 3, 'to' => 4, 'data' => ['item3', 'item4']
+			'per_page' => 2, 'current_page' => 2, 'next_page_url' => '?page=3',
+			'prev_page_url' => '?page=1', 'from' => 3, 'to' => 3, 'data' => ['item5']
 		], $p->toArray());
 	}
 


### PR DESCRIPTION
<h1> Pagination </h1>

I bumped into 2 bugs in the pagination and in the test for the pagination.

<h2> Data </h2>

The data that was beeing fetched was the same on every page.
I fixed this by edditing the formula for the items.

<h2> Root </h2>

The paginator worked fine as long as you used it on the root of your application. Saw more people struggeling with the use of the setPath('') fix. I changed the default path to null and removed the forward slash in the constructor so the pagination is usable on a subpage.

I had to fix the matching test, the test results didn't check for the correct values. The second page only should have 1 record.
