### PR TITLE
Remove / Replace core middlewares

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -72,6 +72,14 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	protected $middlewares = array();
 
 	/**
+	 * List of middlewares that need to be removed before getting the HTTP
+	 * kernel
+	 *
+	 * @var array
+	 */
+	protected $forgetMiddlewares = array();
+
+	/**
 	 * All of the registered service providers.
 	 *
 	 * @var array
@@ -648,6 +656,30 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	}
 
 	/**
+	 * Remove all the middlewares classes defined by the given parameter.
+	 * If the parameter is empty, `forgetMiddlewares` will be used.
+	 *
+	 * @param array $middlewares
+	 * @return $this
+	 */
+	protected function removeMiddlewares(array $middlewares = array())
+	{
+		if (empty($middlewares)) {
+			$middlewares = $this->forgetMiddlewares;
+		}
+
+		$middlewares = array_unique($middlewares);
+
+		foreach ($middlewares as $class) {
+			$this->middlewares = array_filter($this->middlewares, function($m) use ($class) {
+				return $m['class'] != $class;
+			});
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Register the default, but optional middlewares.
 	 *
 	 * @return void
@@ -672,17 +704,15 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	}
 
 	/**
-	 * Remove a custom middleware from the application.
+	 * Add a middleware class in the list of middlewares that will be removed
+	 * from the application.
 	 *
 	 * @param  string  $class
 	 * @return void
 	 */
 	public function forgetMiddleware($class)
 	{
-		$this->middlewares = array_filter($this->middlewares, function($m) use ($class)
-		{
-			return $m['class'] != $class;
-		});
+		$this->forgetMiddlewares[] = $class;
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -627,12 +627,14 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 	{
 		$sessionReject = $this->bound('session.reject') ? $this['session.reject'] : null;
 
-		$client = with(new \Stack\Builder)
-						->push('Illuminate\Cookie\Guard', $this['encrypter'])
-						->push('Illuminate\Cookie\Queue', $this['cookie'])
-						->push('Illuminate\Session\Middleware', $this['session'], $sessionReject);
+		$client = new \Stack\Builder();
 
-		$this->mergeCustomMiddlewares($client);
+		$this->middleware('Illuminate\Cookie\Guard', [$this['encrypter']])
+			->middleware('Illuminate\Cookie\Queue', [$this['cookie']])
+			->middleware('Illuminate\Session\Middleware', [$this['session'], $sessionReject]);
+
+		$this->removeMiddlewares($this->forgetMiddlewares)
+			->mergeCustomMiddlewares($client);
 
 		return $client->resolve($this);
 	}


### PR DESCRIPTION
This change will let to remove and/or replace the core middleware classes.

I was looking the way to return the session id in a different header (for a RESTfull API), but the `Set-Cookie` header was always set by the session middleware.

So far, it is the only solution that I found to extend `Illuminate\Session\Middleware` to be able to have session without cookies (`Set-Cookie` header), but to send the cookie id on another header.
