### PR TITLE
[5.0] Fix DB::raw in having clause $value

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1059,7 +1059,10 @@ class Builder {
 
 		$this->havings[] = compact('type', 'column', 'operator', 'value', 'boolean');
 
-		$this->addBinding($value, 'having');
+		if ( ! $value instanceof Expression)
+		{
+			$this->addBinding($value, 'having');
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
Issue: https://github.com/laravel/framework/issues/5131

Example (just an example):

``` php
$results = DB::table('item')
            ->where('department', '=', 'popular')
            ->groupBy('category')
            ->having('total', '>', DB::raw('3'))
            ->get(['category', DB::raw('count(*) as "total"')]);

dd($results);
```

Before:

![image](https://cloud.githubusercontent.com/assets/999232/6372148/a83ef676-bce0-11e4-8736-0772b74b5f20.png)

After this fix:

![image](https://cloud.githubusercontent.com/assets/999232/6372155/b03ce522-bce0-11e4-841d-b063f9631227.png)
