### PR TITLE
[5.0] Bug report and bug fix for Support: ServiceProvider 

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -131,16 +131,13 @@ abstract class ServiceProvider {
 	 */
 	public static function pathsToPublish($provider = null, $group = null)
 	{
-		if ($provider and $group)
+		if ($provider && $group)
 		{
-			if (empty(static::$publishes[$provider]))
+			if (empty(static::$publishes[$provider]) || empty(static::$publishGroups[$group]))
 			{
 				return [];
 			}
-			if (empty(static::$publishGroups[$group]))
-			{
-				return [];
-			}
+
 			return array_intersect(static::$publishes[$provider], static::$publishGroups[$group]);
 		}
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -113,7 +113,12 @@ abstract class ServiceProvider {
 
 		if ($group)
 		{
-			static::$publishGroups[$group] = $paths;
+			if ( ! array_key_exists($group, static::$publishGroups))
+			{
+				static::$publishGroups[$group] = [];
+			}
+
+			static::$publishGroups[$group] = array_merge(static::$publishGroups[$group], $paths);
 		}
 	}
 
@@ -126,6 +131,19 @@ abstract class ServiceProvider {
 	 */
 	public static function pathsToPublish($provider = null, $group = null)
 	{
+		if ($provider and $group)
+		{
+			if (empty(static::$publishes[$provider]))
+			{
+				return [];
+			}
+			if (empty(static::$publishGroups[$group]))
+			{
+				return [];
+			}
+			return array_intersect(static::$publishes[$provider], static::$publishGroups[$group]);
+		}
+
 		if ($group && array_key_exists($group, static::$publishGroups))
 		{
 			return static::$publishGroups[$group];

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use Illuminate\Support\ServiceProvider;
+use Mockery as m;
+
+class SupportServiceProviderTest extends PHPUnit_Framework_TestCase {
+
+	public function setUp()
+	{
+		$app = m::mock('Illuminate\\Foundation\\Application')->makePartial();
+		$one = new ServiceProviderForTestingOne($app);
+		$one->boot();
+		$two = new ServiceProviderForTestingTwo($app);
+		$two->boot();
+	}
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+	public function testSimpleAssetsArePublishedCorrectly()
+	{
+		$toPublish = ServiceProvider::pathsToPublish('ServiceProviderForTestingOne');
+		$this->assertArrayHasKey('source/unmarked/one', $toPublish, 'Service provider does not return expected published path key.');
+		$this->assertArrayHasKey('source/tagged/one', $toPublish, 'Service provider does not return expected published path key.');
+		$this->assertEquals(['source/unmarked/one' => 'destination/unmarked/one', 'source/tagged/one' => 'destination/tagged/one'], $toPublish, 'Service provider does not return expected set of published paths.');
+	}
+
+	public function testMultipleAssetsArePublishedCorrectly()
+	{
+		$toPublish = ServiceProvider::pathsToPublish('ServiceProviderForTestingTwo');
+		$this->assertArrayHasKey('source/unmarked/two/a', $toPublish, 'Service provider does not return expected published path key.');
+		$this->assertArrayHasKey('source/unmarked/two/b', $toPublish, 'Service provider does not return expected published path key.');
+		$this->assertArrayHasKey('source/tagged/two/a', $toPublish, 'Service provider does not return expected published path key.');
+		$this->assertArrayHasKey('source/tagged/two/b', $toPublish, 'Service provider does not return expected published path key.');
+		$expected = [
+			'source/unmarked/two/a' => 'destination/unmarked/two/a',
+			'source/unmarked/two/b' => 'destination/unmarked/two/b',
+			'source/tagged/two/a' => 'destination/tagged/two/a',
+			'source/tagged/two/b' => 'destination/tagged/two/b',
+		];
+		$this->assertEquals($expected, $toPublish, 'Service provider does not return expected set of published paths.');
+	}
+
+	public function testSimpleTaggedAssetsArePublishedCorrectly()
+	{
+		$toPublish = ServiceProvider::pathsToPublish('ServiceProviderForTestingOne', 'some_tag');
+		$this->assertArrayNotHasKey('source/tagged/two/a', $toPublish, 'Service provider does return unexpected tagged path key.');
+		$this->assertArrayNotHasKey('source/tagged/two/b', $toPublish, 'Service provider does return unexpected tagged path key.');
+		$this->assertArrayHasKey('source/tagged/one', $toPublish, 'Service provider does not return expected tagged path key.');
+		$this->assertEquals(['source/tagged/one' => 'destination/tagged/one'], $toPublish, 'Service provider does not return expected set of published tagged paths.');
+	}
+
+	public function testMultipleTaggedAssetsArePublishedCorrectly()
+	{
+		$toPublish = ServiceProvider::pathsToPublish('ServiceProviderForTestingTwo', 'some_tag');
+		$this->assertArrayHasKey('source/tagged/two/a', $toPublish, 'Service provider does not return expected tagged path key.');
+		$this->assertArrayHasKey('source/tagged/two/b', $toPublish, 'Service provider does not return expected tagged path key.');
+		$this->assertArrayNotHasKey('source/tagged/one', $toPublish, 'Service provider does return unexpected tagged path key.');
+		$expected = [
+			'source/tagged/two/a' => 'destination/tagged/two/a',
+			'source/tagged/two/b' => 'destination/tagged/two/b',
+		];
+		$this->assertEquals($expected, $toPublish, 'Service provider does not return expected set of published tagged paths.');
+	}
+
+	public function testMultipleTaggedAssetsAreMergedCorrectly()
+	{
+		$toPublish = ServiceProvider::pathsToPublish(null, 'some_tag');
+		$this->assertArrayHasKey('source/tagged/two/a', $toPublish, 'Service provider does not return expected tagged path key.');
+		$this->assertArrayHasKey('source/tagged/two/b', $toPublish, 'Service provider does not return expected tagged path key.');
+		$this->assertArrayHasKey('source/tagged/one', $toPublish, 'Service provider does not return expected tagged path key.');
+		$expected = [
+			'source/tagged/one' => 'destination/tagged/one',
+			'source/tagged/two/a' => 'destination/tagged/two/a',
+			'source/tagged/two/b' => 'destination/tagged/two/b',
+		];
+		$this->assertEquals($expected, $toPublish, 'Service provider does not return expected set of published tagged paths.');
+	}
+}
+
+
+class ServiceProviderForTestingOne extends ServiceProvider {
+
+	public function register()
+	{
+
+	}
+
+	public function boot()
+	{
+		$this->publishes(['source/unmarked/one' => 'destination/unmarked/one']);
+		$this->publishes(['source/tagged/one' => 'destination/tagged/one'], 'some_tag');
+	}
+}
+
+
+class ServiceProviderForTestingTwo extends ServiceProvider {
+
+	public function register()
+	{
+
+	}
+
+	public function boot()
+	{
+		$this->publishes(['source/unmarked/two/a' => 'destination/unmarked/two/a']);
+		$this->publishes(['source/unmarked/two/b' => 'destination/unmarked/two/b']);
+		$this->publishes(['source/tagged/two/a' => 'destination/tagged/two/a'], 'some_tag');
+		$this->publishes(['source/tagged/two/b' => 'destination/tagged/two/b'], 'some_tag');
+	}
+}


### PR DESCRIPTION
Bug description:
- when method ServiceProvider::publishes() with non-empty $group parameter is called multiple times,
  paths provided this way are not merged (as might be expected) but overwritten
- when method ServiceProvider::pathsToPublish() with both $provider and $group parameter are called,
  parameter $provider is ignored.

This patch fixes both issues.
When method ServiceProvider::pathsToPublish() is called with both $provider and $group parameters,
only those paths, which fulfill both conditions - i.e. were registered by that specified provider and marked by that specified group - are returned.
