### PR TITLE
[5.1] A query scope can return falsy values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -813,7 +813,9 @@ class Builder {
 	{
 		array_unshift($parameters, $this);
 
-		return call_user_func_array(array($this->model, $scope), $parameters) ?: $this;
+		$scopeResult = call_user_func_array(array($this->model, $scope), $parameters);
+
+		return is_null($scopeResult) ? $this : $scopeResult;
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -506,8 +506,6 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class EloquentBuilderTestModelStub extends Illuminate\Database\Eloquent\Model {}
-
 class EloquentBuilderTestScopeStub extends Illuminate\Database\Eloquent\Model {
 	public function scopeApproved($query)
 	{
@@ -517,12 +515,6 @@ class EloquentBuilderTestScopeStub extends Illuminate\Database\Eloquent\Model {
 	{
 		return array();
 	}
-}
-
-class EloquentBuilderTestWithTrashedStub extends Illuminate\Database\Eloquent\Model {
-	use Illuminate\Database\Eloquent\SoftDeletes;
-	protected $table = 'table';
-	public function getKeyName() { return 'foo'; }
 }
 
 class EloquentBuilderTestNestedStub extends Illuminate\Database\Eloquent\Model {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -378,6 +378,15 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($builder, $result);
 	}
 
+	public function testQueryScopeReturningEmptyArray()
+	{
+		$builder = $this->getBuilder();
+		$builder->getQuery()->shouldReceive('from');
+		$builder->setModel($model = new EloquentBuilderTestScopeStub);
+		$result = $builder->listsThings();
+
+		$this->assertEquals(array(), $result);
+	}
 
 	public function testNestedWhere()
 	{
@@ -503,6 +512,10 @@ class EloquentBuilderTestScopeStub extends Illuminate\Database\Eloquent\Model {
 	public function scopeApproved($query)
 	{
 		$query->where('foo', 'bar');
+	}
+	public function scopeListsThings($query)
+	{
+		return array();
 	}
 }
 


### PR DESCRIPTION
This is rebased to master from #7982.
## 

This pull request is linked to the issue #7643. Initially, I was hesitant about the attended behavior of query scopes but, after few days of reflexion, I think that a small modification is necessary.

A query scope can return something else than the query builder. The current implementation make it possible and it is implicitly encouraged by the official documentation (if not, the return statement should be superfluous). Then, query scope should also be able to return falsy things (`false`,  `array()`, `0`, `""`...).

My pull request make it possible except for `NULL` because the current unit tests show that, when we return nothing, the query scope mechanism returns the query builder by default.

With this modification, we could write scopes like `countApproved()` or `listsThings()` that could make the code cleaner. My initial use case was to get an array directly usable by the `Form::select()` helper (id => name).
## 

And, because "leave the campground cleaner than you found it", I have removed stub classes in DatabaseEloquentBuilderTest that was unused.
