### PR TITLE
[5.1] Improved Exception Reporting

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -43,7 +43,7 @@ class Handler implements ExceptionHandlerContract {
 	 */
 	public function report(Exception $e)
 	{
-		if ($this->shouldReport())
+		if ($this->shouldReport($e))
 		{
 			$this->log->error($e);
 		}

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -43,9 +43,10 @@ class Handler implements ExceptionHandlerContract {
 	 */
 	public function report(Exception $e)
 	{
-		if ($this->shouldntReport($e)) return;
-
-		$this->log->error((string) $e);
+		if ($this->shouldReport())
+		{
+			$this->log->error($e);
+		}
 	}
 
 	/**


### PR DESCRIPTION
It can be very useful to have the entire exception passed through to the
logger. An example use case would be logging to bugsnag by having a
bugsnag logger object, and passing the entire exception means we can
extract more detail from it. This is not a breaking change because psr
says that the "message" should be a string, or be stringish, which an
exception object is.
