### PR TITLE
[5.0] Added support for relative URLs in queue:subscribe

### DIFF
--- a/src/Illuminate/Queue/Console/SubscribeCommand.php
+++ b/src/Illuminate/Queue/Console/SubscribeCommand.php
@@ -91,7 +91,15 @@ class SubscribeCommand extends Command {
 	{
 		$subscribers = $this->getCurrentSubscribers();
 
-		$subscribers[] = array('url' => $this->argument('url'));
+		$url = $this->argument('url');
+
+		// If the provided url is not in a full format, convert it into one.
+		if ( ! starts_with($url, ['http://', 'https://']))
+		{
+			$url = app('url')->to($url);
+		}
+
+		$subscribers[] = array('url' => $url);
 
 		return $subscribers;
 	}


### PR DESCRIPTION
Currently you need to enter a full URL when executing a `php artisan queue:subscribe` command. I'm adding a simple check to convert a non-full URL to a full one (environment-based), so that we can run something like `php artisan queue:subscribe laravel queue/receive` everywhere.
