### PR TITLE
Set perPage default parameter to null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -243,7 +243,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
 	 */
-	public function paginate($perPage = 15, $columns = ['*'])
+	public function paginate($perPage = null, $columns = ['*'])
 	{
 		$total = $this->query->getCountForPagination();
 


### PR DESCRIPTION
Set the perPage default parameter to null so the value defined in a Model will be used.
