### PR TITLE
escape url in pagination bootstrap presenter

### DIFF
--- a/src/Illuminate/Pagination/BootstrapThreePresenter.php
+++ b/src/Illuminate/Pagination/BootstrapThreePresenter.php
@@ -76,7 +76,7 @@ class BootstrapThreePresenter implements PresenterContract {
 	{
 		$rel = is_null($rel) ? '' : ' rel="'.$rel.'"';
 
-		return '<li><a href="'.$url.'"'.$rel.'>'.$page.'</a></li>';
+		return '<li><a href="'.urlencode($url).'"'.$rel.'>'.$page.'</a></li>';
 	}
 
 	/**


### PR DESCRIPTION
Pager links are not escaped.
This corrupts links when some parameter matches with html entity like &reg.
