### PR TITLE
[5.0] Fix hasNested boolean operator

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -593,11 +593,11 @@ class Builder {
 			}
 			else
 			{
-				$q->has(array_shift($relations), $operator, $count, $boolean, $callback);
+				$q->has(array_shift($relations), $operator, $count, 'and', $callback);
 			}
 		};
 
-		return $this->whereHas(array_shift($relations), $closure);
+		return $this->has(array_shift($relations), '>=', 1, $boolean, $closure);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -459,6 +459,22 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testOrHasNested()
+	{
+		$model = new EloquentBuilderTestModelParentStub;
+
+		$builder = $model->whereHas('foo', function ($q) {
+			$q->has('bar');
+		})->orWhereHas('foo', function ($q) {
+			$q->has('baz');
+		});
+
+		$result = $model->has('foo.bar')->orHas('foo.baz')->toSql();
+
+		$this->assertEquals($builder->toSql(), $result);
+	}
+
+
 	protected function mockConnectionForModel($model, $database)
 	{
 		$grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';
@@ -538,6 +554,10 @@ class EloquentBuilderTestModelParentStub extends Illuminate\Database\Eloquent\Mo
 
 class EloquentBuilderTestModelCloseRelatedStub extends Illuminate\Database\Eloquent\Model {
 	public function bar()
+	{
+		return $this->hasMany('EloquentBuilderTestModelFarRelatedStub');
+	}
+	public function baz()
 	{
 		return $this->hasMany('EloquentBuilderTestModelFarRelatedStub');
 	}


### PR DESCRIPTION
The same as #7214 only for ver 5.

@taylorotwell As for the explanation you asked for - check the closed PR to 4.2 and mind that I created this `hasNested` feature with this bug to begin with.. 
It's rather edge case, to call `whereHas(..)->orWhereHas(..)` but still a bug.
