### PR TITLE
[4.2] Fix Model::touchOwners() for belongsToMany relationship.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1593,9 +1593,16 @@ abstract class Model implements ArrayAccess, ArrayableInterface, JsonableInterfa
 		{
 			$this->$relation()->touch();
 
-			if ( ! is_null($this->$relation))
+			if ($this->$relation instanceof Model)
 			{
 				$this->$relation->touchOwners();
+			}
+			elseif ($this->$relation instanceof Collection)
+			{
+				$this->$relation->each(function (Model $relation)
+				{
+					$relation->touchOwners();
+				});
 			}
 		}
 	}


### PR DESCRIPTION
In version 4.2 touchOwners() is called on Collection object in case that relation is BelongsToMany.

This fix is also merged in version 5.0.

This fix is copy-paste from: https://github.com/laravel/framework/blob/5.0/src/Illuminate/Database/Eloquent/Model.php#L1619
