### PR TITLE
[5.0] Allow jsonb field key notation for postgres

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -73,7 +73,12 @@ abstract class Grammar {
 			}
 			else
 			{
-				$wrapped[] = $this->wrapValue($segment);
+				// to allow column->'name' for Postgres
+				if(strpos($segment, '->')){
+					$wrapped[] = $segment;
+				}else{
+					$wrapped[] = $this->wrapValue($segment);
+				}
 			}
 		}
 

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -73,10 +73,13 @@ abstract class Grammar {
 			}
 			else
 			{
-				// to allow column->'name' for Postgres
-				if(strpos($segment, '->')){
+				// Allow column->'name' notation for Postgres
+				if(strpos($segment, '->'))
+				{
 					$wrapped[] = $segment;
-				}else{
+				}
+				else
+				{
 					$wrapped[] = $this->wrapValue($segment);
 				}
 			}


### PR DESCRIPTION
Connected with #8240 issue. After this commit it's possible to do this

```
$content = \App\Content::where('id', '=', 1)->select('id', "title->'en' AS title")->get();
```
