### PR TITLE
Updating AppName to replace looser matchers first

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -112,15 +112,15 @@ class AppNameCommand extends Command {
 	protected function replaceNamespace($path)
 	{
 		$search = [
+			$this->currentRoot.'\\',
 			'namespace '.$this->currentRoot.';',
 			'namespace '.$this->currentRoot.'\\',
-			$this->currentRoot.'\\',
 		];
 
 		$replace = [
+			$this->argument('name').'\\',
 			'namespace '.$this->argument('name').';',
 			'namespace '.$this->argument('name').'\\',
-			$this->argument('name').'\\',
 		];
 
 		$this->replaceIn($path, $search, $replace);


### PR DESCRIPTION
## Description of Problem

Right now when you run `php artisan app:name MyApp` on a fresh Laravel 5 installation you will find several instances of `MyMyApp` around the application.  This can be verified by running `git diff | grep MyMyApp` after running the task inside of a git project.  This occurs because the looser matches were at the end of the search/replace array.
## Solution

Putting them at the beginning will replace the general instances first, then cascade through all namespace declarations to make sure everything is covered.
## Steps to Reproduce
1. Clone Laravel 5 and run `composer install` or branch your own code if the namespace is `App`
2. Run `php artisan app:name MyApp`
3. Run `git diff | grep MyMyApp` and notice several instances exist
4. Run `git reset --hard && composer install` to return your app to the previous state
## Caveat: This is still broken.

Let's say you named your app namespace with something else that is declared inside of the existing namespaces.  For example `Console`, then change it again to `App`.  You will still change all instances of `Console` throughout the app to be `App`.  Perhaps the loosest match on just `<namespace>\\` should ultimately be removed?  This will have its own side effects but I'm just presenting it as an option.

The broken state is still broken in the original version, so this is a _less_ broken version.  Not perfect, but while using simple string replacement, this should at least prevent a few more edge cases.
