### PR TITLE
[5.1] Add optional priority to Eloquent observer

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -356,9 +356,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * Register an observer with the Model.
 	 *
 	 * @param  object|string  $class
+	 * @param  int  $priority
 	 * @return void
 	 */
-	public static function observe($class)
+	public static function observe($class, $priority = 0)
 	{
 		$instance = new static;
 
@@ -371,7 +372,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		{
 			if (method_exists($class, $event))
 			{
-				static::registerModelEvent($event, $className.'@'.$event);
+				static::registerModelEvent($event, $className.'@'.$event, $priority);
 			}
 		}
 	}


### PR DESCRIPTION
This enables Eloquent model observers to set a priority.

The priority parameter is supported in Laravel's events framework, so why not support it in the corresponding Eloquent methods as well.

Example use case: custom defined observers for events like saving are currently being fired after package observers get into play. This may not be viable. By implementing the priority parameter this behavior can be altered and the observer can be handled as it suites the developer.
