### PR TITLE
[5.1] Easy application namespace determination

### DIFF
--- a/src/Illuminate/Console/AppNamespaceDetectorTrait.php
+++ b/src/Illuminate/Console/AppNamespaceDetectorTrait.php
@@ -1,21 +1,17 @@
 <?php namespace Illuminate\Console;
 
+use Illuminate\Container\Container;
+
 trait AppNamespaceDetectorTrait {
 
 	/**
-	 * Get the application namespace from the Kernel object.
+	 * Get the application namespace.
 	 *
 	 * @return string
-	 *
-	 * @throws \RuntimeException
 	 */
 	protected function getAppNamespace()
 	{
-		$kernelContract = app()->runningInConsole()
-							? 'Illuminate\Contracts\Console\Kernel'
-							: 'Illuminate\Contracts\Http\Kernel';
-
-		return strtok(get_class(app($kernelContract)), '\\').'\\';
+		return Container::getInstance()->getNamespace();
 	}
 
 }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -5,8 +5,6 @@ use Symfony\Component\Console\Input\InputArgument;
 
 abstract class GeneratorCommand extends Command {
 
-	use AppNamespaceDetectorTrait;
-
 	/**
 	 * The filesystem instance.
 	 *
@@ -70,7 +68,7 @@ abstract class GeneratorCommand extends Command {
 	 */
 	protected function getPath($name)
 	{
-		$name = str_replace($this->getAppNamespace(), '', $name);
+		$name = str_replace($this->laravel->getNamespace(), '', $name);
 
 		return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
 	}
@@ -83,7 +81,7 @@ abstract class GeneratorCommand extends Command {
 	 */
 	protected function parseName($name)
 	{
-		$rootNamespace = $this->getAppNamespace();
+		$rootNamespace = $this->laravel->getNamespace();
 
 		if (starts_with($name, $rootNamespace))
 		{
@@ -150,7 +148,7 @@ abstract class GeneratorCommand extends Command {
 		);
 
 		$stub = str_replace(
-			'DummyRootNamespace', $this->getAppNamespace(), $stub
+			'DummyRootNamespace', $this->laravel->getNamespace(), $stub
 		);
 
 		return $this;

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -100,6 +100,13 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	protected $environmentFile = '.env';
 
 	/**
+	 * The application namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = null;
+
+	/**
 	 * Create a new Illuminate application instance.
 	 *
 	 * @param  string|null  $basePath
@@ -935,6 +942,34 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 		parent::flush();
 
 		$this->loadedProviders = [];
+	}
+
+	/**
+	 * Get the used kernel object.
+	 *
+	 * @return \Illuminate\Contracts\Console\Kernel|\Illuminate\Contracts\Http\Kernel
+	 */
+	protected function getKernel()
+	{
+		$kernelContract = $this->runningInConsole()
+					? 'Illuminate\Contracts\Console\Kernel'
+					: 'Illuminate\Contracts\Http\Kernel';
+
+		return $this->make($kernelContract);
+	}
+
+	/**
+	 * Get the application namespace.
+	 *
+	 * @return string
+	 */
+	public function getNamespace()
+	{
+		if ( ! is_null($this->namespace)) return $this->namespace;
+
+		$this->namespace = strtok(get_class($this->getKernel()), '\\').'\\';
+
+		return $this->namespace;
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -4,12 +4,9 @@ use Illuminate\Console\Command;
 use Illuminate\Foundation\Composer;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Console\AppNamespaceDetectorTrait;
 use Symfony\Component\Console\Input\InputArgument;
 
 class AppNameCommand extends Command {
-
-	use AppNamespaceDetectorTrait;
 
 	/**
 	 * The console command name.
@@ -68,7 +65,7 @@ class AppNameCommand extends Command {
 	 */
 	public function fire()
 	{
-		$this->currentRoot = trim($this->getAppNamespace(), '\\');
+		$this->currentRoot = trim($this->laravel->getNamespace(), '\\');
 
 		$this->setBootstrapNamespaces();
 

--- a/src/Illuminate/Foundation/Console/HandlerEventCommand.php
+++ b/src/Illuminate/Foundation/Console/HandlerEventCommand.php
@@ -38,9 +38,9 @@ class HandlerEventCommand extends GeneratorCommand {
 
 		$event = $this->option('event');
 
-		if ( ! starts_with($event, $this->getAppNamespace()))
+		if ( ! starts_with($event, $this->laravel->getNamespace()))
 		{
-			$event = $this->getAppNamespace().'Events\\'.$event;
+			$event = $this->laravel->getNamespace().'Events\\'.$event;
 		}
 
 		$stub = str_replace(

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -38,9 +38,9 @@ class ListenerMakeCommand extends GeneratorCommand {
 
 		$event = $this->option('event');
 
-		if ( ! starts_with($event, $this->getAppNamespace()))
+		if ( ! starts_with($event, $this->laravel->getNamespace()))
 		{
-			$event = $this->getAppNamespace().'Events\\'.$event;
+			$event = $this->laravel->getNamespace().'Events\\'.$event;
 		}
 
 		$stub = str_replace(


### PR DESCRIPTION
Follows #8084

Okay, so I've spent some time trying to investigate how to determine application namespace outside laravel core (in a package in my case) 
I found it pretty confusing because:
1) It's not documented
2) You have to use internal trait
3) The trait is situated in the Console component (`Illuminate\Console\AppNamespaceDetectorTrait`)

What about straightforward `app()->getNamespace()`?
