### PR TITLE
Adds "--path" to the migrate:reset command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -56,9 +56,11 @@ class ResetCommand extends Command {
 
 		$pretend = $this->input->getOption('pretend');
 
+        $path = $this->input->getOption('path');
+
 		while (true)
 		{
-			$count = $this->migrator->rollback($pretend);
+            $count = $this->migrator->rollback($pretend, $path);
 
 			// Once the migrator has run we will grab the note output and send it out to
 			// the console screen, since the migrator itself functions without having
@@ -85,6 +87,8 @@ class ResetCommand extends Command {
 			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
 
 			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
+
+            array('path', null, InputOption::VALUE_OPTIONAL, 'The path of migration files to reset.'),
 		);
 	}
 

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -178,4 +178,27 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 		$this->connection = $name;
 	}
 
+    /**
+     * Get migration entries from the database by path
+     *
+     * @param array $path
+     * @return array
+     */
+    public function getByPath($path)
+    {
+        // List down all the files inside the given path, sort by descending
+        $files = scandir($path);
+
+        $migrationEntries = [];
+        foreach ($files as $file) {
+            // Remove the .php from the filenames
+            $migrationEntries[] = str_replace('.php', '', $file);
+        }
+
+        return $this->table()->whereIn('migration', $migrationEntries)
+            ->where('batch', $this->getLastBatchNumber())
+            ->orderBy('migration', 'desc')
+            ->get();
+    }
+
 }

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -62,4 +62,12 @@ interface MigrationRepositoryInterface {
 	 */
 	public function setSource($name);
 
+    /**
+     * Get migration entries from the database by path
+     *
+     * @param array $path
+     * @return array
+     */
+    public function getByPath($path);
+
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -142,20 +142,29 @@ class Migrator {
 		$this->note("<info>Migrated:</info> $file");
 	}
 
-	/**
-	 * Rollback the last migration operation.
-	 *
-	 * @param  bool  $pretend
-	 * @return int
-	 */
-	public function rollback($pretend = false)
+    /**
+     * Rollback the last migration operation.
+     *
+     * @param  bool $pretend
+     * @param  string|null $path
+     * @return int
+     */
+	public function rollback($pretend = false, $path = null)
 	{
 		$this->notes = array();
 
 		// We want to pull in the last batch of migrations that ran on the previous
 		// migration operation. We'll then reverse those migrations and run each
 		// of them "down" to reverse the last migration "operation" which ran.
-		$migrations = $this->repository->getLast();
+        if (is_null($path))
+        {
+            $migrations = $this->repository->getLast();
+        }
+        else
+        {
+            // We grab the migrations that exist in the path specified
+            $migrations = $this->repository->getByPath($path);
+        }
 
 		if (count($migrations) == 0)
 		{


### PR DESCRIPTION
Hi all,

I've added a `--path` option to the `migrate:reset` command.

Usage for this should be similar to the `php artisan migrate --path="..."` command.

I'm adding this because we have the option of doing a migration from a specified path but have no option to reset the migration from that path itself.

Hoping you consider this pull request.

Thanks
Chris
