### PR TITLE
[5.0] Making TestCase::createApplication() a static method, so that it could be called from setUpBeforeClass() static method

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -13,7 +13,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
 	 *
 	 * @return \Symfony\Component\HttpKernel\HttpKernelInterface
 	 */
-	abstract public function createApplication();
+	abstract public static function createApplication();
 
 	/**
 	 * Setup the test environment.


### PR DESCRIPTION
As I stated in #8459 (and got binned), PHPUnit's `setUpBeforeClass()` static method becomes useless without Facades and other resources of the app. I dug into the Laravel codebase and discovered that actually there is a `TestCase::createApplication()` method which instantiates the app for unit-testing purposes. Problem is, this method can't be called statically as it is not static itself. So making it static will make things easier, as being static method, it can be called within both static and non-static contexts.

As I make this PR, I am not sure if it will break inner workings of framework as a whole (I believe it shouldn't). So we will see how tests go.

I also would like to urge our framework maintainers to merge this one into [5.0] rather than waiting for [5.1] release. It's very important feature I require in my open-source project guys! I could use the content of that method in my `setUpBeforeClass()` implementation of course, but I really don't want to dupe code as this facility already exists. Thank you in advance for understanding!
