### PR TITLE
[5.0] Removed An Unused Import

### DIFF
--- a/src/Illuminate/Foundation/Testing/ApplicationTrait.php
+++ b/src/Illuminate/Foundation/Testing/ApplicationTrait.php
@@ -1,6 +1,5 @@
 <?php namespace Illuminate\Foundation\Testing;
 
-use Dotenv;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
 


### PR DESCRIPTION
Missed out when reverting mutable dotenv.

Signed-off-by: crynobone crynobone@gmail.com
