### PR TITLE
Fix redirect docblock

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -136,7 +136,7 @@ class RedirectResponse extends BaseRedirectResponse {
 	/**
 	 * Flash a container of errors to the session.
 	 *
-	 * @param  \Illuminate\Contracts\Support\MessageProvider|array  $provider
+	 * @param  \Illuminate\Contracts\Support\MessageProvider|array|string  $provider
 	 * @param  string  $key
 	 * @return $this
 	 */
@@ -154,7 +154,7 @@ class RedirectResponse extends BaseRedirectResponse {
 	/**
 	 * Parse the given errors into an appropriate value.
 	 *
-	 * @param  \Illuminate\Contracts\Support\MessageProvider|array  $provider
+	 * @param  \Illuminate\Contracts\Support\MessageProvider|array|string  $provider
 	 * @return \Illuminate\Support\MessageBag
 	 */
 	protected function parseErrors($provider)


### PR DESCRIPTION
You can pass a single error as a string. It'll automatically be [converted to an array](https://github.com/laravel/framework/blob/5.0/src/Illuminate/Http/RedirectResponse.php#L167) when passed to the `MessageBag` constructor.
