### PR TITLE
Use LONGTEXT instead of TEXT

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -16,7 +16,7 @@ class CreateFailedJobsTable extends Migration
             $table->increments('id');
             $table->text('connection');
             $table->text('queue');
-            $table->text('payload');
+            $table->longText('payload');
             $table->timestamp('failed_at');
         });
     }

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -15,7 +15,7 @@ class CreateJobsTable extends Migration
         Schema::create('jobs', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('queue');
-            $table->text('payload');
+            $table->longText('payload');
             $table->tinyInteger('attempts')->unsigned();
             $table->tinyInteger('reserved')->unsigned();
             $table->unsignedInteger('reserved_at')->nullable();


### PR DESCRIPTION
I was trying something like:

```
public function __construct($data)
{
   $this->data = $data;
}
```

The problem occurs when `$data` is too big and the `payload` column can't handle so many bytes. To prevent this scenario i think that's better to use `longText()` instead of `text()`.
