### PR TITLE
[5.1] Handle HttpResponseException in Kernel

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -6,6 +6,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Http\Exception\HttpResponseException;
 use Illuminate\Contracts\Routing\TerminableMiddleware;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
 
@@ -298,6 +299,10 @@ class Kernel implements KernelContract {
 	 */
 	protected function renderException($request, Exception $e)
 	{
+		if ($e instanceof HttpResponseException)
+		{
+			return $e->getResponse();
+		}
 		return $this->app['Illuminate\Contracts\Debug\ExceptionHandler']->render($request, $e);
 	}
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -287,6 +287,11 @@ class Kernel implements KernelContract {
 	 */
 	protected function reportException(Exception $e)
 	{
+		if ($e instanceof HttpResponseException)
+		{
+			return;
+		}
+
 		$this->app['Illuminate\Contracts\Debug\ExceptionHandler']->report($e);
 	}
 
@@ -303,6 +308,7 @@ class Kernel implements KernelContract {
 		{
 			return $e->getResponse();
 		}
+
 		return $this->app['Illuminate\Contracts\Debug\ExceptionHandler']->render($request, $e);
 	}
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -10,7 +10,6 @@ use Illuminate\Routing\Matching\HostValidator;
 use Illuminate\Routing\Matching\MethodValidator;
 use Illuminate\Routing\Matching\SchemeValidator;
 use Symfony\Component\Routing\Route as SymfonyRoute;
-use Illuminate\Http\Exception\HttpResponseException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Route {
@@ -122,24 +121,17 @@ class Route {
 	{
 		$this->container = $this->container ?: new Container;
 
-		try
+		if ( ! is_string($this->action['uses']))
 		{
-			if ( ! is_string($this->action['uses']))
-			{
-				return $this->runCallable($request);
-			}
-
-			if ($this->customDispatcherIsBound())
-			{
-				return $this->runWithCustomDispatcher($request);
-			}
-
-			return $this->runController($request);
+			return $this->runCallable($request);
 		}
-		catch (HttpResponseException $e)
+
+		if ($this->customDispatcherIsBound())
 		{
-			return $e->getResponse();
+			return $this->runWithCustomDispatcher($request);
 		}
+
+		return $this->runController($request);
 	}
 
 	/**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -14,10 +14,6 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
 		$router = $this->getRouter();
-		$router->get('foo/bar', function() { throw new Illuminate\Http\Exception\HttpResponseException(new Response('hello')); });
-		$this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
-
-		$router = $this->getRouter();
 		$route = $router->get('foo/bar', array('domain' => 'api.{name}.bar', function($name) { return $name; }));
 		$route = $router->get('foo/bar', array('domain' => 'api.{name}.baz', function($name) { return $name; }));
 		$this->assertEquals('taylor', $router->dispatch(Request::create('http://api.taylor.bar/foo/bar', 'GET'))->getContent());


### PR DESCRIPTION
I have same issue as in #8887

When application throws `HttpResponseException` I cannot redefine its rendering or get any useful information about where it was actually thrown.

This patch allows to redefine `renderException` method in Kernel to change the logic of `HttpResponseException` handling and catch info in `reportException` method.

Also removed the test as the exception is not handled by `Route` class anymore.
