### PR TITLE
Allow date input format override in models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2772,7 +2772,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		// the connection grammar's date format. We will auto set the values.
 		elseif (in_array($key, $this->getDates()) && $value)
 		{
-			$value = $this->fromDateTime($value);
+			$value = $this->fromDateTime($value, $this->getInputDateFormat($key));
 		}
 
 		if ($this->isJsonCastable($key))
@@ -2810,9 +2810,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * Convert a DateTime to a storable string.
 	 *
 	 * @param  \DateTime|int  $value
+	 * @param  string         $inputDateFormat
 	 * @return string
 	 */
-	public function fromDateTime($value)
+	public function fromDateTime($value, $inputDateFormat = null)
 	{
 		$format = $this->getDateFormat();
 
@@ -2845,7 +2846,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		// can return back the finally formatted DateTime instances to the devs.
 		else
 		{
-			$value = Carbon::createFromFormat($format, $value);
+			$value = Carbon::createFromFormat($inputDateFormat ?: $format, $value);
 		}
 
 		return $value->format($format);
@@ -2896,6 +2897,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	protected function getDateFormat()
 	{
 		return $this->getConnection()->getQueryGrammar()->getDateFormat();
+	}
+
+	/**
+	 * Get the format for input dates.
+	 *
+	 * @param  string  $attribute
+	 * @return string
+	 */
+	protected function getInputDateFormat($attribute)
+	{
+		return $this->getDateFormat();
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -341,6 +341,18 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf('Carbon\Carbon', $model->created_at);
 	}
 
+	public function testTimestampsAreCreatedFromStringsWithAlternativeFormat()
+	{
+		$model = $this->getMock('EloquentDateModelStub', array('getInputDateFormat'));
+		$model->expects($this->any())->method('getInputDateFormat')->will($this->returnValue('d.m.Y H:i'));
+
+		$model->created_at = '21.01.2015 12:10';
+		$this->assertInstanceOf('Carbon\Carbon', $model->created_at);
+
+		$model->updated_at = Carbon\Carbon::now();
+		$this->assertInstanceOf('Carbon\Carbon', $model->updated_at);
+	}
+
 
 	public function testInsertProcess()
 	{


### PR DESCRIPTION
``` php
$user->updated_at = '21.01.2015 12:30';
```

To parse date inputs with custom formats one must currently set mutators for each attribute.

``` php
public function setCreatedAtAttribute($date)
{
    $this->attributes['created_at'] = $date ? Carbon::createFromFormat('d.m.Y H:i', $date)->toDateTimeString() : null;
}

public function setUpdatedAtAttribute($date)
{
    $this->attributes['updated_at'] = $date ? Carbon::createFromFormat('d.m.Y H:i', $date)->toDateTimeString() : null;
}
```

This pull request allows us to override input date format.

Simple case:

``` php
protected function getInputDateFormat($attribute)
{
    return 'd.m.Y H:i';
}
```

More complex example:

``` php
protected function getInputDateFormat($attribute)
{
    switch ($attribute) {
        case 'created_at':
        case 'updated_at':
            return 'd.m.Y H:i';

        case 'birth_day':
            return 'd.m.Y';
    }

    return $this->getDateFormat();
}
```
