### PR TITLE
[5.1] Use Reponse constants for HTTP status code instead of magic numbers.

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -353,7 +353,7 @@ class Guard implements GuardContract {
 	{
 		$headers = ['WWW-Authenticate' => 'Basic'];
 
-		return new Response('Invalid credentials.', 401, $headers);
+		return new Response('Invalid credentials.', Response::HTTP_UNAUTHORIZED, $headers);
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -130,7 +130,7 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	{
 		if ($this->ajax() || $this->wantsJson())
 		{
-			return new JsonResponse($errors, 422);
+			return new JsonResponse($errors, Response::HTTP_UNPROCESSABLE_ENTITY);
 		}
 
 		return $this->redirector->to($this->getRedirectUrl())
@@ -145,7 +145,7 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	 */
 	public function forbiddenResponse()
 	{
-		return new Response('Forbidden', 403);
+		return new Response('Forbidden', Response::HTTP_FORBIDDEN);
 	}
 
 	/**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -186,7 +186,7 @@ class RouteCollection implements Countable, IteratorAggregate {
 		{
 			return (new Route('OPTIONS', $request->path(), function() use ($methods)
 			{
-				return new Response('', 200, array('Allow' => implode(',', $methods)));
+				return new Response('', Response::HTTP_OK, array('Allow' => implode(',', $methods)));
 
 			}))->bind($request);
 		}


### PR DESCRIPTION
Promote the use of standard HTTP constants in the Response class.
