### PR TITLE
[5.0] defer caching mutated attributes to first use

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3209,7 +3209,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		// need to be fast. This will let us always know the attributes we mutate.
 		foreach (get_class_methods($class) as $method)
 		{
-			if (preg_match('/^get(.+)Attribute$/', $method, $matches))
+			// The strpos() check is here to avoid a regular expression, which is slow.
+			if (strpos($method, 'Attribute') !== false && preg_match('/^get(.+)Attribute$/', $method, $matches))
 			{
 				if (static::$snakeAttributes) $matches[1] = snake_case($matches[1]);
 


### PR DESCRIPTION
This defers the cost of looking up the mutators to use, and makes it free if a particular model class is never converted to an array (as might be the case in especially backend or queue processing.)

In the application this change came from, models are automatically rebooted at the beginning of each test to ensure a consistent test environment.  As such, this change improved performance in the test suite by about 7%.

The improvement this will have on other applications will vary much more wildly.

There shouldn't be any backwards-compatibility impact to this change, unless someone overrode `getMutatedAttributes()`.  If they did so without calling the parent implementation, they probably replaced the logic anyway.
