### PR TITLE
[5.0]Independ connection option for each connection name

### DIFF
--- a/src/Illuminate/Redis/Database.php
+++ b/src/Illuminate/Redis/Database.php
@@ -55,10 +55,10 @@ class Database implements DatabaseContract {
 	{
 		$clients = array();
 
-		$options = $this->getClientOptions($servers);
-
 		foreach ($servers as $key => $server)
 		{
+			$options = $this->getClientOptions($server);
+
 			$clients[$key] = new Client($server, $options);
 		}
 
@@ -68,12 +68,12 @@ class Database implements DatabaseContract {
 	/**
 	 * Get any client options from the configuration array.
 	 *
-	 * @param  array  $servers
+	 * @param  mixed  $server
 	 * @return array
 	 */
-	protected function getClientOptions(array $servers)
+	protected function getClientOptions($server)
 	{
-		return isset($servers['options']) ? (array) $servers['options'] : [];
+		return isset($server['options']) ? (array) $server['options'] : [];
 	}
 
 	/**


### PR DESCRIPTION
Hi.

In current 5.0.17, the ability to use Redis Client option create one extra client and all client inherit the same option.

My edit makes each client have their own option and there is no extra client being created.

Before:

![screen shot 2015-03-20 at 4 56 49 pm](https://cloud.githubusercontent.com/assets/1284948/6748667/242eaf16-cf23-11e4-966f-4d4af6bfd01c.png)

After:
![screen shot 2015-03-20 at 4 55 22 pm](https://cloud.githubusercontent.com/assets/1284948/6748673/31cf388e-cf23-11e4-9f4e-0554dbe55633.png)

Sample Configuration:

```
    'redis' => [

        'cluster' => false,
        'default' => [
            'host'     => '127.0.0.1',
            'port'     => 6379,
            'database' => 1
        ],
        'phpiredis' => [
            'host'     => '127.0.0.1',
            'port'     => 6379,
            'database' => 1,
            'options' => [
                'connections' => [
                    'tcp'  => 'Predis\Connection\PhpiredisStreamConnection',
                ]
            ],
        ],

    ],
```
