### PR TITLE
[5.1] Update str_slug to convert "&" to "and", and also allow other custom replacements

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -279,9 +279,9 @@ class Str {
 	/**
 	 * Generate a URL friendly "slug" from a given string.
 	 *
-	 * @param  string $title
-	 * @param  string $separator
-	 * @param array $replacements
+	 * @param  string  $title
+	 * @param  string  $separator
+	 * @param  array   $replacements
 	 * @return string
 	 */
 	public static function slug($title, $separator = '-', $replacements = array())

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -279,13 +279,18 @@ class Str {
 	/**
 	 * Generate a URL friendly "slug" from a given string.
 	 *
-	 * @param  string  $title
-	 * @param  string  $separator
+	 * @param  string $title
+	 * @param  string $separator
+	 * @param array $replacements
 	 * @return string
 	 */
-	public static function slug($title, $separator = '-')
+	public static function slug($title, $separator = '-', $replacements = array())
 	{
 		$title = static::ascii($title);
+
+		$replacements['&'] = isset($replacements['&']) ? $replacements['&'] : 'and';
+
+		$title = strtr($title, $replacements);
 
 		// Convert all dashes/underscores into separator
 		$flip = $separator == '-' ? '_' : '-';

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -709,13 +709,14 @@ if ( ! function_exists('str_slug'))
 	/**
 	 * Generate a URL friendly "slug" from a given string.
 	 *
-	 * @param  string  $title
-	 * @param  string  $separator
+	 * @param  string $title
+	 * @param  string $separator
+	 * @param  array $replacements
 	 * @return string
 	 */
-	function str_slug($title, $separator = '-')
+	function str_slug($title, $separator = '-', $replacements = array())
 	{
-		return Str::slug($title, $separator);
+		return Str::slug($title, $separator, $replacements);
 	}
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -709,9 +709,9 @@ if ( ! function_exists('str_slug'))
 	/**
 	 * Generate a URL friendly "slug" from a given string.
 	 *
-	 * @param  string $title
-	 * @param  string $separator
-	 * @param  array $replacements
+	 * @param  string  $title
+	 * @param  string  $separator
+	 * @param  array   $replacements
 	 * @return string
 	 */
 	function str_slug($title, $separator = '-', $replacements = array())

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -85,6 +85,10 @@ class SupportStrTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('hello-world', Str::slug('hello-world'));
 		$this->assertEquals('hello-world', Str::slug('hello_world'));
 		$this->assertEquals('hello_world', Str::slug('hello_world', '_'));
+		$this->assertEquals('hello-and-goodbye', Str::slug('hello & goodbye'));
+		$this->assertEquals('hello-or-goodbye', Str::slug('hello || goodbye', '-', array('||' => 'or')));
+		$this->assertEquals('hello-and-or-goodbye', Str::slug('hello & || goodbye', '-', array('||' => 'or')));
+		$this->assertEquals('hello-or-also-goodbye', Str::slug('hello || & goodbye', '-', array('||' => 'or', '&' => 'also')));
 	}
 
 


### PR DESCRIPTION
It would be nice if when I _sluggified_ `Friends & Family` it came out as `friends-and-family` instead of `friends-family`

Behaviour after commit:

``` php
$string = "Friends & Family";

$slug = str_slug($string); // 'friends-and-family'
```

And, just for fun:

``` php
$string = "Hello || Goodbye";

$replacements = [
    '||' => 'or',
]

$slug = str_slug($string, '-', $replacements); // 'hello-or-goodbye'
```

could also be used to adjust for other languages, or whatever:

``` php
$string = "Bonjour & Au revoir";

$replacements = [
    '&' => 'et',
]

$slug = str_slug($string, '-', $replacements); // 'bounjour-et-au-revoir'
```
