### PR TITLE
[5.0] Proposal: Immutable model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -168,6 +168,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	protected $morphClass;
 
 	/**
+	 * Indicates if the model is immutable
+	 *
+	 * @var bool
+	 */
+	protected $immutable = false;
+
+	/**
 	 * Indicates if the model exists.
 	 *
 	 * @var bool
@@ -1483,7 +1490,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		// If the model already exists in the database we can just update our record
 		// that is already in this database using the current IDs in this "where"
 		// clause to only update this model. Otherwise, we'll just insert them.
-		if ($this->exists)
+		if ($this->exists && ! $this->isImmutable())
 		{
 			$saved = $this->performUpdate($query, $options);
 		}
@@ -1587,6 +1594,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		if ($this->incrementing)
 		{
+			// Unset the primary key if model exists and it is immutable
+			if ($this->exists && $this->isImmutable() && !array_key_exists($this->getKeyName(), $this->getDirty()))
+			{
+				unset($attributes[$this->getKeyName()]);
+			}
 			$this->insertAndSetId($query, $attributes);
 		}
 
@@ -1941,6 +1953,27 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	public function setTable($table)
 	{
 		$this->table = $table;
+	}
+
+	/**
+	 * Get immutable flag.
+	 *
+	 * @return bool
+	 */
+	public function isImmutable()
+	{
+		return $this->immutable;
+	}
+
+	/**
+	 * Set immutable flag.
+	 *
+	 * @param  bool  $flag
+	 * @return void
+	 */
+	public function setImmutable($flag)
+	{
+		$this->immutable = ($flag == true);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -383,6 +383,33 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testImmutableModelSave()
+	{
+		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes', 'updateTimestamps'));
+
+		$model->exists = true;
+		$model->setImmutable(true);
+
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('insertGetId')->once()->with(array('id' => 2, 'foo' => 'bar'), 'id')->andReturn(2);
+		$query->shouldReceive('insertGetId')->once()->with(array('foo' => 'new'), 'id')->andReturn(3);
+
+		$model->method('newQueryWithoutScopes')->will($this->returnValue($query));
+		$model->method('updateTimestamps');
+
+		$model->setAttribute('id', 2);
+		$model->setAttribute('foo', 'bar');
+
+		$this->assertTrue($model->save());
+		$this->assertEquals(2, $model->id);
+
+		$model->setAttribute('foo', 'new');
+
+		$this->assertTrue($model->save());
+		$this->assertEquals(3, $model->id);
+	}
+
+
 	public function testInsertIsCancelledIfCreatingEventReturnsFalse()
 	{
 		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes'));


### PR DESCRIPTION
Immutable model state which forces `save` method to insert new model regardless if it already exists.

Useful when you need to keep revisions in database (e. g. content changes history or currency rates).
