### PR TITLE
Adding a Postmark Mail Transport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
     "suggest": {
         "aws/aws-sdk-php": "Required to use the SQS queue driver (~2.4).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.4).",
-        "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers (~5.0).",
+        "guzzlehttp/guzzle": "Required to use the Mailgun, Mandrill, and Postmark mail drivers (~5.0).",
         "iron-io/iron_mq": "Required to use the iron queue driver (~1.5).",
         "league/flysystem-aws-s3-v2": "Required to use the Flysystem S3 driver (~1.0).",
         "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0).",

--- a/src/Illuminate/Mail/Transport/PostmarkTransport.php
+++ b/src/Illuminate/Mail/Transport/PostmarkTransport.php
@@ -1,0 +1,254 @@
+<?php namespace Illuminate\Mail\Transport;
+
+use Swift_Transport;
+use GuzzleHttp\Client;
+use Swift_Mime_Message;
+use Swift_Events_EventListener;
+
+class PostmarkTransport implements Swift_Transport {
+
+	/**
+	 * The Postmark Server Token key.
+	 *
+	 * @var string
+	 */
+	protected $serverToken;
+
+	/**
+	 * Create a new Postmark transport instance.
+	 *
+	 * @param  string  $serverToken
+	 * @return void
+	 */
+	public function __construct($serverToken)
+	{
+		$this->serverToken = $serverToken;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isStarted()
+	{
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function start()
+	{
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function stop()
+	{
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function send(Swift_Mime_Message $message, &$failedRecipients = null)
+	{
+		$client = $this->getHttpClient();
+
+		return $client->post('https://api.postmarkapp.com/email', [
+			'headers' => [
+				'X-Postmark-Server-Token' => $this->serverToken,
+			],
+			'json' => $this->getMessagePayload($message),
+		]);
+	}
+
+	/**
+	 * Convert email dictionary with emails and names
+	 * to array of emails with names.
+	 *
+	 * @param array $emails
+	 * @return array
+	 */
+	private function convertEmailsArray(array $emails)
+	{
+		$convertedEmails = array();
+		foreach ($emails as $email => $name)
+		{
+			$convertedEmails[] = $name
+			? '"'.str_replace('"', '\\"', $name)."\" <{$email}>"
+			: $email;
+		}
+		return $convertedEmails;
+	}
+
+	/**
+	 * @param Swift_Mime_Message $message
+	 * @param string              $mimeType
+	 * @return Swift_Mime_MimePart
+	 */
+	private function getMIMEPart(\Swift_Mime_Message $message, $mimeType)
+	{
+		foreach ($message->getChildren() as $part)
+		{
+			if (strpos($part->getContentType(), $mimeType) === 0 &&  ! ($part instanceof \Swift_Mime_Attachment))
+			{
+				return $part;
+			}
+		}
+	}
+
+	/**
+	 * Convert a Swift Mime Message to a Postmark Payload.
+	 *
+	 * @param  Swift_Mime_Message $message
+	 * @return object
+	 */
+	private function getMessagePayload(Swift_Mime_Message $message)
+	{
+
+		$data = array(
+			'From'    => join(',', $this->convertEmailsArray($message->getFrom())),
+			'To'      => join(',', $this->convertEmailsArray($message->getTo())),
+			'Subject' => $message->getSubject(),
+		);
+
+		if ($cc = $message->getCc())
+		{
+			$data['Cc'] = join(',', $this->convertEmailsArray($cc));
+		}
+		if ($reply_to = $message->getReplyTo())
+		{
+			$data['ReplyTo'] = join(',', $this->convertEmailsArray($reply_to));
+		}
+		if ($bcc = $message->getBcc())
+		{
+			$data['Bcc'] = join(',', $this->convertEmailsArray($bcc));
+		}
+
+		//Get the primary message.
+		switch ($message->getContentType())
+		{
+			case 'text/html':
+			case 'multipart/alternative':
+				$data['HtmlBody'] = $message->getBody();
+				break;
+			default:
+				$data['TextBody'] = $message->getBody();
+				break;
+		}
+
+		// Provide an alternate view from the secondary parts.
+		if ($plain = $this->getMIMEPart($message, 'text/plain'))
+		{
+			$data['TextBody'] = $plain->getBody();
+		}
+		if ($html = $this->getMIMEPart($message, 'text/html'))
+		{
+			$data['HtmlBody'] = $html->getBody();
+		}
+		if ($message->getChildren())
+		{
+			$data['Attachments'] = array();
+			foreach ($message->getChildren() as $attachment)
+			{
+				if (is_object($attachment) and $attachment instanceof \Swift_Mime_Attachment)
+				{
+					$data['Attachments'][] = array(
+						'Name'        => $attachment->getFilename(),
+						'Content'     => base64_encode($attachment->getBody()),
+						'ContentType' => $attachment->getContentType(),
+					);
+				}
+			}
+		}
+		if ($message->getHeaders())
+		{
+			$data['Headers'] = [];
+
+			foreach ($message->getHeaders()->getAll() as $key => $value)
+			{
+				$fieldName = $value->getFieldName();
+
+				if ($fieldName != 'Subject' &&
+					$fieldName != 'Content-Type' &&
+					$fieldName != 'MIME-Version' &&
+					$fieldName != 'Date'
+				)
+				{
+
+					if ($value instanceof \Swift_Mime_Headers_UnstructuredHeader ||
+						$value instanceof \Swift_Mime_Headers_OpenDKIMHeader)
+					{
+						array_push($data['Headers'], [
+							"Name"  => $fieldName,
+							"Value" => $value->getValue(),
+						]);
+					}
+					else if ($value instanceof \Swift_Mime_Headers_DateHeader ||
+						$value instanceof \Swift_Mime_Headers_IdentificationHeader ||
+						$value instanceof \Swift_Mime_Headers_ParameterizedHeader ||
+						$value instanceof \Swift_Mime_Headers_PathHeader)
+					{
+						if ($value->getFieldName() != 'Subject')
+						{
+							array_push($data['Headers'], [
+								"Name"  => $fieldName,
+								"Value" => $value->getFieldBody(),
+							]);
+						}
+						if ($value->getFieldName() == 'Message-ID')
+						{
+							array_push($data['Headers'], [
+								"Name"  => 'X-PM-KeepID',
+								"Value" => 'true',
+							]);
+						}
+					}
+				}
+			}
+		}
+		return $data;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function registerPlugin(Swift_Events_EventListener $plugin)
+	{
+		//
+	}
+
+	/**
+	 * Get a new HTTP client instance.
+	 *
+	 * @return \GuzzleHttp\Client
+	 */
+	protected function getHttpClient()
+	{
+		return new Client;
+	}
+
+	/**
+	 * Get the API key being used by the transport.
+	 *
+	 * @return string
+	 */
+	public function getServerToken()
+	{
+		return $this->token;
+	}
+
+	/**
+	 * Set the API Server Token being used by the transport.
+	 *
+	 * @param  string  $serverToken
+	 * @return void
+	 */
+	public function setServerToken($serverToken)
+	{
+		return $this->serverToken = $serverToken;
+	}
+
+}

--- a/src/Illuminate/Mail/Transport/PostmarkTransport.php
+++ b/src/Illuminate/Mail/Transport/PostmarkTransport.php
@@ -68,7 +68,7 @@ class PostmarkTransport implements Swift_Transport {
 	 * Convert email dictionary with emails and names
 	 * to array of emails with names.
 	 *
-	 * @param  array $emails
+	 * @param  array  $emails
 	 * @return array
 	 */
 	private function convertEmailsArray(array $emails)
@@ -88,8 +88,8 @@ class PostmarkTransport implements Swift_Transport {
 	 * Excludes parts of type \Swift_Mime_Attachment as those
 	 * are handled later.
 	 *
-	 * @param  Swift_Mime_Message $message
-	 * @param  string             $mimeType
+	 * @param  Swift_Mime_Message  $message
+	 * @param  string              $mimeType
 	 * @return Swift_Mime_MimePart
 	 */
 	private function getMIMEPart(\Swift_Mime_Message $message, $mimeType)
@@ -106,7 +106,7 @@ class PostmarkTransport implements Swift_Transport {
 	/**
 	 * Convert a Swift Mime Message to a Postmark Payload.
 	 *
-	 * @param  Swift_Mime_Message $message
+	 * @param  Swift_Mime_Message  $message
 	 * @return object
 	 */
 	private function getMessagePayload(Swift_Mime_Message $message)
@@ -125,8 +125,8 @@ class PostmarkTransport implements Swift_Transport {
 	/**
 	 * Applies the recipients of the message into the API Payload.
 	 *
-	 * @param  array              $payload
-	 * @param  Swift_Mime_Message $message
+	 * @param  array               $payload
+	 * @param  Swift_Mime_Message  $message
 	 * @return object
 	 */
 	private function processRecipients(&$payload, $message)
@@ -153,8 +153,8 @@ class PostmarkTransport implements Swift_Transport {
 	 * Applies the message parts and attachments
 	 * into the API Payload.
 	 *
-	 * @param  array              $payload
-	 * @param  Swift_Mime_Message $message
+	 * @param  array               $payload
+	 * @param  Swift_Mime_Message  $message
 	 * @return object
 	 */
 	private function processMessageParts(&$payload, $message)
@@ -200,8 +200,8 @@ class PostmarkTransport implements Swift_Transport {
 	/**
 	 * Applies the headers into the API Payload.
 	 *
-	 * @param  array              $payload
-	 * @param  Swift_Mime_Message $message
+	 * @param  array               $payload
+	 * @param  Swift_Mime_Message  $message
 	 * @return object
 	 */
 	private function processHeaders(&$payload, $message)

--- a/src/Illuminate/Mail/Transport/PostmarkTransport.php
+++ b/src/Illuminate/Mail/Transport/PostmarkTransport.php
@@ -84,6 +84,10 @@ class PostmarkTransport implements Swift_Transport {
 	}
 
 	/**
+	 * Gets MIME parts that match the message type.
+	 * Excludes parts of type \Swift_Mime_Attachment as those
+	 * are handled later.
+	 *
 	 * @param  Swift_Mime_Message $message
 	 * @param  string             $mimeType
 	 * @return Swift_Mime_MimePart
@@ -118,6 +122,13 @@ class PostmarkTransport implements Swift_Transport {
 		return $payload;
 	}
 
+	/**
+	 * Applies the recipients of the message into the API Payload.
+	 *
+	 * @param  array              $payload
+	 * @param  Swift_Mime_Message $message
+	 * @return object
+	 */
 	private function processRecipients(&$payload, $message)
 	{
 		$payload['From'] = join(',', $this->convertEmailsArray($message->getFrom()));
@@ -138,6 +149,14 @@ class PostmarkTransport implements Swift_Transport {
 		}
 	}
 
+	/**
+	 * Applies the message parts and attachments
+	 * into the API Payload.
+	 *
+	 * @param  array              $payload
+	 * @param  Swift_Mime_Message $message
+	 * @return object
+	 */
 	private function processMessageParts(&$payload, $message)
 	{
 		//Get the primary message.
@@ -178,6 +197,13 @@ class PostmarkTransport implements Swift_Transport {
 		}
 	}
 
+	/**
+	 * Applies the headers into the API Payload.
+	 *
+	 * @param  array              $payload
+	 * @param  Swift_Mime_Message $message
+	 * @return object
+	 */
 	private function processHeaders(&$payload, $message)
 	{
 		if ($message->getHeaders())

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -2,12 +2,13 @@
 
 use Aws\Ses\SesClient;
 use Illuminate\Support\Manager;
-use Swift_SmtpTransport as SmtpTransport;
 use Swift_MailTransport as MailTransport;
+use Swift_SmtpTransport as SmtpTransport;
 use Illuminate\Mail\Transport\LogTransport;
+use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\Mail\Transport\MailgunTransport;
 use Illuminate\Mail\Transport\MandrillTransport;
-use Illuminate\Mail\Transport\SesTransport;
+use Illuminate\Mail\Transport\PostmarkTransport;
 use Swift_SendmailTransport as SendmailTransport;
 
 class TransportManager extends Manager {
@@ -102,6 +103,18 @@ class TransportManager extends Manager {
 		$config = $this->app['config']->get('services.mandrill', array());
 
 		return new MandrillTransport($config['secret']);
+	}
+
+	/**
+	 * Create an instance of the Postmark Swift Transport driver.
+	 *
+	 * @return \Illuminate\Mail\Transport\PostmarkTransport
+	 */
+	protected function createPostmarkDriver()
+	{
+		$config = $this->app['config']->get('services.postmark', array());
+
+		return new PostmarkTransport($config['serverToken']);
 	}
 
 	/**

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "suggest": {
-        "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers (~5.0)."
+        "guzzlehttp/guzzle": "Required to use the Mailgun, Mandrill, and Postmark mail drivers (~5.0)."
     },
     "minimum-stability": "dev"
 }

--- a/tests/Mail/MailPostmarkTransportTest.php
+++ b/tests/Mail/MailPostmarkTransportTest.php
@@ -1,0 +1,74 @@
+<?php
+
+class MailPostmarkTransportTest extends PHPUnit_Framework_TestCase {
+
+	public function testSend()
+	{
+		$message = new Swift_Message('Is alive!', 'Doo-wah-ditty.');
+		$message->setFrom('johnny5@example.com', 'Johnny #5');
+		$message->addTo('you@example.com', 'A. Friend');
+		$message->addTo('you+two@example.com');
+		$message->addCc('another+1@example.com');
+		$message->addCc('another+2@example.com', 'Extra 2');
+		$message->addBcc('another+3@example.com');
+		$message->addBcc('another+4@example.com', 'Extra 4');
+		$message->addPart('<q>Help me Rhonda</q>', 'text/html');
+		$message->attach(Swift_Attachment::newInstance('This is the plain text attachment.', 'hello.txt', 'text/plain'));
+		$message->setPriority(1);
+
+		$headers   = $message->getHeaders();
+		$messageId = $headers->get('Message-ID')->getId();
+
+		$transport = new PostmarkTransportStub('TESTING_SERVER');
+
+		$client = $this->getMock('GuzzleHttp\Client', array('post'));
+		$transport->setHttpClient($client);
+
+		$client->expects($this->once())
+		       ->method('post')
+		       ->with($this->equalTo('https://api.postmarkapp.com/email'),
+			       $this->equalTo([
+				        'headers' => [
+					        'X-Postmark-Server-Token' => 'TESTING_SERVER',
+				        ],
+				        'json'      => [
+					        'From'     => '"Johnny #5" <johnny5@example.com>',
+					        'To'       => '"A. Friend" <you@example.com>,you+two@example.com',
+					        'Cc'       => 'another+1@example.com,"Extra 2" <another+2@example.com>',
+					        'Bcc'      => 'another+3@example.com,"Extra 4" <another+4@example.com>',
+					        'Subject'  => 'Is alive!',
+					        'TextBody' => 'Doo-wah-ditty.',
+					        'HtmlBody' => '<q>Help me Rhonda</q>',
+					        'Headers'  => [
+						        ['Name'   => 'Message-ID', 'Value'   => '<'.$messageId.'>'],
+						        ['Name'   => 'X-PM-KeepID', 'Value'   => 'true'],
+						        ['Name'   => 'X-Priority', 'Value'   => '1 (Highest)'],
+					        ],
+					        'Attachments' => [
+						        [
+							        'ContentType' => 'text/plain',
+							        'Content'     => 'VGhpcyBpcyB0aGUgcGxhaW4gdGV4dCBhdHRhY2htZW50Lg==',
+							        'Name'        => 'hello.txt',
+						        ],
+					        ],
+				        ],
+			        ])
+		       );
+
+		$transport->send($message);
+	}
+}
+
+class PostmarkTransportStub extends \Illuminate\Mail\Transport\PostmarkTransport {
+	protected $client;
+
+	protected function getHttpClient()
+	{
+		return $this->client;
+	}
+
+	public function setHttpClient($client)
+	{
+		$this->client = $client;
+	}
+}


### PR DESCRIPTION
This commit adds a transport to interact with the Postmark REST API. 

Note that even though the `use` statements `src/Illuminate/Mail/TransportManager.php` have been alphabetized, all of the previous `use` statements are still present. I've also integrated version into a test Laravel project and confirmed proper function of the transport against the live API.

If this PR is accepted, I will submit corresponding updates to the `config\services.php` in laravel/laravel, and the documentation laravel/documentation.

Please let me know if you have any questions, and thanks!
