### PR TITLE
Change typehinting in Bladecompiler to extend via __invoke

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -687,10 +687,10 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	/**
 	 * Register a custom Blade compiler.
 	 *
-	 * @param  \Closure  $compiler
+	 * @param  callable  $compiler
 	 * @return void
 	 */
-	public function extend(Closure $compiler)
+	public function extend(callable $compiler)
 	{
 		$this->extensions[] = $compiler;
 	}


### PR DESCRIPTION
To use classes to extend Blade, it has to implement __invoke to satisfy callable typehinting. Anonymous function are still working as well.
Taylor wanted it in the 5.0-Branch.
