### PR TITLE
[5.0] Deletes the old session from persistence on the invalidating

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -213,9 +213,9 @@ class Store implements SessionInterface {
 	 */
 	public function invalidate($lifetime = null)
 	{
-		$this->attributes = array();
+		$this->clear();
 
-		return $this->migrate();
+		return $this->migrate(true, $lifetime);
 	}
 
 	/**

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -84,10 +84,17 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 	{
 		$session = $this->getSession();
 		$oldId = $session->getId();
+
 		$session->set('foo','bar');
 		$this->assertGreaterThan(0, count($session->all()));
-		$session->getHandler()->shouldReceive('destroy')->never();
+
+		$session->flash('name', 'Taylor');
+		$this->assertTrue($session->has('name'));
+
+		$session->getHandler()->shouldReceive('destroy')->once()->with($oldId);
 		$this->assertTrue($session->invalidate());
+
+		$this->assertFalse($session->has('name'));
 		$this->assertNotEquals($oldId, $session->getId());
 		$this->assertCount(0, $session->all());
 	}


### PR DESCRIPTION
Now the `invalidate()` clears all session attributes, regenerates and deletes the old session.
