### PR TITLE
Add argument to cache:clear to specify store name.

### DIFF
--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Foundation\Application;
+use Illuminate\Cache\Console\ClearCommand;
+
+class ClearCommandTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testClearWithNoStoreOption()
+	{
+		$command = new ClearCommandTestStub(
+			$cacheManager = m::mock('Illuminate\Cache\CacheManager')
+		);
+
+		$cacheRepository = m::mock('\Illuminate\Contracts\Cache\Repository');
+
+		$app = new Application();
+		$command->setLaravel($app);
+		
+		$cacheManager->shouldReceive('store')->once()->with(null)->andReturn($cacheRepository);
+		$cacheRepository->shouldReceive('flush')->once();
+		
+		$this->runCommand($command);
+	}
+
+
+	public function testClearWithStoreOption()
+	{
+		$command = new ClearCommandTestStub(
+			$cacheManager = m::mock('Illuminate\Cache\CacheManager')
+		);
+
+		$cacheRepository = m::mock('\Illuminate\Contracts\Cache\Repository');
+
+		$app = new Application();
+		$command->setLaravel($app);
+		
+		$cacheManager->shouldReceive('store')->once()->with('foo')->andReturn($cacheRepository);
+		$cacheRepository->shouldReceive('flush')->once();
+		
+		$this->runCommand($command, ['store' => 'foo']);
+	}
+
+
+	public function testClearWithInvalidStoreOption()
+	{
+		$command = new ClearCommandTestStub(
+			$cacheManager = m::mock('Illuminate\Cache\CacheManager')
+		);
+
+		$cacheRepository = m::mock('\Illuminate\Contracts\Cache\Repository');
+
+		$app = new Application();
+		$command->setLaravel($app);
+		
+		$cacheManager->shouldReceive('store')->once()->with('bar')->andThrow('\InvalidArgumentException');
+		$cacheRepository->shouldReceive('flush')->never();
+		
+		$this->runCommand($command, ['store' => 'bar']);
+	}
+
+
+	protected function runCommand($command, $input = array())
+	{
+		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+	}
+
+}
+
+class ClearCommandTestStub extends ClearCommand {
+
+	public function call($command, array $arguments = array())
+	{
+		//
+	}
+
+}


### PR DESCRIPTION
This adds an argument to the `cache:clear` command so that you can specify the store that will be cleared. If nothing is passed it will clear the default store as it normally does. Tests included.
