### PR TITLE
[5.0] Change Class BladeCompiler , Created methods addFooter and getFooter.

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -810,9 +810,9 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	}
 
 	/**
-	 * Add Footer
+	 * Add footer.
 	 * 
-	 * @param string $footer
+	 * @param  string $footer
 	 * @return void
 	 */
 	public function addFooter($footer)
@@ -821,7 +821,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	}
 
 	/**
-	 * Get Footer used for the compiler.
+	 * Get footer used for the compiler.
 	 * 
 	 * @return array
 	 */

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -809,4 +809,25 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 		$this->echoFormat = $format;
 	}
 
+	/**
+	 * Add Footer
+	 * 
+	 * @param string $footer
+	 * @return void
+	 */
+	public function addFooter($footer)
+	{
+		$this->footer[] = $footer;
+	}
+
+	/**
+	 * Get Footer used for the compiler.
+	 * 
+	 * @return array
+	 */
+	public function getFooter()
+	{
+		return $this->footer;
+	}
+
 }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -668,12 +668,14 @@ empty
 		$this->assertSame([$openingTag, $closingTag], $compiler->getEscapedContentTags());
 	}
 
+	
 	public function testCompileAddAndGetFooter()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
 		$compiler->addFooter('foo-bar');
 		$this->assertEquals(['foo-bar'], $compiler->getFooter());
 	}
+
 
 	public function testGetTagsProvider()
 	{

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -668,6 +668,12 @@ empty
 		$this->assertSame([$openingTag, $closingTag], $compiler->getEscapedContentTags());
 	}
 
+	public function testCompileAddAndGetFooter()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$compiler->addFooter('foo-bar');
+		$this->assertEquals(['foo-bar'], $compiler->getFooter());
+	}
 
 	public function testGetTagsProvider()
 	{


### PR DESCRIPTION
Created methods to manipulate the footer owned by BladeCompiler class.
So when using the Blade extensions, can change the behavior of extends tag.

In the example below , I changed the tag to case the request is ajax , I change the template.
eg:

``` php
Blade::extend(function($view, $compiler) {
    $pattern = '/@extends\(\s*(.+)\s*\)/';
    if (preg_match($pattern, $view, $result))
    {
        $view  = preg_replace($pattern, '', $view);
        $compiler->addFooter("<?php echo \$__env->make(Request::ajax()?'empty':{$result[1]}, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>");
     }
     return $view;
});
```
