### PR TITLE
Register Facades for Migration Commands

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/BaseCommand.php
@@ -14,4 +14,17 @@ class BaseCommand extends Command {
 		return $this->laravel->databasePath().'/migrations';
 	}
 
+    /**
+     * Allow facade use for migration commands.
+     *
+     * @return void
+     */
+    protected function allowFacades()
+    {
+        if(method_exists($this->laravel, 'withFacades'))
+        {
+            $this->laravel->withFacades();
+        }
+    }
+
 }

--- a/src/Illuminate/Database/Console/Migrations/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/BaseCommand.php
@@ -14,17 +14,16 @@ class BaseCommand extends Command {
 		return $this->laravel->databasePath().'/migrations';
 	}
 
-    /**
-     * Allow facade use for migration commands.
-     *
-     * @return void
-     */
-    protected function allowFacades()
-    {
-        if(method_exists($this->laravel, 'withFacades'))
-        {
-            $this->laravel->withFacades();
-        }
-    }
-
+	/**
+	* Allow facade use for migration commands.
+	*
+	* @return void
+	*/
+	protected function allowFacades()
+	{
+		if(method_exists($this->laravel, 'withFacades'))
+		{
+	    		$this->laravel->withFacades();
+		}
+	}
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -51,7 +51,7 @@ class MigrateCommand extends BaseCommand {
 	{
 		if ( ! $this->confirmToProceed()) return;
 
-        $this->allowFacades();
+        	$this->allowFacades();
 
 		$this->prepareDatabase();
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -51,6 +51,8 @@ class MigrateCommand extends BaseCommand {
 	{
 		if ( ! $this->confirmToProceed()) return;
 
+        $this->allowFacades();
+
 		$this->prepareDatabase();
 
 		// The pretend option can be used for "simulating" the migration and grabbing

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -4,7 +4,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Symfony\Component\Console\Input\InputOption;
 
-class RefreshCommand extends Command {
+class RefreshCommand extends BaseCommand {
 
 	use ConfirmableTrait;
 
@@ -30,6 +30,8 @@ class RefreshCommand extends Command {
 	public function fire()
 	{
 		if ( ! $this->confirmToProceed()) return;
+
+        $this->allowFacades();
 
 		$database = $this->input->getOption('database');
 

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -31,7 +31,7 @@ class RefreshCommand extends BaseCommand {
 	{
 		if ( ! $this->confirmToProceed()) return;
 
-        $this->allowFacades();
+        	$this->allowFacades();
 
 		$database = $this->input->getOption('database');
 

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -52,7 +52,7 @@ class ResetCommand extends BaseCommand {
 	{
 		if ( ! $this->confirmToProceed()) return;
 
-        $this->allowFacades();
+        	$this->allowFacades();
 
 		$this->migrator->setConnection($this->input->getOption('database'));
 

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -5,7 +5,7 @@ use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
-class ResetCommand extends Command {
+class ResetCommand extends BaseCommand {
 
 	use ConfirmableTrait;
 
@@ -51,6 +51,8 @@ class ResetCommand extends Command {
 	public function fire()
 	{
 		if ( ! $this->confirmToProceed()) return;
+
+        $this->allowFacades();
 
 		$this->migrator->setConnection($this->input->getOption('database'));
 

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -5,7 +5,7 @@ use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Migrations\Migrator;
 use Symfony\Component\Console\Input\InputOption;
 
-class RollbackCommand extends Command {
+class RollbackCommand extends BaseCommand {
 
 	use ConfirmableTrait;
 
@@ -51,6 +51,8 @@ class RollbackCommand extends Command {
 	public function fire()
 	{
 		if ( ! $this->confirmToProceed()) return;
+
+        $this->allowFacades();
 
 		$this->migrator->setConnection($this->input->getOption('database'));
 

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -52,7 +52,7 @@ class RollbackCommand extends BaseCommand {
 	{
 		if ( ! $this->confirmToProceed()) return;
 
-        $this->allowFacades();
+        	$this->allowFacades();
 
 		$this->migrator->setConnection($this->input->getOption('database'));
 


### PR DESCRIPTION
Lumen framework does not come shipped with facades enabled. So, to
avoid having to enable them if you only needed them for migrations, I
suggest that on migration commands the application registers
facades.

This allows for portability of Laravel code to Lumen and for users to
capitalize on migrations without having to turn on facades (since DI is
disabled in migrations & seeds).
