### PR TITLE
[5.1] Added RunMigrations trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/RunMigrations.php
+++ b/src/Illuminate/Foundation/Testing/RunMigrations.php
@@ -1,0 +1,25 @@
+<?php namespace Illuminate\Foundation\Testing;
+
+trait RunMigrations
+{
+    /**
+     * @before
+     */
+    public function runMigrations()
+    {
+        // run application migrations
+        $this->artisan('migrate');
+
+        // register the rollback action before destroying
+        // the application
+        $this->beforeApplicationDestroyed(function() {
+            $this->rollbackMigrations();
+        });
+    }
+
+
+    public function rollbackMigrations()
+    {
+        $this->artisan('migrate:rollback');
+    }
+}


### PR DESCRIPTION
Trait to automatically `migrate` at begining of each test and automatically `rollback` at the end.

Example usage:

``` php
<?php

use Illuminate\Foundation\Testing\RunMigrations;

class UserTest extends TestCase
{
    use RunMigrations;

    // your tests
}
```
