### PR TITLE
Optional newline on info and comment functions

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -287,7 +287,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 */
 	public function info($string, $newline = true) 
 	{
-		if ($newline) 
+		if ($newline)
 		{
 	    		$this->output->writeln("<info>$string</info>");
 		} 
@@ -296,7 +296,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	    		$this->output->write("<info>$string</info>");
 		}
 	}
-	
+
 	/**
 	 * Write a string as standard output.
 	 *

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -290,7 +290,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 		if ($newline)
 		{
 	    		$this->output->writeln("<info>$string</info>");
-		} 
+		}
 		else
 		{
 	    		$this->output->write("<info>$string</info>");
@@ -304,13 +304,13 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * @param  bool  $newline
 	 * @return void
 	 */
-	public function line($string, $newline = true) 
+	public function line($string, $newline = true)
 	{
-		if ($newline) 
+		if ($newline)
 		{
 	    		$this->output->writeln($string);
-		} 
-		else 
+		}
+		else
 		{
 	    		$this->output->write($string);
 		}

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -282,16 +282,16 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * Write a string as information output.
 	 *
 	 * @param  string  $string
-	 * @param  bool  $newline 
+	 * @param  bool  $newline
 	 * @return void
 	 */
-	public function info($string, $newline = true) 
+	public function info($string, $newline = true)
 	{
 		if ($newline)
 		{
 	    		$this->output->writeln("<info>$string</info>");
 		} 
-		else 
+		else
 		{
 	    		$this->output->write("<info>$string</info>");
 		}

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -282,7 +282,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * Write a string as information output.
 	 *
 	 * @param  string  $string
-	 * @param  bool  $newline
+	 * @param  bool  $newline 
 	 * @return void
 	 */
 	public function info($string, $newline = true) 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -279,25 +279,41 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	}
 
 	/**
-	 * Write a string as information output.
-	 *
-	 * @param  string  $string
-	 * @return void
-	 */
-	public function info($string)
+	* Write a string as information output.
+	*
+	* @param  string  $string
+	* @param  bool  $newline
+	* @return void
+	*/
+	public function info($string, $newline = true) 
 	{
-		$this->output->writeln("<info>$string</info>");
+		if ($newline) 
+		{
+	    		$this->output->writeln("<info>$string</info>");
+		} 
+		else 
+		{
+	    		$this->output->write("<info>$string</info>");
+		}
 	}
-
+	
 	/**
-	 * Write a string as standard output.
-	 *
-	 * @param  string  $string
-	 * @return void
-	 */
-	public function line($string)
+	* Write a string as standard output.
+	*
+	* @param  string  $string
+	* @param  bool  $newline
+	* @return void
+	*/
+	public function line($string, $newline = true) 
 	{
-		$this->output->writeln($string);
+		if ($newline) 
+		{
+	    		$this->output->writeln($string);
+		} 
+		else 
+		{
+	    		$this->output->write($string);
+		}
 	}
 
 	/**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -279,12 +279,12 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	}
 
 	/**
-	* Write a string as information output.
-	*
-	* @param  string  $string
-	* @param  bool  $newline
-	* @return void
-	*/
+	 * Write a string as information output.
+	 *
+	 * @param  string  $string
+	 * @param  bool  $newline
+	 * @return void
+	 */
 	public function info($string, $newline = true) 
 	{
 		if ($newline) 
@@ -298,12 +298,12 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	}
 	
 	/**
-	* Write a string as standard output.
-	*
-	* @param  string  $string
-	* @param  bool  $newline
-	* @return void
-	*/
+	 * Write a string as standard output.
+	 *
+	 * @param  string  $string
+	 * @param  bool  $newline
+	 * @return void
+	 */
 	public function line($string, $newline = true) 
 	{
 		if ($newline) 


### PR DESCRIPTION
It may be useful for some verbose Artisan commands to add a bool parameter 'newline' to 'info' function and 'comment' function. When 'newline' is true, the info or comment line will printed with 'writeln', otherwise will printed with 'write'.
The functions 'comment', 'question' and 'error' work only with 'writeln' because they need to be _highlighted_ in some way during the execution of Artisan command.
