### PR TITLE
[5.0] fixed global scope case where eager loading inside scope causes 'is null'

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -150,6 +150,7 @@ abstract class Relation {
 	 */
 	public static function noConstraints(Closure $callback)
 	{
+		$previous = static::$constraints;
 		static::$constraints = false;
 
 		// When resetting the relation where clause, we want to shift the first element
@@ -157,7 +158,7 @@ abstract class Relation {
 		// as "extra" on the relationships, and not original relation constraints.
 		$results = call_user_func($callback);
 
-		static::$constraints = true;
+		static::$constraints = $previous;
 
 		return $results;
 	}


### PR DESCRIPTION
See https://github.com/laravel/framework/pull/7898.

Any input / advice / test help appreciated.
