### PR TITLE
[5.1] Adding a cache directive to blade

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -640,6 +640,31 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	}
 
 	/**
+	 * Compile the cache statements into valid PHP.
+	 *
+	 * @param  string  $expression
+	 * @return string
+	 */
+	protected function compileCache($expression)
+	{
+		// we need to remove the brackets so that we can add the closure as the last argument
+		$expression = preg_replace('/^\(|\)$/', '', $expression);
+
+		return "<?php \$__fc_vars = get_defined_vars(); \$__env->cache({$expression}, function() use (\$__fc_vars) { extract(\$__fc_vars);?>";
+	}
+
+	/**
+	 * Compile the endcache statements into valid PHP.
+	 *
+	 * @param  string  $expression
+	 * @return string
+	 */
+	protected function compileEndcache($expression)
+	{
+		return "<?php }); ?>";
+	}
+
+	/**
 	 * Compile the extends statements into valid PHP.
 	 *
 	 * @param  string  $expression

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -7,7 +7,7 @@ use Illuminate\View\Engines\EngineResolver;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\View\Factory as FactoryContract;
-use Illuminate\Contracts\Cache\Factory as Cache;
+use Illuminate\Contracts\Cache\Repository as Cache;
 
 class Factory implements FactoryContract {
 
@@ -33,9 +33,9 @@ class Factory implements FactoryContract {
 	protected $events;
 
 	/**
-	 * The cache instance.
+	 * The cache repository instance.
 	 *
-	 * @var \Illuminate\Contracts\Cache\Factory
+	 * @var \Illuminate\Contracts\Cache\Repository
 	 */
 	protected $cache;
 

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -108,6 +108,7 @@ class Factory implements FactoryContract {
 	 * @param  \Illuminate\View\Engines\EngineResolver  $engines
 	 * @param  \Illuminate\View\ViewFinderInterface  $finder
 	 * @param  \Illuminate\Contracts\Events\Dispatcher  $events
+	 * @param  \Illuminate\Contracts\Cache\Repository  $cache
 	 * @return void
 	 */
 	public function __construct(EngineResolver $engines, ViewFinderInterface $finder, Dispatcher $events, Cache $cache)
@@ -560,9 +561,10 @@ class Factory implements FactoryContract {
 	 *
 	 * @param  string  $section
 	 * @param  string  $content
+	 * @param  Closure $closure
 	 * @return void
 	 */
-	public function cache($key, $condition = true, \Closure $closure)
+	public function cache($key, $condition = true, Closure $closure)
 	{
 		if (! $condition) {
 			return $closure();

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -860,9 +860,9 @@ class Factory implements FactoryContract {
 	}
 
 	/**
-	 * Get the cache instance.
+	 * Get the cache repository instance.
 	 *
-	 * @return \Illuminate\Contracts\Cache\Factory
+	 * @return \Illuminate\Contracts\Cache\Repository
 	 */
 	public function getCache()
 	{
@@ -870,9 +870,9 @@ class Factory implements FactoryContract {
 	}
 
 	/**
-	 * Set the cache instance.
+	 * Set the cache repository instance.
 	 *
-	 * @param  \Illuminate\Contracts\Cache\Factory
+	 * @param  \Illuminate\Contracts\Cache\Repository
 	 * @return void
 	 */
 	public function setCache(Cache $cache)

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -113,7 +113,7 @@ class ViewServiceProvider extends ServiceProvider {
 
 			$finder = $app['view.finder'];
 
-			$env = new Factory($resolver, $finder, $app['events']);
+			$env = new Factory($resolver, $finder, $app['events'], $app['cache']);
 
 			// We will also set the container instance on this view environment since the
 			// view composers may be classes registered in the container, which allows

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -113,7 +113,9 @@ class ViewServiceProvider extends ServiceProvider {
 
 			$finder = $app['view.finder'];
 
-			$env = new Factory($resolver, $finder, $app['events'], $app['cache']);
+			$cache = $app['cache.store'];
+
+			$env = new Factory($resolver, $finder, $app['events'], $cache);
 
 			// We will also set the container instance on this view environment since the
 			// view composers may be classes registered in the container, which allows

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -212,6 +212,35 @@ test';
 	}
 
 
+	public function testCacheIsCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$this->assertEquals(
+			'<?php $__fc_vars = get_defined_vars(); $__env->cache(\'key\', function() use ($__fc_vars) { extract($__fc_vars);?>',
+			$compiler->compileString('@cache(\'key\')')
+		);
+		$this->assertEquals(
+			'<?php $__fc_vars = get_defined_vars(); $__env->cache(\'breeze\', true, function() use ($__fc_vars) { extract($__fc_vars);?>',
+			$compiler->compileString('@cache(\'breeze\', true)')
+		);
+		$this->assertEquals(
+			'<?php $__fc_vars = get_defined_vars(); $__env->cache(\'boom\', false, function() use ($__fc_vars) { extract($__fc_vars);?>',
+			$compiler->compileString('@cache(\'boom\', false)')
+		);
+		$this->assertEquals(
+			'<?php $__fc_vars = get_defined_vars(); $__env->cache(\'guest\', Auth::guest(), function() use ($__fc_vars) { extract($__fc_vars);?>',
+			$compiler->compileString('@cache(\'guest\', Auth::guest())')
+		);
+	}
+
+
+	public function testEndcacheIsCompiled()
+	{
+		$compiler = new BladeCompiler($this->getFiles(), __DIR__);
+		$this->assertEquals('<?php }); ?>', $compiler->compileString('@endcache'));
+	}
+
+
 	public function testPushIsCompiled()
 	{
 		$compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -434,7 +434,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 			m::mock('Illuminate\View\Engines\EngineResolver'),
 			m::mock('Illuminate\View\ViewFinderInterface'),
 			m::mock('Illuminate\Contracts\Events\Dispatcher'),
-			m::mock('Illuminate\Contracts\Cache\Factory')
+			m::mock('Illuminate\Contracts\Cache\Repository')
 		);
 	}
 
@@ -445,7 +445,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 			m::mock('Illuminate\View\Engines\EngineResolver'),
 			m::mock('Illuminate\View\ViewFinderInterface'),
 			m::mock('Illuminate\Contracts\Events\Dispatcher'),
-			m::mock('Illuminate\Contracts\Cache\Factory')
+			m::mock('Illuminate\Contracts\Cache\Repository')
 		);
 	}
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -267,6 +267,19 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testCacheHandling()
+	{
+		$factory = $this->getFactory();
+		$factory->getCache()->shouldReceive('get')->once()->with('foo');
+		$factory->getCache()->shouldReceive('forever')->once()->with('foo', 'hi');
+		$factory->cache('bar', false, function() {});
+		$result = $factory->cache('foo', true, function() {
+			echo 'hi';
+		});
+		$this->assertEquals('hi', $result);
+	}
+
+
 	public function testSingleStackPush()
 	{
 		$factory = $this->getFactory();
@@ -420,7 +433,8 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 		return new Factory(
 			m::mock('Illuminate\View\Engines\EngineResolver'),
 			m::mock('Illuminate\View\ViewFinderInterface'),
-			m::mock('Illuminate\Contracts\Events\Dispatcher')
+			m::mock('Illuminate\Contracts\Events\Dispatcher'),
+			m::mock('Illuminate\Contracts\Cache\Factory')
 		);
 	}
 
@@ -430,7 +444,8 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase {
 		return array(
 			m::mock('Illuminate\View\Engines\EngineResolver'),
 			m::mock('Illuminate\View\ViewFinderInterface'),
-			m::mock('Illuminate\Contracts\Events\Dispatcher')
+			m::mock('Illuminate\Contracts\Events\Dispatcher'),
+			m::mock('Illuminate\Contracts\Cache\Factory')
 		);
 	}
 


### PR DESCRIPTION
This will add the ability for blade to cache fragments of a view.

Anything between @cache($key) or @cache($key, $condition) and the closing @endcache directives will be cached, speeding up complex fragments that don't change frequently, e.g. complex nested navigation, static pages converted from markdown etc

Inspiration, and re-implementation of https://github.com/gchaincl/laravel-fragment-caching by @gchaincl
