### PR TITLE
[5.1] Dropped "ircmaxell/password-compat"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "classpreloader/classpreloader": "~1.2",
         "danielstjules/stringy": "~1.8",
         "doctrine/inflector": "~1.0",
-        "ircmaxell/password-compat": "~1.0",
         "jeremeamia/superclosure": "~2.0",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -16,8 +16,7 @@
     "require": {
         "php": ">=5.5.9",
         "illuminate/contracts": "5.1.*",
-        "illuminate/support": "5.1.*",
-        "ircmaxell/password-compat": "~1.0"
+        "illuminate/support": "5.1.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Now that we're 5.5.9+, we don't need it.
