### PR TITLE
[5.0] Guard method onceUsingId not returning false but throwing exception

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -510,9 +510,13 @@ class Guard implements GuardContract {
 	 */
 	public function onceUsingId($id)
 	{
-		$this->setUser($this->provider->retrieveById($id));
-
-		return $this->user instanceof UserContract;
+		$user = $this->provider->retrieveById($id);
+		if ($user)
+		{
+			$this->setUser($user);
+			return $this->user instanceof UserContract;
+		}
+		return false;
 	}
 
 	/**
@@ -710,7 +714,7 @@ class Guard implements GuardContract {
 	 * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
 	 * @return void
 	 */
-	public function setUser(UserContract $user = null)
+	public function setUser(UserContract $user)
 	{
 		$this->user = $user;
 

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -710,7 +710,7 @@ class Guard implements GuardContract {
 	 * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
 	 * @return void
 	 */
-	public function setUser(UserContract $user)
+	public function setUser(UserContract $user = null)
 	{
 		$this->user = $user;
 

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -510,11 +510,10 @@ class Guard implements GuardContract {
 	 */
 	public function onceUsingId($id)
 	{
-		$user = $this->provider->retrieveById($id);
-		if ($user)
+		if ( ! is_null($user = $this->provider->retrieveById($id)))
 		{
 			$this->setUser($user);
-			return $this->user instanceof UserContract;
+			return true;
 		}
 		return false;
 	}

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -246,6 +246,14 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals($user, $guard->loginUsingId(10));
 	}
+	
+	
+	public function testOnceUsingIdFailure()
+	{
+		$guard = $this->getGuard();
+		$guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
+		$this->assertFalse($guard->onceUsingId(11));
+	}
 
 
 	public function testUserUsesRememberCookieIfItExists()


### PR DESCRIPTION
Fixed Guard implementation not accepting a null value for the setUser call leading to an exception in onceUsingId instead of returning false if the provider returns null for the specified user ID.
