### PR TITLE
Added test-segments to DatabasePostgresSchemaGrammarTest and DatabaseMySqlSchemaGrammarTest to test for issue #7484.

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -17,7 +17,7 @@ class PostgresGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $serials = array('bigInteger', 'integer');
+	protected $serials = array('bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger');
 
 	/**
 	 * Compile the query to determine if a table exists.
@@ -307,7 +307,7 @@ class PostgresGrammar extends Grammar {
 	 */
 	protected function typeMediumInteger(Fluent $column)
 	{
-		return 'integer';
+		return $column->autoIncrement ? 'serial' : 'integer';
 	}
 
 	/**
@@ -318,7 +318,7 @@ class PostgresGrammar extends Grammar {
 	 */
 	protected function typeTinyInteger(Fluent $column)
 	{
-		return 'smallint';
+		return $column->autoIncrement ? 'smallserial' : 'smallint';
 	}
 
 	/**
@@ -329,7 +329,7 @@ class PostgresGrammar extends Grammar {
 	 */
 	protected function typeSmallInteger(Fluent $column)
 	{
-		return 'smallint';
+		return $column->autoIncrement ? 'smallserial' : 'smallint';
 	}
 
 	/**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -337,6 +337,13 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table `users` add `foo` mediumint not null', $statements[0]);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->mediumInteger('foo', true);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` add `foo` mediumint not null auto_increment primary key', $statements[0]);
 	}
 
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -355,6 +355,13 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table `users` add `foo` smallint not null', $statements[0]);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->smallInteger('foo', true);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` add `foo` smallint not null auto_increment primary key', $statements[0]);
 	}
 
 
@@ -366,6 +373,13 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table `users` add `foo` tinyint not null', $statements[0]);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->tinyInteger('foo', true);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table `users` add `foo` tinyint not null auto_increment primary key', $statements[0]);
 	}
 
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -298,6 +298,13 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table "users" add column "foo" smallint not null', $statements[0]);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->tinyInteger('foo', true);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table "users" add column "foo" smallserial primary key not null', $statements[0]);
 	}
 
 
@@ -309,6 +316,13 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table "users" add column "foo" smallint not null', $statements[0]);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->smallInteger('foo', true);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table "users" add column "foo" smallserial primary key not null', $statements[0]);
 	}
 
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -280,6 +280,13 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(1, count($statements));
 		$this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
+
+		$blueprint = new Blueprint('users');
+		$blueprint->mediumInteger('foo', true);
+		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+		$this->assertEquals(1, count($statements));
+		$this->assertEquals('alter table "users" add column "foo" serial primary key not null', $statements[0]);
 	}
 
 


### PR DESCRIPTION
Added test-segments to DatabasePostgresSchemaGrammarTest and DatabaseMySqlSchemaGrammarTest to test for issue #7484.

Rephrase of the bug, since the original issue was closed:

> Following Schema Builder code line, written for primarily MySQL:
> $table->mediumInteger('id', true, true);
> doesn't behave as expected when Db-driver is changed to PgSQL. Instead of creating a Not-Nullable PRIMARY INTEGER column, it just creates simple Not-Nullable INTEGER column which is not PRIMARY. Could this bug be fixed in upcoming dev-master release?
