### PR TITLE
[5.0] Allow quoting ENV file values.

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 if ( ! function_exists('abort'))
 {
 	/**
@@ -596,6 +598,11 @@ if ( ! function_exists('env'))
 			case 'empty':
 			case '(empty)':
 				return '';
+		}
+		
+		if (Str::startsWith($value, '"') && Str::endsWith($value, '"'))
+		{
+			return substr($value, 1, -1);
 		}
 
 		return $value;


### PR DESCRIPTION
This fixes issues such as #7660, where the _value_ of an environment variable was "null" (or any other of the reserved words).

This PR allows quoting these values with double quotes.

We can discuss the details (single vs. double quotes, fastest implementation etc.), but I think this should really be fixed.

Why was this valid issue closed and even locked anyway? :angry: 
