### PR TITLE
Add type hinting on $parameters

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -543,7 +543,7 @@ class Container implements ArrayAccess, ContainerContract {
 	 * @param  array  $parameters
 	 * @return array
 	 */
-	protected function getMethodDependencies($callback, $parameters = [])
+	protected function getMethodDependencies($callback, array $parameters = [])
 	{
 		$dependencies = [];
 
@@ -634,7 +634,7 @@ class Container implements ArrayAccess, ContainerContract {
 	 * @param  array   $parameters
 	 * @return mixed
 	 */
-	public function make($abstract, $parameters = [])
+	public function make($abstract, array $parameters = [])
 	{
 		$abstract = $this->getAlias($abstract);
 
@@ -763,7 +763,7 @@ class Container implements ArrayAccess, ContainerContract {
 	 *
 	 * @throws BindingResolutionException
 	 */
-	public function build($concrete, $parameters = [])
+	public function build($concrete, array $parameters = [])
 	{
 		// If the concrete type is actually a Closure, we will just execute it and
 		// hand back the results of the functions, which allows functions to be
@@ -824,7 +824,7 @@ class Container implements ArrayAccess, ContainerContract {
 	 * @param  array  $primitives
 	 * @return array
 	 */
-	protected function getDependencies($parameters, array $primitives = [])
+	protected function getDependencies(array $parameters, array $primitives = [])
 	{
 		$dependencies = [];
 

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -102,7 +102,7 @@ interface Container {
 	 * @param  array   $parameters
 	 * @return mixed
 	 */
-	public function make($abstract, $parameters = array());
+	public function make($abstract, array $parameters = []);
 
 	/**
 	 * Call the given Closure / class@method and inject its dependencies.
@@ -112,7 +112,7 @@ interface Container {
 	 * @param  string|null  $defaultMethod
 	 * @return mixed
 	 */
-	public function call($callback, array $parameters = array(), $defaultMethod = null);
+	public function call($callback, array $parameters = [], $defaultMethod = null);
 
 	/**
 	 * Determine if the given abstract type has been resolved.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -601,7 +601,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	 * @param  array   $parameters
 	 * @return mixed
 	 */
-	public function make($abstract, $parameters = array())
+	public function make($abstract, array $parameters = array())
 	{
 		$abstract = $this->getAlias($abstract);
 


### PR DESCRIPTION
Without type hinting, the following code will work because it allows to change `$parameters` to any type.

```
    $container = new Container;
    $container->bind('bar', function($c, $parameters)
    {
        return $parameters;
    });
    $this->assertEquals(1, $container->make('bar', 1));
```
