### PR TITLE
allow mocking Input::get() calls

### DIFF
--- a/src/Illuminate/Support/Facades/Input.php
+++ b/src/Illuminate/Support/Facades/Input.php
@@ -16,6 +16,10 @@ class Input extends Facade {
 	 */
 	public static function get($key = null, $default = null)
 	{
+		if (static::isMock()) {
+			return call_user_func_array(array(static::getFacadeRoot(), 'get'), array($key, $default));
+		}
+
 		return static::$app['request']->input($key, $default);
 	}
 

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -57,6 +57,12 @@ class SupportFacadeTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('bar', FacadeStub::foo());
 	}
 
+	public function testCanMockDeclaredChildMethods()
+	{
+		FacadeStub::shouldReceive('hello')->once()->andReturn('hello Matt');
+		$this->assertEquals('hello Matt', FacadeStub::hello('Mike'));
+	}
+
 }
 
 class FacadeStub extends Illuminate\Support\Facades\Facade {
@@ -64,6 +70,15 @@ class FacadeStub extends Illuminate\Support\Facades\Facade {
 	protected static function getFacadeAccessor()
 	{
 		return 'foo';
+	}
+
+	public static function hello($name)
+	{
+		if (static::isMock()) {
+			return call_user_func_array(array(static::getFacadeRoot(), 'hello'), array($name));
+		}
+
+		return 'hello ' . $name;
 	}
 
 }


### PR DESCRIPTION
If you are mocking the input facade, calls to Input::get() are not mockable because the get method calls the original instance.

This PR checks if Input has been mocked, and calls get() on the mock instead of the original instance.

To reproduce the issue you can comment out the similar check I added to FacadeStub and run the tests.
