### PR TITLE
[5.1] Pass Exception object to view

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -117,7 +117,7 @@ class Handler implements ExceptionHandlerContract {
 
 		if (view()->exists("errors.{$status}"))
 		{
-			return response()->view("errors.{$status}", [], $status);
+			return response()->view("errors.{$status}", ['e' => $e], $status);
 		}
 		else
 		{


### PR DESCRIPTION
Sometimes when making a custom error view you'd like to be able to show the very error message thrown by the framework. Or sometimes you yourself break the application with a App::abort(404, 'User not found'), rather than just a default 404. 

By passing the Exception object, you allow for custom 404's, or 500's to better explain to the user what happened.

NB: You can override this very framework handler method in the app Handler class. But that's complicating things too much I think.
