### PR TITLE
Add a facility to create WHERE ... IN (SELECT...) constraints for relationship queries (has(),  whereHas(), ...) to avoid full table scans.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -561,6 +561,21 @@ class Builder {
 
 		$relation = $this->getHasRelationQuery($relation);
 
+		// If we don't need to count but only check for existence of a relationship we
+		// will try to use a faster WHERE ... IN (SELECT ...) constraint instead of a
+		// count query
+		if ( (($operator == '>=') && ($count == 1)) || (($operator == '>') && ($count == 0)) ) {
+			// check if the relationship offers to create a WHERE... IN constraint.
+			if (method_exists($relation, 'getWhereHasOneConstraints')) {
+				$whereHasOneConstraints = $relation->getWhereHasOneConstraints($callback, $this);
+				if (is_array($whereHasOneConstraints) && !empty($whereHasOneConstraints)) {
+					// we got our constraint. Apply it and we are done.
+					return $this->whereRaw($whereHasOneConstraints['sql'], $whereHasOneConstraints['bindings'], $boolean);
+				}
+			}
+		}
+
+
 		$query = $relation->getRelationCountQuery($relation->getRelated()->newQuery(), $this);
 
 		if ($callback) call_user_func($callback, $query);

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Database\Eloquent\Relations;
 
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
@@ -317,6 +318,34 @@ class BelongsToMany extends Relation {
 		$key = $this->wrap($this->getQualifiedParentKeyName());
 
 		return $query->where($hash.'.'.$this->foreignKey, '=', new Expression($key));
+	}
+
+
+	/**
+	 * Get the data for a relationship WHERE... IN constraint for faster processing of has().
+	 *
+	 * @param  \Closure|null  $callback
+	 * @param  \Illuminate\Database\Eloquent\Builder  $parent
+	 * @return array|null
+	 */
+	 public function getWhereHasOneConstraints($callback, $parent) {
+
+		if ($parent->getQuery()->from == $this->getRelated()->newQuery()->getQuery()->from) {
+			// Table aliasing isn't implemented here. Return null to tell the caller to fall back
+			// to the count query method.
+			return null;
+		}
+
+		$parentKey = $this->wrap($this->getQualifiedParentKeyName());
+		$selectKey = $this->wrap($this->getHasCompareKey());
+
+		if ($callback) call_user_func($callback, $this->query);
+		$this->query->select(new Expression($selectKey));
+
+		return array(
+			'sql' => new Expression($parentKey .' in (' . $this->query->toSql() . ')'),
+			'bindings' => $this->query->getBindings(),
+		);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Database\Eloquent\Relations;
 
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
@@ -99,6 +100,29 @@ abstract class HasOneOrMany extends Relation {
 	{
 		return 'self_'.md5(microtime(true));
 	}
+
+
+	/**
+	 * Get the data for a relationship WHERE... IN constraint for faster processing of has().
+	 *
+	 * @param  \Closure|null  $callback
+	 * @param  \Illuminate\Database\Eloquent\Builder  $parent
+	 * @return array|null
+	 */
+	 public function getWhereHasOneConstraints($callback, $parent) {
+
+		$parentKey = $this->wrap($this->getQualifiedParentKeyName());
+		$selectKey = $this->wrap($this->getHasCompareKey());
+
+		if ($callback) call_user_func($callback, $this->query);
+		$this->query->select(new Expression($selectKey));
+
+		return array(
+			'sql' => new Expression($parentKey .' in (' . $this->query->toSql() . ')'),
+			'bindings' => $this->query->getBindings(),
+		);
+	}
+
 
 	/**
 	 * Set the constraints for an eager load of the relation.


### PR DESCRIPTION
Add a facility to create WHERE ... IN (SELECT...) constraints for relationship queries (has(),  whereHas(), ...) to avoid full table scans.

See #8720 for details.

The facility is implemented for belongsTo, BelongsToMany, HasOne and HasMany. Other relationship types (i.e. Morph*) are not implemented yet.
The code falls back to the old behaviour whenever the new query strategy is not applicable or implemented.
