### PR TITLE
[5.0] Use the slice method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -408,7 +408,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 */
 	public function forPage($page, $perPage)
 	{
-		return new static(array_slice($this->items, ($page - 1) * $perPage, $perPage));
+		return $this->slice(($page - 1) * $perPage, $perPage);
 	}
 
 	/**


### PR DESCRIPTION
The collection already has a `slice` method, so let's use that in `forPage`.
