### PR TITLE
Add support for parameters to middleware

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -121,8 +121,10 @@ class Pipeline implements PipelineContract {
 				}
 				else
 				{
-					return $this->container->make($pipe)
-							->{$this->method}($passable, $stack);
+					list($name, $parameters) = $this->parsePipeString($pipe);
+
+					return call_user_func_array([$this->container->make($name), $this->method],
+					                            array_merge([$passable, $stack], $parameters));
 				}
 			};
 		};
@@ -140,6 +142,24 @@ class Pipeline implements PipelineContract {
 		{
 			return call_user_func($destination, $passable);
 		};
+	}
+
+	/**
+	 * Parse full pipe string to get name and parameters
+	 *
+	 * @param string $pipe
+	 * @return array
+	 */
+	protected  function parsePipeString($pipe)
+	{
+		list($name, $parameters) = array_pad(explode(':', $pipe, 2), 2, []);
+
+		if (is_string($parameters))
+		{
+			$parameters = explode(',', $parameters);
+		}
+
+		return [$name, $parameters];
 	}
 
 }

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -117,15 +117,13 @@ class ControllerDispatcher {
 	 */
 	protected function getMiddleware($instance, $method)
 	{
-		$middleware = $this->router->getMiddleware();
-
 		$results = [];
 
 		foreach ($instance->getMiddleware() as $name => $options)
 		{
 			if ( ! $this->methodExcludedByOptions($method, $options))
 			{
-				$results[] = array_get($middleware, $name, $name);
+				$results[] = $this->router->resolveMiddlewareClassName($name);
 			}
 		}
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -711,11 +711,26 @@ class Router implements RegistrarContract {
 	 */
 	public function gatherRouteMiddlewares(Route $route)
 	{
-		return Collection::make($route->middleware())->map(function($m)
+		return Collection::make($route->middleware())->map(function($name)
 		{
-			return Collection::make(array_get($this->middleware, $m, $m));
+			return Collection::make($this->resolveMiddlewareClassName($name));
+		})
+		->collapse()->all();
+	}
 
-		})->collapse()->all();
+	/**
+	 * Resolve the middleware name to a class name preserving passed parameters
+	 *
+	 * @param $name
+	 * @return string
+	 */
+	public function resolveMiddlewareClassName($name)
+	{
+		$map = $this->middleware;
+
+		list($name, $parameters) = array_pad(explode(':', $name, 2), 2, null);
+
+		return array_get($map, $name, $name).($parameters ? ':'.$parameters : '');
 	}
 
 	/**

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -26,11 +26,36 @@ class PipelineTest extends PHPUnit_Framework_TestCase {
 		unset($_SERVER['__test.pipe.two']);
 	}
 
+	public function testPipelineUsageWithParameters()
+	{
+		$parameters = ['one','two'];
+
+		$result = (new Pipeline(new Illuminate\Container\Container))
+			->send('foo')
+			->through('PipelineTestParameterPipe:'.implode(',', $parameters))
+			->then(function($piped) {
+				return $piped;
+			});
+
+		$this->assertEquals('foo', $result);
+		$this->assertEquals($parameters, $_SERVER['__test.pipe.parameters']);
+
+		unset($_SERVER['__test.pipe.parameters']);
+	}
+
 }
 
 class PipelineTestPipeOne {
 	public function handle($piped, $next) {
 		$_SERVER['__test.pipe.one'] = $piped;
+		return $next($piped);
+	}
+}
+
+class PipelineTestParameterPipe {
+	public function handle($piped, $next, $parameter1 = null, $parameter2 = null)
+	{
+		$_SERVER['__test.pipe.parameters'] = [$parameter1, $parameter2];
 		return $next($piped);
 	}
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -804,7 +804,8 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 	{
 		unset(
 			$_SERVER['route.test.controller.before.filter'], $_SERVER['route.test.controller.after.filter'],
-			$_SERVER['route.test.controller.middleware'], $_SERVER['route.test.controller.except.middleware']
+			$_SERVER['route.test.controller.middleware'], $_SERVER['route.test.controller.except.middleware'],
+			$_SERVER['route.test.controller.middleware.parameters']
 		);
 		$router = new Router(new Illuminate\Events\Dispatcher, $container = new Illuminate\Container\Container);
 		$router->filter('route.test.controller.before.filter', function()
@@ -825,6 +826,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($_SERVER['route.test.controller.before.filter']);
 		$this->assertTrue($_SERVER['route.test.controller.after.filter']);
 		$this->assertTrue($_SERVER['route.test.controller.middleware']);
+		$this->assertEquals(['foo', 'bar'], $_SERVER['route.test.controller.middleware.parameters']);
 		$this->assertFalse(isset($_SERVER['route.test.controller.except.middleware']));
 	}
 
@@ -848,6 +850,7 @@ class RouteTestControllerStub extends Illuminate\Routing\Controller {
 	public function __construct()
 	{
 		$this->middleware('RouteTestControllerMiddleware');
+		$this->middleware('RouteTestControllerParameterizedMiddleware:foo,bar');
 		$this->middleware('RouteTestControllerExceptMiddleware', ['except' => 'index']);
 		$this->beforeFilter('route.test.controller.before.filter');
 		$this->afterFilter('route.test.controller.after.filter');
@@ -862,6 +865,14 @@ class RouteTestControllerMiddleware {
 	public function handle($request, $next)
 	{
 		$_SERVER['route.test.controller.middleware'] = true;
+		return $next($request);
+	}
+}
+
+class RouteTestControllerParameterizedMiddleware {
+	public function handle($request, $next, $parameter1, $parameter2)
+	{
+		$_SERVER['route.test.controller.middleware.parameters'] = [$parameter1, $parameter2];
 		return $next($request);
 	}
 }


### PR DESCRIPTION
_PR for issue #6470_

This allows to pass parameters to middleware.
(Actually it enables this for basically any class sent through the Pipeline)

The behavior is much the same that it is with filters. Parameters can be specified after `:` and multiple parameters are delimited by `,`. They will get passed as multiple arguments to the `handle()` function.
#### Example

Middleware:

```
class ParameterizedMiddleware {
    public function handle($request, $next, $parameter1, $parameter2)
    {
        // do awesome parameterized stuff
        echo $parameter1; // foo
        echo $parameter2; // bar
        return $next($request);
    }
}
```

Usage for controller:

```
$this->middleware('parameterized:foo,bar');
```

Usage for route:

```
Route::get('test', ['middleware' => 'parameterized:foo,bar', 'uses' => 'TestController@index']);
```
