### PR TITLE
[5.1] Eloquent relations improvements

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -183,6 +183,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	protected $onDirtyEvents = [];
 
 	/**
+	 * Stores links to relations without extra query parameters
+	 *
+	 * @var array
+	 */
+	public $belongingRelations = [];
+
+	/**
 	 * Indicates whether attributes are snake cased on arrays.
 	 *
 	 * @var bool
@@ -2671,6 +2678,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		{
 			throw new LogicException('Relationship method must return an object of type '
 				. 'Illuminate\Database\Eloquent\Relations\Relation');
+		}
+
+		if ($relations instanceof BelongsTo)
+		{
+			$parentClass = get_class($relations->getRelated());
+			if (array_key_exists($parentClass, $this->belongingRelations))
+			{
+				// Load parent from relation cache
+				return $this->relations[$method] = $this->belongingRelations[$parentClass];
+			}
 		}
 
 		return $this->relations[$method] = $relations->getResults();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -812,6 +812,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		$otherKey = $otherKey ?: $instance->getKeyName();
 
+		$this->onDirty($foreignKey, function() use ($relation)
+		{
+			if ($this->relationLoaded($relation))
+			{
+				unset($this->relations[$relation]);
+			}
+		});
+
 		return new BelongsTo($query, $this, $foreignKey, $otherKey, $relation);
 	}
 
@@ -836,6 +844,22 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		}
 
 		list($type, $id) = $this->getMorphs($name, $type, $id);
+
+		$this->onDirty($type, function() use ($name)
+		{
+			if ($this->relationLoaded($name))
+			{
+				unset($this->relations[$name]);
+			}
+		});
+
+		$this->onDirty($id, function() use ($name)
+		{
+			if ($this->relationLoaded($name))
+			{
+				unset($this->relations[$name]);
+			}
+		});
 
 		// If the type value is null it is probably safe to assume we're eager loading
 		// the relationship. When that is the case we will pass in a dummy query as

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -11,7 +11,17 @@ class HasMany extends HasOneOrMany {
 	 */
 	public function getResults()
 	{
-		return $this->query->get();
+		$related = $this->query->get();
+
+		if (static::$constraints)
+		{
+			$related->each(function ($model)
+			{
+				$model->belongingRelations[get_class($this->parent)] = $this->parent;
+			});
+		}
+
+		return $related;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -11,7 +11,13 @@ class HasOne extends HasOneOrMany {
 	 */
 	public function getResults()
 	{
-		return $this->query->first();
+		$related = $this->query->first();
+		if (static::$constraints)
+		{
+			// Populate relation cache for related model
+			$related->belongingRelations[get_class($this->parent)] = $this->parent;
+		}
+		return $related;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -11,7 +11,17 @@ class MorphMany extends MorphOneOrMany {
 	 */
 	public function getResults()
 	{
-		return $this->query->get();
+		$related = $this->query->get();
+
+		if (static::$constraints)
+		{
+			$related->each(function ($model)
+			{
+				$model->belongingRelations[get_class($this->parent)] = $this->parent;
+			});
+		}
+
+		return $related;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -11,7 +11,13 @@ class MorphOne extends MorphOneOrMany {
 	 */
 	public function getResults()
 	{
-		return $this->query->first();
+		$related = $this->query->first();
+		if (static::$constraints)
+		{
+			// Populate relation cache for related model
+			$related->belongingRelations[get_class($this->parent)] = $this->parent;
+		}
+		return $related;
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -172,9 +172,17 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$model->foo = 'bar';
 		// make sure foo isn't synced so we can test that dirty attributes only are updated
 		$model->syncOriginal();
+
+		// add an event for dirty attribute
+		$foo = true;
+		$model->onDirty('name', function() use (&$foo)
+		{
+			$foo = false;
+		});
 		$model->name = 'taylor';
 		$model->exists = true;
 		$this->assertTrue($model->save());
+		$this->assertFalse($foo);
 	}
 
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -978,6 +978,28 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testRelationDroppedOnForeignKeyChanged()
+	{
+		$model = $this->getMock('EloquentModelStub', array('newQueryWithoutScopes', 'updateTimestamps'));
+		$query = m::mock('Illuminate\Database\Eloquent\Builder');
+		$query->shouldReceive('where')->once()->with('id', '=', 1);
+		$query->shouldReceive('update')->once()->with(array('belongs_to_stub_id' => 5));
+		$model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
+		$model->expects($this->once())->method('updateTimestamps');
+
+		$model->id = 1;
+		$model->belongs_to_stub_id = 1;
+		$model->syncOriginal();
+		$relation = $model->belongsToStub();
+		$model->setRelation('belongsToStub', []);
+		$model->belongs_to_stub_id = 5;
+		$model->exists = true;
+		$model->save();
+
+		$this->assertFalse($model->relationLoaded('belongsToStub'));
+	}
+
+
 	public function testModelsAssumeTheirName()
 	{
 		$model = new EloquentModelWithoutTableStub;


### PR DESCRIPTION
**Work is still in progress, however I want to know if you would accept such changes**

The patch applies two fixes to eloquent belonging relations:
1. Drop relation on change of relative field

``` php
$child = new Child();
$parent_id = $child->parent->id; //Assume parent_id is 888. Parent is still there and loaded

$child->parent_id = 999;
$child->save();

$parent_id = $child->parent->id; //We still get old parent loaded previosly - which is a bug
```

The patch forces such relations to be cleared on model update.

`onDirty` method added to provide internal saving event without Event package.
1. Inject parent to children on resolving having relations (fixes #8085)

``` php
$child = $parent->child; //HasOne, HasMany, MorphOne, etc. relation

$parent_id = $child->parent->id; //New query which can cause n+1 problem

$childrent = $parent->children()->with('parent'); // Works but nonscence - unnescessary extra query.
```

In this patch parent model automatically injected into children in one-to-many relations.

Next - I plan to fix  #5414, #6368 and implement some more relations improvements.
