### PR TITLE
[5.0] Much verbose output in assertResponseStatus() method

### DIFF
--- a/src/Illuminate/Foundation/Testing/AssertionsTrait.php
+++ b/src/Illuminate/Foundation/Testing/AssertionsTrait.php
@@ -14,7 +14,7 @@ trait AssertionsTrait {
 	{
 		$actual = $this->response->getStatusCode();
 
-		return PHPUnit::assertTrue($this->response->isOk(), 'Expected status code 200, got ' .$actual);
+		return PHPUnit::assertTrue($this->response->isOk(), 'Expected status code 200, got ' . $actual);
 	}
 
 	/**
@@ -25,7 +25,7 @@ trait AssertionsTrait {
 	 */
 	public function assertResponseStatus($code)
 	{
-		return PHPUnit::assertEquals($code, $this->response->getStatusCode());
+		return PHPUnit::assertEquals($code, $this->response->getStatusCode(), 'Expected status code ' . $code . ', got ' . $actual);
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Testing/AssertionsTrait.php
+++ b/src/Illuminate/Foundation/Testing/AssertionsTrait.php
@@ -25,6 +25,8 @@ trait AssertionsTrait {
 	 */
 	public function assertResponseStatus($code)
 	{
+		$actual = $this->response->getStatusCode();
+		
 		return PHPUnit::assertEquals($code, $this->response->getStatusCode(), "Expected status code $code, got $actual");
 	}
 

--- a/src/Illuminate/Foundation/Testing/AssertionsTrait.php
+++ b/src/Illuminate/Foundation/Testing/AssertionsTrait.php
@@ -14,7 +14,7 @@ trait AssertionsTrait {
 	{
 		$actual = $this->response->getStatusCode();
 
-		return PHPUnit::assertTrue($this->response->isOk(), 'Expected status code 200, got '.$actual);
+		return PHPUnit::assertTrue($this->response->isOk(), 'Expected status code 200, got $actual');
 	}
 
 	/**
@@ -25,7 +25,7 @@ trait AssertionsTrait {
 	 */
 	public function assertResponseStatus($code)
 	{
-		return PHPUnit::assertEquals($code, $this->response->getStatusCode(), 'Expected status code '.$code.', got '.$actual);
+		return PHPUnit::assertEquals($code, $this->response->getStatusCode(), 'Expected status code $code, got $actual');
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Testing/AssertionsTrait.php
+++ b/src/Illuminate/Foundation/Testing/AssertionsTrait.php
@@ -14,7 +14,7 @@ trait AssertionsTrait {
 	{
 		$actual = $this->response->getStatusCode();
 
-		return PHPUnit::assertTrue($this->response->isOk(), 'Expected status code 200, got ' . $actual);
+		return PHPUnit::assertTrue($this->response->isOk(), 'Expected status code 200, got '.$actual);
 	}
 
 	/**
@@ -25,7 +25,7 @@ trait AssertionsTrait {
 	 */
 	public function assertResponseStatus($code)
 	{
-		return PHPUnit::assertEquals($code, $this->response->getStatusCode(), 'Expected status code ' . $code . ', got ' . $actual);
+		return PHPUnit::assertEquals($code, $this->response->getStatusCode(), 'Expected status code '.$code.', got '.$actual);
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Testing/AssertionsTrait.php
+++ b/src/Illuminate/Foundation/Testing/AssertionsTrait.php
@@ -14,7 +14,7 @@ trait AssertionsTrait {
 	{
 		$actual = $this->response->getStatusCode();
 
-		return PHPUnit::assertTrue($this->response->isOk(), 'Expected status code 200, got $actual');
+		return PHPUnit::assertTrue($this->response->isOk(), "Expected status code 200, got $actual");
 	}
 
 	/**
@@ -25,7 +25,7 @@ trait AssertionsTrait {
 	 */
 	public function assertResponseStatus($code)
 	{
-		return PHPUnit::assertEquals($code, $this->response->getStatusCode(), 'Expected status code $code, got $actual');
+		return PHPUnit::assertEquals($code, $this->response->getStatusCode(), "Expected status code $code, got $actual");
 	}
 
 	/**


### PR DESCRIPTION
Much verbose output in assertResponseStatus() method, where the output tells what was expected, what is actual.
