### PR TITLE
Use the rename function

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -164,9 +164,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract {
 	 */
 	public function move($from, $to)
 	{
-		$this->driver->copy($from, $to);
-
-		$this->driver->delete($from);
+		$this->driver->rename($from, $to);
 	}
 
 	/**


### PR DESCRIPTION
Update the "move" function of the Adapter to use the "rename" function of the driver, instead of using a copy/delete combination.
