### PR TITLE
[5.1] Rename methods for consistency

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -186,17 +186,6 @@ class Builder {
 	}
 
 	/**
-	 * Alias for the "value" method.
-	 *
-	 * @param  string  $column
-	 * @return mixed
-	 */
-	public function pluck($column)
-	{
-		return $this->value($column);
-	}
-
-	/**
 	 * Chunk the results of the query.
 	 *
 	 * @param  int  $count
@@ -227,9 +216,9 @@ class Builder {
 	 * @param  string  $key
 	 * @return array
 	 */
-	public function lists($column, $key = null)
+	public function pluck($column, $key = null)
 	{
-		$results = $this->query->lists($column, $key);
+		$results = $this->query->pluck($column, $key);
 
 		// If the model has a mutator for the requested column, we will spin through
 		// the results and mutate the values so that the mutated version of these

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -50,7 +50,7 @@ class Builder {
 	 * @var array
 	 */
 	protected $passthru = array(
-		'toSql', 'lists', 'insert', 'insertGetId', 'pluck', 'count',
+		'toSql', 'lists', 'insert', 'insertGetId', 'count',
 		'min', 'max', 'avg', 'sum', 'exists', 'getBindings',
 	);
 
@@ -173,16 +173,27 @@ class Builder {
 	}
 
 	/**
-	 * Pluck a single column from the database.
+	 * Get a single column from the database.
+	 *
+	 * @param  string  $column
+	 * @return mixed
+	 */
+	public function value($column)
+	{
+		$result = $this->first(array($column));
+
+		if ($result) return $result->{$column};
+	}
+
+	/**
+	 * Alias for the "value" method.
 	 *
 	 * @param  string  $column
 	 * @return mixed
 	 */
 	public function pluck($column)
 	{
-		$result = $this->first(array($column));
-
-		if ($result) return $result->{$column};
+		return $this->value($column);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -529,7 +529,7 @@ class BelongsToMany extends Relation {
 
 		$fullKey = $related->getQualifiedKeyName();
 
-		return $this->getQuery()->select($fullKey)->lists($related->getKeyName());
+		return $this->getQuery()->select($fullKey)->pluck($related->getKeyName());
 	}
 
 	/**
@@ -734,7 +734,7 @@ class BelongsToMany extends Relation {
 		// First we need to attach any of the associated models that are not currently
 		// in this joining table. We'll spin through the given IDs, checking to see
 		// if they exist in the array of current ones, and if not we will insert.
-		$current = $this->newPivotQuery()->lists($this->otherKey);
+		$current = $this->newPivotQuery()->pluck($this->otherKey);
 
 		$records = $this->formatSyncList($ids);
 

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -45,7 +45,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface {
 	 */
 	public function getRan()
 	{
-		return $this->table()->lists('migration');
+		return $this->table()->pluck('migration');
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1514,7 +1514,7 @@ class Builder {
 
 		$results = new Collection($this->get($columns));
 
-		return $results->lists($columns[0], array_get($columns, 1))->all();
+		return $results->pluck($columns[0], array_get($columns, 1))->all();
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1331,17 +1331,6 @@ class Builder {
 	}
 
 	/**
-	 * Alias for the "value" method.
-	 *
-	 * @param  string  $column
-	 * @return mixed
-	 */
-	public function pluck($column)
-	{
-		return $this->value($column);
-	}
-
-	/**
 	 * Execute the query and get the first result.
 	 *
 	 * @param  array   $columns
@@ -1519,9 +1508,9 @@ class Builder {
 	 * @param  string  $key
 	 * @return array
 	 */
-	public function lists($column, $key = null)
+	public function pluck($column, $key = null)
 	{
-		$columns = $this->getListSelect($column, $key);
+		$columns = $this->getPluckSelect($column, $key);
 
 		$results = new Collection($this->get($columns));
 
@@ -1529,13 +1518,25 @@ class Builder {
 	}
 
 	/**
-	 * Get the columns that should be used in a list array.
+	* Alias for the "pluck" method.
+	*
+	* @param  string  $column
+	* @param  string  $key
+	* @return array
+	*/
+	public function lists($column, $key = null)
+	{
+		return $this->pluck($column);
+	}
+
+	/**
+	 * Get the columns that should be used in a pluck array.
 	 *
 	 * @param  string  $column
 	 * @param  string  $key
 	 * @return array
 	 */
-	protected function getListSelect($column, $key)
+	protected function getPluckSelect($column, $key)
 	{
 		$select = is_null($key) ? array($column) : array($column, $key);
 
@@ -1559,9 +1560,9 @@ class Builder {
 	 */
 	public function implode($column, $glue = null)
 	{
-		if (is_null($glue)) return implode($this->lists($column));
+		if (is_null($glue)) return implode($this->pluck($column));
 
-		return implode($glue, $this->lists($column));
+		return implode($glue, $this->pluck($column));
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1318,16 +1318,27 @@ class Builder {
 	}
 
 	/**
-	 * Pluck a single column's value from the first result of a query.
+	 * Get a single column's value from the first result of a query.
+	 *
+	 * @param  string  $column
+	 * @return mixed
+	 */
+	public function value($column)
+	{
+		$result = (array) $this->first(array($column));
+
+		return count($result) > 0 ? reset($result) : null;
+	}
+
+	/**
+	 * Alias for the "value" method.
 	 *
 	 * @param  string  $column
 	 * @return mixed
 	 */
 	public function pluck($column)
 	{
-		$result = (array) $this->first(array($column));
-
-		return count($result) > 0 ? reset($result) : null;
+		return $this->value($column);
 	}
 
 	/**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -302,7 +302,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
 		if (is_array($first) || is_object($first))
 		{
-			return implode($glue, $this->lists($value)->all());
+			return implode($glue, $this->pluck($value)->all());
 		}
 
 		return implode($value, $this->items);
@@ -367,9 +367,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 * @param  string  $key
 	 * @return static
 	 */
-	public function lists($value, $key = null)
+	public function pluck($value, $key = null)
 	{
 		return new static(array_pluck($this->items, $value, $key));
+	}
+
+	/**
+	 * Alias for the "pluck" method.
+	 *
+	 * @param  string  $value
+	 * @param  string  $key
+	 * @return static
+	 */
+	public function lists($value, $key = null)
+	{
+		return $this->pluck($value, $key);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -409,7 +409,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
-		$query->shouldReceive('lists')->once()->with('role_id')->andReturn(array(1, 2, 3));
+		$query->shouldReceive('pluck')->once()->with('role_id')->andReturn(array(1, 2, 3));
 		$relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(array()), $this->equalTo(false));
 		$relation->expects($this->once())->method('detach')->with($this->equalTo(array(1)));
 		$relation->getRelated()->shouldReceive('touches')->andReturn(false);
@@ -436,7 +436,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
-		$query->shouldReceive('lists')->once()->with('role_id')->andReturn(array(1, 2, 3));
+		$query->shouldReceive('pluck')->once()->with('role_id')->andReturn(array(1, 2, 3));
 		$relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(array('foo' => 'bar')), $this->equalTo(false));
 		$relation->expects($this->once())->method('updateExistingPivot')->with($this->equalTo(3), $this->equalTo(array('baz' => 'qux')), $this->equalTo(false))->will($this->returnValue(true));
 		$relation->expects($this->once())->method('detach')->with($this->equalTo(array(1)));
@@ -454,7 +454,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
-		$query->shouldReceive('lists')->once()->with('role_id')->andReturn(array(1, 2, 3));
+		$query->shouldReceive('pluck')->once()->with('role_id')->andReturn(array(1, 2, 3));
 		$relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(array('foo' => 'bar')), $this->equalTo(false));
 		$relation->expects($this->once())->method('updateExistingPivot')->with($this->equalTo(3), $this->equalTo(array('baz' => 'qux')), $this->equalTo(false))->will($this->returnValue(false));
 		$relation->expects($this->once())->method('detach')->with($this->equalTo(array(1)));
@@ -471,7 +471,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation->getRelated()->shouldReceive('freshTimestamp')->andReturn(100);
 		$relation->getRelated()->shouldReceive('getQualifiedKeyName')->andReturn('table.id');
 		$relation->getQuery()->shouldReceive('select')->once()->with('table.id')->andReturn($relation->getQuery());
-		$relation->getQuery()->shouldReceive('lists')->once()->with('id')->andReturn(array(1, 2, 3));
+		$relation->getQuery()->shouldReceive('pluck')->once()->with('id')->andReturn(array(1, 2, 3));
 		$relation->getRelated()->shouldReceive('newQuery')->once()->andReturn($query = m::mock('StdClass'));
 		$query->shouldReceive('whereIn')->once()->with('id', array(1, 2, 3))->andReturn($query);
 		$query->shouldReceive('update')->once()->with(array('updated_at' => 100));
@@ -500,7 +500,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
-		$query->shouldReceive('lists')->once()->with('role_id')->andReturn(array(1, 2, 3));
+		$query->shouldReceive('pluck')->once()->with('role_id')->andReturn(array(1, 2, 3));
 
 		$collection = m::mock('Illuminate\Database\Eloquent\Collection');
 		$collection->shouldReceive('modelKeys')->once()->andReturn(array(1, 2, 3));
@@ -532,7 +532,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('where')->once()->with('foo', '=', 'bar')->andReturn($query);
 
 		// This is so $relation->sync() works
-		$query->shouldReceive('lists')->once()->with('role_id')->andReturn([1, 2, 3]);
+		$query->shouldReceive('pluck')->once()->with('role_id')->andReturn([1, 2, 3]);
 		$relation->expects($this->once())->method('formatSyncList')->with([1, 2, 3])->will($this->returnValue([1 => [],2 => [],3 => []]));
 
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -141,23 +141,23 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testPluckMethodWithModelFound()
+	public function testValueMethodWithModelFound()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', array($this->getMockQueryBuilder()));
 		$mockModel = new StdClass;
 		$mockModel->name = 'foo';
 		$builder->shouldReceive('first')->with(array('name'))->andReturn($mockModel);
 
-		$this->assertEquals('foo', $builder->pluck('name'));
+		$this->assertEquals('foo', $builder->value('name'));
 	}
 
 
-	public function testPluckMethodWithModelNotFound()
+	public function testValueMethodWithModelNotFound()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', array($this->getMockQueryBuilder()));
 		$builder->shouldReceive('first')->with(array('name'))->andReturn(null);
 
-		$this->assertNull($builder->pluck('name'));
+		$this->assertNull($builder->value('name'));
 	}
 
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -182,27 +182,27 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testListsReturnsTheMutatedAttributesOfAModel()
+	public function testPluckReturnsTheMutatedAttributesOfAModel()
 	{
 		$builder = $this->getBuilder();
-		$builder->getQuery()->shouldReceive('lists')->with('name', '')->andReturn(array('bar', 'baz'));
+		$builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(array('bar', 'baz'));
 		$builder->setModel($this->getMockModel());
 		$builder->getModel()->shouldReceive('hasGetMutator')->with('name')->andReturn(true);
-		$builder->getModel()->shouldReceive('newFromBuilder')->with(array('name' => 'bar'))->andReturn(new EloquentBuilderTestListsStub(array('name' => 'bar')));
-		$builder->getModel()->shouldReceive('newFromBuilder')->with(array('name' => 'baz'))->andReturn(new EloquentBuilderTestListsStub(array('name' => 'baz')));
+		$builder->getModel()->shouldReceive('newFromBuilder')->with(array('name' => 'bar'))->andReturn(new EloquentBuilderTestPluckStub(array('name' => 'bar')));
+		$builder->getModel()->shouldReceive('newFromBuilder')->with(array('name' => 'baz'))->andReturn(new EloquentBuilderTestPluckStub(array('name' => 'baz')));
 
-		$this->assertEquals(array('foo_bar', 'foo_baz'), $builder->lists('name'));
+		$this->assertEquals(array('foo_bar', 'foo_baz'), $builder->pluck('name'));
 	}
 
 
-	public function testListsWithoutModelGetterJustReturnTheAttributesFoundInDatabase()
+	public function testPluckWithoutModelGetterJustReturnTheAttributesFoundInDatabase()
 	{
 		$builder = $this->getBuilder();
-		$builder->getQuery()->shouldReceive('lists')->with('name', '')->andReturn(array('bar', 'baz'));
+		$builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(array('bar', 'baz'));
 		$builder->setModel($this->getMockModel());
 		$builder->getModel()->shouldReceive('hasGetMutator')->with('name')->andReturn(false);
 
-		$this->assertEquals(array('bar', 'baz'), $builder->lists('name'));
+		$this->assertEquals(array('bar', 'baz'), $builder->pluck('name'));
 	}
 
 
@@ -525,7 +525,7 @@ class EloquentBuilderTestNestedStub extends Illuminate\Database\Eloquent\Model {
 	use Illuminate\Database\Eloquent\SoftDeletes;
 }
 
-class EloquentBuilderTestListsStub {
+class EloquentBuilderTestPluckStub {
 	protected $attributes;
 	public function __construct($attributes)
 	{

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -202,14 +202,6 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testLists()
-	{
-		$data = new Collection(array((object) array('name' => 'taylor', 'email' => 'foo'), (object) array('name' => 'dayle', 'email' => 'bar')));
-		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->lists('email', 'name')->all());
-		$this->assertEquals(array('foo', 'bar'), $data->lists('email')->all());
-	}
-
-
 	public function testOnlyReturnsCollectionWithGivenModelKeys()
 	{
 		$one = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -169,13 +169,13 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testListsRetrieval()
+	public function testPluckRetrieval()
 	{
 		EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
 		EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
 
-		$simple = EloquentTestUser::oldest('id')->lists('users.email');
-		$keyed = EloquentTestUser::oldest('id')->lists('users.email', 'users.id');
+		$simple = EloquentTestUser::oldest('id')->pluck('users.email');
+		$keyed = EloquentTestUser::oldest('id')->pluck('users.email', 'users.id');
 
 		$this->assertEquals(['taylorotwell@gmail.com', 'abigailotwell@gmail.com'], $simple);
 		$this->assertEquals([1 => 'taylorotwell@gmail.com', 2 => 'abigailotwell@gmail.com'], $keyed);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -559,7 +559,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(1, $model->id);
 		$this->assertTrue($model->exists);
 		$this->assertEquals(2, count($model->relationMany));
-		$this->assertEquals([2, 3], $model->relationMany->lists('id')->all());
+		$this->assertEquals([2, 3], $model->relationMany->pluck('id')->all());
 	}
 
 

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -18,7 +18,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 		$connectionMock = m::mock('Illuminate\Database\Connection');
 		$repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
 		$repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
-		$query->shouldReceive('lists')->once()->with('migration')->andReturn('bar');
+		$query->shouldReceive('pluck')->once()->with('migration')->andReturn('bar');
 
 		$this->assertEquals('bar', $repo->getRan());
 	}

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -792,12 +792,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testPluckMethodReturnsSingleColumn()
+	public function testValueMethodReturnsSingleColumn()
 	{
 		$builder = $this->getBuilder();
 		$builder->getConnection()->shouldReceive('select')->once()->with('select "foo" from "users" where "id" = ? limit 1', array(1), true)->andReturn(array(array('foo' => 'bar')));
 		$builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, array(array('foo' => 'bar')))->andReturn(array(array('foo' => 'bar')));
-		$results = $builder->from('users')->where('id', '=', 1)->pluck('foo');
+		$results = $builder->from('users')->where('id', '=', 1)->value('foo');
 		$this->assertEquals('bar', $results);
 	}
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -754,7 +754,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			return $results;
 		});
-		$results = $builder->from('users')->where('id', '=', 1)->lists('foo');
+		$results = $builder->from('users')->where('id', '=', 1)->pluck('foo');
 		$this->assertEquals(array('bar', 'baz'), $results);
 
 		$builder = $this->getBuilder();
@@ -763,7 +763,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		{
 			return $results;
 		});
-		$results = $builder->from('users')->where('id', '=', 1)->lists('foo', 'id');
+		$results = $builder->from('users')->where('id', '=', 1)->pluck('foo', 'id');
 		$this->assertEquals(array(1 => 'bar', 10 => 'baz'), $results);
 	}
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -302,23 +302,23 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testListsWithArrayAndObjectValues()
+	public function testPluckWithArrayAndObjectValues()
 	{
 		$data = new Collection(array((object) array('name' => 'taylor', 'email' => 'foo'), array('name' => 'dayle', 'email' => 'bar')));
-		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->lists('email', 'name')->all());
-		$this->assertEquals(array('foo', 'bar'), $data->lists('email')->all());
+		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->pluck('email', 'name')->all());
+		$this->assertEquals(array('foo', 'bar'), $data->pluck('email')->all());
 	}
 
 
-	public function testListsWithArrayAccessValues()
+	public function testPluckWithArrayAccessValues()
 	{
 		$data = new Collection(array(
 			new TestArrayAccessImplementation(array('name' => 'taylor', 'email' => 'foo')),
 			new TestArrayAccessImplementation(array('name' => 'dayle', 'email' => 'bar'))
 		));
 
-		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->lists('email', 'name')->all());
-		$this->assertEquals(array('foo', 'bar'), $data->lists('email')->all());
+		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->pluck('email', 'name')->all());
+		$this->assertEquals(array('foo', 'bar'), $data->pluck('email')->all());
 	}
 
 
@@ -475,13 +475,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testGetListValueWithAccessors()
+	public function testGetPluckValueWithAccessors()
 	{
 		$model    = new TestAccessorEloquentTestStub(array('some' => 'foo'));
 		$modelTwo = new TestAccessorEloquentTestStub(array('some' => 'bar'));
 		$data     = new Collection(array($model, $modelTwo));
 
-		$this->assertEquals(array('foo', 'bar'), $data->lists('some')->all());
+		$this->assertEquals(array('foo', 'bar'), $data->pluck('some')->all());
 	}
 
 
@@ -603,7 +603,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		));
 
 		$c = $c->sortBy('foo.bar');
-		$this->assertEquals(array(2, 1), $c->lists('id')->all());
+		$this->assertEquals(array(2, 1), $c->pluck('id')->all());
 	}
 
 


### PR DESCRIPTION
`$query->pluck($column)` is now `$query->value($column)`.

We'll have to note this breaking change in the upgrade docs.

---

`$query->lists($column)` is now `$query->pluck($column)`.

Keeping `lists` as an alias to `pluck` for BC.

---

`$collection->lists($key)` is now `$collection->pluck($key)`.

Keeping `lists` as an alias to `pluck` for BC.
