### PR TITLE
[5.0] Don't throw warning on missing relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3072,7 +3072,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function getRelation($relation)
 	{
-		return $this->relations[$relation];
+		return array_get($this->relations, $relation, null);
 	}
 
 	/**


### PR DESCRIPTION
I may not always know beforehand if a model has a given relation. So calling

``` php
$model->getRelation('myRelation')
```

could potentially result in a PHP undefined index warning. This PR is backwards compatible, it just fixes the potential warning.
