### PR TITLE
[5.1] Filesystem::put accepts config array

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Filesystem.php
+++ b/src/Illuminate/Contracts/Filesystem/Filesystem.php
@@ -39,10 +39,10 @@ interface Filesystem {
 	 *
 	 * @param  string  $path
 	 * @param  string  $contents
-	 * @param  string  $visibility
+	 * @param  string|array|null  $config
 	 * @return bool
 	 */
-	public function put($path, $contents, $visibility = null);
+	public function put($path, $contents, $config = null);
 
 	/**
 	 * Get the visibility for the given path.

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -65,12 +65,28 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract {
 	 *
 	 * @param  string  $path
 	 * @param  string  $contents
-	 * @param  string  $visibility
+	 * @param  string|array|null  $config
 	 * @return bool
 	 */
-	public function put($path, $contents, $visibility = null)
+	public function put($path, $contents, $config = null)
 	{
-		return $this->driver->put($path, $contents, ['visibility' => $this->parseVisibility($visibility)]);
+		if (is_array($config))
+		{
+			$visibility = null;
+
+			if (in_array('visibility', $config))
+			{
+				$visibility = $config['visibility'];
+			}
+
+			$config['visibility'] = $this->parseVisibility($visibility);
+		}
+		else
+		{
+			$config = ['visibility' => $this->parseVisibility($config)];
+		}
+
+		return $this->driver->put($path, $contents, $config);
 	}
 
 	/**


### PR DESCRIPTION
This fixes #8788

Retain default setting of sending a string to determine visibility option, but allow other config values to be set.

Higher functions look for these values to be optionally overridden, so now you can send along config options to override defaults.
