### PR TITLE
[5.0] Corrected the behaviour of getRestoredPropertyValue

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -62,7 +62,7 @@ trait SerializesModels {
 	protected function getRestoredPropertyValue($value)
 	{
 		return $value instanceof ModelIdentifier
-						? (new $value->class)->find($value->id) : $value;
+						? (new $value->class)->findOrFail($value->id) : $value;
 	}
 
 	/**


### PR DESCRIPTION
If the model existed when we serialized the command, then we must make sure that it still exists to avoid fatal errors down the line.
