### PR TITLE
[5.0] Queue : make getTime() protected

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -194,7 +194,7 @@ abstract class Queue {
 	 *
 	 * @return int
 	 */
-	public function getTime()
+	protected function getTime()
 	{
 		return time();
 	}


### PR DESCRIPTION
`getTime()` should be protected just as https://github.com/laravel/framework/blob/5.0/src/Illuminate/Queue/Jobs/Job.php#L237-L245
