### PR TITLE
Add optional priority to Eloquent observer

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -358,7 +358,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param  object|string  $class
 	 * @return void
 	 */
-	public static function observe($class)
+	public static function observe($class, $priority = 0)
 	{
 		$instance = new static;
 
@@ -371,7 +371,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		{
 			if (method_exists($class, $event))
 			{
-				static::registerModelEvent($event, $className.'@'.$event);
+				static::registerModelEvent($event, $className.'@'.$event, $priority);
 			}
 		}
 	}


### PR DESCRIPTION
This enables Eloquent model observers to set a priority.

The priority parameter is supported in Laravel's events framework, so why not support it in the corresponding Eloquent methods as well.

Example use case: custom defined observers for events like `saving` are currently being fired **after** package observers get into play. This may not be viable. By implementing the priority parameter this behavior can be altered and the observer can be handled as it suites the developer.
