### PR TITLE
[5.1] Deprecate array_fetch

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -122,6 +122,8 @@ class Arr {
 	 * @param  array   $array
 	 * @param  string  $key
 	 * @return array
+	 *
+	 * @deprecated since version 5.1. Use pluck instead.
 	 */
 	public static function fetch($array, $key)
 	{

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -118,6 +118,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 	 *
 	 * @param  string  $key
 	 * @return static
+	 *
+	 * @deprecated since version 5.1. Use pluck instead.
 	 */
 	public function fetch($key)
 	{

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -128,6 +128,8 @@ if ( ! function_exists('array_fetch'))
 	 * @param  array   $array
 	 * @param  string  $key
 	 * @return array
+	 *
+	 * @deprecated since version 5.1. Use array_pluck instead.
 	 */
 	function array_fetch($array, $key)
 	{


### PR DESCRIPTION
Also removed it [from the docs](https://github.com/laravel/docs/pull/1475).
