### PR TITLE
[5.0] Model : $key calculated only if necessary

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -697,9 +697,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function fresh(array $with = array())
 	{
+		if ( ! $this->exists) return;
+
 		$key = $this->getKeyName();
 
-		return $this->exists ? static::with($with)->where($key, $this->getKey())->first() : null;
+		return static::with($with)->where($key, $this->getKey())->first();
 	}
 
 	/**


### PR DESCRIPTION
`$key` does not need to be calculated if the model does not exist.
