### PR TITLE
[5.0] Call unset only once

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -948,9 +948,7 @@ class Route {
 			throw new LogicException("Unable to prepare route [{$this->uri}] for serialization. Uses Closure.");
 		}
 
-		unset($this->container);
-
-		unset($this->compiled);
+		unset($this->container, $this->compiled);
 	}
 
 	/**


### PR DESCRIPTION
No need to call `unset` twice
