### PR TITLE
[5.0] Ask for confirmation before running 'artisan fresh'

### DIFF
--- a/src/Illuminate/Foundation/Console/FreshCommand.php
+++ b/src/Illuminate/Foundation/Console/FreshCommand.php
@@ -26,6 +26,15 @@ class FreshCommand extends Command {
 	 */
 	public function fire()
 	{
+		$this->output->writeln('<bg=yellow;fg=black;>WARNING:</bg=yellow;fg=black;>');
+		$this->output->writeln('<bg=yellow;fg=black;>This is a destructive command. Please take a time to review what it does at:</bg=yellow;fg=black;>');
+		$this->output->writeln('<bg=yellow;fg=black;>Illuminate/Foundation/Console/FreshCommand.php</bg=yellow;fg=black;>');
+		$this->info('');
+		$answer = $this->ask('Are you sure you want to continue? [Y|n]', 'n');
+		if (in_array($answer, array('Y', 'y'), true) === false) {
+				return;
+		}
+		
 		$files = new Filesystem;
 
 		$files->deleteDirectory(app_path('Services'));


### PR DESCRIPTION
Hello,

although we can assume that the programmer's project is tracked under a VCS/SCM, it would be good to confirm before running the cleanup this command does. And even if it is tracked, if for some reason it is run in a productive environment, this could cause some serious trouble [for a while] depending on the reaction time.

Any thoughts?
