### PR TITLE
[5.1] Upgraded Laravel's usage of the AWS SDK for PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "illuminate/view": "self.version"
     },
     "require-dev": {
-        "aws/aws-sdk-php": "~2.4",
+        "aws/aws-sdk-php": "~2.4|~3.0",
         "iron-io/iron_mq": "~2.0",
         "pda/pheanstalk": "~3.0",
         "predis/predis": "~1.0",
@@ -101,7 +101,7 @@
         }
     },
     "suggest": {
-        "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (~2.4).",
+        "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (~2.4|~3.0).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.4).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
         "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers (~6.0).",

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -55,10 +55,10 @@ class SesTransport implements Swift_Transport {
 	public function send(Swift_Mime_Message $message, &$failedRecipients = null)
 	{
 		return $this->ses->sendRawEmail([
-			'Source' => $message->getSender(),
+			'Source' => key($message->getSender()),
 			'Destinations' => $this->getTo($message),
 			'RawMessage' => [
-				'Data' => base64_encode((string) $message),
+				'Data' => $this->getMessage($message),
 			],
 		]);
 	}
@@ -91,6 +91,26 @@ class SesTransport implements Swift_Transport {
 		}
 
 		return $destinations;
+	}
+
+	/**
+	 * Get the "message" payload field for the API request.
+	 *
+	 * This method provides compatibility with Version 2 and Version 3 of the AWS SDK.
+	 *
+	 * @param  \Swift_Mime_Message  $message
+	 * @return array
+	 */
+	protected function getMessage(Swift_Mime_Message $message)
+	{
+		$message = (string) $message;
+
+		// Version 2 of the SDK requires you to explicitly base64_encode().
+		if (defined('Aws\Common\Aws::VERSION')) {
+			$message = base64_encode($message);
+		}
+
+		return $message;
 	}
 
 }

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -13,6 +13,18 @@ class SqsConnector implements ConnectorInterface {
 	 */
 	public function connect(array $config)
 	{
+		// Adjust configuration for V3 of the AWS SDK.
+		if (defined('Aws\Sdk::VERSION')) {
+			$config += [
+				'version' => 'latest',
+				'credentials' => [
+					'key'    => $config['key'],
+					'secret' => $config['secret'],
+				],
+			];
+			unset($config['key'], $config['secret']);
+		}
+
 		$sqs = SqsClient::factory($config);
 
 		return new SqsQueue($sqs, $config['queue']);

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Aws\Ses\SesClient;
+use Illuminate\Foundation\Application;
+use Illuminate\Mail\TransportManager;
+use Illuminate\Mail\Transport\SesTransport;
+use Illuminate\Support\Collection;
+
+class MailSesTransportTest extends PHPUnit_Framework_TestCase {
+
+	public function testGetTransport()
+	{
+		/** @var Application $app */
+		$app = [
+			'config' => new Collection([
+				'services.ses' => [
+					'key'    => 'foo',
+					'secret' => 'bar',
+					'region' => 'baz',
+				]
+			])
+		];
+
+		$manager = new TransportManager($app);
+
+		/** @var SesTransport $transport */
+		$transport = $manager->driver('ses');
+
+		/** @var SesClient $ses */
+		$ses = $this->readAttribute($transport, 'ses');
+
+		$this->assertEquals('baz', $ses->getRegion());
+	}
+
+	public function testSend()
+	{
+		$message = new Swift_Message('Foo subject', 'Bar body');
+		$message->setSender('myself@example.com');
+		$message->setTo('me@example.com');
+		$message->setBcc('you@example.com');
+
+		$client = $this->getMockBuilder('Aws\Ses\SesClient')
+			->setMethods(['sendRawEmail'])
+			->disableOriginalConstructor()
+			->getMock();
+		$transport = new SesTransport($client);
+
+		// Version 3 of the SDK base64 encodes the message automatically, but
+		// since we mocking away the whole SDK client, we need to simulate it.
+		$expectedData = defined('Aws\Sdk::VERSION')
+			? strval($message)
+			: base64_encode($message);
+
+		$client->expects($this->once())
+			->method('sendRawEmail')
+			->with($this->equalTo([
+				'Source' => 'myself@example.com',
+				'Destinations' => [
+					'me@example.com',
+					'you@example.com',
+				],
+				'RawMessage' => ['Data' => $expectedData],
+			]));
+
+		$transport->send($message);
+	}
+}

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -19,16 +19,14 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 		$this->baseUrl = 'https://sqs.someregion.amazonaws.com';
 		$this->releaseDelay = 0;
 
-		// The Aws\Common\AbstractClient needs these three constructor parameters
-		$this->credentials = new Credentials( $this->key, $this->secret );
-		$this->signature = new SignatureV4( $this->service, $this->region );
-		$this->config = new Collection();
-
 		// This is how the modified getQueue builds the queueUrl
 		$this->queueUrl = $this->baseUrl . '/' . $this->account . '/' . $this->queueName;
 
 		// Get a mock of the SqsClient
-		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		$this->mockedSqsClient = $this->getMockBuilder('Aws\Sqs\SqsClient')
+			->setMethods(array('deleteMessage'))
+			->disableOriginalConstructor()
+			->getMock();
 
 		// Use Mockery to mock the IoC Container
 		$this->mockedContainer = m::mock('Illuminate\Container\Container');
@@ -65,7 +63,10 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 
 	public function testDeleteRemovesTheJobFromSqs()
 	{
-		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('deleteMessage'), array($this->credentials, $this->signature, $this->config));
+		$this->mockedSqsClient = $this->getMockBuilder('Aws\Sqs\SqsClient')
+			->setMethods(array('deleteMessage'))
+			->disableOriginalConstructor()
+			->getMock();
 		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->queueName, $this->account));
 		$queue->setContainer($this->mockedContainer);
 		$job = $this->getJob();
@@ -76,7 +77,10 @@ class QueueSqsJobTest extends PHPUnit_Framework_TestCase {
 
 	public function testReleaseProperlyReleasesTheJobOntoSqs()
 	{
-		$this->mockedSqsClient = $this->getMock('Aws\Sqs\SqsClient', array('changeMessageVisibility'), array($this->credentials, $this->signature, $this->config));
+		$this->mockedSqsClient = $this->getMockBuilder('Aws\Sqs\SqsClient')
+			->setMethods(array('changeMessageVisibility'))
+			->disableOriginalConstructor()
+			->getMock();
 		$queue = $this->getMock('Illuminate\Queue\SqsQueue', array('getQueue'), array($this->mockedSqsClient, $this->queueName, $this->account));
 		$queue->setContainer($this->mockedContainer);
 		$job = $this->getJob();

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -3,7 +3,6 @@
 use Mockery as m;
 
 use Aws\Sqs\SqsClient;
-use Guzzle\Service\Resource\Model;
 
 class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 
@@ -31,13 +30,14 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase {
 		$this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
 		$this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
 
-		$this->mockedSendMessageResponseModel = new Model(array('Body' => $this->mockedPayload,
+		$resultClass = defined('Aws\Sdk::VERSION') ? 'Aws\Result' : 'Guzzle\Service\Resource\Model';
+		$this->mockedSendMessageResponseModel = new $resultClass(array('Body' => $this->mockedPayload,
 						      			'MD5OfBody' => md5($this->mockedPayload),
 						      			'ReceiptHandle' => $this->mockedReceiptHandle,
 						      			'MessageId' => $this->mockedMessageId,
 						      			'Attributes' => array('ApproximateReceiveCount' => 1)));
 
-		$this->mockedReceiveMessageResponseModel = new Model(array('Messages' => array( 0 => array(
+		$this->mockedReceiveMessageResponseModel = new $resultClass(array('Messages' => array( 0 => array(
 												'Body' => $this->mockedPayload,
 						     						'MD5OfBody' => md5($this->mockedPayload),
 						      						'ReceiptHandle' => $this->mockedReceiptHandle,


### PR DESCRIPTION
The Queue and Mail components have had their usage of the AWS SDK for PHP upgraded such that it works with the new [Version 3](http://blogs.aws.amazon.com/php/post/Tx29HZZVCASVU21/Version-3-of-the-AWS-SDK-for-PHP) of the SDK and the older Version 2. The version constraint used for the SDK is now `~2.4|~3.0`.

This PR along with #8918 make it so the following dependency closures are all allowed:
- Laravel 5.1 + Guzzle 6 + AWS SDK 3
- Laravel 5.1 + Guzzle 5 + AWS SDK 3
- Laravel 5.1 + Guzzle 6 + Guzzle 3 + AWS SDK 2
- Laravel 5.1 + Guzzle 5 + Guzzle 3 + AWS SDK 2

I added a unit test in the Mail component and modified some in the Queue component. Unit tests all pass when using Version 2.x and Version 3.x of the AWS SDK. I did not do any manual tests via the framework, since I am not currently setup to do that. You might consider doing this if you have some code that exercises the SES or SQS features, and you need additional peace of mind.
