### PR TITLE
Fixes the problem with macros returning Renderable implementations

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -390,14 +390,18 @@ class View implements ArrayAccess, ViewContract {
 		throw new BadMethodCallException("Method [$method] does not exist on view.");
 	}
 
-	/**
-	 * Get the string contents of the view.
-	 *
-	 * @return string
-	 */
-	public function __toString()
-	{
-		return $this->render();
-	}
+    /**
+     * Get the string contents of the view.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        try {
+            return $this->render();
+        } catch (\Exception $e) {
+            return $e->getMessage();
+        }
+    }
 
 }

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -397,11 +397,7 @@ class View implements ArrayAccess, ViewContract {
      */
     public function __toString()
     {
-        try {
-            return $this->render();
-        } catch (\Exception $e) {
-            return $e->getMessage();
-        }
+        return $this->render();
     }
 
 }

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Mockery as m;
+
 class SupportMacroableTest extends PHPUnit_Framework_TestCase {
 
 	private $macroable;
@@ -44,6 +46,19 @@ class SupportMacroableTest extends PHPUnit_Framework_TestCase {
 		$result = TestMacroable::tryStatic();
 		$this->assertEquals('static', $result);
 	}
+
+
+    public function testCallingRenderableMacro()
+    {
+        $renderable = m::mock('Illuminate\Contracts\Support\Renderable');
+        $renderable->shouldReceive('render')->once()->andReturn('output');
+
+        TestMacroable::macro('tryRenderable', function() use ($renderable) {
+            return $renderable;
+        });
+
+        $this->assertEquals('output', TestMacroable::tryRenderable());
+    }
 
 }
 

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -203,6 +203,14 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+    public function testViewExceptionHandling()
+    {
+        $view = $this->getView();
+
+        $this->assertEquals('Method Mockery_0_Illuminate_View_Factory::incrementRender() does not exist on this mock object', (string) $view);
+    }
+
+
 	protected function getView()
 	{
 		return new View(

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -203,14 +203,6 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-    public function testViewExceptionHandling()
-    {
-        $view = $this->getView();
-
-        $this->assertEquals('Method Mockery_0_Illuminate_View_Factory::incrementRender() does not exist on this mock object', (string) $view);
-    }
-
-
 	protected function getView()
 	{
 		return new View(


### PR DESCRIPTION
As per this previous PR: https://github.com/laravel/framework/pull/7965

The issue is around macros that return view components - resulting in (possibly) exceptions being thrown when the view is rendered via __toString. This ensures that if a macroable class implements a macro that returns a view, it will be rendered correctly and the exception handling work as expected - and everyone's happy!
