### PR TITLE
fix default values for mysql timestamp

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -523,7 +523,7 @@ class MySqlGrammar extends Grammar {
 	 */
 	protected function typeTimestamp(Fluent $column)
 	{
-		if ( ! $column->nullable) return 'timestamp default 0';
+		if ( ! $column->nullable) return 'timestamp default CURRENT_TIMESTAMP';
 
 		return 'timestamp';
 	}
@@ -536,7 +536,7 @@ class MySqlGrammar extends Grammar {
 	 */
 	protected function typeTimestampTz(Fluent $column)
 	{
-		if ( ! $column->nullable) return 'timestamp default 0';
+		if ( ! $column->nullable) return 'timestamp default CURRENT_TIMESTAMP';
 
 		return 'timestamp';
 	}

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -530,7 +530,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table `users` add `foo` timestamp default 0 not null', $statements[0]);
+		$this->assertEquals('alter table `users` add `foo` timestamp default CURRENT_TIMESTAMP not null', $statements[0]);
 	}
 
 	public function testAddingTimeStampTz()
@@ -540,7 +540,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table `users` add `foo` timestamp default 0 not null', $statements[0]);
+		$this->assertEquals('alter table `users` add `foo` timestamp default CURRENT_TIMESTAMP not null', $statements[0]);
 	}
 
 	public function testAddingTimeStamps()
@@ -550,7 +550,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
-		$this->assertEquals('alter table `users` add `created_at` timestamp default 0 not null, add `updated_at` timestamp default 0 not null', $statements[0]);
+		$this->assertEquals('alter table `users` add `created_at` timestamp default CURRENT_TIMESTAMP not null, add `updated_at` timestamp default CURRENT_TIMESTAMP not null', $statements[0]);
 	}
 
 


### PR DESCRIPTION
I noticed the error bellow when using timestamps in mysql with fields  with no default value set:

´´´´
[Illuminate\Database\QueryException]

SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default val

ue for 'created_at' (SQL: create table `users` (`id` int unsigned not null

auto_increment primary key, `name` varchar(255) not null, `email` varchar(2

55) not null, `password` varchar(60) not null, `remember_token` varchar(100

) null, `created_at` timestamp default 0 not null, `updated_at` timestamp d

efault 0 not null) default character set utf8 collate utf8_unicode_ci)

[PDOException]

SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default val

ue for 'created_at'
´´´´

I suggest change the default value in code from 0 to the constant CURRENT_TIMESTAMP, who represent the cuerrent timestamp value.
