### PR TITLE
[5.1] Added "accepts" method to the request class

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -622,6 +622,26 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	}
 
 	/**
+	 * Determines whether a request accepts JSON.
+	 *
+	 * @return bool
+	 */
+	public function acceptsJson()
+	{
+		return $this->accepts('application/json');
+	}
+
+	/**
+	 * Determines whether a request accepts HTML.
+	 *
+	 * @return bool
+	 */
+	public function acceptsHtml()
+	{
+		return $this->accepts('text/html');
+	}
+
+	/**
 	 * Get the data format expected in the response.
 	 *
 	 * @param  string  $default

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -604,14 +604,14 @@ class Request extends SymfonyRequest implements ArrayAccess {
 
 			foreach ((array) $contentTypes as $type)
 			{
-				$split = explode('/', $type);
-
-				if ($accept === $type || $accept === $split[0].'/*')
+				if ($accept === $type || $accept === strtok('/', $type).'/*')
 				{
 					return true;
 				}
 
-				if (preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $accept))
+				$split = explode('/', $accept);
+
+				if (preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type))
 				{
 					return true;
 				}

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -586,6 +586,42 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	}
 
 	/**
+	 * Determines whether the current requests accepts a given content type.
+	 *
+	 * @param  string|array  $contentTypes
+	 * @return bool
+	 */
+	public function accepts($contentTypes)
+	{
+		$accepts = $this->getAcceptableContentTypes();
+
+		foreach ($accepts as $accept)
+		{
+			if ($accept === '*/*')
+			{
+				return true;
+			}
+
+			foreach ((array) $contentTypes as $type)
+			{
+				$split = explode('/', $type);
+
+				if ($accept === $type || $accept === $split[0].'/*')
+				{
+					return true;
+				}
+
+				if (preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $accept))
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get the data format expected in the response.
 	 *
 	 * @param  string  $default

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -450,12 +450,14 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
 		$this->assertEquals('json', $request->format());
 		$this->assertTrue($request->accepts('application/json'));
+		$this->assertTrue($request->accepts('application/baz+json'));
 		$this->assertTrue($request->acceptsJson());
 		$this->assertFalse($request->acceptsHtml());
 
 		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/foo+json']);
 		$this->assertTrue($request->accepts('application/foo+json'));
-		$this->assertTrue($request->accepts('application/json'));
+		$this->assertFalse($request->accepts('application/bar+json'));
+		$this->assertFalse($request->accepts('application/json'));
 
 		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*']);
 		$this->assertTrue($request->accepts('application/xml'));
@@ -477,6 +479,18 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testFormatReturnsAcceptsAll()
+	{
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => '*/*']);
+		$this->assertEquals('html', $request->format());
+		$this->assertTrue($request->accepts('text/html'));
+		$this->assertTrue($request->accepts('foo/bar'));
+		$this->assertTrue($request->accepts('application/baz+xml'));
+		$this->assertTrue($request->acceptsHtml());
+		$this->assertTrue($request->acceptsJson());
+	}
+
+
 	public function testFormatReturnsAcceptsMultiple()
 	{
 		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json,text/*']);
@@ -484,6 +498,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($request->accepts('text/html'));
 		$this->assertTrue($request->accepts('text/foo'));
 		$this->assertTrue($request->accepts('application/json'));
+		$this->assertTrue($request->accepts('application/baz+json'));
 	}
 
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -432,17 +432,50 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 
 	public function testFormatReturnsAcceptableFormat()
 	{
-		$request = Request::create('/', 'GET', array(), array(), array(), array('HTTP_ACCEPT' => 'application/json'));
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
 		$this->assertEquals('json', $request->format());
 		$this->assertTrue($request->wantsJson());
 
-		$request = Request::create('/', 'GET', array(), array(), array(), array('HTTP_ACCEPT' => 'application/atom+xml'));
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/atom+xml']);
 		$this->assertEquals('atom', $request->format());
 		$this->assertFalse($request->wantsJson());
 
-		$request = Request::create('/', 'GET', array(), array(), array(), array('HTTP_ACCEPT' => 'is/not/known'));
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'is/not/known']);
 		$this->assertEquals('html', $request->format());
 		$this->assertEquals('foo', $request->format('foo'));
+	}
+
+	public function testFormatReturnsAcceptsJson()
+	{
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
+		$this->assertEquals('json', $request->format());
+		$this->assertTrue($request->accepts('*/*'));
+		$this->assertTrue($request->accepts('application/json'));
+		$this->assertTrue($request->accepts('application/*'));
+		$this->assertTrue($request->acceptsJson());
+		$this->assertFalse($request->acceptsHtml());
+
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/foo+json']);
+		$this->assertTrue($request->accepts('application/foo+json'));
+	}
+
+
+	public function testFormatReturnsAcceptsHtml()
+	{
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'text/html']);
+		$this->assertEquals('html', $request->format());
+		$this->assertTrue($request->accepts('*/*'));
+		$this->assertTrue($request->accepts('text/html'));
+		$this->assertTrue($request->acceptsHtml());
+		$this->assertFalse($request->acceptsJson());
+	}
+
+
+	public function testFormatReturnsAcceptsMultiple()
+	{
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json,text/html']);
+		$this->assertTrue($request->accepts(['*/*', 'text/html', 'application/json']));
+		$this->assertTrue($request->accepts('*/*'));
 	}
 
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -449,14 +449,17 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	{
 		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
 		$this->assertEquals('json', $request->format());
-		$this->assertTrue($request->accepts('*/*'));
 		$this->assertTrue($request->accepts('application/json'));
-		$this->assertTrue($request->accepts('application/*'));
 		$this->assertTrue($request->acceptsJson());
 		$this->assertFalse($request->acceptsHtml());
 
 		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/foo+json']);
 		$this->assertTrue($request->accepts('application/foo+json'));
+		$this->assertTrue($request->accepts('application/json'));
+
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*']);
+		$this->assertTrue($request->accepts('application/xml'));
+		$this->assertTrue($request->accepts('application/json'));
 	}
 
 
@@ -464,18 +467,23 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	{
 		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'text/html']);
 		$this->assertEquals('html', $request->format());
-		$this->assertTrue($request->accepts('*/*'));
 		$this->assertTrue($request->accepts('text/html'));
 		$this->assertTrue($request->acceptsHtml());
 		$this->assertFalse($request->acceptsJson());
+
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'text/*']);
+		$this->assertTrue($request->accepts('text/html'));
+		$this->assertTrue($request->accepts('text/plain'));
 	}
 
 
 	public function testFormatReturnsAcceptsMultiple()
 	{
-		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json,text/html']);
-		$this->assertTrue($request->accepts(['*/*', 'text/html', 'application/json']));
-		$this->assertTrue($request->accepts('*/*'));
+		$request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json,text/*']);
+		$this->assertTrue($request->accepts(['text/html', 'application/json']));
+		$this->assertTrue($request->accepts('text/html'));
+		$this->assertTrue($request->accepts('text/foo'));
+		$this->assertTrue($request->accepts('application/json'));
 	}
 
 


### PR DESCRIPTION
This method can be really useful when working out if the client actually supports a given content type.

---

Replaces #8888.
