### PR TITLE
Resolve Schema\Builder on Migration to avoid Facades

### DIFF
--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -1,5 +1,7 @@
 <?php namespace Illuminate\Database\Migrations;
 
+use Illuminate\Database\Schema\Builder;
+
 abstract class Migration {
 
 	/**
@@ -8,6 +10,21 @@ abstract class Migration {
 	 * @var string
 	 */
 	protected $connection;
+	
+	/**
+	 * The schema builder for migrations.
+	 * 
+	 * @var Builder
+	 */
+	 protected $builder;
+
+	/**
+	 * Construct an instance of Migration.
+	 */
+	function __construct()
+	{
+		$this->builder = app('db')->connection($this->connection)->getSchemaBuilder();
+	}
 
 	/**
 	 * Get the migration connection name.
@@ -18,5 +35,15 @@ abstract class Migration {
 	{
 		return $this->connection;
 	}
+	
+	/**
+	 * Get the schema builder.
+	 * 
+	 * @return Builder
+	 */
+	 public function builder()
+	 {
+	 	return $this->builder;
+	 }
 
 }


### PR DESCRIPTION
Lumen framework does not come shipped with facades enabled. So, to avoid having to enable them if you only needed them for migrations, I suggest that the schema builder be added to the Migration abstract class so a user can easily create a migration without the use of facades.

Of course, someone can create their own BaseMigration abstract class that extends this Migration and put the object there. However, I think this enhances the ease of development when using the artisan command since MigrationCreator creates a stub already extending the Migration abstract class.

The use case would be: 

```
public function up()
{
    $this->builder()->create('users', function(Blueprint $table) {
        $table->increments('id')
        ...
    };
}
...
```
