### PR TITLE
[5.1] Allow arrays to be passed to array_pluck and data_get

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -273,13 +273,15 @@ class Arr {
 	 * Pluck an array of values from an array.
 	 *
 	 * @param  array   $array
-	 * @param  string  $value
-	 * @param  string  $key
+	 * @param  string|array  $value
+	 * @param  string|array|null  $key
 	 * @return array
 	 */
 	public static function pluck($array, $value, $key = null)
 	{
 		$results = [];
+
+		list($value, $key) = static::explodePluckParameters($value, $key);
 
 		foreach ($array as $item)
 		{
@@ -301,6 +303,22 @@ class Arr {
 		}
 
 		return $results;
+	}
+
+	/**
+	 * Explode the "value" and "key" arguments passed to "pluck".
+	 *
+	 * @param  string|array  $value
+	 * @param  string|array|null  $key
+	 * @return array
+	 */
+	protected static function explodePluckParameters($value, $key)
+	{
+		$value = is_array($value) ? $value : explode('.', $value);
+
+		$key = is_null($key) || is_array($key) ? $key : explode('.', $key);
+
+		return [$value, $key];
 	}
 
 	/**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -379,7 +379,7 @@ if ( ! function_exists('data_get'))
 	 * Get an item from an array or object using "dot" notation.
 	 *
 	 * @param  mixed   $target
-	 * @param  string  $key
+	 * @param  string|array  $key
 	 * @param  mixed   $default
 	 * @return mixed
 	 */
@@ -387,7 +387,9 @@ if ( ! function_exists('data_get'))
 	{
 		if (is_null($key)) return $target;
 
-		foreach (explode('.', $key) as $segment)
+		$key = is_array($key) ? $key : explode('.', $key);
+
+		foreach ($key as $segment)
 		{
 			if (is_array($target))
 			{

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -73,6 +73,16 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testArrayPluckWithNestedKeys()
+	{
+		$array = [['user' => ['taylor', 'otwell']], ['user' => ['dayle', 'rees']]];
+		$this->assertEquals(['taylor', 'dayle'], array_pluck($array, 'user.0'));
+		$this->assertEquals(['taylor', 'dayle'], array_pluck($array, ['user', 0]));
+		$this->assertEquals(['taylor' => 'otwell', 'dayle' => 'rees'], array_pluck($array, 'user.1', 'user.0'));
+		$this->assertEquals(['taylor' => 'otwell', 'dayle' => 'rees'], array_pluck($array, ['user', 1], ['user', 0]));
+	}
+
+
 	public function testArrayExcept()
 	{
 		$array = ['name' => 'taylor', 'age' => 26];
@@ -284,6 +294,7 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	{
 		$object = (object) array('users' => array('name' => array('Taylor', 'Otwell')));
 		$array = array((object) array('users' => array((object) array('name' => 'Taylor'))));
+		$dottedArray = array('users' => array('first.name' => 'Taylor'));
 		$arrayAccess = new SupportTestArrayAccess(['price' => 56, 'user' => new SupportTestArrayAccess(['name' => 'John'])]);
 
 		$this->assertEquals('Taylor', data_get($object, 'users.name.0'));
@@ -291,6 +302,8 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		$this->assertNull(data_get($array, '0.users.3'));
 		$this->assertEquals('Not found', data_get($array, '0.users.3', 'Not found'));
 		$this->assertEquals('Not found', data_get($array, '0.users.3', function (){ return 'Not found'; }));
+		$this->assertEquals('Taylor', data_get($dottedArray, ['users', 'first.name']));
+		$this->assertEquals('Not found', data_get($dottedArray, ['users', 'last.name'], 'Not found'));
 		$this->assertEquals(56, data_get($arrayAccess, 'price'));
 		$this->assertEquals('John', data_get($arrayAccess, 'user.name'));
 		$this->assertEquals('void', data_get($arrayAccess, 'foo', 'void'));


### PR DESCRIPTION
This has the benefit of:
1. Allowing you to extract data from arrays whose keys have dots in them.
2. Considerably speeds up `array_pluck`, since it won't explode the `$key` and `$value` on every iteration.
