### PR TITLE
Fix setting timezone.

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -37,7 +37,7 @@ class LoadConfiguration {
 			$this->loadConfigurationFiles($app, $config);
 		}
 
-		date_default_timezone_set($config['app.timezone']);
+		date_default_timezone_set($config['timezone']);
 
 		mb_internal_encoding('UTF-8');
 	}


### PR DESCRIPTION
If I set `timezone` in `config/app.php` then I get `date_default_timezone_set(): Timezone ID` error. 
This is because `$config['app.timezone']` is undefined. 
`$config['timezone']` is what we need here.
