### PR TITLE
str_limit default $end to use proper ellipsis

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -632,7 +632,7 @@ if ( ! function_exists('str_limit'))
 	 * @param  string  $end
 	 * @return string
 	 */
-	function str_limit($value, $limit = 100, $end = '...')
+	function str_limit($value, $limit = 100, $end = '…')
 	{
 		return Str::limit($value, $limit, $end);
 	}


### PR DESCRIPTION
Changed str_limit default $end to use proper ellipsis. A proper ellipsis is not 3 dots but a single character. Hope to see this changed for Laravel 4 too.
