### PR TITLE
[5.1] Return a collection from lists()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1503,7 +1503,7 @@ class Builder {
 
 		$results = new Collection($this->get($columns));
 
-		return $results->lists($columns[0], array_get($columns, 1));
+		return $results->lists($columns[0], array_get($columns, 1))->all();
 	}
 
 	/**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -311,7 +311,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
 		if (is_array($first) || is_object($first))
 		{
-			return implode($glue, $this->lists($value));
+			return implode($glue, $this->lists($value)->all());
 		}
 
 		return implode($value, $this->items);
@@ -374,11 +374,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 *
 	 * @param  string  $value
 	 * @param  string  $key
-	 * @return array
+	 * @return static
 	 */
 	public function lists($value, $key = null)
 	{
-		return array_pluck($this->items, $value, $key);
+		return new static(array_pluck($this->items, $value, $key));
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -205,8 +205,8 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 	public function testLists()
 	{
 		$data = new Collection(array((object) array('name' => 'taylor', 'email' => 'foo'), (object) array('name' => 'dayle', 'email' => 'bar')));
-		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->lists('email', 'name'));
-		$this->assertEquals(array('foo', 'bar'), $data->lists('email'));
+		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->lists('email', 'name')->all());
+		$this->assertEquals(array('foo', 'bar'), $data->lists('email')->all());
 	}
 
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -559,7 +559,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, $model->id);
 		$this->assertTrue($model->exists);
 		$this->assertEquals(2, count($model->relationMany));
-		$this->assertEquals([2, 3], $model->relationMany->lists('id'));
+		$this->assertEquals([2, 3], $model->relationMany->lists('id')->all());
 	}
 
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -305,8 +305,8 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	public function testListsWithArrayAndObjectValues()
 	{
 		$data = new Collection(array((object) array('name' => 'taylor', 'email' => 'foo'), array('name' => 'dayle', 'email' => 'bar')));
-		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->lists('email', 'name'));
-		$this->assertEquals(array('foo', 'bar'), $data->lists('email'));
+		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->lists('email', 'name')->all());
+		$this->assertEquals(array('foo', 'bar'), $data->lists('email')->all());
 	}
 
 
@@ -317,8 +317,8 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 			new TestArrayAccessImplementation(array('name' => 'dayle', 'email' => 'bar'))
 		));
 
-		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->lists('email', 'name'));
-		$this->assertEquals(array('foo', 'bar'), $data->lists('email'));
+		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->lists('email', 'name')->all());
+		$this->assertEquals(array('foo', 'bar'), $data->lists('email')->all());
 	}
 
 
@@ -481,7 +481,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$modelTwo = new TestAccessorEloquentTestStub(array('some' => 'bar'));
 		$data     = new Collection(array($model, $modelTwo));
 
-		$this->assertEquals(array('foo', 'bar'), $data->lists('some'));
+		$this->assertEquals(array('foo', 'bar'), $data->lists('some')->all());
 	}
 
 
@@ -603,7 +603,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		));
 
 		$c = $c->sortBy('foo.bar');
-		$this->assertEquals(array(2, 1), $c->lists('id'));
+		$this->assertEquals(array(2, 1), $c->lists('id')->all());
 	}
 
 


### PR DESCRIPTION
It is currently **the only method** that doesn't return a collection.

---

In many many situations, you want to chain more methods onto the result.

Here's a simple example:

``` php
$users = Post::with('comments.user')->find(1)->comments->lists('user')->unique();
```

Could have used a `HasManyThrough` instead (unless it's a morph), but it's just an example.
