### PR TITLE
[5.1] Update AWS SDK instantiation syntax

### DIFF
--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -79,7 +79,7 @@ class TransportManager extends Manager {
 
 		unset($config['key'], $config['secret']);
 
-		return new SesTransport(SesClient::factory($config));
+		return new SesTransport(new SesClient($config));
 	}
 
 	/**

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -23,7 +23,7 @@ class SqsConnector implements ConnectorInterface {
 
 		unset($config['key'], $config['secret']);
 
-		return new SqsQueue(SqsClient::factory($config), $config['queue']);
+		return new SqsQueue(new SqsClient($config), $config['queue']);
 	}
 
 }


### PR DESCRIPTION
Switches from using `factory()` to constructor, since V2 no longer supported.
