### PR TITLE
[5.0] Changed implementation of offsetGet in Request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -744,7 +744,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function offsetGet($offset)
 	{
-		return $this->input($offset);
+		return $this->all()[$offset];
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -744,7 +744,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function offsetGet($offset)
 	{
-		return $this->all()[$offset];
+        return $this->offsetExists($offset) ? $this->all()[$offset] : null;
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -744,7 +744,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function offsetGet($offset)
 	{
-        return $this->offsetExists($offset) ? $this->all()[$offset] : null;
+        return array_get($this->all(), $offset, null);
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -778,11 +778,11 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function __get($key)
 	{
-		$input = $this->input();
+		$all = $this->all();
 
-		if (array_key_exists($key, $input))
+		if (array_key_exists($key, $all))
 		{
-			return $this->input($key);
+			return array_get($this->all(), $key, null);
 		}
 		elseif ( ! is_null($this->route()))
 		{

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -744,7 +744,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function offsetGet($offset)
 	{
-        return array_get($this->all(), $offset, null);
+		return array_get($this->all(), $offset, null);
 	}
 
 	/**


### PR DESCRIPTION
Currently the `offsetGet()` implementation in `Illuminate\Http\Request` only looks for indexes in `input()`. This causes a problem when you're dispatching a command using `Illuminate\Foundation\Bus\DispatchesCommands::dispatchFrom()` because `offsetExists()` in `Request` uses the `all()` method rather than just the `input()` method.

This means that with the current implementation, a file upload from a request will be dispatched to a command with a `null` value rather than as an `UploadedFile`. The fix I propose will solve this problem by looking for the index in the `all()` method instead of just looking using `input()`.
