### PR TITLE
[5.1] Fix undefined response exception in CrawlerTrait

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -201,7 +201,7 @@ trait CrawlerTrait
         } catch (PHPUnitException $e) {
             $message = $message ?: "A request to [{$uri}] failed. Received status code [{$status}].";
 
-            throw new PHPUnitException($message, null, $this->response->exception);
+            throw new PHPUnitException($message, null, $e);
         }
     }
 


### PR DESCRIPTION
There was 1 error:

1) ExampleTest::testBasicExample
ErrorException: Undefined property: Symfony\Component\HttpFoundation\Response::$exception
