### PR TITLE
Prevent Filesystem::deleteDirectory() following symlinks

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -383,7 +383,7 @@ class Filesystem {
 			// If the item is a directory, we can just recurse into the function and
 			// delete that sub-directory otherwise we'll just delete the file and
 			// keep iterating through each file until the directory is cleaned.
-			if ($item->isDir())
+			if ($item->isDir() && ! $item->isLink())
 			{
 				$this->deleteDirectory($item->getPathname());
 			}


### PR DESCRIPTION
If the directory being deleted contains a symlink, `deleteDirectory()` currently follows the symlink and deletes the contents of the target directory. (Then `@rmdir()` silently fails to delete the link itself, so the directory itself cannot be deleted either.) This fixes it so the symlink is deleted but not followed.
