### PR TITLE
[5.1] Cleanup List Commands

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -42,9 +42,7 @@ class RouteListCommand extends Command {
 	 *
 	 * @var array
 	 */
-	protected $headers = array(
-		'Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware',
-	);
+	protected $headers = ['Domain', 'Method', 'URI', 'Name', 'Action', 'Middleware'];
 
 	/**
 	 * Create a new route command instance.
@@ -82,7 +80,7 @@ class RouteListCommand extends Command {
 	 */
 	protected function getRoutes()
 	{
-		$results = array();
+		$results = [];
 
 		foreach ($this->routes as $route)
 		{

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -18,6 +18,15 @@ class ListFailedCommand extends Command {
 	 */
 	protected $description = 'List all of the failed queue jobs';
 
+
+	/**
+	 * The table headers for the command.
+	 *
+	 * @var array
+	 */
+	protected $headers = ['ID', 'Connection', 'Queue', 'Class', 'Failed At'];
+
+
 	/**
 	 * Execute the console command.
 	 *
@@ -25,23 +34,31 @@ class ListFailedCommand extends Command {
 	 */
 	public function fire()
 	{
-		$rows = array();
+		$jobs = $this->getFailedJobs();
 
-		foreach ($this->laravel['queue.failer']->all() as $failed)
-		{
-			$rows[] = $this->parseFailedJob((array) $failed);
-		}
-
-		if (count($rows) == 0)
+		if (count($jobs) == 0)
 		{
 			return $this->info('No failed jobs!');
 		}
 
-		$table = $this->getHelperSet()->get('table');
+		$this->displayFailedJobs($jobs);
+	}
 
-		$table->setHeaders(array('ID', 'Connection', 'Queue', 'Class', 'Failed At'))
-              ->setRows($rows)
-              ->render($this->output);
+	/**
+	 * Compile the failed jobs into a displayable format.
+	 *
+	 * @return array
+	 */
+	protected function getFailedJobs()
+	{
+		$results = [];
+
+		foreach ($this->laravel['queue.failer']->all() as $failed)
+		{
+			$results[] = $this->parseFailedJob((array) $failed);
+		}
+
+		return array_filter($results);
 	}
 
 	/**
@@ -59,4 +76,14 @@ class ListFailedCommand extends Command {
 		return $row;
 	}
 
+	/**
+	 * Display the failed jobs in the console.
+	 *
+	 * @param  array  $jobs
+	 * @return void
+	 */
+	protected function displayFailedJobs(array $jobs)
+	{
+		$this->table($this->headers, $jobs);
+	}
 }


### PR DESCRIPTION
This makes the `ListFailedCommand` internally the same as `RouteListCommand` and fixes a deprecation warning, that for me, prevented the command from actually continuing.
