### PR TITLE
Tweak Collection@random

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -6,6 +6,7 @@ use ArrayIterator;
 use CachingIterator;
 use JsonSerializable;
 use IteratorAggregate;
+use InvalidArgumentException;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
@@ -467,14 +468,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 *
 	 * @param  int  $amount
 	 * @return mixed
+	 *
+	 * @throws \InvalidArgumentException
 	 */
 	public function random($amount = 1)
 	{
-		if ($this->isEmpty()) return;
+		if ($amount > ($count = $this->count()))
+		{
+			throw new InvalidArgumentException("You requested {$amount} items, but there are only {$count} items in the collection");
+		}
 
 		$keys = array_rand($this->items, $amount);
 
-		return is_array($keys) ? array_intersect_key($this->items, array_flip($keys)) : $this->items[$keys];
+		if ($amount == 1) return $this->items[$keys];
+
+		return new static(array_intersect_key($this->items, array_flip($keys)));
 	}
 
 	/**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -345,19 +345,22 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	public function testRandom()
 	{
 		$data = new Collection(array(1, 2, 3, 4, 5, 6));
+
 		$random = $data->random();
 		$this->assertInternalType('integer', $random);
 		$this->assertContains($random, $data->all());
+
 		$random = $data->random(3);
+		$this->assertInstanceOf('Illuminate\Support\Collection', $random);
 		$this->assertCount(3, $random);
 	}
 
-
-	public function testRandomOnEmpty()
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testRandomThrowsAnErrorWhenRequestingMoreItemsThanAreAvailable()
 	{
-		$data = new Collection();
-		$random = $data->random();
-		$this->assertNull($random);
+		(new Collection)->random();
 	}
 
 


### PR DESCRIPTION
1. If more than 1 item is requested, a collection instance is returned.
2. Requesting more items than are in the collection will throw an `InvalidArgumentException` error. Previously, a PHP warning was thrown (or `null` returned if the collection is empty).
