### PR TITLE
Passing 404 to view() method

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -114,7 +114,7 @@ class Handler implements ExceptionHandlerContract {
 
 		if (view()->exists("errors.{$status}"))
 		{
-			return response()->view("errors.{$status}", [], $status);
+			return response()->view("errors.{$status}", []);
 		}
 		else
 		{


### PR DESCRIPTION
When We pass 404 as the third arugument to the view function, the view is not being rendered.I think that causes problem to render the custom 404 page in the laravel 5 application. Would like to Discuss.
