### PR TITLE
Add "be" Helper For Escape Blade Template Entities + "be" Helper Test

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -823,3 +823,39 @@ if ( ! function_exists('with'))
 		return $object;
 	}
 }
+
+if ( ! function_exists('be'))
+{
+	/**
+	 * Escape Blade Template entities in a string.
+	 *
+	 * @param  string  $value
+	 * @return string
+	 */
+	function be($value)
+	{
+		$blade_entities = [
+			'{{', '}}', '{{--', '--}}', 
+			'@{{', '{!!', '!!}', '@parent', 
+			'@extends', '@stop', '@endsection', '@yield', 
+			'@show', '@if', '@elseif', '@else',
+			'@endif', '@unless', '@endunless', '@for', 
+			'@endfor', '@foreach', '@endforeach', '@forelse', 
+			'@empty', '@endforelse', '@while', '@endwhile',
+			'@include', '@overwrite', '@lang', '@choice',
+			'@section',
+		];
+		$replace_value = [
+			'&#123;&#123;', '&#125;&#125;', '&#123;&#123;--', '--&#125;&#125;', 
+			'&#64;&#123;&#123;', '&#123;!!', '!!&#125;', '&#64;parent', 
+			'&#64;extends', '&#64;stop', '&#64;endsection', '&#64;yield', 
+			'&#64;show', '&#64;if', '&#64;elseif', '&#64;else',
+			'&#64;endif', '&#64;unless', '&#64;endunless', '&#64;for', 
+			'&#64;endfor', '&#64;foreach', '&#64;endforeach', '&#64;forelse', 
+			'&#64;empty', '&#64;endforelse', '&#64;while', '&#64;endwhile',
+			'&#64;include', '&#64;overwrite', '&#64;lang', '&#64;choice',
+			'&#64;section',
+		];
+		return str_replace($blade_entities, $replace_value, $value);
+	}
+}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -387,6 +387,17 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('firstname' => 'Ferid'), $developer);
 	}
 
+	public function testBe()
+	{
+		$value_with_blade_entities  = "<html><body>{!! @section('base') @parent";
+		$value_with_blade_entities .= " @endsection !!} @if(1==1) {{'OK'}} @endif </body></html>";
+
+		$value_stripped_expected  = "<html><body>&#123;!! &#64;section('base') &#64;parent";
+		$value_stripped_expected .= " &#64;endsection !!&#125; &#64;if(1==1) &#123;&#123;'OK'&#125;&#125; &#64;endif </body></html>";
+
+		$this->assertEquals($value_stripped_expected, be($value_with_blade_entities));
+	}
+
 }
 
 trait SupportTestTraitOne {}


### PR DESCRIPTION
I am a laracasts.com's user and recently I submitted a post using "@parent" blade directive and it bugged the website. So I realize maybe It'd be interesting to have a blade strip helper function. It can also be a security problem as well because blade directives are converted to php executable code. 
