### PR TITLE
Fix for decryption of X-XSRF-TOKEN via header

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -59,7 +59,7 @@ class VerifyCsrfToken implements Middleware {
 		$header = $request->header('X-XSRF-TOKEN');
 
 		return StringUtils::equals($token, $request->input('_token')) ||
-		       ($header && StringUtils::equals($token, $this->encrypter->decrypt($header)));
+		       ($header && StringUtils::equals($token, $header));
 	}
 
 	/**


### PR DESCRIPTION
Currently when using the header `X-XSRF-TOKEN` you get a 500 Internal Server error as [the token is trying to be converted into valid JSON](https://github.com/laravel/framework/blob/5.0/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php#L62), which it never will.

To rectify this, the header check should be:

```
($header && StringUtils::equals($token, $header)
```

After making that change, my AJAX requests are running correctly.
