### PR TITLE
Added more flexibility to `get` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -159,6 +159,11 @@ class Builder {
 	 */
 	public function get($columns = array('*'))
 	{
+		if (is_string($columns))
+		{
+			$columns = func_get_args();
+		}
+		
 		$models = $this->getModels($columns);
 
 		// If we actually found models we will also eager load any relationships that


### PR DESCRIPTION
`get()` method on `Illuminate\Database\Eloquent\Builder` requires an array
to get the selected rows from database. It's sometimes a bit of pain to
send the `$columns` parameter as an array while there is an option to send
multiple parameters as strings.
