### PR TITLE
Fix Http\Request::input() phpdoc @return

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -282,7 +282,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 *
 	 * @param  string  $key
 	 * @param  mixed   $default
-	 * @return string
+	 * @return string|array
 	 */
 	public function input($key = null, $default = null)
 	{


### PR DESCRIPTION
Fix Http\Request::input() phpdoc @return type: method can return array instead of string
