### PR TITLE
[5.1] Revert collection casting to base collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Query\Builder as QueryBuilder;
@@ -2744,7 +2745,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 			case 'json':
 				return json_decode($value, true);
 			case 'collection':
-				return $this->newCollection(json_decode($value, true));
+				return new BaseCollection(json_decode($value, true));
 			default:
 				return $value;
 		}


### PR DESCRIPTION
Currently collection casting passes a value through `newCollection` method which IMO supposed to return a set of models, but not internal model attributes.

Collection casting returns Eloquent Collection by default (which is for model-related operations only, isn't it?) and if I define my custom collection I get a ridiculous situation

``` php
class SomeModelExtendedCollection extends EloquentCollection {

    //... A huge amount of model-related methods

    public function offsetGet($key)
    {
        if ($key == 'new') return new SomeModel; //Just for example
        return parent::offsetGet($key);
    }
}

class SomeModel extends Model {

    protected $casts = [
            'set_of_attributes' => 'collection',
    ];

    public function newCollection(array $models = array())
    {
         return new SomeModelExtendedCollection($models);
    }

    public function getSpecialCollectionAttribute($value)
    {
        return new AttributeCollection(json_decode($value, true)); //Just another collection extension
    }

}

$models = SomeModel::all(); //Everything ok - we get SomeModelExtendedCollection
$models['new']; //instance of SomeModel - ok.
get_class($models[0]->special_collection; //AttributeCollection - ok!

// And here comes wrong logic
get_class($models[0]->set_of_attributes); //WTF? SomeModelExtendedCollection? I don't expect it to be here
$models[0]->set_of_attributes['new']; //and of course I get an instance of SomeModel (inside of an attribute!)
```
