### PR TITLE
[5.1] Collection : avoid getArrayableItems

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -25,11 +25,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 * @param  mixed  $items
 	 * @return void
 	 */
-	public function __construct($items = array())
+	public function __construct($items = [])
 	{
-		$items = is_null($items) ? [] : $this->getArrayableItems($items);
-
-		$this->items = (array) $items;
+		$this->items = is_array($items) ? $items : $this->getArrayableItems($items);
 	}
 
 	/**
@@ -967,14 +965,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	{
 		if ($items instanceof self)
 		{
-			$items = $items->all();
+			return $items->all();
 		}
 		elseif ($items instanceof Arrayable)
 		{
-			$items = $items->toArray();
+			return $items->toArray();
 		}
 
-		return $items;
+		return (array) $items;
 	}
 
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Support\Collection;
+use Illuminate\Contracts\Support\Arrayable;
 
 class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 
@@ -43,6 +44,47 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$c = new Collection();
 
 		$this->assertTrue($c->isEmpty());
+	}
+
+
+	public function testEmptyCollectionIsConstructed()
+	{
+		$collection = new Collection('foo');
+		$this->assertSame(['foo'], $collection->all());
+
+		$collection = new Collection(2);
+		$this->assertSame([2], $collection->all());
+
+		$collection = new Collection(false);
+		$this->assertSame([false], $collection->all());
+
+		$collection = new Collection(null);
+		$this->assertSame([], $collection->all());
+
+		$collection = new Collection;
+		$this->assertSame([], $collection->all());
+	}
+
+
+	public function testGetArrayableItems()
+	{
+		$collection = new Collection;
+
+		$class  = new ReflectionClass($collection);
+		$method = $class->getMethod('getArrayableItems');
+		$method->setAccessible(true);
+
+		$items = new TestArrayableObject;
+		$array = $method->invokeArgs($collection, [$items]);
+		$this->assertSame(['foo' => 'bar'], $array);
+
+		$items = new Collection(['foo' => 'bar']);
+		$array = $method->invokeArgs($collection, [$items]);
+		$this->assertSame(['foo' => 'bar'], $array);
+
+		$items = ['foo' => 'bar'];
+		$array = $method->invokeArgs($collection, [$items]);
+		$this->assertSame(['foo' => 'bar'], $array);
 	}
 
 
@@ -799,5 +841,13 @@ class TestArrayAccessImplementation implements ArrayAccess
 	public function offsetUnset($offset)
 	{
 		unset($this->arr[$offset]);
+	}
+}
+
+class TestArrayableObject implements Arrayable
+{
+	public function toArray()
+	{
+		return ['foo' => 'bar'];
 	}
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -192,6 +192,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testMergeNull()
+	{
+		$c = new Collection(array('name' => 'Hello'));
+		$this->assertEquals(array('name' => 'Hello'), $c->merge(null)->all());
+	}
+
+
 	public function testMergeArray()
 	{
 		$c = new Collection(array('name' => 'Hello'));
@@ -213,6 +220,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testDiffNull()
+	{
+		$c = new Collection(array('id' => 1, 'first_word' => 'Hello'));
+		$this->assertEquals(array('id' => 1, 'first_word' => 'Hello'), $c->diff(null)->all());
+	}
+
+
 	public function testEach()
 	{
 		$c = new Collection($original = [1, 2, 'foo' => 'bar', 'bam' => 'baz']);
@@ -224,6 +238,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$result = [];
 		$c->each(function($item, $key) use (&$result) { $result[$key] = $item; if (is_string($key)) return false; });
 		$this->assertEquals([1, 2, 'foo' => 'bar'], $result);
+	}
+
+
+	public function testIntersectNull()
+	{
+		$c = new Collection(array('id' => 1, 'first_word' => 'Hello'));
+		$this->assertEquals([], $c->intersect(null)->all());
 	}
 
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -47,7 +47,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-	public function testEmptyCollectionIsConstructed()
+	public function testCollectionIsConstructed()
 	{
 		$collection = new Collection('foo');
 		$this->assertSame(['foo'], $collection->all());


### PR DESCRIPTION
Thanks @JosephSilber for the awesome work on collection ! It's really great to get most of the functions chainable.

If I chain 10 functions to my collection, I will also execute 10 times `getArrayableItems` which does not make sense as all chained function return a new static with an array as an argument.

Also added some tests on constructor and `getArrayableItems` function.
