### PR TITLE
[5.0] Use str_ helper calls everywhere

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -1,6 +1,5 @@
 <?php namespace Illuminate\Database;
 
-use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Database\Connectors\ConnectionFactory;
 
@@ -82,7 +81,7 @@ class DatabaseManager implements ConnectionResolverInterface {
 	{
 		$name = $name ?: $this->getDefaultConnection();
 
-		return Str::endsWith($name, ['::read', '::write'])
+		return ends_with($name, ['::read', '::write'])
                             ? explode('::', $name, 2) : [$name, null];
 	}
 

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -1,6 +1,5 @@
 <?php namespace Illuminate\Foundation\Console;
 
-use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -55,7 +54,7 @@ class KeyGenerateCommand extends Command {
 	 */
 	protected function getRandomKey()
 	{
-		return Str::random(32);
+		return str_random(32);
 	}
 
 	/**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Str;
 use Illuminate\Container\Container;
 
 if ( ! function_exists('abort'))
@@ -626,7 +625,7 @@ if ( ! function_exists('env'))
 				return;
 		}
 
-		if (Str::startsWith($value, '"') && Str::endsWith($value, '"'))
+		if (starts_with($value, '"') && ends_with($value, '"'))
 		{
 			return substr($value, 1, -1);
 		}

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -1,6 +1,5 @@
 <?php namespace Illuminate\Routing;
 
-use Illuminate\Support\Str;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Traits\Macroable;
@@ -130,7 +129,7 @@ class ResponseFactory implements FactoryContract {
 
 		if ( ! is_null($name))
 		{
-			return $response->setContentDisposition($disposition, $name, str_replace('%', '', Str::ascii($name)));
+			return $response->setContentDisposition($disposition, $name, str_replace('%', '', ascii($name)));
 		}
 
 		return $response;

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -550,6 +550,20 @@ if ( ! function_exists('preg_replace_sub'))
 	}
 }
 
+if ( ! function_exists('ascii'))
+{
+	/**
+	 * Transliterate a UTF-8 value to ASCII.
+	 *
+	 * @param  string  $value
+	 * @return string
+	 */
+	function ascii($value)
+	{
+		return Str::ascii($value);
+	}
+}
+
 if ( ! function_exists('snake_case'))
 {
 	/**


### PR DESCRIPTION
Instead of having either `Str::` static calls, either calls to `str_` helpers functions
