### PR TITLE
Move method call out of loop.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2449,6 +2449,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	public function relationsToArray()
 	{
 		$attributes = array();
+
 		$hidden = $this->getHidden();
 
 		foreach ($this->getArrayableRelations() as $key => $value)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2449,10 +2449,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	public function relationsToArray()
 	{
 		$attributes = array();
+		$hidden = $this->getHidden();
 
 		foreach ($this->getArrayableRelations() as $key => $value)
 		{
-			if (in_array($key, $this->getHidden())) continue;
+			if (in_array($key, $hidden)) continue;
 
 			// If the values implements the Arrayable interface we can just call this
 			// toArray method on the instances which will convert both models and


### PR DESCRIPTION
I propose this change because the implementations of `getHidden()` (which was introduced in #7685) could be rather complicated, so we should not call it inside the loop.

Potential limitation: the method now gets called even if `getArrayableRelations()` returns an empty array.
