### PR TITLE
[5.1] Change default fetch mode to FETCH_OBJ

### DIFF
--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -44,7 +44,7 @@ class Manager {
 	 */
 	protected function setupDefaultConfiguration()
 	{
-		$this->container['config']['database.fetch'] = PDO::FETCH_CLASS;
+		$this->container['config']['database.fetch'] = PDO::FETCH_OBJ;
 
 		$this->container['config']['database.default'] = 'default';
 	}

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -44,7 +44,7 @@ class Manager {
 	 */
 	protected function setupDefaultConfiguration()
 	{
-		$this->container['config']['database.fetch'] = PDO::FETCH_ASSOC;
+		$this->container['config']['database.fetch'] = PDO::FETCH_CLASS;
 
 		$this->container['config']['database.default'] = 'default';
 	}

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -66,7 +66,7 @@ class Connection implements ConnectionInterface {
 	 *
 	 * @var int
 	 */
-	protected $fetchMode = PDO::FETCH_ASSOC;
+	protected $fetchMode = PDO::FETCH_CLASS;
 
 	/**
 	 * The number of active transactions.

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -66,7 +66,7 @@ class Connection implements ConnectionInterface {
 	 *
 	 * @var int
 	 */
-	protected $fetchMode = PDO::FETCH_CLASS;
+	protected $fetchMode = PDO::FETCH_OBJ;
 
 	/**
 	 * The number of active transactions.


### PR DESCRIPTION
Let's at least unify the default config setting in v5.1 so that both the standalone component and Laravel's base use `FETCH_CLASS` by default.

See #8107 
/ping @jchamberlain 
