### PR TITLE
[5.0] Allow composer require illuminate/routing without extra illuminate/events

### DIFF
--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -12,6 +12,7 @@
         "php": ">=5.4.0",
         "illuminate/container": "5.0.*",
         "illuminate/contracts": "5.0.*",
+        "illuminate/events": "5.0.*",
         "illuminate/http": "5.0.*",
         "illuminate/pipeline": "5.0.*",
         "illuminate/session": "5.0.*",


### PR DESCRIPTION
If we are trying to use `illuminate/routing`, we are required to manually require `illuminate/events` as it's used in the [`__construct`](https://github.com/laravel/framework/blob/5.0/src/Illuminate/Routing/Router.php#L110) method of  `Illuminate\Routing\Router.php`. This change will allow us to only require `illuminate/routing` if we want to use the routing system without the main Laravel framework.
