### PR TITLE
Remove hard coded string from AuthenticatesAndRegistersUsers.php

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesAndRegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesAndRegistersUsers.php
@@ -95,7 +95,7 @@ trait AuthenticatesAndRegistersUsers {
 	 */
 	protected function getFailedLoginMesssage()
 	{
-		return 'These credentials do not match our records.';
+		return trans('auth.failedLoginMessage');
 	}
 
 	/**


### PR DESCRIPTION
Uses trans to be able to localize the failed login message.

Related to: https://github.com/laravel/laravel/pull/3292
