### PR TITLE
Sending to a Specified Address

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -49,6 +49,18 @@ class MailServiceProvider extends ServiceProvider {
 			{
 				$mailer->alwaysFrom($from['address'], $from['name']);
 			}
+			
+			// If a "to" address is set, we will set it on the mailer so that all mail
+			// messages sent by the applications will utilize the same "to" address
+			// on each one, which makes it easier for a develop to test, view and share
+			// emails sent from a development or staging environment without spamming
+			// real customers.
+			$to = $app['config']['mail.to'];
+
+			if (is_array($to) && isset($to['address']))
+			{
+				$mailer->alwaysTo($to['address'], $to['name']);
+			}
 
 			// Here we will determine if the mailer should be in "pretend" mode for this
 			// environment, which will simply write out e-mail to the logs instead of

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -108,6 +108,18 @@ class Mailer {
 	{
 		$this->from = compact('address', 'name');
 	}
+	
+	/**
+	 * Set the global to address and name.
+	 *
+	 * @param  string  $address
+	 * @param  string  $name
+	 * @return void
+	 */
+	public function alwaysTo($address, $name = null)
+	{
+		$this->to = compact('address', 'name');
+	}
 
 	/**
 	 * Send a new message when only a plain part.


### PR DESCRIPTION
Sometimes you want to avoid email real customers. The two solutions given by Laravel as per as the official documentation are:
- Using "pretend" to log the emails into the log file.
- Using something like http://mailtrap.io.

Like with [Symfony2](http://symfony.com/doc/current/cookbook/email/dev_environment.html#sending-to-a-specified-address), here we also give the ability to the developer to specify one email address which will receive every single email from his application. Could be very useful on a staging environment where you don't want to email real customers and where the actual tester wouldn't have access to the log files or wouldn't be able to use mailtrap.
