### PR TITLE
[5.0] Adds "--path" to the migrate:reset command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -56,9 +56,11 @@ class ResetCommand extends Command {
 
 		$pretend = $this->input->getOption('pretend');
 
+		$path = $this->input->getOption('path');
+
 		while (true)
 		{
-			$count = $this->migrator->rollback($pretend);
+			$count = $this->migrator->rollback($pretend, $path);
 
 			// Once the migrator has run we will grab the note output and send it out to
 			// the console screen, since the migrator itself functions without having
@@ -85,6 +87,8 @@ class ResetCommand extends Command {
 			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
 
 			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
+
+			array('path', null, InputOption::VALUE_OPTIONAL, 'The path of migration files to reset.'),
 		);
 	}
 

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -61,6 +61,31 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 	}
 
 	/**
+	 * Get migration entries from the database by path.
+	 *
+	 * @param  string  $path
+	 * @return array
+	 */
+	public function getByPath($path)
+	{
+		// List down all the PHP files in the given path.
+		$files = glob($path . '/*.php');
+
+		$migrationEntries = [];
+
+		foreach ($files as $file)
+		{
+			// Get the base file name, without the path and .php suffix.
+			$migrationEntries[] = basename($file, '.php');
+		}
+
+		return $this->table()->whereIn('migration', $migrationEntries)
+			->where('batch', $this->getLastBatchNumber())
+			->orderBy('migration', 'desc')
+			->get();
+	}
+
+	/**
 	 * Log that a migration was run.
 	 *
 	 * @param  string  $file

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -17,6 +17,14 @@ interface MigrationRepositoryInterface {
 	public function getLast();
 
 	/**
+	 * Get migration entries from the database by path.
+	 *
+	 * @param  string  $path
+	 * @return array
+	 */
+	public function getByPath($path);
+
+	/**
 	 * Log that a migration was run.
 	 *
 	 * @param  string  $file

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -146,16 +146,25 @@ class Migrator {
 	 * Rollback the last migration operation.
 	 *
 	 * @param  bool  $pretend
+	 * @param  string|null  $path
 	 * @return int
 	 */
-	public function rollback($pretend = false)
+	public function rollback($pretend = false, $path = null)
 	{
 		$this->notes = array();
 
 		// We want to pull in the last batch of migrations that ran on the previous
 		// migration operation. We'll then reverse those migrations and run each
 		// of them "down" to reverse the last migration "operation" which ran.
-		$migrations = $this->repository->getLast();
+		if (is_null($path))
+		{
+			$migrations = $this->repository->getLast();
+		}
+		else
+		{
+			// We grab the migrations that exist in the path specified
+			$migrations = $this->repository->getByPath($path);
+		}
 
 		if (count($migrations) == 0)
 		{

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -16,7 +16,7 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 		$command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
 		$command->setLaravel(new AppDatabaseMigrationStub());
 		$migrator->shouldReceive('setConnection')->once()->with(null);
-		$migrator->shouldReceive('rollback')->twice()->with(false)->andReturn(true, false);
+		$migrator->shouldReceive('rollback')->twice()->with(false, null)->andReturn(true, false);
 		$migrator->shouldReceive('getNotes')->andReturn(array());
 
 		$this->runCommand($command);
@@ -28,7 +28,7 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 		$command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
 		$command->setLaravel(new AppDatabaseMigrationStub());
 		$migrator->shouldReceive('setConnection')->once()->with('foo');
-		$migrator->shouldReceive('rollback')->twice()->with(true)->andReturn(true, false);
+		$migrator->shouldReceive('rollback')->twice()->with(true, null)->andReturn(true, false);
 		$migrator->shouldReceive('getNotes')->andReturn(array());
 
 		$this->runCommand($command, array('--pretend' => true, '--database' => 'foo'));


### PR DESCRIPTION
Hi all,

I've added a `--path` option to the `migrate:reset` command.

Usage for this should be similar to the `php artisan migrate --path="..."` command.

So after doing the above command, you can do this:

 `php artisan migrate:reset --path="..."`

I'm adding this because we have the option of doing a migration from a specified path but have no option to reset the migration from that path itself.

Hoping you consider this pull request.

Thanks
Chris
