### PR TITLE
fix error on MySQL when no default value is set on timestamps fields

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -536,7 +536,7 @@ class MySqlGrammar extends Grammar {
 	 */
 	protected function typeTimestampTz(Fluent $column)
 	{
-		if ( ! $column->nullable) return 'timestamp default 0';
+		if ( ! $column->nullable) return 'timestamp default CURRENT_TIMESTAMP';
 
 		return 'timestamp';
 	}


### PR DESCRIPTION
I noticed this error when try to migrate a table in Laravel with timestamp with no default value set, the code I use is like:

$table->timestamp('created_at');

and the error I noticed is like this:

[Illuminate\Database\QueryException]

SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default val

ue for 'created_at' (SQL: create table users (id int unsigned not null

auto_increment primary key, name varchar(255) not null, email varchar(2

55) not null, password varchar(60) not null, remember_token varchar(100

) null, created_at timestamp default 0 not null, updated_at timestamp d

efault 0 not null) default character set utf8 collate utf8_unicode_ci)

[PDOException]

SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default val

ue for 'created_at'
