### PR TITLE
Fix elixir() helper url generation

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -670,7 +670,7 @@ if ( ! function_exists('elixir'))
 
 		if (isset($manifest[$file]))
 		{
-			return '/build/'.$manifest[$file];
+			return asset('/build/'.$manifest[$file]);
 		}
 
 		throw new InvalidArgumentException("File {$file} not defined in asset manifest.");


### PR DESCRIPTION
With this change elixir() now generates paths through asset(). This basically affects non top-level applications (i.e., http://domain.tld/laravelapp), where the old code returned assets URLs to the top level instead of within the `laravelapp` folder.

**Warning**: this change is potentially app-breaking for users with such non-top-level laravel installations. This is because before the patch some work-around had to be used (such as adding `/laravelapp` manually) and the newly generated URL will be wrong for them. I think this PR is the proper way to fix it, but it may make sense to delay it until 5.1 or something like that.
