### PR TITLE
[5.0] Will now return false on file already existing

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -52,7 +52,8 @@ abstract class GeneratorCommand extends Command {
 
 		if ($this->files->exists($path = $this->getPath($name)))
 		{
-			return $this->error($this->type.' already exists!');
+			$this->error($this->type.' already exists!');
+			return false;
 		}
 
 		$this->makeDirectory($path);

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -33,7 +33,7 @@ class ModelMakeCommand extends GeneratorCommand {
 	 */
 	public function fire()
 	{
-		if(parent::fire() != false)
+		if(parent::fire() == null)
 		{
 			if ( ! $this->option('no-migration'))
 			{

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -33,13 +33,14 @@ class ModelMakeCommand extends GeneratorCommand {
 	 */
 	public function fire()
 	{
-		parent::fire();
-
-		if ( ! $this->option('no-migration'))
+		if(parent::fire() != false)
 		{
-			$table = str_plural(snake_case(class_basename($this->argument('name'))));
+			if ( ! $this->option('no-migration'))
+			{
+				$table = str_plural(snake_case(class_basename($this->argument('name'))));
 
-			$this->call('make:migration', ['name' => "create_{$table}_table", '--create' => $table]);
+				$this->call('make:migration', ['name' => "create_{$table}_table", '--create' => $table]);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #8877

Generator command now returns false when the file already exists and have updated the make:model command to make use of this so a migration is only created when a model does not exist.

This may not be the most efficient way to complete this but I thought I would try and help :)
