### PR TITLE
Added validation for application name in app:name command.

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -112,12 +112,12 @@ class AppNameCommand extends Command {
 	{
 		$namespace = $this->argument('name') . "\\";
 
-    foreach(get_declared_classes() as $name)
+                foreach(get_declared_classes() as $name)
 		{
-    	if(strpos($name, $namespace) === 0) return true;
+    	        	if(strpos($name, $namespace) === 0) return true;
 		}
 
-    return false;
+    		return false;
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -65,6 +65,15 @@ class AppNameCommand extends Command {
 	 */
 	public function fire()
 	{
+		if ( ! $this->validNamespace())
+		{
+			return $this->error('Invalid application name.');
+		}
+		elseif ($this->namespaceExists())
+		{
+			return $this->error('This name is already used in a namespace.');
+		}
+
 		$this->currentRoot = trim($this->laravel->getNamespace(), '\\');
 
 		$this->setBootstrapNamespaces();
@@ -82,6 +91,33 @@ class AppNameCommand extends Command {
 		$this->composer->dumpAutoloads();
 
 		$this->call('clear-compiled');
+	}
+
+	/**
+	 * Determine if the name is a valid namespace.
+	 *
+	 * @return bool
+	 */
+	protected function validNamespace()
+	{
+		return preg_match('/^[a-z_]\w+$/i', $this->argument('name'));
+	}
+
+	/**
+	 * Determine if there is already a namespace with same name.
+	 *
+	 * @return bool
+	 */
+	protected function namespaceExists()
+	{
+		$namespace = $this->argument('name') . "\\";
+
+    foreach(get_declared_classes() as $name)
+		{
+    	if(strpos($name, $namespace) === 0) return true;
+		}
+
+    return false;
 	}
 
 	/**


### PR DESCRIPTION
Makes sure the application name is a valid namespace name and there are no conflicting namespaces.

Just found out that the app:name command can break your app if you don't use a proper application name and there is no validation for invalid names.

For example if you use an invalid name like '8Gig' the application breaks (But you can do a global find and replace to fix this)

```
#php artisan app:name 8Gig

Application namespace set!

#php artisan app:name SafeName

PHP Parse error:  syntax error, unexpected '8' (T_LNUMBER), expecting identifier (T_STRING) or \\ (T_NS_SEPARATOR) or '{' in C:\laravel\laravel\app\Console\Kernel.php on line 1
PHP Stack trace:
PHP   1. {main}() C:\laravel\laravel\artisan:0
PHP   2. Illuminate\Foundation\Application->make() C:\laravel\laravel\artisan:31
PHP   3. Illuminate\Container\Container->make() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Foundation\Application.php:613
PHP   4. Illuminate\Container\Container->build() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:656
PHP   5. Illuminate\Container\Container->Illuminate\Container\{closure}() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:773
PHP   6. Illuminate\Foundation\Application->make() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:229
PHP   7. Illuminate\Container\Container->make() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Foundation\Application.php:613
PHP   8. Illuminate\Container\Container->build() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:656
PHP   9. ReflectionClass->__construct() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:776
PHP  10. spl_autoload_call() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:776
PHP  11. Composer\Autoload\ClassLoader->loadClass() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:0
PHP  12. Composer\Autoload\includeFile() C:\laravel\laravel\vendor\composer\ClassLoader.php:301

```

Also if you use some name which is already used in vendor namespace it can cause more trouble

```
#php artisan app:name Illuminate

Application namespace set!

#php artisan app:name SafeName

Application namespace set!

php artisan
PHP Fatal error:  Class 'SafeName\Foundation\Console\Kernel' not found in C:\laravel\laravel\app\Console\Kernel.php on line 6
PHP Stack trace:
PHP   1. {main}() C:\laravel\laravel\artisan:0
PHP   2. Illuminate\Foundation\Application->make() C:\laravel\laravel\artisan:31
PHP   3. Illuminate\Container\Container->make() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Foundation\Application.php:613
PHP   4. Illuminate\Container\Container->build() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:656
PHP   5. Illuminate\Container\Container->Illuminate\Container\{closure}() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:773
PHP   6. Illuminate\Foundation\Application->make() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:229
PHP   7. Illuminate\Container\Container->make() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Foundation\Application.php:613
PHP   8. Illuminate\Container\Container->build() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:656
PHP   9. ReflectionClass->__construct() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:776
PHP  10. spl_autoload_call() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:776
PHP  11. Composer\Autoload\ClassLoader->loadClass() C:\laravel\laravel\vendor\laravel\framework\src\Illuminate\Container\Container.php:0
PHP  12. Composer\Autoload\includeFile() C:\laravel\laravel\vendor\composer\ClassLoader.php:301
PHP  13. include() C:\laravel\laravel\vendor\composer\ClassLoader.php:412

```

It would have been great if there are some validations which checks for invalid application names and conflicting namespaces.
