### PR TITLE
[5.0] Passing names to several controllers

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -221,9 +221,10 @@ class Router implements RegistrarContract {
 	 */
 	public function controllers(array $controllers)
 	{
-		foreach ($controllers as $uri => $name)
+		foreach ($controllers as $uri => $action)
 		{
-			$this->controller($uri, $name);
+			$action = $this->convertToControllerAction($action);
+			$this->controller($uri, array_get($action, 'uses'), array_get($action, 'names', []));
 		}
 	}
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -758,6 +758,25 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('bar'));
 	}
 
+	public function testControllerNaming()
+	{
+		$router = $this->getRouter();
+		$router->controller('home', 'RouteTestInspectedControllerStub', [
+			'getFoo' => 'foo',
+		]);
+
+		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo'));
+
+		$router = $this->getRouter();
+		$router->controllers([
+			'home' => [
+				'uses' => 'RouteTestInspectedControllerStub',
+				'names' => ['getFoo' => 'bar']
+			],
+		]);
+		
+		$this->assertTrue($router->getRoutes()->hasNamedRoute('bar'));
+	}
 
 	public function testRouterFiresRoutedEvent()
 	{


### PR DESCRIPTION
Currently router allows to pass names as third attribute `$router->controller('foo', 'Foo', ['getIndex' => 'index']);` but this feature is not available when passing several controllers.

This fix allows to pass complex structures to `controllers` method

``` php
$router->controllers([
    'foo' => 'FooController',
    'bar' => [
        'uses' => 'BarController', 
        'names' => [
            'getIndex' => 'bar.index',
            'postSave' => 'bar.save',
        ]
    ],
]);
```

The fix does not break any compatibilities.
Tests provided.
