### PR TITLE
Dump Composer autoload when creating a queue table migration.

### DIFF
--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Foundation\Composer;
 use Illuminate\Filesystem\Filesystem;
 
 class FailedTableCommand extends Command {
@@ -27,16 +28,22 @@ class FailedTableCommand extends Command {
 	protected $files;
 
 	/**
+	 * @var \Illuminate\Foundation\Composer
+	 */
+	protected $composer;
+
+	/**
 	 * Create a new failed queue jobs table command instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files)
+	public function __construct(Filesystem $files, Composer $composer)
 	{
 		parent::__construct();
 
 		$this->files = $files;
+		$this->composer = $composer;
 	}
 
 	/**
@@ -51,6 +58,8 @@ class FailedTableCommand extends Command {
 		$this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/failed_jobs.stub'));
 
 		$this->info('Migration created successfully!');
+
+		$this->composer->dumpAutoloads();
 	}
 
 	/**

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Foundation\Composer;
 use Illuminate\Filesystem\Filesystem;
 
 class TableCommand extends Command {
@@ -27,16 +28,22 @@ class TableCommand extends Command {
 	protected $files;
 
 	/**
+	 * @var \Illuminate\Foundation\Composer
+	 */
+	protected $composer;
+
+	/**
 	 * Create a new queue job table command instance.
 	 *
 	 * @param  \Illuminate\Filesystem\Filesystem  $files
 	 * @return void
 	 */
-	public function __construct(Filesystem $files)
+	public function __construct(Filesystem $files, Composer $composer)
 	{
 		parent::__construct();
 
 		$this->files = $files;
+		$this->composer = $composer;
 	}
 
 	/**
@@ -51,6 +58,8 @@ class TableCommand extends Command {
 		$this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/jobs.stub'));
 
 		$this->info('Migration created successfully!');
+
+		$this->composer->dumpAutoloads();
 	}
 
 	/**

--- a/src/Illuminate/Queue/ConsoleServiceProvider.php
+++ b/src/Illuminate/Queue/ConsoleServiceProvider.php
@@ -26,7 +26,7 @@ class ConsoleServiceProvider extends ServiceProvider {
 	{
 		$this->app->singleton('command.queue.table', function($app)
 		{
-			return new TableCommand($app['files']);
+			return new TableCommand($app['files'], $app['composer']);
 		});
 
 		$this->app->singleton('command.queue.failed', function()

--- a/tests/Queue/QueueFailedTableCommandTest.php
+++ b/tests/Queue/QueueFailedTableCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Queue\Console\FailedTableCommand as QueueFailedTableCommand;
+use Illuminate\Foundation\Application;
+use Mockery as m;
+
+class QueueFailedTableCommandTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testCreateMakesMigration()
+	{
+		$command = new QueueFailedTableCommandTestStub(
+			$files = m::mock('Illuminate\Filesystem\Filesystem'),
+			$composer = m::mock('Illuminate\Foundation\Composer')
+		);
+		$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
+
+		$app = new Application();
+		$app['path.database'] = __DIR__;
+		$app['migration.creator'] = $creator;
+		$command->setLaravel($app);
+		$path = __DIR__ . '/migrations';
+		$creator->shouldReceive('create')->once()->with('create_failed_jobs_table', $path)->andReturn($path);
+		$files->shouldReceive('get')->once()->andReturn('foo');
+		$files->shouldReceive('put')->once()->with($path, 'foo');
+		$composer->shouldReceive('dumpAutoloads')->once();
+
+		$this->runCommand($command);
+	}
+
+
+	protected function runCommand($command, $input = array())
+	{
+		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+	}
+
+}
+
+class QueueFailedTableCommandTestStub extends QueueFailedTableCommand {
+
+	public function call($command, array $arguments = array())
+	{
+		//
+	}
+
+}

--- a/tests/Queue/QueueTableCommandTest.php
+++ b/tests/Queue/QueueTableCommandTest.php
@@ -6,46 +6,46 @@ use Mockery as m;
 
 class QueueTableCommandTest extends PHPUnit_Framework_TestCase {
 
-  public function tearDown()
-  {
-    m::close();
-  }
+	public function tearDown()
+	{
+		m::close();
+	}
 
 
-  public function testCreateMakesMigration()
-  {
-    $command = new QueueTableCommandTestStub(
-      $files = m::mock('Illuminate\Filesystem\Filesystem'),
-      $composer = m::mock('Illuminate\Foundation\Composer')
-    );
-    $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
+	public function testCreateMakesMigration()
+	{
+		$command = new QueueTableCommandTestStub(
+			$files = m::mock('Illuminate\Filesystem\Filesystem'),
+			$composer = m::mock('Illuminate\Foundation\Composer')
+		);
+		$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
 
-    $app = new Application();
-    $app['path.database'] = __DIR__;
-    $app['migration.creator'] = $creator;
-    $command->setLaravel($app);
-    $path = __DIR__ . '/migrations';
-    $creator->shouldReceive('create')->once()->with('create_jobs_table', $path)->andReturn($path);
-    $files->shouldReceive('get')->once()->andReturn('foo');
-    $files->shouldReceive('put')->once()->with($path, 'foo');
-    $composer->shouldReceive('dumpAutoloads')->once();
+		$app = new Application();
+		$app['path.database'] = __DIR__;
+		$app['migration.creator'] = $creator;
+		$command->setLaravel($app);
+		$path = __DIR__ . '/migrations';
+		$creator->shouldReceive('create')->once()->with('create_jobs_table', $path)->andReturn($path);
+		$files->shouldReceive('get')->once()->andReturn('foo');
+		$files->shouldReceive('put')->once()->with($path, 'foo');
+		$composer->shouldReceive('dumpAutoloads')->once();
 
-    $this->runCommand($command);
-  }
+		$this->runCommand($command);
+	}
 
 
-  protected function runCommand($command, $input = array())
-  {
-    return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
-  }
+	protected function runCommand($command, $input = array())
+	{
+		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+	}
 
 }
 
 class QueueTableCommandTestStub extends QueueTableCommand {
 
-  public function call($command, array $arguments = array())
-  {
-    //
-  }
+	public function call($command, array $arguments = array())
+	{
+		//
+	}
 
 }

--- a/tests/Queue/QueueTableCommandTest.php
+++ b/tests/Queue/QueueTableCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Queue\Console\TableCommand as QueueTableCommand;
+use Illuminate\Foundation\Application;
+use Mockery as m;
+
+class QueueTableCommandTest extends PHPUnit_Framework_TestCase {
+
+  public function tearDown()
+  {
+    m::close();
+  }
+
+
+  public function testCreateMakesMigration()
+  {
+    $command = new QueueTableCommandTestStub(
+      $files = m::mock('Illuminate\Filesystem\Filesystem'),
+      $composer = m::mock('Illuminate\Foundation\Composer')
+    );
+    $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
+
+    $app = new Application();
+    $app['path.database'] = __DIR__;
+    $app['migration.creator'] = $creator;
+    $command->setLaravel($app);
+    $path = __DIR__ . '/migrations';
+    $creator->shouldReceive('create')->once()->with('create_jobs_table', $path)->andReturn($path);
+    $files->shouldReceive('get')->once()->andReturn('foo');
+    $files->shouldReceive('put')->once()->with($path, 'foo');
+    $composer->shouldReceive('dumpAutoloads')->once();
+
+    $this->runCommand($command);
+  }
+
+
+  protected function runCommand($command, $input = array())
+  {
+    return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+  }
+
+}
+
+class QueueTableCommandTestStub extends QueueTableCommand {
+
+  public function call($command, array $arguments = array())
+  {
+    //
+  }
+
+}


### PR DESCRIPTION
I just used the `queue:table` command to generate it's migration, but got this error when trying to roll the migrations back:

```
PHP Fatal error:  Class 'CreateJobsTable' not found in /home/vagrant/Code/app/vendor/laravel/framework/src/Illuminate/Database/Migrations/Migrator.php on line 301
```

I investigated and all other Laravel migration commands [automatically](https://github.com/laravel/framework/blob/5.0/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php#L74) dump the Composer autoload, except the Queue one. This should fix it.
