### PR TITLE
[5.0] Fix touchOwners() on many to many relationship.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1622,9 +1622,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		{
 			$this->$relation()->touch();
 
-			if ( ! is_null($this->$relation))
+			if ( ! is_null($this->$relation) && $this->$relation instanceof Model)
 			{
 				$this->$relation->touchOwners();
+			}
+			elseif ( ! is_null($this->$relation) && $this->$relation instanceof Collection)
+			{
+				$this->$relation->each(function (Model $relation)
+				{
+					$relation->touchOwners();
+				});
 			}
 		}
 	}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1622,16 +1622,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		{
 			$this->$relation()->touch();
 
-			if ( ! is_null($this->$relation) && $this->$relation instanceof Model)
+			if ( ! is_null($this->$relation))
 			{
-				$this->$relation->touchOwners();
-			}
-			elseif ( ! is_null($this->$relation) && $this->$relation instanceof Collection)
-			{
-				$this->$relation->each(function (Model $relation)
+				if ($this->$relation instanceof Model)
 				{
-					$relation->touchOwners();
-				});
+					$this->$relation->touchOwners();
+				}
+				elseif ($this->$relation instanceof Collection)
+				{
+					$this->$relation->each(function (Model $relation)
+					{
+						$relation->touchOwners();
+					});
+				}
 			}
 		}
 	}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1622,19 +1622,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		{
 			$this->$relation()->touch();
 
-			if ( ! is_null($this->$relation))
+			if ($this->$relation instanceof Model)
 			{
-				if ($this->$relation instanceof Model)
+				$this->$relation->touchOwners();
+			}
+			elseif ($this->$relation instanceof Collection)
+			{
+				$this->$relation->each(function (Model $relation)
 				{
-					$this->$relation->touchOwners();
-				}
-				elseif ($this->$relation instanceof Collection)
-				{
-					$this->$relation->each(function (Model $relation)
-					{
-						$relation->touchOwners();
-					});
-				}
+					$relation->touchOwners();
+				});
 			}
 		}
 	}


### PR DESCRIPTION
If we assign many to many relation to `$touches` property, we will get an exception on every call for `touchOwners()`: `Call to undefined method Illuminate\Database\Eloquent\Collection::touchOwners()`.
So I iterate on each model within collection to call `touchOwners()` method on it instead of collection instance.
