### PR TITLE
[5.0] Use unguarded method for forceFill and forceCreate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -416,13 +416,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function forceFill(array $attributes)
 	{
-		static::unguard();
+		// Since some versions of PHP have a bug that prevents it from properly
+		// binding the late static context in a closure, we will first store
+		// the model in a variable, which we will then use in the closure.
+		$model = $this;
 
-		$this->fill($attributes);
-
-		static::reguard();
-
-		return $this;
+		return static::unguarded(function() use ($model, $attributes)
+		{
+			return $model->fill($attributes);
+		});
 	}
 
 	/**
@@ -537,18 +539,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public static function forceCreate(array $attributes)
 	{
-		if (static::$unguarded)
+		// Since some versions of PHP have a bug that prevents it from properly
+		// binding the late static context in a closure, we will first store
+		// the model in a variable, which we will then use in the closure.
+		$model = new static;
+
+		return static::unguarded(function() use ($model, $attributes)
 		{
-			return static::create($attributes);
-		}
-
-		static::unguard();
-
-		$model = static::create($attributes);
-
-		static::reguard();
-
-		return $model;
+			return $model->create($attributes);
+		});
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -105,6 +105,15 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testForceCreateMethodSavesNewModelWithGuardedAttributes()
+	{
+		$_SERVER['__eloquent.saved'] = false;
+		$model = EloquentModelSaveStub::forceCreate(['id' => 21]);
+		$this->assertTrue($_SERVER['__eloquent.saved']);
+		$this->assertEquals(21, $model->id);
+	}
+
+
 	public function testFindMethodCallsQueryBuilderCorrectly()
 	{
 		$result = EloquentModelFindStub::find(1);
@@ -705,6 +714,13 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testForceFillMethodFillsGuardedAttributes()
+	{
+		$model = (new EloquentModelSaveStub)->forceFill(['id' => 21]);
+		$this->assertEquals(21, $model->id);
+	}
+
+
 	public function testUnguardAllowsAnythingToBeSet()
 	{
 		$model = new EloquentModelStub;
@@ -1300,7 +1316,7 @@ class EloquentDateModelStub extends EloquentModelStub {
 
 class EloquentModelSaveStub extends Model {
 	protected $table = 'save_stub';
-	protected $guarded = array();
+	protected $guarded = ['id'];
 	public function save(array $options = array()) { $_SERVER['__eloquent.saved'] = true; }
 	public function setIncrementing($value)
 	{


### PR DESCRIPTION
In #8213 we were affected by a bug in PHP with late static binding.

The use of `unguarded` [was subsequently reverted](https://github.com/laravel/framework/commit/08467056dbfc7fd5e862d39b7b24a606a26f1893), but it unfortunately duplicated the logic in those methods. Additionally, it re-introduced the bug in `forceFill` that the original PR had fixed: if eloquent was unguarded, calling `forceFill` incorrectly reguards it.

This PR aims to fix all this, and also adds tests for both methods.
