### PR TITLE
Prevent PHP Object Injection on unencrypted cookie storage

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -120,7 +120,7 @@ class Store implements SessionInterface {
 
 		if ($data)
 		{
-			$data = @unserialize($this->prepareForUnserialize($data));
+			$data = json_decode($this->prepareForUnserialize($data), true);
 
 			if ($data !== false) return $data;
 		}
@@ -252,7 +252,7 @@ class Store implements SessionInterface {
 
 		$this->ageFlashData();
 
-		$this->handler->write($this->getId(), $this->prepareForStorage(serialize($this->attributes)));
+		$this->handler->write($this->getId(), $this->prepareForStorage(json_encode($this->attributes)));
 
 		$this->started = false;
 	}

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -13,7 +13,7 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 	public function testSessionIsLoadedFromHandler()
 	{
 		$session = $this->getSession();
-		$session->getHandler()->shouldReceive('read')->once()->with($this->getSessionId())->andReturn(serialize(array('foo' => 'bar', 'bagged' => array('name' => 'taylor'))));
+		$session->getHandler()->shouldReceive('read')->once()->with($this->getSessionId())->andReturn(json_encode(array('foo' => 'bar', 'bagged' => array('name' => 'taylor'))));
 		$session->registerBag(new Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag('bagged'));
 		$session->start();
 
@@ -103,7 +103,7 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 	public function testSessionIsProperlySaved()
 	{
 		$session = $this->getSession();
-		$session->getHandler()->shouldReceive('read')->once()->andReturn(serialize(array()));
+		$session->getHandler()->shouldReceive('read')->once()->andReturn(json_encode(array()));
 		$session->start();
 		$session->put('foo', 'bar');
 		$session->flash('baz', 'boom');


### PR DESCRIPTION
Using `unserialize()` is risky; `json_decode()` is a safer alternative.

Cookie-based session storage + not using encryption = pwned.
