### PR TITLE
[5.1] Convert PSR-7 to Illuminate Reponse

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Events\Dispatcher;
+use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 use Illuminate\Contracts\Routing\Registrar as RegistrarContract;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -1213,7 +1214,17 @@ class Router implements RegistrarContract {
 	 */
 	public function prepareResponse($request, $response)
 	{
-		if ( ! $response instanceof SymfonyResponse)
+		if ($response instanceof PsrResponseInterface)
+		{
+			$psrResponse = $response;
+			$response = new Response(
+			  $psrResponse->getBody()->__toString(),
+			  $psrResponse->getStatusCode(),
+			  $psrResponse->getHeaders()
+		  	);
+        		$response->setProtocolVersion($psrResponse->getProtocolVersion());
+		}
+		elseif ( ! $response instanceof SymfonyResponse)
 		{
 			$response = new Response($response);
 		}


### PR DESCRIPTION
Currently, a Symfony PSR-7 Bridge is being created (https://github.com/symfony/psr-http-message-bridge) and will probably be added to Symfony 2.8 or the Framework bundle. However, I'm not sure about the timeframe/compatibility.

This PR adds a simple PSR-7 Response converter, so a PSR-7 response could be returned from a controller/route, eg. for 3rd party libraries.

Considerations:
- If the bridge is stable, we could use the `HttpFoundationFactory` to convert messages and perhaps extend the support for resolving Requests and other conversions.
- If the middleware is going to support PSR-7 responses, they shouldn't be cast to IlluminateResponse objects, but right now it has to be a string of SymfonyResponse, otherwise will fail.
- There isn't much use of PSR-7 except Guzzle 6 that I now of, but probably more will follow.

Other solutions to implement as 3rd party:
- Don't cast the Response in the router and handle it somewhere else (middleware?)
- Provide extension point before preparing the response.
