### PR TITLE
[5.1] Add view:clear command

### DIFF
--- a/src/Illuminate/Foundation/Console/ViewClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewClearCommand.php
@@ -1,0 +1,60 @@
+<?php namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+class ViewClearCommand extends Command {
+
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'view:clear';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Clear all compiled view files';
+
+	/**
+	 * The filesystem instance.
+	 *
+	 * @var \Illuminate\Filesystem\Filesystem
+	 */
+	protected $files;
+
+	/**
+	 * Create a new config clear command instance.
+	 *
+	 * @param  \Illuminate\Filesystem\Filesystem  $files
+	 * @return void
+	 */
+	public function __construct(Filesystem $files)
+	{
+		parent::__construct();
+
+		$this->files = $files;
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return void
+	 */
+	public function fire()
+	{
+		// Because glob ignores hidden files, .gitignore will be preserved.
+		$views = $this->files->glob($this->laravel['config']['view.compiled'].'/*');
+
+		foreach ($views as $view)
+		{
+			$this->files->delete($view);
+		}
+
+		$this->info('Compiled views cleared!');
+	}
+
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Foundation\Console\OptimizeCommand;
 use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Foundation\Console\EventMakeCommand;
 use Illuminate\Foundation\Console\ModelMakeCommand;
+use Illuminate\Foundation\Console\ViewClearCommand;
 use Illuminate\Foundation\Console\RouteCacheCommand;
 use Illuminate\Foundation\Console\RouteClearCommand;
 use Illuminate\Foundation\Console\CommandMakeCommand;
@@ -69,6 +70,7 @@ class ArtisanServiceProvider extends ServiceProvider {
 		'Tinker' => 'command.tinker',
 		'Up' => 'command.up',
 		'VendorPublish' => 'command.vendor.publish',
+		'ViewClear' => 'command.view.clear',
 	];
 
 	/**
@@ -423,6 +425,19 @@ class ArtisanServiceProvider extends ServiceProvider {
 		$this->app->singleton('command.vendor.publish', function($app)
 		{
 			return new VendorPublishCommand($app['files']);
+		});
+	}
+
+	/**
+	 * Register the command.
+	 *
+	 * @return void
+	 */
+	protected function registerViewClearCommand()
+	{
+		$this->app->singleton('command.view.clear', function($app)
+		{
+			return new ViewClearCommand($app['files']);
 		});
 	}
 


### PR DESCRIPTION
This adds a command to delete all the compiled view files. I often had to clear the view files when working on Blade extensions, since the original view stays the same and Laravel doesn't recompile.

Usage:

```
php artisan view:clear
```
