### PR TITLE
[5.0] hasMany or hasOne neets to check for foreign_key != null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -47,6 +47,7 @@ abstract class HasOneOrMany extends Relation {
 		if (static::$constraints)
 		{
 			$this->query->where($this->foreignKey, '=', $this->getParentKey());
+			$this->query->whereNotNull($this->foreignKey);
 		}
 	}
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -181,6 +181,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 	protected function getRelation()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder->shouldReceive('whereNotNull')->with('table.foreign_key');
 		$builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
 		$related = m::mock('Illuminate\Database\Eloquent\Model');
 		$builder->shouldReceive('getModel')->andReturn($related);

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -113,6 +113,7 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 	protected function getRelation()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder->shouldReceive('whereNotNull')->with('table.foreign_key');
 		$builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
 		$related = m::mock('Illuminate\Database\Eloquent\Model');
 		$builder->shouldReceive('getModel')->andReturn($related);

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -173,6 +173,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 	protected function getOneRelation()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
 		$builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
 		$related = m::mock('Illuminate\Database\Eloquent\Model');
 		$builder->shouldReceive('getModel')->andReturn($related);
@@ -187,6 +188,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 	protected function getManyRelation()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
 		$builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
 		$related = m::mock('Illuminate\Database\Eloquent\Model');
 		$builder->shouldReceive('getModel')->andReturn($related);

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -27,6 +27,7 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
 		$parent = m::mock('Illuminate\Database\Eloquent\Model');
 		$parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 		$builder->shouldReceive('getModel')->andReturn($related = m::mock('StdClass'));
+		$builder->shouldReceive('whereNotNull');
 		$builder->shouldReceive('where');
 		$relation = new HasOne($builder, $parent, 'foreign_key', 'id');
 		$related->shouldReceive('getTable')->andReturn('table');


### PR DESCRIPTION
In case your model using HasOne, HasMany the query building needs additional
check for foreign_key != null

If don't you will receive any related item having foreign_key = null on a new object.
Example of wrong behaviour:

$foo = new Foo();
$foo->save();

$bar = new Bar();
$this_should_not_holding_any_relation = $bar->getFoos()->getResutls()->toArray()

In fact currenctly $bar->getFoos() finds any Foo() having foreign_key = null.
SQL is "where bar.id = foo.foreign_key"
wich is in fact "null = null" (any unrelated foo item)
