### PR TITLE
[5.0] Remove openssl_random_pseudo_bytes() check

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -213,11 +213,6 @@ class Str {
 	 */
 	public static function random($length = 16)
 	{
-		if ( ! function_exists('openssl_random_pseudo_bytes'))
-		{
-			throw new RuntimeException('OpenSSL extension is required.');
-		}
-
 		$bytes = openssl_random_pseudo_bytes($length * 2);
 
 		if ($bytes === false)


### PR DESCRIPTION
Not sure why we need a `function_exists()` check on `openssl_random_pseudo_bytes()` here, as the function is [natively supported by PHP 5 >= 5.3.0](https://php.net/manual/en/function.openssl-random-pseudo-bytes.php).
