### PR TITLE
[5.0] Return null on non-existent relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3068,11 +3068,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * Get a specified relationship.
 	 *
 	 * @param  string  $relation
-	 * @return mixed
+	 * @return null|mixed
 	 */
 	public function getRelation($relation)
 	{
-		return $this->relations[$relation];
+		return array_get($this->relations, $relation, null);
 	}
 
 	/**


### PR DESCRIPTION
Currently the method throws undefined offset error - which is not good.
