### PR TITLE
Allow both encrypted + unencrypted CSRF header token

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -54,12 +54,14 @@ class VerifyCsrfToken implements Middleware {
 	 */
 	protected function tokensMatch($request)
 	{
-		$token = $request->session()->token();
+		$token = $request->input('_token') ?: $request->header('X-CSRF-TOKEN');
 
-		$header = $request->header('X-XSRF-TOKEN');
+		if ( ! $token && $header = $request->header('X-XSRF-TOKEN'))
+		{
+			$token = $this->encrypter->decrypt($header);
+		}
 
-		return StringUtils::equals($token, $request->input('_token')) ||
-		       ($header && StringUtils::equals($token, $this->encrypter->decrypt($header)));
+		return StringUtils::equals($request->session()->token(), $token);
 	}
 
 	/**


### PR DESCRIPTION
I know something similar has been submitted before, but currently CSRF works for these situations:
- CSRF works for hidden _token input
- CSRF works automatically for Angular, which uses the encrypted value from the cookie (+ X-XSRF-TOKEN header)

But it doesn't for other common use-cases:
- Plain text token header
- Scripts that use X-CSRF convention

Proposal: Also check the X-CSRF-TOKEN header for plain-text token. This make it easier to add a meta-tag to the page which javascript checks.
`<meta name="csrf-token" content="<?= csrf_token ?>" />`

Some frameworks/scripts already use this convention. like [Jquery UJS](https://github.com/rails/jquery-ujs/blob/519aad962496497870621e5b6afe2a727a28839d/src/rails.js#L57-L61)

```
CSRFProtection: function(xhr) {
      var token = $('meta[name="csrf-token"]').attr('content');
      if (token) xhr.setRequestHeader('X-CSRF-Token', token);
    },
```

We see a lot of issues by people not understaning the decryption or need to remove it. This will allow all cases:
1. Check the _token input, plain text
2. Check the X-CSRF-TOKEN, plain text
3. Check the X-XSRF-TOKEN, encrypted

And a section would needed to be added to the docs, but I'm willing to write that, with a few simple examples.

Fixes #7418 #7437 #7436 #7373 #7435 #7288 #7287
