### PR TITLE
[5.0] Application : fix docblock

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -21,7 +21,7 @@ class Application extends SymfonyApplication implements ApplicationContract {
 	/**
 	 * The output from the previous command.
 	 *
-	 * @var \Symfony\Component\Console\Output\OutputInterface
+	 * @var \Symfony\Component\Console\Output\BufferedOutput
 	 */
 	protected $lastOutput;
 


### PR DESCRIPTION
`$lastOutput` is a `BufferedOutput` (as we use function `fetch`)
BTW, BufferedOutput extends Output that implements OutputInterface
