### PR TITLE
Wildcard overrides for resource controllers

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -47,10 +47,21 @@ class ResourceRegistrar {
 			return;
 		}
 
-		// We need to extract the base resource from the resource name. Nested resources
-		// are supported in the framework, but we need to know what name to use for a
-		// place-holder on the route wildcards, which should be the base resources.
-		$base = $this->getResourceWildcard(last(explode('.', $name)));
+        // We need to extract the base resource from the resource name.
+        $resource = last(explode('.', $name));
+
+        // Wildcards for a single or nested resource may be overridden using the wildcards option.
+        // Overrides are performed by matching the wildcards key with the resource name. If a key
+        // matches a resource name, the value of the wildcard is used instead of the resource name.
+        if(isset($options['wildcards'][$resource]))
+        {
+            $resource = $options['wildcards'][$resource];
+        }
+
+		// Nested resources are supported in the framework, but we need to know what
+        // name to use for a place-holder on the route wildcards, which should be
+		// the base resources.
+        $base = $this->getResourceWildcard($resource);
 
 		$defaults = $this->resourceDefaults;
 
@@ -126,9 +137,10 @@ class ResourceRegistrar {
 	 * Get the base resource URI for a given resource.
 	 *
 	 * @param  string  $resource
+     * @param  array   $options
 	 * @return string
 	 */
-	public function getResourceUri($resource)
+	public function getResourceUri($resource, $options)
 	{
 		if ( ! str_contains($resource, '.')) return $resource;
 
@@ -137,9 +149,14 @@ class ResourceRegistrar {
 		// paths however they need to, as some do not have any wildcards at all.
 		$segments = explode('.', $resource);
 
-		$uri = $this->getNestedResourceUri($segments);
+		$uri = $this->getNestedResourceUri($segments, $options);
 
-		return str_replace('/{'.$this->getResourceWildcard(last($segments)).'}', '', $uri);
+        $resource = last($segments);
+
+        if(isset($options['wildcards'][$resource]))
+            return str_replace('/{'.$this->getResourceWildcard($options['wildcards'][$resource]).'}', '', $uri);
+
+		return str_replace('/{'.$this->getResourceWildcard($resource).'}', '', $uri);
 	}
 
 	/**
@@ -148,13 +165,17 @@ class ResourceRegistrar {
 	 * @param  array   $segments
 	 * @return string
 	 */
-	protected function getNestedResourceUri(array $segments)
+	protected function getNestedResourceUri(array $segments, $options)
 	{
 		// We will spin through the segments and create a place-holder for each of the
 		// resource segments, as well as the resource itself. Then we should get an
 		// entire string for the resource URI that contains all nested resources.
-		return implode('/', array_map(function($s)
+		return implode('/', array_map(function($s) use ($options)
 		{
+            //If a wildcard for a resource has been set to be overridden
+            if(isset($options['wildcards'][$s]))
+                return $s.'/{'.$this->getResourceWildcard($options['wildcards'][$s]).'}';
+
 			return $s.'/{'.$this->getResourceWildcard($s).'}';
 
 		}, $segments));
@@ -243,7 +264,7 @@ class ResourceRegistrar {
 	 */
 	protected function addResourceIndex($name, $base, $controller, $options)
 	{
-		$uri = $this->getResourceUri($name);
+		$uri = $this->getResourceUri($name, $options);
 
 		$action = $this->getResourceAction($name, $controller, 'index', $options);
 
@@ -261,7 +282,7 @@ class ResourceRegistrar {
 	 */
 	protected function addResourceCreate($name, $base, $controller, $options)
 	{
-		$uri = $this->getResourceUri($name).'/create';
+		$uri = $this->getResourceUri($name, $options).'/create';
 
 		$action = $this->getResourceAction($name, $controller, 'create', $options);
 
@@ -279,7 +300,7 @@ class ResourceRegistrar {
 	 */
 	protected function addResourceStore($name, $base, $controller, $options)
 	{
-		$uri = $this->getResourceUri($name);
+		$uri = $this->getResourceUri($name, $options);
 
 		$action = $this->getResourceAction($name, $controller, 'store', $options);
 
@@ -297,7 +318,7 @@ class ResourceRegistrar {
 	 */
 	protected function addResourceShow($name, $base, $controller, $options)
 	{
-		$uri = $this->getResourceUri($name).'/{'.$base.'}';
+		$uri = $this->getResourceUri($name, $options).'/{'.$base.'}';
 
 		$action = $this->getResourceAction($name, $controller, 'show', $options);
 
@@ -315,7 +336,7 @@ class ResourceRegistrar {
 	 */
 	protected function addResourceEdit($name, $base, $controller, $options)
 	{
-		$uri = $this->getResourceUri($name).'/{'.$base.'}/edit';
+		$uri = $this->getResourceUri($name, $options).'/{'.$base.'}/edit';
 
 		$action = $this->getResourceAction($name, $controller, 'edit', $options);
 
@@ -335,7 +356,7 @@ class ResourceRegistrar {
 	{
 		$this->addPutResourceUpdate($name, $base, $controller, $options);
 
-		return $this->addPatchResourceUpdate($name, $base, $controller);
+		return $this->addPatchResourceUpdate($name, $base, $controller, $options);
 	}
 
 	/**
@@ -349,24 +370,25 @@ class ResourceRegistrar {
 	 */
 	protected function addPutResourceUpdate($name, $base, $controller, $options)
 	{
-		$uri = $this->getResourceUri($name).'/{'.$base.'}';
+		$uri = $this->getResourceUri($name, $options).'/{'.$base.'}';
 
 		$action = $this->getResourceAction($name, $controller, 'update', $options);
 
 		return $this->router->put($uri, $action);
 	}
 
-	/**
-	 * Add the update method for a resourceful route.
-	 *
-	 * @param  string  $name
-	 * @param  string  $base
-	 * @param  string  $controller
-	 * @return void
-	 */
-	protected function addPatchResourceUpdate($name, $base, $controller)
+    /**
+     * Add the update method for a resourceful route.
+     *
+     * @param  string $name
+     * @param  string $base
+     * @param  string $controller
+     * @param  array  $options
+     * @return void
+     */
+	protected function addPatchResourceUpdate($name, $base, $controller, $options)
 	{
-		$uri = $this->getResourceUri($name).'/{'.$base.'}';
+		$uri = $this->getResourceUri($name, $options).'/{'.$base.'}';
 
 		$this->router->patch($uri, $controller.'@update');
 	}
@@ -382,7 +404,7 @@ class ResourceRegistrar {
 	 */
 	protected function addResourceDestroy($name, $base, $controller, $options)
 	{
-		$uri = $this->getResourceUri($name).'/{'.$base.'}';
+		$uri = $this->getResourceUri($name, $options).'/{'.$base.'}';
 
 		$action = $this->getResourceAction($name, $controller, 'destroy', $options);
 

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -47,21 +47,21 @@ class ResourceRegistrar {
 			return;
 		}
 
-        // We need to extract the base resource from the resource name.
-        $resource = last(explode('.', $name));
+		// We need to extract the base resource from the resource name.
+		$resource = last(explode('.', $name));
 
-        // Wildcards for a single or nested resource may be overridden using the wildcards option.
-        // Overrides are performed by matching the wildcards key with the resource name. If a key
-        // matches a resource name, the value of the wildcard is used instead of the resource name.
-        if(isset($options['wildcards'][$resource]))
-        {
-            $resource = $options['wildcards'][$resource];
-        }
+		// Wildcards for a single or nested resource may be overridden using the wildcards option.
+		// Overrides are performed by matching the wildcards key with the resource name. If a key
+		// matches a resource name, the value of the wildcard is used instead of the resource name.
+		if (isset($options['wildcards'][$resource]))
+		{
+			$resource = $options['wildcards'][$resource];
+		}
 
 		// Nested resources are supported in the framework, but we need to know what
-        // name to use for a place-holder on the route wildcards, which should be
+		// name to use for a place-holder on the route wildcards, which should be
 		// the base resources.
-        $base = $this->getResourceWildcard($resource);
+		$base = $this->getResourceWildcard($resource);
 
 		$defaults = $this->resourceDefaults;
 
@@ -137,7 +137,7 @@ class ResourceRegistrar {
 	 * Get the base resource URI for a given resource.
 	 *
 	 * @param  string  $resource
-     * @param  array   $options
+	 * @param  array   $options
 	 * @return string
 	 */
 	public function getResourceUri($resource, $options)
@@ -151,10 +151,10 @@ class ResourceRegistrar {
 
 		$uri = $this->getNestedResourceUri($segments, $options);
 
-        $resource = last($segments);
+		$resource = last($segments);
 
-        if(isset($options['wildcards'][$resource]))
-            return str_replace('/{'.$this->getResourceWildcard($options['wildcards'][$resource]).'}', '', $uri);
+		if (isset($options['wildcards'][$resource]))
+			return str_replace('/{'.$this->getResourceWildcard($options['wildcards'][$resource]).'}', '', $uri);
 
 		return str_replace('/{'.$this->getResourceWildcard($resource).'}', '', $uri);
 	}
@@ -162,7 +162,8 @@ class ResourceRegistrar {
 	/**
 	 * Get the URI for a nested resource segment array.
 	 *
-	 * @param  array   $segments
+	 * @param  array $segments
+	 * @param  array $options
 	 * @return string
 	 */
 	protected function getNestedResourceUri(array $segments, $options)
@@ -172,9 +173,9 @@ class ResourceRegistrar {
 		// entire string for the resource URI that contains all nested resources.
 		return implode('/', array_map(function($s) use ($options)
 		{
-            //If a wildcard for a resource has been set to be overridden
-            if(isset($options['wildcards'][$s]))
-                return $s.'/{'.$this->getResourceWildcard($options['wildcards'][$s]).'}';
+			//If a wildcard for a resource has been set to be overridden
+			if (isset($options['wildcards'][$s]))
+				return $s.'/{'.$this->getResourceWildcard($options['wildcards'][$s]).'}';
 
 			return $s.'/{'.$this->getResourceWildcard($s).'}';
 
@@ -377,15 +378,15 @@ class ResourceRegistrar {
 		return $this->router->put($uri, $action);
 	}
 
-    /**
-     * Add the update method for a resourceful route.
-     *
-     * @param  string $name
-     * @param  string $base
-     * @param  string $controller
-     * @param  array  $options
-     * @return void
-     */
+	/**
+	 * Add the update method for a resourceful route.
+	 *
+	 * @param  string $name
+	 * @param  string $base
+	 * @param  string $controller
+	 * @param  array  $options
+	 * @return void
+	 */
 	protected function addPatchResourceUpdate($name, $base, $controller, $options)
 	{
 		$uri = $this->getResourceUri($name, $options).'/{'.$base.'}';

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -708,11 +708,32 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo-bars/{foo_bars}', $routes[0]->getUri());
 
 		$router = $this->getRouter();
+		$router->resource('foo-bars', 'FooController', array('only' => array('show'), 'wildcards' => array('foo-bars' => 'foo_bar_id')));
+		$routes = $router->getRoutes();
+		$routes = $routes->getRoutes();
+
+		$this->assertEquals('foo-bars/{foo_bar_id}', $routes[0]->getUri());
+
+		$router = $this->getRouter();
 		$router->resource('foo-bars.foo-bazs', 'FooController', array('only' => array('show')));
 		$routes = $router->getRoutes();
 		$routes = $routes->getRoutes();
 
 		$this->assertEquals('foo-bars/{foo_bars}/foo-bazs/{foo_bazs}', $routes[0]->getUri());
+
+		$router = $this->getRouter();
+		$router->resource('foo-bars.foo-bazs', 'FooController', array('only' => array('show'), 'wildcards' => array('foo-bars' => 'foo_bar_id')));
+		$routes = $router->getRoutes();
+		$routes = $routes->getRoutes();
+
+		$this->assertEquals('foo-bars/{foo_bar_id}/foo-bazs/{foo_bazs}', $routes[0]->getUri());
+
+		$router = $this->getRouter();
+		$router->resource('foo-bars.foo-bazs', 'FooController', array('only' => array('show'), 'wildcards' => array('foo-bars' => 'foo_bar_id', 'foo-bazs' => 'foo_baz_id')));
+		$routes = $router->getRoutes();
+		$routes = $routes->getRoutes();
+
+		$this->assertEquals('foo-bars/{foo_bar_id}/foo-bazs/{foo_baz_id}', $routes[0]->getUri());
 
 		$router = $this->getRouter();
 		$router->resource('foo-bars', 'FooController', array('only' => array('show'), 'as' => 'prefix'));


### PR DESCRIPTION
##### Resource controllers default wildcard of the resource name can be overridden using the wildcards array in the resource controllers options.
###### Example 1

```
Route::resource('photo', 'PhotoCommentController', ['wildcards' => ['photo' => 'photo_id']]);
```

| Method | URI | Name |
| --- | --- | --- |
| POST | photo/{photo_id} | photo.store |
| GET | HEAD | photo/{photo_id} |
| GET | HEAD | photo/{photo_id}/edit |
| PUT | photo/{photo_id} | photo.update |
| PATCH | photo/{photo_id} |  |
| DELETE | photo/{photo_id} | photo.destroy |
###### Example 2

```
Route::resource('photo.comment', 'PhotoCommentController', ['wildcards' => ['photo' => 'photo_id']]);
```

| Method | URI | Name |
| --- | --- | --- |
| GET | HEAD | photo/{photo_id}/comment |
| GET | HEAD | photo/{photo_id}/comment/create |
| POST | photo/{photo_id}/comment/{comment} | photo.comment.store |
| GET | HEAD | photo/{photo_id}/comment/{comment} |
| GET | HEAD | photo/{photo_id}/comment/{comment}/edit |
| PUT | photo/{photo_id}/comment/{comment} | photo.comment.update |
| PATCH | photo/{photo_id}/comment/{comment} |  |
| DELETE | photo/{photo_id}/comment/{comment} | photo.comment.destroy |
###### Example 3

```
Route::resource('photo.comment', 'PhotoCommentController', ['wildcards' => ['photo' => 'photo_id', 'comment' => 'comment_id']]);
```

| Method | URI | Name |
| --- | --- | --- |
| GET | HEAD | photo/{photo_id}/comment |
| GET | HEAD | photo/{photo_id}/comment/create |
| POST | photo/{photo_id}/comment/{comment_id} | photo.comment.store |
| GET | HEAD | photo/{photo_id}/comment/{comment_id} |
| GET | HEAD | photo/{photo_id}/comment/{comment_id}/edit |
| PUT | photo/{photo_id}/comment/{comment_id} | photo.comment.update |
| PATCH | photo/{photo_id}/comment/{comment_id} |  |
| DELETE | photo/{photo_id}/comment/{comment_id} | photo.comment.destroy |

This makes using [route parameters](laravel.com/docs/5.0/routing#route-parameters) much more predictable when using single controllers for multiple routes. The route parameter can be used instead of a guessing a segment.
