### PR TITLE
[5.1] Remove requirement to get session driver from configuration when caching config

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -48,9 +48,7 @@ class ConfigCacheCommand extends Command {
 	{
 		$this->call('config:clear');
 
-		$config = $this->setRealSessionDriver(
-			$this->getFreshConfiguration()
-		);
+		$config = $this->getFreshConfiguration();
 
 		$this->files->put(
 			$this->laravel->getCachedConfigPath(), '<?php return '.var_export($config, true).';'.PHP_EOL
@@ -71,23 +69,6 @@ class ConfigCacheCommand extends Command {
 		$app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
 
 		return $app['config']->all();
-	}
-
-	/**
-	 * Set the "real" session driver on the configuratoin array.
-	 *
-	 * Typically the SessionManager forces the driver to "array" in CLI environment.
-	 *
-	 * @param  array  $config
-	 * @return array
-	 */
-	protected function setRealSessionDriver(array $config)
-	{
-		$session = require $this->laravel->configPath().'/session.php';
-
-		$config['session']['driver'] = $session['driver'];
-
-		return $config;
 	}
 
 }


### PR DESCRIPTION
With changes in 30391aa (for 5.0) session for console request no longer uses array driver therefore it should be the same as requesting from HTTP kernel.

This could be targeted to 5.0 but I worried if it could cause some regression somewhere. Will re-PR if needed.

Signed-off-by: crynobone crynobone@gmail.com
