### PR TITLE
$column type correction

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -421,7 +421,7 @@ class Builder {
 	/**
 	 * Add a basic where clause to the query.
 	 *
-	 * @param  string  $column
+	 * @param  mixed   $column
 	 * @param  string  $operator
 	 * @param  mixed   $value
 	 * @param  string  $boolean


### PR DESCRIPTION
The first parameter `$column` could be `string`, `array`, or `instanceof Closure`.
