### PR TITLE
Add ability to configure remember me cookie as secure and httpOnly.

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -352,7 +352,7 @@ class Guard implements GuardContract {
 	 * @param  bool   $login
 	 * @return bool
 	 */
-	public function attempt(array $credentials = [], $remember = false, $login = true)
+	public function attempt(array $credentials = [], $remember = false, $login = true, $secure = false, $httpOnly = true)
 	{
 		$this->fireAttemptEvent($credentials, $remember, $login);
 
@@ -363,7 +363,7 @@ class Guard implements GuardContract {
 		// fact valid we'll log the users into the application and return true.
 		if ($this->hasValidCredentials($user, $credentials))
 		{
-			if ($login) $this->login($user, $remember);
+			if ($login) $this->login($user, $remember, $secure, $httpOnly);
 
 			return true;
 		}

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -422,7 +422,7 @@ class Guard implements GuardContract {
 	 * @param  bool  $remember
 	 * @return void
 	 */
-	public function login(UserContract $user, $remember = false)
+	public function login(UserContract $user, $remember = false, $secure = false, $httpOnly = true)
 	{
 		$this->updateSession($user->getAuthIdentifier());
 
@@ -433,7 +433,7 @@ class Guard implements GuardContract {
 		{
 			$this->createRememberTokenIfDoesntExist($user);
 
-			$this->queueRecallerCookie($user);
+			$this->queueRecallerCookie($user, $secure, $httpOnly);
 		}
 
 		// If we have an event dispatcher instance set we will fire an event so that
@@ -507,11 +507,11 @@ class Guard implements GuardContract {
 	 * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
 	 * @return void
 	 */
-	protected function queueRecallerCookie(UserContract $user)
+	protected function queueRecallerCookie(UserContract $user, $secure = false, $httpOnly = true)
 	{
 		$value = $user->getAuthIdentifier().'|'.$user->getRememberToken();
 
-		$this->getCookieJar()->queue($this->createRecaller($value));
+		$this->getCookieJar()->queue($this->createRecaller($value, $secure, $httpOnly));
 	}
 
 	/**
@@ -520,9 +520,9 @@ class Guard implements GuardContract {
 	 * @param  string  $value
 	 * @return \Symfony\Component\HttpFoundation\Cookie
 	 */
-	protected function createRecaller($value)
+	protected function createRecaller($value, $secure = false, $httpOnly = true)
 	{
-		return $this->getCookieJar()->forever($this->getRecallerName(), $value);
+		return $this->getCookieJar()->forever($this->getRecallerName(), $value, null, null, $secure, $httpOnly);
 	}
 
 	/**


### PR DESCRIPTION
Add ability to configure remember me cookie as secure and httpOnly. The default values of CookieJar::forever() is kept for backwards compatibility.
