### PR TITLE
[5.0] Fix (?) Blade's createOpenMatcher()

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -712,7 +712,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function createOpenMatcher($function)
 	{
-		return '/(?<!\w)(\s*)@'.$function.'(\s*\(.*)\)/';
+		return '/(?<!\w)(\s*)@'.$function.'\s*\((.*)\)/';
 	}
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -584,6 +584,28 @@ empty
 	}
 
 
+	public function testCreateOpenMatcher()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$compiler->extend(
+			function($view, BladeCompiler $compiler)
+			{
+				$pattern = $compiler->createOpenMatcher('datetime');
+				$replace = '<?php echo $2->format(\'m/d/Y H:i\'); ?>';
+				return preg_replace($pattern, '$1'.$replace, $view);
+			}
+		);
+
+		$string = '@if($foo)
+@datetime($var)
+@endif';
+		$expected = '<?php if($foo): ?>
+<?php echo $var->format(\'m/d/Y H:i\'); ?>
+<?php endif; ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
+
+
 	public function testConfiguringContentTags()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
That regex included the opening, but not the closing paren in its match. Reported in #8228 by @Arrilot.

Some things to consider:
- There might have been some weird reason to include the opening paren. After all, it was still possible to generate valid PHP code, but the patterns and replacements looked very weird.
- The method is not used anywhere in the source code. It was part of the example in the docs, that was unfortunately completely [removed](https://github.com/laravel/docs/commit/918256fbc30ec5e56f6eb2277eb67bffdb45c13b). :cry: Should be added again if this gets merged.
