### PR TITLE
[5.0] Fix overload in parseName() method

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -95,7 +95,7 @@ abstract class GeneratorCommand extends Command {
 			$name = str_replace('/', '\\', $name);
 		}
 
-		return $this->parseName($this->getDefaultNamespace(trim($rootNamespace, '\\')).'\\'.$name);
+		return $this->getDefaultNamespace(trim($rootNamespace, '\\')).'\\'.$name;
 	}
 
 	/**


### PR DESCRIPTION
On line 98, the method parseName() ever call himself causing overload.
I removed the $this->parseName() on line 98 for fix the overload.
I do not know if it's ok, but I believe solve the problem.

Problem: use root namespace without application name, for example, use "\Models\" and not "\App\Models", is problem.
