### PR TITLE
[5.0] Provide collection with final models instead of StdClass in Model@hydrate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -491,12 +491,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	{
 		$instance = (new static)->setConnection($connection);
 
-		$collection = $instance->newCollection($items);
-
-		return $collection->map(function ($item) use ($instance)
+		$items = array_map(function ($item) use ($instance)
 		{
 			return $instance->newFromBuilder($item);
-		});
+		}, $items);
+
+		return $instance->newCollection($items);
 	}
 
 	/**


### PR DESCRIPTION
Tiny fix that makes `Eloquent\Collection` unaware of `StdClass` so it doesn't need to `map` its elements.

Current behaviour isn't a problem until you want pseudo-typehinting for custom collection - then it makes it inconvenient, because you need to check for the type and `StdObject` as well.

Here's an example - the easy way with typehinting:

``` php
class AttributeBag extends Collection implements AttributeBagContract
{
    public function __construct($attributes = [])
    {
        foreach ($attributes as $attribute) {
            $this->add($attribute);
        }
    }

    public function add($item)
    {
        return $this->addAttribute($item);
    }

    protected function addAttribute(Attribute $item)
    {
        // ...
    }
}
```

This is not working (relations etc) due to the fact that `hydrate` first creates the collection and makes the collection mutate its elements:

``` php
    public static function hydrate(array $items, $connection = null)
    {
        $instance = (new static)->setConnection($connection);

        $collection = $instance->newCollection($items); // THIS IS BAD

        return $collection->map(function ($item) use ($instance)
        {
            return $instance->newFromBuilder($item);
        });
    }
```

This PR changes the order in `hydrate`, so the collection is provided with its final items.
