### PR TITLE
[5.0] escape url in pagination bootstrap presenter

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -921,7 +921,7 @@ class Connection implements ConnectionInterface {
 	/**
 	 * Get the schema grammar used by the connection.
 	 *
-	 * @return \Illuminate\Database\Query\Grammars\Grammar
+	 * @return \Illuminate\Database\Schema\Grammars\Grammar
 	 */
 	public function getSchemaGrammar()
 	{

--- a/src/Illuminate/Pagination/BootstrapThreePresenter.php
+++ b/src/Illuminate/Pagination/BootstrapThreePresenter.php
@@ -76,7 +76,7 @@ class BootstrapThreePresenter implements PresenterContract {
 	{
 		$rel = is_null($rel) ? '' : ' rel="'.$rel.'"';
 
-		return '<li><a href="'.$url.'"'.$rel.'>'.$page.'</a></li>';
+		return '<li><a href="'.urlencode($url).'"'.$rel.'>'.$page.'</a></li>';
 	}
 
 	/**

--- a/src/Illuminate/Pagination/BootstrapThreePresenter.php
+++ b/src/Illuminate/Pagination/BootstrapThreePresenter.php
@@ -76,7 +76,7 @@ class BootstrapThreePresenter implements PresenterContract {
 	{
 		$rel = is_null($rel) ? '' : ' rel="'.$rel.'"';
 
-		return '<li><a href="'.urlencode($url).'"'.$rel.'>'.$page.'</a></li>';
+		return '<li><a href="'.htmlentities($url).'"'.$rel.'>'.$page.'</a></li>';
 	}
 
 	/**


### PR DESCRIPTION
Pager links are not escaped.
This corrupts links when some parameter matches with html entity like &reg.
