### PR TITLE
[5.1][Console][WIP] Laravel Console Style

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -29,7 +29,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	/**
 	 * The output interface implementation.
 	 *
-	 * @var \Symfony\Component\Console\Output\OutputInterface
+	 * @var \Illuminate\Console\LaravelStyle
 	 */
 	protected $output;
 
@@ -96,7 +96,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	{
 		$this->input = $input;
 
-		$this->output = $output;
+		$this->output = new LaravelStyle($input, $output);
 
 		return parent::run($input, $output);
 	}
@@ -182,11 +182,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 */
 	public function confirm($question, $default = false)
 	{
-		$helper = $this->getHelperSet()->get('question');
-
-		$question = new ConfirmationQuestion("<question>{$question}</question> ", $default);
-
-		return $helper->ask($this->input, $this->output, $question);
+		return $this->output->confirm($question, $default);
 	}
 
 	/**
@@ -198,11 +194,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 */
 	public function ask($question, $default = null)
 	{
-		$helper = $this->getHelperSet()->get('question');
-
-		$question = new Question("<question>$question</question> ", $default);
-
-		return $helper->ask($this->input, $this->output, $question);
+		return $this->output->ask($question, $default);
 	}
 
 	/**
@@ -215,13 +207,11 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 */
 	public function askWithCompletion($question, array $choices, $default = null)
 	{
-		$helper = $this->getHelperSet()->get('question');
-
-		$question = new Question("<question>$question</question> ", $default);
+		$question = new Question($question, $default);
 
 		$question->setAutocompleterValues($choices);
 
-		return $helper->ask($this->input, $this->output, $question);
+		return $this->output->askQuestion($question);
 	}
 
 	/**
@@ -233,13 +223,11 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 */
 	public function secret($question, $fallback = true)
 	{
-		$helper = $this->getHelperSet()->get('question');
-
-		$question = new Question("<question>$question</question> ");
+		$question = new Question($question);
 
 		$question->setHidden(true)->setHiddenFallback($fallback);
 
-		return $helper->ask($this->input, $this->output, $question);
+		return $this->output->askQuestion($question);
 	}
 
 	/**
@@ -254,13 +242,11 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 */
 	public function choice($question, array $choices, $default = null, $attempts = null, $multiple = null)
 	{
-		$helper = $this->getHelperSet()->get('question');
-
-		$question = new ChoiceQuestion("<question>$question</question> ", $choices, $default);
+		$question = new ChoiceQuestion($question, $choices, $default);
 
 		$question->setMaxAttempts($attempts)->setMultiselect($multiple);
 
-		return $helper->ask($this->input, $this->output, $question);
+		return $this->output->askQuestion($question);
 	}
 
 	/**
@@ -286,7 +272,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 */
 	public function info($string)
 	{
-		$this->output->writeln("<info>$string</info>");
+		$this->output->success($string);
 	}
 
 	/**
@@ -308,7 +294,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 */
 	public function comment($string)
 	{
-		$this->output->writeln("<comment>$string</comment>");
+		$this->output->note($string);
 	}
 
 	/**
@@ -330,7 +316,7 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	 */
 	public function error($string)
 	{
-		$this->output->writeln("<error>$string</error>");
+		$this->output->error($string);
 	}
 
 	/**

--- a/src/Illuminate/Console/LaravelStyle.php
+++ b/src/Illuminate/Console/LaravelStyle.php
@@ -1,0 +1,195 @@
+<?php namespace Illuminate\Console;
+
+use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Application as ConsoleApplication;
+
+class LaravelStyle extends SymfonyStyle {
+
+	/**
+	 * The maximum line length to display.
+	 *
+	 * @var int
+	 */
+	private $lineLength;
+
+	/**
+	 * Create a new Laravel style instance.
+	 *
+	 * @param  InputInterface  $input
+	 * @param  OutputInterface  $output
+	 * @return void
+	 */
+	public function __construct(InputInterface $input, OutputInterface $output)
+	{
+		$this->lineLength = min($this->getTerminalWidth(), self::MAX_LINE_LENGTH);
+
+		parent::__construct($input, $output);
+	}
+
+	/**
+	 * Formats informational text.
+	 *
+	 * @param  string|array  $messages
+	 * @return void
+	 */
+	public function text($messages)
+	{
+		foreach ((array) $messages as $message)
+		{
+			$this->writeln($message);
+		}
+	}
+
+	/**
+	 * Formats a success result bar.
+	 *
+	 * @param  string|array  $message
+	 * @return void
+	 */
+	public function success($message)
+	{
+		$this->styledText($message, 'info');
+	}
+
+	/**
+	 * Formats a note.
+	 *
+	 * @param  string|array  $message
+	 * @return void
+	 */
+	public function note($message)
+	{
+		$this->styledText($message, 'comment');
+	}
+
+	/**
+	 * Formats an error message.
+	 *
+	 * @param  string|array  $message
+	 * @return void
+	 */
+	public function error($message)
+	{
+		$this->styledText($message, 'error');
+	}
+
+	/**
+	 * Formats a warning block.
+	 *
+	 * @param  string|array  $message
+	 * @return void
+	 */
+	public function warning($message)
+	{
+		$this->borderedBlock($message, 'comment');
+	}
+
+	/**
+	 * Formats a caution block.
+	 *
+	 * @param  string|array  $message
+	 * @return void
+	 */
+	public function caution($message)
+	{
+		$this->borderedBlock($message, 'error', '!');
+	}
+
+    /**
+     * Formats a table.
+     *
+     * @param  array $headers
+     * @param  array $rows
+     * @return void
+     */
+	public function table(array $headers, array $rows)
+	{
+		$table = new Table($this);
+
+		$table->setHeaders($headers)->setRows($rows)->setStyle('default')->render();
+	}
+
+	/**
+	 * Formats text with a given style.
+	 *
+	 * @param  string|array  $messages
+	 * @param  string|null  $style
+	 * @return void
+	 */
+	protected function styledText($messages, $style = null)
+	{
+		foreach ((array) $messages as $message)
+		{
+			if ($style)
+			{
+				$message = sprintf('<%s>%s</>', $style, $message);
+			}
+
+			$this->writeln($message);
+		}
+	}
+
+	/**
+	 * Formats a bordered block with a given style.
+	 *
+	 * @param  string|array  $messages
+	 * @param  string|null  $style
+	 * @param  string  $borderChar
+	 * @param  int  $paddingSize
+	 * @return void
+	 */
+	protected function borderedBlock($messages, $style = null, $borderChar = '*', $paddingSize = 3)
+	{
+		$lines = [];
+		$messages = (array) $messages;
+		$prefix = $borderChar . str_repeat(' ', $paddingSize);
+
+		// Get the length of the longest string
+		$length = max(array_map('Symfony\Component\Console\Helper\Helper::strlen',  $messages));
+		$length = min($length, $this->lineLength - 2 * $paddingSize - 2);
+
+		foreach ($messages as $key => $message)
+		{
+			// Explode the message if it's too long.
+			$message = OutputFormatter::escape($message);
+			$parts = explode("\n", wordwrap($message, $length));
+
+			// Add new line after each message, if not only 1 message
+			if (count($messages) > 1 && $key < count($messages) - 1) {
+				$parts[] = '';
+			}
+
+			// Add the parts with a prefix/suffix
+			foreach ($parts as $part)
+			{
+				$suffix = str_repeat(' ', $paddingSize + $length - Helper::strlen($part)) . $borderChar;
+				$lines[] = $prefix . $part . $suffix;
+			}
+		}
+
+		// Add border as first and last item in the array
+		$border = str_repeat($borderChar, $length + 2 * $paddingSize + 2);
+		$lines[] = $border;
+		array_unshift($lines, $border);
+
+		// Write all the messages in the correct style
+		$this->styledText($lines, $style);
+	}
+
+	/**
+	 * Get the width of the terminal window.
+	 *
+	 * @return int
+	 */
+	private function getTerminalWidth()
+	{
+		$application = new ConsoleApplication();
+		$dimensions = $application->getTerminalDimensions();
+
+		return $dimensions[0] ?: self::MAX_LINE_LENGTH;
+	}
+}


### PR DESCRIPTION
In Symfony 2.7, Style Guide helpers are added (see https://github.com/symfony/symfony/pull/14057 and https://github.com/symfony/symfony/commit/96b4210de5386c88b279cfc62088ef54e461c701 )

This adds a [StyleInterface](https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/Console/Style/StyleInterface.php) with a few common helpers, similar to the helpers that Laravel currently adds.

Perhaps it would be a good idea to make a Laravel Style, that perhaps extends the Symfony one. The existing helper functions could be redirected to the Style ouput, new methods can also be directed to the style helper or be available as $style for example.

The OutputStyle also implements the OutputInterface, so the Output could be changed to the OutputStyle.

Pros:
- Easier to use
- Prettier ouput
- Uniformity between commands
- Leverage Symfony helpers/code
- Interoperability with Symfony

Cons:
- Some helpers have different signatures, so might give confusion.

Example:

``` php
    public function run(InputInterface $input, OutputInterface $output)
    {
        $this->input = $input;
        $this->output = new LaravelStyle($input, $output);
        return parent::run($input, $output);
    }

    public function ask($question, $default = null)
    {
        return $this->output ->ask($question, $default);
    }
```

Table with current/symfony helpers:

| Symfony StyleInterface | Laravel Command |
| --- | --- |
| title($message) | n/a |
| section($message) | n/a |
| listing(array $elements) | n/a |
| text($message) | line($string) |
| success($message) | info($string) |
| error($message) | error($string) |
| warning($message) | (warning in ConfirmableTrait) |
| note($message) | comment($string) |
| caution($message) | n/a |
| n/a | question($string) |
| table(array $headers, array $rows) | table(array $headers, array $rows, $style = 'default') |
| ask($question, $default = null, $validator = null) | ask($question, $default = null) |
| askHidden($question, $validator = null) | secret($question, $fallback = true) |
| n/a | askWithCompletion($question, array $choices, $default = null) |
| confirm($question, $default = true) | confirm($question, $default = false) |
| choice($question, array $choices, $default = null) | choice($question, array $choices, $default = null, $attempts = null, $multiple = null) |
| newLine($count = 1) | n/a |
| progressStart($max = 0) | n/a |
| progressAdvance($step = 1) | n/a |
| progressFinish() | n/a |

As this is for 5.1 (because only in Symfony 2.7), we could change the signatures perhaps, if it's worth the BC break. Otherwise keep the existing method signatures and make the style available for new helpers.

This PR is a Work in Progress. It replaces #8306
This shows how it could work, but it should be decided which style we want to follow. The old Laravel style is a bit more 'compact' then Symfony, which has more newlines etc and more verbose errors/notes. See https://github.com/symfony/symfony/pull/14057 for screenshots.

Todo
- [x] Replace OutputInterface with LaravelStyle
- [x] Use askQuestion to reduce code in Command
- [x] Move table from Command to LaravelStyle
- [x] Move comment/info etc to LaravelStyle
- [x] Decide on preferable default format for questions, tables, blocks, errors etc in LaravelStyle.
