### PR TITLE
[5.1] Changed implementation of offsetGet in Request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -744,9 +744,9 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function offsetGet($offset)
 	{
-        $all = $this->all();
+		$all = $this->all();
 
-        return array_get($all, $offset, null);
+		return array_get($all, $offset, null);
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -784,7 +784,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 
 		if (array_key_exists($key, $all))
 		{
-			return $this->all();
+			return $all[$key];
 		}
 		elseif ( ! is_null($this->route()))
 		{

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -746,7 +746,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	{
 		$all = $this->all();
 
-		return array_get($all, $offset, null);
+		return array_get($all, $offset);
 	}
 
 	/**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -784,7 +784,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 
 		if (array_key_exists($key, $all))
 		{
-			return $this->all($key);
+			return $this->all();
 		}
 		elseif ( ! is_null($this->route()))
 		{

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -744,17 +744,9 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function offsetGet($offset)
 	{
-		$input = $this->input();
+        $all = $this->all();
 
-		if (array_has($input, $offset))
-		{
-			return array_get($input, $offset);
-		}
-
-		if ($this->hasFile($offset))
-		{
-			return $this->file($offset);
-		}
+        return array_get($all, $offset, null);
 	}
 
 	/**
@@ -788,11 +780,11 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	 */
 	public function __get($key)
 	{
-		$input = $this->input();
+		$all = $this->all();
 
-		if (array_key_exists($key, $input))
+		if (array_key_exists($key, $all))
 		{
-			return $this->input($key);
+			return $this->all($key);
 		}
 		elseif ( ! is_null($this->route()))
 		{


### PR DESCRIPTION
This PR replaces https://github.com/laravel/framework/pull/8789 to target it to 5.1.

Currently the `offsetGet()` implementation in `Illuminate\Http\Request` only looks for indexes in `input()`. This causes a problem when you're dispatching a command using `Illuminate\Foundation\Bus\DispatchesCommands::dispatchFrom()` because `offsetExists()` in `Request` uses the `all()` method rather than just the `input()` method.

This means that with the current implementation, a file upload from a request will be dispatched to a command with a `null` value rather than as an `UploadedFile`. The fix I propose will solve this problem by looking for the index in the `all()` method instead of just looking using `input()`.
