### PR TITLE
Strip parentheses in column type when set to column change options.

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -350,23 +350,39 @@ abstract class Grammar extends BaseGrammar {
 		)->getColumn($fluent['name']);
 	}
 
-	/**
-	 * Get the Doctrine column change options.
-	 *
-	 * @param  \Illuminate\Support\Fluent  $fluent
-	 * @return array
-	 */
-	protected function getDoctrineColumnChangeOptions(Fluent $fluent)
-	{
-		$options = ['type' => Type::getType($fluent['type'])];
+    /**
+     * Get the Doctrine column change options.
+     *
+     * @param  \Illuminate\Support\Fluent  $fluent
+     * @return array
+     */
+    protected function getDoctrineColumnChangeOptions(Fluent $fluent)
+    {
 
-		if (in_array($fluent['type'], ['text', 'mediumText', 'longText']))
-		{
-			$options['length'] = $this->calculateDoctrineTextLength($fluent['type']);
-		}
+        $options = ['type' => Type::getType($this->getDoctrineColumnBaseType($this->getType($fluent)))];
 
-		return $options;
-	}
+        if (in_array($fluent['type'], ['text', 'mediumText', 'longText']))
+        {
+            $options['length'] = $this->calculateDoctrineTextLength($fluent['type']);
+        }
+
+        return $options;
+    }
+
+    /**
+     * Strip column type parentheses
+     *
+     * @param $type
+     * @return string
+     */
+    protected function getDoctrineColumnBaseType($type)
+    {
+        if ($parenPos = strpos($type, '('))
+        {
+            $type = substr($type, 0, $parenPos);
+        }
+        return $type;
+    }
 
 	/**
 	 * Calculate the proper column length to force the Doctrine text type.


### PR DESCRIPTION
https://github.com/laravel/framework/commit/72d3febb752fb252148f8cd7a677587db8f20d04 broke changing columns of type bigint (and probably others) in v5.0.6. This change simply strips the parentheses when set in the column options during a change operation. Now both decimal and bigint change operations work.
