### PR TITLE
[5.0] Foundation: use a lookup for app->getProvider()

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -72,6 +72,15 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	protected $serviceProviders = array();
 
 	/**
+	 * A lookup of service providers by name.
+	 *
+	 * If the a provider is force-registered twice, only the first instance is included.
+	 *
+	 * @var array
+	 */
+	protected $serviceProviderLookup = array();
+
+	/**
 	 * The names of the loaded service providers.
 	 *
 	 * @var array
@@ -500,10 +509,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	{
 		$name = is_string($provider) ? $provider : get_class($provider);
 
-		return array_first($this->serviceProviders, function($key, $value) use ($name)
-		{
-			return $value instanceof $name;
-		});
+		return array_get($this->serviceProviderLookup, $name);
 	}
 
 	/**
@@ -528,6 +534,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 		$this['events']->fire($class = get_class($provider), array($provider));
 
 		$this->serviceProviders[] = $provider;
+
+		// We also add this to a lookup, which makes getProvider nice and fast.
+		$this->serviceProviderLookup = array_add($this->serviceProviderLookup, $class, $provider);
 
 		$this->loadedProviders[$class] = true;
 	}


### PR DESCRIPTION
This greatly improves the performance of `getProvider()`, and therefore `register()`.

In one application with only a few more providers than the default (and no messing with providers otherwise), its 163 tests complete about 8% faster with this change applied.  I especially don't like waiting for tests to complete, but surely this improves application speed as well - and this is a pretty cheap change for 8%, imho.

I've tried to keep this as backwards compatible as possible.  A more ideal change, I think, would be to use `$loadedProviders` for this purpose or else just keep only one of each provider in `$serviceProviders` (which could then replace both arrays.)  However, both changes could have backwards compatibility impact.

The performance was measured primarily on Windows using PHP 5.6.7 and a series of 5 trials each, eliminating one outlier.  However, based on the profile this change came from and quick checks on a Linux vm, it should apply in any environment.
