### PR TITLE
[5.0] Add argument to cache:clear to specify store name.

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Cache\CacheManager;
+use Symfony\Component\Console\Input\InputArgument;
 
 class ClearCommand extends Command {
 
@@ -46,13 +47,27 @@ class ClearCommand extends Command {
 	 */
 	public function fire()
 	{
-		$this->laravel['events']->fire('cache:clearing');
+		$storeName = $this->argument('store');
 
-		$this->cache->flush();
+		$this->laravel['events']->fire('cache:clearing', [$storeName]);
 
-		$this->laravel['events']->fire('cache:cleared');
+		$this->cache->store($storeName)->flush();
+
+		$this->laravel['events']->fire('cache:cleared', [$storeName]);
 
 		$this->info('Application cache cleared!');
+	}
+
+	/**
+	 * Get the console command arguments.
+	 *
+	 * @return array
+	 */
+	protected function getArguments()
+	{
+		return [
+			['store', InputArgument::OPTIONAL, 'The name of the store you would like to clear.'],
+		];
 	}
 
 }

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Foundation\Application;
+use Illuminate\Cache\Console\ClearCommand;
+
+class ClearCommandTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testClearWithNoStoreOption()
+	{
+		$command = new ClearCommandTestStub(
+			$cacheManager = m::mock('Illuminate\Cache\CacheManager')
+		);
+
+		$cacheRepository = m::mock('\Illuminate\Contracts\Cache\Repository');
+
+		$app = new Application();
+		$command->setLaravel($app);
+		
+		$cacheManager->shouldReceive('store')->once()->with(null)->andReturn($cacheRepository);
+		$cacheRepository->shouldReceive('flush')->once();
+		
+		$this->runCommand($command);
+	}
+
+
+	public function testClearWithStoreOption()
+	{
+		$command = new ClearCommandTestStub(
+			$cacheManager = m::mock('Illuminate\Cache\CacheManager')
+		);
+
+		$cacheRepository = m::mock('\Illuminate\Contracts\Cache\Repository');
+
+		$app = new Application();
+		$command->setLaravel($app);
+		
+		$cacheManager->shouldReceive('store')->once()->with('foo')->andReturn($cacheRepository);
+		$cacheRepository->shouldReceive('flush')->once();
+		
+		$this->runCommand($command, ['store' => 'foo']);
+	}
+
+
+	public function testClearWithInvalidStoreOption()
+	{
+		$command = new ClearCommandTestStub(
+			$cacheManager = m::mock('Illuminate\Cache\CacheManager')
+		);
+
+		$cacheRepository = m::mock('\Illuminate\Contracts\Cache\Repository');
+
+		$app = new Application();
+		$command->setLaravel($app);
+		
+		$cacheManager->shouldReceive('store')->once()->with('bar')->andThrow('\InvalidArgumentException');
+		$cacheRepository->shouldReceive('flush')->never();
+		$this->setExpectedException('InvalidArgumentException');
+
+		$this->runCommand($command, ['store' => 'bar']);
+	}
+
+
+	protected function runCommand($command, $input = array())
+	{
+		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+	}
+
+}
+
+class ClearCommandTestStub extends ClearCommand {
+
+	public function call($command, array $arguments = array())
+	{
+		//
+	}
+
+}


### PR DESCRIPTION
Sorry about the delay. This is #7893 retargeted for 5.0.
This adds an argument to the `cache:clear` command so that you can specify the store that will be cleared. If nothing is passed it will clear the default store as it normally does. Tests included.
