### PR TITLE
Fire event before final response

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -81,14 +81,18 @@ class Kernel implements KernelContract {
 	{
 		try
 		{
-			return $this->sendRequestThroughRouter($request);
+			$response = $this->sendRequestThroughRouter($request);
 		}
 		catch (Exception $e)
 		{
 			$this->reportException($e);
 
-			return $this->renderException($request, $e);
+			$response = $this->renderException($request, $e);
 		}
+
+		$this->app['events']->fire('kernel.response', array($request, $response));
+
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
Currently the response cannot be altered when an exception is thrown. This PR fires an `kernel.response` event for both the regular and exception responses, so they can be altered.

Example use cases:
- Adding headers to all responses (example, CORS needs headers to all responses, also errors)
- Adding extra html to the final response (eg. profiler also on errors)

Other possible solutions:
- Different event for error and response
- Let the exceptions also be run through the regular middleware?

In Laravel 4.x the error responses could be handled with middleware, right now this isn't possible.
