### PR TITLE
[5.0] Route prefixing not working in some cases

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -756,7 +756,9 @@ class Route {
 	 */
 	public function prefix($prefix)
 	{
-		$this->uri = trim($prefix, '/').'/'.trim($this->uri, '/');
+		$uri = rtrim($prefix, '/').'/'.ltrim($this->uri, '/');
+
+		$this->uri = trim($uri , '/');
 
 		return $this;
 	}

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -642,6 +642,48 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('foo', $routes[0]->getPrefix());
 	}
 
+	public function testRoutePrefixing()
+	{
+		/**
+		 * Prefix route
+		 */
+		$router = $this->getRouter();
+		$router->get('foo/bar', function() { return 'hello'; });
+
+		$routes = $router->getRoutes();
+		$routes = $routes->getRoutes();
+
+		$routes[0]->prefix('prefix');
+
+		$this->assertEquals('prefix/foo/bar', $routes[0]->uri());
+
+		/**
+		 * Use empty prefix
+		 */
+		$router = $this->getRouter();
+		$router->get('foo/bar', function() { return 'hello'; });
+
+		$routes = $router->getRoutes();
+		$routes = $routes->getRoutes();
+
+		$routes[0]->prefix('/');
+
+		$this->assertEquals('foo/bar', $routes[0]->uri());
+
+		/**
+		 * Prefix homepage
+		 */
+		$router = $this->getRouter();
+		$router->get('/', function() { return 'hello'; });
+
+		$routes = $router->getRoutes();
+		$routes = $routes->getRoutes();
+
+		$routes[0]->prefix('prefix');
+
+		$this->assertEquals('prefix', $routes[0]->uri());
+	}
+
 
 	public function testMergingControllerUses()
 	{


### PR DESCRIPTION
Route '/' does not work after using `$route->prefix('someprefix');`
