### PR TITLE
[5.1] Have Collection@map preserve keys

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -3,7 +3,6 @@
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Collection as BaseCollection;
 
 class MorphTo extends BelongsTo {
 
@@ -188,11 +187,11 @@ class MorphTo extends BelongsTo {
 	{
 		$foreign = $this->foreignKey;
 
-		return BaseCollection::make($this->dictionary[$type])->map(function($models) use ($foreign)
+		return collect($this->dictionary[$type])->map(function($models) use ($foreign)
 		{
 			return head($models)->{$foreign};
 
-		})->unique();
+		})->values()->unique();
 	}
 
 	/**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -395,7 +395,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 */
 	public function map(callable $callback)
 	{
-		return new static(array_map($callback, $this->items, array_keys($this->items)));
+		$keys = array_keys($this->items);
+
+		$items = array_map($callback, $this->items, $keys);
+
+		return new static(array_combine($keys, $items));
 	}
 
 	/**
@@ -750,9 +754,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 */
 	public function transform(callable $callback)
 	{
-		$keys = array_keys($this->items);
-
-		$this->items = array_combine($keys, array_map($callback, $this->items, $keys));
+		$this->items = $this->map($callback)->all();
 
 		return $this;
 	}

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -493,6 +493,14 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testMap()
+	{
+		$data = new Collection(['first' => 'taylor', 'last' => 'otwell']);
+		$data = $data->map(function($item, $key) { return $key.'-'.strrev($item); });
+		$this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
+	}
+
+
 	public function testTransform()
 	{
 		$data = new Collection(['first' => 'taylor', 'last' => 'otwell']);


### PR DESCRIPTION
Just like `transform`.

If people really want to reset the keys, they can call `values` on the result.
