### PR TITLE
[5.0] vendor:publish command show statuses for directory copy

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -106,12 +106,20 @@ class VendorPublishCommand extends Command {
 			'to' => new Flysystem(new LocalAdapter($to)),
 		]);
 
+		$copied = 0;
+
 		foreach ($manager->listContents('from://', true) as $file)
 		{
 			if ($file['type'] === 'file' && ( ! $manager->has('to://'.$file['path']) || $this->option('force')))
 			{
 				$manager->put('to://'.$file['path'], $manager->read('from://'.$file['path']));
+				$copied++;
 			}
+		}
+
+		if ($copied)
+		{
+			$this->status($from, $to, "$copied Files From");
 		}
 	}
 


### PR DESCRIPTION
Hi, 
I find this is useful when developping packages, as it shows that what was expected happens. If files are already published, the command still prints nothing so there is no confusion about overwriting files.
