### PR TITLE
[5.0] Register Dumper with IOC container

### DIFF
--- a/src/Illuminate/Support/Debug/DebugServiceProvider.php
+++ b/src/Illuminate/Support/Debug/DebugServiceProvider.php
@@ -1,0 +1,20 @@
+<?php namespace Illuminate\Support\Debug;
+
+use Illuminate\Support\ServiceProvider;
+
+class DebugServiceProvider extends ServiceProvider {
+
+	/**
+	 * Register the service provider.
+	 *
+	 * @return void
+	 */
+	public function register()
+	{
+		$this->app->bind('dumper', function()
+		{
+			return new Dumper;
+		});
+	}
+
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -450,7 +450,7 @@ if ( ! function_exists('dd'))
 	 */
 	function dd()
 	{
-		array_map(function($x) { (new Dumper)->dump($x); }, func_get_args());
+		array_map(function($x) { app('dumper')->dump($x); }, func_get_args());
 
 		die;
 	}


### PR DESCRIPTION
There's a ton of situations where the Symfony VarDumper is a complete
pain in the ass, for example when developing APIs and trying to read debug
output in a REST client, because you end up getting hit with a ton of
unreadable HTML instead of something easy to read.

This PR binds the default dumper to the IOC container, and changes `dd`
to resolve the dumper out of the IOC instead of just newing up an
instance. Zero end user changes, but it allows picky people to swap it
out for a simpler implementation if the Symfony one is causing them
headaches :)
