### PR TITLE
[5.0] Use snake_case instead of strtolower in make model command.

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -37,7 +37,7 @@ class ModelMakeCommand extends GeneratorCommand {
 
 		if ( ! $this->option('no-migration'))
 		{
-			$table = str_plural(strtolower(class_basename($this->argument('name'))));
+			$table = str_plural(snake_case(class_basename($this->argument('name'))));
 
 			$this->call('make:migration', ['name' => "create_{$table}_table", '--create' => $table]);
 		}


### PR DESCRIPTION
Replaced `strtolower` with `snake_case`. Reason being, when I create a model called `OrderItem`, the migration it generated created a table named `orderitems`. I’d have expected the table to be named `order_items` instead.
