### PR TITLE
Simplify filterContentsByType

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -1,7 +1,6 @@
 <?php namespace Illuminate\Filesystem;
 
 use InvalidArgumentException;
-use Illuminate\Support\Collection;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\FilesystemInterface;
 use League\Flysystem\FileNotFoundException;
@@ -283,10 +282,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract {
 	 */
 	protected function filterContentsByType($contents, $type)
 	{
-		return Collection::make($contents)
-			->where('type', $type)
-			->fetch('path')
-			->values()->all();
+		return collect($contents)->where('type', $type)->lists('path');
 	}
 
 	/**


### PR DESCRIPTION
No need to call `values()`, since [`Arr::fetch` already does that](https://github.com/laravel/framework/blob/5.0/src/Illuminate/Support/Arr.php#L122).
