### PR TITLE
[5.1] New mechanism for extending Blade

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -264,7 +264,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 			{
 				$match[0] = $this->$method(array_get($match, 3));
 			}
-			else if (isset($this->statements[$match[1]]))
+			elseif (isset($this->statements[$match[1]]))
 			{
 				$match[0] = call_user_func($this->statements[$match[1]], array_get($match, 3));
 			}

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -707,39 +707,6 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	}
 
 	/**
-	 * Get the regular expression for a generic Blade function.
-	 *
-	 * @param  string  $function
-	 * @return string
-	 */
-	public function createMatcher($function)
-	{
-		return '/(?<!\w)(\s*)@'.$function.'(\s*\(.*\))/';
-	}
-
-	/**
-	 * Get the regular expression for a generic Blade function.
-	 *
-	 * @param  string  $function
-	 * @return string
-	 */
-	public function createOpenMatcher($function)
-	{
-		return '/(?<!\w)(\s*)@'.$function.'(\s*\(.*)\)/';
-	}
-
-	/**
-	 * Create a plain Blade matcher.
-	 *
-	 * @param  string  $function
-	 * @return string
-	 */
-	public function createPlainMatcher($function)
-	{
-		return '/(?<!\w)(\s*)@'.$function.'(\s*)/';
-	}
-
-	/**
 	 * Sets the raw tags used for the compiler.
 	 *
 	 * @param  string  $openTag

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -557,6 +557,19 @@ empty
 	}
 
 
+	public function testCustomShortStatements()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$compiler->addStatement('customControl', function($expression) {
+			return '<?php echo custom_control(); ?>';
+		});
+
+		$string = '@customControl';
+		$expected = '<?php echo custom_control(); ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
+
+
 	public function testConfiguringContentTags()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -540,50 +540,6 @@ empty
 	}
 
 
-	public function testCreateMatcher()
-	{
-		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
-		$compiler->extend(
-			function($view, BladeCompiler $compiler)
-			{
-				$pattern = $compiler->createMatcher('customControl');
-				$replace = '<?php echo custom_control$2; ?>';
-				return preg_replace($pattern, '$1'.$replace, $view);
-			}
-		);
-
-		$string = '@if($foo)
-@customControl(10, $foo, \'bar\')
-@endif';
-		$expected = '<?php if($foo): ?>
-<?php echo custom_control(10, $foo, \'bar\'); ?>
-<?php endif; ?>';
-		$this->assertEquals($expected, $compiler->compileString($string));
-	}
-
-
-	public function testCreatePlainMatcher()
-	{
-		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
-		$compiler->extend(
-			function($view, BladeCompiler $compiler)
-			{
-				$pattern = $compiler->createPlainMatcher('customControl');
-				$replace = '<?php echo custom_control; ?>';
-				return preg_replace($pattern, '$1'.$replace.'$2', $view);
-			}
-		);
-
-		$string = '@if($foo)
-@customControl
-@endif';
-		$expected = '<?php if($foo): ?>
-<?php echo custom_control; ?>
-<?php endif; ?>';
-		$this->assertEquals($expected, $compiler->compileString($string));
-	}
-
-
 	public function testConfiguringContentTags()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -540,6 +540,23 @@ empty
 	}
 
 
+	public function testCustomStatements()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$compiler->addStatement('customControl', function($expression) {
+			return "<?php echo custom_control{$expression}; ?>";
+		});
+
+		$string = '@if($foo)
+@customControl(10, $foo, \'bar\')
+@endif';
+		$expected = '<?php if($foo): ?>
+<?php echo custom_control(10, $foo, \'bar\'); ?>
+<?php endif; ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
+
+
 	public function testConfiguringContentTags()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
This is my proposal on how to improve Blade extensions in the next release.

The idea: Instead of doing replacements on their own in a closure passed to `Blade::extend()`, users can now pass a tag name and a closure to `Blade::addStatement()` (the latter simply returning the proper replacement for the tag, while it receives the arguments passed to the tag as an argument). Take a look at the unit test for an example.

Includes a test and an Otwellian comment.

@taylorotwell may have some opinions on whether we still need `extend()`, naming for these methods etc.

This should be relevant for issues such as #8138 and #8228. It is my replacement for #8275.
/cc @Arrilot
