### PR TITLE
Add check for migration table in reset command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -54,6 +54,13 @@ class ResetCommand extends Command {
 
 		$this->migrator->setConnection($this->input->getOption('database'));
 
+		if ( ! $this->migrator->repositoryExists())
+		{
+			$this->output->writeln('<comment>Migration table not found.</comment>');
+
+			return;
+		}
+
 		$pretend = $this->input->getOption('pretend');
 
 		$this->migrator->reset($pretend);

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -16,6 +16,7 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 		$command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
 		$command->setLaravel(new AppDatabaseMigrationStub());
 		$migrator->shouldReceive('setConnection')->once()->with(null);
+		$migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 		$migrator->shouldReceive('reset')->once()->with(false);
 		$migrator->shouldReceive('getNotes')->andReturn([]);
 
@@ -28,6 +29,7 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 		$command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
 		$command->setLaravel(new AppDatabaseMigrationStub());
 		$migrator->shouldReceive('setConnection')->once()->with('foo');
+		$migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 		$migrator->shouldReceive('reset')->once()->with(true);
 		$migrator->shouldReceive('getNotes')->andReturn([]);
 


### PR DESCRIPTION
Proposed here: #8564

This simply checks if the migration table exists when `migrate:reset` is called. If not it will skip the rest and show a note instead of throwing an error.
