### PR TITLE
[5.1] Remove !is_array() check.  It is not needed.

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -237,7 +237,7 @@ class Arr {
 
 		foreach (explode('.', $key) as $segment)
 		{
-			if ( ! is_array($array) || ! array_key_exists($segment, $array))
+			if ( ! array_key_exists($segment, $array))
 			{
 				return value($default);
 			}


### PR DESCRIPTION
This PR is resulting from https://github.com/laravel/framework/pull/8902#discussion_r31134908

Upon further investigation it looks like we can gain about 25-30% improvement by removing the !is_array() check.  It seems like the !is_array() is superfluous.  I know this is micro optimization, but 25% is pretty good especially when every single request is impacted by the array_get function.

Here's my benchmark script:
https://gist.github.com/yadakhov/19a9b26d77befda6c134

This is my result:
![Result](http://i.imgur.com/x8DX2TT.png)
