### PR TITLE
Issue with ltrim replace with preg_replace

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -86,9 +86,11 @@ class LoadConfiguration {
 	 */
 	private function getConfigurationNesting(SplFileInfo $file)
 	{
-		if ($tree = ltrim(dirname($file->getRealPath()), config_path()))
+		$pattern = '/^'. preg_quote(config_path(), DIRECTORY_SEPARATOR).'/';
+
+		if ($tree = preg_replace($pattern, '', dirname($file->getRealPath()) ))
 		{
-			$tree = str_replace(DIRECTORY_SEPARATOR, '.', $tree) . '.';
+			$tree = str_replace(DIRECTORY_SEPARATOR, '.', substr($tree, 1)) . '.';
 		}
 
 		return $tree;


### PR DESCRIPTION
We were having issues with the ltrim function in PHP causing it to 'cut into' our directory structure. See the following example:

``` php
print ltrim('/home/vagrant/Code/dci/config/deviseasdf1', '/home/vagrant/Code/dci/config');
```

**Expected Result:** `deviseasdf1`

**What you get is:** `seasdf1`

This is causing Laravel to look in a non-existent directory for the config file. For the solution I have replaced ltrim with a preg_replace and then trimmed off the extra slash with a substr.
