### PR TITLE
[5.0] Fixing array_merge error when no dates present on model.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2813,6 +2813,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function getDates()
 	{
+		if (false === $this->dates) {
+			return array();
+		}
+
 		$defaults = array(static::CREATED_AT, static::UPDATED_AT);
 
 		return array_merge($this->dates, $defaults);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2813,7 +2813,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function getDates()
 	{
-		if (false === $this->dates) {
+		if ( ! $this->dates) {
 			return array();
 		}
 


### PR DESCRIPTION
Signed-off-by: Ashley Meadows takingsides@gmail.com

During a seeder, when attempting to load model data where no dates are set an error occurs:

```
  [ErrorException]                            
  array_merge(): Argument #1 is not an array
```

Example Model:

``` php
<?php namespace Vendor\Package\Models;

use Illuminate\Database\Eloquent\Model;

class Country extends Model
{
    protected $table = 'core__country';

    protected $dates = false;
}
```

Example Seeder:

``` php
    .. snip ..
    foreach ($data as $country => $states) {
        $countryId = Country::where('iso2_code', $country)->first()->pluck('id');

        dd($countryId); // ErrorException

        array_walk($states, function (&$value) use ($countryId) {
            $value = ['country_id' => $countryId, 'name' => $value];
        });

        State::insert($states);
    }
    .. snip ..
```
