### PR TITLE
Add --database flag to migrate:status command

### DIFF
--- a/src/Illuminate/Console/DatabaseTrait.php
+++ b/src/Illuminate/Console/DatabaseTrait.php
@@ -1,0 +1,23 @@
+<?php namespace Illuminate\Console;
+
+trait DatabaseTrait
+{
+
+	/**
+	 * The migrator instance.
+	 *
+	 * @var \Illuminate\Database\Migrations\Migrator
+	 */
+	protected $migrator;
+
+	/**
+	 * Select the database if specified.
+	 *
+	 * @return void
+	 */
+	protected function selectDatabase()
+	{
+		$this->migrator->setConnection($this->input->getOption('database'));
+	}
+
+}

--- a/src/Illuminate/Console/MigrateTrait.php
+++ b/src/Illuminate/Console/MigrateTrait.php
@@ -1,7 +1,6 @@
 <?php namespace Illuminate\Console;
 
-trait MigrateTrait
-{
+trait MigrateTrait {
 
 	/**
 	 * The migrator instance.

--- a/src/Illuminate/Console/MigrateTrait.php
+++ b/src/Illuminate/Console/MigrateTrait.php
@@ -1,6 +1,6 @@
 <?php namespace Illuminate\Console;
 
-trait DatabaseTrait
+trait MigrateTrait
 {
 
 	/**

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -1,13 +1,13 @@
 <?php namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\ConfirmableTrait;
-use Illuminate\Console\DatabaseTrait;
+use Illuminate\Console\MigrateTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
 class MigrateCommand extends BaseCommand {
 
-	use ConfirmableTrait, DatabaseTrait;
+	use ConfirmableTrait, MigrateTrait;
 
 	/**
 	 * The console command name.
@@ -26,7 +26,7 @@ class MigrateCommand extends BaseCommand {
 	/**
 	 * Create a new migration command instance.
 	 *
-	 * @param  \Illuminate\Database\Migrations\Migrator $migrator
+	 * @param  \Illuminate\Database\Migrations\Migrator  $migrator
 	 * @return void
 	 */
 	public function __construct(Migrator $migrator)
@@ -106,17 +106,17 @@ class MigrateCommand extends BaseCommand {
 	 */
 	protected function getOptions()
 	{
-		return [
-			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+		return array(
+			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
 
-			['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
+			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
 
-			['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
+			array('path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'),
 
-			['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
+			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
 
-			['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
-		];
+			array('seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'),
+		);
 	}
 
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Database\Console\Migrations;
 
-use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\MigrateTrait;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -1,12 +1,13 @@
 <?php namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Console\DatabaseTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
 class MigrateCommand extends BaseCommand {
 
-	use ConfirmableTrait;
+	use ConfirmableTrait, DatabaseTrait;
 
 	/**
 	 * The console command name.
@@ -23,16 +24,9 @@ class MigrateCommand extends BaseCommand {
 	protected $description = 'Run the database migrations';
 
 	/**
-	 * The migrator instance.
-	 *
-	 * @var \Illuminate\Database\Migrations\Migrator
-	 */
-	protected $migrator;
-
-	/**
 	 * Create a new migration command instance.
 	 *
-	 * @param  \Illuminate\Database\Migrations\Migrator  $migrator
+	 * @param  \Illuminate\Database\Migrations\Migrator $migrator
 	 * @return void
 	 */
 	public function __construct(Migrator $migrator)
@@ -51,6 +45,7 @@ class MigrateCommand extends BaseCommand {
 	{
 		if ( ! $this->confirmToProceed()) return;
 
+		$this->selectDatabase();
 		$this->prepareDatabase();
 
 		// The pretend option can be used for "simulating" the migration and grabbing
@@ -96,8 +91,6 @@ class MigrateCommand extends BaseCommand {
 	 */
 	protected function prepareDatabase()
 	{
-		$this->migrator->setConnection($this->input->getOption('database'));
-
 		if ( ! $this->migrator->repositoryExists())
 		{
 			$options = array('--database' => $this->input->getOption('database'));
@@ -113,17 +106,17 @@ class MigrateCommand extends BaseCommand {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+		return [
+			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
 
-			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
+			['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
-			array('path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'),
+			['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
 
-			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
+			['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
 
-			array('seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'),
-		);
+			['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -1,8 +1,8 @@
 <?php namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\Command;
-use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\MigrateTrait;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -2,13 +2,13 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
-use Illuminate\Console\DatabaseTrait;
+use Illuminate\Console\MigrateTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
 class ResetCommand extends Command {
 
-	use ConfirmableTrait, DatabaseTrait;
+	use ConfirmableTrait, MigrateTrait;
 
 	/**
 	 * The console command name.

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -2,12 +2,13 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Console\DatabaseTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
 class ResetCommand extends Command {
 
-	use ConfirmableTrait;
+	use ConfirmableTrait, DatabaseTrait;
 
 	/**
 	 * The console command name.
@@ -22,13 +23,6 @@ class ResetCommand extends Command {
 	 * @var string
 	 */
 	protected $description = 'Rollback all database migrations';
-
-	/**
-	 * The migrator instance.
-	 *
-	 * @var \Illuminate\Database\Migrations\Migrator
-	 */
-	protected $migrator;
 
 	/**
 	 * Create a new migration rollback command instance.
@@ -52,7 +46,7 @@ class ResetCommand extends Command {
 	{
 		if ( ! $this->confirmToProceed()) return;
 
-		$this->migrator->setConnection($this->input->getOption('database'));
+		$this->selectDatabase();
 
 		$pretend = $this->input->getOption('pretend');
 

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -1,8 +1,8 @@
 <?php namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\Command;
-use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Console\MigrateTrait;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -2,12 +2,13 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Console\DatabaseTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
 class RollbackCommand extends Command {
 
-	use ConfirmableTrait;
+	use ConfirmableTrait, DatabaseTrait;
 
 	/**
 	 * The console command name.
@@ -22,13 +23,6 @@ class RollbackCommand extends Command {
 	 * @var string
 	 */
 	protected $description = 'Rollback the last database migration';
-
-	/**
-	 * The migrator instance.
-	 *
-	 * @var \Illuminate\Database\Migrations\Migrator
-	 */
-	protected $migrator;
 
 	/**
 	 * Create a new migration rollback command instance.
@@ -52,7 +46,7 @@ class RollbackCommand extends Command {
 	{
 		if ( ! $this->confirmToProceed()) return;
 
-		$this->migrator->setConnection($this->input->getOption('database'));
+		$this->selectDatabase();
 
 		$pretend = $this->input->getOption('pretend');
 

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -2,13 +2,13 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
-use Illuminate\Console\DatabaseTrait;
+use Illuminate\Console\MigrateTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
 class RollbackCommand extends Command {
 
-	use ConfirmableTrait, DatabaseTrait;
+	use ConfirmableTrait, MigrateTrait;
 
 	/**
 	 * The console command name.

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -85,9 +85,9 @@ class StatusCommand extends BaseCommand {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
-		);
+		return [
+			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -1,8 +1,12 @@
 <?php namespace Illuminate\Database\Console\Migrations;
 
+use Illuminate\Console\DatabaseTrait;
 use Illuminate\Database\Migrations\Migrator;
+use Symfony\Component\Console\Input\InputOption;
 
 class StatusCommand extends BaseCommand {
+
+	use DatabaseTrait;
 
 	/**
 	 * The console command name.
@@ -17,13 +21,6 @@ class StatusCommand extends BaseCommand {
 	 * @var string
 	 */
 	protected $description = 'Show a list of migrations up/down';
-
-	/**
-	 * The migrator instance.
-	 *
-	 * @var \Illuminate\Database\Migrations\Migrator
-	 */
-	protected $migrator;
 
 	/**
 	 * Create a new migration rollback command instance.
@@ -45,6 +42,8 @@ class StatusCommand extends BaseCommand {
 	 */
 	public function fire()
 	{
+		$this->selectDatabase();
+
 		if ( ! $this->migrator->repositoryExists())
 		{
 			return $this->error('No migrations found.');
@@ -77,6 +76,18 @@ class StatusCommand extends BaseCommand {
 	protected function getAllMigrationFiles()
 	{
 		return $this->migrator->getMigrationFiles($this->getMigrationPath());
+	}
+
+	/**
+	 * Get the console command options.
+	 *
+	 * @return array
+	 */
+	protected function getOptions()
+	{
+		return [
+			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -1,12 +1,12 @@
 <?php namespace Illuminate\Database\Console\Migrations;
 
-use Illuminate\Console\DatabaseTrait;
+use Illuminate\Console\MigrateTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
 class StatusCommand extends BaseCommand {
 
-	use DatabaseTrait;
+	use MigrateTrait;
 
 	/**
 	 * The console command name.
@@ -85,9 +85,9 @@ class StatusCommand extends BaseCommand {
 	 */
 	protected function getOptions()
 	{
-		return [
-			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
-		];
+		return array(
+			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+		);
 	}
 
 }


### PR DESCRIPTION
Move relevant methods to a separate trait to allow all migrate commands to use the same stuff

If you can run migrations on separate database declarations, it makes sense to be able to check the status of migrations on them as well. I think.
