### PR TITLE
[5.1] Remove model find method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -659,18 +659,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	}
 
 	/**
-	 * Find a model by its primary key.
-	 *
-	 * @param  mixed  $id
-	 * @param  array  $columns
-	 * @return \Illuminate\Support\Collection|static|null
-	 */
-	public static function find($id, $columns = array('*'))
-	{
-		return static::query()->find($id, $columns);
-	}
-
-	/**
 	 * Find a model by its primary key or return new static.
 	 *
 	 * @param  mixed  $id

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -114,23 +114,9 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testFindMethodCallsQueryBuilderCorrectly()
-	{
-		$result = EloquentModelFindStub::find(1);
-		$this->assertEquals('foo', $result);
-	}
-
-
 	public function testFindMethodUseWritePdo()
 	{
 		$result =  EloquentModelFindWithWritePdoStub::onWriteConnection()->find(1);
-	}
-
-
-	public function testFindMethodWithArrayCallsQueryBuilderCorrectly()
-	{
-		$result = EloquentModelFindManyStub::find(array(1, 2));
-		$this->assertEquals('foo', $result);
 	}
 
 


### PR DESCRIPTION
It'll defer to the query builder.

If someone has been overriding `find` in their own model and calling `parent::find()`, they should now change it to `static::query()->find()`.

As for tests: [the builder has its own tests](https://github.com/laravel/framework/blob/5.0/tests/Database/DatabaseEloquentBuilderTest.php#L15), and [the model has integration tests](https://github.com/laravel/framework/blob/5.0/tests/Database/DatabaseEloquentIntegrationTest.php#L96-L113).
