### PR TITLE
[5.0] Simplify the find method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -70,7 +70,7 @@ class Builder {
 	 *
 	 * @param  mixed  $id
 	 * @param  array  $columns
-	 * @return \Illuminate\Database\Eloquent\Model|static|null
+	 * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|null
 	 */
 	public function find($id, $columns = array('*'))
 	{
@@ -87,15 +87,15 @@ class Builder {
 	/**
 	 * Find a model by its primary key.
 	 *
-	 * @param  array  $id
+	 * @param  array  $ids
 	 * @param  array  $columns
-	 * @return \Illuminate\Database\Eloquent\Model|Collection|static
+	 * @return \Illuminate\Database\Eloquent\Collection
 	 */
-	public function findMany($id, $columns = array('*'))
+	public function findMany($ids, $columns = array('*'))
 	{
-		if (empty($id)) return $this->model->newCollection();
+		if (empty($ids)) return $this->model->newCollection();
 
-		$this->query->whereIn($this->model->getQualifiedKeyName(), $id);
+		$this->query->whereIn($this->model->getQualifiedKeyName(), $ids);
 
 		return $this->get($columns);
 	}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -684,11 +684,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public static function find($id, $columns = array('*'))
 	{
-		$instance = new static;
-
-		if (is_array($id) && empty($id)) return $instance->newCollection();
-
-		return $instance->newQuery()->find($id, $columns);
+		return static::query()->find($id, $columns);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -87,9 +87,30 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 
 	public function testBasicModelRetrieval()
 	{
-		EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+		EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+		EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
 		$model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')->first();
 		$this->assertEquals('taylorotwell@gmail.com', $model->email);
+
+		$model = EloquentTestUser::find(1);
+		$this->assertInstanceOf('EloquentTestUser', $model);
+		$this->assertEquals(1, $model->id);
+
+		$model = EloquentTestUser::find(2);
+		$this->assertInstanceOf('EloquentTestUser', $model);
+		$this->assertEquals(2, $model->id);
+
+		$void = EloquentTestUser::find(3);
+		$this->assertNull($void);
+
+		$collection = EloquentTestUser::find([]);
+		$this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $collection);
+		$this->assertEquals(0, $collection->count());
+
+		$collection = EloquentTestUser::find([1, 2, 3]);
+		$this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $collection);
+		$this->assertEquals(2, $collection->count());
 	}
 
 


### PR DESCRIPTION
Since we can't completely remove the `find` method for [backwards compatibility](https://github.com/laravel/framework/pull/7923#issuecomment-79021131) reasons, we should at least not have any duplicated logic.

This also adds Eloquent integration tests for the `find` method.
