### PR TITLE
Pass composer instance into FailedTableCommand

### DIFF
--- a/src/Illuminate/Queue/ConsoleServiceProvider.php
+++ b/src/Illuminate/Queue/ConsoleServiceProvider.php
@@ -51,7 +51,7 @@ class ConsoleServiceProvider extends ServiceProvider {
 
 		$this->app->singleton('command.queue.failed-table', function($app)
 		{
-			return new FailedTableCommand($app['files']);
+			return new FailedTableCommand($app['files'], $app['composer']);
 		});
 
 		$this->commands(


### PR DESCRIPTION
Fixes the issue introduced with #7499
