### PR TITLE
[5.0] Adjusting Model::touchOwners to not touch on creation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1622,7 +1622,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		{
 			$this->$relation()->touch();
 
-			if ( ! is_null($this->$relation))
+			if (count($this->$relation))
 			{
 				$this->$relation->touchOwners();
 			}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1622,7 +1622,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		{
 			$this->$relation()->touch();
 
-			if (count($this->$relation))
+			if (!is_null($this->$relation) && count($this->$relation))
 			{
 				$this->$relation->touchOwners();
 			}


### PR DESCRIPTION
Fixes #6386 in 5.0. Re-post of #8128 after testing several scenarios.
