### PR TITLE
[5.0] Use collection to remove soft delete scope

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -36,18 +36,10 @@ class SoftDeletingScope implements ScopeInterface {
 
 		$query = $builder->getQuery();
 
-		foreach ((array) $query->wheres as $key => $where)
+		$query->wheres = collect($query->wheres)->reject(function($where) use ($column)
 		{
-			// If the where clause is a soft delete date constraint, we will remove it from
-			// the query and reset the keys on the wheres. This allows this developer to
-			// include deleted model in a relationship result set that is lazy loaded.
-			if ($this->isSoftDeleteConstraint($where, $column))
-			{
-				unset($query->wheres[$key]);
-
-				$query->wheres = array_values($query->wheres);
-			}
-		}
+			return $this->isSoftDeleteConstraint($where, $column);
+		})->values()->all();
 	}
 
 	/**


### PR DESCRIPTION
It is much clearer this way.

Also, before it was changing the array inside the `foreach` loop, which is generally an anti-pattern — you don't want to mess with the array while iterating over it.
