### PR TITLE
Fixes broken interoperability with Twig

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3351,8 +3351,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		}
 
 		$query = $this->newQuery();
-
-		return call_user_func_array(array($query, $method), $parameters);
+		if(method_exists($query, $method))
+		{
+			return call_user_func_array(array($query, $method), $parameters);
+		}
 	}
 
 	/**


### PR DESCRIPTION
BadMethodCallException happened when accessing dynamic properties of a new Model being rendered using Twig
