### PR TITLE
[5.0] Avoid double check and useless call to Collection::make

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -47,7 +47,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
 		$this->lastPage = (int) ceil($total / $perPage);
 		$this->currentPage = $this->setCurrentPage($currentPage, $this->lastPage);
 		$this->path = $this->path != '/' ? rtrim($this->path, '/').'/' : $this->path;
-		$this->items = $items instanceof Collection ? $items : Collection::make($items);
+		$this->items = new Collection($items);
 	}
 
 	/**


### PR DESCRIPTION
`Collection::make` does nothing more than calling `Collection::__construct` and `$items instanceof Collection` is already checked in  `Collection::getArrayableItems`.
