### PR TITLE
Update docblock getGrammar in Database\Query\Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1976,7 +1976,7 @@ class Builder {
 	/**
 	 * Get the query grammar instance.
 	 *
-	 * @return \Illuminate\Database\Grammar
+	 * @return \Illuminate\Database\Query\Grammars\Grammar
 	 */
 	public function getGrammar()
 	{


### PR DESCRIPTION
Return correct object for `getGrammar`. The class `\Illuminate\Database\Query\Grammars\Grammar` is injected in the constructor, so it should also be returning that class in the getter.
