### PR TITLE
[5.0] Remove find method from the model class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -70,7 +70,7 @@ class Builder {
 	 *
 	 * @param  mixed  $id
 	 * @param  array  $columns
-	 * @return \Illuminate\Database\Eloquent\Model|static|null
+	 * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|null
 	 */
 	public function find($id, $columns = array('*'))
 	{
@@ -87,15 +87,15 @@ class Builder {
 	/**
 	 * Find a model by its primary key.
 	 *
-	 * @param  array  $id
+	 * @param  array  $ids
 	 * @param  array  $columns
-	 * @return \Illuminate\Database\Eloquent\Model|Collection|static
+	 * @return \Illuminate\Database\Eloquent\Collection
 	 */
-	public function findMany($id, $columns = array('*'))
+	public function findMany($ids, $columns = array('*'))
 	{
-		if (empty($id)) return $this->model->newCollection();
+		if (empty($ids)) return $this->model->newCollection();
 
-		$this->query->whereIn($this->model->getQualifiedKeyName(), $id);
+		$this->query->whereIn($this->model->getQualifiedKeyName(), $ids);
 
 		return $this->get($columns);
 	}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -676,22 +676,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	}
 
 	/**
-	 * Find a model by its primary key.
-	 *
-	 * @param  mixed  $id
-	 * @param  array  $columns
-	 * @return \Illuminate\Support\Collection|static|null
-	 */
-	public static function find($id, $columns = array('*'))
-	{
-		$instance = new static;
-
-		if (is_array($id) && empty($id)) return $instance->newCollection();
-
-		return $instance->newQuery()->find($id, $columns);
-	}
-
-	/**
 	 * Find a model by its primary key or return new static.
 	 *
 	 * @param  mixed  $id

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -87,9 +87,27 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 
 	public function testBasicModelRetrieval()
 	{
-		EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+		EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+		EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
 		$model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')->first();
 		$this->assertEquals('taylorotwell@gmail.com', $model->email);
+
+		$model = EloquentTestUser::find(1);
+		$this->assertInstanceOf('EloquentTestUser', $model);
+		$this->assertEquals(1, $model->id);
+
+		$model = EloquentTestUser::find(2);
+		$this->assertInstanceOf('EloquentTestUser', $model);
+		$this->assertEquals(2, $model->id);
+
+		$collection = EloquentTestUser::find([]);
+		$this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $collection);
+		$this->assertEquals(0, $collection->count());
+
+		$collection = EloquentTestUser::find([1, 2, 3]);
+		$this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $collection);
+		$this->assertEquals(2, $collection->count());
 	}
 
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -104,23 +104,9 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testFindMethodCallsQueryBuilderCorrectly()
-	{
-		$result = EloquentModelFindStub::find(1);
-		$this->assertEquals('foo', $result);
-	}
-
-
 	public function testFindMethodUseWritePdo()
 	{
 		$result =  EloquentModelFindWithWritePdoStub::onWriteConnection()->find(1);
-	}
-
-
-	public function testFindMethodWithArrayCallsQueryBuilderCorrectly()
-	{
-		$result = EloquentModelFindManyStub::find(array(1, 2));
-		$this->assertEquals('foo', $result);
 	}
 
 
@@ -1285,15 +1271,6 @@ class EloquentModelSaveStub extends Illuminate\Database\Eloquent\Model {
 	}
 }
 
-class EloquentModelFindStub extends Illuminate\Database\Eloquent\Model {
-	public function newQuery()
-	{
-		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
-		$mock->shouldReceive('find')->once()->with(1, array('*'))->andReturn('foo');
-		return $mock;
-	}
-}
-
 class EloquentModelFindWithWritePdoStub extends Illuminate\Database\Eloquent\Model {
 	public function newQuery()
 	{
@@ -1322,15 +1299,6 @@ class EloquentModelHydrateRawStub extends Illuminate\Database\Eloquent\Model {
 	{
 		$mock = m::mock('Illuminate\Database\Connection');
 		$mock->shouldReceive('select')->once()->with('SELECT ?', array('foo'))->andReturn(array());
-		return $mock;
-	}
-}
-
-class EloquentModelFindManyStub extends Illuminate\Database\Eloquent\Model {
-	public function newQuery()
-	{
-		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
-		$mock->shouldReceive('find')->once()->with(array(1, 2), array('*'))->andReturn('foo');
 		return $mock;
 	}
 }


### PR DESCRIPTION
It will defer to the builder class, like all other static methods.
