### PR TITLE
Properly terminate Route Middlewares that implement TerminableMiddleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -120,12 +120,10 @@ class Kernel implements KernelContract {
 	 */
 	public function terminate($request, $response)
 	{
-		$globalMiddlewares = $this->middleware;
 		$routeResolver = $request->getRouteResolver();
 		$routeMiddlewares = $this->router->gatherRouteMiddlewares($routeResolver());
-		$middlewares = array_merge($globalMiddlewares, $routeMiddlewares);
 
-		foreach ($middlewares as $middleware)
+		foreach (array_merge($this->middleware, $routeMiddlewares) as $middleware)
 		{
 			$instance = $this->app->make($middleware);
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -120,7 +120,12 @@ class Kernel implements KernelContract {
 	 */
 	public function terminate($request, $response)
 	{
-		foreach ($this->middleware as $middleware)
+		$globalMiddlewares = $this->middleware;
+		$routeResolver = $request->getRouteResolver();
+		$routeMiddlewares = $this->router->gatherRouteMiddlewares($routeResolver());
+		$middlewares = array_merge($globalMiddlewares, $routeMiddlewares);
+
+		foreach ($middlewares as $middleware)
 		{
 			$instance = $this->app->make($middleware);
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -699,7 +699,7 @@ class Router implements RegistrarContract {
 	 * @param  \Illuminate\Routing\Route  $route
 	 * @return array
 	 */
-	protected function gatherRouteMiddlewares(Route $route)
+	public function gatherRouteMiddlewares(Route $route)
 	{
 		return Collection::make($route->middleware())->map(function($m)
 		{


### PR DESCRIPTION
Might be a bug, but Route Middlewares that implement TerminableMiddleware do not have their terminate method called on shutdown. One example of this not happening is when the Session middleware is used as a route middleware.
