### PR TITLE
[5.0] Fix getDates() mutator when date is UNIX timestamp (for 0 value)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2595,7 +2595,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		// date fields without having to create a mutator for each property.
 		elseif (in_array($key, $this->getDates()))
 		{
-			if ($value) return $this->asDateTime($value);
+			if (!is_null($value)) return $this->asDateTime($value);
 		}
 
 		return $value;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -333,6 +333,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf('Carbon\Carbon', $model->created_at);
 
 		$model = new EloquentDateModelStub;
+		$model->created_at = 0;
+		$this->assertInstanceOf('Carbon\Carbon', $model->created_at);
+
+		$model = new EloquentDateModelStub;
 		$model->created_at = '2012-01-01';
 		$this->assertInstanceOf('Carbon\Carbon', $model->created_at);
 	}


### PR DESCRIPTION
Fix for issue #7547

Add new assert in testTimestampsAreCreatedFromStringsAndIntegers() method. Add case when UNIX timestamp is 0

Fix getAttributeValue method.
