### PR TITLE
Make swiftmailer reconnect to support daemonized queues

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -250,6 +250,9 @@ class Mailer implements MailerContract, MailQueueContract {
 	 */
 	public function handleQueuedMessage($job, $data)
 	{
+		// Stop and let swift automatically reconnect to support queue daemon mode
+		$this->getSwiftMailer()->getTransport()->stop();
+
 		$this->send($data['view'], $data['data'], $this->getQueuedCallable($data));
 
 		$job->delete();


### PR DESCRIPTION
this bug with suggested fix was noted here
https://github.com/symfony/SwiftmailerBundle/issues/39

fix was tested and works locally
