### PR TITLE
[5.0] Fix bug in Translator::sortReplacements function.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -620,7 +620,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 		// and grab the corresponding values for the sorted keys from this array.
 		foreach ($this->items as $key => $value)
 		{
-			$results[$key] = $callback($value);
+			$results[$key] = $callback($value, $key);
 		}
 
 		$descending ? arsort($results, $options)

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -145,9 +145,9 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	 */
 	protected function sortReplacements(array $replace)
 	{
-		return (new Collection($replace))->sortBy(function($r)
+		return (new Collection($replace))->sortBy(function($value, $key)
 		{
-			return mb_strlen($r) * -1;
+			return mb_strlen($key) * -1;
 		});
 	}
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -36,6 +36,7 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 	{
 		$t = $this->getMock('Illuminate\Translation\Translator', null, array($this->getLoader(), 'en'));
 		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(array('foo' => 'foo', 'baz' => 'breeze :foo :foobar'));
+		$this->assertEquals('breeze bar taylor', $t->get('foo::bar.baz', array('foo' => 'bar', 'foobar' => 'taylor'), 'en'));
 		$this->assertEquals('breeze foo bar baz taylor', $t->get('foo::bar.baz', array('foo' => 'foo bar baz', 'foobar' => 'taylor'), 'en'));
 		$this->assertEquals('foo', $t->get('foo::bar.foo'));
 	}

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -36,7 +36,7 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 	{
 		$t = $this->getMock('Illuminate\Translation\Translator', null, array($this->getLoader(), 'en'));
 		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(array('foo' => 'foo', 'baz' => 'breeze :foo :foobar'));
-		$this->assertEquals('breeze bar taylor', $t->get('foo::bar.baz', array('foo' => 'bar', 'foobar' => 'taylor'), 'en'));
+		$this->assertEquals('breeze foo bar baz taylor', $t->get('foo::bar.baz', array('foo' => 'foo bar baz', 'foobar' => 'taylor'), 'en'));
 		$this->assertEquals('foo', $t->get('foo::bar.foo'));
 	}
 


### PR DESCRIPTION
Fix #7997 issue.
In sortReplacements function we should order trans function $parameters array by keys length, not by value's. 
