### PR TITLE
Get `vendor` path's base path dynamically for `artisan optimize`

### DIFF
--- a/src/Illuminate/Foundation/Console/Optimize/config.php
+++ b/src/Illuminate/Foundation/Console/Optimize/config.php
@@ -1,6 +1,17 @@
 <?php
 
-$basePath = $app['path.base'];
+$getVendorBasePath = function () {
+    $typicalCoreClass     = 'Illuminate\Config\Repository';
+    $typicalCoreClassPath = str_replace('/', DIRECTORY_SEPARATOR, '/vendor/laravel/framework/src/Illuminate/Config/Repository.php');
+
+    $realClassPath = (new ReflectionObject(new $typicalCoreClass))->getFileName();
+
+    return strpos($realClassPath, $typicalCoreClassPath) ?
+        substr($realClassPath, 0, (strlen($realClassPath) - strlen($typicalCoreClassPath))) :
+        preg_replace('/\/vendor\/compiled\.php$/', '', $realClassPath);
+};
+
+$basePath = $getVendorBasePath();
 
 return array_map('realpath', array(
     $basePath.'/vendor/laravel/framework/src/Illuminate/Contracts/Container/Container.php',


### PR DESCRIPTION
There're people who doesn't put `vendor/laravel` on the same directory as  `app` and want to use `artisan optimize`.

(like this)[https://github.com/laravel/framework/issues/8637]

Here is my solution.

I think `Laravel` is flexible like this.
