### PR TITLE
migrate:status shows unreadable chars on Windows console

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -56,7 +56,7 @@ class StatusCommand extends BaseCommand {
 
 		foreach ($this->getAllMigrationFiles() as $migration)
 		{
-			$migrations[] = in_array($migration, $ran) ? ['<info>✔</info>', $migration] : ['<fg=red>✗</fg=red>', $migration];
+			$migrations[] = in_array($migration, $ran) ? ['<info>Y</info>', $migration] : ['<fg=red>N</fg=red>', $migration];
 		}
 
 		if (count($migrations) > 0)


### PR DESCRIPTION
On windows the checkmark and X show as unreadable chars.  For example
the checkmark shows "Γ£ö".  Updated to simply show a Y or N.

![capture](https://cloud.githubusercontent.com/assets/7214374/6242523/de6190e8-b6fe-11e4-82a0-206c30dacd93.PNG)

![capture2](https://cloud.githubusercontent.com/assets/7214374/6242527/fe757f7a-b6fe-11e4-837b-9cbb6aac6366.PNG)
