### PR TITLE
Money

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "ext-openssl": "*",
         "ext-mcrypt": "*",
         "ext-mbstring": "*",
+        "browner12/money": "~0.1",
         "classpreloader/classpreloader": "~1.2",
         "danielstjules/stringy": "~1.8",
         "doctrine/inflector": "~1.0",

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -511,6 +511,18 @@ class Blueprint {
 		return $this->bigInteger($column, $autoIncrement, true);
 	}
 
+    /**
+     * Create a money column on the table.
+     *
+     * @param string $column
+     * @param bool $big
+     * @return \Illuminate\Support\Fluent
+     */
+    public function money($column, $big = false)
+    {
+        return ($big) ? $this->unsignedBigInteger($column) : $this->unsignedInteger($column);
+    }
+
 	/**
 	 * Create a new float column on the table.
 	 *


### PR DESCRIPTION
the ability to automatically create Carbon objects from a stored value is great. I think this feature should be extended to automatically create Money objects from a stored value.

This commit uses the same basic techniques to convert values to Carbon objects, and applies them to create Money objects.

To utilize this functionality it is as simple as creating a `monies` property on your model, with the key being the field/attribute name, and the value being the currency you wish to use for it.

``` php
protected $monies = [
    'price'  => 'usd',
    'price2' => 'eur',
    'price3' => 'aud',
];
```

this also adds a helper method for migrations to create a money field.  it is simply a wrapper for unsigned integer. this means that monies should be stored in their sub units (i.e cents) rather than their base units (i.e. dollars).

``` php
$table->money('price')
```

I am using a Money package I created myself. Obviously I would be an idiot if I didn't try with my package first, but there are other money packages available if need be.

this commit is fully backwards compatible, but as a new feature should probably be released in a minor update.
