### PR TITLE
[5.0] Implemented Kernel::addMiddleware method to add middleware at runtime.

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -152,6 +152,22 @@ class Kernel implements KernelContract {
 	}
 
 	/**
+	 * Add a new middleware to the stack if it does not already exist.
+	 *
+	 * @param  string  $middleware
+	 * @return $this
+	 */
+	public function addMiddleware($middleware)
+	{
+		if (array_search($middleware, $this->middleware) === false)
+		{
+			$this->middleware[] = $middleware;
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Bootstrap the application for HTTP requests.
 	 *
 	 * @return void


### PR DESCRIPTION
As per title and previous issue #6211.

This first checks to see if the middleware is already in the stack before adding it. This allows a custom order if it's required, otherwise it just adds it to the end.
