### PR TITLE
pass model binding value to callback

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -911,7 +911,7 @@ class Router implements RegistrarContract {
 			// developer a little greater flexibility to decide what will happen.
 			if ($callback instanceof Closure)
 			{
-				return call_user_func_array($callback, [$value]);
+				return call_user_func($callback, $value);
 			}
 
 			throw new NotFoundHttpException;

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -911,7 +911,7 @@ class Router implements RegistrarContract {
 			// developer a little greater flexibility to decide what will happen.
 			if ($callback instanceof Closure)
 			{
-				return call_user_func($callback);
+				return call_user_func_array($callback, [$value]);
 			}
 
 			throw new NotFoundHttpException;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -555,6 +555,14 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('missing', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
 	}
 
+	public function testModelBindingWithBindingClosure()
+	{
+		$router = $this->getRouter();
+		$router->get('foo/{bar}', function($name) { return $name; });
+		$router->model('bar', 'RouteModelBindingNullStub', function($value) { return (new RouteModelBindingClosureStub())->findAlternate($value); });
+		$this->assertEquals('tayloralt', $router->dispatch(Request::create('foo/TAYLOR', 'GET'))->getContent());
+	}
+
 
 	public function testGroupMerging()
 	{
@@ -884,6 +892,10 @@ class RouteModelBindingStub {
 
 class RouteModelBindingNullStub {
 	public function find($value) {}
+}
+
+class RouteModelBindingClosureStub {
+	public function findAlternate($value) { return strtolower($value) . "alt"; }
 }
 
 class RouteTestFilterStub {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -555,6 +555,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('missing', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
 	}
 
+
 	public function testModelBindingWithBindingClosure()
 	{
 		$router = $this->getRouter();


### PR DESCRIPTION
Previously, the wildcard value bound in a route was not available in the callback that is executed if the class's `find` method doesn't return anything.

The change to `call_user_func_array` and passing of `$value` gives userland straightforward access to the wildcard that hasn't been found and allows the developer to decide if indeed the resource wasn't found or if it uses an alternate technique to locate it (finding by a slug etc).
