### PR TITLE
[5.0] Fixed pagination when build it manually

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -67,7 +67,8 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
 		$this->items = $this->items->slice($offset, $this->perPage + 1);
 		$this->hasMore = count($this->items) > ($this->perPage);
 
-		if ($this->hasMore) {
+		if ($this->hasMore)
+		{
 			$this->items->pop();
 		}
 	}

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -62,9 +62,14 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
 	 */
 	protected function checkForMorePages()
 	{
+		$offset = ($this->currentPage - 1) * $this->perPage;
+
+		$this->items = $this->items->slice($offset, $this->perPage + 1);
 		$this->hasMore = count($this->items) > ($this->perPage);
 
-		$this->items = $this->items->slice(0, $this->perPage);
+		if ($this->hasMore) {
+			$this->items->pop();
+		}
 	}
 
 	/**

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -157,16 +157,16 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase {
 
 	public function testSimplePaginatorReturnsRelevantContextInformation()
 	{
-		$p = new Paginator($array = ['item3', 'item4', 'item5'], 2, 2);
+		$p = new Paginator($array = ['item3', 'item4', 'item5', 'item6', 'item7'], 2, 2);
 
 		$this->assertEquals(2, $p->currentPage());
 		$this->assertTrue($p->hasPages());
 		$this->assertTrue($p->hasMorePages());
-		$this->assertEquals(['item3', 'item4'], $p->items());
+		$this->assertEquals(['item5', 'item6'], $p->items());
 
 		$this->assertEquals([
 			'per_page' => 2, 'current_page' => 2, 'next_page_url' => '/?page=3',
-			'prev_page_url' => '/?page=1', 'from' => 3, 'to' => 4, 'data' => ['item3', 'item4']
+			'prev_page_url' => '/?page=1', 'from' => 3, 'to' => 4, 'data' => ['item5', 'item6']
 		], $p->toArray());
 	}
 


### PR DESCRIPTION
When constructing the pagination manually, the list of items being returned is always the same. I believe this will fix issue #8156 
