### PR TITLE
[5.1] PSR2 and short array syntax

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,9 +2,12 @@
 
 /build export-ignore
 /tests export-ignore
+.editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .scrutinizer.yml export-ignore
+.php_cs export-ignore
+.styleci.yml export-ingore
 .travis.yml export-ignore
 phpunit.php export-ignore
 phpunit.xml export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 composer.phar
 composer.lock
 .DS_Store
+.php_cs.cache
 Thumbs.db

--- a/.php_cs
+++ b/.php_cs
@@ -1,12 +1,15 @@
 <?php
 
 $finder = Symfony\Component\Finder\Finder::create()
-	->files()
-	->in(__DIR__)
-	->name('*.stub')
-	->ignoreDotFiles(true)
-	->ignoreVCS(true);
+    ->files()
+    ->in(__DIR__)
+    ->name('*.php')
+    ->name('*.stub')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true);
 
 return Symfony\CS\Config\Config::create()
-	->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
-	->finder($finder);
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->fixers(array('short_array_syntax'))
+    ->setUsingCache(true)
+    ->finder($finder);

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,4 @@
+preset: psr2
+
+enabled:
+  - short_array_syntax


### PR DESCRIPTION
@taylorotwell , after checking the new Broadcasting package for 5.1, I've noticed it was PSR-2.
The release of 5.1 could be a good opportunity to convert all source code to PSR-2 with short arrays syntax.

The initial conversion might takes time and can be done just before the release, next PSR-2 fixes will be much faster as they will rely on the `.php_cs.cache` file to speed up the process.

This PR also comes with :
- `.editorconfig` so that it uses 4 spaces instead of tabs
- `.styleci.yml` definition : @GrahamCampbell has done a great job with https://styleci.io and it would worth to integrate it to check that each PR respects coding standard.
