### PR TITLE
Add support to LIKE BINARY

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -172,7 +172,7 @@ class Builder {
 	 */
 	protected $operators = array(
 		'=', '<', '>', '<=', '>=', '<>', '!=',
-		'like', 'not like', 'between', 'ilike',
+		'like', 'like binary', 'not like', 'between', 'ilike',
 		'&', '|', '^', '<<', '>>',
 		'rlike', 'regexp', 'not regexp', 
 		'~', '~*', '!~', '!~*', 'similar to',


### PR DESCRIPTION
I added "like binary" in $operators to support operator when use "where" and others functions
