### PR TITLE
Fix Blade sequential compileString() calls

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -78,8 +78,6 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	public function compile($path = null)
 	{
-		$this->footer = array();
-
 		if ($path)
 		{
 			$this->setPath($path);
@@ -123,6 +121,8 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	public function compileString($value)
 	{
 		$result = '';
+		// reset compiler state before compilation
+		$this->footer = array();
 
 		// Here we will loop through all of the tokens returned by the Zend lexer and
 		// parse each one into the corresponding valid PHP. We will then have this

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -646,6 +646,7 @@ empty
 		$this->assertEquals(['{{{', '}}}'], $compiler->getEscapedContentTags());
 	}
 
+
 	public function testSequentialCompileStringCalls()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -646,19 +646,19 @@ empty
 		$this->assertEquals(['{{{', '}}}'], $compiler->getEscapedContentTags());
 	}
 
-  public function testSequentialCompileStringCalls()
-  {
-    $compiler = new BladeCompiler($this->getFiles(), __DIR__);
-    $string = '@extends(\'foo\')
+	public function testSequentialCompileStringCalls()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$string = '@extends(\'foo\')
 test';
-    $expected = "test".PHP_EOL.'<?php echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
-    $this->assertEquals($expected, $compiler->compileString($string));
-
-    // use the same compiler instance to compile another template with @extends directive
-    $string = '@extends(name(foo))'.PHP_EOL.'test';
-    $expected = "test".PHP_EOL.'<?php echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
-    $this->assertEquals($expected, $compiler->compileString($string));
-  }
+		$expected = "test".PHP_EOL.'<?php echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+		
+		// use the same compiler instance to compile another template with @extends directive
+		$string = '@extends(name(foo))'.PHP_EOL.'test';
+		$expected = "test".PHP_EOL.'<?php echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+		$this->assertEquals($expected, $compiler->compileString($string));
+	}
 
 
 	/**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -646,6 +646,20 @@ empty
 		$this->assertEquals(['{{{', '}}}'], $compiler->getEscapedContentTags());
 	}
 
+  public function testSequentialCompileStringCalls()
+  {
+    $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+    $string = '@extends(\'foo\')
+test';
+    $expected = "test".PHP_EOL.'<?php echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+    $this->assertEquals($expected, $compiler->compileString($string));
+
+    // use the same compiler instance to compile another template with @extends directive
+    $string = '@extends(name(foo))'.PHP_EOL.'test';
+    $expected = "test".PHP_EOL.'<?php echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>';
+    $this->assertEquals($expected, $compiler->compileString($string));
+  }
+
 
 	/**
 	 * @dataProvider testGetTagsProvider()


### PR DESCRIPTION
Clear compilation artifacts ($this->footer) before starting another compilation.
Issue is exposed when calling compileString() twice for templates with @extends directive.
