### PR TITLE
[5.0] Add default boolean scope functionality

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -817,6 +817,18 @@ class Builder {
 	}
 
 	/**
+	 * Add the default boolean scope to the query.
+	 * 
+	 * @param  string  $column
+	 * @param  bool    $boolean
+	 * @return \Illuminate\Database\Query\Builder
+	 */
+	protected function addBooleanColumnScope($column, $boolean)
+	{
+		return $this->where($column, $boolean);
+	}
+
+	/**
 	 * Get the underlying query builder instance.
 	 *
 	 * @return \Illuminate\Database\Query\Builder|static
@@ -928,6 +940,14 @@ class Builder {
 		elseif (method_exists($this->model, $scope = 'scope'.ucfirst($method)))
 		{
 			return $this->callScope($scope, $parameters);
+		}
+		elseif ( ! is_null($this->model['fillable']) && in_array($column = 'is_'.$method, $this->model['fillable']))
+		{
+			return $this->addBooleanColumnScope($column, true);
+		}
+		elseif ( ! is_null($this->model['fillable']) && starts_with($method, 'not') && in_array($column = 'is_'.lcfirst(substr($method, 3)), $this->model['fillable']))
+		{
+			return $this->addBooleanColumnScope($column, false);
 		}
 
 		$result = call_user_func_array(array($this->query, $method), $parameters);


### PR DESCRIPTION
A proposal to add a default scope for any boolean column following the naming convention of `is_differential`, using the style of `differential()` and `notDifferential()` to query.

So a user model with a column `is_active` could be queried as so:

```
User::active()->get() or User::notActive()->get()
```

or a party model with `is_awesome`:

```
Party::awesome()->latest()->get()
```

without defining any scopes inside the model.

I find myself creating these kinds of scopes all the time to make the code more readable.
