### PR TITLE
Removed unused resolvable function

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -121,17 +121,6 @@ class Container implements ArrayAccess, ContainerContract {
 	}
 
 	/**
-	 * Determine if a given string is resolvable.
-	 *
-	 * @param  string  $abstract
-	 * @return bool
-	 */
-	protected function resolvable($abstract)
-	{
-		return $this->bound($abstract);
-	}
-
-	/**
 	 * Determine if the given abstract type has been bound.
 	 *
 	 * @param  string  $abstract


### PR DESCRIPTION
In `Illuminate\Container\Container` there is a protected function `resolvable()` which calls the public function `bound()` however the `resolvable()` function isn't used in the `Container` class nor in any class that extends the `Container` class (the `Illuminate\Foundation\Application` class), instead the `bound()` function is used directly.
Hence having an additional `resolvable()` function is not necessary.

Note: there might be a slight change that there are some classes in third party software that extend the `Container` class and use the `resolvable()` function, so this could be breaking compatibility.
