### PR TITLE
[5.0] Force seed on refresh command, if --force is supplied

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -72,7 +72,11 @@ class RefreshCommand extends Command {
 	{
 		$class = $this->option('seeder') ?: 'DatabaseSeeder';
 
-		$this->call('db:seed', array('--database' => $database, '--class' => $class));
+		$force = $this->input->getOption('force');
+
+		$this->call('db:seed', array(
+			'--database' => $database, '--class' => $class, '--force' => $force,
+		));
 	}
 
 	/**


### PR DESCRIPTION
Currently, if you run `php artisan migrate:refresh --seed --force` Artisan will force the migrations to refresh, but will then require a confirmation before seeding. This change simply passes the `--force` flag to the seeder.
