### PR TITLE
Pass Exception object to view

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -117,7 +117,7 @@ class Handler implements ExceptionHandlerContract {
 
 		if (view()->exists("errors.{$status}"))
 		{
-			return response()->view("errors.{$status}", [], $status);
+			return response()->view("errors.{$status}", ['e' => $e], $status);
 		}
 		else
 		{


### PR DESCRIPTION
When using custom error views, I'd like to see the Exception object passed to the view for nicer custom error messages.
