### PR TITLE
Catch console exceptions

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -46,7 +46,7 @@ class Application extends SymfonyApplication implements ApplicationContract {
 		$this->event = $events;
 		$this->laravel = $laravel;
 		$this->setAutoExit(false);
-		$this->setCatchExceptions(!$this->laravel->make('config')->get('app.debug');
+		$this->setCatchExceptions(!$this->laravel->make('config')->get('app.debug'));
 
 		$events->fire('artisan.start', [$this]);
 	}

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -46,7 +46,7 @@ class Application extends SymfonyApplication implements ApplicationContract {
 		$this->event = $events;
 		$this->laravel = $laravel;
 		$this->setAutoExit(false);
-		$this->setCatchExceptions(false);
+		$this->setCatchExceptions(!$this->laravel['config']['app.debug']);
 
 		$events->fire('artisan.start', [$this]);
 	}

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -46,7 +46,7 @@ class Application extends SymfonyApplication implements ApplicationContract {
 		$this->event = $events;
 		$this->laravel = $laravel;
 		$this->setAutoExit(false);
-		$this->setCatchExceptions(!$this->laravel['config']['app.debug']);
+		$this->setCatchExceptions(!$this->laravel->make('config')->get('app.debug');
 
 		$events->fire('artisan.start', [$this]);
 	}


### PR DESCRIPTION
Console exceptions are not being caught even if `app.debug` config is set to `false`. When an error is found, the full stacktrace is printed out in the terminal, making really difficult to understand what's really happening as the error message is shown at the first line and the stacktrace could have 100+ lines.

When console errors are caught, an elegant red message naming the exception and its message is shown, much more elegant for production and even debug sometimes.
