### PR TITLE
[5.1] Allow BelongsTo@associate to be used with only an id

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -232,14 +232,18 @@ class BelongsTo extends Relation {
 	/**
 	 * Associate the model instance to the given parent.
 	 *
-	 * @param  \Illuminate\Database\Eloquent\Model  $model
+	 * @param  \Illuminate\Database\Eloquent\Model|int  $model
 	 * @return \Illuminate\Database\Eloquent\Model
 	 */
-	public function associate(Model $model)
+	public function associate($model)
 	{
-		$this->parent->setAttribute($this->foreignKey, $model->getAttribute($this->otherKey));
+		$otherKey = ($model instanceof Model ? $model->getAttribute($this->otherKey) : $model);
 
-		return $this->parent->setRelation($this->relation, $model);
+		$this->parent->setAttribute($this->foreignKey, $otherKey);
+
+		if ($model instanceof Model) $this->parent->setRelation($this->relation, $model);
+
+		return $this->parent;
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -112,7 +112,7 @@ class MorphTo extends BelongsTo {
 	 * @param  \Illuminate\Database\Eloquent\Model  $model
 	 * @return \Illuminate\Database\Eloquent\Model
 	 */
-	public function associate(Model $model)
+	public function associate($model)
 	{
 		$this->parent->setAttribute($this->foreignKey, $model->getKey());
 

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -76,6 +76,17 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testAssociateMethodSetsForeignKeyOnModelById()
+	{
+		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+		$relation = $this->getRelation($parent);
+		$parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
+
+		$relation->associate(1);
+	}
+
+
 	protected function getRelation($parent = null)
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');


### PR DESCRIPTION
_Closes #8618_

Instead of:

```
$account = Account::find(10);
$user->account()->associate($account);
$user->save();
```

You can now just do:

```
$user->account()->associate(10);
$user->save();
```
