### PR TITLE
Simplify eloquent collection contains

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -67,19 +67,19 @@ class Collection extends BaseCollection {
 	 */
 	public function contains($key, $value = null)
 	{
-		if (func_num_args() == 1 && ! $key instanceof Closure)
+		if (func_num_args() == 2)
+		{
+			return parent::contains($key, $value);
+		}
+
+		if ( ! $this->useAsCallable($key))
 		{
 			$key = $key instanceof Model ? $key->getKey() : $key;
 
-			return $this->filter(function($m) use ($key)
+			return parent::contains(function($k, $m) use ($key)
 			{
 				return $m->getKey() === $key;
-
-			})->count() > 0;
-		}
-		elseif (func_num_args() == 2)
-		{
-			return $this->where($key, $value)->count() > 0;
+			});
 		}
 
 		return parent::contains($key);


### PR DESCRIPTION
We shouldn't be calling `where` or `filter` here. Once we found a match, there's no reason to continue spinning through all models.

Ping @ibrasho & @Arrilot
