### PR TITLE
[5.0] Routing: cache URL root and scheme per request

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -22,7 +22,7 @@ class UrlGenerator implements UrlGeneratorContract {
 	protected $request;
 
 	/**
-	 * The force URL root.
+	 * The forced URL root.
 	 *
 	 * @var string
 	 */
@@ -34,6 +34,20 @@ class UrlGenerator implements UrlGeneratorContract {
 	 * @var string
 	 */
 	protected $forceSchema;
+
+	/**
+	 * A cached copy of the URL root for the current request.
+	 *
+	 * @var string|null
+	 */
+	protected $cachedRoot;
+
+	/**
+	 * A cached copy of the URL schema for the current request.
+	 *
+	 * @var string|null
+	 */
+	protected $cachedSchema;
 
 	/**
 	 * The root namespace being applied to controller actions.
@@ -215,7 +229,12 @@ class UrlGenerator implements UrlGeneratorContract {
 	{
 		if (is_null($secure))
 		{
-			return $this->forceSchema ?: $this->request->getScheme().'://';
+			if (is_null($this->cachedSchema))
+			{
+				$this->cachedSchema = $this->forceSchema ?: $this->request->getScheme().'://';
+			}
+
+			return $this->cachedSchema;
 		}
 
 		return $secure ? 'https://' : 'http://';
@@ -230,6 +249,7 @@ class UrlGenerator implements UrlGeneratorContract {
 	public function forceSchema($schema)
 	{
 		$this->forceSchema = $schema.'://';
+		$this->cachedSchema = null;
 	}
 
 	/**
@@ -551,7 +571,12 @@ class UrlGenerator implements UrlGeneratorContract {
 	{
 		if (is_null($root))
 		{
-			$root = $this->forcedRoot ?: $this->request->root();
+			if (is_null($this->cachedRoot))
+			{
+				$this->cachedRoot = $this->forcedRoot ?: $this->request->root();
+			}
+
+			$root = $this->cachedRoot;
 		}
 
 		$start = starts_with($root, 'http://') ? 'http://' : 'https://';
@@ -568,6 +593,7 @@ class UrlGenerator implements UrlGeneratorContract {
 	public function forceRootUrl($root)
 	{
 		$this->forcedRoot = rtrim($root, '/');
+		$this->cachedRoot = null;
 	}
 
 	/**
@@ -615,6 +641,8 @@ class UrlGenerator implements UrlGeneratorContract {
 	public function setRequest(Request $request)
 	{
 		$this->request = $request;
+		$this->cachedRoot = null;
+		$this->cachedSchema = null;
 	}
 
 	/**


### PR DESCRIPTION
This cuts down on time spent determining e.g. route URLs, which can end up being a lot depending on the application (for example, lists, navigation, etc. may contain many links.)

In an application that generates about 150 total URLs on a list page, this improves runtime by over 7%.

There should be no backward compatibility impact from this change, in general usage.  If a user mutates `ServerBag`/`HeaderBag` values directly, after retrieving a URL, it could generate stale results, but this is already generally a problem in `request->getBaseUrl()`, so it would've generated partially stale results before as well.
