### PR TITLE
Added more flexibility to `get` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -159,6 +159,11 @@ class Builder {
 	 */
 	public function get($columns = array('*'))
 	{
+		if(is_string($columns))
+		{
+			$columns = func_get_args();
+		}
+
 		$models = $this->getModels($columns);
 
 		// If we actually found models we will also eager load any relationships that

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1351,17 +1351,6 @@ class Builder {
 	 */
 	public function get($columns = array('*'))
 	{
-		if (is_string($columns)) 
-		{
-			$selects = func_get_args();
-			$columns = [];
-
-			foreach ($selects as $select) 
-			{
-				$columns[] = $select;
-			}
-		}
-
 		return $this->getFresh($columns);
 	}
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1353,17 +1353,12 @@ class Builder {
 	{
 		if (is_string($columns)) 
 		{
-
 			$selects = func_get_args();
-
 			$columns = [];
 
 			foreach ($selects as $select) {
-
 				$columns[] = $select;
-
 			}
-
 		}
 
 		return $this->getFresh($columns);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1351,7 +1351,8 @@ class Builder {
 	 */
 	public function get($columns = array('*'))
 	{
-		if (is_string($columns)) {
+		if (is_string($columns)) 
+		{
 
 			$selects = func_get_args();
 
@@ -1362,7 +1363,7 @@ class Builder {
 				$columns[] = $select;
 
 			}
-			
+
 		}
 
 		return $this->getFresh($columns);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1356,7 +1356,8 @@ class Builder {
 			$selects = func_get_args();
 			$columns = [];
 
-			foreach ($selects as $select) {
+			foreach ($selects as $select) 
+			{
 				$columns[] = $select;
 			}
 		}

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1351,6 +1351,20 @@ class Builder {
 	 */
 	public function get($columns = array('*'))
 	{
+		if (is_string($columns)) {
+
+			$selects = func_get_args();
+
+			$columns = [];
+
+			foreach ($selects as $select) {
+
+				$columns[] = $select;
+
+			}
+			
+		}
+
 		return $this->getFresh($columns);
 	}
 


### PR DESCRIPTION
`get()` method on `Illuminate\Database\Query\Builder` requires an array to
get the selected rows from database. It's sometimes a bit of pain to
send the `$columns` parameter as an array while there is an option to send
multiple parameters as strings.
