### PR TITLE
[5.0] Cast the $failed variable to object since it can be received as an ar…

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -30,7 +30,7 @@ class RetryCommand extends Command {
 
 		if ( ! is_null($failed))
 		{
-            $failed = (object)$failed;
+			$failed = (object)$failed;
 
 			$failed->payload = $this->resetAttempts($failed->payload);
 

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -30,6 +30,8 @@ class RetryCommand extends Command {
 
 		if ( ! is_null($failed))
 		{
+            $failed = (object)$failed;
+
 			$failed->payload = $this->resetAttempts($failed->payload);
 
 			$this->laravel['queue']->connection($failed->connection)->pushRaw($failed->payload, $failed->queue);


### PR DESCRIPTION
As soon as we use our custom implementations of a FailedJobProvider, we get an Exception

```
[ErrorException]
Trying to get property of non-object
```

``` php
    /**
     * Get a single failed job.
     *
     * @param  mixed  $id
     * @return array
     */
    public function find($id);
```

We need to cast the array to object and it's working or Interface annotation need to be updated.
