### PR TITLE
Input::has should return true when a null value is given

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -246,6 +246,8 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	{
 		$keys = is_array($key) ? $key : func_get_args();
 
+		if ( ! $this->exists($keys)) return false;
+
 		foreach ($keys as $value)
 		{
 			if ($this->isEmptyString($value)) return false;
@@ -262,9 +264,9 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	protected function isEmptyString($key)
 	{
-		$boolOrArray = is_bool($this->input($key)) || is_array($this->input($key));
+		$value = $this->input($key);
 
-		return ! $boolOrArray && trim((string) $this->input($key)) === '';
+		return is_string($value) && trim($value) === '';
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -246,6 +246,11 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	{
 		$keys = is_array($key) ? $key : func_get_args();
 
+		if( ! $this->exists($keys))
+		{
+			return false;
+		}
+
 		foreach ($keys as $value)
 		{
 			if ($this->isEmptyString($value)) return false;
@@ -262,9 +267,9 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	protected function isEmptyString($key)
 	{
-		$boolOrArray = is_bool($this->input($key)) || is_array($this->input($key));
+		$value = $this->input($key);
 
-		return ! $boolOrArray && trim((string) $this->input($key)) === '';
+		return is_string($value) && trim($value) === '';
 	}
 
 	/**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -180,17 +180,17 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 
 	public function testHasMethod()
 	{
-		$request = Request::create('/', 'GET', array('name' => 'Taylor'));
+		$request = Request::create('/', 'GET', ['name' => 'Taylor']);
 		$this->assertTrue($request->has('name'));
 		$this->assertFalse($request->has('foo'));
 		$this->assertFalse($request->has('name', 'email'));
 
-		$request = Request::create('/', 'GET', array('name' => 'Taylor', 'email' => 'foo'));
+		$request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
 		$this->assertTrue($request->has('name'));
 		$this->assertTrue($request->has('name', 'email'));
 
 		//test arrays within query string
-		$request = Request::create('/', 'GET', array('foo' => array('bar', 'baz')));
+		$request = Request::create('/', 'GET', ['foo' => ['bar', 'baz']]);
 		$this->assertTrue($request->has('foo'));
 	}
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -192,6 +192,12 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		//test arrays within query string
 		$request = Request::create('/', 'GET', ['foo' => ['bar', 'baz']]);
 		$this->assertTrue($request->has('foo'));
+
+		$request = Request::create('/', 'GET', ['parent_id' => null, 'yes' => true, 'no' => false, 'empty' => '']);
+		$this->assertTrue($request->has('parent_id'));
+		$this->assertTrue($request->has('yes'));
+		$this->assertTrue($request->has('no'));
+		$this->assertFalse($request->has('empty'));
 	}
 
 


### PR DESCRIPTION
Currently `Input::has('key')` is too restrictive. If a `null` value is passed through the request, which happens often in APIs, `Input::has` returns false. This is because it only expects booleans, arrays and strings as values for the input.

This pull request fixes the issue.
