### PR TITLE
[5.1] Return this from seeJsonContains

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -303,6 +303,8 @@ trait CrawlerTrait
                 "Unable to find JSON fragment [{$expected}] within [{$actual}]."
             );
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
seeJsonContains was not returning $this, breaking methods chaining
