### PR TITLE
[L5] Loading deferred Provider before eager loaded ones

### DIFF
--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -67,6 +67,8 @@ class ProviderRepository {
 			$this->registerLoadEvents($provider, $events);
 		}
 
+		$this->app->setDeferredServices($manifest['deferred']);
+		
 		// We will go ahead and register all of the eagerly loaded providers with the
 		// application so their services can be registered with the application as
 		// a provided service. Then we will set the deferred service list on it.
@@ -75,7 +77,7 @@ class ProviderRepository {
 			$this->app->register($this->createProvider($provider));
 		}
 
-		$this->app->setDeferredServices($manifest['deferred']);
+		
 	}
 
 	/**


### PR DESCRIPTION
I had the situation that I used the cache ( $this->app['cache'] ) in one of my ServiceProvider since cache is an deferred provider it wasn't yet registered as such. Therefore Laravel couldn't resolve it. Or lazy load it.

After I changed this. It worked.
