### PR TITLE
[5.0] Fix model generator table name

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -37,7 +37,7 @@ class ModelMakeCommand extends GeneratorCommand {
 
 		if ( ! $this->option('no-migration'))
 		{
-			$table = str_plural(strtolower(class_basename($this->argument('name'))));
+			$table = str_plural(snake_case(class_basename($this->argument('name'))));
 
 			$this->call('make:migration', ['name' => "create_{$table}_table", '--create' => $table]);
 		}


### PR DESCRIPTION
According to conventions table name should be snake cased.
