### PR TITLE
[5.0] Fixed wrong routes with optional parameters

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -299,7 +299,7 @@ class UrlGenerator implements UrlGeneratorContract {
 		if (count($parameters))
 		{
 			$path = preg_replace_sub(
-				'/\{.*?\}/', $parameters, $this->replaceNamedParameters($path, $parameters)
+				'/\{[^?]+?\}/', $parameters, $this->replaceNamedParameters($path, $parameters)
 			);
 		}
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -541,7 +541,14 @@ if ( ! function_exists('preg_replace_sub'))
 	{
 		return preg_replace_callback($pattern, function($match) use (&$replacements)
 		{
-			return array_shift($replacements);
+			foreach ($replacements as $key => $value)
+			{
+				if (is_int($key))
+				{
+					unset($replacements[$key]);
+					return $value;
+				}
+			}
 
 		}, $subject);
 	}

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -71,6 +71,12 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$routes->add($route);
 
 		/**
+		 * Optional Parameter...
+		 */
+		$route = new Illuminate\Routing\Route(array('GET'), 'foo/bar/{baz?}', array('as' => 'foobaz'));
+		$routes->add($route);
+
+		/**
 		 * HTTPS...
 		 */
 		$route = new Illuminate\Routing\Route(array('GET'), 'foo/baz', array('as' => 'baz', 'https'));
@@ -103,6 +109,8 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('http://www.foo.com/foo/bar/otwell/breeze/taylor?fly=wall', $url->route('bar', array('boom' => 'taylor', 'baz' => 'otwell', 'fly' => 'wall')));
 		$this->assertEquals('http://www.foo.com/foo/bar/2', $url->route('foobar', 2));
 		$this->assertEquals('http://www.foo.com/foo/bar/taylor', $url->route('foobar', 'taylor'));
+		$this->assertEquals('http://www.foo.com/foo/bar/taylor', $url->route('foobar', array('taylor')));
+		$this->assertEquals('http://www.foo.com/foo/bar/otwell?foo=taylor', $url->route('foobar', array('foo' => 'taylor', 'otwell')));
 		$this->assertEquals('/foo/bar/taylor/breeze/otwell?fly=wall', $url->route('bar', array('taylor', 'otwell', 'fly' => 'wall'), false));
 		$this->assertEquals('https://www.foo.com/foo/baz', $url->route('baz'));
 		$this->assertEquals('http://www.foo.com/foo/bam', $url->action('foo@bar'));
@@ -112,6 +120,11 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('/foo/bar#derp', $url->route('fragment', array(), false));
 		$this->assertEquals('/foo/bar?foo=bar#derp', $url->route('fragment', array('foo' => 'bar'), false));
 		$this->assertEquals('/foo/bar?baz=%C3%A5%CE%B1%D1%84#derp', $url->route('fragment', array('baz' => 'åαф'), false));
+		$this->assertEquals('http://www.foo.com/foo/bar/wall?taylor', $url->route('foobaz', array('taylor', 'baz' => 'wall')));
+		$this->assertEquals('http://www.foo.com/foo/bar/wall?taylor', $url->route('foobaz', array('baz' => 'wall', 'taylor')));
+		$this->assertEquals('http://www.foo.com/foo/bar?fly=wall&taylor', $url->route('foobaz', array('taylor', 'fly' => 'wall')));
+		$this->assertEquals('http://www.foo.com/foo/bar?fly=wall&taylor', $url->route('foobaz', array('fly' => 'wall', 'taylor')));
+		$this->assertEquals('http://www.foo.com/foo/bar?taylor', $url->route('foobaz', 'taylor'));
 	}
 
 


### PR DESCRIPTION
This fixes issue #7881 that wrong routes are generated when optional route parameters are used. Turns out that the solution is a bit more complicated because of the wantet behaviour to replace named placeholders with parameters having numeric keys.

The problem also exists in Laravel 4.1 and 4.2
