### PR TITLE
[5.1] Allow a collection of scalars to be easily sorted

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -618,14 +618,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	/**
 	 * Sort through each item with a callback.
 	 *
-	 * @param  callable  $callback
+	 * @param  callable|null  $callback
 	 * @return static
 	 */
-	public function sort(callable $callback)
+	public function sort(callable $callback = null)
 	{
 		$items = $this->items;
 
-		uasort($items, $callback);
+		$callback ? uasort($items, $callback) : natcasesort($items);
 
 		return new static($items);
 	}

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -236,6 +236,22 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testSort()
 	{
+		$data = (new Collection([5, 3, 1, 2, 4]))->sort();
+
+		$this->assertEquals(range(1, 5), array_values($data->all()));
+	}
+
+
+	public function testSortWithStrings()
+	{
+		$data = (new Collection(['foo', 'bar-10', 'bar-1']))->sort();
+
+		$this->assertEquals(['bar-1', 'bar-10', 'foo'], array_values($data->all()));
+	}
+
+
+	public function testSortWithCallback()
+	{
 		$data = (new Collection([5, 3, 1, 2, 4]))->sort(function($a, $b)
 		{
 			if ($a === $b)


### PR DESCRIPTION
``` php
collect([3, 1, 2])->sort(); // [1, 2, 3]
```
