### PR TITLE
[5.0] Proposal: Add options to middleware generator

### DIFF
--- a/src/Illuminate/Routing/Console/MiddlewareMakeCommand.php
+++ b/src/Illuminate/Routing/Console/MiddlewareMakeCommand.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Routing\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class MiddlewareMakeCommand extends GeneratorCommand {
 
@@ -32,7 +33,17 @@ class MiddlewareMakeCommand extends GeneratorCommand {
 	 */
 	protected function getStub()
 	{
-		return __DIR__.'/stubs/middleware.stub';
+		if ($this->option('terminable'))
+		{
+			return __DIR__.'/stubs/middleware-terminable.stub';
+		}
+
+		if ($this->option('after'))
+		{
+			return __DIR__.'/stubs/middleware-after.stub';
+		}
+
+		return __DIR__.'/stubs/middleware-before.stub';
 	}
 
 	/**
@@ -44,6 +55,20 @@ class MiddlewareMakeCommand extends GeneratorCommand {
 	protected function getDefaultNamespace($rootNamespace)
 	{
 		return $rootNamespace.'\Http\Middleware';
+	}
+
+	/**
+	 * Get the console command options.
+	 *
+	 * @return array
+	 */
+	protected function getOptions()
+	{
+		return array(
+			array('after', null, InputOption::VALUE_NONE, 'Indicates that the after middleware should be generated.'),
+
+			array('terminable', null, InputOption::VALUE_NONE, 'Indicates that the terminable middleware should be generated.'),
+		);
 	}
 
 }

--- a/src/Illuminate/Routing/Console/stubs/middleware-after.stub
+++ b/src/Illuminate/Routing/Console/stubs/middleware-after.stub
@@ -1,8 +1,9 @@
 <?php namespace {{namespace}};
 
 use Closure;
+use Illuminate\Contracts\Routing\Middleware;
 
-class {{class}} {
+class {{class}} implements Middleware {
 
 	/**
 	 * Handle an incoming request.
@@ -13,7 +14,11 @@ class {{class}} {
 	 */
 	public function handle($request, Closure $next)
 	{
-		return $next($request);
+		$response = $next($request);
+
+		//
+
+		return $response;
 	}
 
 }

--- a/src/Illuminate/Routing/Console/stubs/middleware-before.stub
+++ b/src/Illuminate/Routing/Console/stubs/middleware-before.stub
@@ -1,0 +1,20 @@
+<?php namespace {{namespace}};
+
+use Closure;
+use Illuminate\Contracts\Routing\Middleware;
+
+class {{class}} implements Middleware {
+
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  \Closure  $next
+	 * @return mixed
+	 */
+	public function handle($request, Closure $next)
+	{
+		return $next($request);
+	}
+
+}

--- a/src/Illuminate/Routing/Console/stubs/middleware-terminable.stub
+++ b/src/Illuminate/Routing/Console/stubs/middleware-terminable.stub
@@ -1,0 +1,32 @@
+<?php namespace {{namespace}};
+
+use Closure;
+use Illuminate\Contracts\Routing\TerminableMiddleware;
+
+class {{class}} implements TerminableMiddleware {
+
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  \Closure  $next
+	 * @return mixed
+	 */
+	public function handle($request, Closure $next)
+	{
+		return $next($request);
+	}
+
+	/**
+	 * Perform any final actions for the request lifecycle.
+	 *
+	 * @param  \Symfony\Component\HttpFoundation\Request  $request
+	 * @param  \Symfony\Component\HttpFoundation\Response  $response
+	 * @return void
+	 */
+	public function terminate($request, $response)
+	{
+		//
+	}
+
+}


### PR DESCRIPTION
By default `php artisan make:middleware` generates a before middleware stub.
This PR gives the ability to generate `after` and `terminable` middlewares as well.

I also noticed that there is a Illuminate\Contracts\Routing\Middleware contract, all examples from the documentation implement it, but the stub and  the existing middlewares in laravel/laravel don't.

Not sure which way is meant to be more correct but i prefer the one with interfaces
