### PR TITLE
fix thrown exception if file is not existing

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -119,7 +119,7 @@ class Filesystem {
 			try {
 				if ( ! @unlink($path)) 
 					$success = false; 
-			} catch (\Exception $e) {
+			} catch (\ErrorException $e) {
 				$success = false;
 			}
 		}

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -115,7 +115,14 @@ class Filesystem {
 
 		$success = true;
 
-		foreach ($paths as $path) { if ( ! @unlink($path)) $success = false; }
+		foreach ($paths as $path) { 
+			try {
+				if ( ! @unlink($path)) 
+					$success = false; 
+			} catch (\Exception $e) {
+				$success = false;
+			}
+		}
 
 		return $success;
 	}


### PR DESCRIPTION
`unlink` throws an `\ErrorException` if the file, we want to delete, is not existing. This patch catches the exception and sets `$success` to `false`.

If the file is a session file (f.ex. `storage/framework/session/HASH`), this ends in an thrown exception in the login process.
