### PR TITLE
Add column aliasing option in Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -524,13 +524,7 @@ class Builder {
 		else
 		{
 			$args = func_get_args();
-
-			// If the provided column is an alias, use the actual column name
-			if ( in_array($column, $this->model->getAliases()) )
-			{
-				$args[0] = array_search($column, $this->model->getAliases());
-			}
-
+			$args[0] = $this->model->unaliasColumn($column);
 			call_user_func_array(array($this->query, 'where'), $args);
 		}
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -523,7 +523,15 @@ class Builder {
 		}
 		else
 		{
-			call_user_func_array(array($this->query, 'where'), func_get_args());
+			$args = func_get_args();
+
+			// If the provided column is an alias, use the actual column name
+			if ( in_array($column, $this->model->getAliases()) )
+			{
+				$args[0] = array_search($column, $this->model->getAliases());
+			}
+
+			call_user_func_array(array($this->query, 'where'), $args);
 		}
 
 		return $this;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2095,7 +2095,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	}
 
 	/**
-	 * Get the aliases for the model.
+	 * Set the column alias mappings.
+	 *
+	 * @param  array  $aliases
+	 * @return void
+	 */
+	public function setAliases(array $aliases)
+	{
+		$this->aliases = $aliases;
+	}
+
+	/**
+	 * Get the column alias mappings for the model.
 	 *
 	 * @return array
 	 */
@@ -2181,17 +2192,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	public function setAppends(array $appends)
 	{
 		$this->appends = $appends;
-	}
-
-	/**
-	 * Set the column alias mappings.
-	 *
-	 * @param  array  $aliases
-	 * @return void
-	 */
-	public function setAliases(array $aliases)
-	{
-		$this->aliases = $aliases;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -84,6 +84,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	protected $original = array();
 
 	/**
+	 * The model's column-to-alias mappings.
+	 *
+	 * @var array
+	 */
+	protected $aliases = array();
+
+	/**
 	 * The loaded relationships for the model.
 	 *
 	 * @var array
@@ -2167,6 +2174,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	}
 
 	/**
+	 * Set the column alias mappings.
+	 *
+	 * @param  array  $aliases
+	 * @return void
+	 */
+	public function setAliases(array $aliases)
+	{
+		$this->aliases = $aliases;
+	}
+
+	/**
 	 * Get the fillable attributes for the model.
 	 *
 	 * @return array
@@ -2380,6 +2398,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	public function attributesToArray()
 	{
 		$attributes = $this->getArrayableAttributes();
+
+		foreach ($this->aliases as $original => $alias)
+		{
+			$attributes[$alias] = $attributes[$original];
+			unset($attributes[$original]);
+		}
 
 		// If an attribute is a date, we will cast it to a string after converting it
 		// to a DateTime / Carbon instance. This is so we will get some consistent

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2095,6 +2095,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	}
 
 	/**
+	 * Get the aliases for the model.
+	 *
+	 * @return array
+	 */
+	public function getAliases()
+	{
+		return $this->aliases;
+	}
+
+	/**
 	 * Get the hidden attributes for the model.
 	 *
 	 * @return array

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -408,7 +408,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testSimpleWhere()
 	{
 		$builder = $this->getBuilder();
-		$builder->getModel()->shouldReceive('getAliases')->andReturn(array());
+		$builder->getModel()->shouldReceive('unaliasColumn')->with('foo')->andReturn('foo');
 		$builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'bar');
 		$result = $builder->where('foo', '=', 'bar');
 		$this->assertEquals($result, $builder);
@@ -417,7 +417,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testWhereWithAlias()
 	{
 		$builder = $this->getBuilder();
-		$builder->getModel()->shouldReceive('getAliases')->andReturn(array('foo' => 'bar'));
+		$builder->getModel()->shouldReceive('unaliasColumn')->with('bar')->andReturn('foo');
 		$builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'baz');
 		$result = $builder->where('bar', '=', 'baz');
 		$this->assertEquals($result, $builder);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -279,7 +279,6 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testGetRelationProperlySetsNestedRelationships()
 	{
 		$builder = $this->getBuilder();
-		$builder->setModel($this->getMockModel());
 		$builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock('stdClass'));
 		$relationQuery = m::mock('stdClass');
 		$relation->shouldReceive('getQuery')->andReturn($relationQuery);
@@ -293,7 +292,6 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testGetRelationProperlySetsNestedRelationshipsWithSimilarNames()
 	{
 		$builder = $this->getBuilder();
-		$builder->setModel($this->getMockModel());
 		$builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock('stdClass'));
 		$builder->getModel()->shouldReceive('ordersGroups')->once()->andReturn($groupsRelation = m::mock('stdClass'));
 
@@ -410,8 +408,18 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	public function testSimpleWhere()
 	{
 		$builder = $this->getBuilder();
+		$builder->getModel()->shouldReceive('getAliases')->andReturn(array());
 		$builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'bar');
 		$result = $builder->where('foo', '=', 'bar');
+		$this->assertEquals($result, $builder);
+	}
+
+	public function testWhereWithAlias()
+	{
+		$builder = $this->getBuilder();
+		$builder->getModel()->shouldReceive('getAliases')->andReturn(array('foo' => 'bar'));
+		$builder->getQuery()->shouldReceive('where')->once()->with('foo', '=', 'baz');
+		$result = $builder->where('bar', '=', 'baz');
 		$this->assertEquals($result, $builder);
 	}
 
@@ -490,7 +498,9 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 
 	protected function getBuilder()
 	{
-		return new Builder($this->getMockQueryBuilder());
+		$builder = new Builder($this->getMockQueryBuilder());
+		$builder->setModel($this->getMockModel());
+		return $builder;
 	}
 
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -581,6 +581,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model = new EloquentModelStub;
 		$model->name = 'foo';
 		$model->age = null;
+		$model->email = 'test@laravel.com';
+		$model->setAliases(array('email' => 'emailAddress'));
 		$model->password = 'password1';
 		$model->setHidden(array('password'));
 		$model->setRelation('names', new Illuminate\Database\Eloquent\Collection(array(
@@ -599,6 +601,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertNull($array['group']);
 		$this->assertEquals(array(), $array['multi']);
 		$this->assertFalse(isset($array['password']));
+		$this->assertEquals('test@laravel.com',$array['emailAddress']);
+		$this->assertFalse(isset($array['email']));
 
 		$model->setAppends(array('appendable'));
 		$array = $model->toArray();


### PR DESCRIPTION
This allows developers to use Eloquent model attribute names that differ from the actual names of the columns. This is accomplished by adding an `$aliases` field to the Model (similar to `$appends`, `visible`, `hidden`, etc.)

For example, if you're dealing with a legacy database you can't change, you can remap some ugly field names to friendlier ones:

``` php
protected $aliases = [
    'FIELD_03' => 'email',
    'FIELD_12' => 'name'
];
```

This allows you to access the fields by the alias name:

``` php
User::find($id)->email; // returns the value in database column FIELD_03
```

It works with query builder too, so this:

``` php
User::where('FIELD_12', 'like', 'jobs')
  ->orWhere('FIELD_03','sjobs@apple.com')
```

Becomes:

``` php
User::where('name', 'like', 'jobs')
  ->orWhere('email','sjobs@apple.com')
```
