### PR TITLE
[5.1] Added preserveKeys to Collection groupBy method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -235,9 +235,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 * Group an associative array by a field or using a callback.
 	 *
 	 * @param  callable|string  $groupBy
+	 * @param  bool             $preserveKeys
 	 * @return static
 	 */
-	public function groupBy($groupBy)
+	public function groupBy($groupBy, $preserveKeys = false)
 	{
 		$groupBy = $this->valueRetriever($groupBy);
 
@@ -252,7 +253,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 				$results[$groupKey] = new static;
 			}
 
-			$results[$groupKey]->push($value);
+			$results[$groupKey]->offsetSet($preserveKeys ? $key : null, $value);
 		}
 
 		return new static($results);


### PR DESCRIPTION
I made it an opt-in option, so it won't change the default behavior.

This is helpful when using `->keyBy()` prior to calling `->groupBy()`. The current behavior, calling the following will wipe out the previously set keys.

``` php
$result = $collection
  ->keyBy('id')
  ->groupBy('parent_id');

// yields
$result = [
  '2' => [
    '0' => [
      'id' => '1',
      'name' => 'foo',
      'parent_id' => '2'
    ]
  ],
  '3' => [
    '0' => [
      'id' => '2',
      'name' => 'bar',
      'parent_id' => '3'
    ]
  ]
]
```

Setting $preserveKeys to `true` will keep them in tact.

``` php
$result = $collection
  ->keyBy('id')
  ->groupBy('parent_id', true);

// yields
$result = [
  '2' => [
    '1' => [
      'id' => '1',
      'name' => 'foo',
      'parent_id' => '2'
    ]
  ],
  '3' => [
    '2' => [
      'id' => '2',
      'name' => 'bar',
      'parent_id' => '3'
    ]
  ]
]
```
