### PR TITLE
[5.0] Allow getDirty to handle date casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3029,6 +3029,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 			{
 				$dirty[$key] = $value;
 			}
+			elseif (in_array($key, $this->getDates()) && ! is_null($value) && ! is_null($this->original[$key]))
+			{
+				if ($value === $this->original[$key]) continue;
+
+				$current = $this->asDateTime($value);
+
+				$original = $this->asDateTime($this->original[$key]);
+
+				if ($current->getTimestamp() !== $original->getTimestamp())
+				{
+					$dirty[$key] = $value;
+				}
+			}
 			elseif ($value !== $this->original[$key] &&
                                  ! $this->originalIsNumericallyEquivalent($key))
 			{


### PR DESCRIPTION
Consider an existing model which has the eloquent dates attribute filled.
Set an identical date value (Ex. 'Y-m-d') on such a date field, the field will turn-up dirty.
This happens because the `setAttribute` method will create a Carbon object from this set date, which will return a grammar defined date format (Ex. 'Y-m-d H:i:s').

This pull request aims to let `getDirty` handle this correctly. 

https://github.com/laravel/framework/issues/8666
