### PR TITLE
[5.1] Return false to break out of the loop

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -116,7 +116,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 */
 	public function each(callable $callback)
 	{
-		array_map($callback, $this->items);
+		foreach ($this->items as $key => $item)
+		{
+			if ($callback($item, $key) === false) break;
+		}
 
 		return $this;
 	}

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -171,6 +171,20 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testEach()
+	{
+		$c = new Collection($original = [1, 2, 'foo' => 'bar', 'bam' => 'baz']);
+
+		$result = [];
+		$c->each(function($item, $key) use (&$result) { $result[$key] = $item; });
+		$this->assertEquals($original, $result);
+
+		$result = [];
+		$c->each(function($item, $key) use (&$result) { if (is_string($key)) return false; $result[$key] = $item; });
+		$this->assertEquals([1, 2], $result);
+	}
+
+
 	public function testIntersectCollection()
 	{
 		$c = new Collection(array('id' => 1, 'first_word' => 'Hello'));


### PR DESCRIPTION
Allows the collection's `each` callback to return `false` in order to break out of the loop.

Prior art: [jQuery's `.each()` method](http://api.jquery.com/each/).
