### PR TITLE
[5.0] Unset references

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -185,6 +185,8 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
 			$message = str_replace($replace, array($message, $messageKey), $format);
 		}
 
+		unset($message);
+
 		return $messages;
 	}
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1827,6 +1827,8 @@ class Validator implements ValidatorContract {
 			$parameter = $this->getDisplayableValue($attribute, $parameter);
 		}
 
+		unset($parameter);
+
 		return str_replace(':values', implode(', ', $parameters), $message);
 	}
 


### PR DESCRIPTION
Reference of a `&$value` remain even after the foreach loop, it’s a recommendation destroy it.
