### PR TITLE
[5.0] Prevent forceCreate() from changing guarded status

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -554,11 +554,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public static function forceCreate(array $attributes)
 	{
-		static::unguard();
+		$needsUnguarding = ! static::$unguarded;
+
+		if ($needsUnguarding) static::unguard();
 
 		$model = static::create($attributes);
 
-		static::reguard();
+		if ($needsUnguarding) static::reguard();
 
 		return $model;
 	}


### PR DESCRIPTION
Currently, calling forceCreate() on a previously unguarded model will unexpectedly guard the model before it returns.  I presume this is not the desired behavior.

(Now merging on 5.0 instead of master.  See: https://github.com/laravel/framework/pull/7975)
