### PR TITLE
[5.2] Split attribute and relation accessors

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2537,31 +2537,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 */
 	public function getAttribute($key)
 	{
-		$inAttributes = array_key_exists($key, $this->attributes);
-
 		// If the key references an attribute, we can just go ahead and return the
 		// plain attribute value from the model. This allows every attribute to
 		// be dynamically accessed through the _get method without accessors.
-		if ($inAttributes || $this->hasGetMutator($key))
+		if (array_key_exists($key, $this->attributes) || $this->hasGetMutator($key))
 		{
 			return $this->getAttributeValue($key);
 		}
 
-		// If the key already exists in the relationships array, it just means the
-		// relationship has already been loaded, so we'll just return it out of
-		// here because there is no need to query within the relations twice.
-		if ($this->relationLoaded($key))
-		{
-			return $this->relations[$key];
-		}
-
-		// If the "attribute" exists as a method on the model, we will just assume
-		// it is a relationship and will load and return results from the query
-		// and hydrate the relationship's value on the "relationships" array.
-		if (method_exists($this, $key))
-		{
-			return $this->getRelationshipFromMethod($key);
-		}
+		return $this->getRelationValue($key);
 	}
 
 	/**
@@ -2570,7 +2554,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  string  $key
 	 * @return mixed
 	 */
-	protected function getAttributeValue($key)
+	public function getAttributeValue($key)
 	{
 		$value = $this->getAttributeFromArray($key);
 
@@ -2599,6 +2583,31 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Get a relationship.
+	 *
+	 * @param  string  $key
+	 * @return mixed
+	 */
+	public function getRelationValue($key)
+	{
+		// If the key already exists in the relationships array, it just means the
+		// relationship has already been loaded, so we'll just return it out of
+		// here because there is no need to query within the relations twice.
+		if ($this->relationLoaded($key))
+		{
+			return $this->relations[$key];
+		}
+
+		// If the "attribute" exists as a method on the model, we will just assume
+		// it is a relationship and will load and return results from the query
+		// and hydrate the relationship's value on the "relationships" array.
+		if (method_exists($this, $key))
+		{
+			return $this->getRelationshipFromMethod($key);
+		}
 	}
 
 	/**


### PR DESCRIPTION
A slight extension of `Model` class.

So far we have `getAttribute` method which returns either attribute or relation and also a protected `getAttributeValue` method which returns only an attribute but cannot be accessed from outside.

This allows to get a plain attribute value or plain relation value from outside without duplicating internal model logic.

``` php
$model->getAttributeValue('foo'); //Get attribute only - do not return relation if it exists
$model->getRelationValue('bar'); //Get relation only - event if attribute with same name exists
```
