### PR TITLE
[5.1] Deprecate the query builder's pluck method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -50,8 +50,8 @@ class Builder {
 	 * @var array
 	 */
 	protected $passthru = array(
-		'toSql', 'insert', 'insertGetId', 'count',
-		'min', 'max', 'avg', 'sum', 'exists', 'getBindings',
+		'insert', 'insertGetId', 'getBindings', 'toSql',
+		'exists', 'count', 'min', 'max', 'avg', 'sum',
 	);
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -50,7 +50,7 @@ class Builder {
 	 * @var array
 	 */
 	protected $passthru = array(
-		'toSql', 'lists', 'insert', 'insertGetId', 'count',
+		'toSql', 'insert', 'insertGetId', 'count',
 		'min', 'max', 'avg', 'sum', 'exists', 'getBindings',
 	);
 
@@ -173,27 +173,29 @@ class Builder {
 	}
 
 	/**
-	 * Pluck a single column's value from the first result of a query.
+	 * Get a single column's value from the first result of a query.
 	 *
 	 * @param  string  $column
 	 * @return mixed
 	 */
 	public function value($column)
 	{
-		return $this->pluck($column);
-	}
-
-	/**
-	 * Pluck a single column from the database.
-	 *
-	 * @param  string  $column
-	 * @return mixed
-	 */
-	public function pluck($column)
-	{
 		$result = $this->first(array($column));
 
 		if ($result) return $result->{$column};
+	}
+
+	/**
+	 * An alias for the "value" method.
+	 *
+	 * @param  string  $column
+	 * @return mixed
+	 *
+	 * @deprecated since version 5.1
+	 */
+	public function pluck($column)
+	{
+		return $this->value($column);
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1318,27 +1318,29 @@ class Builder {
 	}
 
 	/**
-	 * Pluck a single column's value from the first result of a query.
+	 * Get a single column's value from the first result of a query.
 	 *
 	 * @param  string  $column
 	 * @return mixed
 	 */
 	public function value($column)
 	{
-		return $this->pluck($column);
-	}
-
-	/**
-	 * Pluck a single column's value from the first result of a query.
-	 *
-	 * @param  string  $column
-	 * @return mixed
-	 */
-	public function pluck($column)
-	{
 		$result = (array) $this->first(array($column));
 
 		return count($result) > 0 ? reset($result) : null;
+	}
+
+	/**
+	 * Alias for the "value" method.
+	 *
+	 * @param  string  $column
+	 * @return mixed
+	 *
+	 * @deprecated since version 5.1
+	 */
+	public function pluck($column)
+	{
+		return $this->value($column);
 	}
 
 	/**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -141,23 +141,23 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testPluckMethodWithModelFound()
+	public function testValueMethodWithModelFound()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', array($this->getMockQueryBuilder()));
 		$mockModel = new StdClass;
 		$mockModel->name = 'foo';
 		$builder->shouldReceive('first')->with(array('name'))->andReturn($mockModel);
 
-		$this->assertEquals('foo', $builder->pluck('name'));
+		$this->assertEquals('foo', $builder->value('name'));
 	}
 
 
-	public function testPluckMethodWithModelNotFound()
+	public function testValueMethodWithModelNotFound()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder[first]', array($this->getMockQueryBuilder()));
 		$builder->shouldReceive('first')->with(array('name'))->andReturn(null);
 
-		$this->assertNull($builder->pluck('name'));
+		$this->assertNull($builder->value('name'));
 	}
 
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -792,12 +792,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testPluckMethodReturnsSingleColumn()
+	public function testValueMethodReturnsSingleColumn()
 	{
 		$builder = $this->getBuilder();
 		$builder->getConnection()->shouldReceive('select')->once()->with('select "foo" from "users" where "id" = ? limit 1', array(1), true)->andReturn(array(array('foo' => 'bar')));
 		$builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, array(array('foo' => 'bar')))->andReturn(array(array('foo' => 'bar')));
-		$results = $builder->from('users')->where('id', '=', 1)->pluck('foo');
+		$results = $builder->from('users')->where('id', '=', 1)->value('foo');
 		$this->assertEquals('bar', $results);
 	}
 


### PR DESCRIPTION
BTW, Wordpress uses [`get_var`](https://codex.wordpress.org/Class_Reference/wpdb).

![Wordpress get_var](http://i.imgur.com/Tc56lmP.png)
