### PR TITLE
Process closures properly in Eloquent Collection::contains()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -67,7 +67,7 @@ class Collection extends BaseCollection {
 	 */
 	public function contains($key, $value = null)
 	{
-		if (func_num_args() == 1)
+		if (func_num_args() == 1 && ! is_callable($key))
 		{
 			return ! is_null($this->find($key));
 		}

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -89,7 +89,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 			});
 		}
 
-		if ($key instanceof Closure)
+		if (is_callable($key))
 		{
 			return ! is_null($this->first($key));
 		}


### PR DESCRIPTION
Only call `find()` when $key is not a callable.
