### PR TITLE
[5.1] Don't throw warning on missing relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3043,7 +3043,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function getRelation($relation)
 	{
-		return $this->relations[$relation];
+		return array_get($this->relations, $relation);
 	}
 
 


### PR DESCRIPTION
Calling

``` php
$model->getRelation('myRelation')
```

on a relation that doesn't exist could potentially result in a PHP undefined index warning while returning NULL. This PR simply removes the warning while still returning NULL. 

This PR is backwards incompatible in that it removes an unhelpful, uncatchable PHP warning. The result of the method call is still the same though (NULL returned on missing relation), so no code changes are required.
