### PR TITLE
Simplify composer require illuminate/events as both require illuminate/contracts.

### DIFF
--- a/src/Illuminate/Database/README.md
+++ b/src/Illuminate/Database/README.md
@@ -34,7 +34,7 @@ $capsule->setAsGlobal();
 $capsule->bootEloquent();
 ```
 
-> `composer require "illuminate/events=5.0.*"` required when you need to use observers with Eloquent.
+> `composer require "illuminate/events"` required when you need to use observers with Eloquent.
 
 Once the Capsule instance has been registered. You may use it like so:
 


### PR DESCRIPTION
Reduce stuff to be maintained during release cycle.

Signed-off-by: crynobone crynobone@gmail.com
