### PR TITLE
[5.1] Removed Unused Property

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -19,13 +19,6 @@ class Application extends SymfonyApplication implements ApplicationContract {
 	protected $laravel;
 
 	/**
-	 * The event dispatcher implementation.
-	 *
-	 * @var \Illuminate\Contracts\Events\Dispatcher
-	 */
-	protected $events;
-
-	/**
 	 * The output from the previous command.
 	 *
 	 * @var \Symfony\Component\Console\Output\OutputInterface
@@ -43,7 +36,6 @@ class Application extends SymfonyApplication implements ApplicationContract {
 	{
 		parent::__construct('Laravel Framework', $laravel->version());
 
-		$this->event = $events;
 		$this->laravel = $laravel;
 		$this->setAutoExit(false);
 		$this->setCatchExceptions(false);


### PR DESCRIPTION
We only use the event dispatcher in the constructor to fire an event, then we never use it again.
