### PR TITLE
[5.0] Fix Validator contract in ValidatesRequest trait

### DIFF
--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Validation\Validator;
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exception\HttpResponseException;
 
 trait ValidatesRequests {
@@ -61,12 +61,12 @@ trait ValidatesRequests {
 	/**
 	 * Format the validation errors to be returned.
 	 *
-	 * @param  \Illuminate\Validation\Validator  $validator
+	 * @param  \Illuminate\Contracts\Validation\Validator  $validator
 	 * @return array
 	 */
 	protected function formatValidationErrors(Validator $validator)
 	{
-		return $validator->errors()->getMessages();
+		return $validator->getMessageBag()->getMessages();
 	}
 
 	/**


### PR DESCRIPTION
The `ValidatesRequest` trait violates the `\Illuminate\Contracts\Validation\Validator` contract in the `formatValidationErrors()` method:

``` php
    /**
     * Format the validation errors to be returned.
     *
     * @param  \Illuminate\Validation\Validator  $validator
     * @return array
     */
    protected function formatValidationErrors(Validator $validator)
    {
        return $validator->errors()->getMessages();
    }
```

Instead of using the contract, `formatValidationErrors` creates a dependency towards `\Illuminate\Validation\Validator`. 

Though the `Validator` contract does not provide an `errors()` method as used in `formatValidationErrors()`, it _does_ provide the `getMessageBag()` method. As `errors()` is just an alias for `getMessageBag()`, replacing the method call is sufficient to remove the dependency towards `\Illuminate\Validation\Validator`.
