### PR TITLE
[5.0] Allow users to set redirectAfterLogout

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesAndRegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesAndRegistersUsers.php
@@ -107,7 +107,7 @@ trait AuthenticatesAndRegistersUsers {
 	{
 		$this->auth->logout();
 
-		return redirect('/');
+		return redirect(property_exists($this, 'redirectAfterLogout') ? $this->redirectAfterLogout : '/');
 	}
 
 	/**


### PR DESCRIPTION
Apparently you shouldn't code early morning without coffee, @taylorotwell was correct in it not returning previously.

Didn't use logoutPath because it's not really a path in the same way loginPath is.
