### PR TITLE
[5.0] Check for a file to provide parameter value in Dispatcher

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -154,6 +154,11 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
 
 		if (isset($source[$parameter->name]))
 		{
+			if (is_object($source->files) && is_null($source[$parameter->name]) && $source->file($parameter->name))
+			{
+				return $source->file($parameter->name);
+			}
+
 			return $source[$parameter->name];
 		}
 


### PR DESCRIPTION
If we have a files object in source, and the value would otherwise be null, and we have the file we’re referencing, then return that instead.

This fixes #8137 
