### PR TITLE
env()  requires index if no $default value present

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -592,7 +592,13 @@ if ( ! function_exists('env'))
 	{
 		$value = getenv($key);
 
-		if ($value === false) return value($default);
+		if ($value === false) {
+			if (func_num_args() == 1) {
+				throw new \RuntimeException("Environment variable $key not found.");
+			} else {
+				return value($default);
+			}
+		}
 
 		switch (strtolower($value))
 		{


### PR DESCRIPTION
Explicit is better than implicit. 

I think `env()` should not confuse index not found (this is an error) with null as default value (this is a specified behaivor).

This modified version throws `RuntimeException` when env var not found, and `$default` not specified by user. 

(i personally use this modified version as `env_require()` in my project :grinning: )
