### PR TITLE
Add the Postgresql regular expression operators 

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -198,7 +198,7 @@ class Builder {
 		'=', '<', '>', '<=', '>=', '<>', '!=',
 		'like', 'not like', 'between', 'ilike',
 		'&', '|', '^', '<<', '>>',
-		'rlike', 'regexp', 'not regexp',
+		'rlike', 'regexp', 'not regexp', '~',
 	);
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -198,7 +198,9 @@ class Builder {
 		'=', '<', '>', '<=', '>=', '<>', '!=',
 		'like', 'not like', 'between', 'ilike',
 		'&', '|', '^', '<<', '>>',
-		'rlike', 'regexp', 'not regexp', '~',
+		'rlike', 'regexp', 'not regexp', 
+		'~', '~*', '!~', '!~*', 'similar to',
+                'not similar to',
 	);
 
 	/**


### PR DESCRIPTION
Add the Postgresql regular expression operators to the list of valid operators in the Eloquent query builder. I don't want to second-guess the code that is already there, so the approach I took was to just add the additional operators, but I was not sure what the purpose validating the operator is. The number of arguments check seems like a very useful shortcut, but it seems like this validity check will make it more difficult to be forward compatible with new RDBMS features and it doesn't look like the code is treating the third parameter as the boolean parameter in the case of invalid operator, so that third parameter just gets ignored if the operator is not in the array of valid operators. Perhaps it would be better to eliminate the check entirely, but I'm not familiar enough with the code to make that call.
