### PR TITLE
[5.0] Logic error using Aggregate + Order By

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1640,6 +1640,10 @@ class Builder {
 
 		$previousColumns = $this->columns;
 
+		$previousOrders = $this->orders;
+
+		$this->orders = null;
+
 		$results = $this->get($columns);
 
 		// Once we have executed the query, we will reset the aggregate property so
@@ -1648,6 +1652,8 @@ class Builder {
 		$this->aggregate = null;
 
 		$this->columns = $previousColumns;
+
+		$this->orders = $previousOrders;
 
 		if (isset($results[0]))
 		{


### PR DESCRIPTION
Laravel does not protect us from bad standards, which are allowed in MySQL but not PostgreSQL. Specifically using an aggregate function with an order by clause.

The proposed pull request fixes the issue demontrated below by temporarily removing the `orders` constraint from aggregate queries, and then reapplying them afterwards.
## Steps to replicate

Create application using driver **PostgreSQL**

```
// Create a table with some other index
Schema::create('some_table', function($table)
{
    $table->engine = 'InnoDB';
    $table->increments('id');
    $table->string('slug')->index();
});

class SomeModel extends Eloquent {
    public $table = 'some_table';
}

// Problem is here...
SomeModel::orderBy('slug')->count();

// SQL output
select count(*) as aggregate from "some_table" order by "slug" asc
```

The above SQL output is allegedly "non-standards compliant". Functionally, there is no reason ever to supply "ORDER BY" for an aggregate function. MySQL allows it through because it is non standards compliant, however PostgeSQL throws an error.
## Problem demonstrated in PostgreSQL

PostgreSQL will not allow "order by" due to standards.

```
// Schema
CREATE TABLE some_table(
    id serial PRIMARY KEY,
    slug VARCHAR (50) UNIQUE NOT NULL
);

// SQL
select count(*) as aggregate from "some_table" order by "slug" asc

ERROR: column "some_table.slug" must appear in the GROUP BY clause or be used in an aggregate function Position: 57
```

[See fiddle](http://sqlfiddle.com/#!15/18bbb/1)

```
// SQL output should be
select count(*) as aggregate from "some_table"

// Output
Record Count: 1; Execution Time: 1ms
```

[See fiddle](http://sqlfiddle.com/#!15/18bbb/3)
## Problem demonstrated in MySQL

MySQL will allow "order by" due to non standards. Functionally they are no different.

```
// Schema
create table some_table (
    `id` int unsigned not null auto_increment primary key,
    `slug` varchar(255) not null
);

// SQL
select count(*) as aggregate from `some_table` order by `slug` asc

// Output
Record Count: 1; Execution Time: 1ms
```

[See fiddle](http://sqlfiddle.com/#!9/3db5a/1)

```
// SQL
select count(*) as aggregate from `some_table`

// Output
Record Count: 1; Execution Time: 1ms
```

[See fiddle](http://sqlfiddle.com/#!9/3db5a/2)
## Unit tests

I may need some help writing a unit test for this, since there is no `toAggregateSql()` method.

```
public function testMySqlCountAndOrderBy()
{
    $builder = $this->getMySqlBuilder();
    $builder->select('*')->from('users');
    $builder->skip(5)->take(10);
    $builder->orderBy('id', 'desc'); // This should be stripped off

    $result = $builder->toAggregateSql('count'); // Method does not exist... help??

    $this->assertEquals('select count(*) as aggregate from `users` limit 10 offset 5', $result);
}
```

Basing this on a [previous pull request](https://github.com/laravel/framework/pull/6295) where @janhartigan was of assistance.
## References
- https://github.com/octobercms/october/issues/1111
- https://github.com/rainlab/forum-plugin/issues/61
