### PR TITLE
Add trigger for setting vlucas/phpdotenv to mutable

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -16,7 +16,7 @@ class DetectEnvironment {
 	{
 		try
 		{
-			if( "mutable" == getenv('VAR_MUT') )
+			if (getenv('VAR_MUT') == "mutable")
 			{
 				Dotenv::makeMutable();
 			}

--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -17,7 +17,9 @@ class DetectEnvironment {
 		try
 		{
 			if( "mutable" == getenv('VAR_MUT') )
+			{
 				Dotenv::makeMutable();
+			}
 
 			Dotenv::load($app['path.base'], $app->environmentFile());
 		}

--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -16,6 +16,9 @@ class DetectEnvironment {
 	{
 		try
 		{
+			if( "mutable" == getenv('VAR_MUT') )
+				Dotenv::makeMutable();
+
 			Dotenv::load($app['path.base'], $app->environmentFile());
 		}
 		catch (InvalidArgumentException $e)


### PR DESCRIPTION
For allowing `.env` files to override environment variables defined in `Homestead.yaml`.

As Homestead has been designed with the idea of hosting multiple projects from a single Vagrant box I had assumed that any environment variables defined by its YAML configuration file were simply defaults, and that specifying a different value for a given variable in an individual project's `.env` file would override it. After about an hour of debugging and discussion in the #laravel IRC channel it became apparent that this is caused by [Dotenv](https://github.com/vlucas/phpdotenv) being set to immutable by default, something which Laravel does not provide a means to alter.

I propose adding a trigger which developers can use by adding an environment `value:key` pair to their `Homestead.yaml` file. If this is found, Dotenv will be set to mutable and it will then be possible to override YAML-defined environment variables on a per-project basis while still providing a catch-all default value.

``` yaml
variables:
    - key: VAR_MUT
      value: mutable
```

This will not change how Laravel and Homestead operate for the vast majority of users, and environment variables will remain immutable by default. However, it will provide a quick and easy way to make them mutable for those who feel they benefit from it.
