### PR TITLE
Added $plainAction to Mailer's addContent() function. When a text view...

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -274,7 +274,9 @@ class Mailer {
 
 		if (isset($plain))
 		{
-			$message->addPart($this->getView($plain, $data), 'text/plain');
+			$plainAction = (isset($view) ? 'addPart' : 'setBody');
+
+			$message->$plainAction($this->getView($plain, $data), 'text/plain');
 		}
 	}
 


### PR DESCRIPTION
...was passed in, the plain-text email was being added as a MIME rather than set as the body.  This was breaking for certain mail 'clients' that can only read plain-text (e.g. the boundary added by swift was showing up in the body of the plain-text email, from the client's point of view).  I should also consider adding this to the addPart call for the $raw section.

Example mailing code:

``` php
return \Mail::send(
            ['text' => 'test.email'],
            [
                'message' => 'data and stuff'
            ],
            function($message)
            {
                $message->to('lamoni@private.com')
                    ->subject('Test Subject')
                    ->from('test@private.com');

            }
        );

```

Before making the change, emails were being parsed by the plain-text clients incorrectly due to the inability to parse the MIME boundaries added by addPart().  We can see that the Content-type and Content-transfer-encoding were being parsed as part of the message body.  

Email as parsed by plain-text client:

```
content-type: text/plain; charset="utf-8"
content-transfer-encoding: quoted-printable

data and stuff
```

After making the change to addContent():

data and stuff
