### PR TITLE
[5.0] route:list command throwing an error when instance or closure filters are set.

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Illuminate\Console\Command;
+use Illuminate\Routing\Controller;
 use Symfony\Component\Console\Input\InputOption;
 
 class RouteListCommand extends Command {
@@ -152,6 +153,8 @@ class RouteListCommand extends Command {
 	 */
 	protected function getControllerMiddleware($actionName)
 	{
+		Controller::setRouter($this->laravel['router']);
+
 		$segments = explode('@', $actionName);
 
 		return $this->getControllerMiddlewareFromInstance(


### PR DESCRIPTION
The command is throwing an error if any controller has an instance or closure filter set since the register methods are calling the `getRouter` method.

Not sure if this is the best solution but it works.
