### PR TITLE
[5.0] Removed redundant foreach in Arr::except()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -91,10 +91,7 @@ class Arr {
 	 */
 	public static function except($array, $keys)
 	{
-		foreach ((array) $keys as $key)
-		{
-			static::forget($array, $key);
-		}
+		static::forget($array, $keys);
 
 		return $array;
 	}


### PR DESCRIPTION
In `Arr:except()`:

```
foreach ((array) $keys as $key)
{
    static::forget($array, $key);
}
```

In `Arr::forget()`:

```
foreach ((array) $keys as $key)
{
    // forget
}
```
