### PR TITLE
[5.0] Add new Verify Post Size middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyPostSize.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyPostSize.php
@@ -1,0 +1,55 @@
+<?php namespace Illuminate\Foundation\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Routing\Middleware;
+use Illuminate\Http\Exception\PostTooLargeException;
+
+class VerifyPostSize implements Middleware {
+
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  \Closure  $next
+	 * @return mixed
+	 * 
+	 * @throws \Illuminate\Http\Exception\PostTooLargeException
+	 */
+	public function handle($request, Closure $next)
+	{
+		if ($request->server('CONTENT_LENGTH') > $this->getPostMaxSize())
+		{
+			throw new PostTooLargeException;
+		}
+
+		return $next($request);
+	}
+	
+	/**
+	 * Determine the server 'post_max_size' as bytes.
+	 *
+	 * @return int
+	 */
+   	protected function getPostMaxSize()
+   	{
+		$postMaxSize = ini_get('post_max_size');
+		
+		switch (substr($postMaxSize, -1))
+		{
+			case 'M':
+			case 'm':
+				return (int) $postMaxSize * 1048576;
+				
+			case 'K':
+			case 'k':
+				return (int) $postMaxSize * 1024;
+				
+			case 'G':
+			case 'g':
+				return (int) $postMaxSize * 1073741824;
+		}
+		
+		return (int) $postMaxSize;
+	}
+	
+}

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyPostSize.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyPostSize.php
@@ -39,11 +39,9 @@ class VerifyPostSize implements Middleware {
 			case 'M':
 			case 'm':
 				return (int) $postMaxSize * 1048576;
-				
 			case 'K':
 			case 'k':
 				return (int) $postMaxSize * 1024;
-				
 			case 'G':
 			case 'g':
 				return (int) $postMaxSize * 1073741824;

--- a/src/Illuminate/Http/Exception/PostTooLargeException.php
+++ b/src/Illuminate/Http/Exception/PostTooLargeException.php
@@ -1,0 +1,5 @@
+<?php namespace Illuminate\Http\Exception;
+
+use Exception;
+
+class PostTooLargeException extends Exception {}


### PR DESCRIPTION
So I was doing some AJAX file uploading, and kept getting random `TokenMismatchException` errors. After much debugging - I realised the issue related to `post_max_size`.

If the file I was attempted to upload was greater than my `post_max_size` - PHP clears the super globals of `$_POST` and `$_FILE` - **but** still sends the server the POST request (which is now empty).

The problem is that the empty post hits Laravel, and when doing CSRF detection there is no `_token` - so you'll get a `TokenMismatchException`, leading you on wild goose chases as to why your forms are not sending correct tokens.

It also means that the user will be shown an incorrect error. Rather than be told they are uploading a file that is _way_ to large - it just throws a 500 error with the wrong message.

I did some investigating - and there is a way to detect this situation. I propose we include this as part of the HTTP Middleware.

Originally mentioned here: https://github.com/laravel/framework/issues/8202

The `getPostMaxSize()` function is using a script similar to the one described on the php.net page: http://php.net/manual/en/function.ini-get.php
