### PR TITLE
AddedModel::each() method for streaming results

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -304,6 +304,20 @@ class Connection implements ConnectionInterface {
 		});
 	}
 
+    /**
+     * Get the PDOStatement for a select query.
+     *
+     * @param string $query
+     * @param array $bindings
+     * @return \PDOStatement
+     */
+    public function getPdoStatement($query, $bindings = array())
+    {
+        $result = $this->getPdoForSelect()->query($query);
+        $result->execute($bindings);
+        return $result;
+    }
+
 	/**
 	 * Get the PDO connection to use for a select query.
 	 *

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -83,6 +83,15 @@ interface ConnectionInterface {
 	 */
 	public function affectingStatement($query, $bindings = array());
 
+    /**
+     * Get the PDO result for a given query
+     *
+     * @param $query
+     * @param array $bindings
+     * @return mixed
+     */
+    public function getPdoStatement($query, $bindings = array());
+
 	/**
 	 * Run a raw, unprepared query against the PDO connection.
 	 *

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -185,6 +185,23 @@ class Builder {
 		if ($result) return $result->{$column};
 	}
 
+    /**
+     * Stream through results and pass them to a callback.
+     *
+     * @param callable $callback
+     */
+    public function each(callable $callback)
+    {
+        $statement = $this->query->getConnection()->getPdoStatement(
+            $this->query->toSql(),
+            $this->query->getBindings()
+        );
+
+        while($attributes = $statement->fetch()) {
+            call_user_func($callback, $this->model->newFromBuilder($attributes));
+        }
+    }
+
 	/**
 	 * Chunk the results of the query.
 	 *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -658,6 +658,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		return $instance->newQuery()->get($columns);
 	}
 
+    /**
+     * Stream through results and pass them to a callback.
+     *
+     * @param callable $callback
+     */
+    public static function each(callable $callback)
+    {
+        return static::query()->each($callback);
+    }
+
 	/**
 	 * Find a model by its primary key.
 	 *

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -410,7 +410,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
 
         $called = 0;
-        EloquentTestUser::each(function(EloquentTestUser $user) USE (&$called) {
+        EloquentTestUser::each(function(EloquentTestUser $user) use (&$called) {
                 $called++;
                 switch ($called) {
                     case 1:

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -404,6 +404,28 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+    public function testEachFiresCallbackWithModelExpectedTimes()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+        $called = 0;
+        EloquentTestUser::each(function(EloquentTestUser $user) USE (&$called) {
+                $called++;
+                switch ($called) {
+                    case 1:
+                        $this->assertEquals('taylorotwell@gmail.com', $user->email);
+                        break;
+                    case 2:
+                        $this->assertEquals('abigailotwell@gmail.com', $user->email);
+                        break;
+                }
+        });
+
+        $this->assertEquals(2, $called);
+    }
+
+
 	/**
 	 * Helpers...
 	 */


### PR DESCRIPTION
Using `all()` or `get()` for fetching results loads the entire result set into memory in a `Collection` object. For large data sets, or low-resource environments, this isn't possible without running out of memory.

This new method `each($callback)` allows you to iterate through results, only loading 1 into memory at a time.
