### PR TITLE
[5.1] Memcached sessions: allow configuration of cache store to use

### DIFF
--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -107,7 +107,7 @@ class SessionManager extends Manager {
 	{
 		$store = $this->app['config']['session.memcached_store'];
 
-		// Verify store uses the memcached driver
+		// Verify store uses the memcached driver.
 		$repository = $this->app['cache']->store($store);
 		if ( ! $repository->getStore() instanceof MemcachedStore)
 		{

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -109,7 +109,7 @@ class SessionManager extends Manager {
 
 		// Verify store uses the memcached driver
 		$repository = $this->app['cache']->store($store);
-		if (!($repository->getStore() instanceof MemcachedStore))
+		if ( ! $repository->getStore() instanceof MemcachedStore)
 		{
 			throw new RuntimeException("session.memcached_store [{$store}] is not a memcached store.");
 		}

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Support\Manager;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler;
+use Illuminate\Cache\MemcachedStore;
+use RuntimeException;
 
 class SessionManager extends Manager {
 
@@ -103,7 +105,18 @@ class SessionManager extends Manager {
 	 */
 	protected function createMemcachedDriver()
 	{
-		return $this->createCacheBased('memcached');
+		$store = $this->app['config']['session.memcached_store'];
+
+		// Verify store uses the memcached driver
+		$repository = $this->app['cache']->store($store);
+		if (!($repository->getStore() instanceof MemcachedStore))
+		{
+			throw new RuntimeException("session.memcached_store [{$store}] is not a memcached store.");
+		}
+
+		$minutes = $this->app['config']['session.lifetime'];
+
+		return $this->buildSession(new CacheBasedSessionHandler($repository, $minutes));
 	}
 
 	/**

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -1,9 +1,9 @@
 <?php namespace Illuminate\Session;
 
-use Illuminate\Support\Manager;
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler;
-use Illuminate\Cache\MemcachedStore;
 use RuntimeException;
+use Illuminate\Support\Manager;
+use Illuminate\Cache\MemcachedStore;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler;
 
 class SessionManager extends Manager {
 


### PR DESCRIPTION
Just as with database and redis sessions the `connection` can be specified, for memcached sessions this PR allows the `store` for the session to be specified, rather than simply using the default `memcached` store.

Here is a suggested modification to `config/session.php`:

```
    /*
    |--------------------------------------------------------------------------
    | Session Cache Store
    |--------------------------------------------------------------------------
    |
    | When using the "memcached" session driver, you may specify a cache store
    | that should be used for these sessions. This should correspond to a
    | store in your cache configuration options which uses the memcached
    | driver.
    |
    */

    'memcached_store' => 'memcachedstorefoo',
```
