### PR TITLE
Remove dead code (stubs) in test classes

### DIFF
--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -139,13 +139,6 @@ class BusDispatcherTestSelfHandlingCommand implements Illuminate\Contracts\Bus\S
 	}
 }
 
-class BusDispatcherTestBasicHandler {
-	public function handle(BusDispatcherTestBasicCommand $command)
-	{
-
-	}
-}
-
 class BusDispatcherTestQueuedHandler implements Illuminate\Contracts\Queue\ShouldBeQueued {
 
 }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -513,19 +513,11 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class EloquentBuilderTestModelStub extends Illuminate\Database\Eloquent\Model {}
-
 class EloquentBuilderTestScopeStub extends Illuminate\Database\Eloquent\Model {
 	public function scopeApproved($query)
 	{
 		$query->where('foo', 'bar');
 	}
-}
-
-class EloquentBuilderTestWithTrashedStub extends Illuminate\Database\Eloquent\Model {
-	use Illuminate\Database\Eloquent\SoftDeletes;
-	protected $table = 'table';
-	public function getKeyName() { return 'foo'; }
 }
 
 class EloquentBuilderTestNestedStub extends Illuminate\Database\Eloquent\Model {

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -205,13 +205,6 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 class EloquentMorphResetModelStub extends Illuminate\Database\Eloquent\Model {}
 
 
-class EloquentMorphResetBuilderStub extends Illuminate\Database\Eloquent\Builder {
-	public function __construct() { $this->query = new EloquentRelationQueryStub; }
-	public function getModel() { return new EloquentMorphResetModelStub; }
-	public function isSoftDeleting() { return false; }
-}
-
-
 class EloquentMorphQueryStub extends Illuminate\Database\Query\Builder {
 	public function __construct() {}
 }

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -91,8 +91,6 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 }
 
 
-class DatabaseEloquentPivotTestModelStub extends Illuminate\Database\Eloquent\Model {}
-
 class DatabaseEloquentPivotTestDateStub extends Illuminate\Database\Eloquent\Relations\Pivot {
 	public function getDates()
 	{

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -76,16 +76,6 @@ class EloquentRelationResetModelStub extends Illuminate\Database\Eloquent\Model 
 }
 
 
-class EloquentRelationResetStub extends Illuminate\Database\Eloquent\Builder {
-	public function __construct() { $this->query = new EloquentRelationQueryStub; }
-	public function getModel() { return new EloquentRelationResetModelStub; }
-}
-
-
-class EloquentRelationQueryStub extends Illuminate\Database\Query\Builder {
-	public function __construct() {}
-}
-
 class EloquentRelationStub extends \Illuminate\Database\Eloquent\Relations\Relation {
 	public function addConstraints() {}
 	public function addEagerConstraints(array $models) {}

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -107,17 +107,3 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase {
 	}
 
 }
-
-
-class DatabaseSoftDeletingScopeBuilderStub {
-	public $extensions = [];
-	public $onDelete;
-	public function extend($name, $callback)
-	{
-		$this->extensions[$name] = $callback;
-	}
-	public function onDelete($callback)
-	{
-		$this->onDelete = $callback;
-	}
-}

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -135,33 +135,6 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class ApplicationCustomExceptionHandlerStub extends Illuminate\Foundation\Application {
-
-	public function prepareResponse($value)
-	{
-		$response = m::mock('Symfony\Component\HttpFoundation\Response');
-		$response->shouldReceive('send')->once();
-		return $response;
-	}
-
-	protected function setExceptionHandler(Closure $handler) { return $handler; }
-
-}
-
-class ApplicationKernelExceptionHandlerStub extends Illuminate\Foundation\Application {
-
-	protected function setExceptionHandler(Closure $handler) { return $handler; }
-
-}
-
-class ApplicationGetMiddlewaresStub extends Illuminate\Foundation\Application
-{
-	public function getMiddlewares()
-	{
-		return $this->middlewares;
-	}
-}
-
 class ApplicationDeferredSharedServiceProviderStub extends Illuminate\Support\ServiceProvider {
 	protected $defer = true;
 	public function register()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1443,10 +1443,3 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 	}
 
 }
-
-
-class ValidatorTestAfterCallbackStub {
-	public function validate() {
-		$_SERVER['__validator.after.test'] = true;
-	}
-}


### PR DESCRIPTION
There were a lot of unused stubs in the bottom of test classes. This pull request removes them :)
