### PR TITLE
Allowing for a missing map method in RouteServiceProvider

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -65,7 +65,8 @@ class RouteServiceProvider extends ServiceProvider {
 	 */
 	protected function loadRoutes()
 	{
-		$this->app->call([$this, 'map']);
+		if (method_exists($this, 'map'))
+			$this->app->call([$this, 'map']);
 	}
 
 	/**


### PR DESCRIPTION
I submitted #7527 yesterday which had a no-op `map` function. You pointed out that it breaks dependency injection for that function, so I took a slightly different approach here by only calling the `map` function through the container if it exists.
