### PR TITLE
[5.1] Minor change

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -611,9 +611,7 @@ class Guard implements GuardContract {
 	 */
 	protected function createRememberTokenIfDoesntExist(UserContract $user)
 	{
-		$rememberToken = $user->getRememberToken();
-
-		if (empty($rememberToken))
+		if (empty($user->getRememberToken()))
 		{
 			$this->refreshRememberToken($user);
 		}


### PR DESCRIPTION
PHP 5.5 accepts arbitrary expression arguments to `empty()`.

https://wiki.php.net/rfc/empty_isset_exprs
