### PR TITLE
Return true in Query Builder's insert() method if empty array provided

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1658,6 +1658,11 @@ class Builder {
 	 */
 	public function insert(array $values)
 	{
+		if (empty($values))
+		{
+			return true;
+		}
+
 		// Since every insert gets treated like a batch insert, we will make sure the
 		// bindings are structured in a way that is convenient for building these
 		// inserts statements by verifying the elements are actually an array.


### PR DESCRIPTION
In Query Builder, there is an error returned when empty array is provided as the first parameter. It makes SQL queries use the following syntax:

``` sql
INSERT INTO `table` () VALUES ()
```

Unfortunetely, SQL throws an errors for empty list of values. I think it shouldn't be an error to provide empty array for insertion, instead it can just do nothing.

Related issue: #7493 
