### PR TITLE
Fix base URL bug

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -630,6 +630,28 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	/**
 	 * {@inheritdoc}
 	 */
+	protected function prepareBaseUrl()
+	{
+		$scriptName = $this->server->get('SCRIPT_NAME');
+
+		if (starts_with(ltrim($this->server->get('REQUEST_URI'), '/'), ltrim($scriptName, '/')))
+		{
+			// if the request URI starts with the script name we can assume
+			// that the filename is used in the URI and use that as base URL
+			$baseUrl = $scriptName;
+		}
+		else
+		{
+			// otherwise we'll just use the directory path relative to the document root
+			$baseUrl = dirname($scriptName);
+		}
+
+		return rtrim($baseUrl, '/\\');
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function duplicate(array $query = null, array $request = null, array $attributes = null, array $cookies = null, array $files = null, array $server = null)
 	{
 		return parent::duplicate($query, $request, $attributes, $cookies, array_filter((array) $files), $server);


### PR DESCRIPTION
_This solves the issue #8441_

It might not be considered as a real bug, but the Symfony Request makes a mistake when determining the base URL of a request.
If the application is running under domain root, following URLs will all produce the same path info:

```
http://laravel.app/
http://laravel.app/foo/bar/index.php
```

`foo/bar` can be replaced with anything, the page will still work and **not** return a 404.

For a live example hit: http://laravel.com/foo/index.php/docs/5.0/

This PR fixes that behavior but I'd really like some feedback from you guys:
1. Is it OK to fix this just within Laravel or should it be fixed in the Symfony Request class?
2. I'm unsure if this covers all (necessary) cases. Especially since the original `prepareBaseUrl()` is a lot more complicated. What do you think?
