### PR TITLE
[5.1] Use proper docblock for deprecation

### DIFF
--- a/src/Illuminate/Foundation/Bus/DispatchesCommands.php
+++ b/src/Illuminate/Foundation/Bus/DispatchesCommands.php
@@ -3,7 +3,7 @@
 use ArrayAccess;
 
 /**
- * This trait is deprecated. Use the DispatchesJobs trait.
+ * @deprecated since version 5.1. Use the DispatchesJobs trait instead.
  */
 trait DispatchesCommands {
 


### PR DESCRIPTION
So that IDEs can properly warn people using it.
