### PR TITLE
[5.0] Additional check when retrieving tagged services

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -395,7 +395,8 @@ class Container implements ArrayAccess, ContainerContract {
 	{
 		$results = [];
 
-		if (isset($this->tags[$tag])) {
+		if (isset($this->tags[$tag]))
+		{
 			foreach ($this->tags[$tag] as $abstract)
 			{
 				$results[] = $this->make($abstract);

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -395,9 +395,11 @@ class Container implements ArrayAccess, ContainerContract {
 	{
 		$results = [];
 
-		foreach ($this->tags[$tag] as $abstract)
-		{
-			$results[] = $this->make($abstract);
+		if (isset($this->tags[$tag])) {
+			foreach ($this->tags[$tag] as $abstract)
+			{
+				$results[] = $this->make($abstract);
+			}
 		}
 
 		return $results;

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -497,6 +497,8 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(2, count($container->tagged('foo')));
 		$this->assertInstanceOf('ContainerImplementationStub', $container->tagged('foo')[0]);
 		$this->assertInstanceOf('ContainerImplementationStubTwo', $container->tagged('foo')[1]);
+
+		$this->assertEmpty($container->tagged('this_tag_does_not_exist'));
 	}
 
 }


### PR DESCRIPTION
When working with tagged services, a call to `$this->tagged('this_tag_has_no_matching_services')` will trigger a PHP Notice (Undefined index, line 399).
Furthermore, there is no way to know if a tag has been declared or not (no `hasTag` method).

This PR simply adds a check so that no PHP notice is triggered (an alternative would be to throw an exception, but that's maybe a bit hard)
