### PR TITLE
Add a setEmailView method to enable changing the password reset view

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -253,4 +253,15 @@ class PasswordBroker implements PasswordBrokerContract {
 		return $this->tokens;
 	}
 
+	/**
+	 * Set the emailView in runtime.
+	 *
+	 * @param  string $view
+	 * @return  void
+	 */
+	public function setEmailView($view)
+	{
+		$this->emailView = $view;
+	}
+
 }


### PR DESCRIPTION
With this small change we could use different view files for the password reset links. I know, it's not a usual thing, but maybe useful for multi-language applications or if you have different type of users (administrators and users).
