### PR TITLE
[5.0] Add dropIfExists() support for SQL Server

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -133,6 +133,18 @@ class SqlServerGrammar extends Grammar {
 	}
 
 	/**
+	 * Compile a drop table (if exists) command.
+	 *
+	 * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+	 * @param  \Illuminate\Support\Fluent  $command
+	 * @return string
+	 */
+	public function compileDropIfExists(Blueprint $blueprint, Fluent $command)
+	{
+		return 'if exists (select * from INFORMATION_SCHEMA.TABLES where TABLE_NAME = \''.$blueprint->getTable().'\') drop table '.$blueprint->getTable();
+	}
+
+	/**
 	 * Compile a drop column command.
 	 *
 	 * @param  \Illuminate\Database\Schema\Blueprint  $blueprint


### PR DESCRIPTION
SQL Server is currently the only driver lacking dropIfExists() support, giving no warning when it is used.  This solution was tested on Windows Server 2012 running SQL Server 2014 and should be compatible with SQL Server going all the way back to v7.

The other drivers use `$this->wrapTable($blueprint)` which wraps the table name in double quotes.  SQL Server choked on this, so I've used `$blueprint->getTable()` instead.  Hope that won't be a problem.

See [this StackOverflow discussion](http://stackoverflow.com/a/14290099/161752) for more details.
