### PR TITLE
[5.0] Add a local key override option to HasManyThrough relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -902,7 +902,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  string|null  $secondKey
 	 * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
 	 */
-	public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null)
+	public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null)
 	{
 		$through = new $through;
 
@@ -910,7 +910,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		$secondKey = $secondKey ?: $through->getForeignKey();
 
-		return new HasManyThrough((new $related)->newQuery(), $this, $through, $firstKey, $secondKey);
+		$localKey = $localKey ?: $this->getKeyName();
+
+		return new HasManyThrough((new $related)->newQuery(), $this, $through, $firstKey, $secondKey, $localKey);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -29,6 +29,13 @@ class HasManyThrough extends Relation {
 	protected $secondKey;
 
 	/**
+	 * The local key on the relationship
+	 *
+	 * @var string
+	 */
+	protected $localKey;
+
+	/**
 	 * Create a new has many through relationship instance.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -38,11 +45,12 @@ class HasManyThrough extends Relation {
 	 * @param  string  $secondKey
 	 * @return void
 	 */
-	public function __construct(Builder $query, Model $farParent, Model $parent, $firstKey, $secondKey)
+	public function __construct(Builder $query, Model $farParent, Model $parent, $firstKey, $secondKey, $localKey)
 	{
 		$this->firstKey = $firstKey;
 		$this->secondKey = $secondKey;
 		$this->farParent = $farParent;
+		$this->localKey = $localKey;
 
 		parent::__construct($query, $parent);
 	}
@@ -56,11 +64,13 @@ class HasManyThrough extends Relation {
 	{
 		$parentTable = $this->parent->getTable();
 
+		$localValue = $this->farParent[$this->localKey];
+
 		$this->setJoin();
 
 		if (static::$constraints)
 		{
-			$this->query->where($parentTable.'.'.$this->firstKey, '=', $this->farParent->getKey());
+			$this->query->where($parentTable.'.'.$this->firstKey, '=', $localValue);
 		}
 	}
 

--- a/tests/Database/DatabaseEloquentHasManyThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughTest.php
@@ -65,6 +65,35 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(0, count($models[2]->foo));
 	}
 
+	public function testModelsAreProperlyMatchedToParentsWithNonPrimaryKey()
+	{
+		$relation = $this->getRelationForNonPrimaryKey();
+
+		$result1 = new EloquentHasManyThroughModelStub;
+		$result1->country_id = 1;
+		$result2 = new EloquentHasManyThroughModelStub;
+		$result2->country_id = 2;
+		$result3 = new EloquentHasManyThroughModelStub;
+		$result3->country_id = 2;
+
+		$model1 = new EloquentHasManyThroughModelStub;
+		$model1->id = 1;
+		$model2 = new EloquentHasManyThroughModelStub;
+		$model2->id = 2;
+		$model3 = new EloquentHasManyThroughModelStub;
+		$model3->id = 3;
+
+		$relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function($array) { return new Collection($array); });
+		$models = $relation->match(array($model1, $model2, $model3), new Collection(array($result1, $result2, $result3)), 'foo');
+
+		$this->assertEquals(1, $models[0]->foo[0]->country_id);
+		$this->assertEquals(1, count($models[0]->foo));
+		$this->assertEquals(2, $models[1]->foo[0]->country_id);
+		$this->assertEquals(2, $models[1]->foo[1]->country_id);
+		$this->assertEquals(2, count($models[1]->foo));
+		$this->assertEquals(0, count($models[2]->foo));
+	}
+
 
 	protected function getRelation()
 	{
@@ -73,7 +102,8 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 		$builder->shouldReceive('where')->with('users.country_id', '=', 1);
 
 		$country = m::mock('Illuminate\Database\Eloquent\Model');
-		$country->shouldReceive('getKey')->andReturn(1);
+		$country->shouldReceive('getKeyName')->andReturn('id');
+		$country->shouldReceive('offsetGet')->andReturn(1);
 		$country->shouldReceive('getForeignKey')->andReturn('country_id');
 		$user = m::mock('Illuminate\Database\Eloquent\Model');
 		$user->shouldReceive('getTable')->andReturn('users');
@@ -86,7 +116,30 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 		$user->shouldReceive('getKey')->andReturn(1);
 		$user->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
 		$user->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-		return new HasManyThrough($builder, $country, $user, 'country_id', 'user_id');
+		return new HasManyThrough($builder, $country, $user, 'country_id', 'user_id', $country->getKeyName());
+	}
+
+	protected function getRelationForNonPrimaryKey()
+	{
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder->shouldReceive('join')->once()->with('users', 'users.id', '=', 'posts.user_id');
+		$builder->shouldReceive('where')->with('users.country_id', '=', 1);
+
+		$country = m::mock('Illuminate\Database\Eloquent\Model');
+		$country->shouldReceive('offsetGet')->andReturn(1);
+		$country->shouldReceive('getForeignKey')->andReturn('country_id');
+		$user = m::mock('Illuminate\Database\Eloquent\Model');
+		$user->shouldReceive('getTable')->andReturn('users');
+		$user->shouldReceive('getQualifiedKeyName')->andReturn('users.id');
+		$post = m::mock('Illuminate\Database\Eloquent\Model');
+		$post->shouldReceive('getTable')->andReturn('posts');
+
+		$builder->shouldReceive('getModel')->andReturn($post);
+
+		$user->shouldReceive('getKey')->andReturn(1);
+		$user->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
+		$user->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
+		return new HasManyThrough($builder, $country, $user, 'country_id', 'user_id', 'other_id');
 	}
 
 }


### PR DESCRIPTION
#### Why:

When adding a HasManyThrough relationship, the primary key on the model is assumed.  Sometimes you want the relation to use a different key than the primary key.  This pull request allows for that.
#### How:

Add an optional fifth argument in the `src/Illuminate/Database/Eloquent/Model:hasManyThrough` method called `$localKey`.  If provided, the hasManyThrough relation will look up the value of that attribute on the model instead of the value of the primary key.  If nothing is passed in, we pass the name of the primary key field so the lookup proceeds as normal.
#### Test:

`tests/Database/DatabaseEloquentHasManyThroughTest.php`
I modified and added the tests as needed.
