### PR TITLE
[5.0] Delete migrations in fresh command

### DIFF
--- a/src/Illuminate/Foundation/Console/FreshCommand.php
+++ b/src/Illuminate/Foundation/Console/FreshCommand.php
@@ -41,6 +41,9 @@ class FreshCommand extends Command {
 		$files->put(base_path('resources/assets/less/app.less'), ''.PHP_EOL);
 		$files->deleteDirectory(base_path('resources/assets/less/bootstrap'));
 
+		$files->delete(base_path('database/migrations/2014_10_12_000000_create_users_table.php'));
+		$files->delete(base_path('database/migrations/2014_10_12_100000_create_password_resets_table.php'));
+
 		$files->put(app_path('Http/routes.php'), $files->get(__DIR__.'/stubs/fresh-routes.stub'));
 		$files->put(app_path('Providers/AppServiceProvider.php'), $files->get(__DIR__.'/stubs/fresh-app-provider.stub'));
 


### PR DESCRIPTION
As long as we delete other auth scaffolding, migrations should be cleared too
