### PR TITLE
[5.0] Fix selected columns on hasManyThrough

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -203,6 +203,8 @@ class HasManyThrough extends Relation {
 		// First we'll add the proper select columns onto the query so it is run with
 		// the proper columns. Then, we will get the results and hydrate out pivot
 		// models with the result of those columns as a separate model relation.
+		$columns = $this->query->getQuery()->columns ? array() : $columns;
+
 		$select = $this->getSelectColumns($columns);
 
 		$models = $this->query->addSelect($select)->getModels();

--- a/tests/Database/DatabaseEloquentHasManyThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughTest.php
@@ -66,6 +66,43 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAllColumnsAreSelectedByDefault()
+	{
+		$select = array('posts.*', 'users.country_id');
+
+		$baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+
+		$relation = $this->getRelation();
+		$relation->getRelated()->shouldReceive('newCollection')->once();
+
+		$builder = $relation->getQuery();
+		$builder->shouldReceive('getQuery')->andReturn($baseBuilder);
+		$builder->shouldReceive('addSelect')->once()->with($select)->andReturn($builder);
+		$builder->shouldReceive('getModels')->once()->andReturn(array());
+
+		$relation->get();
+	}
+
+
+	public function testOnlyProperColumnsAreSelectedIfProvided()
+	{
+		$select = array('users.country_id');
+
+		$baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+		$baseBuilder->columns = array('foo', 'bar');
+
+		$relation = $this->getRelation();
+		$relation->getRelated()->shouldReceive('newCollection')->once();
+
+		$builder = $relation->getQuery();
+		$builder->shouldReceive('getQuery')->andReturn($baseBuilder);
+		$builder->shouldReceive('addSelect')->once()->with($select)->andReturn($builder);
+		$builder->shouldReceive('getModels')->once()->andReturn(array());
+
+		$relation->get();
+	}
+
+
 	protected function getRelation()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');


### PR DESCRIPTION
`HasManyThrough` doesn't let you control which columns you want to select (the same bug that `BelongsToMany` had in the past). It fixes the problem - should be clear by the tests that were added.
