### PR TITLE
[5.1] AppNamespaceDetectorTrait refactoring

### DIFF
--- a/src/Illuminate/Console/AppNamespaceDetectorTrait.php
+++ b/src/Illuminate/Console/AppNamespaceDetectorTrait.php
@@ -1,11 +1,9 @@
 <?php namespace Illuminate\Console;
 
-use RuntimeException;
-
 trait AppNamespaceDetectorTrait {
 
 	/**
-	 * Get the application namespace from the Composer file.
+	 * Get the application namespace from the Kernel object.
 	 *
 	 * @return string
 	 *
@@ -13,17 +11,10 @@ trait AppNamespaceDetectorTrait {
 	 */
 	protected function getAppNamespace()
 	{
-		$composer = json_decode(file_get_contents(base_path().'/composer.json'), true);
+		$kernelContract = app()->runningInConsole() ? 'Illuminate\Contracts\Console\Kernel' : 'Illuminate\Contracts\Http\Kernel';
+		$kernelFullClassName = get_class(app($kernelContract));	
 
-		foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path)
-		{
-			foreach ((array) $path as $pathChoice)
-			{
-				if (realpath(app_path()) == realpath(base_path().'/'.$pathChoice)) return $namespace;
-			}
-		}
-
-		throw new RuntimeException("Unable to detect application namespace.");
+		return strtok($kernelFullClassName, '\\').'\\';
 	}
 
 }


### PR DESCRIPTION
During package development I got into the situation where I wanted to determine the base application namespace (can be changed with `app:name` command) in a package service provider  (equals "on every request")

The only way I've found is `AppNamespaceDetectorTrait` (correct me if I'm wrong pls)

However loading and parsing composer.json on every request is kinda slow.

That's why I propose to parse the kernel object instead.

`microtime()` shows it is ~10 times faster on fresh L5 install.

In my opinion it's cleaner too.
