### PR TITLE
[5.0] Additional option for model hinting in controller generation

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -42,6 +42,50 @@ class ControllerMakeCommand extends GeneratorCommand {
 	}
 
 	/**
+	 * Build the class with the given name.
+	 *
+	 * @param  string  $name
+	 * @return string
+	 */
+	protected function buildClass($name)
+	{
+		$stub = parent::buildClass($name);
+		return $this->replaceModelName($stub);
+	}
+
+	/**
+	 * Build the controller methods with the given model name.
+	 *
+	 * @param  string  $stub
+	 * @return string
+	 */
+	protected function replaceModelName(&$stub)
+	{
+		$modelClass = $this->option('model');
+
+		if (is_null($modelClass))
+		{
+			$model = '$id';
+			$modelHint = 'int  $id';
+			$modelUse = '';
+		}
+		else
+		{
+			$basename = class_basename($modelClass);
+			$argument = strtolower($basename);
+			$model = $basename . ' ' . '$' . $argument;
+			$modelHint = $basename . '  ' . '$' . $argument;
+			$modelUse = 'use ' . $modelClass. ";\n";
+		}
+
+		$stub = str_replace('{{model}}', $model, $stub);
+		$stub = str_replace('{{modelUse}}', $modelUse, $stub);
+		$stub = str_replace('{{modelHint}}', $modelHint, $stub);
+
+		return $stub;
+	}
+
+	/**
 	 * Get the default namespace for the class.
 	 *
 	 * @param  string  $rootNamespace
@@ -61,6 +105,7 @@ class ControllerMakeCommand extends GeneratorCommand {
 	{
 		return array(
 			array('plain', null, InputOption::VALUE_NONE, 'Generate an empty controller class.'),
+			array('model', null, InputOption::VALUE_OPTIONAL, 'Optional model class for binding'),
 		);
 	}
 

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -4,7 +4,7 @@ use {{rootNamespace}}Http\Requests;
 use {{rootNamespace}}Http\Controllers\Controller;
 
 use Illuminate\Http\Request;
-
+{{modelUse}}
 class {{class}} extends Controller {
 
 	/**
@@ -40,10 +40,10 @@ class {{class}} extends Controller {
 	/**
 	 * Display the specified resource.
 	 *
-	 * @param  int  $id
+	 * @param  {{modelHint}}
 	 * @return Response
 	 */
-	public function show($id)
+	public function show({{model}})
 	{
 		//
 	}
@@ -51,10 +51,10 @@ class {{class}} extends Controller {
 	/**
 	 * Show the form for editing the specified resource.
 	 *
-	 * @param  int  $id
+	 * @param  {{modelHint}}
 	 * @return Response
 	 */
-	public function edit($id)
+	public function edit({{model}})
 	{
 		//
 	}
@@ -62,10 +62,10 @@ class {{class}} extends Controller {
 	/**
 	 * Update the specified resource in storage.
 	 *
-	 * @param  int  $id
+	 * @param  {{modelHint}}
 	 * @return Response
 	 */
-	public function update($id)
+	public function update({{model}})
 	{
 		//
 	}
@@ -73,10 +73,10 @@ class {{class}} extends Controller {
 	/**
 	 * Remove the specified resource from storage.
 	 *
-	 * @param  int  $id
+	 * @param  {{modelHint}}
 	 * @return Response
 	 */
-	public function destroy($id)
+	public function destroy({{model}})
 	{
 		//
 	}


### PR DESCRIPTION
New option to generate resource controller with provided model class.
Example:

```
php artisan make:controller TestController --model=App\\Test
```

Will generate a controller with proper hinting of model class in necessary methods

``` php
use App\Test;
// ...
/**
 * Display the specified resource.
 *
 * @param  Test  $test
 * @return Response
 */
public function show(Test $test)
{
    //
}
```
