### PR TITLE
[5.1] Rename Collection@lists to pluck

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1525,7 +1525,7 @@ class Builder {
 
 		$results = new Collection($this->get($columns));
 
-		return $results->lists($columns[0], array_get($columns, 1))->all();
+		return $results->pluck($columns[0], array_get($columns, 1))->all();
 	}
 
 	/**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -305,7 +305,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
 		if (is_array($first) || is_object($first))
 		{
-			return implode($glue, $this->lists($value)->all());
+			return implode($glue, $this->pluck($value)->all());
 		}
 
 		return implode($value, $this->items);
@@ -370,9 +370,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 * @param  string  $key
 	 * @return static
 	 */
-	public function lists($value, $key = null)
+	public function pluck($value, $key = null)
 	{
 		return new static(array_pluck($this->items, $value, $key));
+	}
+
+	/**
+	 * Alias for the "pluck" method.
+	 *
+	 * @param  string  $value
+	 * @param  string  $key
+	 * @return static
+	 */
+	public function lists($value, $key = null)
+	{
+		return $this->pluck($value, $key);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -202,14 +202,6 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testLists()
-	{
-		$data = new Collection(array((object) array('name' => 'taylor', 'email' => 'foo'), (object) array('name' => 'dayle', 'email' => 'bar')));
-		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->lists('email', 'name')->all());
-		$this->assertEquals(array('foo', 'bar'), $data->lists('email')->all());
-	}
-
-
 	public function testOnlyReturnsCollectionWithGivenModelKeys()
 	{
 		$one = m::mock('Illuminate\Database\Eloquent\Model');

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -311,23 +311,23 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testListsWithArrayAndObjectValues()
+	public function testPluckWithArrayAndObjectValues()
 	{
 		$data = new Collection(array((object) array('name' => 'taylor', 'email' => 'foo'), array('name' => 'dayle', 'email' => 'bar')));
-		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->lists('email', 'name')->all());
-		$this->assertEquals(array('foo', 'bar'), $data->lists('email')->all());
+		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->pluck('email', 'name')->all());
+		$this->assertEquals(array('foo', 'bar'), $data->pluck('email')->all());
 	}
 
 
-	public function testListsWithArrayAccessValues()
+	public function testPluckWithArrayAccessValues()
 	{
 		$data = new Collection(array(
 			new TestArrayAccessImplementation(array('name' => 'taylor', 'email' => 'foo')),
 			new TestArrayAccessImplementation(array('name' => 'dayle', 'email' => 'bar'))
 		));
 
-		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->lists('email', 'name')->all());
-		$this->assertEquals(array('foo', 'bar'), $data->lists('email')->all());
+		$this->assertEquals(array('taylor' => 'foo', 'dayle' => 'bar'), $data->pluck('email', 'name')->all());
+		$this->assertEquals(array('foo', 'bar'), $data->pluck('email')->all());
 	}
 
 
@@ -483,13 +483,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testGetListValueWithAccessors()
+	public function testGetPluckValueWithAccessors()
 	{
 		$model    = new TestAccessorEloquentTestStub(array('some' => 'foo'));
 		$modelTwo = new TestAccessorEloquentTestStub(array('some' => 'bar'));
 		$data     = new Collection(array($model, $modelTwo));
 
-		$this->assertEquals(array('foo', 'bar'), $data->lists('some')->all());
+		$this->assertEquals(array('foo', 'bar'), $data->pluck('some')->all());
 	}
 
 
@@ -611,7 +611,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		));
 
 		$c = $c->sortBy('foo.bar');
-		$this->assertEquals(array(2, 1), $c->lists('id')->all());
+		$this->assertEquals(array(2, 1), $c->pluck('id')->all());
 	}
 
 


### PR DESCRIPTION
Keeping `lists` as an alias for BC.
