### PR TITLE
[5.1] Add encryption to Eloquent

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -18,6 +18,8 @@ class DatabaseServiceProvider extends ServiceProvider {
 		Model::setConnectionResolver($this->app['db']);
 
 		Model::setEventDispatcher($this->app['events']);
+
+		Model::setEncrypter($this->app['encrypter']);
 	}
 
 	/**

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -34,6 +34,7 @@
     "suggest": {
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.4).",
         "illuminate/console": "Required to use the database commands (5.1.*).",
+        "illuminate/encryption": "Required to use encryption with Eloquent (5.1.*).",
         "illuminate/events": "Required to use the observers with Eloquent (5.1.*).",
         "illuminate/filesystem": "Required to use the migrations (5.1.*)."
     },


### PR DESCRIPTION
This will allow attributes to automatically be encrypted in the database by simply adding it to an `$encrypt` property on the model:

``` php
class User {

    protected $encrypt = ['email'];

}
```
