### PR TITLE
[5.0] Broken test for Blade

### DIFF
--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -569,7 +569,7 @@ empty
 			function($view, BladeCompiler $compiler)
 			{
 				$pattern = $compiler->createOpenMatcher('datetime');
-				$replace = '<?php echo $2->format(\'m/d/Y H:i\')); ?>';
+				$replace = '<?php echo $2->format(\'m/d/Y H:i\'); ?>';
 				return preg_replace($pattern, '$1'.$replace, $view);
 			}
 		);

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -562,6 +562,28 @@ empty
 	}
 
 
+	public function testCreateOpenMatcher()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$compiler->extend(
+			function($view, BladeCompiler $compiler)
+			{
+				$pattern = $compiler->createOpenMatcher('datetime');
+				$replace = '<?php echo $2->format(\'m/d/Y H:i\')); ?>';
+				return preg_replace($pattern, '$1'.$replace, $view);
+			}
+		);
+
+		$string = '@if($foo)
+@datetime($var)
+@endif';
+		$expected = '<?php if($foo): ?>
+<?php echo $var->format(\'m/d/Y H:i\'); ?>
+<?php endif; ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
+
+
 	public function testCreatePlainMatcher()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
Here is a broken test.

1) The example from the doc http://laravel.com/docs/5.0/templates#extending-blade is not working.
Produces `<?php echo ($var->format('m/d/Y H:i')); ?>` instead of `<?php echo $var->format('m/d/Y H:i'); ?>`
2) There are more `)` than `(` in that example. Seems strange.
Anyway, If you delete the last closing one, test still fails because `createOpenMatcher()` always adds `(` to the beginning (related to #8224), so the whole method seems broken to me

There are no other tests for that method btw
