### PR TITLE
Add replaceRequiredWithAll method in Validator to fix incorrect error message

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1838,6 +1838,20 @@ class Validator implements MessageProviderInterface {
 	}
 
 	/**
+	 * Replace all place-holders for the required_with_all rule.
+	 *
+	 * @param  string  $message
+	 * @param  string  $attribute
+	 * @param  string  $rule
+	 * @param  array   $parameters
+	 * @return string
+	 */
+	protected function replaceRequiredWithAll($message, $attribute, $rule, $parameters)
+	{
+		return $this->replaceRequiredWith($message, $attribute, $rule, $parameters);
+	}
+
+	/**
 	 * Replace all place-holders for the required_without rule.
 	 *
 	 * @param  string  $message


### PR DESCRIPTION
Problem:

```
The height field is required when :values is present.
```

Desired result:

```
The height field is required when field1 / field2 / field3 is present.
```

Just duplicated and renamed a similar method, nothing much but it works now.

https://github.com/laravel/framework/issues/7832

Cheers!
