### PR TITLE
[5.0] Fix for using closure with callable middleware

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -620,7 +620,7 @@ class Route {
 	{
 		return array_first($action, function($key, $value)
 		{
-			return is_callable($value);
+			return is_callable($value) && is_numeric($index);
 		});
 	}
 


### PR DESCRIPTION
Check if the index of the item is numeric so that we don't return the middleware.
