### PR TITLE
Added missing return on FilesystemAdapter.move()

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -164,7 +164,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract {
 	 */
 	public function move($from, $to)
 	{
-		$this->driver->rename($from, $to);
+		return $this->driver->rename($from, $to);
 	}
 
 	/**


### PR DESCRIPTION
The move function of the FilesystemAdapter was missing a `return` for success feedback
