### PR TITLE
[5.0] Extract credentials retrieval to method

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesAndRegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesAndRegistersUsers.php
@@ -74,7 +74,7 @@ trait AuthenticatesAndRegistersUsers {
 			'email' => 'required|email', 'password' => 'required',
 		]);
 
-		$credentials = $request->only('email', 'password');
+		$credentials = $this->getCredentials($request);
 
 		if ($this->auth->attempt($credentials, $request->has('remember')))
 		{
@@ -96,6 +96,16 @@ trait AuthenticatesAndRegistersUsers {
 	protected function getFailedLoginMessage()
 	{
 		return 'These credentials do not match our records.';
+	}
+
+	/**
+	 * @param Request $request
+	 *
+	 * @return array
+	 */
+	protected function getCredentials(Request $request)
+	{
+		return $request->only('email', 'password');
 	}
 
 	/**


### PR DESCRIPTION
Having such in AuthenticatesAndRegistersUsers trait, it makes possible to override only getCredentials method, so while authenticating users, we can also check other fields.
e.g. in AuthController

```
protected function getCredentials(Request $request)
{
    return array_merge($request->only('email', 'password'), ['is_active' => true]);
}
```
