### PR TITLE
Standardize array formatting

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -145,7 +145,7 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
 	 * @return mixed
 	 */
 	protected function getParameterValueForCommand($command, ArrayAccess $source,
-                                                   ReflectionParameter $parameter, array $extras = array())
+                                                   ReflectionParameter $parameter, array $extras = [])
 	{
 		if (array_key_exists($parameter->name, $extras))
 		{

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -9,7 +9,7 @@ class ArrayStore extends TaggableStore implements Store {
 	 *
 	 * @var array
 	 */
-	protected $storage = array();
+	protected $storage = [];
 
 	/**
 	 * Retrieve an item from the cache by key.
@@ -96,7 +96,7 @@ class ArrayStore extends TaggableStore implements Store {
 	 */
 	public function flush()
 	{
-		$this->storage = array();
+		$this->storage = [];
 	}
 
 	/**

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -309,7 +309,7 @@ class CacheManager implements FactoryContract {
 	 */
 	public function __call($method, $parameters)
 	{
-		return call_user_func_array(array($this->store(), $method), $parameters);
+		return call_user_func_array([$this->store(), $method], $parameters);
 	}
 
 }

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -63,7 +63,7 @@ class FileStore implements Store {
 		}
 		catch (Exception $e)
 		{
-			return array('data' => null, 'time' => null);
+			return ['data' => null, 'time' => null];
 		}
 
 		// If the current time is greater than expiration timestamps we will delete
@@ -73,7 +73,7 @@ class FileStore implements Store {
 		{
 			$this->forget($key);
 
-			return array('data' => null, 'time' => null);
+			return ['data' => null, 'time' => null];
 		}
 
 		$data = unserialize(substr($contents, 10));

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -9,7 +9,7 @@ class NullStore extends TaggableStore implements Store {
 	 *
 	 * @var array
 	 */
-	protected $storage = array();
+	protected $storage = [];
 
 	/**
 	 * Retrieve an item from the cache by key.

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -72,7 +72,7 @@ class RedisTaggedCache extends TaggedCache {
 
 		if (count($forever) > 0)
 		{
-			call_user_func_array(array($this->store->connection(), 'del'), $forever);
+			call_user_func_array([$this->store->connection(), 'del'], $forever);
 		}
 	}
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -363,7 +363,7 @@ class Repository implements CacheContract, ArrayAccess {
 			return $this->macroCall($method, $parameters);
 		}
 
-		return call_user_func_array(array($this->store, $method), $parameters);
+		return call_user_func_array([$this->store, $method], $parameters);
 	}
 
 }

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -16,7 +16,7 @@ class TagSet {
 	 *
 	 * @var array
 	 */
-	protected $names = array();
+	protected $names = [];
 
 	/**
 	 * Create a new TagSet instance.
@@ -25,7 +25,7 @@ class TagSet {
 	 * @param  array  $names
 	 * @return void
 	 */
-	public function __construct(Store $store, array $names = array())
+	public function __construct(Store $store, array $names = [])
 	{
 		$this->store = $store;
 		$this->names = $names;
@@ -38,7 +38,7 @@ class TagSet {
 	 */
 	public function reset()
 	{
-		array_walk($this->names, array($this, 'resetTag'));
+		array_walk($this->names, [$this, 'resetTag']);
 	}
 
 	/**
@@ -59,7 +59,7 @@ class TagSet {
 	 */
 	protected function tagIds()
 	{
-		return array_map(array($this, 'tagId'), $this->names);
+		return array_map([$this, 'tagId'], $this->names);
 	}
 
 	/**

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -18,7 +18,7 @@ class Repository implements ArrayAccess, ConfigContract {
 	 * @param  array  $items
 	 * @return void
 	 */
-	public function __construct(array $items = array())
+	public function __construct(array $items = [])
 	{
 		$this->items = $items;
 	}

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -51,7 +51,7 @@ class Application extends SymfonyApplication implements ApplicationContract {
 	 * @param  array  $parameters
 	 * @return int
 	 */
-	public function call($command, array $parameters = array())
+	public function call($command, array $parameters = [])
 	{
 		$parameters['command'] = $command;
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -76,12 +76,12 @@ class Command extends \Symfony\Component\Console\Command\Command {
 		// passed into these commands as "parameters" to control the execution.
 		foreach ($this->getArguments() as $arguments)
 		{
-			call_user_func_array(array($this, 'addArgument'), $arguments);
+			call_user_func_array([$this, 'addArgument'], $arguments);
 		}
 
 		foreach ($this->getOptions() as $options)
 		{
-			call_user_func_array(array($this, 'addOption'), $options);
+			call_user_func_array([$this, 'addOption'], $options);
 		}
 	}
 
@@ -122,7 +122,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * @param  array   $arguments
 	 * @return int
 	 */
-	public function call($command, array $arguments = array())
+	public function call($command, array $arguments = [])
 	{
 		$instance = $this->getApplication()->find($command);
 
@@ -138,7 +138,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 * @param  array   $arguments
 	 * @return int
 	 */
-	public function callSilent($command, array $arguments = array())
+	public function callSilent($command, array $arguments = [])
 	{
 		$instance = $this->getApplication()->find($command);
 
@@ -340,7 +340,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 */
 	protected function getArguments()
 	{
-		return array();
+		return [];
 	}
 
 	/**
@@ -350,7 +350,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 */
 	protected function getOptions()
 	{
-		return array();
+		return [];
 	}
 
 	/**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -198,9 +198,9 @@ abstract class GeneratorCommand extends Command {
 	 */
 	protected function getArguments()
 	{
-		return array(
-			array('name', InputArgument::REQUIRED, 'The name of the class'),
-		);
+		return [
+			['name', InputArgument::REQUIRED, 'The name of the class'],
+		];
 	}
 
 }

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -27,7 +27,7 @@ class CallbackEvent extends Event {
 	 * @param  array  $parameters
 	 * @return void
 	 */
-	public function __construct($callback, array $parameters = array())
+	public function __construct($callback, array $parameters = [])
 	{
 		$this->callback = $callback;
 		$this->parameters = $parameters;

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -18,7 +18,7 @@ class Schedule {
 	 * @param  array   $parameters
 	 * @return \Illuminate\Console\Scheduling\Event
 	 */
-	public function call($callback, array $parameters = array())
+	public function call($callback, array $parameters = [])
 	{
 		$this->events[] = $event = new CallbackEvent($callback, $parameters);
 

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -29,7 +29,7 @@ interface Guard {
 	 * @param  array  $credentials
 	 * @return bool
 	 */
-	public function once(array $credentials = array());
+	public function once(array $credentials = []);
 
 	/**
 	 * Attempt to authenticate a user using the given credentials.
@@ -39,7 +39,7 @@ interface Guard {
 	 * @param  bool   $login
 	 * @return bool
 	 */
-	public function attempt(array $credentials = array(), $remember = false, $login = true);
+	public function attempt(array $credentials = [], $remember = false, $login = true);
 
 	/**
 	 * Attempt to authenticate using HTTP Basic Auth.
@@ -63,7 +63,7 @@ interface Guard {
 	 * @param  array  $credentials
 	 * @return bool
 	 */
-	public function validate(array $credentials = array());
+	public function validate(array $credentials = []);
 
 	/**
 	 * Log a user into the application.

--- a/src/Illuminate/Contracts/Console/Application.php
+++ b/src/Illuminate/Contracts/Console/Application.php
@@ -9,7 +9,7 @@ interface Application {
 	 * @param  array  $parameters
 	 * @return int
 	 */
-	public function call($command, array $parameters = array());
+	public function call($command, array $parameters = []);
 
 	/**
 	 * Get the output from the last command.

--- a/src/Illuminate/Contracts/Console/Kernel.php
+++ b/src/Illuminate/Contracts/Console/Kernel.php
@@ -18,7 +18,7 @@ interface Kernel {
 	 * @param  array  $parameters
 	 * @return int
 	 */
-	public function call($command, array $parameters = array());
+	public function call($command, array $parameters = []);
 
 	/**
 	 * Queue an Artisan console command by name.
@@ -27,7 +27,7 @@ interface Kernel {
 	 * @param  array  $parameters
 	 * @return int
 	 */
-	public function queue($command, array $parameters = array());
+	public function queue($command, array $parameters = []);
 
 	/**
 	 * Get all of the commands registered with the console.

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -102,7 +102,7 @@ interface Container {
 	 * @param  array   $parameters
 	 * @return mixed
 	 */
-	public function make($abstract, $parameters = array());
+	public function make($abstract, $parameters = []);
 
 	/**
 	 * Call the given Closure / class@method and inject its dependencies.
@@ -112,7 +112,7 @@ interface Container {
 	 * @param  string|null  $defaultMethod
 	 * @return mixed
 	 */
-	public function call($callback, array $parameters = array(), $defaultMethod = null);
+	public function call($callback, array $parameters = [], $defaultMethod = null);
 
 	/**
 	 * Determine if the given abstract type has been resolved.

--- a/src/Illuminate/Contracts/Events/Dispatcher.php
+++ b/src/Illuminate/Contracts/Events/Dispatcher.php
@@ -27,7 +27,7 @@ interface Dispatcher {
 	 * @param  array   $payload
 	 * @return mixed
 	 */
-	public function until($event, $payload = array());
+	public function until($event, $payload = []);
 
 	/**
 	 * Fire an event and call the listeners.
@@ -37,7 +37,7 @@ interface Dispatcher {
 	 * @param  bool    $halt
 	 * @return array|null
 	 */
-	public function fire($event, $payload = array(), $halt = false);
+	public function fire($event, $payload = [], $halt = false);
 
 	/**
 	 * Get the event that is currently firing.

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -48,7 +48,7 @@ interface Application extends Container {
 	 * @param  bool   $force
 	 * @return \Illuminate\Support\ServiceProvider
 	 */
-	public function register($provider, $options = array(), $force = false);
+	public function register($provider, $options = [], $force = false);
 
 	/**
 	 * Register a deferred provider and service.

--- a/src/Illuminate/Contracts/Hashing/Hasher.php
+++ b/src/Illuminate/Contracts/Hashing/Hasher.php
@@ -9,7 +9,7 @@ interface Hasher {
 	 * @param  array   $options
 	 * @return string
 	 */
-	public function make($value, array $options = array());
+	public function make($value, array $options = []);
 
 	/**
 	 * Check the given plain value against a hash.
@@ -19,7 +19,7 @@ interface Hasher {
 	 * @param  array   $options
 	 * @return bool
 	 */
-	public function check($value, $hashedValue, array $options = array());
+	public function check($value, $hashedValue, array $options = []);
 
 	/**
 	 * Check if the given hash has been hashed using the given options.
@@ -28,6 +28,6 @@ interface Hasher {
 	 * @param  array   $options
 	 * @return bool
 	 */
-	public function needsRehash($hashedValue, array $options = array());
+	public function needsRehash($hashedValue, array $options = []);
 
 }

--- a/src/Illuminate/Contracts/Logging/Log.php
+++ b/src/Illuminate/Contracts/Logging/Log.php
@@ -9,7 +9,7 @@ interface Log {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function alert($message, array $context = array());
+	public function alert($message, array $context = []);
 
 	/**
 	 * Log a critical message to the logs.
@@ -18,7 +18,7 @@ interface Log {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function critical($message, array $context = array());
+	public function critical($message, array $context = []);
 
 	/**
 	 * Log an error message to the logs.
@@ -27,7 +27,7 @@ interface Log {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function error($message, array $context = array());
+	public function error($message, array $context = []);
 
 	/**
 	 * Log a warning message to the logs.
@@ -36,7 +36,7 @@ interface Log {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function warning($message, array $context = array());
+	public function warning($message, array $context = []);
 
 	/**
 	 * Log a notice to the logs.
@@ -45,7 +45,7 @@ interface Log {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function notice($message, array $context = array());
+	public function notice($message, array $context = []);
 
 	/**
 	 * Log an informational message to the logs.
@@ -54,7 +54,7 @@ interface Log {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function info($message, array $context = array());
+	public function info($message, array $context = []);
 
 	/**
 	 * Log a debug message to the logs.
@@ -63,7 +63,7 @@ interface Log {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function debug($message, array $context = array());
+	public function debug($message, array $context = []);
 
 	/**
 	 * Log a message to the logs.
@@ -73,7 +73,7 @@ interface Log {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function log($level, $message, array $context = array());
+	public function log($level, $message, array $context = []);
 
 	/**
 	 * Register a file log handler.

--- a/src/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Illuminate/Contracts/Queue/Queue.php
@@ -20,7 +20,7 @@ interface Queue {
 	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function pushRaw($payload, $queue = null, array $options = array());
+	public function pushRaw($payload, $queue = null, array $options = []);
 
 	/**
 	 * Push a new job onto the queue after a delay.

--- a/src/Illuminate/Contracts/Redis/Database.php
+++ b/src/Illuminate/Contracts/Redis/Database.php
@@ -9,6 +9,6 @@ interface Database {
 	 * @param  array   $parameters
 	 * @return mixed
 	 */
-	public function command($method, array $parameters = array());
+	public function command($method, array $parameters = []);
 
 }

--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -76,7 +76,7 @@ interface Registrar {
 	 * @param  array   $options
 	 * @return void
 	 */
-	public function resource($name, $controller, array $options = array());
+	public function resource($name, $controller, array $options = []);
 
 	/**
 	 * Create a route group with shared attributes.

--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -10,7 +10,7 @@ interface ResponseFactory {
 	 * @param  array   $headers
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function make($content = '', $status = 200, array $headers = array());
+	public function make($content = '', $status = 200, array $headers = []);
 
 	/**
 	 * Return a new view response from the application.
@@ -21,7 +21,7 @@ interface ResponseFactory {
 	 * @param  array   $headers
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function view($view, $data = array(), $status = 200, array $headers = array());
+	public function view($view, $data = [], $status = 200, array $headers = []);
 
 	/**
 	 * Return a new JSON response from the application.
@@ -32,7 +32,7 @@ interface ResponseFactory {
 	 * @param  int    $options
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function json($data = array(), $status = 200, array $headers = array(), $options = 0);
+	public function json($data = [], $status = 200, array $headers = [], $options = 0);
 
 	/**
 	 * Return a new JSONP response from the application.
@@ -44,7 +44,7 @@ interface ResponseFactory {
 	 * @param  int    $options
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function jsonp($callback, $data = array(), $status = 200, array $headers = array(), $options = 0);
+	public function jsonp($callback, $data = [], $status = 200, array $headers = [], $options = 0);
 
 	/**
 	 * Return a new streamed response from the application.
@@ -54,7 +54,7 @@ interface ResponseFactory {
 	 * @param  array    $headers
 	 * @return \Symfony\Component\HttpFoundation\StreamedResponse
 	 */
-	public function stream($callback, $status = 200, array $headers = array());
+	public function stream($callback, $status = 200, array $headers = []);
 
 	/**
 	 * Create a new file download response.
@@ -65,7 +65,7 @@ interface ResponseFactory {
 	 * @param  null|string  $disposition
 	 * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
 	 */
-	public function download($file, $name = null, array $headers = array(), $disposition = 'attachment');
+	public function download($file, $name = null, array $headers = [], $disposition = 'attachment');
 
 	/**
 	 * Create a new redirect response to the given path.
@@ -76,7 +76,7 @@ interface ResponseFactory {
 	 * @param  bool    $secure
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function redirectTo($path, $status = 302, $headers = array(), $secure = null);
+	public function redirectTo($path, $status = 302, $headers = [], $secure = null);
 
 	/**
 	 * Create a new redirect response to a named route.
@@ -87,7 +87,7 @@ interface ResponseFactory {
 	 * @param  array   $headers
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function redirectToRoute($route, $parameters = array(), $status = 302, $headers = array());
+	public function redirectToRoute($route, $parameters = [], $status = 302, $headers = []);
 
 	/**
 	 * Create a new redirect response to a controller action.
@@ -98,7 +98,7 @@ interface ResponseFactory {
 	 * @param  array   $headers
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function redirectToAction($action, $parameters = array(), $status = 302, $headers = array());
+	public function redirectToAction($action, $parameters = [], $status = 302, $headers = []);
 
 	/**
 	 * Create a new redirect response, while putting the current URL in the session.
@@ -109,7 +109,7 @@ interface ResponseFactory {
 	 * @param  bool    $secure
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function redirectGuest($path, $status = 302, $headers = array(), $secure = null);
+	public function redirectGuest($path, $status = 302, $headers = [], $secure = null);
 
 	/**
 	 * Create a new redirect response to the previously intended location.
@@ -120,6 +120,6 @@ interface ResponseFactory {
 	 * @param  bool    $secure
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function redirectToIntended($default = '/', $status = 302, $headers = array(), $secure = null);
+	public function redirectToIntended($default = '/', $status = 302, $headers = [], $secure = null);
 
 }

--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -10,7 +10,7 @@ interface UrlGenerator {
 	 * @param  bool  $secure
 	 * @return string
 	 */
-	public function to($path, $extra = array(), $secure = null);
+	public function to($path, $extra = [], $secure = null);
 
 	/**
 	 * Generate a secure, absolute URL to the given path.
@@ -19,7 +19,7 @@ interface UrlGenerator {
 	 * @param  array   $parameters
 	 * @return string
 	 */
-	public function secure($path, $parameters = array());
+	public function secure($path, $parameters = []);
 
 	/**
 	 * Generate a URL to an application asset.
@@ -40,7 +40,7 @@ interface UrlGenerator {
 	 *
 	 * @throws \InvalidArgumentException
 	 */
-	public function route($name, $parameters = array(), $absolute = true);
+	public function route($name, $parameters = [], $absolute = true);
 
 	/**
 	 * Get the URL to a controller action.
@@ -50,7 +50,7 @@ interface UrlGenerator {
 	 * @param  bool $absolute
 	 * @return string
 	 */
-	public function action($action, $parameters = array(), $absolute = true);
+	public function action($action, $parameters = [], $absolute = true);
 
 	/**
 	 * Set the root controller namespace.

--- a/src/Illuminate/Contracts/Validation/Factory.php
+++ b/src/Illuminate/Contracts/Validation/Factory.php
@@ -11,7 +11,7 @@ interface Factory {
 	 * @param  array  $customAttributes
 	 * @return \Illuminate\Contracts\Validation\Validator
 	 */
-	public function make(array $data, array $rules, array $messages = array(), array $customAttributes = array());
+	public function make(array $data, array $rules, array $messages = [], array $customAttributes = []);
 
 	/**
 	 * Register a custom validator extension.

--- a/src/Illuminate/Contracts/View/Factory.php
+++ b/src/Illuminate/Contracts/View/Factory.php
@@ -18,7 +18,7 @@ interface Factory {
 	 * @param  array  $mergeData
 	 * @return \Illuminate\Contracts\View\View
 	 */
-	public function file($path, $data = array(), $mergeData = array());
+	public function file($path, $data = [], $mergeData = []);
 
 	/**
 	 * Get the evaluated view contents for the given view.
@@ -28,7 +28,7 @@ interface Factory {
 	 * @param  array  $mergeData
 	 * @return \Illuminate\Contracts\View\View
 	 */
-	public function make($view, $data = array(), $mergeData = array());
+	public function make($view, $data = [], $mergeData = []);
 
 	/**
 	 * Add a piece of shared data to the environment.

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -24,7 +24,7 @@ class CookieJar implements JarContract {
 	 *
 	 * @var array
 	 */
-	protected $queued = array();
+	protected $queued = [];
 
 	/**
 	 * Create a new cookie instance.
@@ -113,7 +113,7 @@ class CookieJar implements JarContract {
 		}
 		else
 		{
-			$cookie = call_user_func_array(array($this, 'make'), func_get_args());
+			$cookie = call_user_func_array([$this, 'make'], func_get_args());
 		}
 
 		$this->queued[$cookie->getName()] = $cookie;
@@ -138,7 +138,7 @@ class CookieJar implements JarContract {
 	 */
 	protected function getPathAndDomain($path, $domain)
 	{
-		return array($path ?: $this->path, $domain ?: $this->domain);
+		return [$path ?: $this->path, $domain ?: $this->domain];
 	}
 
 	/**
@@ -150,7 +150,7 @@ class CookieJar implements JarContract {
 	 */
 	public function setDefaultPathAndDomain($path, $domain)
 	{
-		list($this->path, $this->domain) = array($path, $domain);
+		list($this->path, $this->domain) = [$path, $domain];
 
 		return $this;
 	}

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -84,7 +84,7 @@ class EncryptCookies implements Middleware {
 	 */
 	protected function decryptArray(array $cookie)
 	{
-		$decrypted = array();
+		$decrypted = [];
 
 		foreach ($cookie as $key => $value)
 		{

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -196,7 +196,7 @@ class Manager {
 	 */
 	public static function __callStatic($method, $parameters)
 	{
-		return call_user_func_array(array(static::connection(), $method), $parameters);
+		return call_user_func_array([static::connection(), $method], $parameters);
 	}
 
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -80,7 +80,7 @@ class Connection implements ConnectionInterface {
 	 *
 	 * @var array
 	 */
-	protected $queryLog = array();
+	protected $queryLog = [];
 
 	/**
 	 * Indicates whether queries are being logged.
@@ -115,7 +115,7 @@ class Connection implements ConnectionInterface {
 	 *
 	 * @var array
 	 */
-	protected $config = array();
+	protected $config = [];
 
 	/**
 	 * Create a new database connection instance.
@@ -126,7 +126,7 @@ class Connection implements ConnectionInterface {
 	 * @param  array    $config
 	 * @return void
 	 */
-	public function __construct(PDO $pdo, $database = '', $tablePrefix = '', array $config = array())
+	public function __construct(PDO $pdo, $database = '', $tablePrefix = '', array $config = [])
 	{
 		$this->pdo = $pdo;
 
@@ -249,7 +249,7 @@ class Connection implements ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return mixed
 	 */
-	public function selectOne($query, $bindings = array())
+	public function selectOne($query, $bindings = [])
 	{
 		$records = $this->select($query, $bindings);
 
@@ -263,7 +263,7 @@ class Connection implements ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return array
 	 */
-	public function selectFromWriteConnection($query, $bindings = array())
+	public function selectFromWriteConnection($query, $bindings = [])
 	{
 		return $this->select($query, $bindings, false);
 	}
@@ -276,11 +276,11 @@ class Connection implements ConnectionInterface {
 	 * @param  bool  $useReadPdo
 	 * @return array
 	 */
-	public function select($query, $bindings = array(), $useReadPdo = true)
+	public function select($query, $bindings = [], $useReadPdo = true)
 	{
 		return $this->run($query, $bindings, function($me, $query, $bindings) use ($useReadPdo)
 		{
-			if ($me->pretending()) return array();
+			if ($me->pretending()) return [];
 
 			// For select statements, we'll simply execute the query and return an array
 			// of the database result set. Each element in the array will be a single
@@ -311,7 +311,7 @@ class Connection implements ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return bool
 	 */
-	public function insert($query, $bindings = array())
+	public function insert($query, $bindings = [])
 	{
 		return $this->statement($query, $bindings);
 	}
@@ -323,7 +323,7 @@ class Connection implements ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return int
 	 */
-	public function update($query, $bindings = array())
+	public function update($query, $bindings = [])
 	{
 		return $this->affectingStatement($query, $bindings);
 	}
@@ -335,7 +335,7 @@ class Connection implements ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return int
 	 */
-	public function delete($query, $bindings = array())
+	public function delete($query, $bindings = [])
 	{
 		return $this->affectingStatement($query, $bindings);
 	}
@@ -347,7 +347,7 @@ class Connection implements ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return bool
 	 */
-	public function statement($query, $bindings = array())
+	public function statement($query, $bindings = [])
 	{
 		return $this->run($query, $bindings, function($me, $query, $bindings)
 		{
@@ -366,7 +366,7 @@ class Connection implements ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return int
 	 */
-	public function affectingStatement($query, $bindings = array())
+	public function affectingStatement($query, $bindings = [])
 	{
 		return $this->run($query, $bindings, function($me, $query, $bindings)
 		{
@@ -391,7 +391,7 @@ class Connection implements ConnectionInterface {
 	 */
 	public function unprepared($query)
 	{
-		return $this->run($query, array(), function($me, $query)
+		return $this->run($query, [], function($me, $query)
 		{
 			if ($me->pretending()) return true;
 
@@ -717,7 +717,7 @@ class Connection implements ConnectionInterface {
 	{
 		if (isset($this->events))
 		{
-			$this->events->fire('illuminate.query', array($query, $bindings, $time, $this->getName()));
+			$this->events->fire('illuminate.query', [$query, $bindings, $time, $this->getName()]);
 		}
 
 		if ( ! $this->loggingQueries) return;
@@ -797,7 +797,7 @@ class Connection implements ConnectionInterface {
 	{
 		$driver = $this->getDoctrineDriver();
 
-		$data = array('pdo' => $this->pdo, 'dbname' => $this->getConfig('database'));
+		$data = ['pdo' => $this->pdo, 'dbname' => $this->getConfig('database')];
 
 		return new DoctrineConnection($data, $driver);
 	}
@@ -1029,7 +1029,7 @@ class Connection implements ConnectionInterface {
 	 */
 	public function flushQueryLog()
 	{
-		$this->queryLog = array();
+		$this->queryLog = [];
 	}
 
 	/**

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -27,7 +27,7 @@ interface ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return mixed
 	 */
-	public function selectOne($query, $bindings = array());
+	public function selectOne($query, $bindings = []);
 
 	/**
 	 * Run a select statement against the database.
@@ -36,7 +36,7 @@ interface ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return array
 	 */
-	public function select($query, $bindings = array());
+	public function select($query, $bindings = []);
 
 	/**
 	 * Run an insert statement against the database.
@@ -45,7 +45,7 @@ interface ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return bool
 	 */
-	public function insert($query, $bindings = array());
+	public function insert($query, $bindings = []);
 
 	/**
 	 * Run an update statement against the database.
@@ -54,7 +54,7 @@ interface ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return int
 	 */
-	public function update($query, $bindings = array());
+	public function update($query, $bindings = []);
 
 	/**
 	 * Run a delete statement against the database.
@@ -63,7 +63,7 @@ interface ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return int
 	 */
-	public function delete($query, $bindings = array());
+	public function delete($query, $bindings = []);
 
 	/**
 	 * Execute an SQL statement and return the boolean result.
@@ -72,7 +72,7 @@ interface ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return bool
 	 */
-	public function statement($query, $bindings = array());
+	public function statement($query, $bindings = []);
 
 	/**
 	 * Run an SQL statement and get the number of rows affected.
@@ -81,7 +81,7 @@ interface ConnectionInterface {
 	 * @param  array   $bindings
 	 * @return int
 	 */
-	public function affectingStatement($query, $bindings = array());
+	public function affectingStatement($query, $bindings = []);
 
 	/**
 	 * Run a raw, unprepared query against the PDO connection.

--- a/src/Illuminate/Database/ConnectionResolver.php
+++ b/src/Illuminate/Database/ConnectionResolver.php
@@ -7,7 +7,7 @@ class ConnectionResolver implements ConnectionResolverInterface {
 	 *
 	 * @var array
 	 */
-	protected $connections = array();
+	protected $connections = [];
 
 	/**
 	 * The default connection name.
@@ -22,7 +22,7 @@ class ConnectionResolver implements ConnectionResolverInterface {
 	 * @param  array  $connections
 	 * @return void
 	 */
-	public function __construct(array $connections = array())
+	public function __construct(array $connections = [])
 	{
 		foreach ($connections as $name => $connection)
 		{

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -138,7 +138,7 @@ class ConnectionFactory {
 	 */
 	protected function mergeReadWriteConfig(array $config, array $merge)
 	{
-		return array_except(array_merge($config, $merge), array('read', 'write'));
+		return array_except(array_merge($config, $merge), ['read', 'write']);
 	}
 
 	/**
@@ -203,11 +203,11 @@ class ConnectionFactory {
 	 *
 	 * @throws \InvalidArgumentException
 	 */
-	protected function createConnection($driver, PDO $connection, $database, $prefix = '', array $config = array())
+	protected function createConnection($driver, PDO $connection, $database, $prefix = '', array $config = [])
 	{
 		if ($this->container->bound($key = "db.connection.{$driver}"))
 		{
-			return $this->container->make($key, array($connection, $database, $prefix, $config));
+			return $this->container->make($key, [$connection, $database, $prefix, $config]);
 		}
 
 		switch ($driver)

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -9,13 +9,13 @@ class Connector {
 	 *
 	 * @var array
 	 */
-	protected $options = array(
+	protected $options = [
 		PDO::ATTR_CASE => PDO::CASE_NATURAL,
 		PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
 		PDO::ATTR_ORACLE_NULLS => PDO::NULL_NATURAL,
 		PDO::ATTR_STRINGIFY_FETCHES => false,
 		PDO::ATTR_EMULATE_PREPARES => false,
-	);
+	];
 
 	/**
 	 * Get the PDO options based on the configuration.
@@ -25,7 +25,7 @@ class Connector {
 	 */
 	public function getOptions(array $config)
 	{
-		$options = array_get($config, 'options', array());
+		$options = array_get($config, 'options', []);
 
 		return array_diff_key($this->options, $options) + $options;
 	}

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -9,12 +9,12 @@ class PostgresConnector extends Connector implements ConnectorInterface {
 	 *
 	 * @var array
 	 */
-	protected $options = array(
+	protected $options = [
 		PDO::ATTR_CASE => PDO::CASE_NATURAL,
 		PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
 		PDO::ATTR_ORACLE_NULLS => PDO::NULL_NATURAL,
 		PDO::ATTR_STRINGIFY_FETCHES => false,
-	);
+	];
 
 	/**
 	 * Establish a database connection.

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -9,12 +9,12 @@ class SqlServerConnector extends Connector implements ConnectorInterface {
 	 *
 	 * @var array
 	 */
-	protected $options = array(
+	protected $options = [
 		PDO::ATTR_CASE => PDO::CASE_NATURAL,
 		PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
 		PDO::ATTR_ORACLE_NULLS => PDO::NULL_NATURAL,
 		PDO::ATTR_STRINGIFY_FETCHES => false,
-	);
+	];
 
 	/**
 	 * Establish a database connection.

--- a/src/Illuminate/Database/Console/Migrations/InstallCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/InstallCommand.php
@@ -61,9 +61,9 @@ class InstallCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
-		);
+		return [
+			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -100,7 +100,7 @@ class MigrateCommand extends BaseCommand {
 
 		if ( ! $this->migrator->repositoryExists())
 		{
-			$options = array('--database' => $this->input->getOption('database'));
+			$options = ['--database' => $this->input->getOption('database')];
 
 			$this->call('migrate:install', $options);
 		}
@@ -113,17 +113,17 @@ class MigrateCommand extends BaseCommand {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+		return [
+			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
 
-			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
+			['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
-			array('path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'),
+			['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to be executed.'],
 
-			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
+			['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
 
-			array('seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'),
-		);
+			['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -98,9 +98,9 @@ class MigrateMakeCommand extends BaseCommand {
 	 */
 	protected function getArguments()
 	{
-		return array(
-			array('name', InputArgument::REQUIRED, 'The name of the migration'),
-		);
+		return [
+			['name', InputArgument::REQUIRED, 'The name of the migration'],
+		];
 	}
 
 	/**
@@ -110,11 +110,11 @@ class MigrateMakeCommand extends BaseCommand {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('create', null, InputOption::VALUE_OPTIONAL, 'The table to be created.'),
+		return [
+			['create', null, InputOption::VALUE_OPTIONAL, 'The table to be created.'],
 
-			array('table', null, InputOption::VALUE_OPTIONAL, 'The table to migrate.'),
-		);
+			['table', null, InputOption::VALUE_OPTIONAL, 'The table to migrate.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -35,16 +35,16 @@ class RefreshCommand extends Command {
 
 		$force = $this->input->getOption('force');
 
-		$this->call('migrate:reset', array(
+		$this->call('migrate:reset', [
 			'--database' => $database, '--force' => $force,
-		));
+		]);
 
 		// The refresh command is essentially just a brief aggregate of a few other of
 		// the migration commands and just provides a convenient wrapper to execute
 		// them in succession. We'll also see if we need to re-seed the database.
-		$this->call('migrate', array(
+		$this->call('migrate', [
 			'--database' => $database, '--force' => $force,
-		));
+		]);
 
 		if ($this->needsSeeding())
 		{
@@ -72,7 +72,7 @@ class RefreshCommand extends Command {
 	{
 		$class = $this->option('seeder') ?: 'DatabaseSeeder';
 
-		$this->call('db:seed', array('--database' => $database, '--class' => $class));
+		$this->call('db:seed', ['--database' => $database, '--class' => $class]);
 	}
 
 	/**
@@ -82,15 +82,15 @@ class RefreshCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+		return [
+			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
 
-			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
+			['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
-			array('seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'),
+			['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
 
-			array('seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder.'),
-		);
+			['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -79,13 +79,13 @@ class ResetCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+		return [
+			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
 
-			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
+			['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
-			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
-		);
+			['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -74,13 +74,13 @@ class RollbackCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'),
+		return [
+			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
 
-			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
+			['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
-			array('pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'),
-		);
+			['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Database/Console/SeedCommand.php
+++ b/src/Illuminate/Database/Console/SeedCommand.php
@@ -88,13 +88,13 @@ class SeedCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'DatabaseSeeder'),
+		return [
+			['class', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder', 'DatabaseSeeder'],
 
-			array('database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'),
+			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to seed'],
 
-			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
-		);
+			['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -25,14 +25,14 @@ class DatabaseManager implements ConnectionResolverInterface {
 	 *
 	 * @var array
 	 */
-	protected $connections = array();
+	protected $connections = [];
 
 	/**
 	 * The custom connection resolvers.
 	 *
 	 * @var array
 	 */
-	protected $extensions = array();
+	protected $extensions = [];
 
 	/**
 	 * Create a new database manager instance.
@@ -301,7 +301,7 @@ class DatabaseManager implements ConnectionResolverInterface {
 	 */
 	public function __call($method, $parameters)
 	{
-		return call_user_func_array(array($this->connection(), $method), $parameters);
+		return call_user_func_array([$this->connection(), $method], $parameters);
 	}
 
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -28,14 +28,14 @@ class Builder {
 	 *
 	 * @var array
 	 */
-	protected $eagerLoad = array();
+	protected $eagerLoad = [];
 
 	/**
 	 * All of the registered builder macros.
 	 *
 	 * @var array
 	 */
-	protected $macros = array();
+	protected $macros = [];
 
 	/**
 	 * A replacement for the typical delete function.
@@ -49,10 +49,10 @@ class Builder {
 	 *
 	 * @var array
 	 */
-	protected $passthru = array(
+	protected $passthru = [
 		'toSql', 'lists', 'insert', 'insertGetId', 'pluck', 'count',
 		'min', 'max', 'avg', 'sum', 'exists', 'getBindings',
-	);
+	];
 
 	/**
 	 * Create a new Eloquent query builder instance.
@@ -72,7 +72,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|null
 	 */
-	public function find($id, $columns = array('*'))
+	public function find($id, $columns = ['*'])
 	{
 		if (is_array($id))
 		{
@@ -91,7 +91,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Database\Eloquent\Collection
 	 */
-	public function findMany($ids, $columns = array('*'))
+	public function findMany($ids, $columns = ['*'])
 	{
 		if (empty($ids)) return $this->model->newCollection();
 
@@ -109,7 +109,7 @@ class Builder {
 	 *
 	 * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
 	 */
-	public function findOrFail($id, $columns = array('*'))
+	public function findOrFail($id, $columns = ['*'])
 	{
 		$result = $this->find($id, $columns);
 
@@ -131,7 +131,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Database\Eloquent\Model|static|null
 	 */
-	public function first($columns = array('*'))
+	public function first($columns = ['*'])
 	{
 		return $this->take(1)->get($columns)->first();
 	}
@@ -144,7 +144,7 @@ class Builder {
 	 *
 	 * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
 	 */
-	public function firstOrFail($columns = array('*'))
+	public function firstOrFail($columns = ['*'])
 	{
 		if ( ! is_null($model = $this->first($columns))) return $model;
 
@@ -157,7 +157,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Database\Eloquent\Collection|static[]
 	 */
-	public function get($columns = array('*'))
+	public function get($columns = ['*'])
 	{
 		$models = $this->getModels($columns);
 
@@ -180,7 +180,7 @@ class Builder {
 	 */
 	public function pluck($column)
 	{
-		$result = $this->first(array($column));
+		$result = $this->first([$column]);
 
 		if ($result) return $result->{$column};
 	}
@@ -227,7 +227,7 @@ class Builder {
 		{
 			foreach ($results as $key => &$value)
 			{
-				$fill = array($column => $value);
+				$fill = [$column => $value];
 
 				$value = $this->model->newFromBuilder($fill)->$column;
 			}
@@ -296,7 +296,7 @@ class Builder {
 	 * @param  array   $extra
 	 * @return int
 	 */
-	public function increment($column, $amount = 1, array $extra = array())
+	public function increment($column, $amount = 1, array $extra = [])
 	{
 		$extra = $this->addUpdatedAtColumn($extra);
 
@@ -311,7 +311,7 @@ class Builder {
 	 * @param  array   $extra
 	 * @return int
 	 */
-	public function decrement($column, $amount = 1, array $extra = array())
+	public function decrement($column, $amount = 1, array $extra = [])
 	{
 		$extra = $this->addUpdatedAtColumn($extra);
 
@@ -375,7 +375,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return \Illuminate\Database\Eloquent\Model[]
 	 */
-	public function getModels($columns = array('*'))
+	public function getModels($columns = ['*'])
 	{
 		$results = $this->query->get($columns);
 
@@ -472,7 +472,7 @@ class Builder {
 	 */
 	protected function nestedRelations($relation)
 	{
-		$nested = array();
+		$nested = [];
 
 		// We are basically looking for any relationships that are nested deeper than
 		// the given top-level relationship. We will just check for any relations
@@ -523,7 +523,7 @@ class Builder {
 		}
 		else
 		{
-			call_user_func_array(array($this->query, 'where'), func_get_args());
+			call_user_func_array([$this->query, 'where'], func_get_args());
 		}
 
 		return $this;
@@ -750,7 +750,7 @@ class Builder {
 	 */
 	protected function parseRelations(array $relations)
 	{
-		$results = array();
+		$results = [];
 
 		foreach ($relations as $name => $constraints)
 		{
@@ -761,7 +761,7 @@ class Builder {
 			{
 				$f = function() {};
 
-				list($name, $constraints) = array($constraints, $f);
+				list($name, $constraints) = [$constraints, $f];
 			}
 
 			// We need to separate out any nested includes. Which allows the developers
@@ -784,7 +784,7 @@ class Builder {
 	 */
 	protected function parseNested($name, $results)
 	{
-		$progress = array();
+		$progress = [];
 
 		// If the relation has already been set on the result array, we will not set it
 		// again, since that would override any constraints that were already placed
@@ -813,7 +813,7 @@ class Builder {
 	{
 		array_unshift($parameters, $this);
 
-		return call_user_func_array(array($this->model, $scope), $parameters) ?: $this;
+		return call_user_func_array([$this->model, $scope], $parameters) ?: $this;
 	}
 
 	/**
@@ -930,7 +930,7 @@ class Builder {
 			return $this->callScope($scope, $parameters);
 		}
 
-		$result = call_user_func_array(array($this->query, $method), $parameters);
+		$result = call_user_func_array([$this->query, $method], $parameters);
 
 		return in_array($method, $this->passthru) ? $result : $this;
 	}

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -243,7 +243,7 @@ class Collection extends BaseCollection {
 	{
 		$items = is_null($items) ? $this->items : $items;
 
-		$dictionary = array();
+		$dictionary = [];
 
 		foreach ($items as $value)
 		{

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -74,91 +74,91 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 *
 	 * @var array
 	 */
-	protected $attributes = array();
+	protected $attributes = [];
 
 	/**
 	 * The model attribute's original state.
 	 *
 	 * @var array
 	 */
-	protected $original = array();
+	protected $original = [];
 
 	/**
 	 * The loaded relationships for the model.
 	 *
 	 * @var array
 	 */
-	protected $relations = array();
+	protected $relations = [];
 
 	/**
 	 * The attributes that should be hidden for arrays.
 	 *
 	 * @var array
 	 */
-	protected $hidden = array();
+	protected $hidden = [];
 
 	/**
 	 * The attributes that should be visible in arrays.
 	 *
 	 * @var array
 	 */
-	protected $visible = array();
+	protected $visible = [];
 
 	/**
 	 * The accessors to append to the model's array form.
 	 *
 	 * @var array
 	 */
-	protected $appends = array();
+	protected $appends = [];
 
 	/**
 	 * The attributes that are mass assignable.
 	 *
 	 * @var array
 	 */
-	protected $fillable = array();
+	protected $fillable = [];
 
 	/**
 	 * The attributes that aren't mass assignable.
 	 *
 	 * @var array
 	 */
-	protected $guarded = array('*');
+	protected $guarded = ['*'];
 
 	/**
 	 * The attributes that should be mutated to dates.
 	 *
 	 * @var array
 	 */
-	protected $dates = array();
+	protected $dates = [];
 
 	/**
 	 * The attributes that should be casted to native types.
 	 *
 	 * @var array
 	 */
-	protected $casts = array();
+	protected $casts = [];
 
 	/**
 	 * The relationships that should be touched on save.
 	 *
 	 * @var array
 	 */
-	protected $touches = array();
+	protected $touches = [];
 
 	/**
 	 * User exposed observable events.
 	 *
 	 * @var array
 	 */
-	protected $observables = array();
+	protected $observables = [];
 
 	/**
 	 * The relations to eager load on every query.
 	 *
 	 * @var array
 	 */
-	protected $with = array();
+	protected $with = [];
 
 	/**
 	 * The class name to be used in polymorphic relations.
@@ -200,14 +200,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 *
 	 * @var array
 	 */
-	protected static $booted = array();
+	protected static $booted = [];
 
 	/**
 	 * The array of global scopes on the model.
 	 *
 	 * @var array
 	 */
-	protected static $globalScopes = array();
+	protected static $globalScopes = [];
 
 	/**
 	 * Indicates if all mass assignment is enabled.
@@ -221,14 +221,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 *
 	 * @var array
 	 */
-	protected static $mutatorCache = array();
+	protected static $mutatorCache = [];
 
 	/**
 	 * The many to many relationship methods.
 	 *
 	 * @var array
 	 */
-	public static $manyMethods = array('belongsToMany', 'morphToMany', 'morphedByMany');
+	public static $manyMethods = ['belongsToMany', 'morphToMany', 'morphedByMany'];
 
 	/**
 	 * The name of the "created at" column.
@@ -250,7 +250,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  array  $attributes
 	 * @return void
 	 */
-	public function __construct(array $attributes = array())
+	public function __construct(array $attributes = [])
 	{
 		$this->bootIfNotBooted();
 
@@ -445,7 +445,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  bool   $exists
 	 * @return static
 	 */
-	public function newInstance($attributes = array(), $exists = false)
+	public function newInstance($attributes = [], $exists = false)
 	{
 		// This method just provides a convenient way for us to generate fresh model
 		// instances of this current model. It is particularly useful during the
@@ -464,9 +464,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  string|null  $connection
 	 * @return static
 	 */
-	public function newFromBuilder($attributes = array(), $connection = null)
+	public function newFromBuilder($attributes = [], $connection = null)
 	{
-		$model = $this->newInstance(array(), true);
+		$model = $this->newInstance([], true);
 
 		$model->setRawAttributes((array) $attributes, true);
 
@@ -502,7 +502,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  string|null  $connection
 	 * @return \Illuminate\Database\Eloquent\Collection
 	 */
-	public static function hydrateRaw($query, $bindings = array(), $connection = null)
+	public static function hydrateRaw($query, $bindings = [], $connection = null)
 	{
 		$instance = (new static)->setConnection($connection);
 
@@ -579,7 +579,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  array  $values
 	 * @return static
 	 */
-	public static function updateOrCreate(array $attributes, array $values = array())
+	public static function updateOrCreate(array $attributes, array $values = [])
 	{
 		$instance = static::firstOrNew($attributes);
 
@@ -645,7 +645,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  array  $columns
 	 * @return \Illuminate\Database\Eloquent\Collection|static[]
 	 */
-	public static function all($columns = array('*'))
+	public static function all($columns = ['*'])
 	{
 		$instance = new static;
 
@@ -659,7 +659,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  array  $columns
 	 * @return \Illuminate\Support\Collection|static|null
 	 */
-	public static function find($id, $columns = array('*'))
+	public static function find($id, $columns = ['*'])
 	{
 		return static::query()->find($id, $columns);
 	}
@@ -671,7 +671,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  array  $columns
 	 * @return \Illuminate\Support\Collection|static
 	 */
-	public static function findOrNew($id, $columns = array('*'))
+	public static function findOrNew($id, $columns = ['*'])
 	{
 		if ( ! is_null($model = static::find($id, $columns))) return $model;
 
@@ -684,7 +684,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  array  $with
 	 * @return $this
 	 */
-	public function fresh(array $with = array())
+	public function fresh(array $with = [])
 	{
 		$key = $this->getKeyName();
 
@@ -703,7 +703,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		$query = $this->newQuery()->with($relations);
 
-		$query->eagerLoadRelations(array($this));
+		$query->eagerLoadRelations([$this]);
 
 		return $this;
 	}
@@ -1054,7 +1054,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		$related = snake_case(class_basename($related));
 
-		$models = array($related, $base);
+		$models = [$related, $base];
 
 		// Now that we have the model names in an array we can just sort them and
 		// use the implode function to join them together with an underscores,
@@ -1290,11 +1290,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	public function getObservableEvents()
 	{
 		return array_merge(
-			array(
+			[
 				'creating', 'created', 'updating', 'updated',
 				'deleting', 'deleted', 'saving', 'saved',
 				'restoring', 'restored',
-			),
+			],
 			$this->observables
 		);
 	}
@@ -1403,7 +1403,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  array  $attributes
 	 * @return bool|int
 	 */
-	public function update(array $attributes = array())
+	public function update(array $attributes = [])
 	{
 		if ( ! $this->exists)
 		{
@@ -1428,7 +1428,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		foreach ($this->relations as $models)
 		{
 			$models = $models instanceof Collection
-						? $models->all() : array($models);
+						? $models->all() : [$models];
 
 			foreach (array_filter($models) as $model)
 			{
@@ -1445,7 +1445,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  array  $options
 	 * @return bool
 	 */
-	public function save(array $options = array())
+	public function save(array $options = [])
 	{
 		$query = $this->newQueryWithoutScopes();
 
@@ -1878,7 +1878,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  array  $models
 	 * @return \Illuminate\Database\Eloquent\Collection
 	 */
-	public function newCollection(array $models = array())
+	public function newCollection(array $models = [])
 	{
 		return new Collection($models);
 	}
@@ -2015,7 +2015,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		$id = $id ?: $name.'_id';
 
-		return array($type, $id);
+		return [$type, $id];
 	}
 
 	/**
@@ -2261,7 +2261,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function isGuarded($key)
 	{
-		return in_array($key, $this->guarded) || $this->guarded == array('*');
+		return in_array($key, $this->guarded) || $this->guarded == ['*'];
 	}
 
 	/**
@@ -2271,7 +2271,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function totallyGuarded()
 	{
-		return count($this->fillable) == 0 && $this->guarded == array('*');
+		return count($this->fillable) == 0 && $this->guarded == ['*'];
 	}
 
 	/**
@@ -2450,7 +2450,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function relationsToArray()
 	{
-		$attributes = array();
+		$attributes = [];
 
 		foreach ($this->getArrayableRelations() as $key => $value)
 		{
@@ -2794,7 +2794,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function getDates()
 	{
-		$defaults = array(static::CREATED_AT, static::UPDATED_AT);
+		$defaults = [static::CREATED_AT, static::UPDATED_AT];
 
 		return array_merge($this->dates, $defaults);
 	}
@@ -3002,7 +3002,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function getDirty()
 	{
-		$dirty = array();
+		$dirty = [];
 
 		foreach ($this->attributes as $key => $value)
 		{
@@ -3214,7 +3214,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public static function cacheMutatedAttributes($class)
 	{
-		$mutatedAttributes = array();
+		$mutatedAttributes = [];
 
 		// Here we will extract all of the mutated attributes so that we can quickly
 		// spin through them after we export models to their array form, which we
@@ -3333,14 +3333,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function __call($method, $parameters)
 	{
-		if (in_array($method, array('increment', 'decrement')))
+		if (in_array($method, ['increment', 'decrement']))
 		{
-			return call_user_func_array(array($this, $method), $parameters);
+			return call_user_func_array([$this, $method], $parameters);
 		}
 
 		$query = $this->newQuery();
 
-		return call_user_func_array(array($query, $method), $parameters);
+		return call_user_func_array([$query, $method], $parameters);
 	}
 
 	/**
@@ -3354,7 +3354,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	{
 		$instance = new static;
 
-		return call_user_func_array(array($instance, $method), $parameters);
+		return call_user_func_array([$instance, $method], $parameters);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -115,7 +115,7 @@ class BelongsTo extends Relation {
 	 */
 	protected function getEagerModelKeys(array $models)
 	{
-		$keys = array();
+		$keys = [];
 
 		// First we need to gather all of the keys from the parent models so we know what
 		// to query for via the eager loading query. We will add them to an array then
@@ -133,7 +133,7 @@ class BelongsTo extends Relation {
 		// be what this developer is expecting in a case where this happens to them.
 		if (count($keys) == 0)
 		{
-			return array(0);
+			return [0];
 		}
 
 		return array_values(array_unique($keys));
@@ -173,7 +173,7 @@ class BelongsTo extends Relation {
 		// First we will get to build a dictionary of the child models by their primary
 		// key of the relationship, then we can easily match the children back onto
 		// the parents using that dictionary and the primary key of the children.
-		$dictionary = array();
+		$dictionary = [];
 
 		foreach ($results as $result)
 		{

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -41,7 +41,7 @@ class BelongsToMany extends Relation {
 	 *
 	 * @var array
 	 */
-	protected $pivotColumns = array();
+	protected $pivotColumns = [];
 
 	/**
 	 * Any pivot table restrictions.
@@ -116,7 +116,7 @@ class BelongsToMany extends Relation {
 	 * @param  array   $columns
 	 * @return mixed
 	 */
-	public function first($columns = array('*'))
+	public function first($columns = ['*'])
 	{
 		$results = $this->take(1)->get($columns);
 
@@ -131,7 +131,7 @@ class BelongsToMany extends Relation {
 	 *
 	 * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
 	 */
-	public function firstOrFail($columns = array('*'))
+	public function firstOrFail($columns = ['*'])
 	{
 		if ( ! is_null($model = $this->first($columns))) return $model;
 
@@ -144,12 +144,12 @@ class BelongsToMany extends Relation {
 	 * @param  array  $columns
 	 * @return \Illuminate\Database\Eloquent\Collection
 	 */
-	public function get($columns = array('*'))
+	public function get($columns = ['*'])
 	{
 		// First we'll add the proper select columns onto the query so it is run with
 		// the proper columns. Then, we will get the results and hydrate out pivot
 		// models with the result of those columns as a separate model relation.
-		$columns = $this->query->getQuery()->columns ? array() : $columns;
+		$columns = $this->query->getQuery()->columns ? [] : $columns;
 
 		$select = $this->getSelectColumns($columns);
 
@@ -175,7 +175,7 @@ class BelongsToMany extends Relation {
 	 * @param  array  $columns
 	 * @return \Illuminate\Pagination\Paginator
 	 */
-	public function paginate($perPage = null, $columns = array('*'))
+	public function paginate($perPage = null, $columns = ['*'])
 	{
 		$this->query->addSelect($this->getSelectColumns($columns));
 
@@ -213,7 +213,7 @@ class BelongsToMany extends Relation {
 	 */
 	protected function cleanPivotAttributes(Model $model)
 	{
-		$values = array();
+		$values = [];
 
 		foreach ($model->getAttributes() as $key => $value)
 		{
@@ -298,11 +298,11 @@ class BelongsToMany extends Relation {
 	 * @param  array  $columns
 	 * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
 	 */
-	protected function getSelectColumns(array $columns = array('*'))
+	protected function getSelectColumns(array $columns = ['*'])
 	{
-		if ($columns == array('*'))
+		if ($columns == ['*'])
 		{
-			$columns = array($this->related->getTable().'.*');
+			$columns = [$this->related->getTable().'.*'];
 		}
 
 		return array_merge($columns, $this->getAliasedPivotColumns());
@@ -315,12 +315,12 @@ class BelongsToMany extends Relation {
 	 */
 	protected function getAliasedPivotColumns()
 	{
-		$defaults = array($this->foreignKey, $this->otherKey);
+		$defaults = [$this->foreignKey, $this->otherKey];
 
 		// We need to alias all of the pivot columns with the "pivot_" prefix so we
 		// can easily extract them out of the models and put them into the pivot
 		// relationships when they are retrieved and hydrated into the models.
-		$columns = array();
+		$columns = [];
 
 		foreach (array_merge($defaults, $this->pivotColumns) as $column)
 		{
@@ -446,7 +446,7 @@ class BelongsToMany extends Relation {
 		// First we will build a dictionary of child models keyed by the foreign key
 		// of the relation so that we will easily and quickly match them to their
 		// parents without having a possibly slow inner loops for every models.
-		$dictionary = array();
+		$dictionary = [];
 
 		foreach ($results as $result)
 		{
@@ -502,9 +502,9 @@ class BelongsToMany extends Relation {
 	 * @param  bool   $touch
 	 * @return \Illuminate\Database\Eloquent\Model
 	 */
-	public function save(Model $model, array $joining = array(), $touch = true)
+	public function save(Model $model, array $joining = [], $touch = true)
 	{
-		$model->save(array('touch' => false));
+		$model->save(['touch' => false]);
 
 		$this->attach($model->getKey(), $joining, $touch);
 
@@ -518,7 +518,7 @@ class BelongsToMany extends Relation {
 	 * @param  array  $joinings
 	 * @return array
 	 */
-	public function saveMany(array $models, array $joinings = array())
+	public function saveMany(array $models, array $joinings = [])
 	{
 		foreach ($models as $key => $model)
 		{
@@ -643,14 +643,14 @@ class BelongsToMany extends Relation {
 	 * @param  bool   $touch
 	 * @return \Illuminate\Database\Eloquent\Model
 	 */
-	public function create(array $attributes, array $joining = array(), $touch = true)
+	public function create(array $attributes, array $joining = [], $touch = true)
 	{
 		$instance = $this->related->newInstance($attributes);
 
 		// Once we save the related model, we need to attach it to the base model via
 		// through intermediate table so we'll use the existing "attach" method to
 		// accomplish this which will insert the record and any more attributes.
-		$instance->save(array('touch' => false));
+		$instance->save(['touch' => false]);
 
 		$this->attach($instance->getKey(), $joining, $touch);
 
@@ -664,9 +664,9 @@ class BelongsToMany extends Relation {
 	 * @param  array  $joinings
 	 * @return \Illuminate\Database\Eloquent\Model
 	 */
-	public function createMany(array $records, array $joinings = array())
+	public function createMany(array $records, array $joinings = [])
 	{
-		$instances = array();
+		$instances = [];
 
 		foreach ($records as $key => $record)
 		{
@@ -687,9 +687,9 @@ class BelongsToMany extends Relation {
 	 */
 	public function sync($ids, $detaching = true)
 	{
-		$changes = array(
-			'attached' => array(), 'detached' => array(), 'updated' => array(),
-		);
+		$changes = [
+			'attached' => [], 'detached' => [], 'updated' => [],
+		];
 
 		if ($ids instanceof Collection) $ids = $ids->modelKeys();
 
@@ -735,13 +735,13 @@ class BelongsToMany extends Relation {
 	 */
 	protected function formatSyncList(array $records)
 	{
-		$results = array();
+		$results = [];
 
 		foreach ($records as $id => $attributes)
 		{
 			if ( ! is_array($attributes))
 			{
-				list($id, $attributes) = array($attributes, array());
+				list($id, $attributes) = [$attributes, []];
 			}
 
 			$results[$id] = $attributes;
@@ -760,7 +760,7 @@ class BelongsToMany extends Relation {
 	 */
 	protected function attachNew(array $records, array $current, $touch = true)
 	{
-		$changes = array('attached' => array(), 'updated' => array());
+		$changes = ['attached' => [], 'updated' => []];
 
 		foreach ($records as $id => $attributes)
 		{
@@ -817,7 +817,7 @@ class BelongsToMany extends Relation {
 	 * @param  bool   $touch
 	 * @return void
 	 */
-	public function attach($id, array $attributes = array(), $touch = true)
+	public function attach($id, array $attributes = [], $touch = true)
 	{
 		if ($id instanceof Model) $id = $id->getKey();
 
@@ -837,7 +837,7 @@ class BelongsToMany extends Relation {
 	 */
 	protected function createAttachRecords($ids, array $attributes)
 	{
-		$records = array();
+		$records = [];
 
 		$timed = ($this->hasPivotColumn($this->createdAt()) ||
 			      $this->hasPivotColumn($this->updatedAt()));
@@ -886,10 +886,10 @@ class BelongsToMany extends Relation {
 	{
 		if (is_array($value))
 		{
-			return array($key, array_merge($value, $attributes));
+			return [$key, array_merge($value, $attributes)];
 		}
 
-		return array($value, $attributes);
+		return [$value, $attributes];
 	}
 
 	/**
@@ -947,7 +947,7 @@ class BelongsToMany extends Relation {
 	 * @param  bool  $touch
 	 * @return int
 	 */
-	public function detach($ids = array(), $touch = true)
+	public function detach($ids = [], $touch = true)
 	{
 		if ($ids instanceof Model) $ids = (array) $ids->getKey();
 
@@ -1050,7 +1050,7 @@ class BelongsToMany extends Relation {
 	 * @param  bool   $exists
 	 * @return \Illuminate\Database\Eloquent\Relations\Pivot
 	 */
-	public function newPivot(array $attributes = array(), $exists = false)
+	public function newPivot(array $attributes = [], $exists = false)
 	{
 		$pivot = $this->related->newPivot($this->parent, $attributes, $this->table, $exists);
 
@@ -1063,7 +1063,7 @@ class BelongsToMany extends Relation {
 	 * @param  array  $attributes
 	 * @return \Illuminate\Database\Eloquent\Relations\Pivot
 	 */
-	public function newExistingPivot(array $attributes = array())
+	public function newExistingPivot(array $attributes = [])
 	{
 		return $this->newPivot($attributes, true);
 	}
@@ -1102,7 +1102,7 @@ class BelongsToMany extends Relation {
 	 */
 	public function getRelatedFreshUpdate()
 	{
-		return array($this->related->getUpdatedAtColumn() => $this->related->freshTimestamp());
+		return [$this->related->getUpdatedAtColumn() => $this->related->freshTimestamp()];
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -143,7 +143,7 @@ abstract class HasOneOrMany extends Relation {
 	 */
 	protected function buildDictionary(Collection $results)
 	{
-		$dictionary = array();
+		$dictionary = [];
 
 		$foreign = $this->getPlainForeignKey();
 
@@ -179,7 +179,7 @@ abstract class HasOneOrMany extends Relation {
 	 */
 	public function saveMany(array $models)
 	{
-		array_walk($models, array($this, 'save'));
+		array_walk($models, [$this, 'save']);
 
 		return $models;
 	}
@@ -283,7 +283,7 @@ abstract class HasOneOrMany extends Relation {
 	 */
 	public function createMany(array $records)
 	{
-		$instances = array();
+		$instances = [];
 
 		foreach ($records as $record)
 		{

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -26,7 +26,7 @@ class MorphTo extends BelongsTo {
 	 *
 	 * @var array
 	 */
-	protected $dictionary = array();
+	protected $dictionary = [];
 
 	/*
 	 * Indicates if soft-deleted model instances should be fetched.

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -124,7 +124,7 @@ class MorphToMany extends BelongsToMany {
 	 * @param  bool   $exists
 	 * @return \Illuminate\Database\Eloquent\Relations\Pivot
 	 */
-	public function newPivot(array $attributes = array(), $exists = false)
+	public function newPivot(array $attributes = [], $exists = false)
 	{
 		$pivot = new MorphPivot($this->parent, $attributes, $this->table, $exists);
 

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -31,7 +31,7 @@ class Pivot extends Model {
 	 *
 	 * @var array
 	 */
-	protected $guarded = array();
+	protected $guarded = [];
 
 	/**
 	 * Create a new pivot model instance.

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -112,7 +112,7 @@ abstract class Relation {
 	{
 		$column = $this->getRelated()->getUpdatedAtColumn();
 
-		$this->rawUpdate(array($column => $this->getRelated()->freshTimestampString()));
+		$this->rawUpdate([$column => $this->getRelated()->freshTimestampString()]);
 	}
 
 	/**
@@ -121,7 +121,7 @@ abstract class Relation {
 	 * @param  array  $attributes
 	 * @return int
 	 */
-	public function rawUpdate(array $attributes = array())
+	public function rawUpdate(array $attributes = [])
 	{
 		return $this->query->update($attributes);
 	}
@@ -280,7 +280,7 @@ abstract class Relation {
 	 */
 	public function __call($method, $parameters)
 	{
-		$result = call_user_func_array(array($this->query, $method), $parameters);
+		$result = call_user_func_array([$this->query, $method], $parameters);
 
 		if ($result === $this->query) return $this;
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -59,7 +59,7 @@ trait SoftDeletes {
 
 		$this->{$this->getDeletedAtColumn()} = $time = $this->freshTimestamp();
 
-		$query->update(array($this->getDeletedAtColumn() => $this->fromDateTime($time)));
+		$query->update([$this->getDeletedAtColumn() => $this->fromDateTime($time)]);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -59,9 +59,9 @@ class SoftDeletingScope implements ScopeInterface {
 		{
 			$column = $this->getDeletedAtColumn($builder);
 
-			return $builder->update(array(
+			return $builder->update([
 				$column => $builder->getModel()->freshTimestampString(),
-			));
+			]);
 		});
 	}
 
@@ -109,7 +109,7 @@ class SoftDeletingScope implements ScopeInterface {
 		{
 			$builder->withTrashed();
 
-			return $builder->update(array($builder->getModel()->getDeletedAtColumn() => null));
+			return $builder->update([$builder->getModel()->getDeletedAtColumn() => null]);
 		});
 	}
 

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -17,7 +17,7 @@ abstract class Grammar {
 	 */
 	public function wrapArray(array $values)
 	{
-		return array_map(array($this, 'wrap'), $values);
+		return array_map([$this, 'wrap'], $values);
 	}
 
 	/**
@@ -56,7 +56,7 @@ abstract class Grammar {
 			return $this->wrap($segments[0]).' as '.$this->wrapValue($segments[2]);
 		}
 
-		$wrapped = array();
+		$wrapped = [];
 
 		$segments = explode('.', $value);
 
@@ -99,7 +99,7 @@ abstract class Grammar {
 	 */
 	public function columnize(array $columns)
 	{
-		return implode(', ', array_map(array($this, 'wrap'), $columns));
+		return implode(', ', array_map([$this, 'wrap'], $columns));
 	}
 
 	/**
@@ -110,7 +110,7 @@ abstract class Grammar {
 	 */
 	public function parameterize(array $values)
 	{
-		return implode(', ', array_map(array($this, 'parameter'), $values));
+		return implode(', ', array_map([$this, 'parameter'], $values));
 	}
 
 	/**

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -78,7 +78,7 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	protected function registerCommands()
 	{
-		$commands = array('Migrate', 'Rollback', 'Reset', 'Refresh', 'Install', 'Make', 'Status');
+		$commands = ['Migrate', 'Rollback', 'Reset', 'Refresh', 'Install', 'Make', 'Status'];
 
 		// We'll simply spin through the list of commands that are migration related
 		// and register each one of them with an application container. They will
@@ -214,13 +214,13 @@ class MigrationServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array(
+		return [
 			'migrator', 'migration.repository', 'command.migrate',
 			'command.migrate.rollback', 'command.migrate.reset',
 			'command.migrate.refresh', 'command.migrate.install',
 			'command.migrate.status', 'migration.creator',
 			'command.migrate.make',
-		);
+		];
 	}
 
 }

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -69,7 +69,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 	 */
 	public function log($file, $batch)
 	{
-		$record = array('migration' => $file, 'batch' => $batch);
+		$record = ['migration' => $file, 'batch' => $batch];
 
 		$this->table()->insert($record);
 	}

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -17,7 +17,7 @@ class MigrationCreator {
 	 *
 	 * @var array
 	 */
-	protected $postCreate = array();
+	protected $postCreate = [];
 
 	/**
 	 * Create a new migration creator instance.

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -38,7 +38,7 @@ class Migrator {
 	 *
 	 * @var array
 	 */
-	protected $notes = array();
+	protected $notes = [];
 
 	/**
 	 * Create a new migrator instance.
@@ -66,7 +66,7 @@ class Migrator {
 	 */
 	public function run($path, $pretend = false)
 	{
-		$this->notes = array();
+		$this->notes = [];
 
 		$files = $this->getMigrationFiles($path);
 
@@ -150,7 +150,7 @@ class Migrator {
 	 */
 	public function rollback($pretend = false)
 	{
-		$this->notes = array();
+		$this->notes = [];
 
 		// We want to pull in the last batch of migrations that ran on the previous
 		// migration operation. We'll then reverse those migrations and run each
@@ -219,7 +219,7 @@ class Migrator {
 		// Once we have the array of files in the directory we will just remove the
 		// extension and take the basename of the file which is all we need when
 		// finding the migrations that haven't been run against the databases.
-		if ($files === false) return array();
+		if ($files === false) return [];
 
 		$files = array_map(function($file)
 		{

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -38,13 +38,13 @@ class Builder {
 	 *
 	 * @var array
 	 */
-	protected $bindings = array(
+	protected $bindings = [
 		'select' => [],
 		'join'   => [],
 		'where'  => [],
 		'having' => [],
 		'order'  => [],
-	);
+	];
 
 	/**
 	 * An aggregate function and column to be run.
@@ -170,14 +170,14 @@ class Builder {
 	 *
 	 * @var array
 	 */
-	protected $operators = array(
+	protected $operators = [
 		'=', '<', '>', '<=', '>=', '<>', '!=',
 		'like', 'like binary', 'not like', 'between', 'ilike',
 		'&', '|', '^', '<<', '>>',
 		'rlike', 'regexp', 'not regexp',
 		'~', '~*', '!~', '!~*', 'similar to',
                 'not similar to',
-	);
+	];
 
 	/**
 	 * Whether use write pdo for select.
@@ -209,7 +209,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return $this
 	 */
-	public function select($columns = array('*'))
+	public function select($columns = ['*'])
 	{
 		$this->columns = is_array($columns) ? $columns : func_get_args();
 
@@ -223,7 +223,7 @@ class Builder {
 	 * @param  array   $bindings
 	 * @return \Illuminate\Database\Query\Builder|static
 	 */
-	public function selectRaw($expression, array $bindings = array())
+	public function selectRaw($expression, array $bindings = [])
 	{
 		$this->addSelect(new Expression($expression));
 
@@ -450,7 +450,7 @@ class Builder {
 		// and keep going. Otherwise, we'll require the operator to be passed in.
 		if (func_num_args() == 2)
 		{
-			list($value, $operator) = array($operator, '=');
+			list($value, $operator) = [$operator, '='];
 		}
 		elseif ($this->invalidOperatorAndValue($operator, $value))
 		{
@@ -470,7 +470,7 @@ class Builder {
 		// we will set the operators to '=' and set the values appropriately.
 		if ( ! in_array(strtolower($operator), $this->operators, true))
 		{
-			list($value, $operator) = array($operator, '=');
+			list($value, $operator) = [$operator, '='];
 		}
 
 		// If the value is a Closure, it means the developer is performing an entire
@@ -539,7 +539,7 @@ class Builder {
 	 * @param  string  $boolean
 	 * @return $this
 	 */
-	public function whereRaw($sql, array $bindings = array(), $boolean = 'and')
+	public function whereRaw($sql, array $bindings = [], $boolean = 'and')
 	{
 		$type = 'raw';
 
@@ -557,7 +557,7 @@ class Builder {
 	 * @param  array   $bindings
 	 * @return \Illuminate\Database\Query\Builder|static
 	 */
-	public function orWhereRaw($sql, array $bindings = array())
+	public function orWhereRaw($sql, array $bindings = [])
 	{
 		return $this->whereRaw($sql, $bindings, 'or');
 	}
@@ -1088,7 +1088,7 @@ class Builder {
 	 * @param  string  $boolean
 	 * @return $this
 	 */
-	public function havingRaw($sql, array $bindings = array(), $boolean = 'and')
+	public function havingRaw($sql, array $bindings = [], $boolean = 'and')
 	{
 		$type = 'raw';
 
@@ -1106,7 +1106,7 @@ class Builder {
 	 * @param  array   $bindings
 	 * @return \Illuminate\Database\Query\Builder|static
 	 */
-	public function orHavingRaw($sql, array $bindings = array())
+	public function orHavingRaw($sql, array $bindings = [])
 	{
 		return $this->havingRaw($sql, $bindings, 'or');
 	}
@@ -1157,7 +1157,7 @@ class Builder {
 	 * @param  array  $bindings
 	 * @return $this
 	 */
-	public function orderByRaw($sql, $bindings = array())
+	public function orderByRaw($sql, $bindings = [])
 	{
 		$type = 'raw';
 
@@ -1312,7 +1312,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return mixed|static
 	 */
-	public function find($id, $columns = array('*'))
+	public function find($id, $columns = ['*'])
 	{
 		return $this->where('id', '=', $id)->first($columns);
 	}
@@ -1325,7 +1325,7 @@ class Builder {
 	 */
 	public function pluck($column)
 	{
-		$result = (array) $this->first(array($column));
+		$result = (array) $this->first([$column]);
 
 		return count($result) > 0 ? reset($result) : null;
 	}
@@ -1336,7 +1336,7 @@ class Builder {
 	 * @param  array   $columns
 	 * @return mixed|static
 	 */
-	public function first($columns = array('*'))
+	public function first($columns = ['*'])
 	{
 		$results = $this->take(1)->get($columns);
 
@@ -1349,7 +1349,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return array|static[]
 	 */
-	public function get($columns = array('*'))
+	public function get($columns = ['*'])
 	{
 		return $this->getFresh($columns);
 	}
@@ -1360,7 +1360,7 @@ class Builder {
 	 * @param  array  $columns
 	 * @return array|static[]
 	 */
-	public function getFresh($columns = array('*'))
+	public function getFresh($columns = ['*'])
 	{
 		if (is_null($this->columns)) $this->columns = $columns;
 
@@ -1515,7 +1515,7 @@ class Builder {
 	 */
 	protected function getListSelect($column, $key)
 	{
-		$select = is_null($key) ? array($column) : array($column, $key);
+		$select = is_null($key) ? [$column] : [$column, $key];
 
 		// If the selected column contains a "dot", we will remove it so that the list
 		// operation can run normally. Specifying the table is not needed, since we
@@ -1568,7 +1568,7 @@ class Builder {
 	{
 		if ( ! is_array($columns))
 		{
-			$columns = array($columns);
+			$columns = [$columns];
 		}
 
 		return (int) $this->aggregate(__FUNCTION__, $columns);
@@ -1582,7 +1582,7 @@ class Builder {
 	 */
 	public function min($column)
 	{
-		return $this->aggregate(__FUNCTION__, array($column));
+		return $this->aggregate(__FUNCTION__, [$column]);
 	}
 
 	/**
@@ -1593,7 +1593,7 @@ class Builder {
 	 */
 	public function max($column)
 	{
-		return $this->aggregate(__FUNCTION__, array($column));
+		return $this->aggregate(__FUNCTION__, [$column]);
 	}
 
 	/**
@@ -1604,7 +1604,7 @@ class Builder {
 	 */
 	public function sum($column)
 	{
-		$result = $this->aggregate(__FUNCTION__, array($column));
+		$result = $this->aggregate(__FUNCTION__, [$column]);
 
 		return $result ?: 0;
 	}
@@ -1617,7 +1617,7 @@ class Builder {
 	 */
 	public function avg($column)
 	{
-		return $this->aggregate(__FUNCTION__, array($column));
+		return $this->aggregate(__FUNCTION__, [$column]);
 	}
 
 	/**
@@ -1627,7 +1627,7 @@ class Builder {
 	 * @param  array   $columns
 	 * @return mixed
 	 */
-	public function aggregate($function, $columns = array('*'))
+	public function aggregate($function, $columns = ['*'])
 	{
 		$this->aggregate = compact('function', 'columns');
 
@@ -1665,7 +1665,7 @@ class Builder {
 		// inserts statements by verifying the elements are actually an array.
 		if ( ! is_array(reset($values)))
 		{
-			$values = array($values);
+			$values = [$values];
 		}
 
 		// Since every insert gets treated like a batch insert, we will make sure the
@@ -1682,7 +1682,7 @@ class Builder {
 		// We'll treat every insert like a batch insert so we can easily insert each
 		// of the records into the database consistently. This will make it much
 		// easier on the grammars to just handle one type of record insertion.
-		$bindings = array();
+		$bindings = [];
 
 		foreach ($values as $record)
 		{
@@ -1741,11 +1741,11 @@ class Builder {
 	 * @param  array   $extra
 	 * @return int
 	 */
-	public function increment($column, $amount = 1, array $extra = array())
+	public function increment($column, $amount = 1, array $extra = [])
 	{
 		$wrapped = $this->grammar->wrap($column);
 
-		$columns = array_merge(array($column => $this->raw("$wrapped + $amount")), $extra);
+		$columns = array_merge([$column => $this->raw("$wrapped + $amount")], $extra);
 
 		return $this->update($columns);
 	}
@@ -1758,11 +1758,11 @@ class Builder {
 	 * @param  array   $extra
 	 * @return int
 	 */
-	public function decrement($column, $amount = 1, array $extra = array())
+	public function decrement($column, $amount = 1, array $extra = [])
 	{
 		$wrapped = $this->grammar->wrap($column);
 
-		$columns = array_merge(array($column => $this->raw("$wrapped - $amount")), $extra);
+		$columns = array_merge([$column => $this->raw("$wrapped - $amount")], $extra);
 
 		return $this->update($columns);
 	}

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -10,7 +10,7 @@ class Grammar extends BaseGrammar {
 	 *
 	 * @var array
 	 */
-	protected $selectComponents = array(
+	protected $selectComponents = [
 		'aggregate',
 		'columns',
 		'from',
@@ -23,7 +23,7 @@ class Grammar extends BaseGrammar {
 		'offset',
 		'unions',
 		'lock',
-	);
+	];
 
 	/**
 	 * Compile a select query into SQL.
@@ -33,7 +33,7 @@ class Grammar extends BaseGrammar {
 	 */
 	public function compileSelect(Builder $query)
 	{
-		if (is_null($query->columns)) $query->columns = array('*');
+		if (is_null($query->columns)) $query->columns = ['*'];
 
 		return trim($this->concatenate($this->compileComponents($query)));
 	}
@@ -46,7 +46,7 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function compileComponents(Builder $query)
 	{
-		$sql = array();
+		$sql = [];
 
 		foreach ($this->selectComponents as $component)
 		{
@@ -126,9 +126,9 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function compileJoins(Builder $query, $joins)
 	{
-		$sql = array();
+		$sql = [];
 
-		$query->setBindings(array(), 'join');
+		$query->setBindings([], 'join');
 
 		foreach ($joins as $join)
 		{
@@ -137,7 +137,7 @@ class Grammar extends BaseGrammar {
 			// First we need to build all of the "on" clauses for the join. There may be many
 			// of these clauses so we will need to iterate through each one and build them
 			// separately, then we'll join them up into a single string when we're done.
-			$clauses = array();
+			$clauses = [];
 
 			foreach ($join->clauses as $clause)
 			{
@@ -190,7 +190,7 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function compileWheres(Builder $query)
 	{
-		$sql = array();
+		$sql = [];
 
 		if (is_null($query->wheres)) return '';
 
@@ -477,7 +477,7 @@ class Grammar extends BaseGrammar {
 	 */
 	protected function compileHavings(Builder $query, $havings)
 	{
-		$sql = implode(' ', array_map(array($this, 'compileHaving'), $havings));
+		$sql = implode(' ', array_map([$this, 'compileHaving'], $havings));
 
 		return 'having '.preg_replace('/and |or /', '', $sql, 1);
 	}
@@ -619,7 +619,7 @@ class Grammar extends BaseGrammar {
 
 		if ( ! is_array(reset($values)))
 		{
-			$values = array($values);
+			$values = [$values];
 		}
 
 		$columns = $this->columnize(array_keys(reset($values)));
@@ -663,7 +663,7 @@ class Grammar extends BaseGrammar {
 		// Each one of the columns in the update statements needs to be wrapped in the
 		// keyword identifiers, also a place-holder needs to be created for each of
 		// the values in the list of bindings so we can make the sets statements.
-		$columns = array();
+		$columns = [];
 
 		foreach ($values as $key => $value)
 		{
@@ -715,7 +715,7 @@ class Grammar extends BaseGrammar {
 	 */
 	public function compileTruncate(Builder $query)
 	{
-		return array('truncate '.$this->wrapTable($query->from) => array());
+		return ['truncate '.$this->wrapTable($query->from) => []];
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -9,7 +9,7 @@ class MySqlGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $selectComponents = array(
+	protected $selectComponents = [
 		'aggregate',
 		'columns',
 		'from',
@@ -21,7 +21,7 @@ class MySqlGrammar extends Grammar {
 		'limit',
 		'offset',
 		'lock',
-	);
+	];
 
 	/**
 	 * Compile a select query into SQL.

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -9,11 +9,11 @@ class PostgresGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $operators = array(
+	protected $operators = [
 		'=', '<', '>', '<=', '>=', '<>', '!=',
 		'like', 'not like', 'between', 'ilike',
 		'&', '|', '#', '<<', '>>',
-	);
+	];
 
 	/**
 	 * Compile the lock into SQL.
@@ -60,7 +60,7 @@ class PostgresGrammar extends Grammar {
 	 */
 	protected function compileUpdateColumns($values)
 	{
-		$columns = array();
+		$columns = [];
 
 		// When gathering the columns for an update statement, we'll wrap each of the
 		// columns and convert it to a parameter value. Then we will concatenate a
@@ -83,7 +83,7 @@ class PostgresGrammar extends Grammar {
 	{
 		if ( ! isset($query->joins)) return '';
 
-		$froms = array();
+		$froms = [];
 
 		// When using Postgres, updates with joins list the joined tables in the from
 		// clause, which is different than other systems like MySQL. Here, we will
@@ -129,7 +129,7 @@ class PostgresGrammar extends Grammar {
 	 */
 	protected function compileUpdateJoinWheres(Builder $query)
 	{
-		$joinWheres = array();
+		$joinWheres = [];
 
 		// Here we will just loop through all of the join constraints and compile them
 		// all out then implode them. This should give us "where" like syntax after
@@ -168,7 +168,7 @@ class PostgresGrammar extends Grammar {
 	 */
 	public function compileTruncate(Builder $query)
 	{
-		return array('truncate '.$this->wrapTable($query->from).' restart identity' => array());
+		return ['truncate '.$this->wrapTable($query->from).' restart identity' => []];
 	}
 
 }

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -9,11 +9,11 @@ class SQLiteGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $operators = array(
+	protected $operators = [
 		'=', '<', '>', '<=', '>=', '<>', '!=',
 		'like', 'not like', 'between', 'ilike',
 		'&', '|', '<<', '>>',
-	);
+	];
 
 	/**
 	 * Compile an insert statement into SQL.
@@ -31,7 +31,7 @@ class SQLiteGrammar extends Grammar {
 
 		if ( ! is_array(reset($values)))
 		{
-			$values = array($values);
+			$values = [$values];
 		}
 
 		// If there is only one record being inserted, we will just use the usual query
@@ -44,7 +44,7 @@ class SQLiteGrammar extends Grammar {
 
 		$names = $this->columnize(array_keys(reset($values)));
 
-		$columns = array();
+		$columns = [];
 
 		// SQLite requires us to build the multi-row insert as a listing of select with
 		// unions joining them together. So we'll build out this list of columns and
@@ -67,9 +67,9 @@ class SQLiteGrammar extends Grammar {
 	 */
 	public function compileTruncate(Builder $query)
 	{
-		$sql = array('delete from sqlite_sequence where name = ?' => array($query->from));
+		$sql = ['delete from sqlite_sequence where name = ?' => [$query->from]];
 
-		$sql['delete from '.$this->wrapTable($query->from)] = array();
+		$sql['delete from '.$this->wrapTable($query->from)] = [];
 
 		return $sql;
 	}

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -9,11 +9,11 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $operators = array(
+	protected $operators = [
 		'=', '<', '>', '<=', '>=', '!<', '!>', '<>', '!=',
 		'like', 'not like', 'between', 'ilike',
 		'&', '&=', '|', '|=', '^', '^=',
-	);
+	];
 
 	/**
 	 * Compile a select query into SQL.
@@ -195,7 +195,7 @@ class SqlServerGrammar extends Grammar {
 	 */
 	public function compileTruncate(Builder $query)
 	{
-		return array('truncate table '.$this->wrapTable($query->from) => array());
+		return ['truncate table '.$this->wrapTable($query->from) => []];
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -21,14 +21,14 @@ class JoinClause {
 	 *
 	 * @var array
 	 */
-	public $clauses = array();
+	public $clauses = [];
 
 	/**
 	* The "on" bindings for the join.
 	*
 	* @var array
 	*/
-	public $bindings = array();
+	public $bindings = [];
 
 	/**
 	 * Create a new join clause instance.

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -19,14 +19,14 @@ class Blueprint {
 	 *
 	 * @var array
 	 */
-	protected $columns = array();
+	protected $columns = [];
 
 	/**
 	 * The commands that should be run for the table.
 	 *
 	 * @var array
 	 */
-	protected $commands = array();
+	protected $commands = [];
 
 	/**
 	 * The storage engine that should be used for the table.
@@ -75,7 +75,7 @@ class Blueprint {
 	{
 		$this->addImpliedCommands();
 
-		$statements = array();
+		$statements = [];
 
 		// Each type of command has a corresponding compiler function on the schema
 		// grammar which is used to build the necessary SQL statements to build
@@ -125,7 +125,7 @@ class Blueprint {
 	{
 		foreach ($this->columns as $column)
 		{
-			foreach (array('primary', 'unique', 'index') as $index)
+			foreach (['primary', 'unique', 'index'] as $index)
 			{
 				// If the index has been specified on the given column, but is simply
 				// equal to "true" (boolean), no name has been specified for this
@@ -686,7 +686,7 @@ class Blueprint {
 
 		$this->string("{$name}_type");
 
-		$this->index(array("{$name}_id", "{$name}_type"), $indexName);
+		$this->index(["{$name}_id", "{$name}_type"], $indexName);
 	}
 
 	/**
@@ -709,7 +709,7 @@ class Blueprint {
 	 */
 	protected function dropIndexCommand($command, $type, $index)
 	{
-		$columns = array();
+		$columns = [];
 
 		// If the given "index" is actually an array of columns, the developer means
 		// to drop an index merely by specifying the columns involved without the
@@ -758,7 +758,7 @@ class Blueprint {
 	{
 		$index = strtolower($this->table.'_'.implode('_', $columns).'_'.$type);
 
-		return str_replace(array('-', '.'), '_', $index);
+		return str_replace(['-', '.'], '_', $index);
 	}
 
 	/**
@@ -769,7 +769,7 @@ class Blueprint {
 	 * @param  array   $parameters
 	 * @return \Illuminate\Support\Fluent
 	 */
-	protected function addColumn($type, $name, array $parameters = array())
+	protected function addColumn($type, $name, array $parameters = [])
 	{
 		$attributes = array_merge(compact('type', 'name'), $parameters);
 
@@ -801,7 +801,7 @@ class Blueprint {
 	 * @param  array  $parameters
 	 * @return \Illuminate\Support\Fluent
 	 */
-	protected function addCommand($name, array $parameters = array())
+	protected function addCommand($name, array $parameters = [])
 	{
 		$this->commands[] = $command = $this->createCommand($name, $parameters);
 
@@ -815,7 +815,7 @@ class Blueprint {
 	 * @param  array   $parameters
 	 * @return \Illuminate\Support\Fluent
 	 */
-	protected function createCommand($name, array $parameters = array())
+	protected function createCommand($name, array $parameters = [])
 	{
 		return new Fluent(array_merge(compact('name'), $parameters));
 	}

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -50,7 +50,7 @@ class Builder {
 
 		$table = $this->connection->getTablePrefix().$table;
 
-		return count($this->connection->select($sql, array($table))) > 0;
+		return count($this->connection->select($sql, [$table])) > 0;
 	}
 
 	/**

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -63,7 +63,7 @@ abstract class Grammar extends BaseGrammar {
 	{
 		$newColumn = new Column($command->to, $column->getType(), $column->toArray());
 
-		$tableDiff->renamedColumns = array($command->from => $newColumn);
+		$tableDiff->renamedColumns = [$command->from => $newColumn];
 
 		return $tableDiff;
 	}
@@ -116,7 +116,7 @@ abstract class Grammar extends BaseGrammar {
 	 */
 	protected function getColumns(Blueprint $blueprint)
 	{
-		$columns = array();
+		$columns = [];
 
 		foreach ($blueprint->getAddedColumns() as $column)
 		{

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -11,14 +11,14 @@ class MySqlGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $modifiers = array('Unsigned', 'Nullable', 'Default', 'Increment', 'Comment', 'After');
+	protected $modifiers = ['Unsigned', 'Nullable', 'Default', 'Increment', 'Comment', 'After'];
 
 	/**
 	 * The possible column serials.
 	 *
 	 * @var array
 	 */
-	protected $serials = array('bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger');
+	protected $serials = ['bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger'];
 
 	/**
 	 * Compile the query to determine the list of tables.

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -10,14 +10,14 @@ class PostgresGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $modifiers = array('Increment', 'Nullable', 'Default');
+	protected $modifiers = ['Increment', 'Nullable', 'Default'];
 
 	/**
 	 * The columns available as serials.
 	 *
 	 * @var array
 	 */
-	protected $serials = array('bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger');
+	protected $serials = ['bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger'];
 
 	/**
 	 * Compile the query to determine if a table exists.

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -11,14 +11,14 @@ class SQLiteGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $modifiers = array('Nullable', 'Default', 'Increment');
+	protected $modifiers = ['Nullable', 'Default', 'Increment'];
 
 	/**
 	 * The columns available as serials.
 	 *
 	 * @var array
 	 */
-	protected $serials = array('bigInteger', 'integer');
+	protected $serials = ['bigInteger', 'integer'];
 
 	/**
 	 * Compile the query to determine if a table exists.
@@ -148,7 +148,7 @@ class SQLiteGrammar extends Grammar {
 
 		$columns = $this->prefixArray('add column', $this->getColumns($blueprint));
 
-		$statements = array();
+		$statements = [];
 
 		foreach ($columns as $column)
 		{

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -10,14 +10,14 @@ class SqlServerGrammar extends Grammar {
 	 *
 	 * @var array
 	 */
-	protected $modifiers = array('Increment', 'Nullable', 'Default');
+	protected $modifiers = ['Increment', 'Nullable', 'Default'];
 
 	/**
 	 * The columns available as serials.
 	 *
 	 * @var array
 	 */
-	protected $serials = array('bigInteger', 'integer');
+	protected $serials = ['bigInteger', 'integer'];
 
 	/**
 	 * Compile the query to determine if a table exists.

--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -16,7 +16,7 @@ class MySqlBuilder extends Builder {
 
 		$table = $this->connection->getTablePrefix().$table;
 
-		return count($this->connection->select($sql, array($database, $table))) > 0;
+		return count($this->connection->select($sql, [$database, $table])) > 0;
 	}
 
 	/**
@@ -33,7 +33,7 @@ class MySqlBuilder extends Builder {
 
 		$table = $this->connection->getTablePrefix().$table;
 
-		$results = $this->connection->select($sql, array($database, $table));
+		$results = $this->connection->select($sql, [$database, $table]);
 
 		return $this->connection->getPostProcessor()->processColumnListing($results);
 	}

--- a/src/Illuminate/Database/SeedServiceProvider.php
+++ b/src/Illuminate/Database/SeedServiceProvider.php
@@ -49,7 +49,7 @@ class SeedServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('seeder', 'command.seed');
+		return ['seeder', 'command.seed'];
 	}
 
 }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -20,28 +20,28 @@ class Dispatcher implements DispatcherContract {
 	 *
 	 * @var array
 	 */
-	protected $listeners = array();
+	protected $listeners = [];
 
 	/**
 	 * The wildcard listeners.
 	 *
 	 * @var array
 	 */
-	protected $wildcards = array();
+	protected $wildcards = [];
 
 	/**
 	 * The sorted event listeners.
 	 *
 	 * @var array
 	 */
-	protected $sorted = array();
+	protected $sorted = [];
 
 	/**
 	 * The event firing stack.
 	 *
 	 * @var array
 	 */
-	protected $firing = array();
+	protected $firing = [];
 
 	/**
 	 * The queue resolver instance.
@@ -116,7 +116,7 @@ class Dispatcher implements DispatcherContract {
 	 * @param  array   $payload
 	 * @return void
 	 */
-	public function push($event, $payload = array())
+	public function push($event, $payload = [])
 	{
 		$this->listen($event.'_pushed', function() use ($event, $payload)
 		{
@@ -160,7 +160,7 @@ class Dispatcher implements DispatcherContract {
 	 * @param  array   $payload
 	 * @return mixed
 	 */
-	public function until($event, $payload = array())
+	public function until($event, $payload = [])
 	{
 		return $this->fire($event, $payload, true);
 	}
@@ -194,7 +194,7 @@ class Dispatcher implements DispatcherContract {
 	 * @param  bool    $halt
 	 * @return array|null
 	 */
-	public function fire($event, $payload = array(), $halt = false)
+	public function fire($event, $payload = [], $halt = false)
 	{
 		// When the given "event" is actually an object we will assume it is an event
 		// object and use the class as the event name and this event itself as the
@@ -204,12 +204,12 @@ class Dispatcher implements DispatcherContract {
 			list($payload, $event) = [[$event], get_class($event)];
 		}
 
-		$responses = array();
+		$responses = [];
 
 		// If an array is not given to us as the payload, we will turn it into one so
 		// we can easily use call_user_func_array on the listeners, passing in the
 		// payload to each of them so that they receive each of these arguments.
-		if ( ! is_array($payload)) $payload = array($payload);
+		if ( ! is_array($payload)) $payload = [$payload];
 
 		$this->firing[] = $event;
 
@@ -266,7 +266,7 @@ class Dispatcher implements DispatcherContract {
 	 */
 	protected function getWildcardListeners($eventName)
 	{
-		$wildcards = array();
+		$wildcards = [];
 
 		foreach ($this->wildcards as $key => $listeners)
 		{
@@ -284,7 +284,7 @@ class Dispatcher implements DispatcherContract {
 	 */
 	protected function sortListeners($eventName)
 	{
-		$this->sorted[$eventName] = array();
+		$this->sorted[$eventName] = [];
 
 		// If listeners exist for the given event, we will sort them by the priority
 		// so that we can call them in the correct order. We will cache off these
@@ -345,7 +345,7 @@ class Dispatcher implements DispatcherContract {
 		}
 		else
 		{
-			return array($container->make($class), $method);
+			return [$container->make($class), $method];
 		}
 	}
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -265,7 +265,7 @@ class Filesystem {
 	{
 		$glob = glob($directory.'/*');
 
-		if ($glob === false) return array();
+		if ($glob === false) return [];
 
 		// To get the appropriate files, we'll simply glob the directory and filter
 		// out any "files" that are not truly files so we do not end up with any
@@ -295,7 +295,7 @@ class Filesystem {
 	 */
 	public function directories($directory)
 	{
-		$directories = array();
+		$directories = [];
 
 		foreach (Finder::create()->in($directory)->directories()->depth(0) as $dir)
 		{

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -229,7 +229,7 @@ class FilesystemManager implements FactoryContract {
 	 */
 	public function __call($method, $parameters)
 	{
-		return call_user_func_array(array($this->disk(), $method), $parameters);
+		return call_user_func_array([$this->disk(), $method], $parameters);
 	}
 
 }

--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -39,7 +39,7 @@ class AliasLoader {
 	 * @param  array  $aliases
 	 * @return \Illuminate\Foundation\AliasLoader
 	 */
-	public static function getInstance(array $aliases = array())
+	public static function getInstance(array $aliases = [])
 	{
 		if (is_null(static::$instance)) return static::$instance = new static($aliases);
 
@@ -98,7 +98,7 @@ class AliasLoader {
 	 */
 	protected function prependToLoaderStack()
 	{
-		spl_autoload_register(array($this, 'load'), true, true);
+		spl_autoload_register([$this, 'load'], true, true);
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -48,42 +48,42 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	 *
 	 * @var array
 	 */
-	protected $bootingCallbacks = array();
+	protected $bootingCallbacks = [];
 
 	/**
 	 * The array of booted callbacks.
 	 *
 	 * @var array
 	 */
-	protected $bootedCallbacks = array();
+	protected $bootedCallbacks = [];
 
 	/**
 	 * The array of terminating callbacks.
 	 *
 	 * @var array
 	 */
-	protected $terminatingCallbacks = array();
+	protected $terminatingCallbacks = [];
 
 	/**
 	 * All of the registered service providers.
 	 *
 	 * @var array
 	 */
-	protected $serviceProviders = array();
+	protected $serviceProviders = [];
 
 	/**
 	 * The names of the loaded service providers.
 	 *
 	 * @var array
 	 */
-	protected $loadedProviders = array();
+	protected $loadedProviders = [];
 
 	/**
 	 * The deferred services and their providers.
 	 *
 	 * @var array
 	 */
-	protected $deferredServices = array();
+	protected $deferredServices = [];
 
 	/**
 	 * The custom storage path defined by the developer.
@@ -454,7 +454,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	 * @param  bool   $force
 	 * @return \Illuminate\Support\ServiceProvider
 	 */
-	public function register($provider, $options = array(), $force = false)
+	public function register($provider, $options = [], $force = false)
 	{
 		if ($registered = $this->getProvider($provider) && ! $force)
                                      return $registered;
@@ -525,7 +525,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	 */
 	protected function markAsRegistered($provider)
 	{
-		$this['events']->fire($class = get_class($provider), array($provider));
+		$this['events']->fire($class = get_class($provider), [$provider]);
 
 		$this->serviceProviders[] = $provider;
 
@@ -547,7 +547,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 			$this->loadDeferredProvider($service);
 		}
 
-		$this->deferredServices = array();
+		$this->deferredServices = [];
 	}
 
 	/**
@@ -608,7 +608,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	 * @param  array   $parameters
 	 * @return mixed
 	 */
-	public function make($abstract, $parameters = array())
+	public function make($abstract, $parameters = [])
 	{
 		$abstract = $this->getAlias($abstract);
 
@@ -701,7 +701,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	{
 		$this->bootedCallbacks[] = $callback;
 
-		if ($this->isBooted()) $this->fireAppCallbacks(array($callback));
+		if ($this->isBooted()) $this->fireAppCallbacks([$callback]);
 	}
 
 	/**
@@ -870,7 +870,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	 *
 	 * @throws \Symfony\Component\HttpKernel\Exception\HttpException
 	 */
-	public function abort($code, $message = '', array $headers = array())
+	public function abort($code, $message = '', array $headers = [])
 	{
 		if ($code == 404)
 		{
@@ -960,7 +960,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 
 		$this['translator']->setLocale($locale);
 
-		$this['events']->fire('locale.changed', array($locale));
+		$this['events']->fire('locale.changed', [$locale]);
 	}
 
 	/**
@@ -970,7 +970,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	 */
 	public function registerCoreContainerAliases()
 	{
-		$aliases = array(
+		$aliases = [
 			'app'                  => ['Illuminate\Foundation\Application', 'Illuminate\Contracts\Container\Container', 'Illuminate\Contracts\Foundation\Application'],
 			'artisan'              => ['Illuminate\Console\Application', 'Illuminate\Contracts\Console\Application'],
 			'auth'                 => 'Illuminate\Auth\AuthManager',
@@ -1005,7 +1005,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 			'url'                  => ['Illuminate\Routing\UrlGenerator', 'Illuminate\Contracts\Routing\UrlGenerator'],
 			'validator'            => ['Illuminate\Validation\Factory', 'Illuminate\Contracts\Validation\Factory'],
 			'view'                 => ['Illuminate\View\Factory', 'Illuminate\Contracts\View\Factory'],
-		);
+		];
 
 		foreach ($aliases as $key => $aliases)
 		{

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -50,7 +50,7 @@ class HandleExceptions {
 	 *
 	 * @throws \ErrorException
 	 */
-	public function handleError($level, $message, $file = '', $line = 0, $context = array())
+	public function handleError($level, $message, $file = '', $line = 0, $context = [])
 	{
 		if (error_reporting() & $level)
 		{

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -320,9 +320,9 @@ class AppNameCommand extends Command {
 	 */
 	protected function getArguments()
 	{
-		return array(
-			array('name', InputArgument::REQUIRED, 'The desired namespace.'),
-		);
+		return [
+			['name', InputArgument::REQUIRED, 'The desired namespace.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/CommandMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CommandMakeCommand.php
@@ -87,11 +87,11 @@ class CommandMakeCommand extends GeneratorCommand {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('handler', null, InputOption::VALUE_NONE, 'Indicates that handler class should be generated.'),
+		return [
+			['handler', null, InputOption::VALUE_NONE, 'Indicates that handler class should be generated.'],
 
-			array('queued', null, InputOption::VALUE_NONE, 'Indicates that command should be queued.'),
-		);
+			['queued', null, InputOption::VALUE_NONE, 'Indicates that command should be queued.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -69,9 +69,9 @@ class ConsoleMakeCommand extends GeneratorCommand {
 	 */
 	protected function getArguments()
 	{
-		return array(
-			array('name', InputArgument::REQUIRED, 'The name of the command.'),
-		);
+		return [
+			['name', InputArgument::REQUIRED, 'The name of the command.'],
+		];
 	}
 
 	/**
@@ -81,9 +81,9 @@ class ConsoleMakeCommand extends GeneratorCommand {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that should be assigned.', 'command:name'),
-		);
+		return [
+			['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that should be assigned.', 'command:name'],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/FreshCommand.php
+++ b/src/Illuminate/Foundation/Console/FreshCommand.php
@@ -63,9 +63,9 @@ class FreshCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'),
-		);
+		return [
+			['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/HandlerCommandCommand.php
+++ b/src/Illuminate/Foundation/Console/HandlerCommandCommand.php
@@ -75,9 +75,9 @@ class HandlerCommandCommand extends GeneratorCommand {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('command', null, InputOption::VALUE_REQUIRED, 'The command class the handler handles.'),
-		);
+		return [
+			['command', null, InputOption::VALUE_REQUIRED, 'The command class the handler handles.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/HandlerEventCommand.php
+++ b/src/Illuminate/Foundation/Console/HandlerEventCommand.php
@@ -89,11 +89,11 @@ class HandlerEventCommand extends GeneratorCommand {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('event', null, InputOption::VALUE_REQUIRED, 'The event class the handler handles.'),
+		return [
+			['event', null, InputOption::VALUE_REQUIRED, 'The event class the handler handles.'],
 
-			array('queued', null, InputOption::VALUE_NONE, 'Indicates the event handler should be queued.'),
-		);
+			['queued', null, InputOption::VALUE_NONE, 'Indicates the event handler should be queued.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -133,7 +133,7 @@ class Kernel implements KernelContract {
 	 * @param  array  $parameters
 	 * @return int
 	 */
-	public function call($command, array $parameters = array())
+	public function call($command, array $parameters = [])
 	{
 		$this->bootstrap();
 
@@ -152,7 +152,7 @@ class Kernel implements KernelContract {
 	 * @param  array   $parameters
 	 * @return void
 	 */
-	public function queue($command, array $parameters = array())
+	public function queue($command, array $parameters = [])
 	{
 		$this->app['Illuminate\Contracts\Queue\Queue']->push(
 			'Illuminate\Foundation\Console\QueuedJob', func_get_args()

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -65,9 +65,9 @@ class KeyGenerateCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('show', null, InputOption::VALUE_NONE, 'Simply display the key instead of modifying files.'),
-		);
+		return [
+			['show', null, InputOption::VALUE_NONE, 'Simply display the key instead of modifying files.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -71,9 +71,9 @@ class ModelMakeCommand extends GeneratorCommand {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('no-migration', null, InputOption::VALUE_NONE, 'Do not create a new migration file.'),
-		);
+		return [
+			['no-migration', null, InputOption::VALUE_NONE, 'Do not create a new migration file.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/Optimize/config.php
+++ b/src/Illuminate/Foundation/Console/Optimize/config.php
@@ -2,7 +2,7 @@
 
 $basePath = $app['path.base'];
 
-return array_map('realpath', array(
+return array_map('realpath', [
     $basePath.'/vendor/laravel/framework/src/Illuminate/Contracts/Container/Container.php',
     $basePath.'/vendor/laravel/framework/src/Illuminate/Contracts/Container/ContextualBindingBuilder.php',
     $basePath.'/vendor/laravel/framework/src/Illuminate/Contracts/Foundation/Application.php',
@@ -208,4 +208,4 @@ return array_map('realpath', array(
     $basePath.'/vendor/symfony/finder/Symfony/Component/Finder/Adapter/BsdFindAdapter.php',
     $basePath.'/vendor/symfony/finder/Symfony/Component/Finder/Finder.php',
     $basePath.'/vendor/nesbot/carbon/src/Carbon/Carbon.php',
-));
+]);

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -80,11 +80,11 @@ class OptimizeCommand extends Command {
 	{
 		$this->registerClassPreloaderCommand();
 
-		$this->callSilent('compile', array(
+		$this->callSilent('compile', [
 			'--config' => implode(',', $this->getClassFiles()),
 			'--output' => $this->laravel->getCachedCompilePath(),
 			'--strip_comments' => 1,
-		));
+		]);
 	}
 
 	/**
@@ -125,11 +125,11 @@ class OptimizeCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('force', null, InputOption::VALUE_NONE, 'Force the compiled class file to be written.'),
+		return [
+			['force', null, InputOption::VALUE_NONE, 'Force the compiled class file to be written.'],
 
-			array('psr', null, InputOption::VALUE_NONE, 'Do not optimize Composer dump-autoload.'),
-		);
+			['psr', null, InputOption::VALUE_NONE, 'Do not optimize Composer dump-autoload.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -42,9 +42,9 @@ class RouteListCommand extends Command {
 	 *
 	 * @var array
 	 */
-	protected $headers = array(
+	protected $headers = [
 		'Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware',
-	);
+	];
 
 	/**
 	 * Create a new route command instance.
@@ -82,7 +82,7 @@ class RouteListCommand extends Command {
 	 */
 	protected function getRoutes()
 	{
-		$results = array();
+		$results = [];
 
 		foreach ($this->routes as $route)
 		{
@@ -100,14 +100,14 @@ class RouteListCommand extends Command {
 	 */
 	protected function getRouteInformation(Route $route)
 	{
-		return $this->filterRoute(array(
+		return $this->filterRoute([
 			'host'   => $route->domain(),
 			'method' => implode('|', $route->methods()),
 			'uri'    => $route->uri(),
 			'name'   => $route->getName(),
 			'action' => $route->getActionName(),
 			'middleware' => $this->getMiddleware($route),
-		));
+		]);
 	}
 
 	/**
@@ -207,7 +207,7 @@ class RouteListCommand extends Command {
 	 */
 	protected function getPatternFilters($route)
 	{
-		$patterns = array();
+		$patterns = [];
 
 		foreach ($route->methods() as $method)
 		{
@@ -260,11 +260,11 @@ class RouteListCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name.'),
+		return [
+			['name', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by name.'],
 
-			array('path', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by path.'),
-		);
+			['path', null, InputOption::VALUE_OPTIONAL, 'Filter the routes by path.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -46,11 +46,11 @@ class ServeCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', 'localhost'),
+		return [
+			['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', 'localhost'],
 
-			array('port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', 8000),
-		);
+			['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', 8000],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -163,13 +163,13 @@ class VendorPublishCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('force', null, InputOption::VALUE_NONE, 'Overwrite any existing files.'),
+		return [
+			['force', null, InputOption::VALUE_NONE, 'Overwrite any existing files.'],
 
-			array('provider', null, InputOption::VALUE_OPTIONAL, 'The service provider that has assets you want to publish.'),
+			['provider', null, InputOption::VALUE_OPTIONAL, 'The service provider that has assets you want to publish.'],
 
-			array('tag', null, InputOption::VALUE_OPTIONAL, 'The tag that has assets you want to publish.'),
-		);
+			['tag', null, InputOption::VALUE_OPTIONAL, 'The tag that has assets you want to publish.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
@@ -32,7 +32,7 @@ class ComposerServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('composer');
+		return ['composer'];
 	}
 
 }

--- a/src/Illuminate/Foundation/Testing/AssertionsTrait.php
+++ b/src/Illuminate/Foundation/Testing/AssertionsTrait.php
@@ -98,7 +98,7 @@ trait AssertionsTrait {
 	 * @param  array   $with
 	 * @return void
 	 */
-	public function assertRedirectedTo($uri, $with = array())
+	public function assertRedirectedTo($uri, $with = [])
 	{
 		PHPUnit::assertInstanceOf('Illuminate\Http\RedirectResponse', $this->response);
 
@@ -115,7 +115,7 @@ trait AssertionsTrait {
 	 * @param  array   $with
 	 * @return void
 	 */
-	public function assertRedirectedToRoute($name, $parameters = array(), $with = array())
+	public function assertRedirectedToRoute($name, $parameters = [], $with = [])
 	{
 		$this->assertRedirectedTo($this->app['url']->route($name, $parameters), $with);
 	}
@@ -128,7 +128,7 @@ trait AssertionsTrait {
 	 * @param  array   $with
 	 * @return void
 	 */
-	public function assertRedirectedToAction($name, $parameters = array(), $with = array())
+	public function assertRedirectedToAction($name, $parameters = [], $with = [])
 	{
 		$this->assertRedirectedTo($this->app['url']->action($name, $parameters), $with);
 	}
@@ -182,7 +182,7 @@ trait AssertionsTrait {
 	 * @param  mixed  $format
 	 * @return void
 	 */
-	public function assertSessionHasErrors($bindings = array(), $format = null)
+	public function assertSessionHasErrors($bindings = [], $format = null)
 	{
 		$this->assertSessionHas('errors');
 

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -15,7 +15,7 @@ trait ValidatesRequests {
 	 * @param  array  $messages
 	 * @return void
 	 */
-	public function validate(Request $request, array $rules, array $messages = array())
+	public function validate(Request $request, array $rules, array $messages = [])
 	{
 		$validator = $this->getValidationFactory()->make($request->all(), $rules, $messages);
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -16,7 +16,7 @@ if ( ! function_exists('abort'))
 	 * @throws \Symfony\Component\HttpKernel\Exception\HttpException
 	 * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
 	 */
-	function abort($code, $message = '', array $headers = array())
+	function abort($code, $message = '', array $headers = [])
 	{
 		return app()->abort($code, $message, $headers);
 	}
@@ -31,7 +31,7 @@ if ( ! function_exists('action'))
 	 * @param  array   $parameters
 	 * @return string
 	 */
-	function action($name, $parameters = array())
+	function action($name, $parameters = [])
 	{
 		return app('url')->action($name, $parameters);
 	}
@@ -119,7 +119,7 @@ if ( ! function_exists('back'))
 	 * @param  array  $headers
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	function back($status = 302, $headers = array())
+	function back($status = 302, $headers = [])
 	{
 		return app('redirect')->back($status, $headers);
 	}
@@ -134,7 +134,7 @@ if ( ! function_exists('bcrypt'))
 	 * @param  array   $options
 	 * @return string
 	 */
-	function bcrypt($value, $options = array())
+	function bcrypt($value, $options = [])
 	{
 		return app('hash')->make($value, $options);
 	}
@@ -280,7 +280,7 @@ if ( ! function_exists('info'))
 	 * @param  array   $context
 	 * @return void
 	 */
-	function info($message, $context = array())
+	function info($message, $context = [])
 	{
 		return app('log')->info($message, $context);
 	}
@@ -295,7 +295,7 @@ if ( ! function_exists('logger'))
 	 * @param  array  $context
 	 * @return void
 	 */
-	function logger($message = null, array $context = array())
+	function logger($message = null, array $context = [])
 	{
 		if (is_null($message)) return app('log');
 
@@ -388,7 +388,7 @@ if ( ! function_exists('redirect'))
 	 * @param  bool    $secure
 	 * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
 	 */
-	function redirect($to = null, $status = 302, $headers = array(), $secure = null)
+	function redirect($to = null, $status = 302, $headers = [], $secure = null)
 	{
 		if (is_null($to)) return app('redirect');
 
@@ -422,7 +422,7 @@ if ( ! function_exists('response'))
 	 * @param  array   $headers
 	 * @return \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Routing\ResponseFactory
 	 */
-	function response($content = '', $status = 200, array $headers = array())
+	function response($content = '', $status = 200, array $headers = [])
 	{
 		$factory = app('Illuminate\Contracts\Routing\ResponseFactory');
 
@@ -446,7 +446,7 @@ if ( ! function_exists('route'))
 	 * @param  \Illuminate\Routing\Route  $route
 	 * @return string
 	 */
-	function route($name, $parameters = array(), $absolute = true, $route = null)
+	function route($name, $parameters = [], $absolute = true, $route = null)
 	{
 		return app('url')->route($name, $parameters, $absolute, $route);
 	}
@@ -475,7 +475,7 @@ if ( ! function_exists('secure_url'))
 	 * @param  mixed   $parameters
 	 * @return string
 	 */
-	function secure_url($path, $parameters = array())
+	function secure_url($path, $parameters = [])
 	{
 		return url($path, $parameters, true);
 	}
@@ -527,7 +527,7 @@ if ( ! function_exists('trans'))
 	 * @param  string  $locale
 	 * @return string
 	 */
-	function trans($id = null, $parameters = array(), $domain = 'messages', $locale = null)
+	function trans($id = null, $parameters = [], $domain = 'messages', $locale = null)
 	{
 		if (is_null($id)) return app('translator');
 
@@ -547,7 +547,7 @@ if ( ! function_exists('trans_choice'))
 	 * @param  string  $locale
 	 * @return string
 	 */
-	function trans_choice($id, $number, array $parameters = array(), $domain = 'messages', $locale = null)
+	function trans_choice($id, $number, array $parameters = [], $domain = 'messages', $locale = null)
 	{
 		return app('translator')->transChoice($id, $number, $parameters, $domain, $locale);
 	}
@@ -563,7 +563,7 @@ if ( ! function_exists('url'))
 	 * @param  bool    $secure
 	 * @return string
 	 */
-	function url($path = null, $parameters = array(), $secure = null)
+	function url($path = null, $parameters = [], $secure = null)
 	{
 		return app('Illuminate\Contracts\Routing\UrlGenerator')->to($path, $parameters, $secure);
 	}
@@ -579,7 +579,7 @@ if ( ! function_exists('view'))
 	 * @param  array   $mergeData
 	 * @return \Illuminate\View\View
 	 */
-	function view($view = null, $data = array(), $mergeData = array())
+	function view($view = null, $data = [], $mergeData = [])
 	{
 		$factory = app('Illuminate\Contracts\View\Factory');
 
@@ -645,7 +645,7 @@ if ( ! function_exists('event'))
 	 * @param  bool    $halt
 	 * @return array|null
 	 */
-	function event($event, $payload = array(), $halt = false)
+	function event($event, $payload = [], $halt = false)
 	{
 		return app('events')->fire($event, $payload, $halt);
 	}

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -21,11 +21,11 @@ class BcryptHasher implements HasherContract {
 	 *
 	 * @throws \RuntimeException
 	 */
-	public function make($value, array $options = array())
+	public function make($value, array $options = [])
 	{
 		$cost = isset($options['rounds']) ? $options['rounds'] : $this->rounds;
 
-		$hash = password_hash($value, PASSWORD_BCRYPT, array('cost' => $cost));
+		$hash = password_hash($value, PASSWORD_BCRYPT, ['cost' => $cost]);
 
 		if ($hash === false)
 		{
@@ -43,7 +43,7 @@ class BcryptHasher implements HasherContract {
 	 * @param  array   $options
 	 * @return bool
 	 */
-	public function check($value, $hashedValue, array $options = array())
+	public function check($value, $hashedValue, array $options = [])
 	{
 		return password_verify($value, $hashedValue);
 	}
@@ -55,11 +55,11 @@ class BcryptHasher implements HasherContract {
 	 * @param  array   $options
 	 * @return bool
 	 */
-	public function needsRehash($hashedValue, array $options = array())
+	public function needsRehash($hashedValue, array $options = [])
 	{
 		$cost = isset($options['rounds']) ? $options['rounds'] : $this->rounds;
 
-		return password_needs_rehash($hashedValue, PASSWORD_BCRYPT, array('cost' => $cost));
+		return password_needs_rehash($hashedValue, PASSWORD_BCRYPT, ['cost' => $cost]);
 	}
 
 	/**

--- a/src/Illuminate/Hashing/HashServiceProvider.php
+++ b/src/Illuminate/Hashing/HashServiceProvider.php
@@ -28,7 +28,7 @@ class HashServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('hash');
+		return ['hash'];
 	}
 
 }

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -22,7 +22,7 @@ class JsonResponse extends BaseJsonResponse {
 	 * @param  array  $headers
 	 * @param  int    $options
 	*/
-	public function __construct($data = null, $status = 200, $headers = array(), $options = 0)
+	public function __construct($data = null, $status = 200, $headers = [], $options = 0)
 	{
 		$this->jsonOptions = $options;
 
@@ -44,7 +44,7 @@ class JsonResponse extends BaseJsonResponse {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function setData($data = array())
+	public function setData($data = [])
 	{
 		$this->data = $data instanceof Jsonable
 								   ? $data->toJson($this->jsonOptions)

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -385,7 +385,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function hasFile($key)
 	{
-		if ( ! is_array($files = $this->file($key))) $files = array($files);
+		if ( ! is_array($files = $this->file($key))) $files = [$files];
 
 		foreach ($files as $file)
 		{
@@ -449,7 +449,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 * @param  array   $keys
 	 * @return void
 	 */
-	public function flash($filter = null, $keys = array())
+	public function flash($filter = null, $keys = [])
 	{
 		$flash = ( ! is_null($filter)) ? $this->$filter($keys) : $this->input();
 
@@ -489,7 +489,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function flush()
 	{
-		$this->session()->flashInput(array());
+		$this->session()->flashInput([]);
 	}
 
 	/**

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -71,7 +71,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function emergency($message, array $context = array())
+	public function emergency($message, array $context = [])
 	{
 		return $this->writeLog(__FUNCTION__, $message, $context);
 	}
@@ -83,7 +83,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function alert($message, array $context = array())
+	public function alert($message, array $context = [])
 	{
 		return $this->writeLog(__FUNCTION__, $message, $context);
 	}
@@ -95,7 +95,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function critical($message, array $context = array())
+	public function critical($message, array $context = [])
 	{
 		return $this->writeLog(__FUNCTION__, $message, $context);
 	}
@@ -107,7 +107,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function error($message, array $context = array())
+	public function error($message, array $context = [])
 	{
 		return $this->writeLog(__FUNCTION__, $message, $context);
 	}
@@ -119,7 +119,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function warning($message, array $context = array())
+	public function warning($message, array $context = [])
 	{
 		return $this->writeLog(__FUNCTION__, $message, $context);
 	}
@@ -131,7 +131,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function notice($message, array $context = array())
+	public function notice($message, array $context = [])
 	{
 		return $this->writeLog(__FUNCTION__, $message, $context);
 	}
@@ -143,7 +143,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function info($message, array $context = array())
+	public function info($message, array $context = [])
 	{
 		return $this->writeLog(__FUNCTION__, $message, $context);
 	}
@@ -155,7 +155,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function debug($message, array $context = array())
+	public function debug($message, array $context = [])
 	{
 		return $this->writeLog(__FUNCTION__, $message, $context);
 	}
@@ -168,7 +168,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function log($level, $message, array $context = array())
+	public function log($level, $message, array $context = [])
 	{
 		return $this->writeLog($level, $message, $context);
 	}
@@ -181,7 +181,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 * @param  array  $context
 	 * @return void
 	 */
-	public function write($level, $message, array $context = array())
+	public function write($level, $message, array $context = [])
 	{
 		return $this->writeLog($level, $message, $context);
 	}
@@ -286,7 +286,7 @@ class Writer implements LogContract, PsrLoggerInterface {
 	 * @param  array   $context
 	 * @return void
 	 */
-	protected function fireLogEvent($level, $message, array $context = array())
+	protected function fireLogEvent($level, $message, array $context = [])
 	{
 		// If the event dispatcher is set, we will pass along the parameters to the
 		// log listeners. These are useful for building profilers or other tools

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -76,14 +76,14 @@ class Mailer implements MailerContract, MailQueueContract {
 	 *
 	 * @var array
 	 */
-	protected $failedRecipients = array();
+	protected $failedRecipients = [];
 
 	/**
 	 * Array of parsed views containing html and text view name.
 	 *
 	 * @var array
 	 */
-	protected $parsedViews = array();
+	protected $parsedViews = [];
 
 	/**
 	 * Create a new Mailer instance.
@@ -121,7 +121,7 @@ class Mailer implements MailerContract, MailQueueContract {
 	 */
 	public function raw($text, $callback)
 	{
-		return $this->send(array('raw' => $text), [], $callback);
+		return $this->send(['raw' => $text], [], $callback);
 	}
 
 	/**
@@ -134,7 +134,7 @@ class Mailer implements MailerContract, MailQueueContract {
 	 */
 	public function plain($view, array $data, $callback)
 	{
-		return $this->send(array('text' => $view), $data, $callback);
+		return $this->send(['text' => $view], $data, $callback);
 	}
 
 	/**
@@ -344,7 +344,7 @@ class Mailer implements MailerContract, MailQueueContract {
 	{
 		if ($this->events)
 		{
-			$this->events->fire('mailer.sending', array($message));
+			$this->events->fire('mailer.sending', [$message]);
 		}
 
 		if ( ! $this->pretending)

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -167,7 +167,7 @@ class Message {
 	 * @param  array   $options
 	 * @return $this
 	 */
-	public function attach($file, array $options = array())
+	public function attach($file, array $options = [])
 	{
 		$attachment = $this->createAttachmentFromPath($file);
 
@@ -193,7 +193,7 @@ class Message {
 	 * @param  array   $options
 	 * @return $this
 	 */
-	public function attachData($data, $name, array $options = array())
+	public function attachData($data, $name, array $options = [])
 	{
 		$attachment = $this->createAttachmentFromData($data, $name);
 
@@ -245,7 +245,7 @@ class Message {
 	 * @param  array  $options
 	 * @return $this
 	 */
-	protected function prepAttachment($attachment, $options = array())
+	protected function prepAttachment($attachment, $options = [])
 	{
 		// First we will check for a MIME type on the message, which instructs the
 		// mail client on what type of attachment the file is so that it may be
@@ -287,7 +287,7 @@ class Message {
 	 */
 	public function __call($method, $parameters)
 	{
-		$callable = array($this->swift, $method);
+		$callable = [$this->swift, $method];
 
 		return call_user_func_array($callable, $parameters);
 	}

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -87,7 +87,7 @@ class TransportManager extends Manager {
 	 */
 	protected function createMailgunDriver()
 	{
-		$config = $this->app['config']->get('services.mailgun', array());
+		$config = $this->app['config']->get('services.mailgun', []);
 
 		return new MailgunTransport($config['secret'], $config['domain']);
 	}
@@ -99,7 +99,7 @@ class TransportManager extends Manager {
 	 */
 	protected function createMandrillDriver()
 	{
-		$config = $this->app['config']->get('services.mandrill', array());
+		$config = $this->app['config']->get('services.mandrill', []);
 
 		return new MandrillTransport($config['secret']);
 	}

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -25,7 +25,7 @@ class Pipeline implements PipelineContract {
 	 *
 	 * @var array
 	 */
-	protected $pipes = array();
+	protected $pipes = [];
 
 	/**
 	 * The method to call on each pipe.

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -64,7 +64,7 @@ class BeanstalkdQueue extends Queue implements QueueContract {
 	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function pushRaw($payload, $queue = null, array $options = array())
+	public function pushRaw($payload, $queue = null, array $options = [])
 	{
 		return $this->pheanstalk->useTube($this->getQueue($queue))->put(
 			$payload, Pheanstalk::DEFAULT_PRIORITY, Pheanstalk::DEFAULT_DELAY, $this->timeToRun

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -164,7 +164,7 @@ class Manager {
 	 */
 	public function __call($method, $parameters)
 	{
-		return call_user_func_array(array($this->manager, $method), $parameters);
+		return call_user_func_array([$this->manager, $method], $parameters);
 	}
 
 	/**
@@ -176,7 +176,7 @@ class Manager {
 	 */
 	public static function __callStatic($method, $parameters)
 	{
-		return call_user_func_array(array(static::connection(), $method), $parameters);
+		return call_user_func_array([static::connection(), $method], $parameters);
 	}
 
 }

--- a/src/Illuminate/Queue/Connectors/IronConnector.php
+++ b/src/Illuminate/Queue/Connectors/IronConnector.php
@@ -42,7 +42,7 @@ class IronConnector implements ConnectorInterface {
 	 */
 	public function connect(array $config)
 	{
-		$ironConfig = array('token' => $config['token'], 'project_id' => $config['project']);
+		$ironConfig = ['token' => $config['token'], 'project_id' => $config['project']];
 
 		if (isset($config['host'])) $ironConfig['host'] = $config['host'];
 

--- a/src/Illuminate/Queue/Console/ForgetFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ForgetFailedCommand.php
@@ -43,9 +43,9 @@ class ForgetFailedCommand extends Command {
 	 */
 	protected function getArguments()
 	{
-		return array(
-			array('id', InputArgument::REQUIRED, 'The ID of the failed job'),
-		);
+		return [
+			['id', InputArgument::REQUIRED, 'The ID of the failed job'],
+		];
 	}
 
 }

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -25,7 +25,7 @@ class ListFailedCommand extends Command {
 	 */
 	public function fire()
 	{
-		$rows = array();
+		$rows = [];
 
 		foreach ($this->laravel['queue.failer']->all() as $failed)
 		{
@@ -39,7 +39,7 @@ class ListFailedCommand extends Command {
 
 		$table = $this->getHelperSet()->get('table');
 
-		$table->setHeaders(array('ID', 'Connection', 'Queue', 'Class', 'Failed At'))
+		$table->setHeaders(['ID', 'Connection', 'Queue', 'Class', 'Failed At'])
               ->setRows($rows)
               ->render($this->output);
 	}
@@ -52,7 +52,7 @@ class ListFailedCommand extends Command {
 	 */
 	protected function parseFailedJob(array $failed)
 	{
-		$row = array_values(array_except($failed, array('payload')));
+		$row = array_values(array_except($failed, ['payload']));
 
 		array_splice($row, 3, 0, array_get(json_decode($failed['payload'], true), 'job'));
 

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -115,9 +115,9 @@ class ListenCommand extends Command {
 	 */
 	protected function getArguments()
 	{
-		return array(
-			array('connection', InputArgument::OPTIONAL, 'The name of connection'),
-		);
+		return [
+			['connection', InputArgument::OPTIONAL, 'The name of connection'],
+		];
 	}
 
 	/**
@@ -127,19 +127,19 @@ class ListenCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('queue', null, InputOption::VALUE_OPTIONAL, 'The queue to listen on', null),
+		return [
+			['queue', null, InputOption::VALUE_OPTIONAL, 'The queue to listen on', null],
 
-			array('delay', null, InputOption::VALUE_OPTIONAL, 'Amount of time to delay failed jobs', 0),
+			['delay', null, InputOption::VALUE_OPTIONAL, 'Amount of time to delay failed jobs', 0],
 
-			array('memory', null, InputOption::VALUE_OPTIONAL, 'The memory limit in megabytes', 128),
+			['memory', null, InputOption::VALUE_OPTIONAL, 'The memory limit in megabytes', 128],
 
-			array('timeout', null, InputOption::VALUE_OPTIONAL, 'Seconds a job may run before timing out', 60),
+			['timeout', null, InputOption::VALUE_OPTIONAL, 'Seconds a job may run before timing out', 60],
 
-			array('sleep', null, InputOption::VALUE_OPTIONAL, 'Seconds to wait before checking queue for jobs', 3),
+			['sleep', null, InputOption::VALUE_OPTIONAL, 'Seconds to wait before checking queue for jobs', 3],
 
-			array('tries', null, InputOption::VALUE_OPTIONAL, 'Number of times to attempt a job before logging it failed', 0),
-		);
+			['tries', null, InputOption::VALUE_OPTIONAL, 'Number of times to attempt a job before logging it failed', 0],
+		];
 	}
 
 }

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -66,9 +66,9 @@ class RetryCommand extends Command {
 	 */
 	protected function getArguments()
 	{
-		return array(
-			array('id', InputArgument::REQUIRED, 'The ID of the failed job'),
-		);
+		return [
+			['id', InputArgument::REQUIRED, 'The ID of the failed job'],
+		];
 	}
 
 }

--- a/src/Illuminate/Queue/Console/SubscribeCommand.php
+++ b/src/Illuminate/Queue/Console/SubscribeCommand.php
@@ -58,9 +58,9 @@ class SubscribeCommand extends Command {
 	 */
 	protected function getQueueOptions()
 	{
-		return array(
+		return [
 			'push_type' => $this->getPushType(), 'subscribers' => $this->getSubscriberList(),
-		);
+		];
 	}
 
 	/**
@@ -91,7 +91,7 @@ class SubscribeCommand extends Command {
 	{
 		$subscribers = $this->getCurrentSubscribers();
 
-		$subscribers[] = array('url' => $this->argument('url'));
+		$subscribers[] = ['url' => $this->argument('url')];
 
 		return $subscribers;
 	}
@@ -109,7 +109,7 @@ class SubscribeCommand extends Command {
 		}
 		catch (Exception $e)
 		{
-			return array();
+			return [];
 		}
 	}
 
@@ -132,11 +132,11 @@ class SubscribeCommand extends Command {
 	 */
 	protected function getArguments()
 	{
-		return array(
-			array('queue', InputArgument::REQUIRED, 'The name of Iron.io queue.'),
+		return [
+			['queue', InputArgument::REQUIRED, 'The name of Iron.io queue.'],
 
-			array('url', InputArgument::REQUIRED, 'The URL to be subscribed.'),
-		);
+			['url', InputArgument::REQUIRED, 'The URL to be subscribed.'],
+		];
 	}
 
 	/**
@@ -146,9 +146,9 @@ class SubscribeCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('type', null, InputOption::VALUE_OPTIONAL, 'The push type for the queue.'),
-		);
+		return [
+			['type', null, InputOption::VALUE_OPTIONAL, 'The push type for the queue.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -145,9 +145,9 @@ class WorkCommand extends Command {
 	 */
 	protected function getArguments()
 	{
-		return array(
-			array('connection', InputArgument::OPTIONAL, 'The name of connection', null),
-		);
+		return [
+			['connection', InputArgument::OPTIONAL, 'The name of connection', null],
+		];
 	}
 
 	/**
@@ -157,21 +157,21 @@ class WorkCommand extends Command {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('queue', null, InputOption::VALUE_OPTIONAL, 'The queue to listen on'),
+		return [
+			['queue', null, InputOption::VALUE_OPTIONAL, 'The queue to listen on'],
 
-			array('daemon', null, InputOption::VALUE_NONE, 'Run the worker in daemon mode'),
+			['daemon', null, InputOption::VALUE_NONE, 'Run the worker in daemon mode'],
 
-			array('delay', null, InputOption::VALUE_OPTIONAL, 'Amount of time to delay failed jobs', 0),
+			['delay', null, InputOption::VALUE_OPTIONAL, 'Amount of time to delay failed jobs', 0],
 
-			array('force', null, InputOption::VALUE_NONE, 'Force the worker to run even in maintenance mode'),
+			['force', null, InputOption::VALUE_NONE, 'Force the worker to run even in maintenance mode'],
 
-			array('memory', null, InputOption::VALUE_OPTIONAL, 'The memory limit in megabytes', 128),
+			['memory', null, InputOption::VALUE_OPTIONAL, 'The memory limit in megabytes', 128],
 
-			array('sleep', null, InputOption::VALUE_OPTIONAL, 'Number of seconds to sleep when no job is available', 3),
+			['sleep', null, InputOption::VALUE_OPTIONAL, 'Number of seconds to sleep when no job is available', 3],
 
-			array('tries', null, InputOption::VALUE_OPTIONAL, 'Number of times to attempt a job before logging it failed', 0),
-		);
+			['tries', null, InputOption::VALUE_OPTIONAL, 'Number of times to attempt a job before logging it failed', 0],
+		];
 	}
 
 }

--- a/src/Illuminate/Queue/ConsoleServiceProvider.php
+++ b/src/Illuminate/Queue/ConsoleServiceProvider.php
@@ -67,10 +67,10 @@ class ConsoleServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array(
+		return [
 			'command.queue.table', 'command.queue.failed', 'command.queue.retry',
 			'command.queue.forget', 'command.queue.flush', 'command.queue.failed-table',
-		);
+		];
 	}
 
 }

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -75,7 +75,7 @@ class DatabaseQueue extends Queue implements QueueContract {
 	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function pushRaw($payload, $queue = null, array $options = array())
+	public function pushRaw($payload, $queue = null, array $options = [])
 	{
 		return $this->pushToDatabase(0, $queue, $payload);
 	}

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -74,7 +74,7 @@ class IronQueue extends Queue implements QueueContract {
 	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function pushRaw($payload, $queue = null, array $options = array())
+	public function pushRaw($payload, $queue = null, array $options = [])
 	{
 		if ($this->shouldEncrypt) $payload = $this->crypt->encrypt($payload);
 
@@ -91,7 +91,7 @@ class IronQueue extends Queue implements QueueContract {
 	 */
 	public function recreate($payload, $queue = null, $delay)
 	{
-		$options = array('delay' => $this->getSeconds($delay));
+		$options = ['delay' => $this->getSeconds($delay)];
 
 		return $this->pushRaw($payload, $queue, $options);
 	}
@@ -172,9 +172,9 @@ class IronQueue extends Queue implements QueueContract {
 
 		$body = $this->parseJobBody($r->getContent());
 
-		return (object) array(
+		return (object) [
 			'id' => $r->header('iron-message-id'), 'body' => $body, 'pushed' => true,
-		);
+		];
 	}
 
 	/**

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -136,7 +136,7 @@ abstract class Job {
 	{
 		$segments = explode('@', $job);
 
-		return count($segments) > 1 ? $segments : array($segments[0], 'fire');
+		return count($segments) > 1 ? $segments : [$segments[0], 'fire'];
 	}
 
 	/**

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -69,11 +69,11 @@ class SqsJob extends Job implements JobContract {
 	{
 		parent::delete();
 
-		$this->sqs->deleteMessage(array(
+		$this->sqs->deleteMessage([
 
 			'QueueUrl' => $this->queue, 'ReceiptHandle' => $this->job['ReceiptHandle'],
 
-		));
+		]);
 	}
 
 	/**

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -25,7 +25,7 @@ class NullQueue extends Queue implements QueueContract {
 	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function pushRaw($payload, $queue = null, array $options = array())
+	public function pushRaw($payload, $queue = null, array $options = [])
 	{
 		//
 	}

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -19,7 +19,7 @@ class QueueManager implements FactoryContract, MonitorContract {
 	 *
 	 * @var array
 	 */
-	protected $connections = array();
+	protected $connections = [];
 
 	/**
 	 * Create a new queue manager instance.
@@ -218,7 +218,7 @@ class QueueManager implements FactoryContract, MonitorContract {
 	 */
 	public function __call($method, $parameters)
 	{
-		$callable = array($this->connection(), $method);
+		$callable = [$this->connection(), $method];
 
 		return call_user_func_array($callable, $parameters);
 	}

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -169,7 +169,7 @@ class QueueServiceProvider extends ServiceProvider {
 	 */
 	public function registerConnectors($manager)
 	{
-		foreach (array('Null', 'Sync', 'Database', 'Beanstalkd', 'Redis', 'Sqs', 'Iron') as $connector)
+		foreach (['Null', 'Sync', 'Database', 'Beanstalkd', 'Redis', 'Sqs', 'Iron'] as $connector)
 		{
 			$this->{"register{$connector}Connector"}($manager);
 		}
@@ -330,11 +330,11 @@ class QueueServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array(
+		return [
 			'queue', 'queue.worker', 'queue.listener', 'queue.failer',
 			'command.queue.work', 'command.queue.listen', 'command.queue.restart',
 			'command.queue.subscribe', 'queue.connection',
-		);
+		];
 	}
 
 }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -70,7 +70,7 @@ class RedisQueue extends Queue implements QueueContract {
 	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function pushRaw($payload, $queue = null, array $options = array())
+	public function pushRaw($payload, $queue = null, array $options = [])
 	{
 		$this->getConnection()->rpush($this->getQueue($queue), $payload);
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -54,9 +54,9 @@ class SqsQueue extends Queue implements QueueContract {
 	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function pushRaw($payload, $queue = null, array $options = array())
+	public function pushRaw($payload, $queue = null, array $options = [])
 	{
-		$response = $this->sqs->sendMessage(array('QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload));
+		$response = $this->sqs->sendMessage(['QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload]);
 
 		return $response->get('MessageId');
 	}
@@ -76,11 +76,11 @@ class SqsQueue extends Queue implements QueueContract {
 
 		$delay = $this->getSeconds($delay);
 
-		return $this->sqs->sendMessage(array(
+		return $this->sqs->sendMessage([
 
 			'QueueUrl' => $this->getQueue($queue), 'MessageBody' => $payload, 'DelaySeconds' => $delay,
 
-		))->get('MessageId');
+		])->get('MessageId');
 	}
 
 	/**
@@ -94,7 +94,7 @@ class SqsQueue extends Queue implements QueueContract {
 		$queue = $this->getQueue($queue);
 
 		$response = $this->sqs->receiveMessage(
-			array('QueueUrl' => $queue, 'AttributeNames' => array('ApproximateReceiveCount'))
+			['QueueUrl' => $queue, 'AttributeNames' => ['ApproximateReceiveCount']]
 		);
 
 		if (count($response['Messages']) > 0)

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -27,7 +27,7 @@ class SyncQueue extends Queue implements QueueContract {
 	 * @param  array   $options
 	 * @return mixed
 	 */
-	public function pushRaw($payload, $queue = null, array $options = array())
+	public function pushRaw($payload, $queue = null, array $options = [])
 	{
 		//
 	}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -256,7 +256,7 @@ class Worker {
 		{
 			$data = json_decode($job->getRawBody(), true);
 
-			$this->events->fire('illuminate.queue.failed', array($connection, $job, $data));
+			$this->events->fire('illuminate.queue.failed', [$connection, $job, $data]);
 		}
 	}
 

--- a/src/Illuminate/Redis/Database.php
+++ b/src/Illuminate/Redis/Database.php
@@ -18,7 +18,7 @@ class Database implements DatabaseContract {
 	 * @param  array  $servers
 	 * @return void
 	 */
-	public function __construct(array $servers = array())
+	public function __construct(array $servers = [])
 	{
 		if (isset($servers['cluster']) && $servers['cluster'])
 		{
@@ -38,11 +38,11 @@ class Database implements DatabaseContract {
 	 */
 	protected function createAggregateClient(array $servers)
 	{
-		$servers = array_except($servers, array('cluster'));
+		$servers = array_except($servers, ['cluster']);
 
 		$options = $this->getClientOptions($servers);
 
-		return array('default' => new Client(array_values($servers), $options));
+		return ['default' => new Client(array_values($servers), $options)];
 	}
 
 	/**
@@ -53,7 +53,7 @@ class Database implements DatabaseContract {
 	 */
 	protected function createSingleClients(array $servers)
 	{
-		$clients = array();
+		$clients = [];
 
 		$options = $this->getClientOptions($servers);
 
@@ -94,9 +94,9 @@ class Database implements DatabaseContract {
 	 * @param  array   $parameters
 	 * @return mixed
 	 */
-	public function command($method, array $parameters = array())
+	public function command($method, array $parameters = [])
 	{
-		return call_user_func_array(array($this->clients['default'], $method), $parameters);
+		return call_user_func_array([$this->clients['default'], $method], $parameters);
 	}
 
 	/**

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -31,7 +31,7 @@ class RedisServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('redis');
+		return ['redis'];
 	}
 
 }

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -59,9 +59,9 @@ class ControllerMakeCommand extends GeneratorCommand {
 	 */
 	protected function getOptions()
 	{
-		return array(
-			array('plain', null, InputOption::VALUE_NONE, 'Generate an empty controller class.'),
-		);
+		return [
+			['plain', null, InputOption::VALUE_NONE, 'Generate an empty controller class.'],
+		];
 	}
 
 }

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -19,14 +19,14 @@ abstract class Controller {
 	 *
 	 * @var array
 	 */
-	protected $beforeFilters = array();
+	protected $beforeFilters = [];
 
 	/**
 	 * The "after" filters registered on the controller.
 	 *
 	 * @var array
 	 */
-	protected $afterFilters = array();
+	protected $afterFilters = [];
 
 	/**
 	 * The router instance.
@@ -42,7 +42,7 @@ abstract class Controller {
 	 * @param  array   $options
 	 * @return void
 	 */
-	public function middleware($middleware, array $options = array())
+	public function middleware($middleware, array $options = [])
 	{
 		$this->middleware[$middleware] = $options;
 	}
@@ -54,7 +54,7 @@ abstract class Controller {
 	 * @param  array  $options
 	 * @return void
 	 */
-	public function beforeFilter($filter, array $options = array())
+	public function beforeFilter($filter, array $options = [])
 	{
 		$this->beforeFilters[] = $this->parseFilter($filter, $options);
 	}
@@ -66,7 +66,7 @@ abstract class Controller {
 	 * @param  array  $options
 	 * @return void
 	 */
-	public function afterFilter($filter, array $options = array())
+	public function afterFilter($filter, array $options = [])
 	{
 		$this->afterFilters[] = $this->parseFilter($filter, $options);
 	}
@@ -80,7 +80,7 @@ abstract class Controller {
 	 */
 	protected function parseFilter($filter, array $options)
 	{
-		$parameters = array();
+		$parameters = [];
 
 		$original = $filter;
 
@@ -121,7 +121,7 @@ abstract class Controller {
 	 */
 	protected function registerInstanceFilter($filter)
 	{
-		$this->getRouter()->filter($filter, array($this, substr($filter, 1)));
+		$this->getRouter()->filter($filter, [$this, substr($filter, 1)]);
 
 		return $filter;
 	}
@@ -254,7 +254,7 @@ abstract class Controller {
 	 *
 	 * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
 	 */
-	public function missingMethod($parameters = array())
+	public function missingMethod($parameters = [])
 	{
 		throw new NotFoundHttpException("Controller method not found.");
 	}

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -233,7 +233,7 @@ class ControllerDispatcher {
 	 */
 	protected function filterApplies($filter, $request, $method)
 	{
-		foreach (array('Method', 'On') as $type)
+		foreach (['Method', 'On'] as $type)
 		{
 			if ($this->{"filterFails{$type}"}($filter, $request, $method))
 			{

--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -10,10 +10,10 @@ class ControllerInspector {
 	 *
 	 * @var array
 	 */
-	protected $verbs = array(
+	protected $verbs = [
 		'any', 'get', 'post', 'put', 'patch',
 		'delete', 'head', 'options',
-	);
+	];
 
 	/**
 	 * Get the routable methods for a controller.
@@ -24,7 +24,7 @@ class ControllerInspector {
 	 */
 	public function getRoutable($controller, $prefix)
 	{
-		$routable = array();
+		$routable = [];
 
 		$reflection = new ReflectionClass($controller);
 
@@ -92,7 +92,7 @@ class ControllerInspector {
 	 */
 	protected function getIndexData($data, $prefix)
 	{
-		return array('verb' => $data['verb'], 'plain' => $prefix, 'uri' => $prefix);
+		return ['verb' => $data['verb'], 'plain' => $prefix, 'uri' => $prefix];
 	}
 
 	/**

--- a/src/Illuminate/Routing/GeneratorServiceProvider.php
+++ b/src/Illuminate/Routing/GeneratorServiceProvider.php
@@ -60,9 +60,9 @@ class GeneratorServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array(
+		return [
 			'command.controller.make', 'command.middleware.make',
-		);
+		];
 	}
 
 }

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -48,7 +48,7 @@ class Redirector {
 	 * @param  array  $headers
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	public function back($status = 302, $headers = array())
+	public function back($status = 302, $headers = [])
 	{
 		$back = $this->generator->previous();
 
@@ -62,7 +62,7 @@ class Redirector {
 	 * @param  array  $headers
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	public function refresh($status = 302, $headers = array())
+	public function refresh($status = 302, $headers = [])
 	{
 		return $this->to($this->generator->getRequest()->path(), $status, $headers);
 	}
@@ -76,7 +76,7 @@ class Redirector {
 	 * @param  bool    $secure
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	public function guest($path, $status = 302, $headers = array(), $secure = null)
+	public function guest($path, $status = 302, $headers = [], $secure = null)
 	{
 		$this->session->put('url.intended', $this->generator->full());
 
@@ -92,7 +92,7 @@ class Redirector {
 	 * @param  bool    $secure
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	public function intended($default = '/', $status = 302, $headers = array(), $secure = null)
+	public function intended($default = '/', $status = 302, $headers = [], $secure = null)
 	{
 		$path = $this->session->pull('url.intended', $default);
 
@@ -108,9 +108,9 @@ class Redirector {
 	 * @param  bool    $secure
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	public function to($path, $status = 302, $headers = array(), $secure = null)
+	public function to($path, $status = 302, $headers = [], $secure = null)
 	{
-		$path = $this->generator->to($path, array(), $secure);
+		$path = $this->generator->to($path, [], $secure);
 
 		return $this->createRedirect($path, $status, $headers);
 	}
@@ -123,7 +123,7 @@ class Redirector {
 	 * @param  array   $headers
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	public function away($path, $status = 302, $headers = array())
+	public function away($path, $status = 302, $headers = [])
 	{
 		return $this->createRedirect($path, $status, $headers);
 	}
@@ -136,7 +136,7 @@ class Redirector {
 	 * @param  array   $headers
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	public function secure($path, $status = 302, $headers = array())
+	public function secure($path, $status = 302, $headers = [])
 	{
 		return $this->to($path, $status, $headers, true);
 	}
@@ -150,7 +150,7 @@ class Redirector {
 	 * @param  array   $headers
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	public function route($route, $parameters = array(), $status = 302, $headers = array())
+	public function route($route, $parameters = [], $status = 302, $headers = [])
 	{
 		$path = $this->generator->route($route, $parameters);
 
@@ -166,7 +166,7 @@ class Redirector {
 	 * @param  array   $headers
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	public function action($action, $parameters = array(), $status = 302, $headers = array())
+	public function action($action, $parameters = [], $status = 302, $headers = [])
 	{
 		$path = $this->generator->action($action, $parameters);
 

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -14,7 +14,7 @@ class ResourceRegistrar {
 	 *
 	 * @var array
 	 */
-	protected $resourceDefaults = array('index', 'create', 'store', 'show', 'edit', 'update', 'destroy');
+	protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
 
 	/**
 	 * Create a new resource registrar instance.
@@ -35,7 +35,7 @@ class ResourceRegistrar {
 	 * @param  array   $options
 	 * @return void
 	 */
-	public function register($name, $controller, array $options = array())
+	public function register($name, $controller, array $options = [])
 	{
 		// If the resource name contains a slash, we will assume the developer wishes to
 		// register these resource routes with a prefix so we will set that up out of
@@ -98,7 +98,7 @@ class ResourceRegistrar {
 		// last segment, which will be considered the final resources name we use.
 		$prefix = implode('/', array_slice($segments, 0, -1));
 
-		return array(end($segments), $prefix);
+		return [end($segments), $prefix];
 	}
 
 	/**
@@ -173,7 +173,7 @@ class ResourceRegistrar {
 	{
 		$name = $this->getResourceName($resource, $method, $options);
 
-		return array('as' => $name, 'uses' => $controller.'@'.$method);
+		return ['as' => $name, 'uses' => $controller.'@'.$method];
 	}
 
 	/**

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -49,7 +49,7 @@ class ResponseFactory implements FactoryContract {
 	 * @param  array   $headers
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function make($content = '', $status = 200, array $headers = array())
+	public function make($content = '', $status = 200, array $headers = [])
 	{
 		return new Response($content, $status, $headers);
 	}
@@ -63,7 +63,7 @@ class ResponseFactory implements FactoryContract {
 	 * @param  array   $headers
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function view($view, $data = array(), $status = 200, array $headers = array())
+	public function view($view, $data = [], $status = 200, array $headers = [])
 	{
 		return static::make($this->view->make($view, $data), $status, $headers);
 	}
@@ -77,7 +77,7 @@ class ResponseFactory implements FactoryContract {
 	 * @param  int    $options
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function json($data = array(), $status = 200, array $headers = array(), $options = 0)
+	public function json($data = [], $status = 200, array $headers = [], $options = 0)
 	{
 		if ($data instanceof Arrayable)
 		{
@@ -97,7 +97,7 @@ class ResponseFactory implements FactoryContract {
 	 * @param  int    $options
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function jsonp($callback, $data = array(), $status = 200, array $headers = array(), $options = 0)
+	public function jsonp($callback, $data = [], $status = 200, array $headers = [], $options = 0)
 	{
 		return $this->json($data, $status, $headers, $options)->setCallback($callback);
 	}
@@ -110,7 +110,7 @@ class ResponseFactory implements FactoryContract {
 	 * @param  array    $headers
 	 * @return \Symfony\Component\HttpFoundation\StreamedResponse
 	 */
-	public function stream($callback, $status = 200, array $headers = array())
+	public function stream($callback, $status = 200, array $headers = [])
 	{
 		return new StreamedResponse($callback, $status, $headers);
 	}
@@ -124,7 +124,7 @@ class ResponseFactory implements FactoryContract {
 	 * @param  null|string  $disposition
 	 * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
 	 */
-	public function download($file, $name = null, array $headers = array(), $disposition = 'attachment')
+	public function download($file, $name = null, array $headers = [], $disposition = 'attachment')
 	{
 		$response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
 
@@ -145,7 +145,7 @@ class ResponseFactory implements FactoryContract {
 	 * @param  bool    $secure
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function redirectTo($path, $status = 302, $headers = array(), $secure = null)
+	public function redirectTo($path, $status = 302, $headers = [], $secure = null)
 	{
 		return $this->redirector->to($path, $status, $headers, $secure);
 	}
@@ -159,7 +159,7 @@ class ResponseFactory implements FactoryContract {
 	 * @param  array   $headers
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function redirectToRoute($route, $parameters = array(), $status = 302, $headers = array())
+	public function redirectToRoute($route, $parameters = [], $status = 302, $headers = [])
 	{
 		return $this->redirector->route($route, $parameters, $status, $headers);
 	}
@@ -173,7 +173,7 @@ class ResponseFactory implements FactoryContract {
 	 * @param  array   $headers
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function redirectToAction($action, $parameters = array(), $status = 302, $headers = array())
+	public function redirectToAction($action, $parameters = [], $status = 302, $headers = [])
 	{
 		return $this->redirector->action($action, $parameters, $status, $headers);
 	}
@@ -187,7 +187,7 @@ class ResponseFactory implements FactoryContract {
 	 * @param  bool    $secure
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function redirectGuest($path, $status = 302, $headers = array(), $secure = null)
+	public function redirectGuest($path, $status = 302, $headers = [], $secure = null)
 	{
 		return $this->redirector->guest($path, $status, $headers, $secure);
 	}
@@ -201,7 +201,7 @@ class ResponseFactory implements FactoryContract {
 	 * @param  bool    $secure
 	 * @return \Symfony\Component\HttpFoundation\Response
 	 */
-	public function redirectToIntended($default = '/', $status = 302, $headers = array(), $secure = null)
+	public function redirectToIntended($default = '/', $status = 302, $headers = [], $secure = null)
 	{
 		return $this->redirector->intended($default, $status, $headers, $secure);
 	}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -43,14 +43,14 @@ class Route {
 	 *
 	 * @var array
 	 */
-	protected $defaults = array();
+	protected $defaults = [];
 
 	/**
 	 * The regular expression requirements.
 	 *
 	 * @var array
 	 */
-	protected $wheres = array();
+	protected $wheres = [];
 
 	/**
 	 * The array of matched parameters.
@@ -232,7 +232,7 @@ class Route {
 
 		$this->compiled = with(
 
-			new SymfonyRoute($uri, $optionals, $this->wheres, array(), $this->domain() ?: '')
+			new SymfonyRoute($uri, $optionals, $this->wheres, [], $this->domain() ?: '')
 
 		)->compile();
 	}
@@ -266,7 +266,7 @@ class Route {
 	 */
 	public function beforeFilters()
 	{
-		if ( ! isset($this->action['before'])) return array();
+		if ( ! isset($this->action['before'])) return [];
 
 		return $this->parseFilters($this->action['before']);
 	}
@@ -278,7 +278,7 @@ class Route {
 	 */
 	public function afterFilters()
 	{
-		if ( ! isset($this->action['after'])) return array();
+		if ( ! isset($this->action['after'])) return [];
 
 		return $this->parseFilters($this->action['after']);
 	}
@@ -318,7 +318,7 @@ class Route {
 	 */
 	protected static function explodeArrayFilters(array $filters)
 	{
-		$results = array();
+		$results = [];
 
 		foreach ($filters as $filter)
 		{
@@ -336,7 +336,7 @@ class Route {
 	 */
 	public static function parseFilter($filter)
 	{
-		if ( ! str_contains($filter, ':')) return array($filter, array());
+		if ( ! str_contains($filter, ':')) return [$filter, []];
 
 		return static::parseParameterFilter($filter);
 	}
@@ -351,7 +351,7 @@ class Route {
 	{
 		list($name, $parameters) = explode(':', $filter, 2);
 
-		return array($name, explode(',', $parameters));
+		return [$name, explode(',', $parameters)];
 	}
 
 	/**
@@ -551,7 +551,7 @@ class Route {
 	 */
 	protected function matchToKeys(array $matches)
 	{
-		if (count($this->parameterNames()) == 0) return array();
+		if (count($this->parameterNames()) == 0) return [];
 
 		$parameters = array_intersect_key($matches, array_flip($this->parameterNames()));
 
@@ -590,7 +590,7 @@ class Route {
 		// it is available. Otherwise we will need to find it in the action list.
 		if (is_callable($action))
 		{
-			return array('uses' => $action);
+			return ['uses' => $action];
 		}
 
 		// If no "uses" property has been set, we will dig through the array to find a
@@ -630,10 +630,10 @@ class Route {
 		// To match the route, we will use a chain of responsibility pattern with the
 		// validator implementations. We will spin through each one making sure it
 		// passes and then we will know if the route as a whole matches request.
-		return static::$validators = array(
+		return static::$validators = [
 			new MethodValidator, new SchemeValidator,
 			new HostValidator, new UriValidator,
-		);
+		];
 	}
 
 	/**
@@ -723,7 +723,7 @@ class Route {
 	 */
 	protected function parseWhere($name, $expression)
 	{
-		return is_array($name) ? $name : array($name => $expression);
+		return is_array($name) ? $name : [$name => $expression];
 	}
 
 	/**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -15,28 +15,28 @@ class RouteCollection implements Countable, IteratorAggregate {
 	 *
 	 * @var array
 	 */
-	protected $routes = array();
+	protected $routes = [];
 
 	/**
 	 * An flattened array of all of the routes.
 	 *
 	 * @var array
 	 */
-	protected $allRoutes = array();
+	protected $allRoutes = [];
 
 	/**
 	 * A look-up table of routes by their names.
 	 *
 	 * @var array
 	 */
-	protected $nameList = array();
+	protected $nameList = [];
 
 	/**
 	 * A look-up table of routes by controller action.
 	 *
 	 * @var array
 	 */
-	protected $actionList = array();
+	protected $actionList = [];
 
 	/**
 	 * Add a Route instance to the collection.
@@ -153,12 +153,12 @@ class RouteCollection implements Countable, IteratorAggregate {
 	 */
 	protected function checkForAlternateVerbs($request)
 	{
-		$methods = array_diff(Router::$verbs, array($request->getMethod()));
+		$methods = array_diff(Router::$verbs, [$request->getMethod()]);
 
 		// Here we will spin through all verbs except for the current request verb and
 		// check to see if any routes respond to them. If they do, we will return a
 		// proper error response with the correct headers on the response string.
-		$others = array();
+		$others = [];
 
 		foreach ($methods as $method)
 		{
@@ -186,7 +186,7 @@ class RouteCollection implements Countable, IteratorAggregate {
 		{
 			return (new Route('OPTIONS', $request->path(), function() use ($methods)
 			{
-				return new Response('', 200, array('Allow' => implode(',', $methods)));
+				return new Response('', 200, ['Allow' => implode(',', $methods)]);
 
 			}))->bind($request);
 		}
@@ -233,7 +233,7 @@ class RouteCollection implements Countable, IteratorAggregate {
 	{
 		if (is_null($method)) return $this->getRoutes();
 
-		return array_get($this->routes, $method, array());
+		return array_get($this->routes, $method, []);
 	}
 
 	/**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -63,42 +63,42 @@ class Router implements RegistrarContract {
 	 *
 	 * @var array
 	 */
-	protected $patternFilters = array();
+	protected $patternFilters = [];
 
 	/**
 	 * The registered regular expression based filters.
 	 *
 	 * @var array
 	 */
-	protected $regexFilters = array();
+	protected $regexFilters = [];
 
 	/**
 	 * The registered route value binders.
 	 *
 	 * @var array
 	 */
-	protected $binders = array();
+	protected $binders = [];
 
 	/**
 	 * The globally available parameter patterns.
 	 *
 	 * @var array
 	 */
-	protected $patterns = array();
+	protected $patterns = [];
 
 	/**
 	 * The route group attribute stack.
 	 *
 	 * @var array
 	 */
-	protected $groupStack = array();
+	protected $groupStack = [];
 
 	/**
 	 * All of the verbs supported by the router.
 	 *
 	 * @var array
 	 */
-	public static $verbs = array('GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS');
+	public static $verbs = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
 
 	/**
 	 * Create a new Router instance.
@@ -195,7 +195,7 @@ class Router implements RegistrarContract {
 	 */
 	public function any($uri, $action)
 	{
-		$verbs = array('GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE');
+		$verbs = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'];
 
 		return $this->addRoute($verbs, $uri, $action);
 	}
@@ -235,7 +235,7 @@ class Router implements RegistrarContract {
 	 * @param  array   $names
 	 * @return void
 	 */
-	public function controller($uri, $controller, $names = array())
+	public function controller($uri, $controller, $names = [])
 	{
 		$prepended = $controller;
 
@@ -275,7 +275,7 @@ class Router implements RegistrarContract {
 	 */
 	protected function registerInspected($route, $controller, $method, &$names)
 	{
-		$action = array('uses' => $controller.'@'.$method);
+		$action = ['uses' => $controller.'@'.$method];
 
 		// If a given controller method has been named, we will assign the name to the
 		// controller action array, which provides for a short-cut to method naming
@@ -321,7 +321,7 @@ class Router implements RegistrarContract {
 	 * @param  array   $options
 	 * @return void
 	 */
-	public function resource($name, $controller, array $options = array())
+	public function resource($name, $controller, array $options = [])
 	{
 		(new ResourceRegistrar($this))->register($name, $controller, $options);
 	}
@@ -389,7 +389,7 @@ class Router implements RegistrarContract {
 
 		$new['where'] = array_merge(array_get($old, 'where', []), array_get($new, 'where', []));
 
-		return array_merge_recursive(array_except($old, array('namespace', 'prefix', 'where')), $new);
+		return array_merge_recursive(array_except($old, ['namespace', 'prefix', 'where']), $new);
 	}
 
 	/**
@@ -568,7 +568,7 @@ class Router implements RegistrarContract {
 	 */
 	protected function convertToControllerAction($action)
 	{
-		if (is_string($action)) $action = array('uses' => $action);
+		if (is_string($action)) $action = ['uses' => $action];
 
 		// Here we'll merge any group "uses" statement if necessary so that the action
 		// has the proper clause for this property. Then we can simply set the name
@@ -995,7 +995,7 @@ class Router implements RegistrarContract {
 	 */
 	protected function callFilter($filter, $request, $response = null)
 	{
-		return $this->events->until('router.'.$filter, array($request, $response));
+		return $this->events->until('router.'.$filter, [$request, $response]);
 	}
 
 	/**
@@ -1037,9 +1037,9 @@ class Router implements RegistrarContract {
 	 */
 	public function findPatternFilters($request)
 	{
-		$results = array();
+		$results = [];
 
-		list($path, $method) = array($request->path(), $request->getMethod());
+		list($path, $method) = [$request->path(), $request->getMethod()];
 
 		foreach ($this->patternFilters as $pattern => $filters)
 		{
@@ -1079,7 +1079,7 @@ class Router implements RegistrarContract {
 	 */
 	protected function patternsByMethod($method, $filters)
 	{
-		$results = array();
+		$results = [];
 
 		foreach ($filters as $filter)
 		{
@@ -1156,7 +1156,7 @@ class Router implements RegistrarContract {
 	 */
 	public function callRouteFilter($filter, $parameters, $route, $request, $response = null)
 	{
-		$data = array_merge(array($route, $request, $response), $parameters);
+		$data = array_merge([$route, $request, $response], $parameters);
 
 		return $this->events->until('router.filter: '.$filter, $this->cleanFilterParameters($data));
 	}

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -68,7 +68,7 @@ class UrlGenerator implements UrlGeneratorContract {
 	 *
 	 * @var array
 	 */
-	protected $dontEncode = array(
+	protected $dontEncode = [
 		'%2F' => '/',
 		'%40' => '@',
 		'%3A' => ':',
@@ -83,7 +83,7 @@ class UrlGenerator implements UrlGeneratorContract {
 		'%26' => '&',
 		'%23' => '#',
 		'%25' => '%',
-	);
+	];
 
 	/**
 	 * Create a new URL Generator instance.
@@ -141,7 +141,7 @@ class UrlGenerator implements UrlGeneratorContract {
 	 * @param  bool|null  $secure
 	 * @return string
 	 */
-	public function to($path, $extra = array(), $secure = null)
+	public function to($path, $extra = [], $secure = null)
 	{
 		// First we will check if the URL is already a valid URL. If it is we will not
 		// try to generate a new one but will simply return the URL as is, which is
@@ -171,7 +171,7 @@ class UrlGenerator implements UrlGeneratorContract {
 	 * @param  array   $parameters
 	 * @return string
 	 */
-	public function secure($path, $parameters = array())
+	public function secure($path, $parameters = [])
 	{
 		return $this->to($path, $parameters, true);
 	}
@@ -263,7 +263,7 @@ class UrlGenerator implements UrlGeneratorContract {
 	 *
 	 * @throws \InvalidArgumentException
 	 */
-	public function route($name, $parameters = array(), $absolute = true)
+	public function route($name, $parameters = [], $absolute = true)
 	{
 		if ( ! is_null($route = $this->routes->getByName($name)))
 		{
@@ -382,9 +382,9 @@ class UrlGenerator implements UrlGeneratorContract {
 	 * @param  array  $parameters
 	 * @return array
 	 */
-	protected function replaceRoutableParameters($parameters = array())
+	protected function replaceRoutableParameters($parameters = [])
 	{
-		$parameters = is_array($parameters) ? $parameters : array($parameters);
+		$parameters = is_array($parameters) ? $parameters : [$parameters];
 
 		foreach ($parameters as $key => $parameter)
 		{
@@ -492,7 +492,7 @@ class UrlGenerator implements UrlGeneratorContract {
 	 */
 	protected function addPortToDomain($domain)
 	{
-		if (in_array($this->request->getPort(), array('80', '443')))
+		if (in_array($this->request->getPort(), ['80', '443']))
 		{
 			return $domain;
 		}
@@ -542,7 +542,7 @@ class UrlGenerator implements UrlGeneratorContract {
 	 *
 	 * @throws \InvalidArgumentException
 	 */
-	public function action($action, $parameters = array(), $absolute = true)
+	public function action($action, $parameters = [], $absolute = true)
 	{
 		if ($this->rootNamespace && ! (strpos($action, '\\') === 0))
 		{

--- a/src/Illuminate/Session/CommandsServiceProvider.php
+++ b/src/Illuminate/Session/CommandsServiceProvider.php
@@ -33,7 +33,7 @@ class CommandsServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('command.session.database');
+		return ['command.session.database'];
 	}
 
 }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -230,7 +230,7 @@ class StartSession implements TerminableMiddleware {
 	{
 		$config = $config ?: $this->manager->getSessionConfig();
 
-		return ! in_array($config['driver'], array(null, 'array'));
+		return ! in_array($config['driver'], [null, 'array']);
 	}
 
 	/**

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -27,14 +27,14 @@ class Store implements SessionInterface {
 	 *
 	 * @var array
 	 */
-	protected $attributes = array();
+	protected $attributes = [];
 
 	/**
 	 * The session bags.
 	 *
 	 * @var array
 	 */
-	protected $bags = array();
+	protected $bags = [];
 
 	/**
 	 * The meta-data bag instance.
@@ -48,7 +48,7 @@ class Store implements SessionInterface {
 	 *
 	 * @var array
 	 */
-	protected $bagData = array();
+	protected $bagData = [];
 
 	/**
 	 * The session handler implementation.
@@ -101,7 +101,7 @@ class Store implements SessionInterface {
 	{
 		$this->attributes = array_merge($this->attributes, $this->readFromHandler());
 
-		foreach (array_merge($this->bags, array($this->metaBag)) as $bag)
+		foreach (array_merge($this->bags, [$this->metaBag]) as $bag)
 		{
 			$this->initializeLocalBag($bag);
 
@@ -213,7 +213,7 @@ class Store implements SessionInterface {
 	 */
 	public function invalidate($lifetime = null)
 	{
-		$this->attributes = array();
+		$this->attributes = [];
 
 		return $this->migrate();
 	}
@@ -275,7 +275,7 @@ class Store implements SessionInterface {
 	 */
 	protected function addBagDataToSession()
 	{
-		foreach (array_merge($this->bags, array($this->metaBag)) as $bag)
+		foreach (array_merge($this->bags, [$this->metaBag]) as $bag)
 		{
 			$this->put($bag->getStorageKey(), $this->bagData[$bag->getStorageKey()]);
 		}
@@ -288,11 +288,11 @@ class Store implements SessionInterface {
 	 */
 	public function ageFlashData()
 	{
-		foreach ($this->get('flash.old', array()) as $old) { $this->forget($old); }
+		foreach ($this->get('flash.old', []) as $old) { $this->forget($old); }
 
-		$this->put('flash.old', $this->get('flash.new', array()));
+		$this->put('flash.old', $this->get('flash.new', []));
 
-		$this->put('flash.new', array());
+		$this->put('flash.new', []);
 	}
 
 	/**
@@ -345,7 +345,7 @@ class Store implements SessionInterface {
 	 */
 	public function getOldInput($key = null, $default = null)
 	{
-		$input = $this->get('_old_input', array());
+		$input = $this->get('_old_input', []);
 
 		// Input that is flashed to the session can be easily retrieved by the
 		// developer, making repopulating old forms and the like much more
@@ -370,7 +370,7 @@ class Store implements SessionInterface {
 	 */
 	public function put($key, $value = null)
 	{
-		if ( ! is_array($key)) $key = array($key => $value);
+		if ( ! is_array($key)) $key = [$key => $value];
 
 		foreach ($key as $arrayKey => $arrayValue)
 		{
@@ -387,7 +387,7 @@ class Store implements SessionInterface {
 	 */
 	public function push($key, $value)
 	{
-		$array = $this->get($key, array());
+		$array = $this->get($key, []);
 
 		$array[] = $value;
 
@@ -407,7 +407,7 @@ class Store implements SessionInterface {
 
 		$this->push('flash.new', $key);
 
-		$this->removeFromOldFlashData(array($key));
+		$this->removeFromOldFlashData([$key]);
 	}
 
 	/**
@@ -428,9 +428,9 @@ class Store implements SessionInterface {
 	 */
 	public function reflash()
 	{
-		$this->mergeNewFlashes($this->get('flash.old', array()));
+		$this->mergeNewFlashes($this->get('flash.old', []));
 
-		$this->put('flash.old', array());
+		$this->put('flash.old', []);
 	}
 
 	/**
@@ -456,7 +456,7 @@ class Store implements SessionInterface {
 	 */
 	protected function mergeNewFlashes(array $keys)
 	{
-		$values = array_unique(array_merge($this->get('flash.new', array()), $keys));
+		$values = array_unique(array_merge($this->get('flash.new', []), $keys));
 
 		$this->put('flash.new', $values);
 	}
@@ -469,7 +469,7 @@ class Store implements SessionInterface {
 	 */
 	protected function removeFromOldFlashData(array $keys)
 	{
-		$this->put('flash.old', array_diff($this->get('flash.old', array()), $keys));
+		$this->put('flash.old', array_diff($this->get('flash.old', []), $keys));
 	}
 
 	/**
@@ -512,7 +512,7 @@ class Store implements SessionInterface {
 	 */
 	public function clear()
 	{
-		$this->attributes = array();
+		$this->attributes = [];
 
 		foreach ($this->bags as $bag)
 		{
@@ -573,7 +573,7 @@ class Store implements SessionInterface {
 	 */
 	public function getBagData($name)
 	{
-		return array_get($this->bagData, $name, array());
+		return array_get($this->bagData, $name, []);
 	}
 
 	/**

--- a/src/Illuminate/Support/ClassLoader.php
+++ b/src/Illuminate/Support/ClassLoader.php
@@ -7,7 +7,7 @@ class ClassLoader {
 	 *
 	 * @var array
 	 */
-	protected static $directories = array();
+	protected static $directories = [];
 
 	/**
 	 * Indicates if a ClassLoader has been registered.
@@ -49,7 +49,7 @@ class ClassLoader {
 	{
 		if ($class[0] == '\\') $class = substr($class, 1);
 
-		return str_replace(array('\\', '_'), DIRECTORY_SEPARATOR, $class).'.php';
+		return str_replace(['\\', '_'], DIRECTORY_SEPARATOR, $class).'.php';
 	}
 
 	/**
@@ -61,7 +61,7 @@ class ClassLoader {
 	{
 		if ( ! static::$registered)
 		{
-			static::$registered = spl_autoload_register(array('\Illuminate\Support\ClassLoader', 'load'));
+			static::$registered = spl_autoload_register(['\Illuminate\Support\ClassLoader', 'load']);
 		}
 	}
 
@@ -86,7 +86,7 @@ class ClassLoader {
 	{
 		if (is_null($directories))
 		{
-			static::$directories = array();
+			static::$directories = [];
 		}
 		else
 		{

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -17,7 +17,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 *
 	 * @var array
 	 */
-	protected $items = array();
+	protected $items = [];
 
 	/**
 	 * Create a new collection.
@@ -25,7 +25,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 * @param  mixed  $items
 	 * @return void
 	 */
-	public function __construct($items = array())
+	public function __construct($items = [])
 	{
 		$items = is_null($items) ? [] : $this->getArrayableItems($items);
 

--- a/src/Illuminate/Support/Debug/HtmlDumper.php
+++ b/src/Illuminate/Support/Debug/HtmlDumper.php
@@ -9,7 +9,7 @@ class HtmlDumper extends SymfonyHtmlDumper {
 	 *
 	 * @var array
 	 */
-	protected $styles = array(
+	protected $styles = [
 		'default' => 'background-color:#fff; color:#222; line-height:1.2em; font-weight:normal; font:12px Monaco, Consolas, monospace; word-wrap: break-word; white-space: pre-wrap; position:relative; z-index:100000',
 		'num' => 'color:#a71d5d',
 		'const' => 'color:#795da3',
@@ -23,6 +23,6 @@ class HtmlDumper extends SymfonyHtmlDumper {
 		'meta' => 'color:#b729d9',
 		'key' => 'color:#df5000',
 		'index' => 'color:#a71d5d',
-	);
+	];
 
 }

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -52,7 +52,7 @@ abstract class Facade {
 			$mock = static::createFreshMockInstance($name);
 		}
 
-		return call_user_func_array(array($mock, 'shouldReceive'), func_get_args());
+		return call_user_func_array([$mock, 'shouldReceive'], func_get_args());
 	}
 
 	/**
@@ -166,7 +166,7 @@ abstract class Facade {
 	 */
 	public static function clearResolvedInstances()
 	{
-		static::$resolvedInstance = array();
+		static::$resolvedInstance = [];
 	}
 
 	/**
@@ -219,7 +219,7 @@ abstract class Facade {
 				return $instance->$method($args[0], $args[1], $args[2], $args[3]);
 
 			default:
-				return call_user_func_array(array($instance, $method), $args);
+				return call_user_func_array([$instance, $method], $args);
 		}
 	}
 

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -12,7 +12,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable {
 	 *
 	 * @var array
 	 */
-	protected $attributes = array();
+	protected $attributes = [];
 
 	/**
 	 * Create a new fluent container instance.
@@ -20,7 +20,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable {
 	 * @param  array|object	$attributes
 	 * @return void
 	 */
-	public function __construct($attributes = array())
+	public function __construct($attributes = [])
 	{
 		foreach ($attributes as $key => $value)
 		{

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -17,14 +17,14 @@ abstract class Manager {
 	 *
 	 * @var array
 	 */
-	protected $customCreators = array();
+	protected $customCreators = [];
 
 	/**
 	 * The array of created "drivers".
 	 *
 	 * @var array
 	 */
-	protected $drivers = array();
+	protected $drivers = [];
 
 	/**
 	 * Create a new manager instance.
@@ -136,7 +136,7 @@ abstract class Manager {
 	 */
 	public function __call($method, $parameters)
 	{
-		return call_user_func_array(array($this->driver(), $method), $parameters);
+		return call_user_func_array([$this->driver(), $method], $parameters);
 	}
 
 }

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -14,7 +14,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
 	 *
 	 * @var array
 	 */
-	protected $messages = array();
+	protected $messages = [];
 
 	/**
 	 * Default format for message output.
@@ -29,7 +29,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
 	 * @param  array  $messages
 	 * @return void
 	 */
-	public function __construct(array $messages = array())
+	public function __construct(array $messages = [])
 	{
 		foreach ($messages as $key => $value)
 		{
@@ -140,7 +140,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
 			return $this->transform($this->messages[$key], $format, $key);
 		}
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -153,7 +153,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
 	{
 		$format = $this->checkFormat($format);
 
-		$all = array();
+		$all = [];
 
 		foreach ($this->messages as $key => $messages)
 		{
@@ -180,9 +180,9 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
 		// the messages to be easily formatted to each developer's desires.
 		foreach ($messages as &$message)
 		{
-			$replace = array(':message', ':key');
+			$replace = [':message', ':key'];
 
-			$message = str_replace($replace, array($message, $messageKey), $format);
+			$message = str_replace($replace, [$message, $messageKey], $format);
 		}
 
 		return $messages;

--- a/src/Illuminate/Support/NamespacedItemResolver.php
+++ b/src/Illuminate/Support/NamespacedItemResolver.php
@@ -7,7 +7,7 @@ class NamespacedItemResolver {
 	 *
 	 * @var array
 	 */
-	protected $parsed = array();
+	protected $parsed = [];
 
 	/**
 	 * Parse a key into namespace, group, and item.
@@ -60,7 +60,7 @@ class NamespacedItemResolver {
 
 		if (count($segments) == 1)
 		{
-			return array(null, $group, null);
+			return [null, $group, null];
 		}
 
 		// If there is more than one segment in this group, it means we are pulling
@@ -70,7 +70,7 @@ class NamespacedItemResolver {
 		{
 			$item = implode('.', array_slice($segments, 1));
 
-			return array(null, $group, $item);
+			return [null, $group, $item];
 		}
 	}
 
@@ -91,7 +91,7 @@ class NamespacedItemResolver {
 
 		$groupAndItem = array_slice($this->parseBasicSegments($itemSegments), 1);
 
-		return array_merge(array($namespace), $groupAndItem);
+		return array_merge([$namespace], $groupAndItem);
 	}
 
 	/**

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -9,7 +9,7 @@ class Pluralizer {
 	 *
 	 * @var array
 	 */
-	public static $uncountable = array(
+	public static $uncountable = [
 		'audio',
 		'bison',
 		'chassis',
@@ -33,7 +33,7 @@ class Pluralizer {
 		'species',
 		'swine',
 		'traffic',
-	);
+	];
 
 	/**
 	 * Get the plural form of an English word.
@@ -87,7 +87,7 @@ class Pluralizer {
 	 */
 	protected static function matchCase($value, $comparison)
 	{
-		$functions = array('mb_strtolower', 'mb_strtoupper', 'ucfirst', 'ucwords');
+		$functions = ['mb_strtolower', 'mb_strtoupper', 'ucfirst', 'ucwords'];
 
 		foreach ($functions as $function)
 		{

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -188,7 +188,7 @@ class Str {
 	 */
 	public static function parseCallback($callback, $default)
 	{
-		return static::contains($callback, '@') ? explode('@', $callback, 2) : array($callback, $default);
+		return static::contains($callback, '@') ? explode('@', $callback, 2) : [$callback, $default];
 	}
 
 	/**
@@ -225,7 +225,7 @@ class Str {
 			throw new RuntimeException('Unable to generate random string.');
 		}
 
-		return substr(str_replace(array('/', '+', '='), '', base64_encode($bytes)), 0, $length);
+		return substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $length);
 	}
 
 	/**
@@ -357,7 +357,7 @@ class Str {
 			return static::$studlyCache[$key];
 		}
 
-		$value = ucwords(str_replace(array('-', '_'), ' ', $value));
+		$value = ucwords(str_replace(['-', '_'], ' ', $value));
 
 		return static::$studlyCache[$key] = str_replace(' ', '', $value);
 	}

--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -10,7 +10,7 @@ trait Macroable {
 	 *
 	 * @var array
 	 */
-	protected static $macros = array();
+	protected static $macros = [];
 
 	/**
 	 * Register a custom macro.

--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -77,7 +77,7 @@ class ViewErrorBag implements Countable {
 	 */
 	public function __call($method, $parameters)
 	{
-		return call_user_func_array(array($this->default, $method), $parameters);
+		return call_user_func_array([$this->default, $method], $parameters);
 	}
 
 	/**

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -23,7 +23,7 @@ class FileLoader implements LoaderInterface {
 	 *
 	 * @var array
 	 */
-	protected $hints = array();
+	protected $hints = [];
 
 	/**
 	 * Create a new file loader instance.
@@ -73,7 +73,7 @@ class FileLoader implements LoaderInterface {
 			return $this->loadNamespaceOverrides($lines, $locale, $group, $namespace);
 		}
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -112,7 +112,7 @@ class FileLoader implements LoaderInterface {
 			return $this->files->getRequire($full);
 		}
 
-		return array();
+		return [];
 	}
 
 	/**

--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -57,7 +57,7 @@ class TranslationServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array('translator', 'translation.loader');
+		return ['translator', 'translation.loader'];
 	}
 
 }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -33,7 +33,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	 *
 	 * @var array
 	 */
-	protected $loaded = array();
+	protected $loaded = [];
 
 	/**
 	 * Create a new translator instance.
@@ -57,7 +57,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	 */
 	public function has($key, $locale = null)
 	{
-		return $this->get($key, array(), $locale) !== $key;
+		return $this->get($key, [], $locale) !== $key;
 	}
 
 	/**
@@ -68,7 +68,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	 * @param  string  $locale
 	 * @return string
 	 */
-	public function get($key, array $replace = array(), $locale = null)
+	public function get($key, array $replace = [], $locale = null)
 	{
 		list($namespace, $group, $item) = $this->parseKey($key);
 
@@ -160,7 +160,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	 * @param  string  $locale
 	 * @return string
 	 */
-	public function choice($key, $number, array $replace = array(), $locale = null)
+	public function choice($key, $number, array $replace = [], $locale = null)
 	{
 		$line = $this->get($key, $replace, $locale = $locale ?: $this->locale ?: $this->fallback);
 
@@ -178,7 +178,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	 * @param  string  $locale
 	 * @return string
 	 */
-	public function trans($id, array $parameters = array(), $domain = 'messages', $locale = null)
+	public function trans($id, array $parameters = [], $domain = 'messages', $locale = null)
 	{
 		return $this->get($id, $parameters, $locale);
 	}
@@ -193,7 +193,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	 * @param  string  $locale
 	 * @return string
 	 */
-	public function transChoice($id, $number, array $parameters = array(), $domain = 'messages', $locale = null)
+	public function transChoice($id, $number, array $parameters = [], $domain = 'messages', $locale = null)
 	{
 		return $this->choice($id, $number, $parameters, $locale);
 	}
@@ -268,10 +268,10 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface {
 	{
 		if ( ! is_null($locale))
 		{
-			return array_filter(array($locale, $this->fallback));
+			return array_filter([$locale, $this->fallback]);
 		}
 
-		return array_filter(array($this->locale, $this->fallback));
+		return array_filter([$this->locale, $this->fallback]);
 	}
 
 	/**

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -40,7 +40,7 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface {
 	 * @param  array   $extra
 	 * @return int
 	 */
-	public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = array())
+	public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = [])
 	{
 		$query = $this->table($collection)->where($column, '=', $value);
 
@@ -66,7 +66,7 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface {
 	 * @param  array   $extra
 	 * @return int
 	 */
-	public function getMultiCount($collection, $column, array $values, array $extra = array())
+	public function getMultiCount($collection, $column, array $values, array $extra = [])
 	{
 		$query = $this->table($collection)->whereIn($column, $values);
 

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -33,28 +33,28 @@ class Factory implements FactoryContract {
 	 *
 	 * @var array
 	 */
-	protected $extensions = array();
+	protected $extensions = [];
 
 	/**
 	 * All of the custom implicit validator extensions.
 	 *
 	 * @var array
 	 */
-	protected $implicitExtensions = array();
+	protected $implicitExtensions = [];
 
 	/**
 	 * All of the custom validator message replacers.
 	 *
 	 * @var array
 	 */
-	protected $replacers = array();
+	protected $replacers = [];
 
 	/**
 	 * All of the fallback messages for custom rules.
 	 *
 	 * @var array
 	 */
-	protected $fallbackMessages = array();
+	protected $fallbackMessages = [];
 
 	/**
 	 * The Validator resolver instance.
@@ -85,7 +85,7 @@ class Factory implements FactoryContract {
 	 * @param  array  $customAttributes
 	 * @return \Illuminate\Validation\Validator
 	 */
-	public function make(array $data, array $rules, array $messages = array(), array $customAttributes = array())
+	public function make(array $data, array $rules, array $messages = [], array $customAttributes = [])
 	{
 		// The presence verifier is responsible for checking the unique and exists data
 		// for the validator. It is behind an interface so that multiple versions of

--- a/src/Illuminate/Validation/PresenceVerifierInterface.php
+++ b/src/Illuminate/Validation/PresenceVerifierInterface.php
@@ -13,7 +13,7 @@ interface PresenceVerifierInterface {
 	 * @param  array   $extra
 	 * @return int
 	 */
-	public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = array());
+	public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = []);
 
 	/**
 	 * Count the number of objects in a collection with the given values.
@@ -24,6 +24,6 @@ interface PresenceVerifierInterface {
 	 * @param  array   $extra
 	 * @return int
 	 */
-	public function getMultiCount($collection, $column, array $values, array $extra = array());
+	public function getMultiCount($collection, $column, array $values, array $extra = []);
 
 }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -44,7 +44,7 @@ class Validator implements ValidatorContract {
 	 *
 	 * @var array
 	 */
-	protected $failedRules = array();
+	protected $failedRules = [];
 
 	/**
 	 * The message bag instance.
@@ -65,7 +65,7 @@ class Validator implements ValidatorContract {
 	 *
 	 * @var array
 	 */
-	protected $files = array();
+	protected $files = [];
 
 	/**
 	 * The rules to be applied to the data.
@@ -79,72 +79,72 @@ class Validator implements ValidatorContract {
 	 *
 	 * @var array
 	 */
-	protected $after = array();
+	protected $after = [];
 
 	/**
 	 * The array of custom error messages.
 	 *
 	 * @var array
 	 */
-	protected $customMessages = array();
+	protected $customMessages = [];
 
 	/**
 	 * The array of fallback error messages.
 	 *
 	 * @var array
 	 */
-	protected $fallbackMessages = array();
+	protected $fallbackMessages = [];
 
 	/**
 	 * The array of custom attribute names.
 	 *
 	 * @var array
 	 */
-	protected $customAttributes = array();
+	protected $customAttributes = [];
 
 	/**
 	 * The array of custom displayabled values.
 	 *
 	 * @var array
 	 */
-	protected $customValues = array();
+	protected $customValues = [];
 
 	/**
 	 * All of the custom validator extensions.
 	 *
 	 * @var array
 	 */
-	protected $extensions = array();
+	protected $extensions = [];
 
 	/**
 	 * All of the custom replacer extensions.
 	 *
 	 * @var array
 	 */
-	protected $replacers = array();
+	protected $replacers = [];
 
 	/**
 	 * The size related validation rules.
 	 *
 	 * @var array
 	 */
-	protected $sizeRules = array('Size', 'Between', 'Min', 'Max');
+	protected $sizeRules = ['Size', 'Between', 'Min', 'Max'];
 
 	/**
 	 * The numeric related validation rules.
 	 *
 	 * @var array
 	 */
-	protected $numericRules = array('Numeric', 'Integer');
+	protected $numericRules = ['Numeric', 'Integer'];
 
 	/**
 	 * The validation rules that imply the field is required.
 	 *
 	 * @var array
 	 */
-	protected $implicitRules = array(
+	protected $implicitRules = [
 		'Required', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll', 'RequiredIf', 'Accepted',
-	);
+	];
 
 	/**
 	 * Create a new Validator instance.
@@ -156,7 +156,7 @@ class Validator implements ValidatorContract {
 	 * @param  array  $customAttributes
 	 * @return void
 	 */
-	public function __construct(TranslatorInterface $translator, array $data, array $rules, array $messages = array(), array $customAttributes = array())
+	public function __construct(TranslatorInterface $translator, array $data, array $rules, array $messages = [], array $customAttributes = [])
 	{
 		$this->translator = $translator;
 		$this->customMessages = $messages;
@@ -176,7 +176,7 @@ class Validator implements ValidatorContract {
 	{
 		if (is_null($arrayKey))
 		{
-			$this->files = array();
+			$this->files = [];
 		}
 
 		foreach ($data as $key => $value)
@@ -301,7 +301,7 @@ class Validator implements ValidatorContract {
 	{
 		$current = isset($this->rules[$attribute]) ? $this->rules[$attribute] : [];
 
-		$merge = head($this->explodeRules(array($rules)));
+		$merge = head($this->explodeRules([$rules]));
 
 		$this->rules[$attribute] = array_merge($current, $merge);
 	}
@@ -453,7 +453,7 @@ class Validator implements ValidatorContract {
 	 */
 	protected function passesOptionalCheck($attribute)
 	{
-		if ($this->hasRule($attribute, array('Sometimes')))
+		if ($this->hasRule($attribute, ['Sometimes']))
 		{
 			return array_key_exists($attribute, array_dot($this->data))
 				|| in_array($attribute, array_keys($this->data))
@@ -743,7 +743,7 @@ class Validator implements ValidatorContract {
 	 */
 	protected function validateConfirmed($attribute, $value)
 	{
-		return $this->validateSame($attribute, $value, array($attribute.'_confirmation'));
+		return $this->validateSame($attribute, $value, [$attribute.'_confirmation']);
 	}
 
 	/**
@@ -791,7 +791,7 @@ class Validator implements ValidatorContract {
 	 */
 	protected function validateAccepted($attribute, $value)
 	{
-		$acceptable = array('yes', 'on', '1', 1, true, 'true');
+		$acceptable = ['yes', 'on', '1', 1, true, 'true'];
 
 		return $this->validateRequired($attribute, $value) && in_array($value, $acceptable, true);
 	}
@@ -817,7 +817,7 @@ class Validator implements ValidatorContract {
 	 */
 	protected function validateBoolean($attribute, $value)
 	{
-		$acceptable = array(true, false, 0, 1, '0', '1');
+		$acceptable = [true, false, 0, 1, '0', '1'];
 
 		return in_array($value, $acceptable, true);
 	}
@@ -1034,7 +1034,7 @@ class Validator implements ValidatorContract {
 		// assume that this column to be verified shares the attribute's name.
 		$column = isset($parameters[1]) ? $parameters[1] : $attribute;
 
-		list($idColumn, $id) = array(null, null);
+		list($idColumn, $id) = [null, null];
 
 		if (isset($parameters[2]))
 		{
@@ -1067,7 +1067,7 @@ class Validator implements ValidatorContract {
 	{
 		$idColumn = isset($parameters[3]) ? $parameters[3] : 'id';
 
-		return array($idColumn, $parameters[2]);
+		return [$idColumn, $parameters[2]];
 	}
 
 	/**
@@ -1083,7 +1083,7 @@ class Validator implements ValidatorContract {
 			return $this->getExtraConditions(array_slice($parameters, 4));
 		}
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -1152,7 +1152,7 @@ class Validator implements ValidatorContract {
 	 */
 	protected function getExtraConditions(array $segments)
 	{
-		$extra = array();
+		$extra = [];
 
 		$count = count($segments);
 
@@ -1209,7 +1209,7 @@ class Validator implements ValidatorContract {
 	 */
 	protected function validateActiveUrl($attribute, $value)
 	{
-		$url = str_replace(array('http://', 'https://', 'ftp://'), '', strtolower($value));
+		$url = str_replace(['http://', 'https://', 'ftp://'], '', strtolower($value));
 
 		return checkdnsrr($url, 'A');
 	}
@@ -1223,7 +1223,7 @@ class Validator implements ValidatorContract {
 	 */
 	protected function validateImage($attribute, $value)
 	{
-		return $this->validateMimes($attribute, $value, array('jpeg', 'png', 'gif', 'bmp', 'svg'));
+		return $this->validateMimes($attribute, $value, ['jpeg', 'png', 'gif', 'bmp', 'svg']);
 	}
 
 	/**
@@ -1566,7 +1566,7 @@ class Validator implements ValidatorContract {
 	{
 		$source = $source ?: $this->customMessages;
 
-		$keys = array("{$attribute}.{$lowerRule}", $lowerRule);
+		$keys = ["{$attribute}.{$lowerRule}", $lowerRule];
 
 		// First we will check for a custom message for an attribute specific rule
 		// message for the fields, then we will check for a general custom line
@@ -1613,7 +1613,7 @@ class Validator implements ValidatorContract {
 		{
 			return 'numeric';
 		}
-		elseif ($this->hasRule($attribute, array('Array')))
+		elseif ($this->hasRule($attribute, ['Array']))
 		{
 			return 'array';
 		}
@@ -1658,7 +1658,7 @@ class Validator implements ValidatorContract {
 	 */
 	protected function getAttributeList(array $values)
 	{
-		$attributes = array();
+		$attributes = [];
 
 		// For each attribute in the list we will simply get its displayable form as
 		// this is convenient when replacing lists of parameters like some of the
@@ -1738,7 +1738,7 @@ class Validator implements ValidatorContract {
 	 */
 	protected function replaceBetween($message, $attribute, $rule, $parameters)
 	{
-		return str_replace(array(':min', ':max'), $parameters, $message);
+		return str_replace([':min', ':max'], $parameters, $message);
 	}
 
 	/**
@@ -1931,7 +1931,7 @@ class Validator implements ValidatorContract {
 
 		$parameters[0] = $this->getAttribute($parameters[0]);
 
-		return str_replace(array(':other', ':value'), $parameters, $message);
+		return str_replace([':other', ':value'], $parameters, $message);
 	}
 
 	/**
@@ -2069,7 +2069,7 @@ class Validator implements ValidatorContract {
 	 */
 	protected function parseArrayRule(array $rules)
 	{
-		return array(studly_case(trim(array_get($rules, 0))), array_slice($rules, 1));
+		return [studly_case(trim(array_get($rules, 0))), array_slice($rules, 1)];
 	}
 
 	/**
@@ -2092,7 +2092,7 @@ class Validator implements ValidatorContract {
 			$parameters = $this->parseParameters($rules, $parameter);
 		}
 
-		return array(studly_case(trim($rules)), $parameters);
+		return [studly_case(trim($rules)), $parameters];
 	}
 
 	/**
@@ -2104,7 +2104,7 @@ class Validator implements ValidatorContract {
 	 */
 	protected function parseParameters($rule, $parameter)
 	{
-		if (strtolower($rule) == 'regex') return array($parameter);
+		if (strtolower($rule) == 'regex') return [$parameter];
 
 		return str_getcsv($parameter);
 	}
@@ -2534,7 +2534,7 @@ class Validator implements ValidatorContract {
 	{
 		list($class, $method) = explode('@', $callback);
 
-		return call_user_func_array(array($this->container->make($class), $method), $parameters);
+		return call_user_func_array([$this->container->make($class), $method], $parameters);
 	}
 
 	/**
@@ -2574,7 +2574,7 @@ class Validator implements ValidatorContract {
 	{
 		list($class, $method) = explode('@', $callback);
 
-		return call_user_func_array(array($this->container->make($class), $method), array_slice(func_get_args(), 1));
+		return call_user_func_array([$this->container->make($class), $method], array_slice(func_get_args(), 1));
 	}
 
 	/**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -7,7 +7,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 *
 	 * @var array
 	 */
-	protected $extensions = array();
+	protected $extensions = [];
 
 	/**
 	 * The file currently being compiled.
@@ -21,33 +21,33 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 *
 	 * @var array
 	 */
-	protected $compilers = array(
+	protected $compilers = [
 		'Extensions',
 		'Statements',
 		'Comments',
 		'Echos',
-	);
+	];
 
 	/**
 	 * Array of opening and closing tags for raw echos.
 	 *
 	 * @var array
 	 */
-	protected $rawTags = array('{!!', '!!}');
+	protected $rawTags = ['{!!', '!!}'];
 
 	/**
 	 * Array of opening and closing tags for regular echos.
 	 *
 	 * @var array
 	 */
-	protected $contentTags = array('{{', '}}');
+	protected $contentTags = ['{{', '}}'];
 
 	/**
 	 * Array of opening and closing tags for escaped echos.
 	 *
 	 * @var array
 	 */
-	protected $escapedTags = array('{{{', '}}}');
+	protected $escapedTags = ['{{{', '}}}'];
 
 	/**
 	 * The "regular" / legacy echo string format.
@@ -61,7 +61,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 *
 	 * @var array
 	 */
-	protected $footer = array();
+	protected $footer = [];
 
 	/**
 	 * Counter to keep track of nested forelse statements.
@@ -78,7 +78,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function compile($path = null)
 	{
-		$this->footer = array();
+		$this->footer = [];
 
 		if ($path)
 		{
@@ -626,7 +626,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 			$expression = substr($expression, 1, -1);
 		}
 
-		$data = "<?php echo \$__env->make($expression, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+		$data = "<?php echo \$__env->make($expression, array_except(get_defined_vars(), ['__data', '__path']))->render(); ?>";
 
 		$this->footer[] = $data;
 
@@ -646,7 +646,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 			$expression = substr($expression, 1, -1);
 		}
 
-		return "<?php echo \$__env->make($expression, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
+		return "<?php echo \$__env->make($expression, array_except(get_defined_vars(), ['__data', '__path']))->render(); ?>";
 	}
 
 	/**
@@ -735,7 +735,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function setRawTags($openTag, $closeTag)
 	{
-		$this->rawTags = array(preg_quote($openTag), preg_quote($closeTag));
+		$this->rawTags = [preg_quote($openTag), preg_quote($closeTag)];
 	}
 
 	/**
@@ -750,7 +750,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	{
 		$property = ($escaped === true) ? 'escapedTags' : 'contentTags';
 
-		$this->{$property} = array(preg_quote($openTag), preg_quote($closeTag));
+		$this->{$property} = [preg_quote($openTag), preg_quote($closeTag)];
 	}
 
 	/**

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -17,7 +17,7 @@ class CompilerEngine extends PhpEngine {
 	 *
 	 * @var array
 	 */
-	protected $lastCompiled = array();
+	protected $lastCompiled = [];
 
 	/**
 	 * Create a new Blade view engine instance.
@@ -37,7 +37,7 @@ class CompilerEngine extends PhpEngine {
 	 * @param  array   $data
 	 * @return string
 	 */
-	public function get($path, array $data = array())
+	public function get($path, array $data = [])
 	{
 		$this->lastCompiled[] = $path;
 

--- a/src/Illuminate/View/Engines/EngineInterface.php
+++ b/src/Illuminate/View/Engines/EngineInterface.php
@@ -9,6 +9,6 @@ interface EngineInterface {
 	 * @param  array   $data
 	 * @return string
 	 */
-	public function get($path, array $data = array());
+	public function get($path, array $data = []);
 
 }

--- a/src/Illuminate/View/Engines/EngineResolver.php
+++ b/src/Illuminate/View/Engines/EngineResolver.php
@@ -10,14 +10,14 @@ class EngineResolver {
 	 *
 	 * @var array
 	 */
-	protected $resolvers = array();
+	protected $resolvers = [];
 
 	/**
 	 * The resolved engine instances.
 	 *
 	 * @var array
 	 */
-	protected $resolved = array();
+	protected $resolved = [];
 
 	/**
 	 * Register a new engine resolver.

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -11,7 +11,7 @@ class PhpEngine implements EngineInterface {
 	 * @param  array   $data
 	 * @return string
 	 */
-	public function get($path, array $data = array())
+	public function get($path, array $data = [])
 	{
 		return $this->evaluatePath($path, $data);
 	}

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -43,49 +43,49 @@ class Factory implements FactoryContract {
 	 *
 	 * @var array
 	 */
-	protected $shared = array();
+	protected $shared = [];
 
 	/**
 	 * Array of registered view name aliases.
 	 *
 	 * @var array
 	 */
-	protected $aliases = array();
+	protected $aliases = [];
 
 	/**
 	 * All of the registered view names.
 	 *
 	 * @var array
 	 */
-	protected $names = array();
+	protected $names = [];
 
 	/**
 	 * The extension to engine bindings.
 	 *
 	 * @var array
 	 */
-	protected $extensions = array('blade.php' => 'blade', 'php' => 'php');
+	protected $extensions = ['blade.php' => 'blade', 'php' => 'php'];
 
 	/**
 	 * The view composer events.
 	 *
 	 * @var array
 	 */
-	protected $composers = array();
+	protected $composers = [];
 
 	/**
 	 * All of the finished, captured sections.
 	 *
 	 * @var array
 	 */
-	protected $sections = array();
+	protected $sections = [];
 
 	/**
 	 * The stack of in-progress sections.
 	 *
 	 * @var array
 	 */
-	protected $sectionStack = array();
+	protected $sectionStack = [];
 
 	/**
 	 * The number of active rendering operations.
@@ -119,7 +119,7 @@ class Factory implements FactoryContract {
 	 * @param  array   $mergeData
 	 * @return \Illuminate\View\View
 	 */
-	public function file($path, $data = array(), $mergeData = array())
+	public function file($path, $data = [], $mergeData = [])
 	{
 		$data = array_merge($mergeData, $this->parseData($data));
 
@@ -136,7 +136,7 @@ class Factory implements FactoryContract {
 	 * @param  array   $mergeData
 	 * @return \Illuminate\View\View
 	 */
-	public function make($view, $data = array(), $mergeData = array())
+	public function make($view, $data = [], $mergeData = [])
 	{
 		if (isset($this->aliases[$view])) $view = $this->aliases[$view];
 
@@ -190,7 +190,7 @@ class Factory implements FactoryContract {
 	 * @param  mixed   $data
 	 * @return \Illuminate\View\View
 	 */
-	public function of($view, $data = array())
+	public function of($view, $data = [])
 	{
 		return $this->make($this->names[$view], $data);
 	}
@@ -259,7 +259,7 @@ class Factory implements FactoryContract {
 		{
 			foreach ($data as $key => $value)
 			{
-				$data = array('key' => $key, $iterator => $value);
+				$data = ['key' => $key, $iterator => $value];
 
 				$result .= $this->make($view, $data)->render();
 			}
@@ -345,7 +345,7 @@ class Factory implements FactoryContract {
 	 */
 	public function creator($views, $callback)
 	{
-		$creators = array();
+		$creators = [];
 
 		foreach ((array) $views as $view)
 		{
@@ -363,7 +363,7 @@ class Factory implements FactoryContract {
 	 */
 	public function composers(array $composers)
 	{
-		$registered = array();
+		$registered = [];
 
 		foreach ($composers as $callback => $views)
 		{
@@ -383,7 +383,7 @@ class Factory implements FactoryContract {
 	 */
 	public function composer($views, $callback, $priority = null)
 	{
-		$composers = array();
+		$composers = [];
 
 		foreach ((array) $views as $view)
 		{
@@ -477,7 +477,7 @@ class Factory implements FactoryContract {
 		// given arguments that are passed to the Closure as the composer's data.
 		return function() use ($class, $method)
 		{
-			$callable = array($this->container->make($class), $method);
+			$callable = [$this->container->make($class), $method];
 
 			return call_user_func_array($callable, func_get_args());
 		};
@@ -499,7 +499,7 @@ class Factory implements FactoryContract {
 
 		$method = str_contains($prefix, 'composing') ? 'compose' : 'create';
 
-		return array($class, $method);
+		return [$class, $method];
 	}
 
 	/**
@@ -510,7 +510,7 @@ class Factory implements FactoryContract {
 	 */
 	public function callComposer(View $view)
 	{
-		$this->events->fire('composing: '.$view->getName(), array($view));
+		$this->events->fire('composing: '.$view->getName(), [$view]);
 	}
 
 	/**
@@ -521,7 +521,7 @@ class Factory implements FactoryContract {
 	 */
 	public function callCreator(View $view)
 	{
-		$this->events->fire('creating: '.$view->getName(), array($view));
+		$this->events->fire('creating: '.$view->getName(), [$view]);
 	}
 
 	/**
@@ -658,9 +658,9 @@ class Factory implements FactoryContract {
 	 */
 	public function flushSections()
 	{
-		$this->sections = array();
+		$this->sections = [];
 
-		$this->sectionStack = array();
+		$this->sectionStack = [];
 	}
 
 	/**
@@ -757,7 +757,7 @@ class Factory implements FactoryContract {
 
 		unset($this->extensions[$extension]);
 
-		$this->extensions = array_merge(array($extension => $engine), $this->extensions);
+		$this->extensions = array_merge([$extension => $engine], $this->extensions);
 	}
 
 	/**

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -24,21 +24,21 @@ class FileViewFinder implements ViewFinderInterface {
 	 *
 	 * @var array
 	 */
-	protected $views = array();
+	protected $views = [];
 
 	/**
 	 * The namespace to file path hints.
 	 *
 	 * @var array
 	 */
-	protected $hints = array();
+	protected $hints = [];
 
 	/**
 	 * Register a view extension with the finder.
 	 *
 	 * @var array
 	 */
-	protected $extensions = array('blade.php', 'php');
+	protected $extensions = ['blade.php', 'php'];
 
 	/**
 	 * Create a new file view loader instance.

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -57,7 +57,7 @@ class View implements ArrayAccess, ViewContract {
 	 * @param  array   $data
 	 * @return void
 	 */
-	public function __construct(Factory $factory, EngineInterface $engine, $view, $path, $data = array())
+	public function __construct(Factory $factory, EngineInterface $engine, $view, $path, $data = [])
 	{
 		$this->view = $view;
 		$this->path = $path;
@@ -185,7 +185,7 @@ class View implements ArrayAccess, ViewContract {
 	 * @param  array   $data
 	 * @return $this
 	 */
-	public function nest($key, $view, array $data = array())
+	public function nest($key, $view, array $data = [])
 	{
 		return $this->with($key, $this->factory->make($view, $data));
 	}

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -36,7 +36,7 @@ class ViewServiceProvider extends ServiceProvider {
 			// Next we will register the various engines with the resolver so that the
 			// environment can resolve the engines it needs for various views based
 			// on the extension of view files. We call a method for each engines.
-			foreach (array('php', 'blade') as $engine)
+			foreach (['php', 'blade'] as $engine)
 			{
 				$this->{'register'.ucfirst($engine).'Engine'}($resolver);
 			}

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -188,13 +188,13 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
 		$string = '@extends(\'foo\')
 test';
-		$expected = "test".PHP_EOL.'<?php echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+		$expected = "test".PHP_EOL.'<?php echo $__env->make(\'foo\', array_except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
 		$this->assertEquals($expected, $compiler->compileString($string));
 
 
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
 		$string = '@extends(name(foo))'.PHP_EOL.'test';
-		$expected = "test".PHP_EOL.'<?php echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+		$expected = "test".PHP_EOL.'<?php echo $__env->make(name(foo), array_except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
 		$this->assertEquals($expected, $compiler->compileString($string));
 	}
 
@@ -445,8 +445,8 @@ empty
 	public function testIncludesAreCompiled()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
-		$this->assertEquals('<?php echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@include(\'foo\')'));
-		$this->assertEquals('<?php echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@include(name(foo))'));
+		$this->assertEquals('<?php echo $__env->make(\'foo\', array_except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $compiler->compileString('@include(\'foo\')'));
+		$this->assertEquals('<?php echo $__env->make(name(foo), array_except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $compiler->compileString('@include(name(foo))'));
 	}
 
 


### PR DESCRIPTION
Laravel uses both the long array declaration syntax and the PHP >=5.4 short syntax interchangeably, with no apparent pattern. This PR intends to standardize all array declarations to use the short syntax.

This only touches the src folder and one test file which was affected by the changes. If this PR is accepted I may implement this standardization on all test files as well.
