### PR TITLE
[5.0] Fix Eloquent deleting bug

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1171,7 +1171,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	protected function performDeleteOnModel()
 	{
-		$this->newQuery()->where($this->getKeyName(), $this->getKey())->delete();
+		$this->setKeysForSaveQuery($this->newQuery())->delete();
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -400,8 +400,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	public function testDeleteProperlyDeletesModel()
 	{
 		$model = $this->getMock('Illuminate\Database\Eloquent\Model', array('newQueryWithoutScopes', 'updateTimestamps', 'touchOwners'));
-		$query = m::mock('stdClass');
-		$query->shouldReceive('where')->once()->with('id', 1)->andReturn($query);
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('where')->once()->with('id', '=', 1)->andReturn($query);
 		$query->shouldReceive('delete')->once();
 		$model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
 		$model->expects($this->once())->method('touchOwners');


### PR DESCRIPTION
Bug fix for `delete` query building.

In case a model has specific setKeysForSaveQuery logic (e. g. double primary key without increment) deleting fails because it only uses single primary key.

For example:

``` php

//Schema

$table->unsignedInteger('post_id');
$table->string('language', 2);
$table->primary(['post_id', 'language']);

//Method overwrite (scopes applied to the model but I think the logic is clear)

protected function setKeysForSaveQuery(Builder $query)
{
    $query = parent::setKeysForSaveQuery($query)->withUnavailable();

    $column = $this->getLanguageColumn();

    $query->where($column, '=', $this->getAttribute($column));

    return $query;
}
```
