### PR TITLE
[5.0] Foundation: add better lookup for app->getProvider()

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -72,6 +72,15 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	protected $serviceProviders = array();
 
 	/**
+	 * A lookup of service providers by class name.
+	 *
+	 * If the a provider is force-registered twice, only the first instance is included.
+	 *
+	 * @var array
+	 */
+	protected $registeredProviders = array();
+
+	/**
 	 * The names of the loaded service providers.
 	 *
 	 * @var array
@@ -500,10 +509,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	{
 		$name = is_string($provider) ? $provider : get_class($provider);
 
-		return array_first($this->serviceProviders, function($key, $value) use ($name)
-		{
-			return $value instanceof $name;
-		});
+		return isset($this->registeredProviders[$name]) ? $this->registeredProviders[$name] : null;
 	}
 
 	/**
@@ -530,6 +536,15 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 		$this->serviceProviders[] = $provider;
 
 		$this->loadedProviders[$class] = true;
+		
+		$aliases = class_parents($class) + class_implements($class) + array($class);
+		foreach ($aliases as $alias)
+		{
+			if ( ! isset($this->registeredProviders[$alias]))
+			{
+				$this->registeredProviders[$alias] = $provider;
+			}
+		}
 	}
 
 	/**

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -115,6 +115,15 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testGetProviderByParentClass()
+	{
+		$app = new Application;
+		$app->register('ApplicationChildProviderStub');
+		$this->assertEquals($app->getProvider('ApplicationChildProviderStub'), $app->getProvider('ApplicationParentProviderStub'));
+		$this->assertEquals($app->getProvider('ApplicationChildProviderStub'), $app->getProvider('ApplicationInterfaceProviderStub'));
+	}
+
+
 	public function testEnvironment()
 	{
 		$app = new Application;
@@ -209,5 +218,20 @@ class ApplicationMultiProviderStub extends Illuminate\Support\ServiceProvider {
 	{
 		$this->app->singleton('foo', function() { return 'foo'; });
 		$this->app->singleton('bar', function($app) { return $app['foo'].'bar'; });
+	}
+}
+
+class ApplicationParentProviderStub extends Illuminate\Support\ServiceProvider {
+	public function register()
+	{
+	}
+}
+
+interface ApplicationInterfaceProviderStub {
+}
+
+class ApplicationChildProviderStub extends ApplicationParentProviderStub implements ApplicationInterfaceProviderStub {
+	public function register()
+	{
 	}
 }


### PR DESCRIPTION
This adds a test for the problem that caused the event:generate command to fail.

See #8135, ef371a5a1281bb948c46484de82ab7f0bc106a85.

Sorry for missing this.  Obviously, the `$loadedProviders` array has the same problem.  Should I move it also into the foreach?
