### PR TITLE
[5.1] Cache Doctrine Connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -106,7 +106,7 @@ class Connection implements ConnectionInterface {
 	/**
 	 *  @var \Doctrine\DBAL\Connection
 	 */
-	protected $doctrine_connection;
+	protected $doctrineConnection;
 
 	/**
 	 * The table prefix for the connection.
@@ -800,13 +800,13 @@ class Connection implements ConnectionInterface {
 	 */
 	public function getDoctrineConnection()
 	{
-		if (null === $this->doctrine_connection) {
+		if (is_null($this->doctrineConnection)) {
 			$driver = $this->getDoctrineDriver();
-			$data = array('pdo' => $this->pdo, 'dbname' => $this->getConfig('database'));
-			$this->doctrine_connection = new DoctrineConnection($data, $driver);
-		
+			$data = ['pdo' => $this->pdo, 'dbname' => $this->getConfig('database')];
+			$this->doctrineConnection = new DoctrineConnection($data, $driver);
 		}
-		return $this->doctrine_connection;
+		
+		return $this->doctrineConnection;
 	}
 
 	/**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -104,7 +104,7 @@ class Connection implements ConnectionInterface {
 	protected $database;
 	
 	/**
-	 *  @var \Doctrine\DBAL\Connection
+	 * @var \Doctrine\DBAL\Connection
 	 */
 	protected $doctrineConnection;
 
@@ -800,7 +800,8 @@ class Connection implements ConnectionInterface {
 	 */
 	public function getDoctrineConnection()
 	{
-		if (is_null($this->doctrineConnection)) {
+		if (is_null($this->doctrineConnection))
+		{
 			$driver = $this->getDoctrineDriver();
 			$data = ['pdo' => $this->pdo, 'dbname' => $this->getConfig('database')];
 			$this->doctrineConnection = new DoctrineConnection($data, $driver);

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -102,6 +102,11 @@ class Connection implements ConnectionInterface {
 	 * @var string
 	 */
 	protected $database;
+	
+	/**
+	 *  @var \Doctrine\DBAL\Connection
+	 */
+	protected $doctrine_connection;
 
 	/**
 	 * The table prefix for the connection.
@@ -795,11 +800,13 @@ class Connection implements ConnectionInterface {
 	 */
 	public function getDoctrineConnection()
 	{
-		$driver = $this->getDoctrineDriver();
-
-		$data = array('pdo' => $this->pdo, 'dbname' => $this->getConfig('database'));
-
-		return new DoctrineConnection($data, $driver);
+		if (null === $this->doctrine_connection) {
+			$driver = $this->getDoctrineDriver();
+			$data = array('pdo' => $this->pdo, 'dbname' => $this->getConfig('database'));
+			$this->doctrine_connection = new DoctrineConnection($data, $driver);
+		
+		}
+		return $this->doctrine_connection;
 	}
 
 	/**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -104,6 +104,8 @@ class Connection implements ConnectionInterface {
 	protected $database;
 	
 	/**
+	 * The instance of Doctrine connection.
+	 *
 	 * @var \Doctrine\DBAL\Connection
 	 */
 	protected $doctrineConnection;


### PR DESCRIPTION
It's impossible to configure doctrine connection in one place if I want to retrieve it using 
DB::getDoctrineConnection() because this method returns new connection each time. So I suggest to cache it inside Illuminate\Database\Connection

Also, subject for next issue: There is no logging configured for that doctrice connection. I suggest adding implementation of SQLLoggerInterface to framework which will act like this one:

``` php
class DoctrineSqlLogger implements SQLLoggerInterface
{
    private $current;

    public function startQuery($sql, array $params = null, array $types = null)
    {
        $start = microtime(true);
        $this->current = compact('sql','params','types','start');
    }

    public function stopQuery()
    {
        $cur = $this->current;
        DB::logQuery(
            $cur['sql'],
            $cur['params'],
            microtime(true) - $cur['start']
        );
    }
}

```
