### PR TITLE
[5.1] Add zip function to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -763,6 +763,28 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	}
 
 	/**
+	 * Zip the collection together with one or more arrays
+	 *
+	 * e.g. new Collection([1, 2, 3])->zip([4, 5, 6]);
+	 *      => [[1, 4], [2, 5], [3, 6]]
+	 *
+	 * @param  \Illuminate\Support\Collection|\Illuminate\Contracts\Support\Arrayable|array ...$items
+	 * @return static
+	 */
+	public function zip($items)
+	{
+		$arrayableItems = array_map(function ($items) {
+			return $this->getArrayableItems($items);
+		}, func_get_args());
+
+		$params = array_merge([function () {
+			return new static(func_get_args());
+		}, $this->items], $arrayableItems);
+
+		return new static(call_user_func_array('array_map', $params));
+	}
+
+	/**
 	 * Get the collection of items as a plain array.
 	 *
 	 * @return array

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -630,6 +630,35 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals([], $c->forPage(3, 2)->all());
 	}
 
+
+	public function testZip()
+	{
+		$c = new Collection([1, 2, 3]);
+		$c = $c->zip(new Collection([4, 5, 6]));
+		$this->assertInstanceOf('Illuminate\Support\Collection', $c);
+		$this->assertInstanceOf('Illuminate\Support\Collection', $c[0]);
+		$this->assertInstanceOf('Illuminate\Support\Collection', $c[1]);
+		$this->assertInstanceOf('Illuminate\Support\Collection', $c[2]);
+		$this->assertEquals(3, $c->count());
+		$this->assertEquals([1, 4], $c[0]->all());
+		$this->assertEquals([2, 5], $c[1]->all());
+		$this->assertEquals([3, 6], $c[2]->all());
+
+		$c = new Collection([1, 2, 3]);
+		$c = $c->zip([4, 5, 6], [7, 8, 9]);
+		$this->assertEquals(3, $c->count());
+		$this->assertEquals([1, 4, 7], $c[0]->all());
+		$this->assertEquals([2, 5, 8], $c[1]->all());
+		$this->assertEquals([3, 6, 9], $c[2]->all());
+
+		$c = new Collection([1, 2, 3]);
+		$c = $c->zip([4, 5, 6], [7]);
+		$this->assertEquals(3, $c->count());
+		$this->assertEquals([1, 4, 7], $c[0]->all());
+		$this->assertEquals([2, 5, null], $c[1]->all());
+		$this->assertEquals([3, 6, null], $c[2]->all());
+	}
+
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
Inspired by Ruby and Python: http://apidock.com/ruby/Array/zip

The TL;DR is it lets you "zip" together the items from multiple collections at the same index.

So zipping `[1, 2, 3]` with `[4, 5, 6]` would give you:

```
[
  [1, 4],
  [2, 5],
  [3, 6]
]
```

Stumbled upon the need for this when working on an [Exercism.io](http://exercism.io) problem where you needed to calculate the Hamming distance between two DNA strands.

A `zip` function gives you a cool solution like this:

``` php
function hamming($strandA, $strandB) {
    return (new Collection(str_split($strandA)))
        ->zip(str_split($strandB))
        ->map(function ($item) { return $item[0] === $item[1] ? 0 : 1; })
        ->sum();
}
```

Generally just nice for being able to declaratively iterate over multiple arrays at once :+1: 
