### PR TITLE
[5.0] More Specific DocBlocks

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1578,7 +1578,7 @@ class Builder {
 	 * Retrieve the minimum value of a given column.
 	 *
 	 * @param  string  $column
-	 * @return mixed
+	 * @return float|int
 	 */
 	public function min($column)
 	{
@@ -1589,7 +1589,7 @@ class Builder {
 	 * Retrieve the maximum value of a given column.
 	 *
 	 * @param  string  $column
-	 * @return mixed
+	 * @return float|int
 	 */
 	public function max($column)
 	{
@@ -1600,7 +1600,7 @@ class Builder {
 	 * Retrieve the sum of the values of a given column.
 	 *
 	 * @param  string  $column
-	 * @return mixed
+	 * @return float|int
 	 */
 	public function sum($column)
 	{
@@ -1613,7 +1613,7 @@ class Builder {
 	 * Retrieve the average of the values of a given column.
 	 *
 	 * @param  string  $column
-	 * @return mixed
+	 * @return float|int
 	 */
 	public function avg($column)
 	{
@@ -1625,7 +1625,7 @@ class Builder {
 	 *
 	 * @param  string  $function
 	 * @param  array   $columns
-	 * @return mixed
+	 * @return float|int
 	 */
 	public function aggregate($function, $columns = array('*'))
 	{


### PR DESCRIPTION
These functions always return either an integer or a double, so we should use the most specific types possible in our return annotation. `mixed` should always be avoided when something more specific could be used, like `float|int` in this case.
