### PR TITLE
[5.1] Add make seeder command

### DIFF
--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -1,4 +1,4 @@
-<?php namespace Illuminate\Database\Console;
+<?php namespace Illuminate\Database\Console\Seeds;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;

--- a/src/Illuminate/Database/Console/Seeds/SeedMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedMakeCommand.php
@@ -1,0 +1,102 @@
+<?php namespace Illuminate\Database\Console\Seeds;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Composer;
+use Symfony\Component\Console\Input\InputArgument;
+
+class SeedMakeCommand extends GeneratorCommand {
+
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'make:seeder';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Create a new seeder file';
+
+	/**
+	 * The filesystem instance.
+	 *
+	 * @var \Illuminate\Filesystem\Filesystem
+	 */
+	protected $files;
+
+	/**
+	 * The composer instance.
+	 *
+	 * @var \Illuminate\Foundation\Composer
+	 */
+	protected $composer;
+
+	/**
+	 * The type of class being generated.
+	 *
+	 * @var string
+	 */
+	protected $type = 'Seeder';
+
+	/**
+	 * @param  Filesystem $files
+	 * @param  Composer $composer
+	 * @return void
+	 */
+	public function __construct(Filesystem $files, Composer $composer)
+	{
+		parent::__construct($files);
+
+		$this->files = $files;
+		$this->composer = $composer;
+	}
+
+	/**
+	 * Get the stub file for the generator.
+	 *
+	 * @return string
+	 */
+	protected function getStub()
+	{
+		return __DIR__.'/stubs/seeder.stub';
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return void
+	 */
+	public function fire()
+	{
+		parent::fire();
+
+		$this->composer->dumpAutoloads();
+	}
+
+	/**
+	 * Get the destination class path.
+	 *
+	 * @param  string  $name
+	 * @return string
+	 */
+	protected function getPath($name)
+	{
+		return $this->laravel->databasePath().'/seeds/'.$name.'.php';
+	}
+
+	/**
+	 * Parse the name and format according to the root namespace.
+	 *
+	 * @param  string  $name
+	 * @return string
+	 */
+	protected function parseName($name)
+	{
+		return $name;
+	}
+
+}

--- a/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub
+++ b/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class DummyClass extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/src/Illuminate/Database/SeedServiceProvider.php
+++ b/src/Illuminate/Database/SeedServiceProvider.php
@@ -1,7 +1,8 @@
 <?php namespace Illuminate\Database;
 
+use Illuminate\Database\Console\Seeds\SeedCommand;
+use Illuminate\Database\Console\Seeds\SeedMakeCommand;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Database\Console\SeedCommand;
 
 class SeedServiceProvider extends ServiceProvider {
 
@@ -20,13 +21,14 @@ class SeedServiceProvider extends ServiceProvider {
 	public function register()
 	{
 		$this->registerSeedCommand();
+		$this->registerMakeCommand();
 
 		$this->app->singleton('seeder', function()
 		{
 			return new Seeder;
 		});
 
-		$this->commands('command.seed');
+		$this->commands('command.seed', 'command.seed.make');
 	}
 
 	/**
@@ -43,13 +45,26 @@ class SeedServiceProvider extends ServiceProvider {
 	}
 
 	/**
+	 * Register the make seeder console command.
+	 *
+	 * @return void
+	 */
+	protected function registerMakeCommand()
+	{
+		$this->app->singleton('command.seed.make', function($app)
+		{
+			return new SeedMakeCommand($app['files'], $app['composer']);
+		});
+	}
+
+	/**
 	 * Get the services provided by the provider.
 	 *
 	 * @return array
 	 */
 	public function provides()
 	{
-		return array('seeder', 'command.seed');
+		return array('seeder', 'command.seed', 'command.seed.make');
 	}
 
 }


### PR DESCRIPTION
_Requested here: #8709_

This adds a simple `make:seeder` command to generate a seeder file in `database/seeds`.

Usage example:

```
php artisan make:seeder UserTableSeeder
```
