### PR TITLE
[5.1] Macroable schema blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -3,9 +3,12 @@
 use Closure;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\Schema\Grammars\Grammar;
 
 class Blueprint {
+
+	use Macroable;
 
 	/**
 	 * The table the blueprint describes.

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -24,6 +24,26 @@ class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testBlueprintMacro()
+	{
+		Blueprint::macro('publishing', function()
+		{
+			$this->dateTime('published_from')->nullable();
+			$this->dateTime('published_to')->nullable();
+		});
+
+		$blueprint = new Blueprint('posts');
+
+		$blueprint->publishing();
+
+		$columns = $blueprint->getColumns();
+
+		$this->assertEquals(2, count($columns));
+		$this->assertEquals('published_from', $columns[0]->name);
+		$this->assertTrue($columns[1]->nullable);
+	}
+
+
 	public function testIndexDefaultNames()
 	{
 		$blueprint = new Blueprint('users');


### PR DESCRIPTION
Applies Macroable trait to Blueprint, so developers can create own patches to migrations like `softDeletes()`;

``` php
Blueprint::macro('myProvidedColumn', function()
{
    return $this->string('providedColumn')->default('foo');
});
// ...
$blueprint->myProvidedColumn()->nullable();
```
