### PR TITLE
[5.0] Make sure getRan() returns migrations in proper order.

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -45,7 +45,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 	 */
 	public function getRan()
 	{
-		return $this->table()->lists('migration');
+		return $this->table()->orderBy('migration', 'asc')->lists('migration');
 	}
 
 	/**

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -18,6 +18,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 		$connectionMock = m::mock('Illuminate\Database\Connection');
 		$repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
 		$repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+		$query->shouldReceive('orderBy')->once()->with('migration', 'asc')->andReturn($query);
 		$query->shouldReceive('lists')->once()->with('migration')->andReturn('bar');
 
 		$this->assertEquals('bar', $repo->getRan());


### PR DESCRIPTION
This change makes sure that migrations are returned in order they were (supposed to be) created. Simple lists() does not work here as some databases do not return entries in the same order all of the time.

Without that change artisan migration:reset can fail randomly. migration:reset uses this function from v5.0.28.
