### PR TITLE
[5.0] Ask for confirmation before running 'artisan fresh'

### DIFF
--- a/src/Illuminate/Foundation/Console/FreshCommand.php
+++ b/src/Illuminate/Foundation/Console/FreshCommand.php
@@ -2,8 +2,12 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Console\ConfirmableTrait;
+use Symfony\Component\Console\Input\InputOption;
 
 class FreshCommand extends Command {
+
+	use ConfirmableTrait;
 
 	/**
 	 * The console command name.
@@ -26,6 +30,8 @@ class FreshCommand extends Command {
 	 */
 	public function fire()
 	{
+		if ( ! $this->confirmToProceed()) return;
+
 		$files = new Filesystem;
 
 		$files->deleteDirectory(app_path('Services'));
@@ -48,6 +54,18 @@ class FreshCommand extends Command {
 		$files->put(app_path('Providers/AppServiceProvider.php'), $files->get(__DIR__.'/stubs/fresh-app-provider.stub'));
 
 		$this->info('Scaffolding removed! Enjoy your fresh start.');
+	}
+
+	/**
+	 * Get the console command options.
+	 *
+	 * @return array
+	 */
+	protected function getOptions()
+	{
+		return array(
+			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
+		);
 	}
 
 }


### PR DESCRIPTION
Hello,

although we can assume that the programmer's project is tracked under a VCS/SCM, it would be good to confirm before running the cleanup this command does. But even if it is tracked OR if for some reason it is run in a productive environment OR if the default scaffolding is really in use, this could cause some serious trouble, depending on the reaction time.

Any thoughts?
