### PR TITLE
[5.0] Proposal: Allow object as mail callback

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -385,6 +385,10 @@ class Mailer implements MailerContract, MailQueueContract {
 		{
 			return call_user_func($callback, $message);
 		}
+		elseif (is_object($callback) && method_exists($callback, 'mail'))
+		{
+			return $callback->mail($message);
+		}
 		elseif (is_string($callback))
 		{
 			return $this->container->make($callback)->mail($message);


### PR DESCRIPTION
Example:

``` php
class MyMail {
public function __construct($data) { /* ... */ }
public function mail($message)
{
    $message->from($this->data['from_email'], $this->data['from_name']);
}
}

$mailer->send('my.message', [], $myMailObject);
```
