### PR TITLE
[5.0] Unserialize the data key within the data parameter

### DIFF
--- a/src/Illuminate/Events/CallQueuedHandler.php
+++ b/src/Illuminate/Events/CallQueuedHandler.php
@@ -75,7 +75,7 @@ class CallQueuedHandler {
 
 		if (method_exists($handler, 'failed'))
 		{
-			call_user_func_array([$handler, 'failed'], unserialize($data));
+			call_user_func_array([$handler, 'failed'], unserialize($data['data']));
 		}
 	}
 


### PR DESCRIPTION
The serialized job information is held within the data parameter's 'data' key, not the parameter itself.
