### PR TITLE
Batch insert correction

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -624,12 +624,12 @@ class Grammar extends BaseGrammar {
 
 		$columns = $this->columnize(array_keys(reset($values)));
 
-		// We need to build a list of parameter place-holders of values that are bound
-		// to the query. Each insert should have the exact same amount of parameter
-		// bindings so we can just go off the first list of values in this array.
-		$parameters = $this->parameterize(reset($values));
+		$value = array();
 
-		$value = array_fill(0, count($values), "($parameters)");
+		foreach($values as $record)
+		{
+			$value[] = '('.$this->parameterize($record).')';
+		}
 
 		$parameters = implode(', ', $value);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -926,6 +926,15 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testMultipleInsertsWithExpressionValues()
+	{
+		$builder = $this->getBuilder();
+		$builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (UPPER(\'Foo\')), (LOWER(\'Foo\'))', array())->andReturn(true);
+		$result = $builder->from('users')->insert(array(array('email' => new Raw("UPPER('Foo')")), array('email' => new Raw("LOWER('Foo')"))));
+		$this->assertTrue($result);
+	}
+
+
 	public function testUpdateMethod()
 	{
 		$builder = $this->getBuilder();


### PR DESCRIPTION
No longer uses the first element to define the values of all inserting records.  This was a bug because if one of the parameters was an expression then the same expression value would be inserted for all records.

As an example of the bug, the following code would create 2 records with the **my_string** field set to **HELLO** (uppercase) when in fact the second record should have its field set to **hello** (lowercase).

``` php
    $test_string = 'Hello';
    $records = [
        [
            'my_string' => DB::raw("upper('$test_string')"),
            'my_int' => 1,
        ],
        [
            'my_string' => DB::raw("lower('$test_string')"),
            'my_int' => 2,
        ],
    ];
    DB::table('my_table')->insert($records);
```
