### PR TITLE
[5.0] Directly call writeLog

### DIFF
--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -183,7 +183,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 */
 	public function write($level, $message, array $context = array())
 	{
-		return $this->log($level, $message, $context);
+		return $this->writeLog($level, $message, $context);
 	}
 
 	/**


### PR DESCRIPTION
Useless call to `log()` : `log()` function calls `writeLog()`
