### PR TITLE
[5.0] Added contextual binding on methods test

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -498,7 +498,24 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf('ContainerImplementationStub', $container->tagged('foo')[0]);
 		$this->assertInstanceOf('ContainerImplementationStubTwo', $container->tagged('foo')[1]);
 	}
+    
+    /**
+     * Methods should using contextual binding
+     */
+	public function testContextualBindingOnMethods()
+	{
+		$container = new Container;
+        $container->when("ContainerTestInterfaceStub")->needs("IContainerContractStub")->give("ContainerImplementationStub");
 
+        // Works if using constructor
+		$constructor = $container->make('ContainerTestInterfaceStub');
+		$result = $constructor->getStub();
+        $this->assertInstanceOf("ContainerImplementationStub", $result);
+
+        // Doesn't work if using methods
+		$result = $container->call('ContainerTestInterfaceStub@go');
+        $this->assertInstanceOf("ContainerImplementationStub", $result);
+	}
 }
 
 class ContainerConcreteStub {}
@@ -595,4 +612,21 @@ class ContainerStaticMethodStub
 function containerTestInject(ContainerConcreteStub $stub, $default = 'taylor')
 {
 	return func_get_args();
+}
+
+class ContainerTestInterfaceStub {
+    public function __construct(IContainerContractStub $stub)
+    {
+        $this->stub = $stub;
+    }
+
+	public function go(IContainerContractStub $stub)
+	{
+		return $stub; 
+	}
+
+    public function getStub()
+    {
+        return $this->stub;
+    }
 }


### PR DESCRIPTION
Contextual binding does not work on methods, only constructor functions.

I've added a (currently failing) test that checks that this works. (At least, I think that's what it's testing, I don't fully understand the `Container` class, so apologies if the test is wrong/stupid.)
