### PR TITLE
Make sure mutators also are called from pivot constructor. (L5.0)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -49,7 +49,8 @@ class Pivot extends Model {
 		// The pivot model is a "dynamic" model since we will set the tables dynamically
 		// for the instance. This allows it work for any intermediate tables for the
 		// many to many relationship that are defined by this developer's classes.
-		$this->setRawAttributes($attributes, true);
+		$this->forceFill($attributes);
+		$this->syncOriginal();
 
 		$this->setTable($table);
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -23,6 +23,15 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($pivot->exists);
 	}
 
+	public function testMutatorsAreCalledFromConstructor() {
+			$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
+			$parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+			$pivot = new DatabaseEloquentPivotTestMutatorStub($parent, array('foo' => 'bar'), 'table', true);
+
+			$this->assertTrue($pivot->getMutatorCalled());
+	}
+
 
 	public function testPropertiesUnchangedAreNotDirty()
 	{
@@ -97,5 +106,18 @@ class DatabaseEloquentPivotTestDateStub extends Illuminate\Database\Eloquent\Rel
 	public function getDates()
 	{
 		return array();
+	}
+}
+
+class DatabaseEloquentPivotTestMutatorStub extends Illuminate\Database\Eloquent\Relations\Pivot {
+	private $mutatorCalled = false;
+
+	public function setFooAttribute($value) {
+			$this->mutatorCalled = true;
+			return $value;
+	}
+
+	public function getMutatorCalled() {
+			return $this->mutatorCalled;
 	}
 }

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -24,12 +24,12 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testMutatorsAreCalledFromConstructor() {
-			$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
-			$parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
+		$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
+		$parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
 
-			$pivot = new DatabaseEloquentPivotTestMutatorStub($parent, array('foo' => 'bar'), 'table', true);
+		$pivot = new DatabaseEloquentPivotTestMutatorStub($parent, array('foo' => 'bar'), 'table', true);
 
-			$this->assertTrue($pivot->getMutatorCalled());
+		$this->assertTrue($pivot->getMutatorCalled());
 	}
 
 
@@ -113,11 +113,11 @@ class DatabaseEloquentPivotTestMutatorStub extends Illuminate\Database\Eloquent\
 	private $mutatorCalled = false;
 
 	public function setFooAttribute($value) {
-			$this->mutatorCalled = true;
-			return $value;
+		$this->mutatorCalled = true;
+		return $value;
 	}
 
 	public function getMutatorCalled() {
-			return $this->mutatorCalled;
+		return $this->mutatorCalled;
 	}
 }


### PR DESCRIPTION
This fix makes sure that the Pivot constructor also calls mutators defined on Pivot class by using forceFill instead of setRawAttributes.

This is the same changes as for master (https://github.com/laravel/framework/pull/8900) in case you want to backport the changes.
