### PR TITLE
allow immutables and arrays to work with the pipeline

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -136,9 +136,9 @@ class Pipeline implements PipelineContract {
 	 */
 	protected function getInitialSlice(Closure $destination)
 	{
-		return function() use ($destination)
+		return function($passable) use ($destination)
 		{
-			return call_user_func($destination, $this->passable);
+			return call_user_func($destination, $passable);
 		};
 	}
 


### PR DESCRIPTION
As it stands, the initial slice is defined as a function that calls the destination closure on `$this->passable`, set via the `send` method. However, this makes the pipeline unfit for immutable objects.

In my case, I wanted to use it to sanitize the request input (an array, so it's not passed by reference). For this, I passed the identity function to the `then` method, unfortunately that would only return the initial array as that was stored in `$this->passable`. I came up with a reasonably simple fix, to pass the end result to the destination closure instead.

I don't think this would impact the current functionality in any way, since the framework uses it with objects that are passed by reference, and hence the final passable would be equal to the one set initially.
