### PR TITLE
[5.0] MessageBag : variables set only if and when necessary

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -135,9 +135,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
 		// methods is to return back an array of messages in the first place.
 		if (array_key_exists($key, $this->messages))
 		{
-			$format = $this->checkFormat($format);
-
-			return $this->transform($this->messages[$key], $format, $key);
+			return $this->transform($this->messages[$key], $this->checkFormat($format), $key);
 		}
 
 		return array();

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -130,13 +130,13 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
 	 */
 	public function get($key, $format = null)
 	{
-		$format = $this->checkFormat($format);
-
 		// If the message exists in the container, we will transform it and return
 		// the message. Otherwise, we'll return an empty array since the entire
 		// methods is to return back an array of messages in the first place.
 		if (array_key_exists($key, $this->messages))
 		{
+			$format = $this->checkFormat($format);
+
 			return $this->transform($this->messages[$key], $format, $key);
 		}
 
@@ -178,10 +178,10 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
 		// We will simply spin through the given messages and transform each one
 		// replacing the :message place holder with the real message allowing
 		// the messages to be easily formatted to each developer's desires.
+		$replace = array(':message', ':key');
+
 		foreach ($messages as &$message)
 		{
-			$replace = array(':message', ':key');
-
 			$message = str_replace($replace, array($message, $messageKey), $format);
 		}
 


### PR DESCRIPTION
- `get`: `$format` does not need to be set that early
- `transform`: `$replace` does not need to be set each time in the loop
