### PR TITLE
Casting Nullable Fields

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2724,22 +2724,22 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	{
 		switch ($this->getCastType($key))
 		{
-            case 'int|null':
-            case 'integer|null':
-                if (is_null($value)) return null;
+			case 'int|null':
+			case 'integer|null':
+				if (is_null($value)) return null;
 			case 'int':
 			case 'integer':
 				return (int) $value;
-            case 'real|null':
-            case 'float|null':
-            case 'double|null':
-                if (is_null($value)) return null;
+			case 'real|null':
+			case 'float|null':
+			case 'double|null':
+				if (is_null($value)) return null;
 			case 'real':
 			case 'float':
 			case 'double':
 				return (float) $value;
-            case 'string|null':
-                if (is_null($value)) return null;
+			case 'string|null':
+				if (is_null($value)) return null;
 			case 'string':
 				return (string) $value;
 			case 'bool':

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2722,34 +2722,43 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	protected function castAttribute($key, $value)
 	{
-		switch ($this->getCastType($key))
+		// If the attribute exists within the cast array, we will convert it to
+		// an appropriate native PHP type dependant upon the associated value
+		// given with the key in the pair. Dayle made this comment line up.
+		//
+		// To give the option of passing null back as an optional
+		$castType = $this->getCastType($key);
+		if (strpos($castType, '|null'))
 		{
-			case 'int|null':
-			case 'integer|null':
-				if (is_null($value)) return;
+			if (is_null($value)) return;
+
+			$castType = str_replace('|null', '', $castType);
+		}
+
+		switch ($castType) {
 			case 'int':
 			case 'integer':
 				return (int) $value;
-			case 'real|null':
-			case 'float|null':
-			case 'double|null':
-				if (is_null($value)) return;
+
 			case 'real':
 			case 'float':
 			case 'double':
 				return (float) $value;
-			case 'string|null':
-				if (is_null($value)) return;
+
 			case 'string':
 				return (string) $value;
+
 			case 'bool':
 			case 'boolean':
 				return (bool) $value;
+
 			case 'object':
 				return json_decode($value);
+
 			case 'array':
 			case 'json':
 				return json_decode($value, true);
+
 			default:
 				return $value;
 		}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2724,13 +2724,22 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	{
 		switch ($this->getCastType($key))
 		{
+            case 'int|null':
+            case 'integer|null':
+                if (is_null($value)) return null;
 			case 'int':
 			case 'integer':
 				return (int) $value;
+            case 'real|null':
+            case 'float|null':
+            case 'double|null':
+                if (is_null($value)) return null;
 			case 'real':
 			case 'float':
 			case 'double':
 				return (float) $value;
+            case 'string|null':
+                if (is_null($value)) return null;
 			case 'string':
 				return (string) $value;
 			case 'bool':

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2726,20 +2726,20 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		{
 			case 'int|null':
 			case 'integer|null':
-				if (is_null($value)) return null;
+				if (is_null($value)) return;
 			case 'int':
 			case 'integer':
 				return (int) $value;
 			case 'real|null':
 			case 'float|null':
 			case 'double|null':
-				if (is_null($value)) return null;
+				if (is_null($value)) return;
 			case 'real':
 			case 'float':
 			case 'double':
 				return (float) $value;
 			case 'string|null':
-				if (is_null($value)) return null;
+				if (is_null($value)) return;
 			case 'string':
 				return (string) $value;
 			case 'bool':

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2722,11 +2722,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	protected function castAttribute($key, $value)
 	{
-		// If the attribute exists within the cast array, we will convert it to
-		// an appropriate native PHP type dependant upon the associated value
-		// given with the key in the pair. Dayle made this comment line up.
-		//
-		// To give the option of passing null back as an optional
+		// First we need to check if the cast type should allow NULL to
+		// pass back as a valid response rather than being cast into the
+		// equivalent empty value. Thanks Rafael for this suggestion.
 		$castType = $this->getCastType($key);
 		if (strpos($castType, '|null'))
 		{

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1142,12 +1142,12 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('foo' => 'bar'), $model->eighth);
 		$this->assertEquals('{"foo":"bar"}', $model->eighthAttributeValue());
 
-        $this->assertNull($model->intnullasnull);
+		$this->assertNull($model->intnullasnull);
 		$this->assertInternalType('int', $model->intnullasint);
-        $this->assertNull($model->floatnullasnull);
-        $this->assertInternalType('float', $model->floatnullasfloat);
-        $this->assertNull($model->stringnullasnull);
-        $this->assertInternalType('string', $model->stringnullasstring);
+		$this->assertNull($model->floatnullasnull);
+		$this->assertInternalType('float', $model->floatnullasfloat);
+		$this->assertNull($model->stringnullasnull);
+		$this->assertInternalType('string', $model->stringnullasstring);
 
 		$arr = $model->toArray();
 		$this->assertInternalType('int', $arr['first']);
@@ -1164,12 +1164,12 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('foo' => 'bar'), $arr['seventh']);
 		$this->assertEquals(array('foo' => 'bar'), $arr['eighth']);
 
-        $this->assertNull($arr['intnullasnull']);
+		$this->assertNull($arr['intnullasnull']);
 		$this->assertInternalType('int', $arr['intnullasint']);
-        $this->assertNull($arr['floatnullasnull']);
-        $this->assertInternalType('float', $arr['floatnullasfloat']);
-        $this->assertNull($arr['stringnullasnull']);
-        $this->assertInternalType('string', $arr['stringnullasstring']);
+		$this->assertNull($arr['floatnullasnull']);
+		$this->assertInternalType('float', $arr['floatnullasfloat']);
+		$this->assertNull($arr['stringnullasnull']);
+		$this->assertInternalType('string', $arr['stringnullasstring']);
 	}
 
 
@@ -1357,12 +1357,12 @@ class EloquentModelCastingStub extends Illuminate\Database\Eloquent\Model {
 		'sixth' => 'object',
 		'seventh' => 'array',
 		'eighth' => 'json',
-        'intnullasnull' => 'int|null',
-        'intnullasint' => 'int|null',
-        'floatnullasnull' => 'float|null',
-        'floatnullasfloat' => 'float|null',
-        'stringnullasnull' => 'string|null',
-        'stringnullasstring' => 'string|null',
+		'intnullasnull' => 'int|null',
+		'intnullasint' => 'int|null',
+		'floatnullasnull' => 'float|null',
+		'floatnullasfloat' => 'float|null',
+		'stringnullasnull' => 'string|null',
+		'stringnullasstring' => 'string|null',
 	);
 	public function eighthAttributeValue()
 	{

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1120,12 +1120,12 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->seventh = $obj;
 		$model->eighth = array('foo' => 'bar');
 
-        $model->intnullasnull = null;
-        $model->intnullasint = '87';
-        $model->floatnullasnull = null;
-        $model->floatnullasfloat = '12.4';
-        $model->stringnullasnull = null;
-        $model->stringnullasstring = 'bar';
+		$model->intnullasnull = null;
+		$model->intnullasint = '87';
+		$model->floatnullasnull = null;
+		$model->floatnullasfloat = '12.4';
+		$model->stringnullasnull = null;
+		$model->stringnullasstring = 'bar';
 
 		$this->assertInternalType('int', $model->first);
 		$this->assertInternalType('float', $model->second);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1120,6 +1120,13 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->seventh = $obj;
 		$model->eighth = array('foo' => 'bar');
 
+        $model->intnullasnull = null;
+        $model->intnullasint = '87';
+        $model->floatnullasnull = null;
+        $model->floatnullasfloat = '12.4';
+        $model->stringnullasnull = null;
+        $model->stringnullasstring = 'bar';
+
 		$this->assertInternalType('int', $model->first);
 		$this->assertInternalType('float', $model->second);
 		$this->assertInternalType('string', $model->third);
@@ -1135,6 +1142,13 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('foo' => 'bar'), $model->eighth);
 		$this->assertEquals('{"foo":"bar"}', $model->eighthAttributeValue());
 
+        $this->assertNull($model->intnullasnull);
+		$this->assertInternalType('int', $model->intnullasint);
+        $this->assertNull($model->floatnullasnull);
+        $this->assertInternalType('float', $model->floatnullasfloat);
+        $this->assertNull($model->stringnullasnull);
+        $this->assertInternalType('string', $model->stringnullasstring);
+
 		$arr = $model->toArray();
 		$this->assertInternalType('int', $arr['first']);
 		$this->assertInternalType('float', $arr['second']);
@@ -1149,6 +1163,13 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($obj, $arr['sixth']);
 		$this->assertEquals(array('foo' => 'bar'), $arr['seventh']);
 		$this->assertEquals(array('foo' => 'bar'), $arr['eighth']);
+
+        $this->assertNull($arr['intnullasnull']);
+		$this->assertInternalType('int', $arr['intnullasint']);
+        $this->assertNull($arr['floatnullasnull']);
+        $this->assertInternalType('float', $arr['floatnullasfloat']);
+        $this->assertNull($arr['stringnullasnull']);
+        $this->assertInternalType('string', $arr['stringnullasstring']);
 	}
 
 
@@ -1335,7 +1356,13 @@ class EloquentModelCastingStub extends Illuminate\Database\Eloquent\Model {
 		'fifth' => 'boolean',
 		'sixth' => 'object',
 		'seventh' => 'array',
-		'eighth' => 'json'
+		'eighth' => 'json',
+        'intnullasnull' => 'int|null',
+        'intnullasint' => 'int|null',
+        'floatnullasnull' => 'float|null',
+        'floatnullasfloat' => 'float|null',
+        'stringnullasnull' => 'string|null',
+        'stringnullasstring' => 'string|null',
 	);
 	public function eighthAttributeValue()
 	{


### PR DESCRIPTION
Extension to #6782 Casting Of Eloquent Attributes To Native Types

This has already been suggested by @rwillians in this feature request #7507 before I was ready to make this pull request. 

I was talking to someone in the laravel-dev IRC channel on Tuesday and they were upset at my thoughts to modify it to automatically pass null back on any field as it would break backwards compatibility. To avoid these issues I added these extra types `int|null`, `integer|null`, `real|null`, `float|null`, `double|null` and `string|null` which coincidentally is what @barryvdh was suggesting.

Usage:

```
protected $casts = [
    'nullable_int_field' => 'int|null',
    'nullable_float_field' => 'float|null',
    'nullable_string_field' => 'string|null',
];
```
