### PR TITLE
Add path to assets when referencing elixir assets

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -670,7 +670,7 @@ if ( ! function_exists('elixir'))
 
 		if (isset($manifest[$file]))
 		{
-			return '/build/'.$manifest[$file];
+			return asset('/build/'.$manifest[$file]);
 		}
 
 		throw new InvalidArgumentException("File {$file} not defined in asset manifest.");


### PR DESCRIPTION
The elixir() helper does not work when the project is not in on the root URL.
