### PR TITLE
[5.1] Nested transactions don't rollback

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -479,6 +479,10 @@ class Connection implements ConnectionInterface {
 		{
 			$this->pdo->beginTransaction();
 		}
+		elseif ($this->transactions > 1)
+		{
+			$this->pdo->exec('SAVEPOINT trans'.$this->transactions);
+		}
 
 		$this->fireConnectionEvent('beganTransaction');
 	}
@@ -506,14 +510,14 @@ class Connection implements ConnectionInterface {
 	{
 		if ($this->transactions == 1)
 		{
-			$this->transactions = 0;
-
 			$this->pdo->rollBack();
 		}
-		else
+		elseif ($this->transactions > 1)
 		{
-			--$this->transactions;
+			$this->pdo->exec('ROLLBACK TO SAVEPOINT trans'.$this->transactions);
 		}
+
+		--$this->transactions;
 
 		$this->fireConnectionEvent('rollingBack');
 	}

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -340,7 +340,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 	public function testEmptyMorphToRelationship()
 	{
 		$photo = EloquentTestPhoto::create(['name' => 'Avatar 1']);
-		
+
 		$this->assertNull($photo->imageable);
 	}
 
@@ -368,6 +368,24 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertTrue($result);
 		$this->assertEquals(2, EloquentTestPost::count());
+	}
+
+	public function testNestedTransactions()
+	{
+		$user = EloquentTestUser::create(['email' => 'taylor@laravel.com']);
+
+		$this->connection()->transaction(function () use ($user) {
+			try {
+				$this->connection()->transaction(function () use ($user) {
+					$user->email = 'otwell@laravel.com';
+					$user->save();
+					throw new Exception;
+				});
+			} catch (Exception $e) {}
+
+			$user = EloquentTestUser::first();
+			$this->assertEquals('taylor@laravel.com', $user->email);
+		});
 	}
 
 


### PR DESCRIPTION
Currently, a nested transaction does not rollback. You can see here we just ignore anything past the first transaction:

https://github.com/laravel/framework/blob/5.0/src/Illuminate/Database/Connection.php#L478-L481

This will prove most problematic once the transaction-based integration testing stuff arrives, as no one's transaction dependent code will function correctly in test environments.

First commit is a failing test case, followed by an implementation that solves the issue for MySQL, Postgres and SQLite. Would love for someone with SQL Server experience to help solve for that case.
