### PR TITLE
Filesystem::put accepts config array

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -39,10 +39,10 @@ interface Filesystem {
 	 *
 	 * @param  string  $path
 	 * @param  string|resource  $contents
-	 * @param  string  $visibility
+	 * @param  string|array|null  $config
 	 * @return bool
 	 */
-	public function put($path, $contents, $visibility = null);
+	public function put($path, $contents, $config = null);
 
 	/**
 	 * Get the visibility for the given path.

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -65,13 +65,27 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract {
 	 *
 	 * @param  string  $path
 	 * @param  string|resource  $contents
-	 * @param  string  $visibility
+	 * @param  string|array|null  $config
 	 * @return bool
 	 */
-	public function put($path, $contents, $visibility = null)
+	public function put($path, $contents, $config = null)
 	{
-		$config = ['visibility' => $this->parseVisibility($visibility)];
-        
+		if (is_array($config))
+		{
+			$visibility = null;
+
+			if (in_array('visibility', $config))
+			{
+				$visibility = $this->parseVisibility($config['visibility']);
+			}
+
+			$config['visibility'] = $visibility;
+		}
+		else
+		{
+			$config = ['visibility' => $this->parseVisibility($config)];
+		}
+
 		if (is_resource($contents))
 		{
 			return $this->driver->putStream($path, $contents, $config);


### PR DESCRIPTION
This fixes #8788

Retain default setting of sending a string to determine visibility option, but allow other config values to be set.

Higher functions look for these values to be optionally overridden, so now you can send along config options to override defaults.

@GrahamCampbell Fixed the issues you mentioned - was trying to tidy it into a single change and obviously did something in the wrong order as the other request auto-closed!
