### PR TITLE
[5.0] Add Overloading so that we can use Flysystem Plugins

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -329,4 +329,18 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract {
 		throw new InvalidArgumentException('Unknown visibility: '.$visibility);
 	}
 
+	/**
+	 * Call a Flysystem driver plugin.
+	 *
+	 * @param  string  $method
+	 * @param  array  $arguments
+	 * @return mixed
+	 *
+	 * @throws \BadMethodCallException
+	 */
+	public function __call($method, array $arguments)
+	{
+		return $this->driver->__call($method, $arguments);
+	}
+
 }


### PR DESCRIPTION
Flysystem permits to add plugins to the adapters but Laravel don't when whe extend it with custom Filesystems.
Indeed and for instance I've made a custom filesystem for Google Drive and also created a plugin to get a file by URL instead of path.
Paths don't really exist in Google Drive (URL and IDs).

I can make it work with Laravel with:

``` php
Storage::disk("gdrive")->getDriver()->getByUrl('https://drive.google.com/open?id=###########"&authuser=0');
```

But with this PR I can just do:

``` php
Storage::disk("gdrive")->getByUrl('https://drive.google.com/open?id=###########"&authuser=0');
```

I don't know if it's the best way to do it but the statement of need is here ;-)
What do you think?
