### PR TITLE
[5.0] Update Request::is() to compare with both path() and url()

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -157,7 +157,7 @@ class Request extends SymfonyRequest implements ArrayAccess {
 	{
 		foreach (func_get_args() as $pattern)
 		{
-			if (str_is($pattern, urldecode($this->path())))
+			if (str_is($pattern, urldecode($this->path())) || str_is($pattern, urldecode($this->url())))
 			{
 				return true;
 			}


### PR DESCRIPTION
Currently, is() compares the pattern only with path().
There can be times that the full URL can be sent to Request::is().
For example, action(Controller@Method), that generates a full URL.
