### PR TITLE
Remove dead reference from controller stubs

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/controller.plain.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.plain.stub
@@ -1,6 +1,5 @@
 <?php namespace {{namespace}};
 
-use {{rootNamespace}}Http\Requests;
 use {{rootNamespace}}Http\Controllers\Controller;
 
 use Illuminate\Http\Request;

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -1,6 +1,5 @@
 <?php namespace {{namespace}};
 
-use {{rootNamespace}}Http\Requests;
 use {{rootNamespace}}Http\Controllers\Controller;
 
 use Illuminate\Http\Request;


### PR DESCRIPTION
This PR proposes to update the controller stubs used by the `make:controller` artisan command.

The `use {{rootNamespace}}Http\Requests` declaration that is currently used in the stubs does not match anything. The correct statement would be `use {{rootNamespace}}Http\Requests\Request`.

However, since [this Request class](https://github.com/laravel/laravel/blob/master/app/Http/Requests/Request.php) is an abstract one and, as such, cannot be instantiated, it makes little sense to try to `use` it. I then propose to remove this `use` declaration from the two stubs.
