### PR TITLE
[5.0] Add reset method to migrator to fix infinite loop.

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -56,19 +56,14 @@ class ResetCommand extends Command {
 
 		$pretend = $this->input->getOption('pretend');
 
-		while (true)
+		$this->migrator->reset($pretend);
+
+		// Once the migrator has run we will grab the note output and send it out to
+		// the console screen, since the migrator itself functions without having
+		// any instances of the OutputInterface contract passed into the class.
+		foreach ($this->migrator->getNotes() as $note)
 		{
-			$count = $this->migrator->rollback($pretend);
-
-			// Once the migrator has run we will grab the note output and send it out to
-			// the console screen, since the migrator itself functions without having
-			// any instances of the OutputInterface contract passed into the class.
-			foreach ($this->migrator->getNotes() as $note)
-			{
-				$this->output->writeln($note);
-			}
-
-			if ($count == 0) break;
+			$this->output->writeln($note);
 		}
 	}
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -176,6 +176,33 @@ class Migrator {
 	}
 
 	/**
+	 * Rolls all of the currently applied migrations back.
+	 *
+	 * @param  bool  $pretend
+	 * @return int
+	 */
+	public function reset($pretend = false)
+	{
+		$this->notes = [];
+
+		$migrations = array_reverse($this->repository->getRan());
+
+		if (count($migrations) == 0)
+		{
+			$this->note('<info>Nothing to rollback.</info>');
+
+			return count($migrations);
+		}
+
+		foreach ($migrations as $migration)
+		{
+			$this->runDown((object) ['migration' => $migration], $pretend);
+		}
+
+		return count($migrations);
+	}
+
+	/**
 	 * Run "down" a migration instance.
 	 *
 	 * @param  object  $migration

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -16,8 +16,8 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 		$command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
 		$command->setLaravel(new AppDatabaseMigrationStub());
 		$migrator->shouldReceive('setConnection')->once()->with(null);
-		$migrator->shouldReceive('rollback')->twice()->with(false)->andReturn(true, false);
-		$migrator->shouldReceive('getNotes')->andReturn(array());
+		$migrator->shouldReceive('reset')->once()->with(false);
+		$migrator->shouldReceive('getNotes')->andReturn([]);
 
 		$this->runCommand($command);
 	}
@@ -28,8 +28,8 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 		$command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
 		$command->setLaravel(new AppDatabaseMigrationStub());
 		$migrator->shouldReceive('setConnection')->once()->with('foo');
-		$migrator->shouldReceive('rollback')->twice()->with(true)->andReturn(true, false);
-		$migrator->shouldReceive('getNotes')->andReturn(array());
+		$migrator->shouldReceive('reset')->once()->with(true);
+		$migrator->shouldReceive('getNotes')->andReturn([]);
 
 		$this->runCommand($command, array('--pretend' => true, '--database' => 'foo'));
 	}
@@ -39,6 +39,7 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 	{
 		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
 	}
+
 }
 
 class AppDatabaseMigrationStub extends \Illuminate\Foundation\Application {


### PR DESCRIPTION
This adds a `reset` method to the `Migrator` class in order to fix #8262 and move some migration logic out of the console command. Everything else still functions as before, but it is now possible to call `migrate:reset` with the `--pretend` option without it going into an infinite loop.
The tests associated with the console command were altered accordingly and new test were added for the `reset` method. Moving the logic into a new method also removed the reliance on a `while(true)` loop which wasn't easily testable.
