### PR TITLE
[5.0] Fix incorrect variable assignment

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -43,7 +43,7 @@ class Application extends SymfonyApplication implements ApplicationContract {
 	{
 		parent::__construct('Laravel Framework', $laravel->version());
 
-		$this->event = $events;
+		$this->events = $events;
 		$this->laravel = $laravel;
 		$this->setAutoExit(false);
 		$this->setCatchExceptions(false);


### PR DESCRIPTION
It's very interesting that this hasn't been reported before. Probably people are using the `event()` helper now...

The variable also isn't really used outside of the constructor. Not sure whether it's needed as a class property...
