### PR TITLE
Encrypted attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -126,6 +126,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	protected $guarded = array('*');
 
 	/**
+	 * The attributes that should be enyrypted when being set and decrypted when being get.
+	 *
+	 * @var array
+	 */
+	protected $encrypt = array();
+
+	/**
 	 * The attributes that should be mutated to dates.
 	 *
 	 * @var array
@@ -2584,6 +2591,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	{
 		$value = $this->getAttributeFromArray($key);
 
+		// If an attribute is listed as to "encrypt", we'll decrypt it using Crypt facade.
+		if (in_array($key, $this->encrypt))
+        {
+            $value = \Crypt::decrypt($value);
+        }
+
 		// If the attribute has a get mutator, we will call that then return what
 		// it returns as the value, which is useful for transforming values on
 		// retrieval from the model to a form that is more useful for usage.
@@ -2790,6 +2803,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		if ($this->isJsonCastable($key))
 		{
 			$value = json_encode($value);
+		}
+
+		// If an attribute is listed as to "encrypt", we'll encrypt it using Crypt facade.
+		if (in_array($key, $this->encrypt) && $value)
+		{
+			$value = \Crypt::encrypt($value);
 		}
 
 		$this->attributes[$key] = $value;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2399,12 +2399,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		// If an attribute is listed as to "encrypt", we'll decrypt it using Crypt facade.
 		foreach ($attributes as $key => $value)
-        {
-            if (in_array($key, $this->encrypt) && $value)
-            {
-                $attributes[$key] = \Crypt::decrypt($value);
-            }
-        }
+		{
+			if (in_array($key, $this->encrypt) && $value)
+			{
+				$attributes[$key] = \Crypt::decrypt($value);
+			}
+		}
 
 		// If an attribute is a date, we will cast it to a string after converting it
 		// to a DateTime / Carbon instance. This is so we will get some consistent
@@ -2602,9 +2602,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		// If an attribute is listed as to "encrypt", we'll decrypt it using Crypt facade.
 		if (in_array($key, $this->encrypt))
-        {
-            $value = \Crypt::decrypt($value);
-        }
+		{
+			$value = \Crypt::decrypt($value);
+		}
 
 		// If the attribute has a get mutator, we will call that then return what
 		// it returns as the value, which is useful for transforming values on

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2397,6 +2397,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	{
 		$attributes = $this->getArrayableAttributes();
 
+		// If an attribute is listed as to "encrypt", we'll decrypt it using Crypt facade.
+		foreach ($attributes as $key => $value)
+        {
+            if (in_array($key, $this->encrypt) && $value)
+            {
+                $attributes[$key] = \Crypt::decrypt($value);
+            }
+        }
+
 		// If an attribute is a date, we will cast it to a string after converting it
 		// to a DateTime / Carbon instance. This is so we will get some consistent
 		// formatting while accessing attributes vs. arraying / JSONing a model.


### PR DESCRIPTION
German laws determine that sensitive data must not be stored in plain text, but encrypted. The main purpose of it is that in case the database access is compromised, then the data would be unreadable.

As an example, credit card numbers, emails, first and last names, social security numbers, etc.

For this, we extended the Eloquent/Model.php class in order to address encryptable attributes. So whenever an attribute is "set" we encrypt it and whenever is "get" we decrypt it.

Would be nice to have this in the base-line of Laravel.

In case there's a better alternative on how to implement this, I'm happy to code it.

Thanks.
