### PR TITLE
[5.1] Removes a hardcoded url in ApplicationTrait

### DIFF
--- a/src/Illuminate/Foundation/Testing/ApplicationTrait.php
+++ b/src/Illuminate/Foundation/Testing/ApplicationTrait.php
@@ -71,7 +71,7 @@ trait ApplicationTrait {
 	 */
 	public function callSecure($method, $uri, $parameters = [], $cookies = [], $files = [], $server = [], $content = null)
 	{
-		$uri = 'https://localhost/'.ltrim($uri, '/');
+		$uri = $this->app['url']->secure(ltrim($uri, '/'));
 
 		return $this->response = $this->call($method, $uri, $parameters, $cookies, $files, $server, $content);
 	}


### PR DESCRIPTION
In the trait Illuminate\Foundation\Testing\ApplicationTrait the method `callSecure()` has a hardcoded URL in it (`https://localhost/`) when in reality the framework can handle the calls to a secure URI using the `secure()` method from the class Illuminate\Routing\UrlGenerator.

This PR fixes that issue.
