### PR TITLE
[5.0] Added functionality to Validator each() to work on non-numeric indexed arrays.

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -278,14 +278,14 @@ class Validator implements ValidatorContract {
 		{
 			foreach ($rules as $ruleKey => $ruleValue)
 			{
-                if (!is_string($ruleKey))
-                {
-                    $this->mergeRules("$attribute.$dataKey", $ruleValue);
-                }
-                else
-                {
-                    $this->mergeRules("$attribute.$dataKey.$ruleKey", $ruleValue);
-                }
+				if ( ! is_string($ruleKey))
+				{
+					$this->mergeRules("$attribute.$dataKey", $ruleValue);
+				}
+				else
+				{
+					$this->mergeRules("$attribute.$dataKey.$ruleKey", $ruleValue);
+				}
 			}
 		}
 	}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -276,9 +276,9 @@ class Validator implements ValidatorContract {
 
 		foreach ($data as $dataKey => $dataValue)
 		{
-			foreach ($rules as $ruleValue)
+			foreach ($rules as $ruleKey => $ruleValue)
 			{
-				$this->mergeRules("$attribute.$dataKey", $ruleValue);
+				$this->mergeRules("$attribute.$dataKey.$ruleKey", $ruleValue);
 			}
 		}
 	}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -278,7 +278,14 @@ class Validator implements ValidatorContract {
 		{
 			foreach ($rules as $ruleKey => $ruleValue)
 			{
-				$this->mergeRules("$attribute.$dataKey.$ruleKey", $ruleValue);
+                if (!is_string($ruleKey))
+                {
+                    $this->mergeRules("$attribute.$dataKey", $ruleValue);
+                }
+                else
+                {
+                    $this->mergeRules("$attribute.$dataKey.$ruleKey", $ruleValue);
+                }
 			}
 		}
 	}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1382,14 +1382,27 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$data = ['foo' => [5, 10, 15]];
 
 		$v = new Validator($trans, $data, ['foo' => 'Array']);
-		$v->each('foo', ['field' => 'numeric|min:6|max:14']);
+		$v->each('foo', ['numeric|min:6|max:14']);
 		$this->assertFalse($v->passes());
 
 		$v = new Validator($trans, $data, ['foo' => 'Array']);
-		$v->each('foo', ['field' => 'numeric|min:4|max:16']);
+		$v->each('foo', ['numeric|min:4|max:16']);
 		$this->assertTrue($v->passes());
 	}
 
+    public function testValidateEachWithNonIndexedArray()
+    {
+        $trans = $this->getRealTranslator();
+        $data = ['foobar' => [['key' => 'foo', 'value' => 5], ['key' => 'foo', 'value' => 10]]];
+
+        $v = new Validator($trans, $data, ['foo' => 'Array']);
+        $v->each('foobar', ['key' => 'required', 'value' => 'numeric|min:6|max:14']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, $data, ['foo' => 'Array']);
+        $v->each('foobar', ['key' => 'required', 'value' => 'numeric|min:4|max:16']);
+        $this->assertTrue($v->passes());
+    }
 
 	public function testValidateEachWithNonArrayWithArrayRule()
 	{

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1393,7 +1393,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
     public function testValidateEachWithNonIndexedArray()
     {
         $trans = $this->getRealTranslator();
-        $data = ['foobar' => [['key' => 'foo', 'value' => 5], ['key' => 'foo', 'value' => 10]]];
+        $data = ['foobar' => [
+            ['key' => 'foo', 'value' => 5],
+            ['key' => 'foo', 'value' => 10],
+            ['key' => 'foo', 'value' => 16]
+        ]];
 
         $v = new Validator($trans, $data, ['foo' => 'Array']);
         $v->each('foobar', ['key' => 'required', 'value' => 'numeric|min:6|max:14']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1390,23 +1390,23 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 	}
 
-    public function testValidateEachWithNonIndexedArray()
-    {
-        $trans = $this->getRealTranslator();
-        $data = ['foobar' => [
-            ['key' => 'foo', 'value' => 5],
-            ['key' => 'foo', 'value' => 10],
-            ['key' => 'foo', 'value' => 16]
-        ]];
-
-        $v = new Validator($trans, $data, ['foo' => 'Array']);
-        $v->each('foobar', ['key' => 'required', 'value' => 'numeric|min:6|max:14']);
-        $this->assertFalse($v->passes());
-
-        $v = new Validator($trans, $data, ['foo' => 'Array']);
-        $v->each('foobar', ['key' => 'required', 'value' => 'numeric|min:4|max:16']);
-        $this->assertTrue($v->passes());
-    }
+	public function testValidateEachWithNonIndexedArray()
+	{
+		$trans = $this->getRealTranslator();
+		$data = ['foobar' => [
+			['key' => 'foo', 'value' => 5],
+			['key' => 'foo', 'value' => 10],
+			['key' => 'foo', 'value' => 16]
+		]];
+		
+		$v = new Validator($trans, $data, ['foo' => 'Array']);
+		$v->each('foobar', ['key' => 'required', 'value' => 'numeric|min:6|max:14']);
+		$this->assertFalse($v->passes());
+		
+		$v = new Validator($trans, $data, ['foo' => 'Array']);
+		$v->each('foobar', ['key' => 'required', 'value' => 'numeric|min:4|max:16']);
+		$this->assertTrue($v->passes());
+	}
 
 	public function testValidateEachWithNonArrayWithArrayRule()
 	{


### PR DESCRIPTION
Hi guys,

regarding to #7598 i want to tackle the problem again.

When passing a string indexed array as ruleset to `each()` that one will be interpreted to work on non-numeric indexed arrays.
Otherwise the old way to build the rule will be used. 

I added a new test to show, how I think it should work. Tests are passing this time.

If you reject this solution as well, I won't send pull requests regarding to this topic again. 
Thank you for your time.

best regards,
eric
