### PR TITLE
[5.1] Allow parameters to be passed to the scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -29,24 +29,45 @@ class Schedule {
 	 * Add a new Artisan command event to the schedule.
 	 *
 	 * @param  string  $command
+	 * @param  array  $parameters
 	 * @return \Illuminate\Console\Scheduling\Event
 	 */
-	public function command($command)
+	public function command($command, array $parameters = [])
 	{
-		return $this->exec(PHP_BINARY.' artisan '.$command);
+		return $this->exec(PHP_BINARY.' artisan '.$command, $parameters);
 	}
 
 	/**
 	 * Add a new command event to the schedule.
 	 *
 	 * @param  string  $command
+	 * @param  array  $parameters
 	 * @return \Illuminate\Console\Scheduling\Event
 	 */
-	public function exec($command)
+	public function exec($command, array $parameters = [])
 	{
+		if (count($parameters))
+		{
+			$command .= ' '.$this->compileParameters($parameters);
+		}
+
 		$this->events[] = $event = new Event($command);
 
 		return $event;
+	}
+
+	/**
+	 * Compile parameters for a command.
+	 *
+	 * @param  array  $parameters
+	 * @return string
+	 */
+	protected function compileParameters(array $parameters)
+	{
+		return collect($parameters)->map(function($value, $key)
+		{
+			return is_numeric($key) ? $value : $key.'="'.addslashes($value).'"';
+		})->implode(' ');
 	}
 
 	/**

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Console\Scheduling\Schedule;
+
+class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase {
+
+	public function tearDown()
+	{
+		m::close();
+	}
+
+
+	public function testExecCreatesNewCommand()
+	{
+		$schedule = new Schedule;
+		$schedule->exec('path/to/command');
+		$schedule->exec('path/to/command -f --foo="bar"');
+		$schedule->exec('path/to/command', ['-f']);
+		$schedule->exec('path/to/command', ['--foo' => 'bar']);
+		$schedule->exec('path/to/command', ['-f', '--foo' => 'bar']);
+		$schedule->exec('path/to/command', ['--title' => 'A "real" test']);
+
+		$events = $schedule->events();
+		$this->assertEquals('path/to/command', $events[0]->command);
+		$this->assertEquals('path/to/command -f --foo="bar"', $events[1]->command);
+		$this->assertEquals('path/to/command -f', $events[2]->command);
+		$this->assertEquals('path/to/command --foo="bar"', $events[3]->command);
+		$this->assertEquals('path/to/command -f --foo="bar"', $events[4]->command);
+		$this->assertEquals('path/to/command --title="A \"real\" test"', $events[5]->command);
+	}
+
+
+	public function testCommandCreatesNewArtisanCommand()
+	{
+		$schedule = new Schedule;
+		$schedule->command('queue:listen');
+		$schedule->command('queue:listen --tries="3"');
+		$schedule->command('queue:listen', ['--tries' => 3]);
+
+		$events = $schedule->events();
+		$this->assertEquals(PHP_BINARY.' artisan queue:listen', $events[0]->command);
+		$this->assertEquals(PHP_BINARY.' artisan queue:listen --tries="3"', $events[1]->command);
+		$this->assertEquals(PHP_BINARY.' artisan queue:listen --tries="3"', $events[2]->command);
+	}
+
+}


### PR DESCRIPTION
Much like [calling artisan from anywhere else](http://laravel.com/docs/5.0/artisan#calling-commands-outside-of-cli).

``` php
$schedule->command('db:backup', [
    '--filename'   => Carbon::now()->toDateTimeString(),
    '--database'   => 'forge',
    '--connection' => 'mysql',
    '--disk'       => 's3',
]);
```

This also adds tests for the `Schedule` class, which didn't have any tests before.
