### PR TITLE
[5.0] [Bug] reduce redis wrong connection

### DIFF
--- a/tests/Redis/RedisConnectionTest.txt
+++ b/tests/Redis/RedisConnectionTest.txt
@@ -1,0 +1,44 @@
+<?php
+
+
+class RedisConnectionTest extends PHPUnit_Framework_TestCase {
+
+	public function testRedisNotCreateClusterAndOptionsServer()
+	{
+		$redis = $this->getRedis(false);
+
+		$client = $redis->connection('cluster');
+		$this->assertNull($client, 'cluster parameter should not create as redis server');
+
+		$client = $redis->connection('options');
+		$this->assertNull($client, 'options parameter should not create as redis server');
+	}
+
+
+	public function testRedisClusterNotCreateClusterAndOptionsServer()
+	{
+		$redis = $this->getRedis(true);
+		$client = $redis->connection();
+
+		$this->assertEquals(1, $client->getConnection()->count());
+	}
+
+
+	protected function getRedis($cluster = false)
+	{
+		$servers = [
+			'cluster' => $cluster,
+			'default' => [
+				'host'     => '127.0.0.1',
+				'port'     => 6379,
+				'database' => 0,
+			],
+			'options' => [
+				'prefix' => 'prefix:'
+			],
+		];
+
+		return new Illuminate\Redis\Database($servers);
+	}
+
+}


### PR DESCRIPTION
This pull request is about to fix `Redis\Database` create wrong server
with ‘cluster’ and ‘options’.

When `cluster == false`, `Redis\Database` will invoke
`createSingleClients` method, which call `foreach` with $servers, but
$servers still has parameters `cluster` and `options`, this will cause
no need redis connection.
