### PR TITLE
[5.0] Restrict Request::only() to create non-exist keys

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -309,7 +309,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 		{
 			$value = array_get($input, $key));
 			
-			if( ! is_null($value){
+			if( ! is_null($value)){
 				array_set($results, $key, $value);
 			}
 		}

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -307,7 +307,9 @@ class Request extends SymfonyRequest implements ArrayAccess {
 
 		foreach ($keys as $key)
 		{
-			array_set($results, $key, array_get($input, $key));
+			if(($value = array_get($input, $key)) !== null){
+				array_set($results, $key, $value);
+			}
 		}
 
 		return $results;

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -307,7 +307,9 @@ class Request extends SymfonyRequest implements ArrayAccess {
 
 		foreach ($keys as $key)
 		{
-			if(($value = array_get($input, $key)) !== null){
+			$value = array_get($input, $key));
+			
+			if( ! is_null($value){
 				array_set($results, $key, $value);
 			}
 		}

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -307,7 +307,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 
 		foreach ($keys as $key)
 		{
-			$value = array_get($input, $key));
+			$value = array_get($input, $key);
 			
 			if( ! is_null($value)){
 				array_set($results, $key, $value);


### PR DESCRIPTION
Restrict Request::only() to create array keys that not exists in input

Only doubt is it bugfix or change?
