### PR TITLE
Adding a warning class to console output

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Illuminate\Contracts\Foundation\Application as LaravelApplication;
 
 class Command extends \Symfony\Component\Console\Command\Command {
@@ -331,6 +332,19 @@ class Command extends \Symfony\Component\Console\Command\Command {
 	public function error($string)
 	{
 		$this->output->writeln("<error>$string</error>");
+	}
+
+	/**
+	 * Write a string as warning output.
+	 *
+	 * @param  string  $string
+	 * @return void
+	 */
+	public function warn($string)
+	{
+		$style = new OutputFormatterStyle('yellow');
+		$this->output->getFormatter()->setStyle('warning', $style);
+		$this->output->writeln("<warning>$string</warning>");
 	}
 
 	/**


### PR DESCRIPTION
For artisan commands, add 'warn' to the available output types. It will print the message in yellow text using Symfony's OutputFormatterStyle class.
