### PR TITLE
[5.1] Optimize Arr::get() to use strtok() instead of explode().  ~25% improvement.

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -235,14 +235,15 @@ class Arr {
 
 		if (isset($array[$key])) return $array[$key];
 
-		foreach (explode('.', $key) as $segment)
-		{
-			if ( ! is_array($array) || ! array_key_exists($segment, $array))
-			{
-				return value($default);
-			}
+		$key = strtok($key, '.');
 
-			$array = $array[$segment];
+		while ($key !== false)
+		{
+			if ( ! isset($array[$key])) return value($default);
+
+			$array = $array[$key];
+
+			$key = strtok('.');
 		}
 
 		return $array;

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -235,15 +235,15 @@ class Arr {
 
 		if (isset($array[$key])) return $array[$key];
 
-		$key = strtok($key, '.');
+		$segment = strtok($key, '.');
 
-		while ($key !== false)
+		while ($segment !== false)
 		{
-			if ( ! isset($array[$key])) return value($default);
+			if ( ! isset($array[$segment])) return value($default);
 
-			$array = $array[$key];
+			$array = $array[$segment];
 
-			$key = strtok('.');
+			$segment = strtok('.');
 		}
 
 		return $array;

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -235,15 +235,14 @@ class Arr {
 
 		if (isset($array[$key])) return $array[$key];
 
-		$segment = strtok($key, '.');
-
-		while ($segment !== false)
+		foreach (explode('.', $key) as $segment)
 		{
-			if ( ! isset($array[$segment])) return value($default);
+			if ( ! array_key_exists($segment, $array))
+			{
+				return value($default);
+			}
 
 			$array = $array[$segment];
-
-			$segment = strtok('.');
 		}
 
 		return $array;


### PR DESCRIPTION
Did some googlefu research to optimize the Arr::get() function.  
Came upon this [stackoverflow](http://stackoverflow.com/questions/14704984/best-way-for-dot-notation-access-to-multidimensional-array-in-php) post about using strtok() instead of explode(). Credit to Jack for the algorithm.

Overall, I'm geting about 25% speed improvement for the optimize Arr::get() and no change in memory usage.  array_get() is used about 90 times in the framework codebase especially in the routing.

Benchmark Script
https://gist.github.com/yadakhov/19a9b26d77befda6c134

Benchmark Results
![Benchmark](http://i.imgur.com/LFD0iL1.png)
