### PR TITLE
Request::input() and Request::all() values shouldn't be regenated

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -38,6 +38,18 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	protected $routeResolver;
 
 	/**
+	 * The array containing all inputs of the request.
+	 * @var array
+	 */
+	protected $input;
+
+	/**
+	 * The array containing all inputs and files of the request.
+	 * @var array
+	 */
+	protected $all;
+
+	/**
 	 * Create a new Illuminate HTTP request from server variables.
 	 *
 	 * @return static
@@ -274,7 +286,12 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function all()
 	{
-		return array_replace_recursive($this->input(), $this->files->all());
+		if ($this->all === null)
+		{
+			$this->all = array_replace_recursive($this->input(), $this->files->all());
+		}
+
+		return $this->all;
 	}
 
 	/**
@@ -286,9 +303,12 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function input($key = null, $default = null)
 	{
-		$input = $this->getInputSource()->all() + $this->query->all();
+		if ($this->input === null) 
+		{
+			$this->input = $this->getInputSource()->all() + $this->query->all();
+		}
 
-		return array_get($input, $key, $default);
+		return array_get($this->input, $key, $default);
 	}
 
 	/**


### PR DESCRIPTION
Please correct me if I'm wrong (and close this PR), but apparently as of now the values of `Request::all()` and `Request::input()` are being re-generated everytime the methods are called:

``` php
public function all()
{
    return array_replace_recursive($this->input(), $this->files->all());
}
```

``` php
public function input($key = null, $default = null)
{
    $input = $this->getInputSource()->all() + $this->query->all();
```

Taking into account that these methods can be called multiple times (`all()` are internally called by `only()` and `except()` as well) and thus can be expensive, shouldn't we store those values into a "static" variable, just once, instead?
