### PR TITLE
Allow route middlewares to be grouped together

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -703,9 +703,9 @@ class Router implements RegistrarContract {
 	{
 		return Collection::make($route->middleware())->map(function($m)
 		{
-			return array_get($this->middleware, $m, $m);
+			return Collection::make(array_get($this->middleware, $m, $m));
 
-		})->all();
+		})->collapse()->all();
 	}
 
 	/**


### PR DESCRIPTION
This will allow multiple middlewares to be packaged together under a single identifier. For example, if I wanted to move `Illuminate\Session\Middleware\StartSession` and `Illuminate\View\Middleware\ShareErrorsFromSession` from the global middlewares to the route middlewares, but keep them together so only routes that need sessions would only need to reference a single middleware.

```
    Route::group(['middleware' => ['session']], function() {
        // ...
    });
```

```
    protected $routeMiddleware = [
        'auth' => 'App\Http\Middleware\Authenticate',
        'auth.basic' => 'App\Auth\Middleware\AuthenticateWithBasicAuth',
        'guest' => 'App\Http\Middleware\RedirectIfAuthenticated',
        'session' => [
            'Illuminate\Session\Middleware\StartSession',
            'Illuminate\View\Middleware\ShareErrorsFromSession',
        ]
    ];
```
