### PR TITLE
[5.0] Route Paramaters Can Be Objects

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -370,7 +370,7 @@ class Route {
 	 *
 	 * @param  string  $name
 	 * @param  mixed   $default
-	 * @return string
+	 * @return string|object
 	 */
 	public function getParameter($name, $default = null)
 	{
@@ -382,7 +382,7 @@ class Route {
 	 *
 	 * @param  string  $name
 	 * @param  mixed   $default
-	 * @return string
+	 * @return string|object
 	 */
 	public function parameter($name, $default = null)
 	{


### PR DESCRIPTION
If route model binding is used, parameters can be eloquent models.
