### PR TITLE
[5.0] Normalized return null

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1013,14 +1013,14 @@ class Container implements ArrayAccess, ContainerContract {
 
 		if ($function->getNumberOfParameters() == 0)
 		{
-			return null;
+			return;
 		}
 
 		$expected = $function->getParameters()[0];
 
 		if ( ! $expected->getClass())
 		{
-			return null;
+			return;
 		}
 
 		return $expected->getClass()->name;

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -590,13 +590,13 @@ if ( ! function_exists('env'))
 			case '(false)':
 				return false;
 
-			case 'null':
-			case '(null)':
-				return null;
-
 			case 'empty':
 			case '(empty)':
 				return '';
+
+			case 'null':
+			case '(null)':
+				return;
 		}
 
 		if (Str::startsWith($value, '"') && Str::endsWith($value, '"'))


### PR DESCRIPTION
In all other places in the framework, we prefer `return;` over `return null;`. This pull enforces this in the 3 places that deviated from this.
