### PR TITLE
[5.0] Allow custom resource registrar injection

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -323,7 +323,16 @@ class Router implements RegistrarContract {
 	 */
 	public function resource($name, $controller, array $options = array())
 	{
-		(new ResourceRegistrar($this))->register($name, $controller, $options);
+		if ($this->container && $this->container->bound('Illuminate\Routing\ResourceRegistrar'))
+		{
+			$registrar = $this->container->make('Illuminate\Routing\ResourceRegistrar');
+		}
+		else
+		{
+			$registrar = new ResourceRegistrar($this);
+		}
+
+		$registrar->register($name, $controller, $options);
 	}
 
 	/**


### PR DESCRIPTION
As far as resource routing is harcoded and router cannot be properly replaced with a service provider (It is injected into Kernel before service providers are loaded).

This workaround allows to make a custom resource registrar with needed methods and inject it without replacing router itself.
