### PR TITLE
[5.0] Fix dissociate for morph-to relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -122,6 +122,20 @@ class MorphTo extends BelongsTo {
 	}
 
 	/**
+	 * Dissociate previously associated model from the given parent.
+	 *
+	 * @return \Illuminate\Database\Eloquent\Model
+	 */
+	public function dissociate()
+	{
+		$this->parent->setAttribute($this->foreignKey, null);
+
+		$this->parent->setAttribute($this->morphType, null);
+
+		return $this->parent->setRelation($this->relation, null);
+	}
+
+	/**
 	 * Get the results of the relationship.
 	 *
 	 * Called via eager load method of Eloquent query builder.

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -76,6 +76,18 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDissociateMethodUnsetsForeignKeyOnModel()
+	{
+		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+		$relation = $this->getRelation($parent);
+		$parent->shouldReceive('setAttribute')->once()->with('foreign_key', null);
+		$parent->shouldReceive('setRelation')->once()->with('relation', null);
+
+		$relation->dissociate();
+	}
+
+
 	protected function getRelation($parent = null)
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -80,6 +80,7 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 		$relation->getEager();
 	}
 
+
 	public function testModelsWithSoftDeleteAreProperlyPulled()
 	{
 		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -91,6 +92,7 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 
 		$relation->withTrashed();
 	}
+
 
 	public function testAssociateMethodSetsForeignKeyAndTypeOnModel()
 	{
@@ -108,6 +110,21 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 		$parent->shouldReceive('setRelation')->once()->with('relation', $associate);
 
 		$relation->associate($associate);
+	}
+
+
+	public function testDissociateMethodDeletesUnsetsKeyAndTypeOnModel()
+	{
+		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+
+		$relation = $this->getRelation($parent);
+
+		$parent->shouldReceive('setAttribute')->once()->with('foreign_key', null);
+		$parent->shouldReceive('setAttribute')->once()->with('morph_type', null);
+		$parent->shouldReceive('setRelation')->once()->with('relation', null);
+
+		$relation->dissociate();
 	}
 
 


### PR DESCRIPTION
_Closes #8806_

I also noticed that `BelongsTo@dissociate` didn't have a unit test so I added that as well.
