### PR TITLE
[5.0] Remove unnecessary code

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -57,11 +57,6 @@ class FileStore implements Store {
 		// If the file doesn't exists, we obviously can't return the cache so we will
 		// just return null. Otherwise, we'll get the contents of the file and get
 		// the expiration UNIX timestamps from the start of the file's contents.
-		if ( ! $this->files->exists($path))
-		{
-			return array('data' => null, 'time' => null);
-		}
-
 		try
 		{
 			$expire = substr($contents = $this->files->get($path), 0, 10);

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -1,13 +1,14 @@
 <?php
 
 use Illuminate\Cache\FileStore;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function testNullIsReturnedIfFileDoesntExist()
 	{
 		$files = $this->mockFilesystem();
-		$files->expects($this->once())->method('exists')->will($this->returnValue(false));
+		$files->expects($this->once())->method('get')->will($this->throwException(new FileNotFoundException()));
 		$store = new FileStore($files, __DIR__);
 		$value = $store->get('foo');
 		$this->assertNull($value);
@@ -29,7 +30,6 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 	public function testExpiredItemsReturnNull()
 	{
 		$files = $this->mockFilesystem();
-		$files->expects($this->once())->method('exists')->will($this->returnValue(true));
 		$contents = '0000000000';
 		$files->expects($this->once())->method('get')->will($this->returnValue($contents));
 		$store = $this->getMock('Illuminate\Cache\FileStore', array('forget'), array($files, __DIR__));
@@ -42,7 +42,6 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 	public function testValidItemReturnsContents()
 	{
 		$files = $this->mockFilesystem();
-		$files->expects($this->once())->method('exists')->will($this->returnValue(true));
 		$contents = '9999999999'.serialize('Hello World');
 		$files->expects($this->once())->method('get')->will($this->returnValue($contents));
 		$store = new FileStore($files, __DIR__);


### PR DESCRIPTION
Filesystem::get method check if file exists, and if file doesn't exist, throw FileNotFoundException exception.
So we can remove the additional checking code in order not to touch filesystem twice.

`if ( ! $this->files->exists($path))
{
   return array('data' => null, 'time' => null);
}`
