### PR TITLE
Incorrect Memcached connection failure detection

### DIFF
--- a/src/Illuminate/Cache/MemcachedConnector.php
+++ b/src/Illuminate/Cache/MemcachedConnector.php
@@ -27,9 +27,16 @@ class MemcachedConnector {
 			);
 		}
 
-		if (in_array('255.255.255', $memcached->getVersion()))
+		$memcachedStatus = $memcached->getVersion();
+
+		if (!is_array($memcachedStatus))
 		{
-			throw new RuntimeException("Could not establish connection to one or more Memcached servers.");
+			throw new RuntimeException("No Memcached servers added.");
+		}
+
+		if (in_array('255.255.255', $memcachedStatus) AND count(array_unique($memcachedStatus)) === 1)
+		{
+			throw new RuntimeException("Could not establish Memcached connection.");
 		}
 
 		return $memcached;

--- a/src/Illuminate/Cache/MemcachedConnector.php
+++ b/src/Illuminate/Cache/MemcachedConnector.php
@@ -27,9 +27,9 @@ class MemcachedConnector {
 			);
 		}
 
-		if ($memcached->getVersion() === false)
+		if (in_array('255.255.255', $memcached->getVersion()))
 		{
-			throw new RuntimeException("Could not establish Memcached connection.");
+			throw new RuntimeException("Could not establish connection to one or more Memcached servers.");
 		}
 
 		return $memcached;


### PR DESCRIPTION
Memcached::getVersion() returns a list of servers and their versions. On connection failure it does not return boolean false, it returns the failed server version as "255.255.255". See: http://php.net/manual/en/memcached.getversion.php
