### PR TITLE
[5.1] Get rid of fetch mode configuration code

### DIFF
--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -1,6 +1,5 @@
 <?php namespace Illuminate\Database\Capsule;
 
-use PDO;
 use Illuminate\Container\Container;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Contracts\Events\Dispatcher;

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -44,8 +44,6 @@ class Manager {
 	 */
 	protected function setupDefaultConfiguration()
 	{
-		$this->container['config']['database.fetch'] = PDO::FETCH_ASSOC;
-
 		$this->container['config']['database.default'] = 'default';
 	}
 
@@ -138,19 +136,6 @@ class Manager {
 		{
 			Eloquent::setEventDispatcher($dispatcher);
 		}
-	}
-
-	/**
-	 * Set the fetch mode for the database connections.
-	 *
-	 * @param  int  $fetchMode
-	 * @return $this
-	 */
-	public function setFetchMode($fetchMode)
-	{
-		$this->container['config']['database.fetch'] = $fetchMode;
-
-		return $this;
 	}
 
 	/**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -62,13 +62,6 @@ class Connection implements ConnectionInterface {
 	protected $events;
 
 	/**
-	 * The default fetch mode of the connection.
-	 *
-	 * @var int
-	 */
-	protected $fetchMode = PDO::FETCH_ASSOC;
-
-	/**
 	 * The number of active transactions.
 	 *
 	 * @var int
@@ -289,7 +282,7 @@ class Connection implements ConnectionInterface {
 
 			$statement->execute($me->prepareBindings($bindings));
 
-			return $statement->fetchAll($me->getFetchMode());
+			return $statement->fetchAll(PDO::FETCH_CLASS);
 		});
 	}
 
@@ -989,27 +982,6 @@ class Connection implements ConnectionInterface {
 	public function pretending()
 	{
 		return $this->pretending === true;
-	}
-
-	/**
-	 * Get the default fetch mode for the connection.
-	 *
-	 * @return int
-	 */
-	public function getFetchMode()
-	{
-		return $this->fetchMode;
-	}
-
-	/**
-	 * Set the default fetch mode for the connection.
-	 *
-	 * @param  int  $fetchMode
-	 * @return int
-	 */
-	public function setFetchMode($fetchMode)
-	{
-		$this->fetchMode = $fetchMode;
 	}
 
 	/**

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -57,9 +57,7 @@ class DatabaseManager implements ConnectionResolverInterface {
 	{
 		list($name, $type) = $this->parseConnectionName($name);
 
-		// If we haven't created this connection, we'll create it based on the config
-		// provided in the application. Once we've created the connections we will
-		// set the "fetch mode" for PDO which determines the query return types.
+		// If necessary, create the connection based on the app config.
 		if ( ! isset($this->connections[$name]))
 		{
 			$connection = $this->makeConnection($name);
@@ -185,8 +183,6 @@ class DatabaseManager implements ConnectionResolverInterface {
 	 */
 	protected function prepare(Connection $connection)
 	{
-		$connection->setFetchMode($this->app['config']['database.fetch']);
-
 		if ($this->app->bound('events'))
 		{
 			$connection->setEventDispatcher($this->app['events']);

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -191,15 +191,13 @@ class DatabaseQueue extends Queue implements QueueContract {
 	{
 		$this->database->beginTransaction();
 
-		$job = $this->database->table($this->table)
+		return $this->database->table($this->table)
 					->lockForUpdate()
 					->where('queue', $this->getQueue($queue))
 					->where('reserved', 0)
 					->where('available_at', '<=', $this->getTime())
 					->orderBy('id', 'asc')
 					->first();
-
-		return $job ? (object) $job : null;
 	}
 
 	/**


### PR DESCRIPTION
As discussed multiple times, and in #8078, we should get rid of the fetch mode configuration option in v5.1.

It only causes problems when people change things, as Laravel's code does not expect it to be something else than `PDO::FETCH_OBJECT`.

I also reverted the workaround from #8078.

Something I noticed: for some reason, the default value when only using the database component via Capsule, was set to `PDO::FETCH_ASSOC`. Was there a reason for this? It may have created some of these problems...

Associated PR for laravel/laravel incoming.
