### PR TITLE
[5.0] Generate Trace From FatalErrorException

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -113,7 +113,7 @@ class HandleExceptions {
 	{
 		if ( ! is_null($error = error_get_last()) && $this->isFatal($error['type']))
 		{
-			$this->handleException($this->fatalExceptionFromError($error));
+			$this->handleException($this->fatalExceptionFromError($error, 0));
 		}
 	}
 
@@ -121,12 +121,13 @@ class HandleExceptions {
 	 * Create a new fatal exception instance from an error array.
 	 *
 	 * @param  array  $error
+	 * @param  int|null  $traceOffset
 	 * @return \Symfony\Component\Debug\Exception\FatalErrorException
 	 */
-	protected function fatalExceptionFromError(array $error)
+	protected function fatalExceptionFromError(array $error, $traceOffset = null)
 	{
 		return new FatalErrorException(
-			$error['message'], $error['type'], 0, $error['file'], $error['line']
+			$error['message'], $error['type'], 0, $error['file'], $error['line'], $traceOffset
 		);
 	}
 


### PR DESCRIPTION
Proposal: generate trace when shutdown handler is called using $traceOffset and xdebug from FatalErrorException

Somewhat along the same lines as https://github.com/laravel/framework/issues/7873, I would like to propose a bit of an extension to the `HandleExceptions::handleShutdown`  and `HandleExceptions::fatalExceptionFromError` methods.

Fatal errors can be a pain in the **\* to debug since the stack gets reset in the shutdown handler.  I noticed that the `FatalErrorException` from Symfony that is used in `HandleExceptions::fatalExceptionFromError` can use `xdebug_get_function_stack` to pull the stack from xdebug (if it is loaded) by passing a `$traceOffset` parameter of 0 (zero) or greater.

Adding the $traceOffset param (default null) to `HandleExceptions::fatalExceptionFromError` lets us pass that param to the constructor of `FatalErrorException`.  We can then call `$this->fatalExceptionFromError` in `HandleExceptions::handleShutdown` with a $traceOffset of 0 (zero) to get the full trace.  If xdebug is available and a fatal error triggers `handleShutdown`, you get the full stack trace!

From this:

```
FatalErrorException in HomeController.php line 33:
Call to undefined function do_magic()
in HomeController.php line 33
at HandleExceptions->fatalExceptionFromError(array('type' => '1', 'message' => 'Call to undefined function do_magic()', 'file' => '/projects/php/laravel5/rad/app/Http/Controllers/HomeController.php', 'line' => '33'), '0') in HandleExceptions.php line 27
at HandleExceptions->handleShutdown()
```

Which is moderately useful, at least you can see where the error is occurring... to this which I feel has the potential to be more useful (maybe not in this example :P). Granted it does require xdebug, but at a minimum you still end up with the above "trace".

```
FatalErrorException in HomeController.php line 33:
Call to undefined function do_magic()
in HomeController.php line 33
at FatalErrorException->__construct('message' => '', 'code' => '', 'severity' => '', 'filename' => '', 'lineno' => '', 'traceOffset' => '', 'traceArgs' => '') in HandleExceptions.php line 40
at HandleExceptions->fatalExceptionFromError('error' => '', 'traceOffset' => '') in HandleExceptions.php line 27
at HandleExceptions->handleShutdown() in HandleExceptions.php line 0
at HomeController->index() in Controller.php line 246
at call_user_func_array:{/projects/php/laravel5/rad/vendor/laravel/framework/src/Illuminate/Routing/Controller.php:246}('', '') in Controller.php line 246
at Controller->callAction('method' => '', 'parameters' => '') in ControllerDispatcher.php line 162
at ControllerDispatcher->call('instance' => '', 'route' => '', 'method' => '') in ControllerDispatcher.php line 107
...
```
