### PR TITLE
Adding $listen array to base event service provider

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -4,6 +4,13 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
 class EventServiceProvider extends ServiceProvider {
+	
+	/**
+	 * The event handler mappings for the application.
+	 *
+	 * @var array
+	 */
+	protected $listen = [];
 
 	/**
 	 * The subscriber classes to register.


### PR DESCRIPTION
I'm in the process of hacking away the default service provider structure in a new L5 build since I'm not a big fan of declaring all of my events in a single place. While doing this, I ran across a weird thing...not sure if it should be counted as a bug.

In app.php, I replaced `App\Providers\EventServiceProvider` with `Illuminate\Foundation\Support\Providers\EventServiceProvider`, but when it gets here:

https://github.com/laravel/framework/blob/5.0/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php#L23

..it gets angry that `$this->listen` isn't an array. An easy fix would be to just define that `$listen` property on `Illuminate\Foundation\Support\Providers\EventServiceProvider`, but I'm not sure if what I'm doing is condoned behavior. As it stands, I have to create an `EventServiceProvider` class with just an empty `$listen` property in it, which seems a bit of a waste. Thanks!
