### PR TITLE
[5.0] Fix relations firstOrNew logic

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -629,7 +629,7 @@ class BelongsToMany extends Relation {
 	{
 		if (is_null($instance = $this->where($attributes)->first()))
 		{
-			$instance = $this->related->newInstance();
+			$instance = $this->related->newInstance($attributes);
 		}
 
 		return $instance;

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -125,7 +125,7 @@ abstract class MorphOneOrMany extends HasOneOrMany {
 	{
 		if (is_null($instance = $this->where($attributes)->first()))
 		{
-			$instance = $this->related->newInstance();
+			$instance = $this->related->newInstance($attributes);
 
 			// When saving a polymorphic relationship, we need to set not only the foreign
 			// key, but also the foreign key type, which is typically the class name of

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -110,7 +110,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getOneRelation();
 		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
 		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-		$relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('foo'))->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
 		$model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
 		$model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
 		$model->shouldReceive('save')->never();
@@ -161,7 +161,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getOneRelation();
 		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
 		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-		$relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('foo'))->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
 		$model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
 		$model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
 		$model->shouldReceive('save')->once()->andReturn(true);


### PR DESCRIPTION
`MorphOneOrMany::firstOrNew` and `BelongsToMany::firstOrNew` have invalid logic that differs from other `firstOrNew` implementations.
The new instance is not filled with initial attributes.
