### PR TITLE
[5.1] [Proposal] Allow define hidden/visible options dynamically.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2472,7 +2472,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		foreach ($this->getArrayableRelations() as $key => $value)
 		{
-			if (in_array($key, $this->hidden)) continue;
+			if (in_array($key, $this->getHidden())) continue;
 
 			// If the values implements the Arrayable interface we can just call this
 			// toArray method on the instances which will convert both models and
@@ -2530,12 +2530,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	protected function getArrayableItems(array $values)
 	{
-		if (count($this->visible) > 0)
+		if (count($this->getVisible()) > 0)
 		{
-			return array_intersect_key($values, array_flip($this->visible));
+			return array_intersect_key($values, array_flip($this->getVisible()));
 		}
 
-		return array_diff_key($values, array_flip($this->hidden));
+		return array_diff_key($values, array_flip($this->getHidden()));
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -686,6 +686,56 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testHidden()
+	{
+		$model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+		$model->setHidden(['age', 'id']);
+		$array = $model->toArray();
+		$this->assertArrayHasKey('name', $array);
+		$this->assertArrayNotHasKey('age', $array);
+	}
+
+
+	public function testVisible()
+	{
+		$model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+		$model->setVisible(['name', 'id']);
+		$array = $model->toArray();
+		$this->assertArrayHasKey('name', $array);
+		$this->assertArrayNotHasKey('age', $array);
+	}
+
+
+	public function testHiddenAreIgnoringWhenVisibleExists()
+	{
+		$model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+		$model->setVisible(['name', 'id']);
+		$model->setHidden(['name', 'age']);
+		$array = $model->toArray();
+		$this->assertArrayHasKey('name', $array);
+		$this->assertArrayHasKey('id', $array);
+		$this->assertArrayNotHasKey('age', $array);
+	}
+
+
+	public function testDynamicHidden()
+	{
+		$model = new EloquentModelDynamicHiddenStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+		$array = $model->toArray();
+		$this->assertArrayHasKey('name', $array);
+		$this->assertArrayNotHasKey('age', $array);
+	}
+
+
+	public function testDynamicVisible()
+	{
+		$model = new EloquentModelDynamicVisibleStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+		$array = $model->toArray();
+		$this->assertArrayHasKey('name', $array);
+		$this->assertArrayNotHasKey('age', $array);
+	}
+
+
 	public function testFillable()
 	{
 		$model = new EloquentModelStub;
@@ -1336,5 +1386,23 @@ class EloquentModelCastingStub extends Illuminate\Database\Eloquent\Model {
 	public function eighthAttributeValue()
 	{
 		return $this->attributes['eighth'];
+	}
+}
+
+class EloquentModelDynamicHiddenStub extends Illuminate\Database\Eloquent\Model {
+	protected $table = 'stub';
+	protected $guarded = [];
+	public function getHidden()
+	{
+		return ['age', 'id'];
+	}
+}
+
+class EloquentModelDynamicVisibleStub extends Illuminate\Database\Eloquent\Model {
+	protected $table = 'stub';
+	protected $guarded = [];
+	public function getVisible()
+	{
+		return ['name', 'id'];
 	}
 }


### PR DESCRIPTION
**Problem**
We have many cases when hidden/visible options depend on  user privileges.
For example the API that returns other user info must return also user email only if the user is logged in.

**Solution**
Allow define hidden/visible options more dynamically by overriding getHidden or getVisible methods.

**Example**

``` php
class User extends Illuminate\Database\Eloquent\Model {

    protected $table = 'user';

    public function getHidden()
    {
          if (Auth::check()) {
              return [];
          }
          return ['email'];
    }
}
```

So by default we will keep **_protected $hidden = [];**_ option, but also allow override getHidden method to define this options more dynamically.

What do you think, can be this part of the framework ?
