### PR TITLE
[5.0] Partly backport #8425

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -10,6 +10,15 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	protected $extensions = array();
 
 	/**
+	 * All custom "directive" handlers.
+	 *
+	 * This was implemented as a more usable "extend".
+	 *
+	 * @var array
+	 */
+	protected $customDirectives = [];
+
+	/**
 	 * The file currently being compiled.
 	 *
 	 * @var string
@@ -253,6 +262,10 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 			if (method_exists($this, $method = 'compile'.ucfirst($match[1])))
 			{
 				$match[0] = $this->$method(array_get($match, 3));
+			}
+			elseif (isset($this->customDirectives[$match[1]]))
+			{
+				$match[0] = call_user_func($this->customDirectives[$match[1]], array_get($match, 3));
 			}
 
 			return isset($match[3]) ? $match[0] : $match[0].$match[2];
@@ -691,6 +704,18 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	public function extend(callable $compiler)
 	{
 		$this->extensions[] = $compiler;
+	}
+
+	/**
+	 * Register a handler for custom directives.
+	 *
+	 * @param  string  $name
+	 * @param  callable  $handler
+	 * @return void
+	 */
+	public function directive($name, callable $handler)
+	{
+		$this->customDirectives[$name] = $handler;
 	}
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -584,6 +584,34 @@ empty
 	}
 
 
+	public function testCustomStatements()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$compiler->directive('customControl', function($expression) {
+			return "<?php echo custom_control{$expression}; ?>";
+		});
+		$string = '@if($foo)
+@customControl(10, $foo, \'bar\')
+@endif';
+		$expected = '<?php if($foo): ?>
+<?php echo custom_control(10, $foo, \'bar\'); ?>
+<?php endif; ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
+
+
+	public function testCustomShortStatements()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$compiler->directive('customControl', function($expression) {
+			return '<?php echo custom_control(); ?>';
+		});
+		$string = '@customControl';
+		$expected = '<?php echo custom_control(); ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
+
+
 	public function testConfiguringContentTags()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
There is one tricky issue with #8425 

Imagine L5.1 is out. You are a package maintainer and you want to support both 5.0 and 5.1
However it becomes a problem because on one hand `createMatcher()` that you've used in 5.0 no longer exists in 5.1 and on the other hand `Blade::directive()` does not exist in 5.0. hmm...

That's why i propose:
1. partly backport #8425 ito 5.0 to allow ppl use `Blade::directive()` here without BC breaks 
2. encourage this usage via documentation. 

A note about removing matchers is probably needed here http://laravel.com/docs/master/upgrade too

/cc @franzliedke
