### PR TITLE
[5.1]Fixed non-blade statement additional space

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -255,7 +255,7 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 				$match[0] = $this->$method(array_get($match, 3));
 			}
 
-			return isset($match[3]) ? $match[0] : $match[0].$match[2];
+			return isset($match[3]) ? $match[0] : $match[0];
 		};
 
 		return preg_replace_callback('/\B@(\w+)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', $callback, $value);


### PR DESCRIPTION
For non-blade statement like

``` php
@something    end
```

, Blade convert it to 

``` php
@something        end
```

!!!
It add double space block.
