### PR TITLE
Accept fully qualified name for controller in namespaced group

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -595,7 +595,7 @@ class Router implements RegistrarContract {
 	{
 		$group = last($this->groupStack);
 
-		return isset($group['namespace']) ? $group['namespace'].'\\'.$uses : $uses;
+		return isset($group['namespace']) && strpos($uses, '\\') !== 0 ? $group['namespace'].'\\'.$uses : $uses;
 	}
 
 	/**


### PR DESCRIPTION
Problem:
This won't work in a namespaced route group : `Route::get('test', '\MyCtrl@method');`
`Route::get('test', '\Namespace\MyCtrl@method');` neither
But it should work if we add a backslash.

Solution : check backslash in the begining of the string in prependGroupUses method before adding namespace
