### PR TITLE
Add callable support to helpers and collection

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -1,6 +1,5 @@
 <?php namespace Illuminate\Support;
 
-use Closure;
 use Illuminate\Support\Traits\Macroable;
 
 class Arr {
@@ -28,13 +27,13 @@ class Arr {
 	/**
 	 * Build a new array using a callback.
 	 *
-	 * @param  array     $array
-	 * @param  \Closure  $callback
+	 * @param  array  $array
+	 * @param  callable  $callback
 	 * @return array
 	 */
-	public static function build($array, Closure $callback)
+	public static function build($array, callable $callback)
 	{
-		$results = array();
+		$results = [];
 
 		foreach ($array as $key => $value)
 		{
@@ -54,7 +53,7 @@ class Arr {
 	 */
 	public static function divide($array)
 	{
-		return array(array_keys($array), array_values($array));
+		return [array_keys($array), array_values($array)];
 	}
 
 	/**
@@ -66,7 +65,7 @@ class Arr {
 	 */
 	public static function dot($array, $prepend = '')
 	{
-		$results = array();
+		$results = [];
 
 		foreach ($array as $key => $value)
 		{
@@ -106,7 +105,7 @@ class Arr {
 	{
 		foreach (explode('.', $key) as $segment)
 		{
-			$results = array();
+			$results = [];
 
 			foreach ($array as $value)
 			{
@@ -125,12 +124,12 @@ class Arr {
 	/**
 	 * Return the first element in an array passing a given truth test.
 	 *
-	 * @param  array     $array
-	 * @param  \Closure  $callback
-	 * @param  mixed     $default
+	 * @param  array  $array
+	 * @param  callable  $callback
+	 * @param  mixed  $default
 	 * @return mixed
 	 */
-	public static function first($array, $callback, $default = null)
+	public static function first($array, callable $callback, $default = null)
 	{
 		foreach ($array as $key => $value)
 		{
@@ -143,12 +142,12 @@ class Arr {
 	/**
 	 * Return the last element in an array passing a given truth test.
 	 *
-	 * @param  array     $array
-	 * @param  \Closure  $callback
-	 * @param  mixed     $default
+	 * @param  array  $array
+	 * @param  callable  $callback
+	 * @param  mixed  $default
 	 * @return mixed
 	 */
-	public static function last($array, $callback, $default = null)
+	public static function last($array, callable $callback, $default = null)
 	{
 		return static::first(array_reverse($array), $callback, $default);
 	}
@@ -161,7 +160,7 @@ class Arr {
 	 */
 	public static function flatten($array)
 	{
-		$return = array();
+		$return = [];
 
 		array_walk_recursive($array, function($x) use (&$return) { $return[] = $x; });
 
@@ -275,7 +274,7 @@ class Arr {
 	 */
 	public static function pluck($array, $value, $key = null)
 	{
-		$results = array();
+		$results = [];
 
 		foreach ($array as $item)
 		{
@@ -341,7 +340,7 @@ class Arr {
 			// values at the correct depth. Then we'll keep digging into the array.
 			if ( ! isset($array[$key]) || ! is_array($array[$key]))
 			{
-				$array[$key] = array();
+				$array[$key] = [];
 			}
 
 			$array =& $array[$key];
@@ -353,27 +352,27 @@ class Arr {
 	}
 
 	/**
-	 * Sort the array using the given Closure.
+	 * Sort the array using the given callback.
 	 *
-	 * @param  array     $array
-	 * @param  \Closure  $callback
+	 * @param  array  $array
+	 * @param  callable  $callback
 	 * @return array
 	 */
-	public static function sort($array, Closure $callback)
+	public static function sort($array, callable $callback)
 	{
 		return Collection::make($array)->sortBy($callback)->all();
 	}
 
 	/**
-	 * Filter the array using the given Closure.
+	 * Filter the array using the given callback.
 	 *
-	 * @param  array     $array
-	 * @param  \Closure  $callback
+	 * @param  array  $array
+	 * @param  callable  $callback
 	 * @return array
 	 */
-	public static function where($array, Closure $callback)
+	public static function where($array, callable $callback)
 	{
-		$filtered = array();
+		$filtered = [];
 
 		foreach ($array as $key => $value)
 		{

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -52,11 +52,11 @@ if ( ! function_exists('array_build'))
 	/**
 	 * Build a new array using a callback.
 	 *
-	 * @param  array     $array
-	 * @param  \Closure  $callback
+	 * @param  array  $array
+	 * @param  callable  $callback
 	 * @return array
 	 */
-	function array_build($array, Closure $callback)
+	function array_build($array, callable $callback)
 	{
 		return Arr::build($array, $callback);
 	}
@@ -126,12 +126,12 @@ if ( ! function_exists('array_first'))
 	/**
 	 * Return the first element in an array passing a given truth test.
 	 *
-	 * @param  array     $array
-	 * @param  \Closure  $callback
-	 * @param  mixed     $default
+	 * @param  array  $array
+	 * @param  callable  $callback
+	 * @param  mixed  $default
 	 * @return mixed
 	 */
-	function array_first($array, $callback, $default = null)
+	function array_first($array, callable $callback, $default = null)
 	{
 		return Arr::first($array, $callback, $default);
 	}
@@ -142,9 +142,9 @@ if ( ! function_exists('array_last'))
 	/**
 	 * Return the last element in an array passing a given truth test.
 	 *
-	 * @param  array     $array
-	 * @param  \Closure  $callback
-	 * @param  mixed     $default
+	 * @param  array  $array
+	 * @param  callable  $callback
+	 * @param  mixed  $default
 	 * @return mixed
 	 */
 	function array_last($array, $callback, $default = null)
@@ -281,13 +281,13 @@ if ( ! function_exists('array_set'))
 if ( ! function_exists('array_sort'))
 {
 	/**
-	 * Sort the array using the given Closure.
+	 * Sort the array using the given callback.
 	 *
-	 * @param  array     $array
-	 * @param  \Closure  $callback
+	 * @param  array  $array
+	 * @param  callable  $callback
 	 * @return array
 	 */
-	function array_sort($array, Closure $callback)
+	function array_sort($array, callable $callback)
 	{
 		return Arr::sort($array, $callback);
 	}
@@ -296,13 +296,13 @@ if ( ! function_exists('array_sort'))
 if ( ! function_exists('array_where'))
 {
 	/**
-	 * Filter the array using the given Closure.
+	 * Filter the array using the given callback.
 	 *
-	 * @param  array     $array
-	 * @param  \Closure  $callback
+	 * @param  array  $array
+	 * @param  callable  $callback
 	 * @return array
 	 */
-	function array_where($array, Closure $callback)
+	function array_where($array, callable $callback)
 	{
 		return Arr::where($array, $callback);
 	}


### PR DESCRIPTION
Before we required 5.4, we couldn't use the `callable` check or type-hint. This has resulted in the restriction to a closure in many places where it really shouldn't be.

I've previously tried to solve this [using a `closure` helper](https://github.com/laravel/framework/pull/7362), but that was rejected (and probably with good measure - it's kind of a hack).

This change addresses the root of the problem instead: wherever possible, we now opt for `callable` instead of `Closure`.
