### PR TITLE
Password Broker, queue mail messages.

### DIFF
--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -44,9 +44,10 @@ interface PasswordBroker {
 	 *
 	 * @param  array  $credentials
 	 * @param  \Closure|null  $callback
+     * @param  string  $queue
 	 * @return string
 	 */
-	public function sendResetLink(array $credentials, Closure $callback = null);
+	public function sendResetLink(array $credentials, Closure $callback = null, $queue = null);
 
 	/**
 	 * Reset the password for the given token.


### PR DESCRIPTION
Allow password reset emails to be sent using mail queue, with parameter option for setting the queue.

Relates to issue #8186 
