### PR TITLE
[5.0] introduce Expression contract to allow custom query expressions

### DIFF
--- a/src/Illuminate/Contracts/Database/Expression.php
+++ b/src/Illuminate/Contracts/Database/Expression.php
@@ -1,0 +1,18 @@
+<?php namespace Illuminate\Contracts\Database;
+
+interface Expression {
+
+    /**
+     * Get the value of the expression.
+     *
+     * @return mixed
+     */
+    public function getValue();
+
+    /**
+     * Get the value of the expression.
+     *
+     * @return string
+     */
+    public function __toString();
+}

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -1,6 +1,6 @@
 <?php namespace Illuminate\Database;
 
-use Illuminate\Database\Query\Expression;
+use Illuminate\Contracts\Database\Expression;
 
 abstract class Grammar {
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -9,6 +9,7 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Contracts\Database\Expression as ExpressionContract;
 
 class Builder {
 
@@ -496,7 +497,7 @@ class Builder {
 
 		$this->wheres[] = compact('type', 'column', 'operator', 'value', 'boolean');
 
-		if ( ! $value instanceof Expression)
+		if ( ! $value instanceof ExpressionContract)
 		{
 			$this->addBinding($value, 'where');
 		}
@@ -1059,7 +1060,7 @@ class Builder {
 
 		$this->havings[] = compact('type', 'column', 'operator', 'value', 'boolean');
 
-		if ( ! $value instanceof Expression)
+		if ( ! $value instanceof ExpressionContract)
 		{
 			$this->addBinding($value, 'having');
 		}
@@ -1832,7 +1833,7 @@ class Builder {
 	{
 		return array_values(array_filter($bindings, function($binding)
 		{
-			return ! $binding instanceof Expression;
+			return ! $binding instanceof ExpressionContract;
 		}));
 	}
 

--- a/src/Illuminate/Database/Query/Expression.php
+++ b/src/Illuminate/Database/Query/Expression.php
@@ -1,6 +1,8 @@
 <?php namespace Illuminate\Database\Query;
 
-class Expression {
+use Illuminate\Contracts\Database\Expression as ExpressionContract;
+
+class Expression implements ExpressionContract {
 
 	/**
 	 * The value of the expression.


### PR DESCRIPTION
It replaces `Query\Expression` checks with its interface in order to let developer pass custom, self-evaluating raw sql expressions.

Here's a quick example of why you would want it (example originating from this issue https://github.com/laravel/framework/issues/8236):

**Model:**

``` php
>>> $gis = new Gis
=> <App\Models\Gis #0000000047a2d0f9000000000ebbb990> {}

>>> $gis->name = 'point'
=> "point"

>>> $gis->geom = new Point(55,99)
=> <Sandbox\Geometry\Point #0000000047a2d0ee000000000ebbb990> {}

>>> $gis->geom->getValue() // evaluates to
=> "ST_GeomFromText('POINT(99 55)')"

>>> $gis->save()
=> true

>>> DB::connection('pgsql')->getQueryLog()
=> [
     [
        "query"   => "insert into \"gis\" (\"name\", \"geom\", \"updated_at\", \"created_at\") 
                         values (?, ST_GeomFromText('POINT(99 55)'), ?, ?) returning \"id\"",
        "bindings" => [
            "point",
            "2015-04-28 12:35:09",
            "2015-04-28 12:35:09"
        ],
        "time"     => 7.49
     ]
   ]
```

**Builder:**

``` php
>>> $point = new Point(1,5)
=> <Sandbox\Geometry\Point #0000000054450a74000000003aaa7e9c> {}

>>> DB::table('gis')->where('id', 2)->update(['geom' => $point])
=> 1

// instead of inconvenient
>>> DB::table('gis')->where('id', 2)->update(['geom' => DB::raw("ST_GeomFromText('{$point->whatever()}')")])
```
