### PR TITLE
Resource route delete method

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -14,7 +14,7 @@ class ResourceRegistrar {
 	 *
 	 * @var array
 	 */
-	protected $resourceDefaults = array('index', 'create', 'store', 'show', 'edit', 'update', 'destroy');
+	protected $resourceDefaults = array('index', 'create', 'store', 'show', 'edit', 'update', 'destroy', 'delete');
 
 	/**
 	 * Create a new resource registrar instance.
@@ -387,6 +387,24 @@ class ResourceRegistrar {
 		$action = $this->getResourceAction($name, $controller, 'destroy', $options);
 
 		return $this->router->delete($uri, $action);
+	}
+
+	/**
+	 * Add the delete method for a resourceful route.
+	 *
+	 * @param  string  $name
+	 * @param  string  $base
+	 * @param  string  $controller
+	 * @param  array   $options
+	 * @return \Illuminate\Routing\Route
+	 */
+	protected function addResourceDelete($name, $base, $controller, $options)
+	{
+		$uri = $this->getResourceUri($name).'/{'.$base.'}/delete';
+
+		$action = $this->getResourceAction($name, $controller, 'delete', $options);
+
+		return $this->router->get($uri, $action);
 	}
 
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -686,7 +686,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$router = $this->getRouter();
 		$router->resource('foo', 'FooController');
 		$routes = $router->getRoutes();
-		$this->assertCount(8, $routes);
+		$this->assertCount(9, $routes);
 
 		$router = $this->getRouter();
 		$router->resource('foo', 'FooController', array('only' => array('show', 'destroy')));
@@ -698,7 +698,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$router->resource('foo', 'FooController', array('except' => array('show', 'destroy')));
 		$routes = $router->getRoutes();
 
-		$this->assertCount(6, $routes);
+		$this->assertCount(7, $routes);
 
 		$router = $this->getRouter();
 		$router->resource('foo-bars', 'FooController', array('only' => array('show')));
@@ -736,6 +736,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.edit'));
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.update'));
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.destroy'));
+		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.delete'));
 
 		$router = $this->getRouter();
 		$router->resource('foo.bar', 'FooController');
@@ -747,6 +748,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.edit'));
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.update'));
 		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.destroy'));
+		$this->assertTrue($router->getRoutes()->hasNamedRoute('foo.bar.delete'));
 
 		$router = $this->getRouter();
 		$router->resource('foo', 'FooController', array('names' => array(


### PR DESCRIPTION
This missing method gives a lot of trouble while building web form application.
If you need to quickly delete an instance from index view (e. g. table with 100+ items) - you cannot simply provide a Delete button - ajax request or a form needed.
This solution allows to build the following scheme:

| GET - Form |  | POST/PUT/DELETE - Action |
| --- | --- | --- |
| Edit | -> | Update |
| Create | -> | Store |
| Delete | -> | Destroy |
