### PR TITLE
Add a facility to create WHERE ... IN (SELECT...) constraints for relationship queries (has(),  whereHas(), ...)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -91,6 +91,29 @@ class BelongsTo extends Relation {
 		return $query->where($this->getQualifiedForeignKey(), '=', new Expression($otherKey));
 	}
 
+
+
+	/**
+	 * Get the data for a relationship WHERE... IN constraint for faster processing of has().
+	 *
+	 * @param  \Closure|null  $callback
+	 * @param  \Illuminate\Database\Eloquent\Builder  $parent
+	 * @return array|null
+	 */
+	public function getWhereHasOneConstraints(Closure $callback, $parent) {
+		$parentKey = $this->wrap($this->getQualifiedForeignKey());
+		$selectKey = $this->wrap($this->query->getModel()->getTable().'.'.$this->otherKey);
+
+		if ($callback) call_user_func($callback, $this->query);
+		$this->query->select(new Expression($selectKey));
+
+		return array(
+			'sql' => new Expression($parentKey .' in (' . $this->query->toSql() . ')'),
+			'bindings' => $this->query->getBindings(),
+		);
+	}
+
+
 	/**
 	 * Set the constraints for an eager load of the relation.
 	 *

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Database\Eloquent\Relations;
 
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -101,7 +101,7 @@ class BelongsTo extends Relation {
 	 * @param  \Illuminate\Database\Eloquent\Builder  $parent
 	 * @return array|null
 	 */
-	public function getWhereHasOneConstraints(Closure $callback, $parent) {
+	public function getWhereHasOneConstraints($callback, $parent) {
 		$parentKey = $this->wrap($this->getQualifiedForeignKey());
 		$selectKey = $this->wrap($this->query->getModel()->getTable().'.'.$this->otherKey);
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -294,7 +294,7 @@ class BelongsToMany extends Relation {
 	 * @param  \Illuminate\Database\Eloquent\Builder  $parent
 	 * @return array|null
 	 */
-	 public function getWhereHasOneConstraints(Closure $callback, $parent) {
+	 public function getWhereHasOneConstraints($callback, $parent) {
 
 		if ($parent->getQuery()->from == $this->getRelated()->newQuery()->getQuery()->from) {
 			// Table aliasing isn't implemented here. Return null to tell the caller to fall back

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Database\Eloquent\Relations;
 
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -3,6 +3,7 @@
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Collection;
 
 abstract class HasOneOrMany extends Relation {

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Database\Eloquent\Relations;
 
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -60,7 +60,7 @@ abstract class HasOneOrMany extends Relation {
 	 * @param  \Illuminate\Database\Eloquent\Builder  $parent
 	 * @return array|null
 	 */
-	 public function getWhereHasOneConstraints(Closure $callback, $parent) {
+	 public function getWhereHasOneConstraints($callback, $parent) {
 
 		$parentKey = $this->wrap($this->getQualifiedParentKeyName());
 		$selectKey = $this->wrap($this->getHasCompareKey());

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -50,6 +50,29 @@ abstract class HasOneOrMany extends Relation {
 		}
 	}
 
+
+	/**
+	 * Get the data for a relationship WHERE... IN constraint for faster processing of has().
+	 *
+	 * @param  \Closure|null  $callback
+	 * @param  \Illuminate\Database\Eloquent\Builder  $parent
+	 * @return array|null
+	 */
+	 public function getWhereHasOneConstraints(Closure $callback, $parent) {
+
+		$parentKey = $this->wrap($this->getQualifiedParentKeyName());
+		$selectKey = $this->wrap($this->getHasCompareKey());
+
+		if ($callback) call_user_func($callback, $this->query);
+		$this->query->select(new Expression($selectKey));
+
+		return array(
+			'sql' => new Expression($parentKey .' in (' . $this->query->toSql() . ')'),
+			'bindings' => $this->query->getBindings(),
+		);
+	}
+
+
 	/**
 	 * Set the constraints for an eager load of the relation.
 	 *


### PR DESCRIPTION
Add a facility to create WHERE ... IN (SELECT...) constraints for relationship queries (has(),  whereHas(), ...)

See issue #8720 for details.

The facility is implemented for belongsTo, BelongsToMany, HasOne and HasMany. Other relationship types (i.e. Morph*) are not implemented yet.
The code falls back to the old behaviour whenever the new query strategy is not applicable or implemented.
