### PR TITLE
[5.0] Added a database_path() helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -214,6 +214,20 @@ if ( ! function_exists('csrf_token'))
 	}
 }
 
+if ( ! function_exists('database_path'))
+{
+	/**
+	 * Get the database path.
+	 *
+	 * @param  string  $path
+	 * @return string
+	 */
+	function database_path($path = '')
+	{
+		return app()->make('path.database').($path ? '/'.$path : $path);
+	}
+}
+
 if ( ! function_exists('delete'))
 {
 	/**


### PR DESCRIPTION
Continued from #7117

This mainly to avoid users from using `base_path('database')` for publishing migration since this path can be modified by extending `Illuminate\Foundation\Application`.

Of course another way of preventing this is by using `$this->app->databasePath()` but it seem `base_path('database')` is the widely used structure now. Even used as the doc example http://laravel.com/docs/5.0/packages#publishing-file-groups

Signed-off-by: crynobone crynobone@gmail.com
