### PR TITLE
[5.1] Use the model's getRouteKeyName to improve default model binding resolution for the router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -929,7 +929,9 @@ class Router implements RegistrarContract {
 			// For model binders, we will attempt to retrieve the models using the first
 			// method on the model instance. If we cannot retrieve the models we'll
 			// throw a not found exception otherwise we will return the instance.
-			if ($model = (new $class)->find($value))
+			$instance = new $class;
+
+			if ($model = $instance->where($instance->getRouteKeyName(), $value)->first())
 			{
 				return $model;
 			}

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -911,11 +911,19 @@ class RouteBindingStub {
 }
 
 class RouteModelBindingStub {
-	public function find($value) { return strtoupper($value); }
+	public function getRouteKeyName() { return 'id'; }
+	public function where($key, $value)
+	{
+		$this->value = $value;
+		return $this;
+	}
+	public function first() { return strtoupper($this->value); }
 }
 
 class RouteModelBindingNullStub {
-	public function find($value) {}
+	public function getRouteKeyName() { return 'id'; }
+	public function where($key, $value) { return $this; }
+	public function first() {}
 }
 
 class RouteModelBindingClosureStub {


### PR DESCRIPTION
**App\Post**

``` php
public function getRouteKeyName() {
  return 'slug';
}
```

**App\Providers\RouteServiceProvider**

``` php
$router->model('posts', 'App\Post');
```

Prior to this patch, the model resolution would fail on the router, causing a controller with a type-hinted model to fail.

``` php
public function edit(Post $post, Request $request) {
  echo $post->id; //=> null
}
```
