### PR TITLE
Nested transactions don't roll back

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -479,6 +479,10 @@ class Connection implements ConnectionInterface {
 		{
 			$this->pdo->beginTransaction();
 		}
+		elseif ($this->transactions > 1)
+		{
+			$this->pdo->exec('SAVEPOINT trans'.$this->transactions);
+		}
 
 		$this->fireConnectionEvent('beganTransaction');
 	}
@@ -506,14 +510,14 @@ class Connection implements ConnectionInterface {
 	{
 		if ($this->transactions == 1)
 		{
-			$this->transactions = 0;
-
 			$this->pdo->rollBack();
 		}
-		else
+		elseif ($this->transactions > 1)
 		{
-			--$this->transactions;
+			$this->pdo->exec('ROLLBACK TO trans'.$this->transactions);
 		}
+
+		--$this->transactions;
 
 		$this->fireConnectionEvent('rollingBack');
 	}

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -514,7 +514,7 @@ class Connection implements ConnectionInterface {
 		}
 		elseif ($this->transactions > 1)
 		{
-			$this->pdo->exec('ROLLBACK TO trans'.$this->transactions);
+			$this->pdo->exec('ROLLBACK TO SAVEPOINT trans'.$this->transactions);
 		}
 
 		--$this->transactions;

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -340,7 +340,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 	public function testEmptyMorphToRelationship()
 	{
 		$photo = EloquentTestPhoto::create(['name' => 'Avatar 1']);
-		
+
 		$this->assertNull($photo->imageable);
 	}
 
@@ -368,6 +368,24 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertTrue($result);
 		$this->assertEquals(2, EloquentTestPost::count());
+	}
+
+	public function testNestedTransactions()
+	{
+		$user = EloquentTestUser::create(['email' => 'taylor@laravel.com']);
+
+		$this->connection()->transaction(function () use ($user) {
+			try {
+				$this->connection()->transaction(function () use ($user) {
+					$user->email = 'otwell@laravel.com';
+					$user->save();
+					throw new Exception;
+				});
+			} catch (Exception $e) {}
+
+			$user = EloquentTestUser::first();
+			$this->assertEquals('taylor@laravel.com', $user->email);
+		});
 	}
 
 


### PR DESCRIPTION
Just adding a failing test case. You can see here we're only actually starting a transaction for the first transaction:

https://github.com/laravel/framework/blob/5.0/src/Illuminate/Database/Connection.php#L478-L481

Nested transactions need to make use of savepoints to work correctly.

This test probably doesn't belong in this file, but this was the only place that was already setup for DB integration testing and wanted to present the issue without a big noisy change set.
