### PR TITLE
[Routing] Fix phpdoc return

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -370,7 +370,7 @@ class Route {
 	 *
 	 * @param  string  $name
 	 * @param  mixed   $default
-	 * @return string
+	 * @return mixed
 	 */
 	public function getParameter($name, $default = null)
 	{
@@ -382,7 +382,7 @@ class Route {
 	 *
 	 * @param  string  $name
 	 * @param  mixed   $default
-	 * @return string
+	 * @return mixed
 	 */
 	public function parameter($name, $default = null)
 	{


### PR DESCRIPTION
An example..

``` php
Route::bind('user', function($value)
{
    return User::where('name', $value)->first();
});

Route::bind('post', function($value, Router $route)
{
    // now the $route->parameter('user') should return an instance of the User's class
    return $route->parameter('user')->posts()->where('slug', $value)->first();
});

Route::get('{user}/{post}', function($user, $post)
{
    ...
});
```
