### PR TITLE
Remove unnecessary line

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -153,8 +153,6 @@ class Event {
 	 */
 	protected function callAfterCallbacks(Container $container)
 	{
-		if (empty($this->afterCallbacks)) return;
-
 		foreach ($this->afterCallbacks as $callback)
 		{
 			$container->call($callback);


### PR DESCRIPTION
Not only is there no risk in running a `foreach` on an empty array; this method never gets called with an empty array to begin with.
