### PR TITLE
[4.1] Beanstalkd  setted to 10 minutes timeout to increase performance

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -98,7 +98,7 @@ class BeanstalkdQueue extends Queue implements QueueInterface {
 	{
 		$queue = $this->getQueue($queue);
 
-		$job = $this->pheanstalk->watchOnly($queue)->reserve(0);
+		$job = $this->pheanstalk->watchOnly($queue)->reserve(600);
 
 		if ($job instanceof Pheanstalk_Job)
 		{


### PR DESCRIPTION
As described in the issue, closed without solution, https://github.com/laravel/framework/issues/4225, the listener with beanstalkd keeps restarting when there is no job, the timeout to restart is hard coded, I change it to ten minutes, this way the listener keeps listen to a job for 10 minutes then restarts. All laravel versions has this error, so I changed in all branches. This timeout is vital to CPU performance, when it keeps restarting, spend a lot of the CPU.
