### PR TITLE
[5.0] Share old input in views

### DIFF
--- a/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
+++ b/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
@@ -34,6 +34,9 @@ class ShareErrorsFromSession implements Middleware {
 	 */
 	public function handle($request, Closure $next)
 	{
+		// Make sure old input is available in the view
+		$this->view->share('old', $request->session()->getOldInput());
+
 		// If the current session has an "errors" variable bound to it, we will share
 		// its value with all view instances so the views can easily access errors
 		// without having to bind. An empty bag is set when there aren't errors.


### PR DESCRIPTION
This shares the old input data stored in the session with all views just like errors are stored. Therefore, all views would have access to an `$old` variable just like they currently have `$errors`.

This allows us to do things like this in forms:

``` html
<input type="text" name="foobar" value="{{ $old['foobar'] or $model->foobar }}" />
```

Which is the behaviour we had in L4, where form fields were filled automatically, first with old input (when displaying errors), then with the value from the model.
This is a nice and concise way to do the same in L5, but it's not possible using the `old()` helper function, due to the way the `or` operator is implemented.

---

This is meant as a proposal for @taylorotwell to comment on. Maybe this should go to the master branch instead (as it could theoretically break people's views), and I could add longer comments, too ;)
