### PR TITLE
added InMemoryDatabase trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/InMemoryDatabase.php
+++ b/src/Illuminate/Foundation/Testing/InMemoryDatabase.php
@@ -1,0 +1,18 @@
+<?php namespace Illuminate\Foundation\Testing;
+
+trait InMemoryDatabase
+{
+    /**
+     * @before
+     */
+    public function enableInMemoryDatabase()
+    {
+        $connection = [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+        ];
+
+        config()->set('database.connections.testing', $connection);
+        config()->set('database.default', 'testing');
+    }
+}


### PR DESCRIPTION
That would allow the tests to run in a `':memory:'` sqlite database automatically by using this trait. example:

``` php
<?php

use Illuminate\Foundation\Testing\InMemoryDatabase;

class UserTest extends TestCase
{
    use InMemoryDatabase;

    // tests here
}
```
