### PR TITLE
[5.0] Wildcard option for resource routing

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -41,9 +41,16 @@ class ResourceRegistrar {
 	 */
 	public function register($name, $controller, array $options = array())
 	{
+		$methods = $this->getResourceMethods($this->resourceDefaults, $options);
+
 		if (empty($name) || $name == '/')
 		{
-			throw new InvalidArgumentException('Resource routing is not available for root url');
+			$check = array_intersect($methods, ['store', 'show', 'edit', 'update', 'destroy']);
+
+			if (!empty($check) && !isset($options['wildcard']))
+			{
+				throw new InvalidArgumentException('Resource routing is not available for root url');
+			}
 		}
 
 		// If the resource name contains a slash, we will assume the developer wishes to
@@ -59,11 +66,9 @@ class ResourceRegistrar {
 		// We need to extract the base resource from the resource name. Nested resources
 		// are supported in the framework, but we need to know what name to use for a
 		// place-holder on the route wildcards, which should be the base resources.
-		$base = $this->getResourceWildcard(last(explode('.', $name)));
+		$base = (isset($options['wildcard'])) ? $options['wildcard'] : $this->getResourceWildcard(last(explode('.', $name)));
 
-		$defaults = $this->resourceDefaults;
-
-		foreach ($this->getResourceMethods($defaults, $options) as $m)
+		foreach ($methods as $m)
 		{
 			$this->{'addResource'.ucfirst($m)}($name, $base, $controller, $options);
 		}
@@ -204,7 +209,8 @@ class ResourceRegistrar {
 
 		if ( ! $this->router->hasGroupStack())
 		{
-			return $prefix.$resource.'.'.$method;
+			$resource = $prefix.$resource;
+			return (!empty($resource)) ? $resource.'.'.$method : $method;
 		}
 
 		return $this->getGroupResourceName($prefix, $resource, $method);

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -34,9 +34,15 @@ class ResourceRegistrar {
 	 * @param  string  $controller
 	 * @param  array   $options
 	 * @return void
+	 *
+	 * @throws \InvalidArgumentException
 	 */
 	public function register($name, $controller, array $options = array())
 	{
+		if ($name == '/')
+		{
+			throw new \InvalidArgumentException('Resource routing is not available for root url');
+		}
 		// If the resource name contains a slash, we will assume the developer wishes to
 		// register these resource routes with a prefix so we will set that up out of
 		// the box so they don't have to mess with it. Otherwise, we will continue.

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -1,5 +1,7 @@
 <?php namespace Illuminate\Routing;
 
+use InvalidArgumentException;
+
 class ResourceRegistrar {
 
 	/**
@@ -39,10 +41,11 @@ class ResourceRegistrar {
 	 */
 	public function register($name, $controller, array $options = array())
 	{
-		if ($name == '/')
+		if (empty($name) || $name == '/')
 		{
-			throw new \InvalidArgumentException('Resource routing is not available for root url');
+			throw new InvalidArgumentException('Resource routing is not available for root url');
 		}
+
 		// If the resource name contains a slash, we will assume the developer wishes to
 		// register these resource routes with a prefix so we will set that up out of
 		// the box so they don't have to mess with it. Otherwise, we will continue.

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -723,6 +723,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('prefix.foo-bars.show', $routes[0]->getName());
 	}
 
+
 	/**
 	 * @expectedException InvalidArgumentException
 	 */

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -723,6 +723,15 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('prefix.foo-bars.show', $routes[0]->getName());
 	}
 
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testResourceRoutingException()
+	{
+		$router = $this->getRouter();
+		$router->resource('/', 'FooController');
+	}
+
 
 	public function testResourceRouteNaming()
 	{

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -724,6 +724,26 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testResourceWildcard()
+	{
+		$router = $this->getRouter();
+		$router->resource('foo', 'FooController', array('only' => array('show'), 'wildcard' => 'bar'));
+		$routes = $router->getRoutes();
+		$routes = $routes->getRoutes();
+
+		$this->assertEquals('foo/{bar}', $routes[0]->getUri());
+		$this->assertEquals('foo.show', $routes[0]->getName());
+
+		$router = $this->getRouter();
+		$router->resource('/', 'FooController', array('only' => array('show'), 'wildcard' => 'bar'));
+		$routes = $router->getRoutes();
+		$routes = $routes->getRoutes();
+
+		$this->assertEquals('{bar}', $routes[0]->getUri());
+		$this->assertEquals('show', $routes[0]->getName());
+	}
+
+
 	/**
 	 * @expectedException InvalidArgumentException
 	 */


### PR DESCRIPTION
Alternative to #8335
Allows to map root uri only if it has `wildcard` option or does not require any wildcard.
