### PR TITLE
Map no-op for people with alternate routing systems

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -92,6 +92,13 @@ class RouteServiceProvider extends ServiceProvider {
 	 * @return void
 	 */
 	public function register() {}
+	
+	/**
+	 * Define the routes for the application.
+	 *
+	 * @return void
+	 */
+	public function map() {}
 
 	/**
 	 * Pass dynamic methods onto the router instance.


### PR DESCRIPTION
In my `app.providers` config, I remove `App\Providers\RouteServiceProvider` and replace it with `Illuminate\Foundation\Support\Providers\RouteServiceProvider` because I distribute my routes across the system and have various service providers load them. Having this function avoids an error when the `loadRoutes` method calls `map` through the container and it doesn't exist.
