### PR TITLE
Added log path configurability and log:tail artisan command

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -329,6 +329,24 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	}
 
 	/**
+	 * Get the path to the log file.
+	 * If the path is defined without a leading slash, it will be
+	 * resolved relative to the storage path.
+	 *
+	 * @return string
+	 */
+	public function logPath()
+	{
+		$path = $this['config']->get('log.path', 'logs/laravel.log');
+
+		if(substr($path, 0, 1) != DIRECTORY_SEPARATOR) {
+			$path = $this->storagePath().DIRECTORY_SEPARATOR.$path;
+		}
+
+		return $path;
+	}
+
+	/**
 	 * Get the path to the public / web directory.
 	 *
 	 * @return string

--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -63,7 +63,7 @@ class ConfigureLogging {
 	 */
 	protected function getLogPath(Application $app)
 	{
-		$path = $app->make('config')->get('log.path');
+		$path = $app->make('config')->get('log.path', 'logs/laravel.log');
 
 		// if the path is relative, it should be relative to the storage path
 		if(substr($path, 0, 1) != DIRECTORY_SEPARATOR) {

--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -63,7 +63,8 @@ class ConfigureLogging {
 	 */
 	protected function configureSingleHandler(Application $app, Writer $log)
 	{
-		$log->useFiles($app->storagePath().'/logs/laravel.log');
+		$defaultPath = $app->storagePath().'/logs/laravel.log';
+		$log->useFiles($app->make('config')->get('log.path', $defaultPath));
 	}
 
 	/**
@@ -75,9 +76,10 @@ class ConfigureLogging {
 	 */
 	protected function configureDailyHandler(Application $app, Writer $log)
 	{
+        $defaultPath = $app->storagePath().'/logs/laravel.log';
 		$log->useDailyFiles(
-			$app->storagePath().'/logs/laravel.log',
-			$app->make('config')->get('app.log_max_files', 5)
+			$app->make('config')->get('log.path', $defaultPath),
+			$app->make('config')->get('log.max_files', 5)
 		);
 	}
 

--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -55,25 +55,6 @@ class ConfigureLogging {
 	}
 
 	/**
-	 * Get the log file path.
-	 *
-	 * @param Application $app
-	 *
-	 * @return string
-	 */
-	protected function getLogPath(Application $app)
-	{
-		$path = $app->make('config')->get('log.path', 'logs/laravel.log');
-
-		// if the path is relative, it should be relative to the storage path
-		if(substr($path, 0, 1) != DIRECTORY_SEPARATOR) {
-			$path = $app->storagePath().DIRECTORY_SEPARATOR.$path;
-		}
-
-		return $path;
-	}
-
-	/**
 	 * Configure the Monolog handlers for the application.
 	 *
 	 * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -82,7 +63,7 @@ class ConfigureLogging {
 	 */
 	protected function configureSingleHandler(Application $app, Writer $log)
 	{
-		$log->useFiles($this->getLogPath($app));
+		$log->useFiles($app->logPath());
 	}
 
 	/**
@@ -95,7 +76,7 @@ class ConfigureLogging {
 	protected function configureDailyHandler(Application $app, Writer $log)
 	{
 		$log->useDailyFiles(
-			$app->make('config')->get('log.path', $this->getLogPath($app)),
+			$app->logPath(),
 			$app->make('config')->get('log.max_files', 5)
 		);
 	}

--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -55,6 +55,25 @@ class ConfigureLogging {
 	}
 
 	/**
+	 * Get the log file path.
+	 *
+	 * @param Application $app
+	 *
+	 * @return string
+	 */
+	protected function getLogPath(Application $app)
+	{
+		$path = $app->make('config')->get('log.path');
+
+		// if the path is relative, it should be relative to the storage path
+		if(substr($path, 0, 1) != DIRECTORY_SEPARATOR) {
+			$path = $app->storagePath().DIRECTORY_SEPARATOR.$path;
+		}
+
+		return $path;
+	}
+
+	/**
 	 * Configure the Monolog handlers for the application.
 	 *
 	 * @param  \Illuminate\Contracts\Foundation\Application  $app
@@ -63,8 +82,7 @@ class ConfigureLogging {
 	 */
 	protected function configureSingleHandler(Application $app, Writer $log)
 	{
-		$defaultPath = $app->storagePath().'/logs/laravel.log';
-		$log->useFiles($app->make('config')->get('log.path', $defaultPath));
+		$log->useFiles($this->getLogPath($app));
 	}
 
 	/**
@@ -76,9 +94,8 @@ class ConfigureLogging {
 	 */
 	protected function configureDailyHandler(Application $app, Writer $log)
 	{
-        $defaultPath = $app->storagePath().'/logs/laravel.log';
 		$log->useDailyFiles(
-			$app->make('config')->get('log.path', $defaultPath),
+			$app->make('config')->get('log.path', $this->getLogPath($app)),
 			$app->make('config')->get('log.max_files', 5)
 		);
 	}

--- a/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
@@ -22,6 +22,7 @@ class ConsoleSupportServiceProvider extends AggregateServiceProvider {
 		'Illuminate\Database\MigrationServiceProvider',
 		'Illuminate\Database\SeedServiceProvider',
 		'Illuminate\Foundation\Providers\ComposerServiceProvider',
+		'Illuminate\Log\ConsoleServiceProvider',
 		'Illuminate\Queue\ConsoleServiceProvider',
 		'Illuminate\Routing\GeneratorServiceProvider',
 		'Illuminate\Session\CommandsServiceProvider',

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -303,6 +303,19 @@ if ( ! function_exists('logger'))
 	}
 }
 
+if ( ! function_exists('log_path'))
+{
+	/**
+	 * Get the path to the log file.
+	 *
+	 * @return string
+	 */
+	function log_path()
+	{
+		return app()->logPath();
+	}
+}
+
 if ( ! function_exists('old'))
 {
 	/**

--- a/src/Illuminate/Log/Console/TailCommand.php
+++ b/src/Illuminate/Log/Console/TailCommand.php
@@ -32,7 +32,7 @@ class TailCommand extends Command {
 				$filepath = $this->getDailyLogfile($date);
 				break;
 			case 'single':
-				$filepath = $this->getLogPath();
+				$filepath = log_path();
 				break;
 			default:
 				$this->error(config('app.log')." not supported.");
@@ -55,7 +55,7 @@ class TailCommand extends Command {
 	 */
 	protected function getDailyLogfile($date = null)
 	{
-		$filepath = $this->getLogPath();
+		$filepath = log_path();
 
 		$folder = pathinfo($filepath, PATHINFO_DIRNAME);
 		$filename = pathinfo($filepath, PATHINFO_FILENAME);
@@ -64,14 +64,6 @@ class TailCommand extends Command {
 		$date = date('Y-m-d', $date);
 
 		return "{$folder}".DIRECTORY_SEPARATOR."{$filename}-{$date}.{$ext}";
-	}
-
-	/**
-	 * @return string
-	 */
-	protected function getLogPath()
-	{
-		return config('log.path', storage_path('/logs/laravel.log'));
 	}
 
 	/**

--- a/src/Illuminate/Log/Console/TailCommand.php
+++ b/src/Illuminate/Log/Console/TailCommand.php
@@ -32,7 +32,7 @@ class TailCommand extends Command {
 				$filepath = $this->getDailyLogfile($date);
 				break;
 			case 'single':
-				$filepath = config('log.path');
+				$filepath = $this->getLogPath();
 				break;
 			default:
 				$this->error(config('app.log')." not supported.");
@@ -55,7 +55,7 @@ class TailCommand extends Command {
 	 */
 	protected function getDailyLogfile($date = null)
 	{
-		$filepath = config('log.path');
+		$filepath = $this->getLogPath();
 
 		$folder = pathinfo($filepath, PATHINFO_DIRNAME);
 		$filename = pathinfo($filepath, PATHINFO_FILENAME);
@@ -64,6 +64,14 @@ class TailCommand extends Command {
 		$date = date('Y-m-d', $date);
 
 		return "{$folder}".DIRECTORY_SEPARATOR."{$filename}-{$date}.{$ext}";
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function getLogPath()
+	{
+		return config('log.path', storage_path('/logs/laravel.log'));
 	}
 
 	/**

--- a/src/Illuminate/Log/Console/TailCommand.php
+++ b/src/Illuminate/Log/Console/TailCommand.php
@@ -1,0 +1,30 @@
+<?php namespace Illuminate\Log\Console;
+
+use Illuminate\Console\Command;
+
+class TailCommand extends Command {
+
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'log:tail';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Watch the tail of the log file for changes';
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return void
+	 */
+	public function fire()
+	{
+		dd('hi!');
+	}
+}

--- a/src/Illuminate/Log/ConsoleServiceProvider.php
+++ b/src/Illuminate/Log/ConsoleServiceProvider.php
@@ -1,0 +1,40 @@
+<?php namespace Illuminate\Log;
+
+use Illuminate\Log\Console\TailCommand;
+use Illuminate\Support\ServiceProvider;
+
+class ConsoleServiceProvider extends ServiceProvider {
+
+	/**
+	 * Indicates if loading of the provider is deferred.
+	 *
+	 * @var bool
+	 */
+	protected $defer = true;
+
+	/**
+	 * Register the service provider.
+	 *
+	 * @return void
+	 */
+	public function register()
+	{
+		$this->app->singleton('command.log.tail', function($app)
+		{
+			return new TailCommand();
+		});
+
+		$this->commands('command.log.tail');
+	}
+
+	/**
+	 * Get the services provided by the provider.
+	 *
+	 * @return array
+	 */
+	public function provides()
+	{
+		return array('command.log.tail');
+	}
+
+}

--- a/src/Illuminate/Log/ConsoleServiceProvider.php
+++ b/src/Illuminate/Log/ConsoleServiceProvider.php
@@ -19,7 +19,7 @@ class ConsoleServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton('command.log.tail', function($app)
+		$this->app->singleton('command.log.tail', function()
 		{
 			return new TailCommand();
 		});


### PR DESCRIPTION
In this PR, I've added the ability for the `single` and `daily` log to be customisable - the `path` is now configurable, as well as the number of daily log files to keep.

The code is fully backwards-compatible, and all tests pass.

**Note**: this command will only work on *nix systems; not sure if that's a dealbreaker.
I have found a way to implement `tail`-like functionality in pure PHP, but figured a `passthru` to the real thing would be better and simpler.

**Usage**:

_mode: `single`_
`php artisan log:tail` -> tails the log file (by default stored at `storage/logs/laravel.log` - works with custom paths, too)

_mode: `daily`_
`php artisan log:tail` -> tails the log file (by default stored at `storage/logs/laravel-{$date}.log` - works with custom paths, too)

Custom paths can be specified in the `.env`, relative paths will be resolved relative to the `storage_path`, absolute paths work, too:

``` ini
LOG_PATH=/var/log/mylog.txt
```

You can pass in any `strtotime`-compatible string to the `--date` option:

`php artisan log:tail --date=yesterday`

and you can specify the number of lines...

`php artisan log:tail --lines=0` -> shows only new output in `tail`ed file
