### PR TITLE
fix change column in Grammar.php

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -358,7 +358,7 @@ abstract class Grammar extends BaseGrammar {
 	 */
 	protected function getDoctrineColumnChangeOptions(Fluent $fluent)
 	{
-		$options = ['type' => Type::getType($this->getType($fluent))];
+		$options = ['type' => Type::getType($fluent['type'])];
 
 		if (in_array($fluent['type'], ['text', 'mediumText', 'longText']))
 		{


### PR DESCRIPTION
Bug found changing a float to decimal. 
Artisan returns 
'Doctrine\DBAL\DBALException' with message 'Unknown column type "decimal(8, 2)"

because $this->getType($fluent) returns decimal(8,2).

$fluent['type'] should be used in order to call the proper Doctrine getType function to work
