### PR TITLE
[5.0] Correct page count with group by clauses

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -245,7 +245,7 @@ class Builder {
 	 */
 	public function paginate($perPage = null, $columns = ['*'])
 	{
-		$total = $this->query->getCountForPagination();
+		$total = $this->query->getTotalForPagination();
 
 		$this->query->forPage(
 			$page = Paginator::resolveCurrentPage(),

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1268,6 +1268,17 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testGroupPagination()
+	{
+		$builder = $this->getBuilder();
+		$builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from (select * from "users" group by "id") aggregator_query', array(), true)->andReturn(array(array('aggregate' => 1)));
+		$builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function($builder, $results) { return $results; });
+		$builder->from('users')->groupBy('id');
+		$results = $builder->getGroupCountForPagination();
+		$this->assertEquals(1, $results);
+	}
+
+
 	protected function getBuilder()
 	{
 		$grammar = new Illuminate\Database\Query\Grammars\Grammar;


### PR DESCRIPTION
Additional logic for handling pagination count if the query has a group by clause.

Instead of the count on paginate being determined by
`select count(*) from tablename group by column;`

it queries using
`select count(*) from (select * from tablename group by column) aggregator_query`
