### PR TITLE
[5.0] JSON options support in Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -231,6 +231,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	public static $manyMethods = array('belongsToMany', 'morphToMany', 'morphedByMany');
 
 	/**
+	 * Options used for JSON encoding operations
+	 *
+	 * @var int
+	 */
+	protected static $jsonOptions = 0;
+
+	/**
 	 * The name of the "created at" column.
 	 *
 	 * @var string
@@ -304,6 +311,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 				forward_static_call([get_called_class(), $method]);
 			}
 		}
+	}
+
+	/**
+	 * Set JSON encoding options
+	 *
+	 * @param int $options
+	 */
+	public static function setJsonOptions($options)
+	{
+		static::$jsonOptions = $options;
 	}
 
 	/**
@@ -2354,8 +2371,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  int  $options
 	 * @return string
 	 */
-	public function toJson($options = 0)
+	public function toJson($options = null)
 	{
+		$options = (is_null($options)) ? static::$jsonOptions : $options;
+
 		return json_encode($this->toArray(), $options);
 	}
 
@@ -2789,7 +2808,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		if ($this->isJsonCastable($key))
 		{
-			$value = json_encode($value);
+			$value = json_encode($value, static::$jsonOptions);
 		}
 
 		$this->attributes[$key] = $value;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1204,6 +1204,19 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testModelJsonCastingOptions()
+	{
+		$model = new EloquentModelCastingStub;
+		EloquentModelCastingStub::setJsonOptions(JSON_UNESCAPED_UNICODE);
+		$model->eighth = array('foo' => 'Юникод');
+
+		$this->assertEquals(array('foo' => 'Юникод'), $model->eighth);
+		$this->assertEquals('{"foo":"Юникод"}', $model->eighthAttributeValue());
+
+		$this->assertEquals('{"eighth":{"foo":"Юникод"}}', $model->toJson());
+	}
+
+
 	public function testModelAttributeCastingPreservesNull()
 	{
 		$model = new EloquentModelCastingStub;


### PR DESCRIPTION
Currently JSON encoding options are only applied on converting model to JSON but not on JSON castable attributes.

This patch allows to set JSON casting options globally by calling `Model::setJsonOptions(...)`

Compatibility can be broken only if the new feature is being used but it remains ok if the feature is not touched.
