### PR TITLE
[5.0] Enclose PostgreSQL schema name with double quotes

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -54,7 +54,7 @@ class PostgresConnector extends Connector implements ConnectorInterface {
 		{
 			$schema = $config['schema'];
 
-			$connection->prepare("set search_path to {$schema}")->execute();
+			$connection->prepare("set search_path to \"{$schema}\"")->execute();
 		}
 
 		return $connection;

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -71,7 +71,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 		$connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(array('options')));
 		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(array('options')))->will($this->returnValue($connection));
 		$connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
-		$connection->shouldReceive('prepare')->once()->with("set search_path to public")->andReturn($connection);
+		$connection->shouldReceive('prepare')->once()->with('set search_path to "public"')->andReturn($connection);
 		$connection->shouldReceive('execute')->twice();
 		$result = $connector->connect($config);
 


### PR DESCRIPTION
Schema names must be enclosed with double quotes to prevent PDOException while setting search path to an alphanumerical value. Following exception is from a production environment (v4.2.17). (Note that the first id is a trimmed version of the second id)

[PDOException]
SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near "d959d1fa9f6f2831c1d13ff05baed"
LINE 1: set search_path to 397d959d1fa9f6f2831c1d13ff05baed
