### PR TITLE
Added paginate function back to the BelongsToMany class to fix issues with pivots.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -167,6 +167,24 @@ class BelongsToMany extends Relation {
 
 		return $this->related->newCollection($models);
 	}
+	
+	/**
+	 * Get a paginator for the "select" statement.
+	 *
+	 * @param  int    $perPage
+	 * @param  array  $columns
+	 * @return \Illuminate\Pagination\Paginator
+	 */
+	public function paginate($perPage = null, $columns = array('*'))
+	{
+		$this->query->addSelect($this->getSelectColumns($columns));
+
+		$paginator = $this->query->paginate($perPage, $columns);
+
+		$this->hydratePivotRelation($paginator->items());
+
+		return $paginator;
+	}
 
 	/**
 	 * Hydrate the pivot table relationship on the models.


### PR DESCRIPTION
The BelongsToMany class doesn't have its paginate function like it did in L4. This is causing issues where the pivots are not taken care of correctly. The HasManyThrough class still has its paginate function, so I'm guessing it is supposed to be there.

A query like this below is selecting the messages by the id of pivot table instead of the conversation id because the pivot alias is not being set.

```
Auth::user()->conversations()
            ->with(array('messages' => function($query) {
                $query->orderBy('created_at', 'desc');
             }))
             ->paginate(20);
```

Using get() instead of paginate works correctly and eager loads the correct message ids 

```
select * from `users` where `users`.`id` = '3' limit 1
select `conversations`.*, `conversation_user`.`user_id` as `pivot_user_id`, `conversation_user`.`conversation_id` as `pivot_conversation_id` from `conversations` inner join `conversation_user` on `conversations`.`id` = `conversation_user`.`conversation_id` where `conversation_user`.`user_id` = '3'
select * from `messages` where `messages`.`conversation_id` in ('1', '2', '3', '4', '5', '6', '7', '8') order by `created_at` desc
```

The correct ids are ('1', '2', '3', '4', '5', '6', '7', '8')

When using paginate()

```
select * from `users` where `users`.`id` = '3' limit 1
select count(*) as aggregate from `conversations` inner join `conversation_user` on `conversations`.`id` = `conversation_user`.`conversation_id` where `conversation_user`.`user_id` = '3'
select * from `conversations` inner join `conversation_user` on `conversations`.`id` = `conversation_user`.`conversation_id` where `conversation_user`.`user_id` = '3' limit 20 offset 0
select * from `messages` where `messages`.`conversation_id` in ('1', '3', '5', '7', '9', '11', '13', '15') order by `created_at` desc
```

Uses the user_conversation pivot table ids of ('1', '3', '5', '7', '9', '11', '13', '15')

Adding paginate back to the BelongsToMany class correctly alias the pivots and gives the correct results.

```
select * from `users` where `users`.`id` = '3' limit 1
select count(*) as aggregate from `conversations` inner join `conversation_user` on `conversations`.`id` = `conversation_user`.`conversation_id` where `conversation_user`.`user_id` = '3'
select `conversations`.*, `conversation_user`.`user_id` as `pivot_user_id`, `conversation_user`.`conversation_id` as `pivot_conversation_id` from `conversations` inner join `conversation_user` on `conversations`.`id` = `conversation_user`.`conversation_id` where `conversation_user`.`user_id` = '3' limit 20 offset 0
select * from `messages` where `messages`.`conversation_id` in ('1', '2', '3', '4', '5', '6', '7', '8') order by `created_at` desc
```
