### PR TITLE
Fix merging issue: $path variable may be null

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -85,7 +85,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 			$this->setPath($path);
 		}
 
-		$contents = $this->compileString($this->files->get($path));
+		$contents = $this->compileString($this->files->get($this->getPath()));
 
 		if ( ! is_null($this->cachePath))
 		{

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -70,6 +70,7 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo', $compiler->getPath());
 	}
 
+
 	public function testCompileWithPathSetBefore()
 	{
 		$compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
@@ -81,6 +82,7 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$compiler->compile();
 		$this->assertEquals('foo', $compiler->getPath());
 	}
+
 
 	public function testCompileDoesntStoreFilesWhenCachePathIsNull()
 	{

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -70,6 +70,17 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo', $compiler->getPath());
 	}
 
+	public function testCompileWithPathSetBefore()
+	{
+		$compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
+		$files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
+		$files->shouldReceive('put')->once()->with(__DIR__.'/'.md5('foo'), 'Hello World');
+		// set path before compilation
+		$compiler->setPath('foo');
+		// trigger compilation with null $path
+		$compiler->compile();
+		$this->assertEquals('foo', $compiler->getPath());
+	}
 
 	public function testCompileDoesntStoreFilesWhenCachePathIsNull()
 	{


### PR DESCRIPTION
`$path` can be set earlier with `->setPath()` call. 
So when a null `$path` is passed, `$this->getPath()` should be used.

It was implemented this way before, but was lost probably while resolving merging conflicts (see e4401ea20b687675178db34738a93bffd628919e).
