### PR TITLE
[5.1] Add support for nested indexed arrays to array_pluck and data_get

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -294,7 +294,7 @@ class Arr {
 	/**
 	 * Pluck an array of values from an array.
 	 *
-	 * @param  array   $array
+	 * @param  array|\ArrayAccess  $array
 	 * @param  string|array  $value
 	 * @param  string|array|null  $key
 	 * @return array

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -59,6 +59,8 @@ class Arr {
 		{
 			if ($values instanceof Collection) $values = $values->all();
 
+			if ( ! is_array($values)) continue;
+
 			$results = array_merge($results, $values);
 		}
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -403,8 +403,20 @@ if ( ! function_exists('data_get'))
 
 		$key = is_array($key) ? $key : explode('.', $key);
 
-		foreach ($key as $segment)
+		while (($segment = array_shift($key)) !== null)
 		{
+			if ($segment === '*')
+			{
+				if ( ! is_array($target) && ! $target instanceof ArrayAccess)
+				{
+					return $default;
+				}
+
+				$result = Arr::pluck($target, $key);
+
+				return in_array('*', $key) ? Arr::collapse($result) : $result;
+			}
+
 			if (is_array($target))
 			{
 				if ( ! array_key_exists($segment, $target))

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -83,6 +83,21 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testArrayPluckWithNestedArrays()
+	{
+		$array = [['account' => 'a', 'users' => [
+			['first' => 'taylor', 'last' => 'otwell', 'email' => 'taylorotwell@gmail.com'],
+		],],['account' => 'b', 'users' => [
+			['first' => 'abigail', 'last' => 'otwell'],
+			['first' => 'dayle', 'last' => 'rees'],
+		]]];
+
+		$this->assertEquals([['taylor'], ['abigail', 'dayle']], array_pluck($array, 'users.*.first'));
+		$this->assertEquals(['a' => ['taylor'], 'b' => ['abigail', 'dayle']], array_pluck($array, 'users.*.first', 'account'));
+		$this->assertEquals([['taylorotwell@gmail.com'], [null, null]], array_pluck($array, 'users.*.email'));
+	}
+
+
 	public function testArrayExcept()
 	{
 		$array = ['name' => 'taylor', 'age' => 26];
@@ -317,6 +332,45 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('void', data_get($arrayAccess, 'user.foo', 'void'));
 		$this->assertNull(data_get($arrayAccess, 'foo'));
 		$this->assertNull(data_get($arrayAccess, 'user.foo'));
+	}
+
+
+	public function testDataGetWithNestedArrays()
+	{
+		$array = [['name' => 'taylor', 'email' => 'taylorotwell@gmail.com'], ['name' => 'abigail'], ['name' => 'dayle']];
+
+		$this->assertEquals(['taylor', 'abigail', 'dayle'], data_get($array, '*.name'));
+		$this->assertEquals(['taylorotwell@gmail.com', null, null], data_get($array, '*.email', 'irrelevant'));
+
+		$array = ['users' => [
+			['first' => 'taylor', 'last' => 'otwell', 'email' => 'taylorotwell@gmail.com'],
+			['first' => 'abigail', 'last' => 'otwell'],
+			['first' => 'dayle', 'last' => 'rees'],
+		], 'posts' => null];
+
+		$this->assertEquals(['taylor', 'abigail', 'dayle'], data_get($array, 'users.*.first'));
+		$this->assertEquals(['taylorotwell@gmail.com', null, null], data_get($array, 'users.*.email', 'irrelevant'));
+		$this->assertEquals('not found', data_get($array, 'posts.*.date', 'not found'));
+		$this->assertEquals(null, data_get($array, 'posts.*.date'));
+	}
+
+
+	public function testDataGetWithDoubleNestedArraysCollapsesResult()
+	{
+		$array = ['posts' => [
+			['comments' => [
+				['author' => 'taylor', 'likes' => 4], ['author' => 'abigail', 'likes' => 3]
+			]], ['comments' => [
+				['author' => 'abigail', 'likes' => 2], ['author' => 'dayle']
+			]], ['comments' => [
+				['author' => 'dayle'], ['author' => 'taylor', 'likes' => 1]
+			]],
+		]];
+
+		$this->assertEquals(['taylor', 'abigail', 'abigail', 'dayle', 'dayle', 'taylor'], data_get($array, 'posts.*.comments.*.author'));
+		$this->assertEquals([4, 3, 2, null, null, 1], data_get($array, 'posts.*.comments.*.likes'));
+		$this->assertEquals([], data_get($array, 'posts.*.users.*.name', 'irrelevant'));
+		$this->assertEquals([], data_get($array, 'posts.*.users.*.name'));
 	}
 
 


### PR DESCRIPTION
This has been requested a lot, and for a long time. It's immensely useful in countless situations.

To take just one example:

``` php
$tags = User::with('tags.posts.comments')->find(1)->tags;

$comments = $tags->pluck('posts.*.comments')->collapse()->unique();
```

This would have previously required [way more code and/or an additional query](http://softonsofa.com/laravel-querying-any-level-far-relations-with-simple-trick)<sup>1</sup>.

You can go as far as you need, with as many stars as you need:

``` php
$colors = $users->pluck('orders.*.items.*.product.colors')->collapse()->unique();
```

There are too many use cases to list here. This really puts `data_get` and `array_pluck` on steroids!

---

<sup>1</sup> That excellent article is what actually reminded me about this. See the comments there.
