### PR TITLE
[5.0] FailedJobProviderInterface find() method return value is an array

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -26,7 +26,7 @@ class RetryCommand extends Command {
 	 */
 	public function fire()
 	{
-		$failed = $this->laravel['queue.failer']->find($this->argument('id'));
+		$failed = (object)$this->laravel['queue.failer']->find($this->argument('id'));
 
 		if ( ! is_null($failed))
 		{


### PR DESCRIPTION
As soon as we use our custom implementations of a FailedJobProvider, we get an Exception

```
[ErrorException]
Trying to get property of non-object
```

``` php
    /**
     * Get a single failed job.
     *
     * @param  mixed  $id
     * @return array
     */
    public function find($id);
```

We need to cast the array to object and it's working or Interface annotation need to be updated.
