### PR TITLE
[5.0] DB Query Builder Join Clause 'where in'

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -177,7 +177,10 @@ class Grammar extends BaseGrammar {
 	{
 		$first = $this->wrap($clause['first']);
 
-		$second = $clause['where'] ? '?' : $this->wrap($clause['second']);
+		$isIn = $clause['operator'] === 'in' || $clause['operator'] === 'not in';
+		$second = $clause['where']
+			? ($isIn ? '(' . join(',', array_fill(0, $clause['second'], '?')) . ')' : '?')
+			: $this->wrap($clause['second']);
 
 		return "{$clause['boolean']} $first {$clause['operator']} $second";
 	}

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -55,9 +55,12 @@ class JoinClause {
 	 */
 	public function on($first, $operator, $second, $boolean = 'and', $where = false)
 	{
-		$this->clauses[] = compact('first', 'operator', 'second', 'boolean', 'where');
+		$isIn = $where && ($operator === 'in' || $operator === 'not in') && is_array($second);
 
 		if ($where) $this->bindings[] = $second;
+
+		!$isIn ?: $second = count($second);
+		$this->clauses[] = compact('first', 'operator', 'second', 'boolean', 'where');
 
 		return $this;
 	}
@@ -146,6 +149,54 @@ class JoinClause {
 	public function orWhereNotNull($column)
 	{
 		return $this->whereNotNull($column, 'or');
+	}
+
+	/**
+	 * Add an "on where in (...)" clause to the join.
+	 *
+	 * @param string $column
+	 * @param array $values
+	 * @return \Illuminate\Database\Query\JoinClause
+	 */
+	public function whereIn($column, array $values)
+	{
+		return $this->on($column, 'in', $values, 'and', true);
+	}
+
+	/**
+	 * Add an "on where not in (...)" clause to the join.
+	 *
+	 * @param string $column
+	 * @param array $values
+	 * @return \Illuminate\Database\Query\JoinClause
+	 */
+	public function whereNotIn($column, array $values)
+	{
+		return $this->on($column, 'not in', $values, 'and', true);
+	}
+
+	/**
+	 * Add an "or on where in (...)" clause to the join.
+	 *
+	 * @param string $column
+	 * @param array $values
+	 * @return \Illuminate\Database\Query\JoinClause
+	 */
+	public function orWhereIn($column, array $values)
+	{
+		return $this->on($column, 'in', $values, 'or', true);
+	}
+
+	/**
+	 * Add an "or on where not in (...)" clause to the join.
+	 *
+	 * @param string $column
+	 * @param array $values
+	 * @return \Illuminate\Database\Query\JoinClause
+	 */
+	public function orWhereNotIn($column, array $values)
+	{
+		return $this->on($column, 'not in', $values, 'or', true);
 	}
 
 }


### PR DESCRIPTION
Added Join Clause methods:
- `whereIn`
- `whereNotIn`
- `orWhereIn`
- `orWhereNotIn`

[Issue discussion](https://github.com/laravel/framework/issues/4412)
