### PR TITLE
Unexpected result when array item value is null

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -237,7 +237,7 @@ class Arr {
 
 		foreach (explode('.', $key) as $segment)
 		{
-			if ( ! is_array($array) || ! array_key_exists($segment, $array))
+			if ( ! is_array($array) || ! array_key_exists($segment, $array) || $array[$segment] == null)
 			{
 				return value($default);
 			}


### PR DESCRIPTION
When using array_get on an array item that has `null` as value, the array_get helper returns `null` rather than the expected `$default`
