### PR TITLE
[4.2] Eager loading in Global Scope causes extra constraint / 'is null'

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -150,6 +150,7 @@ abstract class Relation {
 	 */
 	public static function noConstraints(Closure $callback)
 	{
+		$previous = static::$constraints;
 		static::$constraints = false;
 
 		// When resetting the relation where clause, we want to shift the first element
@@ -157,7 +158,7 @@ abstract class Relation {
 		// as "extra" on the relationships, and not original relation constraints.
 		$results = call_user_func($callback);
 
-		static::$constraints = true;
+		static::$constraints = $previous;
 
 		return $results;
 	}


### PR DESCRIPTION
I've found what I believe is a corner-case bug in eloquent related to global scopes. I am unsure of how to write a test for this, any help appreciated! I was originally going to submit this as an issue but figured I'd get the ball rolling here instead.

**The problem**
When I have a global scope setup like below, eloquent is adding an extra `where table.id is null` to the query.

```
<?php 

use \Role;
use Illuminate\Database\Eloquent\ScopeInterface;
use Illuminate\Database\Eloquent\Builder;

class PersonScope implements ScopeInterface {

    private $type = null;
    private $ids  = null;

    public function __construct($type = null)
    {
        $this->type = $type;

        if($this->type)
        {
            // THIS LINE CAUSES THE PROBLEM
            $role = Role::with('users')->where('name', '=', $this->type)->first();   
            // I've also found it doesn't matter which model is used / eager loaded here,
            // it doesn't even matter if I use the results of the query
            // I could have something like:
            // Student::with('user')->get() 
            // and it still causes the `is null` to appear in the query
            $this->ids = $role->users->lists('id'); 
        }
    }

    public function apply(Builder $builder) {
        // only records from the table where id is
        // in the list of all who have the student role        
        if($this->type && $this->ids)
        {
            $builder->whereIn('user_id', $this->ids);
        }
    }

    public function remove(Builder $builder) {

        $query = $builder->getQuery();
        // here you remove the where close to allow developer load   
        // without your global scope condition

        foreach((array)$query->wheres as $key => $where) {

            if($where['column'] == 'user_id') {

                unset($query->wheres[$key]);

                $query->wheres = array_values($query->wheres);

            }
        }

    }
}
```

Now, I've done a fair amount of digging, and found that if the above marked problem line is in my global scope, [this line](https://github.com/laravel/framework/blob/4.2/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php#L74) is the actual culprit of adding the `is null` portion of the query. For some reason, the `static::$constraints` property is `true` in this case, even though `$this->parent` is an empty model (so the foreignKey property is therefore null). So... I tried to track down why `static::$constraints` was true in this case but I couldn't figure out where that was getting set. If I remove the **problem line** from my global scope, `static::$constraints` is never set to true and everything works as expected. I _think_ what happens is since `$constraints` is a static property, the 'first' query (from the eager loaded relation in the scope) sets `$constraints` to true and it carries over to the next call which then causes the `is null`.

I'm happy to create a repo / liferaft (is that still a thing?) for others to reproduce this issue if needed. To summarize the above:

**When I have a global scope that eager loads some other relation, eloquent is adding an `where table.id is null` to the overall query**

Thanks in advance for any insight / clarification!
