### PR TITLE
[Database] Fix bug when create a new instance of the related model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -211,7 +211,7 @@ abstract class HasOneOrMany extends Relation {
 	{
 		if (is_null($instance = $this->where($attributes)->first()))
 		{
-			$instance = $this->related->newInstance();
+			$instance = $this->related->newInstance($attributes);
 
 			$instance->setAttribute($this->getPlainForeignKey(), $this->getParentKey());
 		}

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -57,7 +57,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getRelation();
 		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
 		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-		$relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('StdClass'));
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('foo'))->andReturn($model = m::mock('StdClass'));
 		$model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
 		$this->assertTrue($relation->firstOrNew(array('foo')) instanceof StdClass);
@@ -104,7 +104,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getRelation();
 		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
 		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-		$relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('StdClass'));
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('foo'))->andReturn($model = m::mock('StdClass'));
 		$model->shouldReceive('save')->once()->andReturn(true);
 		$model->shouldReceive('fill')->once()->with(array('bar'));
 		$model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);


### PR DESCRIPTION
When you use the `firstOrNew` method of `HasOneOrMany` relationship (like below) and it doesn't find any record matching with the attributes, then the attributes are not sent when creating a new instance.

``` php
User::find(1)->posts()->firstOrNew(['title' => 'Some title']);
```
