### PR TITLE
[5.0] Add @ifsection statement

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -513,6 +513,17 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	}
 
 	/**
+	 * Compile the section check statements into valid PHP.
+	 *
+	 * @param  string  $expression
+	 * @return string
+	 */
+	protected function compileIfsection($expression)
+	{
+		return "<?php if(\$__env->hasSection{$expression}): ?>";
+	}
+
+	/**
 	 * Compile the if statements into valid PHP.
 	 *
 	 * @param  string  $expression

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -876,6 +876,17 @@ class Factory implements FactoryContract {
 	}
 
 	/**
+	 * Check if section exists.
+	 *
+	 * @param  $name
+	 * @return bool
+	 */
+	public function hasSection($name)
+	{
+		return array_key_exists($name, $this->sections);
+	}
+
+	/**
 	 * Get all of the registered named views in environment.
 	 *
 	 * @return array

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -239,6 +239,19 @@ this is a comment
 	}
 
 
+	public function testIfsectionStatementsAreCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$string = '@ifsection ("foo")
+breeze
+@endif';
+		$expected = '<?php if($__env->hasSection("foo")): ?>
+breeze
+<?php endif; ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
+
+
 	public function testIfStatementsAreCompiled()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -342,6 +342,18 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testHasSection()
+	{
+		$factory = $this->getFactory();
+		$factory->startSection('foo');
+		echo 'hi';
+		$factory->stopSection();
+
+		$this->assertTrue($factory->hasSection('foo'));
+		$this->assertFalse($factory->hasSection('bar'));
+	}
+
+
 	public function testMakeWithSlashAndDot()
 	{
 		$factory = $this->getFactory();


### PR DESCRIPTION
Provides a way to solve a common situation when a section should be wrapped by some markup only if it exists.

```
<div class="row">
    <div id="main">
         @yield('content')
    </div>
    @ifsection('sidebar')
        <div id="sidebar">
             @yield('sidebar')
        </div>
    @endif
</div>
```
