### PR TITLE
[5.0] Proposal: "--skip-migration" option for make:model

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -35,9 +35,12 @@ class ModelMakeCommand extends GeneratorCommand {
 	{
 		parent::fire();
 
-		$table = str_plural(strtolower(class_basename($this->argument('name'))));
+		if ( ! $this->option('skip-migration'))
+		{
+			$table = str_plural(strtolower(class_basename($this->argument('name'))));
 
-		$this->call('make:migration', ['name' => "create_{$table}_table", '--create' => $table]);
+			$this->call('make:migration', ['name' => "create_{$table}_table", '--create' => $table]);
+		}
 	}
 
 	/**
@@ -59,6 +62,18 @@ class ModelMakeCommand extends GeneratorCommand {
 	protected function getDefaultNamespace($rootNamespace)
 	{
 		return $rootNamespace;
+	}
+
+	/**
+	 * Get the console command options.
+	 *
+	 * @return array
+	 */
+	protected function getOptions()
+	{
+		return array(
+			array('skip-migration', null, InputOption::VALUE_NONE, 'Do not create a new migration file.'),
+		);
 	}
 
 }


### PR DESCRIPTION
As several people have already mentioned, sometimes you do not want to create a migration file in 
`php artisan make:model`.

This option is useful for such cases and has no real cons.
