### PR TITLE
[5.0] Model - fromDateTime() improvements and tests

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2828,37 +2828,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	{
 		$format = $this->getDateFormat();
 
-		// If the value is already a DateTime instance, we will just skip the rest of
-		// these checks since they will be a waste of time, and hinder performance
-		// when checking the field. We will just return the DateTime right away.
-		if ($value instanceof DateTime)
-		{
-			//
-		}
-
-		// If the value is totally numeric, we will assume it is a UNIX timestamp and
-		// format the date as such. Once we have the date in DateTime form we will
-		// format it according to the proper format for the database connection.
-		elseif (is_numeric($value))
-		{
-			$value = Carbon::createFromTimestamp($value);
-		}
-
-		// If the value is in simple year, month, day format, we will format it using
-		// that setup. This is for simple "date" fields which do not have hours on
-		// the field. This conveniently picks up those dates and format correct.
-		elseif (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $value))
-		{
-			$value = Carbon::createFromFormat('Y-m-d', $value)->startOfDay();
-		}
-
-		// If this value is some other type of string, we'll create the DateTime with
-		// the format used by the database connection. Once we get the instance we
-		// can return back the finally formatted DateTime instances to the devs.
-		else
-		{
-			$value = Carbon::createFromFormat($format, $value);
-		}
+		$value = $this->asDateTime($value);
 
 		return $value->format($format);
 	}
@@ -2871,10 +2841,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	protected function asDateTime($value)
 	{
+		// If the value is already a DateTime instance, we will just skip the rest of
+		// these checks since they will be a waste of time, and hinder performance
+		// when checking the field. We will just return the DateTime right away.
+		if ($value instanceof DateTime)
+		{
+			//
+		}
+
 		// If this value is an integer, we will assume it is a UNIX timestamp's value
 		// and format a Carbon object from this timestamp. This allows flexibility
 		// when defining your date fields as they might be UNIX timestamps here.
-		if (is_numeric($value))
+		elseif (is_numeric($value))
 		{
 			return Carbon::createFromTimestamp($value);
 		}

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -352,6 +352,27 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testFromDateTime()
+	{
+		$model = new EloquentModelStub();
+
+		$value = Carbon\Carbon::parse('2015-04-17 22:59:01');
+		$this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
+
+		$value = new DateTime('2015-04-17 22:59:01');
+		$this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
+
+		$value = '2015-04-17 22:59:01';
+		$this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
+
+		$value = '2015-04-17';
+		$this->assertEquals('2015-04-17 00:00:00', $model->fromDateTime($value));
+
+		$value = '1429311541';
+		$this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
+	}
+
+
 	public function testInsertProcess()
 	{
 		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes', 'updateTimestamps'));


### PR DESCRIPTION
Now `fromDateTime()` uses `asDateTime()` instead of duplicate the logic.
