### PR TITLE
Remove individual files instead of whole directory in artisan fresh

### DIFF
--- a/src/Illuminate/Foundation/Console/FreshCommand.php
+++ b/src/Illuminate/Foundation/Console/FreshCommand.php
@@ -35,23 +35,29 @@ class FreshCommand extends Command {
 		$files = new Filesystem;
 
 		$files->delete(app_path('Services/Registrar.php'));
+		@rmdir(app_path('Services'));
 		$files->delete(base_path('resources/views/app.blade.php'));
 		$files->delete(base_path('resources/views/home.blade.php'));
 		$files->delete(app_path('Http/Controllers/Auth/AuthController.php'));
 		$files->delete(app_path('Http/Controllers/Auth/PasswordController.php'));
+		@rmdir(app_path('Http/Controllers/Auth'));
 		$files->delete(base_path('resources/views/auth/login.blade.php'));
 		$files->delete(base_path('resources/views/auth/password.blade.php'));
 		$files->delete(base_path('resources/views/auth/register.blade.php'));
 		$files->delete(base_path('resources/views/auth/reset.blade.php'));
+		@rmdir(base_path('resources/views/auth'));
 		$files->delete(base_path('resources/views/emails/password.blade.php'));
+		@rmdir(base_path('resources/views/emails'));
 		$files->delete(app_path('Http/Controllers/HomeController.php'));
 
 		$files->delete(base_path('public/css/app.css'));
+		@rmdir(resources('public/css'));
 		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.eot'));
 		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.svg'));
 		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.ttf'));
 		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.woff'));
 		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.woff2'));
+		@rmdir(resources('public/fonts'));
 		$files->put(base_path('resources/assets/less/app.less'), ''.PHP_EOL);
 		$files->deleteDirectory(base_path('resources/assets/less/bootstrap'));
 

--- a/src/Illuminate/Foundation/Console/FreshCommand.php
+++ b/src/Illuminate/Foundation/Console/FreshCommand.php
@@ -34,16 +34,24 @@ class FreshCommand extends Command {
 
 		$files = new Filesystem;
 
-		$files->deleteDirectory(app_path('Services'));
+		$files->delete(app_path('Services/Registrar.php'));
 		$files->delete(base_path('resources/views/app.blade.php'));
 		$files->delete(base_path('resources/views/home.blade.php'));
-		$files->deleteDirectory(app_path('Http/Controllers/Auth'));
-		$files->deleteDirectory(base_path('resources/views/auth'));
-		$files->deleteDirectory(base_path('resources/views/emails'));
+		$files->delete(app_path('Http/Controllers/Auth/AuthController.php'));
+		$files->delete(app_path('Http/Controllers/Auth/PasswordController.php'));
+		$files->delete(base_path('resources/views/auth/login.blade.php'));
+		$files->delete(base_path('resources/views/auth/password.blade.php'));
+		$files->delete(base_path('resources/views/auth/register.blade.php'));
+		$files->delete(base_path('resources/views/auth/reset.blade.php'));
+		$files->delete(base_path('resources/views/emails/password.blade.php'));
 		$files->delete(app_path('Http/Controllers/HomeController.php'));
 
-		$files->deleteDirectory(base_path('public/css'));
-		$files->deleteDirectory(base_path('public/fonts'));
+		$files->delete(base_path('public/css/app.css'));
+		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.eot'));
+		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.svg'));
+		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.ttf'));
+		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.woff'));
+		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.woff2'));
 		$files->put(base_path('resources/assets/less/app.less'), ''.PHP_EOL);
 		$files->deleteDirectory(base_path('resources/assets/less/bootstrap'));
 

--- a/src/Illuminate/Foundation/Console/FreshCommand.php
+++ b/src/Illuminate/Foundation/Console/FreshCommand.php
@@ -51,13 +51,13 @@ class FreshCommand extends Command {
 		$files->delete(app_path('Http/Controllers/HomeController.php'));
 
 		$files->delete(base_path('public/css/app.css'));
-		@rmdir(resources('public/css'));
+		@rmdir(base_path('public/css'));
 		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.eot'));
 		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.svg'));
 		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.ttf'));
 		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.woff'));
 		$files->delete(base_path('public/fonts/glyphicons-halflings-regular.woff2'));
-		@rmdir(resources('public/fonts'));
+		@rmdir(base_path('public/fonts'));
 		$files->put(base_path('resources/assets/less/app.less'), ''.PHP_EOL);
 		$files->deleteDirectory(base_path('resources/assets/less/bootstrap'));
 


### PR DESCRIPTION
A few days ago, I run `./artisan fresh` on a developing application and it ruined all of my own `App\Services\*` classes, and `resources/assets/less/app.less` stylesheets. (relax - my own code has been recovered with git :grinning:)

On a user modified laravel application, `fresh` command should remove scaffolding safely, or refuses to run. Either is better than destroying user code. 

I changed `fresh` commands to remove individual class/stylesheet/asset files instead of whole directory to avoid this program. 
