### PR TITLE
Actually test that returning false breaks the loop

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -180,8 +180,8 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($original, $result);
 
 		$result = [];
-		$c->each(function($item, $key) use (&$result) { if (is_string($key)) return false; $result[$key] = $item; });
-		$this->assertEquals([1, 2], $result);
+		$c->each(function($item, $key) use (&$result) { $result[$key] = $item; if (is_string($key)) return false; });
+		$this->assertEquals([1, 2, 'foo' => 'bar'], $result);
 	}
 
 


### PR DESCRIPTION
It was `return`ing before adding to the result, so it wasn't properly testing that it `break`s out of the loop.
