### PR TITLE
[5.0] Fix url generation with not enough optional params

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -320,11 +320,11 @@ class UrlGenerator implements UrlGeneratorContract {
 		if (count($parameters))
 		{
 			$path = preg_replace_sub(
-				'/\{.*?\}/', $parameters, $this->replaceNamedParameters($path, $parameters)
+				'/\{.*?[^?]\}/', $parameters, $this->replaceNamedParameters($path, $parameters)
 			);
 		}
 
-		return trim(preg_replace('/\{.*?\?\}/', '', $path), '/');
+		return trim(preg_replace(['/\{.*?\?\}\/?/', '/\{\}/'], '', $path), '/');
 	}
 
 	/**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -278,11 +278,11 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals('http://www.foo.com:8080/foo', $url->route('foo'));
 
-        $this->assertEquals('http://www.foo.com:8080/foo//baz', $url->route('foo', ['two' => 'baz']));
-        $this->assertEquals('http://www.foo.com:8080/foo//stuff', $url->route('foo', ['three' => 'stuff']));
+		$this->assertEquals('http://www.foo.com:8080/foo//baz', $url->route('foo', ['two' => 'baz']));
+		$this->assertEquals('http://www.foo.com:8080/foo//stuff', $url->route('foo', ['three' => 'stuff']));
 
-        $this->assertEquals('http://www.foo.com:8080/foo/bar/baz', $url->route('foo', ['one' => 'bar', 'two' => 'baz']));
-        $this->assertEquals('http://www.foo.com:8080/foo/bar/stuff', $url->route('foo', ['one' => 'bar', 'three' => 'stuff']));
+		$this->assertEquals('http://www.foo.com:8080/foo/bar/baz', $url->route('foo', ['one' => 'bar', 'two' => 'baz']));
+		$this->assertEquals('http://www.foo.com:8080/foo/bar/stuff', $url->route('foo', ['one' => 'bar', 'three' => 'stuff']));
 
 	}
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -277,6 +277,13 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase {
 		$routes->add($route);
 
 		$this->assertEquals('http://www.foo.com:8080/foo', $url->route('foo'));
+
+        $this->assertEquals('http://www.foo.com:8080/foo//baz', $url->route('foo', ['two' => 'baz']));
+        $this->assertEquals('http://www.foo.com:8080/foo//stuff', $url->route('foo', ['three' => 'stuff']));
+
+        $this->assertEquals('http://www.foo.com:8080/foo/bar/baz', $url->route('foo', ['one' => 'bar', 'two' => 'baz']));
+        $this->assertEquals('http://www.foo.com:8080/foo/bar/stuff', $url->route('foo', ['one' => 'bar', 'three' => 'stuff']));
+
 	}
 
 


### PR DESCRIPTION
In case if route has many optional parameters:

``` php
Route::get('/{sort?}/{category?}/{period?}', 'SubjectsController@index');
```

If we will send not all optional parameters, generated url will be contain double or more slashes:

``` php
action('SubjectsController@index', ['sort' => 'top', 'period' => 'month']); 
// http://your.domain/top//month
```

This pull request fixes that behavior:
Placeholders of not passed OPTIONAL parameters will be replaced WITH following slash by empty string.
Placeholders of not passed REQUIRED parameters will be replaced WITHOUT following slash by empty string, to emphasize that they are required
So we will get:

``` php
Route::get('/{sort?}/{category?}/{period?}', 'SubjectsController@index');
action('SubjectsController@index', ['sort' => 'top', 'period' => 'month']); 
// http://your.domain/top/month

// -------------------------------------------------

Route::get('/{sort}/{category}/{period?}', 'SubjectsController@index');
action('SubjectsController@index', ['sort' => 'top', 'period' => 'month']); 
// http://your.domain/top//month
```
