### PR TITLE
[5.0] Revert "correct EOL for multiplatform"

### DIFF
--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -19,7 +19,7 @@ class ViewCompilerEngineTest extends PHPUnit_Framework_TestCase {
 		$engine->getCompiler()->shouldReceive('compile')->once()->with(__DIR__.'/fixtures/foo.php');
 		$results = $engine->get(__DIR__.'/fixtures/foo.php');
 
-		$this->assertEquals("Hello World" . PHP_EOL, $results);
+		$this->assertEquals("Hello World\n", $results);
 	}
 
 
@@ -31,7 +31,7 @@ class ViewCompilerEngineTest extends PHPUnit_Framework_TestCase {
 		$engine->getCompiler()->shouldReceive('compile')->never();
 		$results = $engine->get(__DIR__.'/fixtures/foo.php');
 
-		$this->assertEquals("Hello World" . PHP_EOL, $results);
+		$this->assertEquals("Hello World\n", $results);
 	}
 
 

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -14,7 +14,7 @@ class ViewPhpEngineTest extends PHPUnit_Framework_TestCase {
 	public function testViewsMayBeProperlyRendered()
 	{
 		$engine = new PhpEngine;
-		$this->assertEquals("Hello World" . PHP_EOL, $engine->get(__DIR__.'/fixtures/basic.php'));
+		$this->assertEquals("Hello World\n", $engine->get(__DIR__.'/fixtures/basic.php'));
 	}
 
 }


### PR DESCRIPTION
Reverts laravel/framework#8810. It is totally wrong.
