### PR TITLE
[5.1] Fixes illuminate/console constraint.

### DIFF
--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/contracts": "5.0.*",
+        "illuminate/contracts": "5.1.*",
         "symfony/console": "2.7.*",
         "nesbot/carbon": "~1.0"
     },


### PR DESCRIPTION
```
 Problem 1
    - Installation request for illuminate/console 5.1.* -> satisfiable by illuminate/console[5.1.x-dev].
    - illuminate/console 5.1.x-dev requires illuminate/contracts 5.0.* -> satisfiable by illuminate/contracts[5.0.x-dev, v5.0.0].
    - Can only install one of: illuminate/contracts[5.1.x-dev, 5.0.x-dev].
    - Can only install one of: illuminate/contracts[v5.0.0, 5.1.x-dev].
    - illuminate/container 5.1.x-dev requires illuminate/contracts 5.1.* -> satisfiable by illuminate/contracts[5.1.x-dev].
    - Installation request for illuminate/container 5.1.* -> satisfiable by illuminate/container[5.1.x-dev].
```

Signed-off-by: crynobone crynobone@gmail.com
