### PR TITLE
[5.0] This should fix the view tests on Windows

### DIFF
--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -19,7 +19,8 @@ class ViewCompilerEngineTest extends PHPUnit_Framework_TestCase {
 		$engine->getCompiler()->shouldReceive('compile')->once()->with(__DIR__.'/fixtures/foo.php');
 		$results = $engine->get(__DIR__.'/fixtures/foo.php');
 
-		$this->assertEquals("Hello World\n", $results);
+		$this->assertEquals("Hello World
+", $results);
 	}
 
 
@@ -31,7 +32,8 @@ class ViewCompilerEngineTest extends PHPUnit_Framework_TestCase {
 		$engine->getCompiler()->shouldReceive('compile')->never();
 		$results = $engine->get(__DIR__.'/fixtures/foo.php');
 
-		$this->assertEquals("Hello World\n", $results);
+		$this->assertEquals("Hello World
+", $results);
 	}
 
 

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -14,7 +14,8 @@ class ViewPhpEngineTest extends PHPUnit_Framework_TestCase {
 	public function testViewsMayBeProperlyRendered()
 	{
 		$engine = new PhpEngine;
-		$this->assertEquals("Hello World\n", $engine->get(__DIR__.'/fixtures/basic.php'));
+		$this->assertEquals("Hello World
+", $engine->get(__DIR__.'/fixtures/basic.php'));
 	}
 
 }


### PR DESCRIPTION
This should prevent us from getting issue reports or pull requests such as #8810 again and again.

This solution works because now the newlines should automatically be the same ones used in the stub files, and therefore Git cannot mess them up (depending on the `core.autocrlf` setting).
(This, by the way, is how it is done in the [Blade compiler tests](https://github.com/laravel/framework/blob/ec5a5e169c3d25dbe9511d553078034b16787c58/tests/View/ViewBladeCompilerTest.php), too.)

@GrahamCampbell May I kindly ask you not to lock discussion on tickets like #8812 so quickly? That really hinders discussion and is totally not needed in such cases where nothing is escalating or getting out of hand. :beers: 

/cc @jaschweder
