### PR TITLE
Enable/disable migrations

### DIFF
--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -7,7 +7,14 @@ abstract class Migration {
 	 *
 	 * @var string
 	 */
-	protected $connection;
+  protected $connection;
+
+  /**
+   * Activates/Deactivates the migration
+   *
+   * @var boolean
+   */
+  protected $enabled = true;
 
 	/**
 	 * Get the migration connection name.
@@ -17,6 +24,17 @@ abstract class Migration {
 	public function getConnection()
 	{
 		return $this->connection;
-	}
+  }
+
+  /**
+   * Get the migration activation state.
+   *
+   * @return boolean
+   */
+
+  public function isEnabled()
+  {
+    return $this->enabled;
+  }
 
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -125,21 +125,26 @@ class Migrator {
 		// First we will resolve a "real" instance of the migration class from this
 		// migration file name. Once we have the instances we can run the actual
 		// command such as "up" or "down", or we can just simulate the action.
-		$migration = $this->resolve($file);
+    $migration = $this->resolve($file);
 
-		if ($pretend)
-		{
-			return $this->pretendToRun($migration, 'up');
-		}
+    if($migration->enabled)
+    {
 
-		$migration->up();
+		  if ($pretend)
+		  {
+			  return $this->pretendToRun($migration, 'up');
+		  }
 
-		// Once we have run a migrations class, we will log that it was run in this
-		// repository so that we don't try to run it next time we do a migration
-		// in the application. A migration repository keeps the migrate order.
-		$this->repository->log($file, $batch);
+	  	$migration->up();
 
-		$this->note("<info>Migrated:</info> $file");
+		  // Once we have run a migrations class, we will log that it was run in this
+		  // repository so that we don't try to run it next time we do a migration
+	    // in the application. A migration repository keeps the migrate order.
+		  $this->repository->log($file, $batch);
+
+      $this->note("<info>Migrated:</info> $file");
+    }
+    
 	}
 
 	/**


### PR DESCRIPTION
This is a feature request. By adding an "enabled" switch inside the
Migration abstract class, a developer can control the status of the
migration, e.g. when he's developing a plugin. By default the swith
is set to on.
I have changed the files:
modified:   src/Illuminate/Database/Migrations/Migration.php
modified:   src/Illuminate/Database/Migrations/Migrator.php
