### PR TITLE
[5.1] introduce SoftDeletes contract (and fix soft deleted parents on HasManyThrough)

### DIFF
--- a/src/Illuminate/Contracts/Database/SoftDeletes.php
+++ b/src/Illuminate/Contracts/Database/SoftDeletes.php
@@ -1,0 +1,47 @@
+<?php namespace Illuminate\Contracts\Database;
+
+interface SoftDeletes {
+
+	/**
+	 * Boot soft deletes for the model.
+	 * 
+	 * @return void
+	 */
+	public static function bootSoftDeletes();	
+
+	/**
+	 * Force a hard delete on a soft deleted model.
+	 *
+	 * @return void
+	 */
+	public function forceDelete();
+
+	/**
+	 * Restore a soft-deleted model instance.
+	 *
+	 * @return bool|null
+	 */
+	public function restore();
+
+	/**
+	 * Determine if the model instance has been soft-deleted.
+	 *
+	 * @return bool
+	 */
+	public function trashed();
+
+	/**
+	 * Get the name of the "deleted at" column.
+	 *
+	 * @return string
+	 */
+	public function getDeletedAtColumn();
+
+	/**
+	 * Get the fully qualified "deleted at" column.
+	 *
+	 * @return string
+	 */
+	public function getQualifiedDeletedAtColumn();
+
+}

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -4,6 +4,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Contracts\Database\SoftDeletes;
 
 class HasManyThrough extends Relation {
 
@@ -97,6 +98,21 @@ class HasManyThrough extends Relation {
 		$foreignKey = $this->related->getTable().'.'.$this->secondKey;
 
 		$query->join($this->parent->getTable(), $this->getQualifiedParentKeyName(), '=', $foreignKey);
+
+		if ($this->parentSoftDeletes())
+		{
+			$query->whereNull($this->parent->getQualifiedDeletedAtColumn());
+		}
+	}
+
+	/**
+	 * Determine whether close parent of the relation uses soft deletes.
+	 * 
+	 * @return bool
+	 */
+	public function parentSoftDeletes()
+	{
+		return $this->parent instanceof SoftDeletes;
 	}
 
 	/**


### PR DESCRIPTION
The same as #8246 but additionaly introduces `SoftDeletes` contract in order to be able to reliably determine whether a model uses soft deletes.
