### PR TITLE
Filesystem::put supports stream

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -38,7 +38,7 @@ interface Filesystem {
 	 * Write the contents of a file.
 	 *
 	 * @param  string  $path
-	 * @param  string  $contents
+	 * @param  string|resource  $contents
 	 * @param  string  $visibility
 	 * @return bool
 	 */

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -64,13 +64,22 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract {
 	 * Write the contents of a file.
 	 *
 	 * @param  string  $path
-	 * @param  string  $contents
+	 * @param  string|resource  $contents
 	 * @param  string  $visibility
 	 * @return bool
 	 */
 	public function put($path, $contents, $visibility = null)
 	{
-		return $this->driver->put($path, $contents, ['visibility' => $this->parseVisibility($visibility)]);
+		$config = ['visibility' => $this->parseVisibility($visibility)];
+        
+		if (is_resource($contents))
+		{
+			return $this->driver->putStream($path, $contents, $config);
+		}
+		else
+		{
+			return $this->driver->put($path, $contents, $config);
+		}
 	}
 
 	/**


### PR DESCRIPTION
`Filesystem::put` only supports string now. When I want to write some large data, e.g. move user uploaded file into strorage, I need to read those file first, which will consume lots of memory. `League\Flysystem\AdapterInterface::writeStream` solves this problem, but laravel doesn't expose it to developers.
