### PR TITLE
[5.0] Multi-Level Nested Array Validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1494,10 +1494,7 @@ class Validator implements ValidatorContract {
 	 */
 	protected function validateEach($attribute, $values, $parameters)
 	{
-		if ( ! is_array($values))
-		{
-			return true;
-		}
+		if ( ! is_array($values)) return true;
 
 		$rules = $this->explodeRules($parameters);
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1485,6 +1485,49 @@ class Validator implements ValidatorContract {
 	}
 
 	/**
+     * Validate that an array attribute's child are valid.
+     *
+     * @param  string  $attribute
+     * @param  array   $values
+     * @param  array   $parameters
+     * @return bool
+     */
+    protected function validateEach($attribute, $values, $parameters)
+	{
+        if ( ! is_array($values))
+		{
+            return true;
+        }
+
+        $rules = $this->explodeRules($parameters);
+
+        foreach ($rules as $dataKey => $dataRules)
+		{
+            foreach ($values as $index => $value)
+			{
+                $this->passesEach("{$attribute}.{$index}.{$dataKey}", $dataRules);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if the data passes the validation rules.
+     *
+     * @param  string  $attribute
+     * @param  array   $rules
+     * @return bool
+     */
+    protected function passesEach($attribute, array $rules)
+	{
+        foreach ($rules as $rule)
+		{
+            $this->validate($attribute, $rule);
+        }
+    }
+
+	/**
 	 * Get the date format for an attribute if it has one.
 	 *
 	 * @param  string  $attribute

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1497,11 +1497,21 @@ class Validator implements ValidatorContract {
 		if ( ! is_array($values)) return true;
 
 		$rules = $this->explodeRules($parameters);
+		
+		// No grand children
+		if (isset($rules[0]) && !isset($rules[1])) {
+			foreach ($values as $index => $value) {
+				$this->passesEach("{$attribute}.{$index}", $rules[0]);
+			}
 
+			return true;
+		}
+	
+		// With grand children
 		foreach ($rules as $dataKey => $dataRules)
 		{
 			foreach ($values as $index => $value)
-			{
+			{    
 				$this->passesEach("{$attribute}.{$index}.{$dataKey}", $dataRules);
 			}
 		}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1485,47 +1485,47 @@ class Validator implements ValidatorContract {
 	}
 
 	/**
-     * Validate that an array attribute's child are valid.
-     *
-     * @param  string  $attribute
-     * @param  array   $values
-     * @param  array   $parameters
-     * @return bool
-     */
-    protected function validateEach($attribute, $values, $parameters)
+	 * Validate that an array attribute's child are valid.
+	 *
+	 * @param  string  $attribute
+	 * @param  array   $values
+	 * @param  array   $parameters
+	 * @return bool
+	 */
+	protected function validateEach($attribute, $values, $parameters)
 	{
-        if ( ! is_array($values))
+		if ( ! is_array($values))
 		{
-            return true;
-        }
+			return true;
+		}
 
-        $rules = $this->explodeRules($parameters);
+		$rules = $this->explodeRules($parameters);
 
-        foreach ($rules as $dataKey => $dataRules)
+		foreach ($rules as $dataKey => $dataRules)
 		{
-            foreach ($values as $index => $value)
+			foreach ($values as $index => $value)
 			{
-                $this->passesEach("{$attribute}.{$index}.{$dataKey}", $dataRules);
-            }
-        }
+				$this->passesEach("{$attribute}.{$index}.{$dataKey}", $dataRules);
+			}
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Determine if the data passes the validation rules.
-     *
-     * @param  string  $attribute
-     * @param  array   $rules
-     * @return bool
-     */
-    protected function passesEach($attribute, array $rules)
+	/**
+	 * Determine if the data passes the validation rules.
+	 *
+	 * @param  string  $attribute
+	 * @param  array   $rules
+	 * @return bool
+	 */
+	protected function passesEach($attribute, array $rules)
 	{
-        foreach ($rules as $rule)
+		foreach ($rules as $rule)
 		{
-            $this->validate($attribute, $rule);
-        }
-    }
+			$this->validate($attribute, $rule);
+		}
+	}
 
 	/**
 	 * Get the date format for an attribute if it has one.

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1376,7 +1376,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testValidateEach()
+	public function testEach()
 	{
 		$trans = $this->getRealTranslator();
 		$data = ['foo' => [5, 10, 15]];
@@ -1390,7 +1390,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($v->passes());
 	}
 
-	public function testValidateEachWithNonIndexedArray()
+	public function testEachWithNonIndexedArray()
 	{
 		$trans = $this->getRealTranslator();
 		$data = ['foobar' => [
@@ -1398,17 +1398,17 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 			['key' => 'foo', 'value' => 10],
 			['key' => 'foo', 'value' => 16]
 		]];
-		
+
 		$v = new Validator($trans, $data, ['foo' => 'Array']);
 		$v->each('foobar', ['key' => 'required', 'value' => 'numeric|min:6|max:14']);
 		$this->assertFalse($v->passes());
-		
+
 		$v = new Validator($trans, $data, ['foo' => 'Array']);
 		$v->each('foobar', ['key' => 'required', 'value' => 'numeric|min:4|max:16']);
 		$this->assertTrue($v->passes());
 	}
 
-	public function testValidateEachWithNonArrayWithArrayRule()
+	public function testEachWithNonArrayWithArrayRule()
 	{
 		$trans = $this->getRealTranslator();
 		$v = new Validator($trans, ['foo' => 'string'], ['foo' => 'Array']);
@@ -1420,7 +1420,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * @expectedException InvalidArgumentException
 	 */
-	public function testValidateEachWithNonArrayWithoutArrayRule()
+	public function testEachWithNonArrayWithoutArrayRule()
 	{
 		$trans = $this->getRealTranslator();
 		$v = new Validator($trans, ['foo' => 'string'], ['foo' => 'numeric']);
@@ -1428,6 +1428,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($v->passes());
 	}
 
+	public function testValidateEach()
+	{
+		$v = new Validator(
+			$this->getRealTranslator(),
+			['children' => [['name' => '']]],
+			['children' => ['array', ['each', 'name' => 'required']]]
+		);
+		$this->assertFalse($v->passes());
+	}
 
 	protected function getTranslator()
 	{

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1428,6 +1428,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($v->passes());
 	}
 
+
 	public function testValidateEach()
 	{
 		$v = new Validator(
@@ -1437,6 +1438,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		);
 		$this->assertFalse($v->passes());
 	}
+
 
 	protected function getTranslator()
 	{

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1433,6 +1433,17 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	{
 		$v = new Validator(
 			$this->getRealTranslator(),
+			['children' => ['string', 'string1']],
+			['children' => ['array', ['each', 'required']]]
+		);
+		$this->assertTrue($v->passes());
+	}
+
+
+	public function testValidateEachMultDimensional()
+	{
+		$v = new Validator(
+			$this->getRealTranslator(),
 			['children' => [['name' => '']]],
 			['children' => ['array', ['each', 'name' => 'required']]]
 		);


### PR DESCRIPTION
Alternative to Validator::each() #4024 that supports multi-dimensional nested arrays.

```
$rules = [
    'children' => [
        'array',
        'between:2,6',
        ['each', 
            'name' => 'required|min:3',
            'grandchildren' => [
                'array',
                ['each', 'name' => 'required|min:3']
            ],
        ],
    ],
];
```

I would like to add the functionality so that an array of items (such as string) could be validated using `['each', 'alpha|between3,8']` would loop through each element in the array, applying the rules as it goes. 

Please let me know if you feel this would benefit Laravel and I will continue working on it.
