### PR TITLE
[5.1] Optimize loading of relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -11,6 +11,8 @@ class HasMany extends HasOneOrMany {
 	 */
 	public function getResults()
 	{
+		if ($this->mustBeEmpty) return new Collection;
+
 		return $this->query->get();
 	}
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -11,6 +11,8 @@ class HasOne extends HasOneOrMany {
 	 */
 	public function getResults()
 	{
+		if ($this->mustBeEmpty) return;
+
 		return $this->query->first();
 	}
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -47,9 +47,18 @@ abstract class HasOneOrMany extends Relation {
 	{
 		if (static::$constraints)
 		{
-			$this->query->where($this->foreignKey, '=', $this->getParentKey());
+			$parentKey = $this->getParentKey();
 
-			$this->query->whereNotNull($this->foreignKey);
+			if (is_null($parentKey))
+			{
+				$this->mustBeEmpty = true;
+			}
+			else
+			{
+				$this->query->where($this->foreignKey, '=', $parentKey);
+
+				$this->query->whereNotNull($this->foreignKey);
+			}
 		}
 	}
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -11,6 +11,8 @@ class MorphMany extends MorphOneOrMany {
 	 */
 	public function getResults()
 	{
+		if ($this->mustBeEmpty) return new Collection;
+
 		return $this->query->get();
 	}
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -11,6 +11,8 @@ class MorphOne extends MorphOneOrMany {
 	 */
 	public function getResults()
 	{
+		if ($this->mustBeEmpty) return;
+
 		return $this->query->first();
 	}
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -30,6 +30,13 @@ abstract class Relation {
 	protected $related;
 
 	/**
+	 * Indicates if, based on the set constraints, the relation can't possibly have any results.
+	 *
+	 * @var bool
+	 */
+	protected $mustBeEmpty = false;
+
+	/**
 	 * Indicates if the relation is adding constraints.
 	 *
 	 * @var bool
@@ -100,6 +107,8 @@ abstract class Relation {
 	 */
 	public function getEager()
 	{
+		if ($this->mustBeEmpty) return new Collection;
+
 		return $this->get();
 	}
 

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -76,6 +76,34 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testNoUnnecessaryQueriesAreRunForEmptyRelationship(){
+		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getAttribute')->with('foreign_key')->andReturn(null);
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder->shouldReceive('getModel')->andReturn(m::mock('Illuminate\Database\Eloquent\Model'));
+		$builder->shouldNotReceive('first');
+
+		$relation = new BelongsTo($builder, $parent, 'foreign_key', 'id', 'relation');
+		$relation->getResults();
+	}
+
+
+	public function testNoUnnecessaryQueriesAreRunForEagerLoadingEmptyRelationship(){
+		$model1 = m::mock('Illuminate\Database\Eloquent\Model');
+		$model1->shouldReceive('getAttribute')->with('foreign_key')->andReturn(null);
+		$model2 = clone $model1;
+		$parent = clone $model1;
+
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder->shouldReceive('getModel')->andReturn(m::mock('Illuminate\Database\Eloquent\Model'));
+		$builder->shouldNotReceive('get');
+
+		$relation = new BelongsTo($builder, $parent, 'foreign_key', 'id', 'relation');
+		$relation->addEagerConstraints([$model1, $model2]);
+		$relation->getEager();
+	}
+
+
 	protected function getRelation($parent = null)
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -178,6 +178,18 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testNoUnnecessaryQueriesAreRunForEmptyRelationship(){
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getAttribute')->with('id')->andReturn(null);
+		$builder->shouldReceive('getModel')->andReturn(m::mock('Illuminate\Database\Eloquent\Model'));
+		$builder->shouldNotReceive('get');
+
+		$relation = new HasMany($builder, $parent, 'table.foreign_key', 'id');
+		$relation->getResults();
+	}
+
+
 	protected function getRelation()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -119,6 +119,18 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testNoUnnecessaryQueriesAreRunForEmptyRelationship(){
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getAttribute')->with('id')->andReturn(null);
+		$builder->shouldReceive('getModel')->andReturn(m::mock('Illuminate\Database\Eloquent\Model'));
+		$builder->shouldNotReceive('first');
+
+		$relation = new HasOne($builder, $parent, 'table.foreign_key', 'id');
+		$relation->getResults();
+	}
+
+
 	protected function getRelation()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -170,6 +170,35 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($relation->updateOrCreate(array('foo'),array('bar')) instanceof Model);
 	}
 
+
+	public function testMorphOneNoUnnecessaryQueriesAreRunForEmptyRelationship(){
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getAttribute')->with('id')->andReturn(null);
+		$parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
+		$builder->shouldReceive('getModel')->andReturn(m::mock('Illuminate\Database\Eloquent\Model'));
+		$builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
+		$builder->shouldNotReceive('first');
+
+		$relation = new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+		$relation->getResults();
+	}
+
+
+	public function testMorphManyNoUnnecessaryQueriesAreRunForEmptyRelationship(){
+		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getAttribute')->with('id')->andReturn(null);
+		$parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
+		$builder->shouldReceive('getModel')->andReturn(m::mock('Illuminate\Database\Eloquent\Model'));
+		$builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
+		$builder->shouldNotReceive('get');
+
+		$relation = new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+		$relation->getResults();
+	}
+
+
 	protected function getOneRelation()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');


### PR DESCRIPTION
_Related issue #5289_

For certain results it's pretty easy to tell that they will and should not yield any results. For example a BelongsTo relationship where the foreign key value is null. This PR adds a `mustBeEmpty` flag which is set when the constraints make it clear that there's no result to expect. If that's the case the DB will not be hit but `null` or an empty Collection is returned directly.
