### PR TITLE
Allow broadcasting of short class name.

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -39,7 +39,7 @@ class BroadcastEvent
         $event = unserialize($data['event']);
 
         $this->broadcaster->broadcast(
-            $event->broadcastOn(), get_class($event), $this->getPayloadFromEvent($event)
+            $event->broadcastOn(), $this->getEventName($event), $this->getPayloadFromEvent($event)
         );
 
         $job->delete();
@@ -81,5 +81,23 @@ class BroadcastEvent
         }
 
         return $value;
+    }
+
+    /**
+     * Get the event name to broadcast
+     *
+     * @param mixed $event
+     * @return string
+     */
+    protected function getEventName($event)
+    {
+        $reflector = new ReflectionClass($event);
+
+        if($reflector->implementsInterface('Illuminate\Contracts\Broadcasting\ShouldBroadcastShortName'))
+        {
+            return $reflector->getShortName();
+        }
+
+        return get_class($event);
     }
 }

--- a/src/Illuminate/Contracts/Broadcasting/ShouldBroadcastShortName.php
+++ b/src/Illuminate/Contracts/Broadcasting/ShouldBroadcastShortName.php
@@ -1,0 +1,6 @@
+<?php namespace Illuminate\Contracts\Broadcasting; 
+
+interface ShouldBroadcastShortName extends ShouldBroadcast
+{
+    //
+}

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -1,75 +1,106 @@
 <?php
 
-use Mockery as m;
+namespace {
 
-class BroadcastEventTest extends PHPUnit_Framework_TestCase {
+    use Mockery as m;
+    use Test\NamespacedTestBroadcastEvent;
 
-	public function tearDown()
-	{
-		m::close();
-	}
+    class BroadcastEventTest extends PHPUnit_Framework_TestCase {
 
-
-	public function testBasicEventBroadcastParameterFormatting()
-	{
-		$broadcaster = m::mock('Illuminate\Contracts\Broadcasting\Broadcaster');
-
-		$broadcaster->shouldReceive('broadcast')->once()->with(
-			['test-channel'], 'TestBroadcastEvent', ['firstName' => 'Taylor', 'lastName' => 'Otwell', 'collection' => ['foo' => 'bar']]
-		);
-
-		$event = new TestBroadcastEvent;
-		$serializedEvent = serialize($event);
-		$jobData = ['event' => $serializedEvent];
-
-		$job = m::mock('Illuminate\Contracts\Queue\Job');
-		$job->shouldReceive('delete')->once();
-
-		(new Illuminate\Broadcasting\BroadcastEvent($broadcaster))->fire($job, $jobData);
-	}
+        public function tearDown()
+        {
+            m::close();
+        }
 
 
-	public function testManualParameterSpecification()
-	{
-		$broadcaster = m::mock('Illuminate\Contracts\Broadcasting\Broadcaster');
+        public function testBasicEventBroadcastParameterFormatting()
+        {
+            $broadcaster = m::mock('Illuminate\Contracts\Broadcasting\Broadcaster');
 
-		$broadcaster->shouldReceive('broadcast')->once()->with(
-			['test-channel'], 'TestBroadcastEventWithManualData', ['name' => 'Taylor']
-		);
+            $broadcaster->shouldReceive('broadcast')->once()->with(
+                ['test-channel'], 'TestBroadcastEvent', ['firstName' => 'Taylor', 'lastName' => 'Otwell', 'collection' => ['foo' => 'bar']]
+            );
 
-		$event = new TestBroadcastEventWithManualData;
-		$serializedEvent = serialize($event);
-		$jobData = ['event' => $serializedEvent];
+            $event = new TestBroadcastEvent;
+            $serializedEvent = serialize($event);
+            $jobData = ['event' => $serializedEvent];
 
-		$job = m::mock('Illuminate\Contracts\Queue\Job');
-		$job->shouldReceive('delete')->once();
+            $job = m::mock('Illuminate\Contracts\Queue\Job');
+            $job->shouldReceive('delete')->once();
 
-		(new Illuminate\Broadcasting\BroadcastEvent($broadcaster))->fire($job, $jobData);
-	}
+            (new Illuminate\Broadcasting\BroadcastEvent($broadcaster))->fire($job, $jobData);
+        }
+
+
+        public function testManualParameterSpecification()
+        {
+            $broadcaster = m::mock('Illuminate\Contracts\Broadcasting\Broadcaster');
+
+            $broadcaster->shouldReceive('broadcast')->once()->with(
+                ['test-channel'], 'TestBroadcastEventWithManualData', ['name' => 'Taylor']
+            );
+
+            $event = new TestBroadcastEventWithManualData;
+            $serializedEvent = serialize($event);
+            $jobData = ['event' => $serializedEvent];
+
+            $job = m::mock('Illuminate\Contracts\Queue\Job');
+            $job->shouldReceive('delete')->once();
+
+            (new Illuminate\Broadcasting\BroadcastEvent($broadcaster))->fire($job, $jobData);
+        }
+
+        public function testShortClassNameEventBroadcast()
+        {
+            $broadcaster = m::mock('Illuminate\Contracts\Broadcasting\Broadcaster');
+
+            $broadcaster->shouldReceive('broadcast')->once()->with(
+                ['test-channel'], 'NamespacedTestBroadcastEvent', ['firstName' => 'Taylor', 'lastName' => 'Otwell', 'collection' => ['foo' => 'bar']]
+            );
+
+            $event = new NamespacedTestBroadcastEvent();
+            $serializedEvent = serialize($event);
+            $jobData = ['event' => $serializedEvent];
+
+            $job = m::mock('Illuminate\Contracts\Queue\Job');
+            $job->shouldReceive('delete')->once();
+
+            (new Illuminate\Broadcasting\BroadcastEvent($broadcaster))->fire($job, $jobData);
+        }
+
+    }
+
+
+    class TestBroadcastEvent {
+        public $firstName = 'Taylor';
+        public $lastName = 'Otwell';
+        public $collection;
+        private $title = 'Developer';
+        public function __construct()
+        {
+            $this->collection = collect(['foo' => 'bar']);
+        }
+        public function broadcastOn()
+        {
+            return ['test-channel'];
+        }
+    }
+
+
+    class TestBroadcastEventWithManualData extends TestBroadcastEvent {
+        public function broadcastWith()
+        {
+            return ['name' => 'Taylor'];
+        }
+    }
 
 }
 
+namespace Test {
+    use Illuminate\Contracts\Broadcasting\ShouldBroadcastShortName;
 
-class TestBroadcastEvent {
-	public $firstName = 'Taylor';
-	public $lastName = 'Otwell';
-	public $collection;
-	private $title = 'Developer';
-	public function __construct()
-	{
-		$this->collection = collect(['foo' => 'bar']);
-	}
-	public function broadcastOn()
-	{
-		return ['test-channel'];
-	}
+    class NamespacedTestBroadcastEvent extends \TestBroadcastEvent implements ShouldBroadcastShortName
+    {
+        //
+    }
 }
-
-
-class TestBroadcastEventWithManualData extends TestBroadcastEvent {
-	public function broadcastWith()
-	{
-		return ['name' => 'Taylor'];
-	}
-}
-


### PR DESCRIPTION
All of my events are in the same namespace so it seems a little redundant to use the full namespace in the client side code.
