### PR TITLE
Added Middleware Parameters

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -128,10 +128,7 @@ class Kernel implements KernelContract {
 
 		foreach (array_merge($routeMiddlewares, $this->middleware) as $middleware => $v)
 		{
-			if (is_numeric($middleware))
-			{
-				list($v, $middleware) = [$middleware, $v];
-			}
+			if (is_numeric($middleware)) list($v, $middleware) = [$middleware, $v];
 
 			$instance = $this->app->make($middleware);
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -126,8 +126,13 @@ class Kernel implements KernelContract {
 	{
 		$routeMiddlewares = $this->gatherRouteMiddlewares($request);
 
-		foreach (array_merge($routeMiddlewares, $this->middleware) as $middleware)
+		foreach (array_merge($routeMiddlewares, $this->middleware) as $middleware => $v)
 		{
+			if (is_numeric($middleware))
+			{
+				list($v, $middleware) = [$middleware, $v];
+			}
+
 			$instance = $this->app->make($middleware);
 
 			if ($instance instanceof TerminableMiddleware)

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -70,10 +70,7 @@ class Pipeline implements PipelineContract {
 
 		foreach ($pipes as $k => $v)
 		{
-			if (!is_numeric($k) || $v instanceof Closure)
-			{
-				continue;
-			}
+			if ( ! is_numeric($k) || $v instanceof Closure) continue;
 
 			unset($pipes[$k]);
 			$pipes[$v] = [];

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -66,7 +66,20 @@ class Pipeline implements PipelineContract {
 	 */
 	public function through($pipes)
 	{
-		$this->pipes = is_array($pipes) ? $pipes : func_get_args();
+		$pipes = is_array($pipes) ? $pipes : func_get_args();
+
+		foreach ($pipes as $k => $v)
+		{
+			if (!is_numeric($k) || $v instanceof Closure)
+			{
+				continue;
+			}
+
+			unset($pipes[$k]);
+			$pipes[$v] = [];
+		}
+
+		$this->pipes = $pipes;
 
 		return $this;
 	}
@@ -95,6 +108,10 @@ class Pipeline implements PipelineContract {
 		$firstSlice = $this->getInitialSlice($destination);
 
 		$pipes = array_reverse($this->pipes);
+		array_walk($pipes, function($v, $k) use(&$pipes)
+		{
+			$pipes[$k] = $v instanceof Closure ? [$v, $k] : [$k, $v];
+		});
 
 		return call_user_func(
 			array_reduce($pipes, $this->getSlice(), $firstSlice), $this->passable
@@ -110,7 +127,9 @@ class Pipeline implements PipelineContract {
 	{
 		return function($stack, $pipe)
 		{
-			return function($passable) use ($stack, $pipe)
+			list($pipe, $data) = $pipe;
+
+			return function($passable) use ($stack, $pipe, $data)
 			{
 				// If the pipe is an instance of a Closure, we will just call it directly but
 				// otherwise we'll resolve the pipes out of the container and call it with
@@ -122,7 +141,7 @@ class Pipeline implements PipelineContract {
 				else
 				{
 					return $this->container->make($pipe)
-							->{$this->method}($passable, $stack);
+							->{$this->method}($passable, $stack, $data);
 				}
 			};
 		};

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -43,11 +43,9 @@ abstract class Controller {
 	 * @param  array   $data
 	 * @return void
 	 */
-	public function middleware($middleware, array $options = array(), $data = array())
+	public function middleware($middleware, array $options = [], array $data = [])
 	{
-		$this->middleware[$middleware] = $options + [
-			'data' => $data
-		];
+		$this->middleware[$middleware] = array_merge($options, [ 'data' => $data ]);
 	}
 
 	/**

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -40,11 +40,14 @@ abstract class Controller {
 	 *
 	 * @param  string  $middleware
 	 * @param  array   $options
+	 * @param  array   $data
 	 * @return void
 	 */
-	public function middleware($middleware, array $options = array())
+	public function middleware($middleware, array $options = array(), $data = array())
 	{
-		$this->middleware[$middleware] = $options;
+		$this->middleware[$middleware] = $options + [
+			'data' => $data
+		];
 	}
 
 	/**

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -125,7 +125,7 @@ class ControllerDispatcher {
 		{
 			if ( ! $this->methodExcludedByOptions($method, $options))
 			{
-				$results[] = array_get($middleware, $name, $name);
+				$results[array_get($middleware, $name, $name)] = $options['data'];
 			}
 		}
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -256,7 +256,20 @@ class Route {
 	 */
 	public function middleware()
 	{
-		return (array) array_get($this->action, 'middleware', []);
+		$middleware = (array) array_get($this->action, 'middleware', []);
+
+		foreach ($middleware as $k => $v)
+		{
+			if (!is_numeric($k))
+			{
+				continue;
+			}
+
+			unset($middleware[$k]);
+			$middleware[$v] = [];
+		}
+
+		return $middleware;
 	}
 
 	/**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -260,10 +260,7 @@ class Route {
 
 		foreach ($middleware as $k => $v)
 		{
-			if (!is_numeric($k))
-			{
-				continue;
-			}
+			if ( ! is_numeric($k)) continue;
 
 			unset($middleware[$k]);
 			$middleware[$v] = [];

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -701,10 +701,9 @@ class Router implements RegistrarContract {
 	 */
 	public function gatherRouteMiddlewares(Route $route)
 	{
-		return Collection::make($route->middleware())->map(function($m)
+		return Collection::make($route->middleware())->map(function($m, $k)
 		{
-			return Collection::make(array_get($this->middleware, $m, $m));
-
+			return Collection::make([array_get($this->middleware, $k, $k) => $m]);
 		})->collapse()->all();
 	}
 


### PR DESCRIPTION
This adds middleware parameters (as requested here #6470). The implementation is simple to use.

To pass a parameters to a route middleware, simply do:

``` php
/** etc.. */ [
    'uses' => 'SomeController@method',
    'middleware' => [
        'someMiddleware' => [ /** data to pass */ ],
        'guest' // other middleware works exactly as normal
    ]
] /** etc.. */
```

In a controller:

``` php
$this->middleware('someMiddleware', [ /** options as usual */ ], [ /** data to pass */ ]); 
```

In the Kernal middlewares array:

``` php
protected $middleware = [
    'Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode',
    'Illuminate\Cookie\Middleware\EncryptCookies',
    'Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse',
    'Illuminate\Session\Middleware\StartSession',
    'Illuminate\View\Middleware\ShareErrorsFromSession',
    'App\Http\Middleware\VerifyCsrfToken',
    'App\Http\Middleware\SomeMiddleware' => [ /** data to pass */ ],
];
```

Accessing the data in the middleware is very simple, it is the third parameter to the handle(...) function:

``` php
public function handle($request, Closure $next, $data = [ /** data that was passed */ ])
{
    return $next($request);
}
```
