### PR TITLE
[5.0] Request : useless array cast

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -543,7 +543,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	{
 		if ( ! isset($this->json))
 		{
-			$this->json = new ParameterBag((array) json_decode($this->getContent(), true));
+			$this->json = new ParameterBag(json_decode($this->getContent(), true));
 		}
 
 		if (is_null($key)) return $this->json;


### PR DESCRIPTION
As `json_decode($this->getContent(), true)` already returns an array
