### PR TITLE
Add missing dependency for Illuminate/Support to allow standalone use.

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -13,7 +13,8 @@
         "ext-mbstring": "*",
         "illuminate/contracts": "5.0.*",
         "doctrine/inflector": "~1.0",
-        "danielstjules/stringy": "~1.8"
+        "danielstjules/stringy": "~1.8",
+        "symfony/var-dumper": "2.6.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This would probably be insignificant but I just needed to use `illuminate/support` for a small project and noticed that the `dd()` function wasn't working because `symfony/var-dumper` wasn't pulled by composer.
