### PR TITLE
[5.0] [Bug] reduce redis no need connection

### DIFF
--- a/src/Illuminate/Redis/Database.php
+++ b/src/Illuminate/Redis/Database.php
@@ -20,13 +20,16 @@ class Database implements DatabaseContract {
 	 */
 	public function __construct(array $servers = array())
 	{
-		if (isset($servers['cluster']) && $servers['cluster'])
+		$cluster = array_pull($servers, 'cluster');
+		$options = (array)array_pull($servers, 'options');
+
+		if ($cluster)
 		{
-			$this->clients = $this->createAggregateClient($servers);
+			$this->clients = $this->createAggregateClient($servers, $options);
 		}
 		else
 		{
-			$this->clients = $this->createSingleClients($servers);
+			$this->clients = $this->createSingleClients($servers, $options);
 		}
 	}
 
@@ -34,14 +37,11 @@ class Database implements DatabaseContract {
 	 * Create a new aggregate client supporting sharding.
 	 *
 	 * @param  array  $servers
+	 * @param  array  $options
 	 * @return array
 	 */
-	protected function createAggregateClient(array $servers)
+	protected function createAggregateClient(array $servers, $options = [])
 	{
-		$servers = array_except($servers, array('cluster'));
-
-		$options = $this->getClientOptions($servers);
-
 		return array('default' => new Client(array_values($servers), $options));
 	}
 
@@ -49,13 +49,12 @@ class Database implements DatabaseContract {
 	 * Create an array of single connection clients.
 	 *
 	 * @param  array  $servers
+	 * @param  array  $options
 	 * @return array
 	 */
-	protected function createSingleClients(array $servers)
+	protected function createSingleClients(array $servers, $options = [])
 	{
-		$clients = array();
-
-		$options = $this->getClientOptions($servers);
+		$clients = [];
 
 		foreach ($servers as $key => $server)
 		{
@@ -66,25 +65,14 @@ class Database implements DatabaseContract {
 	}
 
 	/**
-	 * Get any client options from the configuration array.
-	 *
-	 * @param  array  $servers
-	 * @return array
-	 */
-	protected function getClientOptions(array $servers)
-	{
-		return isset($servers['options']) ? (array) $servers['options'] : [];
-	}
-
-	/**
 	 * Get a specific Redis connection instance.
 	 *
 	 * @param  string  $name
-	 * @return \Predis\ClientInterface
+	 * @return \Predis\ClientInterface|null
 	 */
 	public function connection($name = 'default')
 	{
-		return $this->clients[$name ?: 'default'];
+		return array_get($this->clients, $name ?: 'default');
 	}
 
 	/**

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+
+class RedisConnectionTest extends PHPUnit_Framework_TestCase {
+
+	public function testRedisNotCreateClusterAndOptionsServer()
+	{
+		$redis = $this->getRedis(false);
+
+		$client = $redis->connection('cluster');
+		$this->assertNull($client, 'cluster parameter should not create as redis server');
+
+		$client = $redis->connection('options');
+		$this->assertNull($client, 'options parameter should not create as redis server');
+	}
+
+
+	public function testRedisClusterNotCreateClusterAndOptionsServer()
+	{
+		$redis = $this->getRedis(true);
+		$client = $redis->connection();
+
+		$this->assertEquals(1, $client->getConnection()->count());
+	}
+
+
+	protected function getRedis($cluster = false)
+	{
+		$servers = [
+			'cluster' => $cluster,
+			'default' => [
+				'host'     => '127.0.0.1',
+				'port'     => 6379,
+				'database' => 0,
+			],
+			'options' => [
+				'prefix' => 'prefix:'
+			],
+	];
+
+		return new Illuminate\Redis\Database($servers);
+	}
+
+}

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -36,7 +36,7 @@ class RedisConnectionTest extends PHPUnit_Framework_TestCase {
 			'options' => [
 				'prefix' => 'prefix:'
 			],
-	];
+		];
 
 		return new Illuminate\Redis\Database($servers);
 	}


### PR DESCRIPTION
This pull request is about to fix `Redis\Database` create wrong server
with ‘cluster’ and ‘options’.

When `cluster == false`, `Redis\Database` will invoke
`createSingleClients` method, which call `foreach` with $servers, but
$servers still has parameters `cluster` and `options`, this will cause
no need Redis connecting.
