### PR TITLE
Add fire() method on Illuminate\Database\Eloquent\Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1651,6 +1651,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * Fire the given event for the model.
 	 *
 	 * @param  string  $event
+	 * @return mixed
+     */
+	public function fire($event)
+	{
+		return $this->fireModelEvent($event, false);
+	}
+
+	/**
+	 * Fire the given event for the model.
+	 *
+	 * @param  string  $event
 	 * @param  bool    $halt
 	 * @return mixed
 	 */


### PR DESCRIPTION
For many reasons we may need a public method to fire events from a model instance.
## Example

For instance when an user is deleted I want to delete every post associated with it and trigger the deleted event (that is caught by Post to delete associated images for instance)

``` php
class User extends Model{ 

         ......

        static::deleted(function($instance){
            foreach($instance->posts as $post){
                $post->fire('deleting'); // This is now possible
            }
            $instance->posts()->delete();
            return true;
        });
```

The goal here is to do 1 query to delete every post. Keeping the ability to call "deleting" event easily.
## Alternative solutions
- The method fireModelEvent() could become public 
- Add a note on the doc about manually firing `eloquent.event : App\ModelName` to trigger the corresponding events.
