### PR TITLE
Change Eloquent __call logic

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -928,6 +928,20 @@ class Builder {
 	}
 
 	/**
+	 * Determine if a method can be called on object
+	 *
+	 * @param  string  $method
+	 * @return bool
+	 */
+	public function isCallable($method)
+	{
+		return method_exists($this, $method) ||
+			isset($this->macros[$method]) ||
+			method_exists($this->model, 'scope'.ucfirst($method)) ||
+			$this->query->isCallable($method);
+	}
+
+	/**
 	 * Dynamically handle calls into the query instance.
 	 *
 	 * @param  string  $method

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3374,7 +3374,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		$query = $this->newQuery();
 
-		return call_user_func_array(array($query, $method), $parameters);
+		if ($query->isCallable($method))
+		{
+			return call_user_func_array(array($query, $method), $parameters);
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1996,6 +1996,17 @@ class Builder {
 	}
 
 	/**
+	 * Determine if a method can be called on object
+	 *
+	 * @param  string  $method
+	 * @return bool
+	 */
+	public function isCallable($method)
+	{
+		return method_exists($this, $method) || starts_with($method, 'where');
+	}
+
+	/**
 	 * Handle dynamic method calls into the method.
 	 *
 	 * @param  string  $method

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1387,6 +1387,7 @@ class EloquentModelDestroyStub extends Model {
 	public function newQuery()
 	{
 		$mock = m::mock('Illuminate\Database\Eloquent\Builder');
+		$mock->shouldReceive('isCallable')->once()->with('whereIn')->andReturn(true);
 		$mock->shouldReceive('whereIn')->once()->with('id', array(1, 2, 3))->andReturn($mock);
 		$mock->shouldReceive('get')->once()->andReturn(array($model = m::mock('StdClass')));
 		$model->shouldReceive('delete')->once();


### PR DESCRIPTION
Currently Eloquent has unstable __call policy - methods are passed to Eloquent Builder and Query Builder but also a model can have it's own methods which differ from one class to another.

So I cannot check method existance with `method_exists` and If I call something I can get a `BadMethodCallException` from query builder (while I'm calling a method on a model object).

I propose returning `null` on any invalid method call if it is passed to model like `$model->unexistingMethod()` - while `Model::query()->unexistingMethod()` will remain old behavior as It is obvious to get an Exception from builder (which rarely differs in models).

One of examples of incorrect behavior is Twig integration #8366 
