### PR TITLE
[5.0] Fix docblock

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -127,7 +127,7 @@ class Dispatcher implements DispatcherContract {
 	/**
 	 * Register an event subscriber with the dispatcher.
 	 *
-	 * @param  string  $subscriber
+	 * @param  mixed  $subscriber
 	 * @return void
 	 */
 	public function subscribe($subscriber)


### PR DESCRIPTION
$subscriber can be either an object or a string
