### PR TITLE
[5.1] Proposal: Configurable stubs in console generators

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -50,6 +50,11 @@ class ModelMakeCommand extends GeneratorCommand {
 	 */
 	protected function getStub()
 	{
+		if ( ! empty($this->laravel['config']['console.stubs.model.default']))
+		{
+			return base_path($this->laravel['config']['console.stubs.model.default']);
+		}
+
 		return __DIR__.'/stubs/model.stub';
 	}
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -50,12 +50,7 @@ class ModelMakeCommand extends GeneratorCommand {
 	 */
 	protected function getStub()
 	{
-		if ( ! empty($this->laravel['config']['console.stubs.model.default']))
-		{
-			return base_path($this->laravel['config']['console.stubs.model.default']);
-		}
-
-		return __DIR__.'/stubs/model.stub';
+		return $this->laravel['config']->get('console.stubs.model.default', __DIR__.'/stubs/model.stub');
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/RequestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RequestMakeCommand.php
@@ -32,12 +32,7 @@ class RequestMakeCommand extends GeneratorCommand {
 	 */
 	protected function getStub()
 	{
-		if ( ! empty($this->laravel['config']['console.stubs.request.default']))
-		{
-			return base_path($this->laravel['config']['console.stubs.request.default']);
-		}
-
-		return __DIR__.'/stubs/request.stub';
+		return $this->laravel['config']->get('console.stubs.request.default', __DIR__.'/stubs/request.stub');
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Console/RequestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RequestMakeCommand.php
@@ -32,6 +32,11 @@ class RequestMakeCommand extends GeneratorCommand {
 	 */
 	protected function getStub()
 	{
+		if ( ! empty($this->laravel['config']['console.stubs.request.default']))
+		{
+			return base_path($this->laravel['config']['console.stubs.request.default']);
+		}
+
 		return __DIR__.'/stubs/request.stub';
 	}
 

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -35,7 +35,17 @@ class ControllerMakeCommand extends GeneratorCommand {
 	{
 		if ($this->option('plain'))
 		{
+			if ( ! empty($this->laravel['config']['console.stubs.controller.plain']))
+			{
+				return base_path($this->laravel['config']['console.stubs.controller.plain']);
+			}
+
 			return __DIR__.'/stubs/controller.plain.stub';
+		}
+
+		if ( ! empty($this->laravel['config']['console.stubs.controller.default']))
+		{
+			return base_path($this->laravel['config']['console.stubs.controller.default']);
 		}
 
 		return __DIR__.'/stubs/controller.stub';

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -35,20 +35,10 @@ class ControllerMakeCommand extends GeneratorCommand {
 	{
 		if ($this->option('plain'))
 		{
-			if ( ! empty($this->laravel['config']['console.stubs.controller.plain']))
-			{
-				return base_path($this->laravel['config']['console.stubs.controller.plain']);
-			}
-
-			return __DIR__.'/stubs/controller.plain.stub';
+			return $this->laravel['config']->get('console.stubs.controller.plain', __DIR__.'/stubs/controller.plain.stub');
 		}
 
-		if ( ! empty($this->laravel['config']['console.stubs.controller.default']))
-		{
-			return base_path($this->laravel['config']['console.stubs.controller.default']);
-		}
-
-		return __DIR__.'/stubs/controller.stub';
+		return $this->laravel['config']->get('console.stubs.controller.default', __DIR__.'/stubs/controller.stub');
 	}
 
 	/**


### PR DESCRIPTION
In some situations you may want to modify stubs that are used in console generators.

Several use cases:
1. You have a base model and want every model to extend it (This is probably the most relevant one)
2. You want `artisan make:controller` to generate  controller with only one `index()` method.
3. You want  `artisan make:request` to generate request with `authorize()` returning true by default
4. You prefer different codestyle.
I'm sure everyone can make up a couple more.

At the moment this can be achieved by making new artisan commands and extending generators.
I propose another approach using configuration system.

https://github.com/laravel/laravel/pull/3385

Let's start with models, controllers and request and see what Taylor and other feel about it.
