### PR TITLE
Remove unused down method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -756,17 +756,6 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	}
 
 	/**
-	 * Register a maintenance mode event listener.
-	 *
-	 * @param  \Closure  $callback
-	 * @return void
-	 */
-	public function down(Closure $callback)
-	{
-		$this['events']->listen('illuminate.app.down', $callback);
-	}
-
-	/**
 	 * Throw an HttpException with the given data.
 	 *
 	 * @param  int     $code


### PR DESCRIPTION
This removes the down method which was listening for the illuminate.app.down event which is never fired since that code was removed when maintenance mode was moved to middleware.

This is a re-submission of #7513 to the proper branch.
