### PR TITLE
[5.0] Removed openssl_random_pseudo_bytes() check

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -213,11 +213,6 @@ class Str {
 	 */
 	public static function random($length = 16)
 	{
-		if ( ! function_exists('openssl_random_pseudo_bytes'))
-		{
-			throw new RuntimeException('OpenSSL extension is required.');
-		}
-
 		$bytes = openssl_random_pseudo_bytes($length * 2);
 
 		if ($bytes === false)


### PR DESCRIPTION
Since OpenSSL is a [prerequisite](http://laravel.com/docs/5.0#server-requirements), we don't need this `openssl_random_pseudo_bytes()` function check I guess.
