### PR TITLE
[5.0] Add optional config key for log max files

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -75,7 +75,7 @@ class ConfigureLogging {
 	 */
 	protected function configureDailyHandler(Application $app, Writer $log)
 	{
-		$log->useDailyFiles($app->storagePath().'/logs/laravel.log', 5);
+		$log->useDailyFiles($app->storagePath().'/logs/laravel.log', $app['config']['app.log_max_files'] ?: 5);
 	}
 
 	/**


### PR DESCRIPTION
Problem:
Logs are removed after 5 days (5 files), and it's not configurable (or I did not found how). It was configurable in laravel 4, and I think it was a good idea (some people might want to keep 30 log files)

Solution : 
Add an optional config key `app.log_max_files` (with underscore as `locale` and `fallback_locale`). It will not break backward compatibility and we don't need to "hack" Laravel log system.  

Additional note:
Laravel's documentation should be updated if this PR is accepted.
