### PR TITLE
Use the hellip symbol instead of dots ... notation

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -632,7 +632,7 @@ if ( ! function_exists('str_limit'))
 	 * @param  string  $end
 	 * @return string
 	 */
-	function str_limit($value, $limit = 100, $end = '...')
+	function str_limit($value, $limit = 100, $end = '…')
 	{
 		return Str::limit($value, $limit, $end);
 	}


### PR DESCRIPTION
Since the ... actually has its own symbol we should use it. the w3c refference is &hellip; HORIZONTAL ELLIPSIS
