### PR TITLE
[5.0] Add single minute granularity to console scheduling

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -460,7 +460,17 @@ class Event {
 	{
 		return $this->cron('0 0 1 1 * *');
 	}
-
+	
+	/**
+	 * Schedule the event to run every minute.
+	 *
+	 * @return $this
+	 */
+	public function everyMinute()
+	{
+		return $this->cron('* * * * * *');
+	}
+	
 	/**
 	 * Schedule the event to run every five minutes.
 	 *

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -460,7 +460,7 @@ class Event {
 	{
 		return $this->cron('0 0 1 1 * *');
 	}
-	
+
 	/**
 	 * Schedule the event to run every minute.
 	 *
@@ -470,7 +470,7 @@ class Event {
 	{
 		return $this->cron('* * * * * *');
 	}
-	
+
 	/**
 	 * Schedule the event to run every five minutes.
 	 *


### PR DESCRIPTION
I'd venture a guess that some folks would like to run tasks a bit faster than every 5 minutes.
