### PR TITLE
Deep merge for package config

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -59,10 +59,43 @@ abstract class ServiceProvider {
 	 */
 	protected function mergeConfigFrom($path, $key)
 	{
+		$original = (array) require $path;
 		$config = $this->app['config']->get($key, []);
 
-		$this->app['config']->set($key, array_merge(require $path, $config));
+		$this->app['config']->set($key, $this->mergeValues($original, $config));
 	}
+
+
+	/**
+	 * Merge the values from the right array into the left side recursively.
+	 *
+	 * @param array $left Array with values which are overwritten if necessary
+	 * @param array $right Array values to overwrite with
+	 * @return array Recursively merged array
+	 */
+	protected function mergeValues(array $left, array $right)
+	{
+		foreach ($right as $k => $v)
+		{
+			if (!array_key_exists($k, $left))
+			{
+				$left[$k] = $v;
+				continue;
+			}
+
+			if (is_array($right[$k]))
+			{
+				$left[$k] = $this->mergeValues($left[$k], $right[$k]);
+			}
+			else
+			{
+				$left[$k] = $right[$k];
+			}
+		}
+
+		return $left;
+	}
+
 
 	/**
 	 * Register a view file namespace.

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+
+class SupportServiceProviderTest extends PHPUnit_Framework_TestCase
+{
+	private $app;
+
+
+	public function setUp()
+	{
+		parent::setUp();
+
+		$this->app = $this->getMockBuilder('\Illuminate\Contracts\Foundation\Application')->getMock();
+	}
+
+
+	public function testMergeValuesNew()
+	{
+		$left = ['key' => 'value'];
+		$right = ['new' => 'some value'];
+
+		$merged = (new SupportServiceProviderForTest($this->app))->mergeValuesPublic($left, $right);
+
+		$this->assertEquals(['key' => 'value', 'new' => 'some value'], $merged);
+	}
+
+
+	public function testMergeValuesOverwriteScalar()
+	{
+		$left = ['key' => ['value']];
+		$right = ['key' => 'some value'];
+
+		$merged = (new SupportServiceProviderForTest($this->app))->mergeValuesPublic($left, $right);
+
+		$this->assertEquals(['key' => 'some value'], $merged);
+	}
+
+
+	public function testMergeValuesOverwriteArray()
+	{
+		$left = ['key' => ['sub' => 'value', 'some' => 'value']];
+		$right = ['key' => ['some' => 'val']];
+
+		$merged = (new SupportServiceProviderForTest($this->app))->mergeValuesPublic($left, $right);
+
+		$this->assertEquals(['key' => ['sub' => 'value', 'some' => 'val']], $merged);
+	}
+
+
+	public function testMergeValuesOverwriteArrayRecursive()
+	{
+		$left = ['key' => ['sub' => ['some' => 'value']]];
+		$right = ['key' => ['sub' => ['some' => 'val']]];
+
+		$merged = (new SupportServiceProviderForTest($this->app))->mergeValuesPublic($left, $right);
+
+		$this->assertEquals(['key' => ['sub' => ['some' => 'val']]], $merged);
+	}
+}
+
+
+class SupportServiceProviderForTest extends \Illuminate\Support\ServiceProvider
+{
+	public function register() {}
+
+
+	public function mergeValuesPublic(array $left, array $right)
+	{
+		return $this->mergeValues($left, $right);
+	}
+}


### PR DESCRIPTION
Implemented a deep merge for config arrays like Symfony has to avoid the need for Laravel developers to add the whole tree of configuration settings from packages.
