### PR TITLE
Add readme.md for each illuminate/projects

### DIFF
--- a/build/illuminate-readme.md
+++ b/build/illuminate-readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## @vendor @name package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require @package
 ```
 
 ## Official Documentation

--- a/build/illuminate-readme.sh
+++ b/build/illuminate-readme.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env php
+<?php
+
+$sourceDirectory = __DIR__.'/../src/Illuminate';
+$readmeTemplate  = __DIR__.'/illuminate-readme.md';
+
+$dirs = glob($sourceDirectory.'/*', GLOB_ONLYDIR);
+
+foreach ($dirs as $dir)
+{
+	// extract part of the folder name
+	$parts = explode('/', $dir);
+
+	// set variables
+	list($vendor, $name) = array_slice($parts, - 2);
+	$package = strtolower($vendor.'/'.$name);
+	$readme  = $sourceDirectory.'/'.$name.'/readme.md';
+
+	// get template
+	$content = file_get_contents($readmeTemplate);
+
+	// replace variables in template
+	$replacements = [
+		'@name'    => $name,
+		'@vendor'  => $vendor,
+		'@package' => $package,
+	];
+	$output       = str_replace(array_keys($replacements), array_values($replacements), $content);
+
+	// write package readme
+	file_put_contents($readme, $output);
+}
+

--- a/src/Illuminate/Auth/readme.md
+++ b/src/Illuminate/Auth/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Auth package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/auth
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Bus/readme.md
+++ b/src/Illuminate/Bus/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Bus package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/bus
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Cache/readme.md
+++ b/src/Illuminate/Cache/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Cache package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/cache
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Config/readme.md
+++ b/src/Illuminate/Config/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Config package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/config
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Console/readme.md
+++ b/src/Illuminate/Console/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Console package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/console
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Container/readme.md
+++ b/src/Illuminate/Container/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Container package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/container
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Contracts/readme.md
+++ b/src/Illuminate/Contracts/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Contracts package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/contracts
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Cookie/readme.md
+++ b/src/Illuminate/Cookie/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Cookie package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/cookie
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Database/README.md
+++ b/src/Illuminate/Database/README.md
@@ -1,70 +1,32 @@
-## Illuminate Database
+## Illuminate Database package
 
-The Illuminate Database component is a full database toolkit for PHP, providing an expressive query builder, ActiveRecord style ORM, and schema builder. It currently supports MySQL, Postgres, SQL Server, and SQLite. It also serves as the database layer of the Laravel PHP framework.
+This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
-### Usage Instructions
+[![Build Status](https://travis-ci.org/laravel/framework.svg)](https://travis-ci.org/laravel/framework)
+[![Total Downloads](https://poser.pugx.org/laravel/framework/downloads.svg)](https://packagist.org/packages/laravel/framework)
+[![Latest Stable Version](https://poser.pugx.org/laravel/framework/v/stable.svg)](https://packagist.org/packages/laravel/framework)
+[![Latest Unstable Version](https://poser.pugx.org/laravel/framework/v/unstable.svg)](https://packagist.org/packages/laravel/framework)
+[![License](https://poser.pugx.org/laravel/framework/license.svg)](https://packagist.org/packages/laravel/framework)
 
-First, create a new "Capsule" manager instance. Capsule aims to make configuring the library for usage outside of the Laravel framework as easy as possible.
+> **Note:** If you want to build an application using Laravel 5, visit the main [Laravel repository](https://github.com/laravel/laravel).
 
-```PHP
-use Illuminate\Database\Capsule\Manager as Capsule;
+## Contributing
 
-$capsule = new Capsule;
+Issues for this package shall be posted on [Laravel framework issues](http://github.com/laravel/framework/issues).
+Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](http://laravel.com/docs/contributions).
 
-$capsule->addConnection([
-	'driver'    => 'mysql',
-	'host'      => 'localhost',
-	'database'  => 'database',
-	'username'  => 'root',
-	'password'  => 'password',
-	'charset'   => 'utf8',
-	'collation' => 'utf8_unicode_ci',
-	'prefix'    => '',
-]);
+## Installation
 
-// Set the event dispatcher used by Eloquent models... (optional)
-use Illuminate\Events\Dispatcher;
-use Illuminate\Container\Container;
-$capsule->setEventDispatcher(new Dispatcher(new Container));
+Use [Composer](https://getcomposer.org/) to install this package:
 
-// Make this Capsule instance available globally via static methods... (optional)
-$capsule->setAsGlobal();
-
-// Setup the Eloquent ORM... (optional; unless you've used setEventDispatcher())
-$capsule->bootEloquent();
+```sh
+composer require illuminate/database
 ```
 
-> `composer require "illuminate/events=5.0.*"` required when you need to use observers with Eloquent.
+## Official Documentation
 
-Once the Capsule instance has been registered. You may use it like so:
+Documentation for the framework can be found on the [Laravel website](http://laravel.com/docs).
 
-**Using The Query Builder**
+### License
 
-```PHP
-$users = Capsule::table('users')->where('votes', '>', 100)->get();
-```
-Other core methods may be accessed directly from the Capsule in the same manner as from the DB facade:
-```PHP
-$results = Capsule::select('select * from users where id = ?', array(1));
-```
-
-**Using The Schema Builder**
-
-```PHP
-Capsule::schema()->create('users', function($table)
-{
-	$table->increments('id');
-	$table->string('email')->unique();
-	$table->timestamps();
-});
-```
-
-**Using The Eloquent ORM**
-
-```PHP
-class User extends Illuminate\Database\Eloquent\Model {}
-
-$users = User::where('votes', '>', 1)->get();
-```
-
-For further documentation on using the various database facilities this library provides, consult the [Laravel framework documentation](http://laravel.com/docs).
+The Laravel framework is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT).

--- a/src/Illuminate/Encryption/readme.md
+++ b/src/Illuminate/Encryption/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Encryption package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/encryption
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Events/readme.md
+++ b/src/Illuminate/Events/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Events package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/events
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Filesystem/readme.md
+++ b/src/Illuminate/Filesystem/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Filesystem package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/filesystem
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Foundation/readme.md
+++ b/src/Illuminate/Foundation/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Foundation package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/foundation
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Hashing/readme.md
+++ b/src/Illuminate/Hashing/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Hashing package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/hashing
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Http/readme.md
+++ b/src/Illuminate/Http/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Http package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/http
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Log/readme.md
+++ b/src/Illuminate/Log/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Log package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/log
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Mail/readme.md
+++ b/src/Illuminate/Mail/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Mail package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/mail
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Pagination/readme.md
+++ b/src/Illuminate/Pagination/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Pagination package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/pagination
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Pipeline/readme.md
+++ b/src/Illuminate/Pipeline/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Pipeline package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/pipeline
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Redis/readme.md
+++ b/src/Illuminate/Redis/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Redis package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/redis
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Routing/readme.md
+++ b/src/Illuminate/Routing/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Routing package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/routing
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Session/readme.md
+++ b/src/Illuminate/Session/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Session package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/session
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Support/readme.md
+++ b/src/Illuminate/Support/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Support package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/support
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Translation/readme.md
+++ b/src/Illuminate/Translation/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Translation package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/translation
 ```
 
 ## Official Documentation

--- a/src/Illuminate/Validation/readme.md
+++ b/src/Illuminate/Validation/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate Validation package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/validation
 ```
 
 ## Official Documentation

--- a/src/Illuminate/View/readme.md
+++ b/src/Illuminate/View/readme.md
@@ -1,4 +1,4 @@
-## Illuminate Queue package
+## Illuminate View package
 
 This package is part of the [Laravel framework](http://github.com/laravel/framework).
 
@@ -20,7 +20,7 @@ Thank you for considering contributing to the Laravel framework! The contributio
 Use [Composer](https://getcomposer.org/) to install this package:
 
 ```sh
-composer require illuminate/queue
+composer require illuminate/view
 ```
 
 ## Official Documentation


### PR DESCRIPTION
Provides a `readme.md` for each Illuminate packages so that `https://github.com/illuminate/auth/blob/master/readme.md` will not be empty and will provide useful informations.
This readme file will also be accessible at `https://github.com/laravel/framework/tree/master/src/Illuminate/Auth/readme.md`

This PR comes with 2 files in `/build`:
- `build/illuminate-readme.md` is a template that be customized
- `build/illuminate-readme.sh` : generate all readme (except root `readme.md` file)
