### PR TITLE
Add url() check to setPath() in Pagination

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -362,7 +362,7 @@ abstract class AbstractPaginator {
 	 */
 	public function setPath($path)
 	{
-		$this->path = $path;
+		$this->path = url($path);
 
 		return $this;
 	}


### PR DESCRIPTION
Currently the setPath method will return the value passed to the function instead of returning a valid url as suggested by the documentation. The URL generated is currently just 'custom/url?page=2':
#### Customizing The Paginator URI

You may also customize the URI used by the paginator via the `setPath` method:

```
$users = User::paginate();

$users->setPath('custom/url');
```

The example above will create URLs like the following: http://example.com/custom/url?page=2
