### PR TITLE
Return value for env() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -623,7 +623,7 @@ if ( ! function_exists('env'))
 
 			case 'null':
 			case '(null)':
-				return;
+				return null;
 		}
 
 		if (Str::startsWith($value, '"') && Str::endsWith($value, '"'))


### PR DESCRIPTION
Missing return argument in `null` case.
