### PR TITLE
[5.0] Add touchOwners method to DB/Eloquent/Collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -132,6 +132,16 @@ class Collection extends BaseCollection {
 	}
 
 	/**
+	 * Touch the models in the collection.
+	 *
+	 * @return void
+	 */
+	public function touchOwners()
+	{
+		$this->transform(function($m) { $m->touch(); });
+	}
+
+	/**
 	 * Merge the collection with the given items.
 	 *
 	 * @param  \ArrayAccess|array  $items

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -245,4 +245,14 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(new Collection(array($one)), $c->except(array(2, 3)));
 	}
 
+	public function testTouchOwnersTouchesModelsInCollection()
+	{
+		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one->shouldReceive('touch');
+
+		$c = new Collection(array($one));
+
+		$this->assertNull($c->touchOwners());
+	}
+
 }


### PR DESCRIPTION
Fixes #6386 in 5.0.
