### PR TITLE
Create Xmlable contract

### DIFF
--- a/src/Illuminate/Contracts/Support/Xmlable.php
+++ b/src/Illuminate/Contracts/Support/Xmlable.php
@@ -1,0 +1,12 @@
+<?php namespace Illuminate\Contracts\Support;
+
+interface Xmlable {
+
+	/**
+	 * Convert the object to its XML representation.
+	 *
+	 * @return string
+	 */
+	public function toXml();
+
+}


### PR DESCRIPTION
Trying again…

I find myself working with a lot of XML-based web services. The framework has a `Jsonable` contract so thought I would add a `Xmlable` contract in case any one else is like me and unfortunately enough to be working with XML-based web services instead of JSON ones.
