### PR TITLE
added path option to create migration command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/BaseCommand.php
@@ -9,9 +9,13 @@ class BaseCommand extends Command {
 	 *
 	 * @return string
 	 */
-	protected function getMigrationPath()
+	protected function getMigrationPath($path = NULL)
 	{
-		return $this->laravel->databasePath().'/migrations';
+		if (! is_null($path)) {
+          return $this->laravel->basePath(). '/'. $path;
+        } else {
+          return $this->laravel->databasePath().'/migrations';
+        }
 	}
 
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -64,12 +64,14 @@ class MigrateMakeCommand extends BaseCommand {
 
 		$create = $this->input->getOption('create');
 
+		$path = $this->input->getOption('path');
+
 		if ( ! $table && is_string($create)) $table = $create;
 
 		// Now we are ready to write the migration out to disk. Once we've written
 		// the migration out, we will dump-autoload for the entire framework to
 		// make sure that the migrations are registered by the class loaders.
-		$this->writeMigration($name, $table, $create);
+		$this->writeMigration($name, $table, $create, $path);
 
 		$this->composer->dumpAutoloads();
 	}
@@ -82,9 +84,9 @@ class MigrateMakeCommand extends BaseCommand {
 	 * @param  bool    $create
 	 * @return string
 	 */
-	protected function writeMigration($name, $table, $create)
+	protected function writeMigration($name, $table, $create, $path)
 	{
-		$path = $this->getMigrationPath();
+		$path = $this->getMigrationPath($path);
 
 		$file = pathinfo($this->creator->create($name, $path, $table, $create), PATHINFO_FILENAME);
 
@@ -114,6 +116,8 @@ class MigrateMakeCommand extends BaseCommand {
 			array('create', null, InputOption::VALUE_OPTIONAL, 'The table to be created.'),
 
 			array('table', null, InputOption::VALUE_OPTIONAL, 'The table to migrate.'),
+
+			array('path', null, InputOption::VALUE_OPTIONAL, 'The path to store migration.'),
 		);
 	}
 


### PR DESCRIPTION
I've added this option because i've tried create migrations for a package that i'm developing for l5 and i needed create some database migrations relative to that package, but since this option has removed from laravel 5 , i've tweaked the make:migration command a little so it can support the option "path" and in this way user can specify in wich directory the migration it will be stored.
