### PR TITLE
Make 'queue:table' and 'queue:failed-table' respect tables config

### DIFF
--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -55,7 +55,7 @@ class FailedTableCommand extends Command {
 	{
 		$fullPath = $this->createBaseMigration();
 
-		$table = config('queue.failed.table', 'failed_jobs');
+		$table = $this->laravel->make('config')->get('queue.failed.table', 'failed_jobs');
 
 		$stub = str_replace('{{table}}', $table, $this->files->get(__DIR__.'/stubs/failed_jobs.stub'));
 

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -55,7 +55,7 @@ class FailedTableCommand extends Command {
 	{
 		$fullPath = $this->createBaseMigration();
 
-		$table = $this->laravel->make('config')->get('queue.failed.table', 'failed_jobs');
+		$table = $this->laravel['config']['queue.failed.table'];
 
 		$stub = str_replace('{{table}}', $table, $this->files->get(__DIR__.'/stubs/failed_jobs.stub'));
 

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -55,7 +55,11 @@ class FailedTableCommand extends Command {
 	{
 		$fullPath = $this->createBaseMigration();
 
-		$this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/failed_jobs.stub'));
+		$table = config('queue.failed.table', 'failed_jobs');
+
+		$stub = str_replace('{{table}}', $table, $this->files->get(__DIR__.'/stubs/failed_jobs.stub'));
+
+		$this->files->put($fullPath, $stub);
 
 		$this->info('Migration created successfully!');
 

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -55,7 +55,7 @@ class TableCommand extends Command {
 	{
 		$fullPath = $this->createBaseMigration();
 
-		$table = config('queue.connections.database.table', 'jobs');
+		$table = $this->laravel->make('config')->get('queue.connections.database.table', 'jobs');
 
 		$stub = str_replace('{{table}}', $table, $this->files->get(__DIR__.'/stubs/jobs.stub'));
 

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -55,7 +55,7 @@ class TableCommand extends Command {
 	{
 		$fullPath = $this->createBaseMigration();
 
-		$table = $this->laravel->make('config')->get('queue.connections.database.table', 'jobs');
+		$table = $this->laravel['config']['queue.connections.database.table'];
 
 		$stub = str_replace('{{table}}', $table, $this->files->get(__DIR__.'/stubs/jobs.stub'));
 

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -55,7 +55,11 @@ class TableCommand extends Command {
 	{
 		$fullPath = $this->createBaseMigration();
 
-		$this->files->put($fullPath, $this->files->get(__DIR__.'/stubs/jobs.stub'));
+		$table = config('queue.connections.database.table', 'jobs');
+
+		$stub = str_replace('{{table}}', $table, $this->files->get(__DIR__.'/stubs/jobs.stub'));
+
+		$this->files->put($fullPath, $stub);
 
 		$this->info('Migration created successfully!');
 

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -12,7 +12,7 @@ class CreateFailedJobsTable extends Migration {
 	 */
 	public function up()
 	{
-		Schema::create('failed_jobs', function(Blueprint $table)
+		Schema::create('{{table}}', function(Blueprint $table)
 		{
 			$table->increments('id');
 			$table->text('connection');
@@ -29,7 +29,7 @@ class CreateFailedJobsTable extends Migration {
 	 */
 	public function down()
 	{
-		Schema::drop('failed_jobs');
+		Schema::drop('{{table}}');
 	}
 
 }

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -12,7 +12,7 @@ class CreateJobsTable extends Migration {
 	 */
 	public function up()
 	{
-		Schema::create('jobs', function(Blueprint $table)
+		Schema::create('{{table}}', function(Blueprint $table)
 		{
 			$table->bigIncrements('id');
 			$table->string('queue');
@@ -32,7 +32,7 @@ class CreateJobsTable extends Migration {
 	 */
 	public function down()
 	{
-		Schema::drop('jobs');
+		Schema::drop('{{table}}');
 	}
 
 }


### PR DESCRIPTION
Today I configured a new app to use "database" queue driver, and changed the default table name configuration from "jobs" to "laravel_jobs". Right after, I ran `php artisan queue:table` command and, to my surprise, the migration created had "jobs" as table name, instead of "laravel_jobs", as expected.

I dived into the framework code, and it is so f\* good that I was able to quickly craft this PR, which uses the configured custom table names (both for "queue:table" and "queue:failed-table".
