### PR TITLE
[5.0] Allow for HasManyThrough relationships to work over unconventional pivot tables

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -900,9 +900,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  string  $through
 	 * @param  string|null  $firstKey
 	 * @param  string|null  $secondKey
+	 * @param  string|null  $joinKey
 	 * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
 	 */
-	public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null)
+	public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $joinKey = null)
 	{
 		$through = new $through;
 
@@ -910,7 +911,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		$secondKey = $secondKey ?: $through->getForeignKey();
 
-		return new HasManyThrough((new $related)->newQuery(), $this, $through, $firstKey, $secondKey);
+		$joinKey = $joinKey ?: $secondKey;
+
+		return new HasManyThrough((new $related)->newQuery(), $this, $through, $firstKey, $secondKey, $joinKey);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -29,6 +29,13 @@ class HasManyThrough extends Relation {
 	protected $secondKey;
 
 	/**
+	 * The key on which to join the pivot table to the relationship.
+	 *
+	 * @var string
+	 */
+	protected $joinKey;
+
+	/**
 	 * Create a new has many through relationship instance.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -36,12 +43,14 @@ class HasManyThrough extends Relation {
 	 * @param  \Illuminate\Database\Eloquent\Model  $parent
 	 * @param  string  $firstKey
 	 * @param  string  $secondKey
+	 * @param  string  $joinKey
 	 * @return void
 	 */
-	public function __construct(Builder $query, Model $farParent, Model $parent, $firstKey, $secondKey)
+	public function __construct(Builder $query, Model $farParent, Model $parent, $firstKey, $secondKey, $joinKey = null)
 	{
 		$this->firstKey = $firstKey;
 		$this->secondKey = $secondKey;
+		$this->joinKey = $joinKey;
 		$this->farParent = $farParent;
 
 		parent::__construct($query, $parent);
@@ -96,7 +105,9 @@ class HasManyThrough extends Relation {
 
 		$foreignKey = $this->related->getTable().'.'.$this->secondKey;
 
-		$query->join($this->parent->getTable(), $this->getQualifiedParentKeyName(), '=', $foreignKey);
+		$joinKey = $this->joinKey ? $this->parent->getTable().'.'.$this->joinKey : $this->getQualifiedParentKeyName();
+
+		$query->join($this->parent->getTable(), $joinKey, '=', $foreignKey);
 	}
 
 	/**


### PR DESCRIPTION
As per the documentation, a `hasManyThrough` relationship facilitates relating two entities over a third 'pivot' table which is referred to by model name. The existing implementation assumes that the pivot table's primary key joins it to the target table.

This change allows optional specification of the key joining the pivot table to the target relationship's table.

The real-world schema that required this change (this is a legacy schema, and therefore does not follow laravel conventions):

Recipe, with primary key `recipeID`
Ingredient, with primary key `ingredientID` and foreign keys `recipeID`, `fooditemID`
FoodItem, with primary key `fooditemID`

A recipe has-many ingredients. Each ingredient belongs-to a food item.

The Recipe model relates to the FoodItem model as follows:

``` php
public function foodItems()
{
    return $this->hasManyThrough('FoodItem', 'Ingredient', $this->primaryKey, 'fooditemID');
}
```

Prior to the attached changes, the SQL generated was  

```
select * from `fooditems` inner join `ingredients` on `ingredients`.`ingredientID` = `fooditems`.`fooditemID` where `ingredients`.`recipeID` = ?'
```

Which was, of course, incorrect. After the changes, this becomes

```
select * from `fooditems` inner join `ingredients` on `ingredients`.`fooditemID` = `fooditems`.`fooditemID` where `ingredients`.`recipeID` = ?
```
