### PR TITLE
Ignore unwritable file in app:name

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -227,7 +227,10 @@ class AppNameCommand extends Command {
 	 */
 	protected function replaceIn($path, $search, $replace)
 	{
-		$this->files->put($path, str_replace($search, $replace, $this->files->get($path)));
+        if ($this->files->isWritable($path))
+        {
+            $this->files->put($path, str_replace($search, $replace, $this->files->get($path)));
+        }
 	}
 
 	/**


### PR DESCRIPTION
This stops the renaming process, breaking all your namespaces
