### PR TITLE
[5.0] Add orWhereNull() and orWhereNotNull() aliases

### DIFF
--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -115,6 +115,17 @@ class JoinClause {
 	}
 
 	/**
+	 * Add an "or on where is null" clause to the join.
+	 *
+	 * @param  string  $column
+	 * @return \Illuminate\Database\Query\JoinClause
+	 */
+	public function orWhereNull($column)
+	{
+		return $this->whereNull($column, 'or');
+	}
+
+	/**
 	 * Add an "on where is not null" clause to the join
 	 *
 	 * @param  string  $column
@@ -124,6 +135,17 @@ class JoinClause {
 	public function whereNotNull($column, $boolean = 'and')
 	{
 		return $this->on($column, 'is', new Expression('not null'), $boolean, false);
+	}
+
+	/**
+	 * Add an "or on where is not null" clause to the join.
+	 *
+	 * @param  string  $column
+	 * @return \Illuminate\Database\Query\JoinClause
+	 */
+	public function orWhereNotNull($column)
+	{
+		return $this->whereNotNull($column, 'or');
 	}
 
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -661,6 +661,13 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 			$j->on('users.id', '=', 'contacts.id')->whereNull('contacts.deleted_at');
 		});
 		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."deleted_at" is null', $builder->toSql());
+
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->join('contacts', function($j)
+		{
+			$j->on('users.id', '=', 'contacts.id')->orWhereNull('contacts.deleted_at');
+		});
+		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."deleted_at" is null', $builder->toSql());
 	}
 
 
@@ -672,6 +679,13 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 			$j->on('users.id', '=', 'contacts.id')->whereNotNull('contacts.deleted_at');
 		});
 		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."deleted_at" is not null', $builder->toSql());
+
+		$builder = $this->getBuilder();
+		$builder->select('*')->from('users')->join('contacts', function($j)
+		{
+			$j->on('users.id', '=', 'contacts.id')->orWhereNotNull('contacts.deleted_at');
+		});
+		$this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."deleted_at" is not null', $builder->toSql());
 	}
 
 


### PR DESCRIPTION
https://github.com/laravel/framework/blob/5.0/src/Illuminate/Database/Query/Builder.php  has `orWhere()`, `orWhereNull()` and `orWhereNotNull()` aliases.

https://github.com/laravel/framework/blob/5.0/src/Illuminate/Database/Query/JoinClause.php has only `orWhere()`
This PR adds missing methods and improves api consistency
