### PR TITLE
Fix command stubs

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/command-handler.stub
+++ b/src/Illuminate/Foundation/Console/stubs/command-handler.stub
@@ -1,7 +1,6 @@
 <?php namespace {{namespace}};
 
 use {{fullCommand}};
-
 use Illuminate\Queue\InteractsWithQueue;
 
 class {{class}} {

--- a/src/Illuminate/Foundation/Console/stubs/command-queued-with-handler.stub
+++ b/src/Illuminate/Foundation/Console/stubs/command-queued-with-handler.stub
@@ -1,7 +1,6 @@
 <?php namespace {{namespace}};
 
 use {{rootNamespace}}Commands\Command;
-
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldBeQueued;

--- a/src/Illuminate/Foundation/Console/stubs/command-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/command-queued.stub
@@ -1,7 +1,6 @@
 <?php namespace {{namespace}};
 
 use {{rootNamespace}}Commands\Command;
-
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Bus\SelfHandling;

--- a/src/Illuminate/Foundation/Console/stubs/command.stub
+++ b/src/Illuminate/Foundation/Console/stubs/command.stub
@@ -1,7 +1,6 @@
 <?php namespace {{namespace}};
 
 use {{rootNamespace}}Commands\Command;
-
 use Illuminate\Contracts\Bus\SelfHandling;
 
 class {{class}} extends Command implements SelfHandling {


### PR DESCRIPTION
Clean up the `use` section in the command stubs.

Current output gives this:

```
use App\Commands\Command;

use Illuminate\Queue\SerializesModels;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Contracts\Bus\SelfHandling;
use Illuminate\Contracts\Queue\ShouldBeQueued;
```

This pr changes output to this:

```
use App\Commands\Command;
use Illuminate\Queue\SerializesModels;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Contracts\Bus\SelfHandling;
use Illuminate\Contracts\Queue\ShouldBeQueued;
```
