### PR TITLE
replacing getenv($key) with array_get($_ENV, $key)

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -576,9 +576,9 @@ if ( ! function_exists('env'))
 	 */
 	function env($key, $default = null)
 	{
-		$value = getenv($key);
+		$value = array_get($_ENV, $key);
 
-		if ($value === false) return value($default);
+		if ($value === null) return value($default);
 
 		switch (strtolower($value))
 		{


### PR DESCRIPTION
We've been having some issues on some local Windows environments with the new dotenv library. 

When you make rapid, successive AJAX requests to a Laravel app, some of the later requests in this chain seem to carry over `putenv()` values from a previous request, but only until the previous request is finished. This sounds strange, I know, but maybe a diagram can help:

```
Request 1: {starts --- env loaded --- app uses env ---- finishes}
Request 2:                         {starts --- env loaded ------ app uses env ---------finishes}
```

When `finishes` happens, PHP clears the values that were set using `putenv()`, but this appears to be affecting values across multiple requests from the same session.

Debugging `Dotenv` shows us that in the second request, it gets [here](https://github.com/vlucas/phpdotenv/blob/master/src/Dotenv.php#L71) and the environment variable is found...but only when you ask for it from `getenv()`. It's not available in `$_ENV` or `$_SERVER`. Then as the first request dies, it seems to clear out the values previously stored via `putenv()`. I'm not an expert on the PHP innards in Windows, but I suspect this is a bug related to sharing environment data between requests from the same session.

So the reason I'm creating this issue here is because Laravel's `env()` helper uses `getenv()`. Unfortunately in our environment, by the time the second request gets there, it's already been unset from the first request. We can tell `Dotenv` to be mutable, thus ensuring the values get stored in all three environment variable types, but that doesn't help us if Laravel still uses `getenv()`. We could create our own `env()` helper, but then we won't be able to keep up to date with any changes to Laravel's.

This PR represents what I think is a change that won't affect Laravel in any other environments, but will solve this problem in our Windows environment. Any alternate solution is welcome if this one isn't palatable for some reason.
