### PR TITLE
[5.0] Fixed Bad Typehint

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -7,7 +7,7 @@ trait InteractsWithQueue {
 	/**
 	 * The underlying queue job instance.
 	 *
-	 * @var \Illuminate\Contracts\Queue\Jobs
+	 * @var \Illuminate\Contracts\Queue\Job
 	 */
 	protected $job;
 


### PR DESCRIPTION
Wrong contract hinted for job var (Jobs instead of Job) in Illuminate/Queue/InteractsWithQueue.php
