### PR TITLE
PHPDoc autocomplete for Fluent (creating a migration)

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -5,6 +5,16 @@ use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
+/**
+ * @method Fluent nullable()
+ * @method Fluent unsigned()
+ * @method Fluent unique()
+ * @method Fluent default($value)
+ * @method Fluent onUpdate($value)
+ * @method Fluent onDelete($value)
+ * @method Fluent references($value)
+ * @method Fluent on($value)
+ */
 class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable {
 
 	/**


### PR DESCRIPTION
This is a repeat of thallisphp's pull request (which was in the wrong repo). Credit for this change goes to him/her.
https://github.com/illuminate/support/pull/25

This allows editors like PHPStorm to have proper autocompletion while creating a migration using Fluent.
