### PR TITLE
[5.0] Named Resource inside Route Group

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -193,7 +193,7 @@ class ResourceRegistrar {
 		// the resource action. Otherwise we'll just use an empty string for here.
 		$prefix = isset($options['as']) ? $options['as'].'.' : '';
 
-		if ( ! $this->router->hasGroupStack() OR ! empty($prefix))
+		if ( ! $this->router->hasGroupStack() || ! empty($prefix))
 		{
 			return $prefix.$resource.'.'.$method;
 		}

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -193,7 +193,7 @@ class ResourceRegistrar {
 		// the resource action. Otherwise we'll just use an empty string for here.
 		$prefix = isset($options['as']) ? $options['as'].'.' : '';
 
-		if ( ! $this->router->hasGroupStack())
+		if ( ! $this->router->hasGroupStack() OR ! empty($prefix))
 		{
 			return $prefix.$resource.'.'.$method;
 		}


### PR DESCRIPTION
This will solve an issue when a named route::resource is inside a route::group from taking on the prefix as part of the named route.

Therefore any changes in the url prefix will NOT break the named routes.

``` php
$router->group(['prefix' => 'some/other/uri'], function($router)
{
    $route = 'myroute';

    $router->resource('orders', 'OrdersController', ['as' => "{$route}"]);

    $router->get('/', ['as' => "{$route}", 'uses' => 'HomeController@index']);
});
```

```
this myroute.some.other.uri.orders.index becomes myroute.orders.index
```
#7953
