### PR TITLE
[5.1] Use ::class constant

### DIFF
--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Auth;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 class AuthServiceProvider extends ServiceProvider {
 
@@ -48,7 +49,7 @@ class AuthServiceProvider extends ServiceProvider {
 	 */
 	protected function registerUserResolver()
 	{
-		$this->app->bind('Illuminate\Contracts\Auth\Authenticatable', function($app)
+		$this->app->bind(Authenticatable::class, function($app)
 		{
 			return $app['auth']->user();
 		});

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -2,6 +2,7 @@
 
 use Pusher;
 use Closure;
+use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
 use Illuminate\Broadcasting\Broadcasters\LogBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\RedisBroadcaster;
@@ -144,9 +145,7 @@ class BroadcastManager implements FactoryContract
      */
     protected function createLogDriver(array $config)
     {
-        return new LogBroadcaster(
-            $this->app->make('Psr\Log\LoggerInterface')
-        );
+        return new LogBroadcaster($this->app->make(LoggerInterface::class));
     }
 
     /**

--- a/src/Illuminate/Broadcasting/BroadcastServiceProvider.php
+++ b/src/Illuminate/Broadcasting/BroadcastServiceProvider.php
@@ -1,6 +1,9 @@
 <?php namespace Illuminate\Broadcasting;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Broadcasting\BroadcastManager;
+use Illuminate\Contracts\Broadcasting\Factory;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
 
 class BroadcastServiceProvider extends ServiceProvider
 {
@@ -19,17 +22,15 @@ class BroadcastServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('Illuminate\Broadcasting\BroadcastManager', function ($app) {
+        $this->app->singleton(BroadcastManager::class, function ($app) {
             return new BroadcastManager($app);
         });
 
-        $this->app->singleton('Illuminate\Contracts\Broadcasting\Broadcaster', function ($app) {
-            return $app->make('Illuminate\Broadcasting\BroadcastManager')->connection();
+        $this->app->singleton(Broadcaster::class, function ($app) {
+            return $app->make(BroadcastManager::class)->connection();
         });
 
-        $this->app->alias(
-            'Illuminate\Broadcasting\BroadcastManager', 'Illuminate\Contracts\Broadcasting\Factory'
-        );
+        $this->app->alias(BroadcastManager::class, Factory::class);
     }
 
     /**
@@ -40,9 +41,9 @@ class BroadcastServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'Illuminate\Broadcasting\BroadcastManager',
-            'Illuminate\Contracts\Broadcasting\Factory',
-            'Illuminate\Contracts\Broadcasting\Broadcaster',
+            BroadcastManager::class,
+            Factory::class,
+            Broadcaster::class,
         ];
     }
 }

--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -1,6 +1,10 @@
 <?php namespace Illuminate\Bus;
 
+use Illuminate\Bus\Dispatcher;
+use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Bus\QueueingDispatcher;
+use Illuminate\Contracts\Bus\Dispatcher as DispatcherContract;
 
 class BusServiceProvider extends ServiceProvider {
 
@@ -18,21 +22,17 @@ class BusServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton('Illuminate\Bus\Dispatcher', function($app)
+		$this->app->singleton(Dispatcher::class, function($app)
 		{
 			return new Dispatcher($app, function() use ($app)
 			{
-				return $app['Illuminate\Contracts\Queue\Queue'];
+				return $app[Queue::class];
 			});
 		});
 
-		$this->app->alias(
-			'Illuminate\Bus\Dispatcher', 'Illuminate\Contracts\Bus\Dispatcher'
-		);
+		$this->app->alias(Dispatcher::class, DispatcherContract::class);
 
-		$this->app->alias(
-			'Illuminate\Bus\Dispatcher', 'Illuminate\Contracts\Bus\QueueingDispatcher'
-		);
+		$this->app->alias(Dispatcher::class, QueueingDispatcher::class);
 	}
 
 	/**
@@ -43,9 +43,9 @@ class BusServiceProvider extends ServiceProvider {
 	public function provides()
 	{
 		return [
-			'Illuminate\Bus\Dispatcher',
-			'Illuminate\Contracts\Bus\Dispatcher',
-			'Illuminate\Contracts\Bus\QueueingDispatcher',
+			Dispatcher::class,
+			DispatcherContract::class,
+			QueueingDispatcher::class,
 		];
 	}
 

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -229,9 +229,9 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
 			return true;
 		}
 
-		return (new ReflectionClass($this->getHandlerClass($command)))->implementsInterface(
-			'Illuminate\Contracts\Queue\ShouldBeQueued'
-		);
+		$reflection = new ReflectionClass($this->getHandlerClass($command));
+
+		return $reflection->implementsInterface(ShouldBeQueued::class);
 	}
 
 	/**

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -3,6 +3,7 @@
 use Closure;
 use InvalidArgumentException;
 use Illuminate\Contracts\Cache\Store;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Cache\Factory as FactoryContract;
 
 class CacheManager implements FactoryContract {
@@ -233,11 +234,9 @@ class CacheManager implements FactoryContract {
 	{
 		$repository = new Repository($store);
 
-		if ($this->app->bound('Illuminate\Contracts\Events\Dispatcher'))
+		if ($this->app->bound(Dispatcher::class))
 		{
-			$repository->setEventDispatcher(
-				$this->app['Illuminate\Contracts\Events\Dispatcher']
-			);
+			$repository->setEventDispatcher($this->app[Dispatcher::class]);
 		}
 
 		return $repository;

--- a/src/Illuminate/Console/ScheduleServiceProvider.php
+++ b/src/Illuminate/Console/ScheduleServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Console;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Console\Scheduling\ScheduleRunCommand;
 
 class ScheduleServiceProvider extends ServiceProvider {
 
@@ -18,7 +19,7 @@ class ScheduleServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->commands('Illuminate\Console\Scheduling\ScheduleRunCommand');
+		$this->commands(ScheduleRunCommand::class);
 	}
 
 	/**
@@ -29,7 +30,7 @@ class ScheduleServiceProvider extends ServiceProvider {
 	public function provides()
 	{
 		return [
-			'Illuminate\Console\Scheduling\ScheduleRunCommand',
+			ScheduleRunCommand::class,
 		];
 	}
 

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Queue\EntityResolver;
 use Illuminate\Database\Eloquent\QueueEntityResolver;
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Database\Eloquent\Factory as EloquentFactory;
@@ -55,7 +56,7 @@ class DatabaseServiceProvider extends ServiceProvider {
 	 */
 	protected function registerEloquentFactory()
 	{
-		$this->app->singleton('Illuminate\Database\Eloquent\Factory', function()
+		$this->app->singleton(EloquentFactory::class, function()
 		{
 			return EloquentFactory::construct(database_path('factories'));
 		});
@@ -68,7 +69,7 @@ class DatabaseServiceProvider extends ServiceProvider {
 	 */
 	protected function registerQueueableEntityResolver()
 	{
-		$this->app->singleton('Illuminate\Contracts\Queue\EntityResolver', function()
+		$this->app->singleton(EntityResolver::class, function()
 		{
 			return new QueueEntityResolver;
 		});

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2630,8 +2630,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
 		if ( ! $relations instanceof Relation)
 		{
-			throw new LogicException('Relationship method must return an object of type '
-				. 'Illuminate\Database\Eloquent\Relations\Relation');
+			throw new LogicException(
+				'Relationship method must return an object of type '.Relation::class);
 		}
 
 		return $this->relations[$method] = $relations->getResults();

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -4,6 +4,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class HasManyThrough extends Relation {
 
@@ -122,7 +123,7 @@ class HasManyThrough extends Relation {
 	 */
 	public function parentSoftDeletes()
 	{
-		return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses_recursive(get_class($this->parent)));
+		return in_array(SoftDeletes::class, class_uses_recursive(get_class($this->parent)));
 	}
 
 	/**

--- a/src/Illuminate/Events/CallQueuedHandler.php
+++ b/src/Illuminate/Events/CallQueuedHandler.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Events;
 
 use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Container\Container;
 
 class CallQueuedHandler {
@@ -55,7 +56,7 @@ class CallQueuedHandler {
 	 */
 	protected function setJobInstanceIfNecessary(Job $job, $instance)
 	{
-		if (in_array('Illuminate\Queue\InteractsWithQueue', class_uses_recursive(get_class($instance))))
+		if (in_array(InteractsWithQueue::class, class_uses_recursive(get_class($instance))))
 		{
 			$instance->setJob($job);
 		}

--- a/src/Illuminate/Events/EventServiceProvider.php
+++ b/src/Illuminate/Events/EventServiceProvider.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Events;
 
+use Illuminate\Contracts\Queue\Factory;
 use Illuminate\Support\ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider {
@@ -15,7 +16,7 @@ class EventServiceProvider extends ServiceProvider {
 		{
 			return (new Dispatcher($app))->setQueueResolver(function() use ($app)
 			{
-				return $app->make('Illuminate\Contracts\Queue\Factory');
+				return $app->make(Factory::class);
 			});
 		});
 	}

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -7,7 +7,10 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Events\EventServiceProvider;
 use Illuminate\Routing\RoutingServiceProvider;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Illuminate\Foundation\Bootstrap\DetectEnvironment;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -158,7 +161,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 
 		$this->instance('app', $this);
 
-		$this->instance('Illuminate\Container\Container', $this);
+		$this->instance(Container::class, $this);
 	}
 
 	/**
@@ -201,9 +204,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	 */
 	public function afterLoadingEnvironment(Closure $callback)
 	{
-		return $this->afterBootstrapping(
-			'Illuminate\Foundation\Bootstrap\DetectEnvironment', $callback
-		);
+		return $this->afterBootstrapping(DetectEnvironment::class, $callback);
 	}
 
 	/**
@@ -754,7 +755,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	 */
 	public function handle(SymfonyRequest $request, $type = self::MASTER_REQUEST, $catch = true)
 	{
-		return $this['Illuminate\Contracts\Http\Kernel']->handle(Request::createFromBase($request));
+		return $this[HttpKernel::class]->handle(Request::createFromBase($request));
 	}
 
 	/**
@@ -1055,11 +1056,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 	 */
 	protected function getKernel()
 	{
-		$kernelContract = $this->runningInConsole()
-					? 'Illuminate\Contracts\Console\Kernel'
-					: 'Illuminate\Contracts\Http\Kernel';
+		$kernel = $this->runningInConsole() ? ConsoleKernel::class : HttpKernel::class;
 
-		return $this->make($kernelContract);
+		return $this->make($kernel);
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Foundation\Bootstrap;
 
 use Illuminate\Log\Writer;
+use Psr\Log\LoggerInterface;
 use Monolog\Logger as Monolog;
 use Illuminate\Contracts\Foundation\Application;
 
@@ -30,7 +31,7 @@ class ConfigureLogging {
 		// Next, we will bind a Closure that resolves the PSR logger implementation
 		// as this will grant us the ability to be interoperable with many other
 		// libraries which are able to utilize the PSR standardized interface.
-		$app->bind('Psr\Log\LoggerInterface', function($app)
+		$app->bind(LoggerInterface::class, function($app)
 		{
 			return $app['log']->getMonolog();
 		});

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Foundation\Bootstrap;
 
 use ErrorException;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Debug\Exception\FatalErrorException;
@@ -149,7 +150,7 @@ class HandleExceptions {
 	 */
 	protected function getExceptionHandler()
 	{
-		return $this->app->make('Illuminate\Contracts\Debug\ExceptionHandler');
+		return $this->app->make(ExceptionHandler::class);
 	}
 
 }

--- a/src/Illuminate/Foundation/Bus/DispatchesJobs.php
+++ b/src/Illuminate/Foundation/Bus/DispatchesJobs.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Foundation\Bus;
 
 use ArrayAccess;
+use Illuminate\Contracts\Bus\Dispatcher;
 
 trait DispatchesJobs {
 
@@ -12,7 +13,7 @@ trait DispatchesJobs {
 	 */
 	protected function dispatch($job)
 	{
-		return app('Illuminate\Contracts\Bus\Dispatcher')->dispatch($job);
+		return app(Dispatcher::class)->dispatch($job);
 	}
 
 	/**
@@ -24,7 +25,7 @@ trait DispatchesJobs {
 	 */
 	protected function dispatchFromArray($job, array $array)
 	{
-		return app('Illuminate\Contracts\Bus\Dispatcher')->dispatchFromArray($job, $array);
+		return app(Dispatcher::class)->dispatchFromArray($job, $array);
 	}
 
 	/**
@@ -37,7 +38,7 @@ trait DispatchesJobs {
 	 */
 	protected function dispatchFrom($job, ArrayAccess $source, $extras = [])
 	{
-		return app('Illuminate\Contracts\Bus\Dispatcher')->dispatchFrom($job, $source, $extras);
+		return app(Dispatcher::class)->dispatchFrom($job, $source, $extras);
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 
 class ConfigCacheCommand extends Command {
 
@@ -66,7 +67,7 @@ class ConfigCacheCommand extends Command {
 	{
 		$app = require $this->laravel->basePath().'/bootstrap/app.php';
 
-		$app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+		$app->make(ConsoleKernel::class)->bootstrap();
 
 		return $app['config']->all();
 	}

--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 
 class EventGenerateCommand extends Command {
 
@@ -25,9 +26,7 @@ class EventGenerateCommand extends Command {
 	 */
 	public function fire()
 	{
-		$provider = $this->laravel->getProvider(
-			'Illuminate\Foundation\Support\Providers\EventServiceProvider'
-		);
+		$provider = $this->laravel->getProvider(EventServiceProvider::class);
 
 		foreach ($provider->listens() as $event => $listeners)
 		{

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -1,10 +1,13 @@
 <?php namespace Illuminate\Foundation\Console;
 
 use Exception;
+use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\QueuedJob;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Console\Kernel as KernelContract;
 
 class Kernel implements KernelContract {
@@ -71,9 +74,7 @@ class Kernel implements KernelContract {
 	 */
 	protected function defineConsoleSchedule()
 	{
-		$this->app->instance(
-			'Illuminate\Console\Scheduling\Schedule', $schedule = new Schedule
-		);
+		$this->app->instance(Schedule::class, $schedule = new Schedule);
 
 		$this->schedule($schedule);
 	}
@@ -154,9 +155,7 @@ class Kernel implements KernelContract {
 	 */
 	public function queue($command, array $parameters = array())
 	{
-		$this->app['Illuminate\Contracts\Queue\Queue']->push(
-			'Illuminate\Foundation\Console\QueuedJob', func_get_args()
-		);
+		$this->app[Queue::class]->push(QueuedJob::class, func_get_args());
 	}
 
 	/**
@@ -232,7 +231,7 @@ class Kernel implements KernelContract {
 	 */
 	protected function reportException(Exception $e)
 	{
-		$this->app['Illuminate\Contracts\Debug\ExceptionHandler']->report($e);
+		$this->app[ExceptionHandler::class]->report($e);
 	}
 
 	/**
@@ -244,7 +243,7 @@ class Kernel implements KernelContract {
 	 */
 	protected function renderException($output, Exception $e)
 	{
-		$this->app['Illuminate\Contracts\Debug\ExceptionHandler']->renderForConsole($output, $e);
+		$this->app[ExceptionHandler::class]->renderForConsole($output, $e);
 	}
 
 }

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -3,6 +3,7 @@
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 
 class RouteCacheCommand extends Command {
 
@@ -77,7 +78,7 @@ class RouteCacheCommand extends Command {
 	{
 		$app = require $this->laravel->basePath().'/bootstrap/app.php';
 
-		$app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+		$app->make(ConsoleKernel::class)->bootstrap();
 
 		return $app['router']->getRoutes();
 	}

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exception\HttpResponseException;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
+use Illuminate\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 
 class FormRequest extends Request implements ValidatesWhenResolved {
@@ -70,7 +71,7 @@ class FormRequest extends Request implements ValidatesWhenResolved {
 	 */
 	protected function getValidatorInstance()
 	{
-		$factory = $this->container->make('Illuminate\Validation\Factory');
+		$factory = $this->container->make(ValidationFactory::class);
 
 		if (method_exists($this, 'validator'))
 		{

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -5,7 +5,9 @@ use RuntimeException;
 use Illuminate\Routing\Router;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Contracts\Routing\TerminableMiddleware;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
 
@@ -272,7 +274,7 @@ class Kernel implements KernelContract {
 	protected function verifySessionConfigurationIsValid()
 	{
 		if ($this->app['config']['session.driver'] === 'cookie' &&
-			! $this->hasMiddleware('Illuminate\Cookie\Middleware\EncryptCookies')) {
+			! $this->hasMiddleware(EncryptCookies::class)) {
 
 			throw new RuntimeException("Cookie encryption must be enabled to use cookie sessions.");
 		}
@@ -286,7 +288,7 @@ class Kernel implements KernelContract {
 	 */
 	protected function reportException(Exception $e)
 	{
-		$this->app['Illuminate\Contracts\Debug\ExceptionHandler']->report($e);
+		$this->app[ExceptionHandler::class]->report($e);
 	}
 
 	/**
@@ -298,7 +300,7 @@ class Kernel implements KernelContract {
 	 */
 	protected function renderException($request, Exception $e)
 	{
-		return $this->app['Illuminate\Contracts\Debug\ExceptionHandler']->render($request, $e);
+		return $this->app[ExceptionHandler::class]->render($request, $e);
 	}
 
 	/**

--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -1,5 +1,6 @@
 <?php namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Routing\Redirector;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Http\FormRequest;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,8 +30,7 @@ class FormRequestServiceProvider extends ServiceProvider {
 			{
 				$this->initializeRequest($request, $app['request']);
 
-				$request->setContainer($app)
-                        ->setRedirector($app['Illuminate\Routing\Redirector']);
+				$request->setContainer($app)->setRedirector($app[Redirector::class]);
 			});
 		});
 	}

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -10,7 +10,7 @@ class FoundationServiceProvider extends AggregateServiceProvider {
 	 * @var array
 	 */
 	protected $providers = [
-		'Illuminate\Foundation\Providers\FormRequestServiceProvider',
+		FormRequestServiceProvider::class,
 	];
 
 }

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Routing\UrlGenerator;
 
 class RouteServiceProvider extends ServiceProvider {
 
@@ -41,8 +42,7 @@ class RouteServiceProvider extends ServiceProvider {
 	{
 		if (is_null($this->namespace)) return;
 
-		$this->app['Illuminate\Contracts\Routing\UrlGenerator']
-						->setRootControllerNamespace($this->namespace);
+		$this->app[UrlGenerator::class]->setRootControllerNamespace($this->namespace);
 	}
 
 	/**
@@ -76,7 +76,7 @@ class RouteServiceProvider extends ServiceProvider {
 	 */
 	protected function loadRoutesFrom($path)
 	{
-		$router = $this->app['Illuminate\Routing\Router'];
+		$router = $this->app[Router::class];
 
 		if (is_null($this->namespace)) return require $path;
 

--- a/src/Illuminate/Foundation/Testing/ApplicationTrait.php
+++ b/src/Illuminate/Foundation/Testing/ApplicationTrait.php
@@ -1,7 +1,11 @@
 <?php namespace Illuminate\Foundation\Testing;
 
 use Mockery;
+use Illuminate\Bus\Dispatcher as BusDispatcher;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
+use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcherContract;
 
 trait ApplicationTrait
 {
@@ -57,7 +61,7 @@ trait ApplicationTrait
     {
         $events = is_array($events) ? $events : func_get_args();
 
-        $mock = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
+        $mock = Mockery::mock(EventDispatcherContract::class);
 
         $mock->shouldIgnoreMissing();
 
@@ -78,7 +82,7 @@ trait ApplicationTrait
      */
     protected function withoutEvents()
     {
-        $mock = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
+        $mock = Mockery::mock(EventDispatcherContract::class);
 
         $mock->shouldReceive('fire');
 
@@ -99,16 +103,14 @@ trait ApplicationTrait
     {
         $jobs = is_array($jobs) ? $jobs : func_get_args();
 
-        $mock = Mockery::mock('Illuminate\Bus\Dispatcher[dispatch]', [$this->app]);
+        $mock = Mockery::mock(BusDispatcher::class.'[dispatch]', [$this->app]);
 
         foreach ($jobs as $job) {
             $mock->shouldReceive('dispatch')->atLeast()->once()
                 ->with(Mockery::type($job));
         }
 
-        $this->app->instance(
-            'Illuminate\Contracts\Bus\Dispatcher', $mock
-        );
+        $this->app->instance(BusDispatcherContract::class, $mock);
 
         return $this;
     }
@@ -259,6 +261,6 @@ trait ApplicationTrait
      */
     public function artisan($command, $parameters = [])
     {
-        return $this->code = $this->app['Illuminate\Contracts\Console\Kernel']->call($command, $parameters);
+        return $this->code = $this->app[ConsoleKernel::class]->call($command, $parameters);
     }
 }

--- a/src/Illuminate/Foundation/Testing/AssertionsTrait.php
+++ b/src/Illuminate/Foundation/Testing/AssertionsTrait.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Foundation\Testing;
 
 use Illuminate\View\View;
+use Illuminate\Http\RedirectResponse;
 use PHPUnit_Framework_Assert as PHPUnit;
 
 trait AssertionsTrait {
@@ -102,7 +103,7 @@ trait AssertionsTrait {
 	 */
 	public function assertRedirectedTo($uri, $with = array())
 	{
-		PHPUnit::assertInstanceOf('Illuminate\Http\RedirectResponse', $this->response);
+		PHPUnit::assertInstanceOf(RedirectResponse::class, $this->response);
 
 		PHPUnit::assertEquals($this->app['url']->to($uri), $this->response->headers->get('Location'));
 

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Request;
 use InvalidArgumentException;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\DomCrawler\Crawler;
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use PHPUnit_Framework_ExpectationFailedException as PHPUnitException;
 
 trait CrawlerTrait
@@ -587,7 +588,7 @@ trait CrawlerTrait
             $cookies, $files, $server, $content
         );
 
-        return $this->response = $this->app->make('Illuminate\Contracts\Http\Kernel')->handle($request);
+        return $this->response = $this->app->make(HttpKernel::class)->handle($request);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -2,6 +2,7 @@
 
 use Mockery;
 use PHPUnit_Framework_TestCase;
+use Illuminate\Database\Eloquent\Factory as EloquentFactory;
 
 abstract class TestCase extends PHPUnit_Framework_TestCase
 {
@@ -43,7 +44,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         }
 
         if (! $this->factory) {
-            $this->factory = $this->app->make('Illuminate\Database\Eloquent\Factory');
+            $this->factory = $this->app->make(EloquentFactory::class);
         }
     }
 

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\UrlGenerator;
+use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exception\HttpResponseException;
 
@@ -77,7 +79,7 @@ trait ValidatesRequests {
 	 */
 	protected function getRedirectUrl()
 	{
-		return app('Illuminate\Routing\UrlGenerator')->previous();
+		return app(UrlGenerator::class)->previous();
 	}
 
 	/**
@@ -87,7 +89,7 @@ trait ValidatesRequests {
 	 */
 	protected function getValidationFactory()
 	{
-		return app('Illuminate\Contracts\Validation\Factory');
+		return app(Factory::class);
 	}
 
 	/**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -2,6 +2,12 @@
 
 use Illuminate\Support\Str;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Contracts\Routing\ResponseFactory;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\Cookie\Factory as CookieFactory;
+use Illuminate\Database\Eloquent\Factory as EloquentFactory;
 
 if ( ! function_exists('abort'))
 {
@@ -93,7 +99,7 @@ if ( ! function_exists('auth'))
 	 */
 	function auth()
 	{
-		return app('Illuminate\Contracts\Auth\Guard');
+		return app(Guard::class);
 	}
 }
 
@@ -191,11 +197,11 @@ if ( ! function_exists('cookie'))
 	 * @param  string  $domain
 	 * @param  bool    $secure
 	 * @param  bool    $httpOnly
-	 * @return \Symfony\Component\HttpFoundation\Cookie
+	 * @return \Illuminate\Contracts\Cookie\Factory|\Symfony\Component\HttpFoundation\Cookie
 	 */
 	function cookie($name = null, $value = null, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true)
 	{
-		$cookie = app('Illuminate\Contracts\Cookie\Factory');
+		$cookie = app(CookieFactory::class);
 
 		if (is_null($name))
 		{
@@ -280,7 +286,7 @@ if ( ! function_exists('factory'))
 	 */
 	function factory()
 	{
-		$factory = app('Illuminate\Database\Eloquent\Factory');
+		$factory = app(EloquentFactory::class);
 
 		$arguments = func_get_args();
 
@@ -462,7 +468,7 @@ if ( ! function_exists('response'))
 	 */
 	function response($content = '', $status = 200, array $headers = array())
 	{
-		$factory = app('Illuminate\Contracts\Routing\ResponseFactory');
+		$factory = app(ResponseFactory::class);
 
 		if (func_num_args() === 0)
 		{
@@ -603,7 +609,7 @@ if ( ! function_exists('url'))
 	 */
 	function url($path = null, $parameters = array(), $secure = null)
 	{
-		return app('Illuminate\Contracts\Routing\UrlGenerator')->to($path, $parameters, $secure);
+		return app(UrlGenerator::class)->to($path, $parameters, $secure);
 	}
 }
 
@@ -619,7 +625,7 @@ if ( ! function_exists('view'))
 	 */
 	function view($view = null, $data = array(), $mergeData = array())
 	{
-		$factory = app('Illuminate\Contracts\View\Factory');
+		$factory = app(ViewFactory::class);
 
 		if (func_num_args() === 0)
 		{

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Mail;
 
 use Swift_Mailer;
+use Psr\Log\LoggerInterface;
 use Illuminate\Support\ServiceProvider;
 
 class MailServiceProvider extends ServiceProvider {
@@ -64,9 +65,9 @@ class MailServiceProvider extends ServiceProvider {
 	{
 		$mailer->setContainer($app);
 
-		if ($app->bound('Psr\Log\LoggerInterface'))
+		if ($app->bound(LoggerInterface::class))
 		{
-			$mailer->setLogger($app->make('Psr\Log\LoggerInterface'));
+			$mailer->setLogger($app->make(LoggerInterface::class));
 		}
 
 		if ($app->bound('queue'))

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Mail;
 
 use Aws\Ses\SesClient;
+use Psr\Log\LoggerInterface;
 use Illuminate\Support\Manager;
 use GuzzleHttp\Client as HttpClient;
 use Swift_SmtpTransport as SmtpTransport;
@@ -125,7 +126,7 @@ class TransportManager extends Manager {
 	 */
 	protected function createLogDriver()
 	{
-		return new LogTransport($this->app->make('Psr\Log\LoggerInterface'));
+		return new LogTransport($this->app->make(LoggerInterface::class));
 	}
 
 	/**

--- a/src/Illuminate/Pipeline/PipelineServiceProvider.php
+++ b/src/Illuminate/Pipeline/PipelineServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Pipeline;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Pipeline\Hub as HubContract;
 
 class PipelineServiceProvider extends ServiceProvider {
 
@@ -18,9 +19,7 @@ class PipelineServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-		$this->app->singleton(
-			'Illuminate\Contracts\Pipeline\Hub', 'Illuminate\Pipeline\Hub'
-		);
+		$this->app->singleton(HubContract::class, Hub::class);
 	}
 
 	/**
@@ -31,7 +30,7 @@ class PipelineServiceProvider extends ServiceProvider {
 	public function provides()
 	{
 		return [
-			'Illuminate\Contracts\Pipeline\Hub',
+			HubContract::class,
 		];
 	}
 

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -56,7 +56,7 @@ class CallQueuedHandler {
 	 */
 	protected function setJobInstanceIfNecessary(Job $job, $instance)
 	{
-		if (in_array('Illuminate\Queue\InteractsWithQueue', class_uses_recursive(get_class($instance))))
+		if (in_array(InteractsWithQueue::class, class_uses_recursive(get_class($instance))))
 		{
 			$instance->setJob($job);
 		}

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -3,6 +3,7 @@
 use Illuminate\Queue\Worker;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Job;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -92,7 +93,7 @@ class WorkCommand extends Command {
 			$this->worker->setCache($this->laravel['cache']->driver());
 
 			$this->worker->setDaemonExceptionHandler(
-				$this->laravel['Illuminate\Contracts\Debug\ExceptionHandler']
+				$this->laravel[ExceptionHandler::class]
 			);
 
 			return $this->worker->daemon(

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Queue\Jobs;
 
 use DateTime;
+use Illuminate\Contracts\Queue\EntityResolver;
 
 abstract class Job {
 
@@ -215,7 +216,7 @@ abstract class Job {
 	 */
 	protected function getEntityResolver()
 	{
-		return $this->container->make('Illuminate\Contracts\Queue\EntityResolver');
+		return $this->container->make(EntityResolver::class);
 	}
 
 	/**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -87,7 +87,7 @@ abstract class Queue {
 		elseif (is_object($job))
 		{
 			return json_encode([
-				'job' => 'Illuminate\Queue\CallQueuedHandler@call',
+				'job' => CallQueuedHandler::class.'@call',
 				'data' => ['command' => serialize(clone $job)],
 			]);
 		}

--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -62,7 +62,7 @@ class ControllerInspector {
 	 */
 	public function isRoutable(ReflectionMethod $method)
 	{
-		if ($method->class == 'Illuminate\Routing\Controller') return false;
+		if ($method->class == Controller::class) return false;
 
 		return starts_with($method->name, $this->verbs);
 	}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -323,9 +323,9 @@ class Router implements RegistrarContract {
 	 */
 	public function resource($name, $controller, array $options = array())
 	{
-		if ($this->container && $this->container->bound('Illuminate\Routing\ResourceRegistrar'))
+		if ($this->container && $this->container->bound(ResourceRegistrar::class))
 		{
-			$registrar = $this->container->make('Illuminate\Routing\ResourceRegistrar');
+			$registrar = $this->container->make(ResourceRegistrar::class);
 		}
 		else
 		{
@@ -746,7 +746,7 @@ class Router implements RegistrarContract {
 	{
 		$this->current = $route = $this->routes->match($request);
 
-		$this->container->instance('Illuminate\Routing\Route', $route);
+		$this->container->instance(Route::class, $route);
 
 		return $this->substituteBindings($route);
 	}

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -1,6 +1,8 @@
 <?php namespace Illuminate\Routing;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\View\Factory as ViewFactoryContract;
+use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 
 class RoutingServiceProvider extends ServiceProvider {
 
@@ -115,9 +117,9 @@ class RoutingServiceProvider extends ServiceProvider {
 	 */
 	protected function registerResponseFactory()
 	{
-		$this->app->singleton('Illuminate\Contracts\Routing\ResponseFactory', function($app)
+		$this->app->singleton(ResponseFactoryContract::class, function($app)
 		{
-			return new ResponseFactory($app['Illuminate\Contracts\View\Factory'], $app['redirect']);
+			return new ResponseFactory($app[ViewFactoryContract::class], $app['redirect']);
 		});
 	}
 

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Illuminate\Session;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Session\Middleware\StartSession;
 
 class SessionServiceProvider extends ServiceProvider {
 
@@ -15,7 +16,7 @@ class SessionServiceProvider extends ServiceProvider {
 
 		$this->registerSessionDriver();
 
-		$this->app->singleton('Illuminate\Session\Middleware\StartSession');
+		$this->app->singleton(StartSession::class);
 	}
 
 	/**

--- a/src/Illuminate/Support/Facades/Artisan.php
+++ b/src/Illuminate/Support/Facades/Artisan.php
@@ -1,5 +1,7 @@
 <?php namespace Illuminate\Support\Facades;
 
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+
 /**
  * @see \Illuminate\Foundation\Artisan
  */
@@ -12,7 +14,7 @@ class Artisan extends Facade {
 	 */
 	protected static function getFacadeAccessor()
 	{
-		return 'Illuminate\Contracts\Console\Kernel';
+		return ConsoleKernel::class;
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -1,5 +1,7 @@
 <?php namespace Illuminate\Support\Facades;
 
+use Illuminate\Contracts\Bus\Dispatcher as BusDispatcher;
+
 /**
  * @see \Illuminate\Bus\Dispatcher
  */
@@ -12,7 +14,7 @@ class Bus extends Facade {
 	 */
 	protected static function getFacadeAccessor()
 	{
-		return 'Illuminate\Contracts\Bus\Dispatcher';
+		return BusDispatcher::class;
 	}
 
 }

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -1,5 +1,7 @@
 <?php namespace Illuminate\Support\Facades;
 
+use Illuminate\Contracts\Routing\ResponseFactory;
+
 /**
  * @see \Illuminate\Contracts\Routing\ResponseFactory
  */
@@ -12,7 +14,7 @@ class Response extends Facade {
 	 */
 	protected static function getFacadeAccessor()
 	{
-		return 'Illuminate\Contracts\Routing\ResponseFactory';
+		return ResponseFactory::class;
 	}
 
 }

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Connection;
+use Illuminate\Contracts\Auth\CanResetPassword;
+use Illuminate\Auth\Passwords\DatabaseTokenRepository;
 
 class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase {
 
@@ -17,7 +20,7 @@ class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('where')->with('email', 'email')->andReturn($query);
 		$query->shouldReceive('delete')->once();
 		$query->shouldReceive('insert')->once();
-		$user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+		$user = m::mock(CanResetPassword::class);
 		$user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
 		$results = $repo->create($user);
@@ -34,7 +37,7 @@ class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('token', 'token')->andReturn($query);
 		$query->shouldReceive('first')->andReturn(null);
-		$user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+		$user = m::mock(CanResetPassword::class);
 		$user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
 		$this->assertFalse($repo->exists($user, 'token'));
@@ -49,7 +52,7 @@ class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('where')->once()->with('token', 'token')->andReturn($query);
 		$date = date('Y-m-d H:i:s', time() - 300000);
 		$query->shouldReceive('first')->andReturn((object) array('created_at' => $date));
-		$user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+		$user = m::mock(CanResetPassword::class);
 		$user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
 		$this->assertFalse($repo->exists($user, 'token'));
@@ -64,7 +67,7 @@ class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('where')->once()->with('token', 'token')->andReturn($query);
 		$date = date('Y-m-d H:i:s', time() - 600);
 		$query->shouldReceive('first')->andReturn((object) array('created_at' => $date));
-		$user = m::mock('Illuminate\Contracts\Auth\CanResetPassword');
+		$user = m::mock(CanResetPassword::class);
 		$user->shouldReceive('getEmailForPasswordReset')->andReturn('email');
 
 		$this->assertTrue($repo->exists($user, 'token'));
@@ -95,7 +98,7 @@ class AuthDatabaseTokenRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	protected function getRepo()
 	{
-		return new Illuminate\Auth\Passwords\DatabaseTokenRepository(m::mock('Illuminate\Database\Connection'), 'table', 'key');
+		return new DatabaseTokenRepository(m::mock(Connection::class), 'table', 'key');
 	}
 
 }

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -1,6 +1,10 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Database\Connection;
+use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 
@@ -12,14 +16,14 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 
 	public function testRetrieveByIDReturnsUserWhenUserIsFound()
 	{
-		$conn = m::mock('Illuminate\Database\Connection');
+		$conn = m::mock(Connection::class);
 		$conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
 		$conn->shouldReceive('find')->once()->with(1)->andReturn(array('id' => 1, 'name' => 'Dayle'));
-		$hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+		$hasher = m::mock(Hasher::class);
 		$provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
 		$user = $provider->retrieveById(1);
 
-		$this->assertInstanceOf('Illuminate\Auth\GenericUser', $user);
+		$this->assertInstanceOf(GenericUser::class, $user);
 		$this->assertEquals(1, $user->getAuthIdentifier());
 		$this->assertEquals('Dayle', $user->name);
 	}
@@ -27,10 +31,10 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 
 	public function testRetrieveByIDReturnsNullWhenUserIsNotFound()
 	{
-		$conn = m::mock('Illuminate\Database\Connection');
+		$conn = m::mock(Connection::class);
 		$conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
 		$conn->shouldReceive('find')->once()->with(1)->andReturn(null);
-		$hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+		$hasher = m::mock(Hasher::class);
 		$provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
 		$user = $provider->retrieveById(1);
 
@@ -40,15 +44,15 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 
 	public function testRetrieveByCredentialsReturnsUserWhenUserIsFound()
 	{
-		$conn = m::mock('Illuminate\Database\Connection');
+		$conn = m::mock(Connection::class);
 		$conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
 		$conn->shouldReceive('where')->once()->with('username', 'dayle');
 		$conn->shouldReceive('first')->once()->andReturn(array('id' => 1, 'name' => 'taylor'));
-		$hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+		$hasher = m::mock(Hasher::class);
 		$provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
 		$user = $provider->retrieveByCredentials(array('username' => 'dayle', 'password' => 'foo'));
 
-		$this->assertInstanceOf('Illuminate\Auth\GenericUser', $user);
+		$this->assertInstanceOf(GenericUser::class, $user);
 		$this->assertEquals(1, $user->getAuthIdentifier());
 		$this->assertEquals('taylor', $user->name);
 	}
@@ -56,11 +60,11 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 
 	public function testRetrieveByCredentialsReturnsNullWhenUserIsFound()
 	{
-		$conn = m::mock('Illuminate\Database\Connection');
+		$conn = m::mock(Connection::class);
 		$conn->shouldReceive('table')->once()->with('foo')->andReturn($conn);
 		$conn->shouldReceive('where')->once()->with('username', 'dayle');
 		$conn->shouldReceive('first')->once()->andReturn(null);
-		$hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+		$hasher = m::mock(Hasher::class);
 		$provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
 		$user = $provider->retrieveByCredentials(array('username' => 'dayle'));
 
@@ -70,11 +74,11 @@ class AuthDatabaseUserProviderTest extends PHPUnit_Framework_TestCase {
 
 	public function testCredentialValidation()
 	{
-		$conn = m::mock('Illuminate\Database\Connection');
-		$hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+		$conn = m::mock(Connection::class);
+		$hasher = m::mock(Hasher::class);
 		$hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
 		$provider = new Illuminate\Auth\DatabaseUserProvider($conn, $hasher, 'foo');
-		$user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+		$user = m::mock(Authenticatable::class);
 		$user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
 		$result = $provider->validateCredentials($user, array('password' => 'plain'));
 

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -1,6 +1,10 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Connection;
+use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Auth\EloquentUserProvider;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 class AuthEloquentUserProviderTest extends PHPUnit_Framework_TestCase {
 
@@ -39,11 +43,11 @@ class AuthEloquentUserProviderTest extends PHPUnit_Framework_TestCase {
 
 	public function testCredentialValidation()
 	{
-		$conn = m::mock('Illuminate\Database\Connection');
-		$hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
+		$conn = m::mock(Connection::class);
+		$hasher = m::mock(Hasher::class);
 		$hasher->shouldReceive('check')->once()->with('plain', 'hash')->andReturn(true);
-		$provider = new Illuminate\Auth\EloquentUserProvider($hasher, 'foo');
-		$user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+		$provider = new EloquentUserProvider($hasher, 'foo');
+		$user = m::mock(Authenticatable::class);
 		$user->shouldReceive('getAuthPassword')->once()->andReturn('hash');
 		$result = $provider->validateCredentials($user, array('password' => 'plain'));
 
@@ -53,9 +57,9 @@ class AuthEloquentUserProviderTest extends PHPUnit_Framework_TestCase {
 
 	public function testModelsCanBeCreated()
 	{
-		$conn = m::mock('Illuminate\Database\Connection');
-		$hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
-		$provider = new Illuminate\Auth\EloquentUserProvider($hasher, 'EloquentProviderUserStub');
+		$conn = m::mock(Connection::class);
+		$hasher = m::mock(Hasher::class);
+		$provider = new EloquentUserProvider($hasher, 'EloquentProviderUserStub');
 		$model = $provider->createModel();
 
 		$this->assertInstanceOf('EloquentProviderUserStub', $model);
@@ -64,8 +68,8 @@ class AuthEloquentUserProviderTest extends PHPUnit_Framework_TestCase {
 
 	protected function getProviderMock()
 	{
-		$hasher = m::mock('Illuminate\Contracts\Hashing\Hasher');
-		return $this->getMock('Illuminate\Auth\EloquentUserProvider', array('createModel'), array($hasher, 'foo'));
+		$hasher = m::mock(Hasher::class);
+		return $this->getMock(EloquentUserProvider::class, array('createModel'), array($hasher, 'foo'));
 	}
 
 }

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Broadcasting\BroadcastEvent;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
 
 class BroadcastEventTest extends PHPUnit_Framework_TestCase {
 
@@ -12,7 +15,7 @@ class BroadcastEventTest extends PHPUnit_Framework_TestCase {
 
 	public function testBasicEventBroadcastParameterFormatting()
 	{
-		$broadcaster = m::mock('Illuminate\Contracts\Broadcasting\Broadcaster');
+		$broadcaster = m::mock(Broadcaster::class);
 
 		$broadcaster->shouldReceive('broadcast')->once()->with(
 			['test-channel'], 'TestBroadcastEvent', ['firstName' => 'Taylor', 'lastName' => 'Otwell', 'collection' => ['foo' => 'bar']]
@@ -22,16 +25,16 @@ class BroadcastEventTest extends PHPUnit_Framework_TestCase {
 		$serializedEvent = serialize($event);
 		$jobData = ['event' => $serializedEvent];
 
-		$job = m::mock('Illuminate\Contracts\Queue\Job');
+		$job = m::mock(Job::class);
 		$job->shouldReceive('delete')->once();
 
-		(new Illuminate\Broadcasting\BroadcastEvent($broadcaster))->fire($job, $jobData);
+		(new BroadcastEvent($broadcaster))->fire($job, $jobData);
 	}
 
 
 	public function testManualParameterSpecification()
 	{
-		$broadcaster = m::mock('Illuminate\Contracts\Broadcasting\Broadcaster');
+		$broadcaster = m::mock(Broadcaster::class);
 
 		$broadcaster->shouldReceive('broadcast')->once()->with(
 			['test-channel'], 'TestBroadcastEventWithManualData', ['name' => 'Taylor']
@@ -41,10 +44,10 @@ class BroadcastEventTest extends PHPUnit_Framework_TestCase {
 		$serializedEvent = serialize($event);
 		$jobData = ['event' => $serializedEvent];
 
-		$job = m::mock('Illuminate\Contracts\Queue\Job');
+		$job = m::mock(Job::class);
 		$job->shouldReceive('delete')->once();
 
-		(new Illuminate\Broadcasting\BroadcastEvent($broadcaster))->fire($job, $jobData);
+		(new BroadcastEvent($broadcaster))->fire($job, $jobData);
 	}
 
 }

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -3,6 +3,8 @@
 use Mockery as m;
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Contracts\Queue\ShouldBeQueued;
 
 class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 
@@ -30,12 +32,12 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 	{
 		$container = new Container;
 		$dispatcher = new Dispatcher($container, function() {
-			$mock = m::mock('Illuminate\Contracts\Queue\Queue');
+			$mock = m::mock(Queue::class);
 			$mock->shouldReceive('push')->once();
 			return $mock;
 		});
 
-		$dispatcher->dispatch(m::mock('Illuminate\Contracts\Queue\ShouldBeQueued'));
+		$dispatcher->dispatch(m::mock(ShouldBeQueued::class));
 	}
 
 
@@ -43,7 +45,7 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 	{
 		$container = new Container;
 		$dispatcher = new Dispatcher($container, function() {
-			$mock = m::mock('Illuminate\Contracts\Queue\Queue');
+			$mock = m::mock(Queue::class);
 			$mock->shouldReceive('push')->once();
 			return $mock;
 		});
@@ -56,7 +58,7 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 	{
 		$container = new Container;
 		$dispatcher = new Dispatcher($container, function() {
-			$mock = m::mock('Illuminate\Contracts\Queue\Queue');
+			$mock = m::mock(Queue::class);
 			$mock->shouldReceive('laterOn')->once()->with('foo', 10, m::type('BusDispatcherTestSpecificQueueAndDelayCommand'));
 			return $mock;
 		});
@@ -69,7 +71,7 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 	{
 		$container = new Container;
 		$dispatcher = new Dispatcher($container, function() {
-			$mock = m::mock('Illuminate\Contracts\Queue\Queue');
+			$mock = m::mock(Queue::class);
 			$mock->shouldReceive('push')->once();
 			return $mock;
 		});
@@ -88,7 +90,7 @@ class BusDispatcherTest extends PHPUnit_Framework_TestCase {
 		$dispatcher = new Dispatcher($container);
 		$dispatcher->mapUsing(function() { return 'Handler@handle'; });
 
-		$result = $dispatcher->dispatch(m::mock('Illuminate\Contracts\Queue\ShouldBeQueued'));
+		$result = $dispatcher->dispatch(m::mock(ShouldBeQueued::class));
 		$this->assertEquals('foo', $result);
 	}
 

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -1,66 +1,69 @@
 <?php
 
+use Illuminate\Cache\ApcStore;
+use Illuminate\Cache\ApcWrapper;
+
 class CacheApcStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetReturnsNullWhenNotFound()
 	{
-		$apc = $this->getMock('Illuminate\Cache\ApcWrapper', array('get'));
+		$apc = $this->getMock(ApcWrapper::class, array('get'));
 		$apc->expects($this->once())->method('get')->with($this->equalTo('foobar'))->will($this->returnValue(null));
-		$store = new Illuminate\Cache\ApcStore($apc, 'foo');
+		$store = new ApcStore($apc, 'foo');
 		$this->assertNull($store->get('bar'));
 	}
 
 
 	public function testAPCValueIsReturned()
 	{
-		$apc = $this->getMock('Illuminate\Cache\ApcWrapper', array('get'));
+		$apc = $this->getMock(ApcWrapper::class, array('get'));
 		$apc->expects($this->once())->method('get')->will($this->returnValue('bar'));
-		$store = new Illuminate\Cache\ApcStore($apc);
+		$store = new ApcStore($apc);
 		$this->assertEquals('bar', $store->get('foo'));
 	}
 
 
 	public function testSetMethodProperlyCallsAPC()
 	{
-		$apc = $this->getMock('Illuminate\Cache\ApcWrapper', array('put'));
+		$apc = $this->getMock(ApcWrapper::class, array('put'));
 		$apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60));
-		$store = new Illuminate\Cache\ApcStore($apc);
+		$store = new ApcStore($apc);
 		$store->put('foo', 'bar', 1);
 	}
 
 
 	public function testIncrementMethodProperlyCallsAPC()
 	{
-		$apc = $this->getMock('Illuminate\Cache\ApcWrapper', array('increment'));
+		$apc = $this->getMock(ApcWrapper::class, array('increment'));
 		$apc->expects($this->once())->method('increment')->with($this->equalTo('foo'), $this->equalTo(5));
-		$store = new Illuminate\Cache\ApcStore($apc);
+		$store = new ApcStore($apc);
 		$store->increment('foo', 5);
 	}
 
 
 	public function testDecrementMethodProperlyCallsAPC()
 	{
-		$apc = $this->getMock('Illuminate\Cache\ApcWrapper', array('decrement'));
+		$apc = $this->getMock(ApcWrapper::class, array('decrement'));
 		$apc->expects($this->once())->method('decrement')->with($this->equalTo('foo'), $this->equalTo(5));
-		$store = new Illuminate\Cache\ApcStore($apc);
+		$store = new ApcStore($apc);
 		$store->decrement('foo', 5);
 	}
 
 
 	public function testStoreItemForeverProperlyCallsAPC()
 	{
-		$apc = $this->getMock('Illuminate\Cache\ApcWrapper', array('put'));
+		$apc = $this->getMock(ApcWrapper::class, array('put'));
 		$apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
-		$store = new Illuminate\Cache\ApcStore($apc);
+		$store = new ApcStore($apc);
 		$store->forever('foo', 'bar');
 	}
 
 
 	public function testForgetMethodProperlyCallsAPC()
 	{
-		$apc = $this->getMock('Illuminate\Cache\ApcWrapper', array('delete'));
+		$apc = $this->getMock(ApcWrapper::class, array('delete'));
 		$apc->expects($this->once())->method('delete')->with($this->equalTo('foo'));
-		$store = new Illuminate\Cache\ApcStore($apc);
+		$store = new ApcStore($apc);
 		$store->forget('foo');
 	}
 

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -14,7 +14,7 @@ class CacheArrayStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function testStoreItemForeverProperlyStoresInArray()
 	{
-		$mock = $this->getMock('Illuminate\Cache\ArrayStore', array('put'));
+		$mock = $this->getMock(ArrayStore::class, array('put'));
 		$mock->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(0));
 		$mock->forever('foo', 'bar');
 	}

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -2,6 +2,8 @@
 
 use Mockery as m;
 use Illuminate\Cache\DatabaseStore;
+use Illuminate\Database\Connection;
+use Illuminate\Contracts\Encryption\Encrypter;
 
 class CacheDatabaseStoreTest extends PHPUnit_Framework_TestCase {
 
@@ -25,7 +27,7 @@ class CacheDatabaseStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function testNullIsReturnedAndItemDeletedWhenItemIsExpired()
 	{
-		$store = $this->getMock('Illuminate\Cache\DatabaseStore', array('forget'), $this->getMocks());
+		$store = $this->getMock(DatabaseStore::class, array('forget'), $this->getMocks());
 		$table = m::mock('StdClass');
 		$store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
 		$table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
@@ -51,7 +53,7 @@ class CacheDatabaseStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function testEncryptedValueIsInsertedWhenNoExceptionsAreThrown()
 	{
-		$store = $this->getMock('Illuminate\Cache\DatabaseStore', array('getTime'), $this->getMocks());
+		$store = $this->getMock(DatabaseStore::class, array('getTime'), $this->getMocks());
 		$table = m::mock('StdClass');
 		$store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
 		$store->getEncrypter()->shouldReceive('encrypt')->once()->with('bar')->andReturn('bar');
@@ -64,7 +66,7 @@ class CacheDatabaseStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function testEncryptedValueIsUpdatedWhenInsertThrowsException()
 	{
-		$store = $this->getMock('Illuminate\Cache\DatabaseStore', array('getTime'), $this->getMocks());
+		$store = $this->getMock(DatabaseStore::class, array('getTime'), $this->getMocks());
 		$table = m::mock('StdClass');
 		$store->getConnection()->shouldReceive('table')->with('table')->andReturn($table);
 		$store->getEncrypter()->shouldReceive('encrypt')->once()->with('bar')->andReturn('bar');
@@ -82,7 +84,7 @@ class CacheDatabaseStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function testForeverCallsStoreItemWithReallyLongTime()
 	{
-		$store = $this->getMock('Illuminate\Cache\DatabaseStore', array('put'), $this->getMocks());
+		$store = $this->getMock(DatabaseStore::class, array('put'), $this->getMocks());
 		$store->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(5256000));
 		$store->forever('foo', 'bar');
 	}
@@ -113,13 +115,13 @@ class CacheDatabaseStoreTest extends PHPUnit_Framework_TestCase {
 
 	protected function getStore()
 	{
-		return new DatabaseStore(m::mock('Illuminate\Database\Connection'), m::mock('Illuminate\Contracts\Encryption\Encrypter'), 'table', 'prefix');
+		return new DatabaseStore(m::mock(Connection::class), m::mock(Encrypter::class), 'table', 'prefix');
 	}
 
 
 	protected function getMocks()
 	{
-		return array(m::mock('Illuminate\Database\Connection'), m::mock('Illuminate\Contracts\Encryption\Encrypter'), 'table', 'prefix');
+		return array(m::mock(Connection::class), m::mock(Encrypter::class), 'table', 'prefix');
 	}
 
 }

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Cache\FileStore;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
@@ -32,7 +33,7 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 		$files = $this->mockFilesystem();
 		$contents = '0000000000';
 		$files->expects($this->once())->method('get')->will($this->returnValue($contents));
-		$store = $this->getMock('Illuminate\Cache\FileStore', array('forget'), array($files, __DIR__));
+		$store = $this->getMock(FileStore::class, array('forget'), array($files, __DIR__));
 		$store->expects($this->once())->method('forget');
 		$value = $store->get('foo');
 		$this->assertNull($value);
@@ -52,7 +53,7 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 	public function testStoreItemProperlyStoresValues()
 	{
 		$files = $this->mockFilesystem();
-		$store = $this->getMock('Illuminate\Cache\FileStore', array('expiration'), array($files, __DIR__));
+		$store = $this->getMock(FileStore::class, array('expiration'), array($files, __DIR__));
 		$store->expects($this->once())->method('expiration')->with($this->equalTo(10))->will($this->returnValue(1111111111));
 		$contents = '1111111111'.serialize('Hello World');
 		$md5 = md5('foo');
@@ -122,7 +123,7 @@ class CacheFileStoreTest extends PHPUnit_Framework_TestCase {
 
 	protected function mockFilesystem()
 	{
-		return $this->getMock('Illuminate\Filesystem\Filesystem');
+		return $this->getMock(Filesystem::class);
 	}
 
 }

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Cache\MemcachedConnector;
 
 class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase {
 
@@ -12,7 +13,7 @@ class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase {
 
 	public function testServersAreAddedCorrectly()
 	{
-		$connector = $this->getMock('Illuminate\Cache\MemcachedConnector', array('getMemcached'));
+		$connector = $this->getMock(MemcachedConnector::class, array('getMemcached'));
 		$memcached = m::mock('stdClass');
 		$memcached->shouldReceive('addServer')->once()->with('localhost', 11211, 100);
 		$memcached->shouldReceive('getVersion')->once()->andReturn([]);
@@ -28,7 +29,7 @@ class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testExceptionThrownOnBadConnection()
 	{
-		$connector = $this->getMock('Illuminate\Cache\MemcachedConnector', array('getMemcached'));
+		$connector = $this->getMock(MemcachedConnector::class, array('getMemcached'));
 		$memcached = m::mock('stdClass');
 		$memcached->shouldReceive('addServer')->once()->with('localhost', 11211, 100);
 		$memcached->shouldReceive('getVersion')->once()->andReturn(['255.255.255']);

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Redis\Database;
+use Illuminate\Cache\RedisStore;
 
 class CacheRedisStoreTest extends PHPUnit_Framework_TestCase {
 
@@ -93,7 +95,7 @@ class CacheRedisStoreTest extends PHPUnit_Framework_TestCase {
 
 	protected function getRedis()
 	{
-		return new Illuminate\Cache\RedisStore(m::mock('Illuminate\Redis\Database'), 'prefix');
+		return new RedisStore(m::mock(Database::class), 'prefix');
 	}
 
 }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -1,6 +1,10 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Cache\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Events\Dispatcher as EventDispacther;
 
 class CacheRepositoryTest extends PHPUnit_Framework_TestCase {
 
@@ -85,8 +89,8 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	protected function getRepository()
 	{
-		$dispatcher = new \Illuminate\Events\Dispatcher(m::mock('Illuminate\Container\Container'));
-		$repository = new Illuminate\Cache\Repository(m::mock('Illuminate\Contracts\Cache\Store'));
+		$dispatcher = new EventDispacther(m::mock(Container::class));
+		$repository = new Repository(m::mock(Store::class));
 
 		$repository->setEventDispatcher($dispatcher);
 

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -1,8 +1,13 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Foundation\Composer;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
 use Illuminate\Cache\Console\CacheTableCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Illuminate\Database\Migrations\MigrationCreator;
 
 class CacheTableCommandTest extends PHPUnit_Framework_TestCase {
 
@@ -14,10 +19,7 @@ class CacheTableCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testCreateMakesMigration()
 	{
-		$command = new CacheTableCommandTestStub(
-			$files = m::mock('Illuminate\Filesystem\Filesystem'),
-			$composer = m::mock('Illuminate\Foundation\Composer')
-		);
+		$command = new CacheTableCommandTestStub($files = m::mock(Filesystem::class), $composer = m::mock(Composer::class));
 		$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
 
 		$app = new Application();
@@ -36,7 +38,7 @@ class CacheTableCommandTest extends PHPUnit_Framework_TestCase {
 
 	protected function runCommand($command, $input = array())
 	{
-		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+		return $command->run(new ArrayInput($input), new NullOutput);
 	}
 
 }

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Cache\TagSet;
 use Illuminate\Cache\ArrayStore;
+use Illuminate\Contracts\Cache\Store;
 
 class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase {
 
@@ -74,8 +76,8 @@ class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase {
 
 	public function testRedisCacheTagsPushForeverKeysCorrectly()
 	{
-		$store = m::mock('Illuminate\Contracts\Cache\Store');
-		$tagSet = m::mock('Illuminate\Cache\TagSet', array($store, array('foo', 'bar')));
+		$store = m::mock(Store::class);
+		$tagSet = m::mock(TagSet::class, array($store, array('foo', 'bar')));
 		$tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
 		$redis = new Illuminate\Cache\RedisTaggedCache($store, $tagSet);
 		$store->shouldReceive('getPrefix')->andReturn('prefix:');
@@ -90,8 +92,8 @@ class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase {
 
 	public function testRedisCacheForeverTagsCanBeFlushed()
 	{
-		$store = m::mock('Illuminate\Contracts\Cache\Store');
-		$tagSet = m::mock('Illuminate\Cache\TagSet', array($store, array('foo', 'bar')));
+		$store = m::mock(Store::class);
+		$tagSet = m::mock(TagSet::class, array($store, array('foo', 'bar')));
 		$tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
 		$redis = new Illuminate\Cache\RedisTaggedCache($store, $tagSet);
 		$store->shouldReceive('getPrefix')->andReturn('prefix:');

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -1,8 +1,12 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Cache\CacheManager;
 use Illuminate\Foundation\Application;
 use Illuminate\Cache\Console\ClearCommand;
+use Illuminate\Contracts\Cache\Repository;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 class ClearCommandTest extends PHPUnit_Framework_TestCase {
 
@@ -14,14 +18,11 @@ class ClearCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testClearWithNoStoreOption()
 	{
-		$command = new ClearCommandTestStub(
-			$cacheManager = m::mock('Illuminate\Cache\CacheManager')
-		);
+		$command = new ClearCommandTestStub($cacheManager = m::mock(CacheManager::class));
 
-		$cacheRepository = m::mock('\Illuminate\Contracts\Cache\Repository');
+		$cacheRepository = m::mock(Repository::class);
 
-		$app = new Application();
-		$command->setLaravel($app);
+		$command->setLaravel(new Application);
 
 		$cacheManager->shouldReceive('store')->once()->with(null)->andReturn($cacheRepository);
 		$cacheRepository->shouldReceive('flush')->once();
@@ -32,14 +33,11 @@ class ClearCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testClearWithStoreOption()
 	{
-		$command = new ClearCommandTestStub(
-			$cacheManager = m::mock('Illuminate\Cache\CacheManager')
-		);
+		$command = new ClearCommandTestStub($cacheManager = m::mock(CacheManager::class));
 
-		$cacheRepository = m::mock('\Illuminate\Contracts\Cache\Repository');
+		$cacheRepository = m::mock(Repository::class);
 
-		$app = new Application();
-		$command->setLaravel($app);
+		$command->setLaravel(new Application);
 
 		$cacheManager->shouldReceive('store')->once()->with('foo')->andReturn($cacheRepository);
 		$cacheRepository->shouldReceive('flush')->once();
@@ -50,18 +48,15 @@ class ClearCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testClearWithInvalidStoreOption()
 	{
-		$command = new ClearCommandTestStub(
-			$cacheManager = m::mock('Illuminate\Cache\CacheManager')
-		);
+		$command = new ClearCommandTestStub($cacheManager = m::mock(CacheManager::class));
 
-		$cacheRepository = m::mock('\Illuminate\Contracts\Cache\Repository');
+		$cacheRepository = m::mock(Repository::class);
 
-		$app = new Application();
-		$command->setLaravel($app);
+		$command->setLaravel(new Application);
 
-		$cacheManager->shouldReceive('store')->once()->with('bar')->andThrow('\InvalidArgumentException');
+		$cacheManager->shouldReceive('store')->once()->with('bar')->andThrow(InvalidArgumentException::class);
 		$cacheRepository->shouldReceive('flush')->never();
-		$this->setExpectedException('InvalidArgumentException');
+		$this->setExpectedException(InvalidArgumentException::class);
 
 		$this->runCommand($command, ['store' => 'bar']);
 	}
@@ -69,7 +64,7 @@ class ClearCommandTest extends PHPUnit_Framework_TestCase {
 
 	protected function runCommand($command, $input = array())
 	{
-		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+		return $command->run(new ArrayInput($input), new NullOutput);
 	}
 
 }

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -1,6 +1,11 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Console\Application as ConsoleApplication;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
 class ConsoleApplicationTest extends PHPUnit_Framework_TestCase {
 
@@ -13,8 +18,8 @@ class ConsoleApplicationTest extends PHPUnit_Framework_TestCase {
 	public function testAddSetsLaravelInstance()
 	{
 		$app = $this->getMockConsole(['addToParent']);
-		$command = m::mock('Illuminate\Console\Command');
-		$command->shouldReceive('setLaravel')->once()->with(m::type('Illuminate\Contracts\Foundation\Application'));
+		$command = m::mock(Command::class);
+		$command->shouldReceive('setLaravel')->once()->with(m::type(Application::class));
 		$app->expects($this->once())->method('addToParent')->with($this->equalTo($command))->will($this->returnValue($command));
 		$result = $app->add($command);
 
@@ -25,7 +30,7 @@ class ConsoleApplicationTest extends PHPUnit_Framework_TestCase {
 	public function testLaravelNotSetOnSymfonyCommands()
 	{
 		$app = $this->getMockConsole(['addToParent']);
-		$command = m::mock('Symfony\Component\Console\Command\Command');
+		$command = m::mock(SymfonyCommand::class);
 		$command->shouldReceive('setLaravel')->never();
 		$app->expects($this->once())->method('addToParent')->with($this->equalTo($command))->will($this->returnValue($command));
 		$result = $app->add($command);
@@ -37,8 +42,8 @@ class ConsoleApplicationTest extends PHPUnit_Framework_TestCase {
 	public function testResolveAddsCommandViaApplicationResolution()
 	{
 		$app = $this->getMockConsole(['addToParent']);
-		$command = m::mock('Symfony\Component\Console\Command\Command');
-		$app->getLaravel()->shouldReceive('make')->once()->with('foo')->andReturn(m::mock('Symfony\Component\Console\Command\Command'));
+		$command = m::mock(SymfonyCommand::class);
+		$app->getLaravel()->shouldReceive('make')->once()->with('foo')->andReturn(m::mock(SymfonyCommand::class));
 		$app->expects($this->once())->method('addToParent')->with($this->equalTo($command))->will($this->returnValue($command));
 		$result = $app->resolve('foo');
 
@@ -48,10 +53,10 @@ class ConsoleApplicationTest extends PHPUnit_Framework_TestCase {
 
 	protected function getMockConsole(array $methods)
 	{
-		$app = m::mock('Illuminate\Contracts\Foundation\Application', ['version' => '5.1']);
-		$events = m::mock('Illuminate\Contracts\Events\Dispatcher', ['fire' => null]);
+		$app = m::mock(Application::class, ['version' => '5.1']);
+		$events = m::mock(EventDispatcher::class, ['fire' => null]);
 
-		$console = $this->getMock('Illuminate\Console\Application', $methods, [
+		$console = $this->getMock(ConsoleApplication::class, $methods, [
 			$app, $events, 'test-version'
 		]);
 

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Carbon\Carbon;
+use Illuminate\Foundation\Application;
 use Illuminate\Console\Scheduling\Event;
 
 class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase {
@@ -31,7 +32,7 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase {
 
 	public function testBasicCronCompilation()
 	{
-		$app = m::mock('Illuminate\Foundation\Application[isDownForMaintenance,environment]');
+		$app = m::mock(Application::class.'[isDownForMaintenance,environment]');
 		$app->shouldReceive('isDownForMaintenance')->andReturn(false);
 		$app->shouldReceive('environment')->andReturn('production');
 
@@ -64,7 +65,7 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase {
 
 	public function testEventIsDueCheck()
 	{
-		$app = m::mock('Illuminate\Foundation\Application[isDownForMaintenance,environment]');
+		$app = m::mock(Application::class.'[isDownForMaintenance,environment]');
 		$app->shouldReceive('isDownForMaintenance')->andReturn(false);
 		$app->shouldReceive('environment')->andReturn('production');
 		Carbon::setTestNow(Carbon::create(2015, 1, 1, 0, 0, 0));

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Container\Container;
+use Illuminate\Container\BindingResolutionException;
 
 class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 
@@ -347,7 +348,7 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 
 	public function testInternalClassWithDefaultParameters()
 	{
-		$this->setExpectedException('Illuminate\Container\BindingResolutionException', 'Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class ContainerMixedPrimitiveStub');
+		$this->setExpectedException(BindingResolutionException::class, 'Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class ContainerMixedPrimitiveStub');
 		$container = new Container;
 		$parameters = array();
 		$container->make('ContainerMixedPrimitiveStub', $parameters);

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Cookie\CookieJar;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 
 class CookieTest extends PHPUnit_Framework_TestCase {
@@ -57,11 +58,11 @@ class CookieTest extends PHPUnit_Framework_TestCase {
 		$cookie->queue($cookie->make('foo','bar'));
 		$this->assertArrayHasKey('foo', $cookie->getQueuedCookies());
 		$this->assertTrue($cookie->hasQueued('foo'));
-		$this->assertInstanceOf('Symfony\Component\HttpFoundation\Cookie', $cookie->queued('foo'));
+		$this->assertInstanceOf(Cookie::class, $cookie->queued('foo'));
 		$cookie->queue('qu','ux');
 		$this->assertArrayHasKey('qu', $cookie->getQueuedCookies());
 		$this->assertTrue($cookie->hasQueued('qu'));
-		$this->assertInstanceOf('Symfony\Component\HttpFoundation\Cookie', $cookie->queued('qu'));
+		$this->assertInstanceOf(Cookie::class, $cookie->queued('qu'));
 	}
 
 

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -1,6 +1,12 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Container\Container;
+use Illuminate\Database\Connectors\MySqlConnector;
+use Illuminate\Database\Connectors\SQLiteConnector;
+use Illuminate\Database\Connectors\ConnectionFactory;
+use Illuminate\Database\Connectors\PostgresConnector;
+use Illuminate\Database\Connectors\SqlServerConnector;
 
 class DatabaseConnectionFactoryPDOStub extends PDO {
 	public function __construct() {}
@@ -16,7 +22,7 @@ class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase {
 
 	public function testMakeCallsCreateConnection()
 	{
-		$factory = $this->getMock('Illuminate\Database\Connectors\ConnectionFactory', array('createConnector', 'createConnection'), array($container = m::mock('Illuminate\Container\Container')));
+		$factory = $this->getMock(ConnectionFactory::class, array('createConnector', 'createConnection'), array($container = m::mock(Container::class)));
 		$container->shouldReceive('bound')->andReturn(false);
 		$connector = m::mock('stdClass');
 		$config = array('driver' => 'mysql', 'prefix' => 'prefix', 'database' => 'database', 'name' => 'foo');
@@ -34,7 +40,7 @@ class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase {
 
 	public function testMakeCallsCreateConnectionForReadWrite()
 	{
-		$factory = $this->getMock('Illuminate\Database\Connectors\ConnectionFactory', array('createConnector', 'createConnection'), array($container = m::mock('Illuminate\Container\Container')));
+		$factory = $this->getMock(ConnectionFactory::class, array('createConnector', 'createConnection'), array($container = m::mock(Container::class)));
 		$container->shouldReceive('bound')->andReturn(false);
 		$connector = m::mock('stdClass');
 		$config = array(
@@ -61,7 +67,7 @@ class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase {
 
 	public function testMakeCanCallTheContainer()
 	{
-		$factory = $this->getMock('Illuminate\Database\Connectors\ConnectionFactory', array('createConnector'), array($container = m::mock('Illuminate\Container\Container')));
+		$factory = $this->getMock(ConnectionFactory::class, array('createConnector'), array($container = m::mock(Container::class)));
 		$container->shouldReceive('bound')->andReturn(true);
 		$connector = m::mock('stdClass');
 		$config = array('driver' => 'mysql', 'prefix' => 'prefix', 'database' => 'database', 'name' => 'foo');
@@ -78,12 +84,12 @@ class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase {
 
 	public function testProperInstancesAreReturnedForProperDrivers()
 	{
-		$factory = new Illuminate\Database\Connectors\ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
+		$factory = new ConnectionFactory($container = m::mock(Container::class));
 		$container->shouldReceive('bound')->andReturn(false);
-		$this->assertInstanceOf('Illuminate\Database\Connectors\MySqlConnector', $factory->createConnector(array('driver' => 'mysql')));
-		$this->assertInstanceOf('Illuminate\Database\Connectors\PostgresConnector', $factory->createConnector(array('driver' => 'pgsql')));
-		$this->assertInstanceOf('Illuminate\Database\Connectors\SQLiteConnector', $factory->createConnector(array('driver' => 'sqlite')));
-		$this->assertInstanceOf('Illuminate\Database\Connectors\SqlServerConnector', $factory->createConnector(array('driver' => 'sqlsrv')));
+		$this->assertInstanceOf(MySqlConnector::class, $factory->createConnector(['driver' => 'mysql']));
+		$this->assertInstanceOf(SQLiteConnector::class, $factory->createConnector(['driver' => 'sqlite']));
+		$this->assertInstanceOf(PostgresConnector::class, $factory->createConnector(['driver' => 'pgsql']));
+		$this->assertInstanceOf(SqlServerConnector::class, $factory->createConnector(['driver' => 'sqlsrv']));
 	}
 
 
@@ -92,7 +98,7 @@ class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testIfDriverIsntSetExceptionIsThrown()
 	{
-		$factory = new Illuminate\Database\Connectors\ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
+		$factory = new ConnectionFactory($container = m::mock(Container::class));
 		$factory->createConnector(array('foo'));
 	}
 
@@ -102,7 +108,7 @@ class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testExceptionIsThrownOnUnsupportedDriver()
 	{
-		$factory = new Illuminate\Database\Connectors\ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
+		$factory = new ConnectionFactory($container = m::mock(Container::class));
 		$container->shouldReceive('bound')->once()->andReturn(false);
 		$factory->createConnector(array('driver' => 'foo'));
 	}
@@ -110,7 +116,7 @@ class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase {
 
 	public function testCustomConnectorsCanBeResolvedViaContainer()
 	{
-		$factory = new Illuminate\Database\Connectors\ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
+		$factory = new ConnectionFactory($container = m::mock(Container::class));
 		$container->shouldReceive('bound')->once()->with('db.connector.foo')->andReturn(true);
 		$container->shouldReceive('make')->once()->with('db.connector.foo')->andReturn('connector');
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -1,6 +1,11 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Connectors\Connector;
+use Illuminate\Database\Connectors\MySqlConnector;
+use Illuminate\Database\Connectors\SQLiteConnector;
+use Illuminate\Database\Connectors\PostgresConnector;
+use Illuminate\Database\Connectors\SqlServerConnector;
 
 class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 
@@ -12,8 +17,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 
 	public function testOptionResolution()
 	{
-		$connector = new Illuminate\Database\Connectors\Connector;
-		$connector->setDefaultOptions(array(0 => 'foo', 1 => 'bar'));
+		with($connector = new Connector)->setDefaultOptions(array(0 => 'foo', 1 => 'bar'));
 		$this->assertEquals(array(0 => 'baz', 1 => 'bar', 2 => 'boom'), $connector->getOptions(array('options' => array(0 => 'baz', 2 => 'boom'))));
 	}
 
@@ -23,7 +27,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testMySqlConnectCallsCreateConnectionWithProperArguments($dsn, $config)
 	{
-		$connector = $this->getMock('Illuminate\Database\Connectors\MySqlConnector', array('createConnection', 'getOptions'));
+		$connector = $this->getMock(MySqlConnector::class, array('createConnection', 'getOptions'));
 		$connection = m::mock('stdClass');
 		$connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(array('options')));
 		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(array('options')))->will($this->returnValue($connection));
@@ -50,7 +54,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 	{
 		$dsn = 'pgsql:host=foo;dbname=bar;port=111';
 		$config = array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'charset' => 'utf8');
-		$connector = $this->getMock('Illuminate\Database\Connectors\PostgresConnector', array('createConnection', 'getOptions'));
+		$connector = $this->getMock(PostgresConnector::class, array('createConnection', 'getOptions'));
 		$connection = m::mock('stdClass');
 		$connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(array('options')));
 		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(array('options')))->will($this->returnValue($connection));
@@ -66,7 +70,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 	{
 		$dsn = 'pgsql:host=foo;dbname=bar';
 		$config = array('host' => 'foo', 'database' => 'bar', 'schema' => 'public', 'charset' => 'utf8');
-		$connector = $this->getMock('Illuminate\Database\Connectors\PostgresConnector', array('createConnection', 'getOptions'));
+		$connector = $this->getMock(PostgresConnector::class, array('createConnection', 'getOptions'));
 		$connection = m::mock('stdClass');
 		$connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(array('options')));
 		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(array('options')))->will($this->returnValue($connection));
@@ -83,7 +87,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 	{
 		$dsn = 'sqlite::memory:';
 		$config = array('database' => ':memory:');
-		$connector = $this->getMock('Illuminate\Database\Connectors\SQLiteConnector', array('createConnection', 'getOptions'));
+		$connector = $this->getMock(SQLiteConnector::class, array('createConnection', 'getOptions'));
 		$connection = m::mock('stdClass');
 		$connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(array('options')));
 		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(array('options')))->will($this->returnValue($connection));
@@ -97,7 +101,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 	{
 		$dsn = 'sqlite:'.__DIR__;
 		$config = array('database' => __DIR__);
-		$connector = $this->getMock('Illuminate\Database\Connectors\SQLiteConnector', array('createConnection', 'getOptions'));
+		$connector = $this->getMock(SQLiteConnector::class, array('createConnection', 'getOptions'));
 		$connection = m::mock('stdClass');
 		$connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(array('options')));
 		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(array('options')))->will($this->returnValue($connection));
@@ -111,7 +115,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 	{
 		$config = array('host' => 'foo', 'database' => 'bar', 'port' => 111);
 		$dsn = $this->getDsn($config);
-		$connector = $this->getMock('Illuminate\Database\Connectors\SqlServerConnector', array('createConnection', 'getOptions'));
+		$connector = $this->getMock(SqlServerConnector::class, array('createConnection', 'getOptions'));
 		$connection = m::mock('stdClass');
 		$connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(array('options')));
 		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(array('options')))->will($this->returnValue($connection));
@@ -124,7 +128,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 	{
 		$config = array('host' => 'foo', 'database' => 'bar', 'port' => 111, 'appname' => 'baz', 'charset' => 'utf-8');
 		$dsn = $this->getDsn($config);
-		$connector = $this->getMock('Illuminate\Database\Connectors\SqlServerConnector', array('createConnection', 'getOptions'));
+		$connector = $this->getMock(SqlServerConnector::class, array('createConnection', 'getOptions'));
 		$connection = m::mock('stdClass');
 		$connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(array('options')));
 		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(array('options')))->will($this->returnValue($connection));

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -1,8 +1,12 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
@@ -20,7 +24,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$model2->fill(array('name' => 'dayle', 'pivot_user_id' => 3, 'pivot_role_id' => 4));
 		$models = array($model1, $model2);
 
-		$baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+		$baseBuilder = m::mock(Builder::class);
 
 		$relation = $this->getRelation();
 		$relation->getParent()->shouldReceive('getConnectionName')->andReturn('foo.connection');
@@ -31,7 +35,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$relation->getQuery()->shouldReceive('getQuery')->once()->andReturn($baseBuilder);
 		$results = $relation->get();
 
-		$this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $results);
+		$this->assertInstanceOf(Collection::class, $results);
 
 		// Make sure the foreign keys were set on the pivot models...
 		$this->assertEquals('user_id', $results[0]->pivot->getForeignKey());
@@ -58,7 +62,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$model2->fill(array('name' => 'dayle', 'pivot_user_id' => 3, 'pivot_role_id' => 4));
 		$models = array($model1, $model2);
 
-		$baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+		$baseBuilder = m::mock(Builder::class);
 
 		$relation = $this->getRelation()->withTimestamps();
 		$relation->getParent()->shouldReceive('getConnectionName')->andReturn('foo.connection');
@@ -111,8 +115,8 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 	{
 		$relation = $this->getRelation();
 		$relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function($array = array()) { return new Collection($array); });
-		$model = m::mock('Illuminate\Database\Eloquent\Model');
-		$model->shouldReceive('setRelation')->once()->with('foo', m::type('Illuminate\Database\Eloquent\Collection'));
+		$model = m::mock(Model::class);
+		$model->shouldReceive('setRelation')->once()->with('foo', m::type(Collection::class));
 		$models = $relation->initRelation(array($model), 'foo');
 
 		$this->assertEquals(array($model), $models);
@@ -133,7 +137,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testAttachInsertsPivotTableRecord()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('touchIfTouching'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
 		$query->shouldReceive('insert')->once()->with(array(array('user_id' => 1, 'role_id' => 2, 'foo' => 'bar')))->andReturn(true);
@@ -147,7 +151,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testAttachMultipleInsertsPivotTableRecord()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('touchIfTouching'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
 		$query->shouldReceive('insert')->once()->with(
@@ -166,7 +170,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testAttachInsertsPivotTableRecordWithTimestampsWhenNecessary()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('touchIfTouching'), $this->getRelationArguments());
 		$relation->withTimestamps();
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
@@ -182,7 +186,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testAttachInsertsPivotTableRecordWithCustomTimestampColumns()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('touchIfTouching'), $this->getRelationArguments());
 		$relation->withTimestamps('custom_created_at', 'custom_updated_at');
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
@@ -198,7 +202,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testAttachInsertsPivotTableRecordWithACreatedAtTimestamp()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('touchIfTouching'), $this->getRelationArguments());
 		$relation->withPivot('created_at');
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
@@ -214,7 +218,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testAttachInsertsPivotTableRecordWithAnUpdatedAtTimestamp()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('touchIfTouching'), $this->getRelationArguments());
 		$relation->withPivot('updated_at');
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
@@ -230,7 +234,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testDetachRemovesPivotTableRecord()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('touchIfTouching'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -246,7 +250,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testDetachWithSingleIDRemovesPivotTableRecord()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('touchIfTouching'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -262,7 +266,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('touchIfTouching'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -278,8 +282,8 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testFirstMethod()
 	{
-		$relation = m::mock('Illuminate\Database\Eloquent\Relations\BelongsToMany[get]', $this->getRelationArguments());
-		$relation->shouldReceive('get')->once()->andReturn(new Illuminate\Database\Eloquent\Collection([new StdClass]));
+		$relation = m::mock(BelongsToMany::class.'[get]', $this->getRelationArguments());
+		$relation->shouldReceive('get')->once()->andReturn(new Collection([new StdClass]));
 		$relation->shouldReceive('take')->with(1)->once()->andReturn($relation);
 
 		$this->assertTrue($relation->first() instanceof StdClass);
@@ -288,7 +292,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testFindMethod()
 	{
-		$relation = m::mock('Illuminate\Database\Eloquent\Relations\BelongsToMany[first]', $this->getRelationArguments());
+		$relation = m::mock(BelongsToMany::class.'[first]', $this->getRelationArguments());
 		$relation->shouldReceive('first')->once()->andReturn(new StdClass);
 		$relation->shouldReceive('where')->with('roles.id', '=', 'foo')->once()->andReturn($relation);
 
@@ -301,8 +305,8 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testFindManyMethod()
 	{
-		$relation = m::mock('Illuminate\Database\Eloquent\Relations\BelongsToMany[get]', $this->getRelationArguments());
-		$relation->shouldReceive('get')->once()->andReturn(new Illuminate\Database\Eloquent\Collection([new StdClass, new StdClass]));
+		$relation = m::mock(BelongsToMany::class.'[get]', $this->getRelationArguments());
+		$relation->shouldReceive('get')->once()->andReturn(new Collection([new StdClass, new StdClass]));
 		$relation->shouldReceive('whereIn')->with('roles.id', ['foo', 'bar'])->once()->andReturn($relation);
 
 		$related = $relation->getRelated();
@@ -317,7 +321,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testCreateMethodCreatesNewModelAndInsertsAttachmentRecord()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('attach'), $this->getRelationArguments());
 		$relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'))->with(array('attributes'));
 		$model->shouldReceive('save')->once();
 		$model->shouldReceive('getKey')->andReturn('foo');
@@ -329,7 +333,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testFindOrNewMethodFindsModel()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('find'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('find'), $this->getRelationArguments());
 		$relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue($model = m::mock('StdClass')));
 		$relation->getRelated()->shouldReceive('newInstance')->never();
 
@@ -339,7 +343,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testFindOrNewMethodReturnsNewModel()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('find'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('find'), $this->getRelationArguments());
 		$relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue(null));
 		$relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'));
 
@@ -349,7 +353,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testFirstOrNewMethodFindsFirstModel()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('where'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('where'), $this->getRelationArguments());
 		$relation->expects($this->once())->method('where')->with(array('foo'))->will($this->returnValue($relation->getQuery()));
 		$relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
 		$relation->getRelated()->shouldReceive('newInstance')->never();
@@ -360,7 +364,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testFirstOrNewMethodReturnsNewModel()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('where'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('where'), $this->getRelationArguments());
 		$relation->expects($this->once())->method('where')->with(array('foo'))->will($this->returnValue($relation->getQuery()));
 		$relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
 		$relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'));
@@ -371,7 +375,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testFirstOrCreateMethodFindsFirstModel()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('where','create'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('where','create'), $this->getRelationArguments());
 		$relation->expects($this->once())->method('where')->with(array('foo'))->will($this->returnValue($relation->getQuery()));
 		$relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
 		$relation->expects($this->never())->method('create')->with(array('foo'))->will($this->returnValue(null));
@@ -382,7 +386,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testFirstOrCreateMethodReturnsNewModel()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('where','create'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('where','create'), $this->getRelationArguments());
 		$relation->expects($this->once())->method('where')->with(array('foo'))->will($this->returnValue($relation->getQuery()));
 		$relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
 		$relation->expects($this->once())->method('create')->with(array('foo'))->will($this->returnValue($model = m::mock('StdClass')));
@@ -393,7 +397,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('where','create'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('where','create'), $this->getRelationArguments());
 		$relation->expects($this->once())->method('where')->with(array('foo'))->will($this->returnValue($relation->getQuery()));
 		$relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
 		$model->shouldReceive('fill')->once();
@@ -406,7 +410,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testUpdateOrCreateMethodReturnsNewModel()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('where','create'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('where','create'), $this->getRelationArguments());
 		$relation->expects($this->once())->method('where')->with(array('bar'))->will($this->returnValue($relation->getQuery()));
 		$relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
 		$relation->expects($this->once())->method('create')->with(array('foo'))->will($this->returnValue($model = m::mock('StdClass')));
@@ -419,7 +423,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testSyncMethodSyncsIntermediateTableWithGivenArray($list)
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('attach', 'detach'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -446,7 +450,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testSyncMethodSyncsIntermediateTableWithGivenArrayAndAttributes()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach', 'touchIfTouching', 'updateExistingPivot'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('attach', 'detach', 'touchIfTouching', 'updateExistingPivot'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -464,7 +468,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testSyncMethodDoesntReturnValuesThatWereNotUpdated()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach', 'touchIfTouching', 'updateExistingPivot'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('attach', 'detach', 'touchIfTouching', 'updateExistingPivot'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -498,7 +502,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testTouchIfTouching()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('touch', 'touchingParent'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('touch', 'touchingParent'), $this->getRelationArguments());
 		$relation->expects($this->once())->method('touchingParent')->will($this->returnValue(true));
 		$relation->getParent()->shouldReceive('touch')->once();
 		$relation->getParent()->shouldReceive('touches')->once()->with('relation_name')->andReturn(true);
@@ -510,7 +514,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testSyncMethodConvertsCollectionToArrayOfKeys()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', array('attach', 'detach', 'touchIfTouching', 'formatSyncList'), $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, array('attach', 'detach', 'touchIfTouching', 'formatSyncList'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('user_role')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
@@ -518,7 +522,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 		$mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
 		$query->shouldReceive('lists')->once()->with('role_id')->andReturn(array(1, 2, 3));
 
-		$collection = m::mock('Illuminate\Database\Eloquent\Collection');
+		$collection = m::mock(Collection::class);
 		$collection->shouldReceive('modelKeys')->once()->andReturn(array(1, 2, 3));
 		$relation->expects($this->once())->method('formatSyncList')->with(array(1, 2, 3))->will($this->returnValue(array(1 => array(),2 => array(),3 => array())));
 		$relation->sync($collection);
@@ -527,7 +531,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testWherePivotParamsUsedForNewQueries()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\BelongsToMany', ['attach', 'detach', 'touchIfTouching', 'formatSyncList'], $this->getRelationArguments());
+		$relation = $this->getMock(BelongsToMany::class, ['attach', 'detach', 'touchIfTouching', 'formatSyncList'], $this->getRelationArguments());
 
 		// we expect to call $relation->wherePivot()
 		$relation->getQuery()->shouldReceive('where')->once()->andReturn($relation);
@@ -567,20 +571,20 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function getRelationArguments()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent = m::mock(Model::class);
 		$parent->shouldReceive('getKey')->andReturn(1);
 		$parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
 		$parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
 
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
-		$related = m::mock('Illuminate\Database\Eloquent\Model');
+		$builder = m::mock(EloquentBuilder::class);
+		$related = m::mock(Model::class);
 		$builder->shouldReceive('getModel')->andReturn($related);
 
 		$related->shouldReceive('getTable')->andReturn('roles');
 		$related->shouldReceive('getKeyName')->andReturn('id');
 		$related->shouldReceive('newPivot')->andReturnUsing(function()
 		{
-			$reflector = new ReflectionClass('Illuminate\Database\Eloquent\Relations\Pivot');
+			$reflector = new ReflectionClass(Pivot::class);
 			return $reflector->newInstanceArgs(func_get_args());
 		});
 
@@ -592,11 +596,11 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class EloquentBelongsToManyModelStub extends Illuminate\Database\Eloquent\Model {
+class EloquentBelongsToManyModelStub extends Model {
 	protected $guarded = array();
 }
 
-class EloquentBelongsToManyModelPivotStub extends Illuminate\Database\Eloquent\Model {
+class EloquentBelongsToManyModelPivotStub extends Model {
 	public $pivot;
 	public function __construct()
 	{

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -15,7 +17,7 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 	public function testUpdateMethodRetrievesModelAndUpdates()
 	{
 		$relation = $this->getRelation();
-		$mock = m::mock('Illuminate\Database\Eloquent\Model');
+		$mock = m::mock(Model::class);
 		$mock->shouldReceive('fill')->once()->with(array('attributes'))->andReturn($mock);
 		$mock->shouldReceive('save')->once()->andReturn(true);
 		$relation->getQuery()->shouldReceive('first')->once()->andReturn($mock);
@@ -36,7 +38,7 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 	public function testRelationIsProperlyInitialized()
 	{
 		$relation = $this->getRelation();
-		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model = m::mock(Model::class);
 		$model->shouldReceive('setRelation')->once()->with('foo', null);
 		$models = $relation->initRelation(array($model), 'foo');
 
@@ -64,10 +66,10 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 
 	public function testAssociateMethodSetsForeignKeyOnModel()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent = m::mock(Model::class);
 		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
 		$relation = $this->getRelation($parent);
-		$associate = m::mock('Illuminate\Database\Eloquent\Model');
+		$associate = m::mock(Model::class);
 		$associate->shouldReceive('getAttribute')->once()->with('id')->andReturn(1);
 		$parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 		$parent->shouldReceive('setRelation')->once()->with('relation', $associate);
@@ -78,7 +80,7 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 
 	public function testDissociateMethodUnsetsForeignKeyOnModel()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent = m::mock(Model::class);
 		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
 		$relation = $this->getRelation($parent);
 		$parent->shouldReceive('setAttribute')->once()->with('foreign_key', null);
@@ -89,7 +91,7 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 
 	public function testAssociateMethodSetsForeignKeyOnModelById()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent = m::mock(Model::class);
 		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
 		$relation = $this->getRelation($parent);
 		$parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
@@ -99,9 +101,9 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 
 	protected function getRelation($parent = null)
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(Builder::class);
 		$builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
-		$related = m::mock('Illuminate\Database\Eloquent\Model');
+		$related = m::mock(Model::class);
 		$related->shouldReceive('getKeyName')->andReturn('id');
 		$related->shouldReceive('getTable')->andReturn('relation');
 		$builder->shouldReceive('getModel')->andReturn($related);
@@ -111,13 +113,13 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class EloquentBelongsToModelStub extends Illuminate\Database\Eloquent\Model {
+class EloquentBelongsToModelStub extends Model {
 
 	public $foreign_key = 'foreign.value';
 
 }
 
-class AnotherEloquentBelongsToModelStub extends Illuminate\Database\Eloquent\Model {
+class AnotherEloquentBelongsToModelStub extends Model {
 
 	public $foreign_key = 'foreign.value.two';
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
 
 class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
@@ -35,11 +36,11 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testContainsIndicatesIfModelInArray()
 	{
-		$mockModel = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel = m::mock(Model::class);
 		$mockModel->shouldReceive('getKey')->andReturn(1);
-		$mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel2 = m::mock(Model::class);
 		$mockModel2->shouldReceive('getKey')->andReturn(2);
-		$mockModel3 = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel3 = m::mock(Model::class);
 		$mockModel3->shouldReceive('getKey')->andReturn(3);
 		$c = new Collection(array($mockModel, $mockModel2));
 
@@ -51,10 +52,10 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testContainsIndicatesIfKeyedModelInArray()
 	{
-		$mockModel = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel = m::mock(Model::class);
 		$mockModel->shouldReceive('getKey')->andReturn('1');
 		$c = new Collection(array($mockModel));
-		$mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel2 = m::mock(Model::class);
 		$mockModel2->shouldReceive('getKey')->andReturn('2');
 		$c->add($mockModel2);
 
@@ -65,10 +66,10 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testContainsKeyAndValueIndicatesIfModelInArray()
 	{
-		$mockModel1 = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel1 = m::mock(Model::class);
 		$mockModel1->shouldReceive('offsetExists')->with('name')->andReturn(true);
 		$mockModel1->shouldReceive('offsetGet')->with('name')->andReturn('Taylor');
-		$mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel2 = m::mock(Model::class);
 		$mockModel2->shouldReceive('offsetExists')->andReturn(true);
 		$mockModel2->shouldReceive('offsetGet')->with('name')->andReturn('Abigail');
 		$c = new Collection([$mockModel1, $mockModel2]);
@@ -81,9 +82,9 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testContainsClosureIndicatesIfModelInArray()
 	{
-		$mockModel1 = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel1 = m::mock(Model::class);
 		$mockModel1->shouldReceive('getKey')->andReturn(1);
-		$mockModel2 = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel2 = m::mock(Model::class);
 		$mockModel2->shouldReceive('getKey')->andReturn(2);
 		$c = new Collection([$mockModel1, $mockModel2]);
 
@@ -94,7 +95,7 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testFindMethodFindsModelById()
 	{
-		$mockModel = m::mock('Illuminate\Database\Eloquent\Model');
+		$mockModel = m::mock(Model::class);
 		$mockModel->shouldReceive('getKey')->andReturn(1);
 		$c = new Collection(array($mockModel));
 
@@ -105,7 +106,7 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testLoadMethodEagerLoadsGivenRelationships()
 	{
-		$c = $this->getMock('Illuminate\Database\Eloquent\Collection', array('first'), array(array('foo')));
+		$c = $this->getMock(Collection::class, array('first'), array(array('foo')));
 		$mockItem = m::mock('StdClass');
 		$c->expects($this->once())->method('first')->will($this->returnValue($mockItem));
 		$mockItem->shouldReceive('newQuery')->once()->andReturn($mockItem);
@@ -119,13 +120,13 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testCollectionDictionaryReturnsModelKeys()
 	{
-		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one = m::mock(Model::class);
 		$one->shouldReceive('getKey')->andReturn(1);
 
-		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two = m::mock(Model::class);
 		$two->shouldReceive('getKey')->andReturn(2);
 
-		$three = m::mock('Illuminate\Database\Eloquent\Model');
+		$three = m::mock(Model::class);
 		$three->shouldReceive('getKey')->andReturn(3);
 
 		$c = new Collection(array($one, $two, $three));
@@ -136,13 +137,13 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testCollectionMergesWithGivenCollection()
 	{
-		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one = m::mock(Model::class);
 		$one->shouldReceive('getKey')->andReturn(1);
 
-		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two = m::mock(Model::class);
 		$two->shouldReceive('getKey')->andReturn(2);
 
-		$three = m::mock('Illuminate\Database\Eloquent\Model');
+		$three = m::mock(Model::class);
 		$three->shouldReceive('getKey')->andReturn(3);
 
 		$c1 = new Collection(array($one, $two));
@@ -154,13 +155,13 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testCollectionDiffsWithGivenCollection()
 	{
-		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one = m::mock(Model::class);
 		$one->shouldReceive('getKey')->andReturn(1);
 
-		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two = m::mock(Model::class);
 		$two->shouldReceive('getKey')->andReturn(2);
 
-		$three = m::mock('Illuminate\Database\Eloquent\Model');
+		$three = m::mock(Model::class);
 		$three->shouldReceive('getKey')->andReturn(3);
 
 		$c1 = new Collection(array($one, $two));
@@ -172,13 +173,13 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testCollectionIntersectsWithGivenCollection()
 	{
-		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one = m::mock(Model::class);
 		$one->shouldReceive('getKey')->andReturn(1);
 
-		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two = m::mock(Model::class);
 		$two->shouldReceive('getKey')->andReturn(2);
 
-		$three = m::mock('Illuminate\Database\Eloquent\Model');
+		$three = m::mock(Model::class);
 		$three->shouldReceive('getKey')->andReturn(3);
 
 		$c1 = new Collection(array($one, $two));
@@ -190,10 +191,10 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testCollectionReturnsUniqueItems()
 	{
-		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one = m::mock(Model::class);
 		$one->shouldReceive('getKey')->andReturn(1);
 
-		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two = m::mock(Model::class);
 		$two->shouldReceive('getKey')->andReturn(2);
 
 		$c = new Collection(array($one, $two, $two));
@@ -204,13 +205,13 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testOnlyReturnsCollectionWithGivenModelKeys()
 	{
-		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one = m::mock(Model::class);
 		$one->shouldReceive('getKey')->andReturn(1);
 
-		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two = m::mock(Model::class);
 		$two->shouldReceive('getKey')->andReturn(2);
 
-		$three = m::mock('Illuminate\Database\Eloquent\Model');
+		$three = m::mock(Model::class);
 		$three->shouldReceive('getKey')->andReturn(3);
 
 		$c = new Collection(array($one, $two, $three));
@@ -222,13 +223,13 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testExceptReturnsCollectionWithoutGivenModelKeys()
 	{
-		$one = m::mock('Illuminate\Database\Eloquent\Model');
+		$one = m::mock(Model::class);
 		$one->shouldReceive('getKey')->andReturn(1);
 
-		$two = m::mock('Illuminate\Database\Eloquent\Model');
+		$two = m::mock(Model::class);
 		$two->shouldReceive('getKey')->andReturn('2');
 
-		$three = m::mock('Illuminate\Database\Eloquent\Model');
+		$three = m::mock(Model::class);
 		$three->shouldReceive('getKey')->andReturn(3);
 
 		$c = new Collection(array($one, $two, $three));

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -15,7 +17,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 	public function testCreateMethodProperlyCreatesNewModel()
 	{
 		$relation = $this->getRelation();
-		$created = $this->getMock('Illuminate\Database\Eloquent\Model', array('save', 'getKey', 'setAttribute'));
+		$created = $this->getMock(Model::class, array('save', 'getKey', 'setAttribute'));
 		$created->expects($this->once())->method('save')->will($this->returnValue(true));
 		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('name' => 'taylor'))->andReturn($created);
 		$created->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
@@ -127,9 +129,9 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 	public function testRelationIsProperlyInitialized()
 	{
 		$relation = $this->getRelation();
-		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model = m::mock(Model::class);
 		$relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function($array = array()) { return new Collection($array); });
-		$model->shouldReceive('setRelation')->once()->with('foo', m::type('Illuminate\Database\Eloquent\Collection'));
+		$model->shouldReceive('setRelation')->once()->with('foo', m::type(Collection::class));
 		$models = $relation->initRelation(array($model), 'foo');
 
 		$this->assertEquals(array($model), $models);
@@ -180,12 +182,12 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 
 	protected function getRelation()
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(Builder::class);
 		$builder->shouldReceive('whereNotNull')->with('table.foreign_key');
 		$builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
-		$related = m::mock('Illuminate\Database\Eloquent\Model');
+		$related = m::mock(Model::class);
 		$builder->shouldReceive('getModel')->andReturn($related);
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent = m::mock(Model::class);
 		$parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 		$parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
 		$parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
@@ -194,6 +196,6 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class EloquentHasManyModelStub extends Illuminate\Database\Eloquent\Model {
+class EloquentHasManyModelStub extends Model {
 	public $foreign_key = 'foreign.value';
 }

--- a/tests/Database/DatabaseEloquentHasManyThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughTest.php
@@ -1,9 +1,12 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 
@@ -16,9 +19,9 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 	public function testRelationIsProperlyInitialized()
 	{
 		$relation = $this->getRelation();
-		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model = m::mock(Model::class);
 		$relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function($array = array()) { return new Collection($array); });
-		$model->shouldReceive('setRelation')->once()->with('foo', m::type('Illuminate\Database\Eloquent\Collection'));
+		$model->shouldReceive('setRelation')->once()->with('foo', m::type(Collection::class));
 		$models = $relation->initRelation(array($model), 'foo');
 
 		$this->assertEquals(array($model), $models);
@@ -100,7 +103,7 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 	{
 		$select = array('posts.*', 'users.country_id');
 
-		$baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+		$baseBuilder = m::mock(Builder::class);
 
 		$relation = $this->getRelation();
 		$relation->getRelated()->shouldReceive('newCollection')->once();
@@ -118,7 +121,7 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 	{
 		$select = array('users.country_id');
 
-		$baseBuilder = m::mock('Illuminate\Database\Query\Builder');
+		$baseBuilder = m::mock(Builder::class);
 		$baseBuilder->columns = array('foo', 'bar');
 
 		$relation = $this->getRelation();
@@ -135,8 +138,8 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 
 	public function testFirstMethod()
 	{
-		$relation = m::mock('Illuminate\Database\Eloquent\Relations\HasManyThrough[get]', $this->getRelationArguments());
-		$relation->shouldReceive('get')->once()->andReturn(new Illuminate\Database\Eloquent\Collection(['first', 'second']));
+		$relation = m::mock(HasManyThrough::class.'[get]', $this->getRelationArguments());
+		$relation->shouldReceive('get')->once()->andReturn(new Collection(['first', 'second']));
 		$relation->shouldReceive('take')->with(1)->once()->andReturn($relation);
 
 		$this->assertEquals('first', $relation->first());
@@ -145,7 +148,7 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 
 	public function testFindMethod()
 	{
-		$relation = m::mock('Illuminate\Database\Eloquent\Relations\HasManyThrough[first]', $this->getRelationArguments());
+		$relation = m::mock(HasManyThrough::class.'[first]', $this->getRelationArguments());
 		$relation->shouldReceive('where')->with('posts.id', '=', 'foo')->once()->andReturn($relation);
 		$relation->shouldReceive('first')->once()->andReturn(new StdClass);
 
@@ -158,8 +161,8 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 
 	public function testFindManyMethod()
 	{
-		$relation = m::mock('Illuminate\Database\Eloquent\Relations\HasManyThrough[get]', $this->getRelationArguments());
-		$relation->shouldReceive('get')->once()->andReturn(new Illuminate\Database\Eloquent\Collection(['first', 'second']));
+		$relation = m::mock(HasManyThrough::class.'[get]', $this->getRelationArguments());
+		$relation->shouldReceive('get')->once()->andReturn(new Collection(['first', 'second']));
 		$relation->shouldReceive('whereIn')->with('posts.id', ['foo', 'bar'])->once()->andReturn($relation);
 
 		$related = $relation->getRelated();
@@ -196,18 +199,18 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 
 	protected function getRelationArguments()
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(EloquentBuilder::class);
 		$builder->shouldReceive('join')->once()->with('users', 'users.id', '=', 'posts.user_id');
 		$builder->shouldReceive('where')->with('users.country_id', '=', 1);
 
-		$country = m::mock('Illuminate\Database\Eloquent\Model');
+		$country = m::mock(Model::class);
 		$country->shouldReceive('getKeyName')->andReturn('id');
 		$country->shouldReceive('offsetGet')->andReturn(1);
 		$country->shouldReceive('getForeignKey')->andReturn('country_id');
-		$user = m::mock('Illuminate\Database\Eloquent\Model');
+		$user = m::mock(Model::class);
 		$user->shouldReceive('getTable')->andReturn('users');
 		$user->shouldReceive('getQualifiedKeyName')->andReturn('users.id');
-		$post = m::mock('Illuminate\Database\Eloquent\Model');
+		$post = m::mock(Model::class);
 		$post->shouldReceive('getTable')->andReturn('posts');
 
 		$builder->shouldReceive('getModel')->andReturn($post);
@@ -221,17 +224,17 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 
 	protected function getRelationArgumentsForNonPrimaryKey()
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(EloquentBuilder::class);
 		$builder->shouldReceive('join')->once()->with('users', 'users.id', '=', 'posts.user_id');
 		$builder->shouldReceive('where')->with('users.country_id', '=', 1);
 
-		$country = m::mock('Illuminate\Database\Eloquent\Model');
+		$country = m::mock(Model::class);
 		$country->shouldReceive('offsetGet')->andReturn(1);
 		$country->shouldReceive('getForeignKey')->andReturn('country_id');
-		$user = m::mock('Illuminate\Database\Eloquent\Model');
+		$user = m::mock(Model::class);
 		$user->shouldReceive('getTable')->andReturn('users');
 		$user->shouldReceive('getQualifiedKeyName')->andReturn('users.id');
-		$post = m::mock('Illuminate\Database\Eloquent\Model');
+		$post = m::mock(Model::class);
 		$post->shouldReceive('getTable')->andReturn('posts');
 
 		$builder->shouldReceive('getModel')->andReturn($post);
@@ -245,11 +248,11 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class EloquentHasManyThroughModelStub extends Illuminate\Database\Eloquent\Model {
+class EloquentHasManyThroughModelStub extends Model {
 	public $country_id = 'foreign.value';
 }
 
-class EloquentHasManyThroughSoftDeletingModelStub extends Illuminate\Database\Eloquent\Model {
+class EloquentHasManyThroughSoftDeletingModelStub extends Model {
 	use SoftDeletes;
 	public $table = 'users';
 }

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -1,8 +1,12 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
@@ -15,7 +19,7 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 	public function testSaveMethodSetsForeignKeyOnModel()
 	{
 		$relation = $this->getRelation();
-		$mockModel = $this->getMock('Illuminate\Database\Eloquent\Model', array('save'));
+		$mockModel = $this->getMock(Model::class, array('save'));
 		$mockModel->expects($this->once())->method('save')->will($this->returnValue(true));
 		$result = $relation->save($mockModel);
 
@@ -27,7 +31,7 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 	public function testCreateMethodProperlyCreatesNewModel()
 	{
 		$relation = $this->getRelation();
-		$created = $this->getMock('Illuminate\Database\Eloquent\Model', array('save', 'getKey', 'setAttribute'));
+		$created = $this->getMock(Model::class, array('save', 'getKey', 'setAttribute'));
 		$created->expects($this->once())->method('save')->will($this->returnValue(true));
 		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('name' => 'taylor'))->andReturn($created);
 		$created->expects($this->once())->method('setAttribute')->with('foreign_key', 1);
@@ -51,7 +55,7 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 	public function testRelationIsProperlyInitialized()
 	{
 		$relation = $this->getRelation();
-		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model = m::mock(Model::class);
 		$model->shouldReceive('setRelation')->once()->with('foo', null);
 		$models = $relation->initRelation(array($model), 'foo');
 
@@ -98,19 +102,19 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 	public function testRelationCountQueryCanBeBuilt()
 	{
 		$relation = $this->getRelation();
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(EloquentBuilder::class);
 
-		$baseQuery = m::mock('Illuminate\Database\Query\Builder');
+		$baseQuery = m::mock(Builder::class);
 		$baseQuery->from = 'one';
-		$parentQuery = m::mock('Illuminate\Database\Query\Builder');
+		$parentQuery = m::mock(Builder::class);
 		$parentQuery->from = 'two';
 
 		$builder->shouldReceive('getQuery')->once()->andReturn($baseQuery);
 		$builder->shouldReceive('getQuery')->once()->andReturn($parentQuery);
 
-		$builder->shouldReceive('select')->once()->with(m::type('Illuminate\Database\Query\Expression'));
+		$builder->shouldReceive('select')->once()->with(m::type(Expression::class));
 		$relation->getParent()->shouldReceive('getTable')->andReturn('table');
-		$builder->shouldReceive('where')->once()->with('table.foreign_key', '=', m::type('Illuminate\Database\Query\Expression'));
+		$builder->shouldReceive('where')->once()->with('table.foreign_key', '=', m::type(Expression::class));
 		$relation->getQuery()->shouldReceive('getQuery')->andReturn($parentQuery = m::mock('StdClass'));
 		$parentQuery->shouldReceive('getGrammar')->once()->andReturn($grammar = m::mock('StdClass'));
 		$grammar->shouldReceive('wrap')->once()->with('table.id');
@@ -121,12 +125,12 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
 	protected function getRelation()
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(EloquentBuilder::class);
 		$builder->shouldReceive('whereNotNull')->with('table.foreign_key');
 		$builder->shouldReceive('where')->with('table.foreign_key', '=', 1);
-		$related = m::mock('Illuminate\Database\Eloquent\Model');
+		$related = m::mock(Model::class);
 		$builder->shouldReceive('getModel')->andReturn($related);
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent = m::mock(Model::class);
 		$parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 		$parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
 		$parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
@@ -136,6 +140,6 @@ class DatabaseEloquentHasOneTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class EloquentHasOneModelStub extends Illuminate\Database\Eloquent\Model {
+class EloquentHasOneModelStub extends Model {
 	public $foreign_key = 'foreign.value';
 }

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -1,9 +1,11 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 
@@ -61,7 +63,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 	{
 		// Doesn't matter which relation type we use since they share the code...
 		$relation = $this->getOneRelation();
-		$created = m::mock('Illuminate\Database\Eloquent\Model');
+		$created = m::mock(Model::class);
 		$created->shouldReceive('setAttribute')->once()->with('morph_id', 1);
 		$created->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
 		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('name' => 'taylor'))->andReturn($created);
@@ -73,7 +75,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 	public function testFindOrNewMethodFindsModel()
 	{
 		$relation = $this->getOneRelation();
-		$relation->getQuery()->shouldReceive('find')->once()->with('foo', array('*'))->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getQuery()->shouldReceive('find')->once()->with('foo', array('*'))->andReturn($model = m::mock(Model::class));
 		$relation->getRelated()->shouldReceive('newInstance')->never();
 		$model->shouldReceive('setAttribute')->never();
 		$model->shouldReceive('save')->never();
@@ -85,7 +87,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 	{
 		$relation = $this->getOneRelation();
 		$relation->getQuery()->shouldReceive('find')->once()->with('foo', array('*'))->andReturn(null);
-		$relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock(Model::class));
 		$model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
 		$model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
 		$model->shouldReceive('save')->never();
@@ -97,7 +99,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 	{
 		$relation = $this->getOneRelation();
 		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
-		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(Model::class));
 		$relation->getRelated()->shouldReceive('newInstance')->never();
 		$model->shouldReceive('setAttribute')->never();
 		$model->shouldReceive('save')->never();
@@ -110,7 +112,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getOneRelation();
 		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
 		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('foo'))->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('foo'))->andReturn($model = m::mock(Model::class));
 		$model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
 		$model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
 		$model->shouldReceive('save')->never();
@@ -122,7 +124,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 	{
 		$relation = $this->getOneRelation();
 		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
-		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(Model::class));
 		$relation->getRelated()->shouldReceive('newInstance')->never();
 		$model->shouldReceive('setAttribute')->never();
 		$model->shouldReceive('save')->never();
@@ -135,7 +137,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getOneRelation();
 		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
 		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('foo'))->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('foo'))->andReturn($model = m::mock(Model::class));
 		$model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
 		$model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
 		$model->shouldReceive('save')->once()->andReturn(true);
@@ -147,7 +149,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 	{
 		$relation = $this->getOneRelation();
 		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
-		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock(Model::class));
 		$relation->getRelated()->shouldReceive('newInstance')->never();
 		$model->shouldReceive('setAttribute')->never();
 		$model->shouldReceive('fill')->once()->with(array('bar'));
@@ -161,7 +163,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 		$relation = $this->getOneRelation();
 		$relation->getQuery()->shouldReceive('where')->once()->with(array('foo'))->andReturn($relation->getQuery());
 		$relation->getQuery()->shouldReceive('first')->once()->with()->andReturn(null);
-		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('foo'))->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$relation->getRelated()->shouldReceive('newInstance')->once()->with(array('foo'))->andReturn($model = m::mock(Model::class));
 		$model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
 		$model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
 		$model->shouldReceive('save')->once()->andReturn(true);
@@ -172,12 +174,12 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 
 	protected function getOneRelation()
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(EloquentBuilder::class);
 		$builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
 		$builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
-		$related = m::mock('Illuminate\Database\Eloquent\Model');
+		$related = m::mock(Model::class);
 		$builder->shouldReceive('getModel')->andReturn($related);
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent = m::mock(Model::class);
 		$parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 		$parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
 		$builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
@@ -187,12 +189,12 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 
 	protected function getManyRelation()
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(EloquentBuilder::class);
 		$builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
 		$builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
-		$related = m::mock('Illuminate\Database\Eloquent\Model');
+		$related = m::mock(Model::class);
 		$builder->shouldReceive('getModel')->andReturn($related);
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent = m::mock(Model::class);
 		$parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 		$parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
 		$builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
@@ -202,9 +204,9 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase {
 }
 
 
-class EloquentMorphResetModelStub extends Illuminate\Database\Eloquent\Model {}
+class EloquentMorphResetModelStub extends Model {}
 
 
-class EloquentMorphQueryStub extends Illuminate\Database\Query\Builder {
+class EloquentMorphQueryStub extends Builder {
 	public function __construct() {}
 }

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
@@ -26,7 +28,7 @@ class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testAttachInsertsPivotTableRecord()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\MorphToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock(MorphToMany::class, array('touchIfTouching'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
 		$query->shouldReceive('insert')->once()->with(array(array('taggable_id' => 1, 'taggable_type' => get_class($relation->getParent()), 'tag_id' => 2, 'foo' => 'bar')))->andReturn(true);
@@ -40,7 +42,7 @@ class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testDetachRemovesPivotTableRecord()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\MorphToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock(MorphToMany::class, array('touchIfTouching'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
@@ -57,7 +59,7 @@ class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function testDetachMethodClearsAllPivotRecordsWhenNoIDsAreGiven()
 	{
-		$relation = $this->getMock('Illuminate\Database\Eloquent\Relations\MorphToMany', array('touchIfTouching'), $this->getRelationArguments());
+		$relation = $this->getMock(MorphToMany::class, array('touchIfTouching'), $this->getRelationArguments());
 		$query = m::mock('stdClass');
 		$query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
@@ -82,15 +84,15 @@ class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
 
 	public function getRelationArguments()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent = m::mock(Model::class);
 		$parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
 		$parent->shouldReceive('getKey')->andReturn(1);
 		$parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
 		$parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
 		$parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
 
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
-		$related = m::mock('Illuminate\Database\Eloquent\Model');
+		$builder = m::mock(Builder::class);
+		$related = m::mock(Model::class);
 		$builder->shouldReceive('getModel')->andReturn($related);
 
 		$related->shouldReceive('getTable')->andReturn('tags');
@@ -106,6 +108,6 @@ class DatabaseEloquentMorphToManyTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class EloquentMorphToManyModelStub extends Illuminate\Database\Eloquent\Model {
+class EloquentMorphToManyModelStub extends Model {
 	protected $guarded = array();
 }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
@@ -57,8 +59,8 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 
 		$relation->addEagerConstraints(array($one, $two, $three));
 
-		$relation->shouldReceive('createModelByType')->once()->with('morph_type_1')->andReturn($firstQuery = m::mock('Illuminate\Database\Eloquent\Builder'));
-		$relation->shouldReceive('createModelByType')->once()->with('morph_type_2')->andReturn($secondQuery = m::mock('Illuminate\Database\Eloquent\Builder'));
+		$relation->shouldReceive('createModelByType')->once()->with('morph_type_1')->andReturn($firstQuery = m::mock(Builder::class));
+		$relation->shouldReceive('createModelByType')->once()->with('morph_type_2')->andReturn($secondQuery = m::mock(Builder::class));
 		$firstQuery->shouldReceive('getKeyName')->andReturn('id');
 		$secondQuery->shouldReceive('getKeyName')->andReturn('id');
 
@@ -83,7 +85,7 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 
 	public function testModelsWithSoftDeleteAreProperlyPulled()
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(Builder::class);
 
 		$relation = $this->getRelation(null, $builder);
 
@@ -96,12 +98,12 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 
 	public function testAssociateMethodSetsForeignKeyAndTypeOnModel()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent = m::mock(Model::class);
 		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
 
 		$relation = $this->getRelationAssociate($parent);
 
-		$associate = m::mock('Illuminate\Database\Eloquent\Model');
+		$associate = m::mock(Model::class);
 		$associate->shouldReceive('getKey')->once()->andReturn(1);
 		$associate->shouldReceive('getMorphClass')->once()->andReturn('Model');
 
@@ -115,7 +117,7 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 
 	public function testDissociateMethodDeletesUnsetsKeyAndTypeOnModel()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$parent = m::mock(Model::class);
 		$parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
 
 		$relation = $this->getRelation($parent);
@@ -130,9 +132,9 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 
 	protected function getRelationAssociate($parent)
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(Builder::class);
 		$builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
-		$related = m::mock('Illuminate\Database\Eloquent\Model');
+		$related = m::mock(Model::class);
 		$related->shouldReceive('getKey')->andReturn(1);
 		$related->shouldReceive('getTable')->andReturn('relation');
 		$builder->shouldReceive('getModel')->andReturn($related);
@@ -142,20 +144,20 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase {
 
 	public function getRelation($parent = null, $builder = null)
 	{
-		$builder = $builder ?: m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = $builder ?: m::mock(Builder::class);
 		$builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
-		$related = m::mock('Illuminate\Database\Eloquent\Model');
+		$related = m::mock(Model::class);
 		$related->shouldReceive('getKeyName')->andReturn('id');
 		$related->shouldReceive('getTable')->andReturn('relation');
 		$builder->shouldReceive('getModel')->andReturn($related);
 		$parent = $parent ?: new EloquentMorphToModelStub;
-		$morphTo = m::mock('Illuminate\Database\Eloquent\Relations\MorphTo[createModelByType]', array($builder, $parent, 'foreign_key', 'id', 'morph_type', 'relation'));
+		$morphTo = m::mock(MorphTo::class.'[createModelByType]', array($builder, $parent, 'foreign_key', 'id', 'morph_type', 'relation'));
 		return $morphTo;
 	}
 
 }
 
 
-class EloquentMorphToModelStub extends Illuminate\Database\Eloquent\Model {
+class EloquentMorphToModelStub extends Model {
 	public $foreign_key = 'foreign.value';
 }

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
@@ -13,7 +14,7 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 
 	public function testPropertiesAreSetCorrectly()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
+		$parent = m::mock(Model::class.'[getConnectionName]');
 		$parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
 		$pivot = new Pivot($parent, array('foo' => 'bar'), 'table', true);
 
@@ -24,7 +25,7 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testMutatorsAreCalledFromConstructor() {
-		$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
+		$parent = m::mock(Model::class.'[getConnectionName]');
 		$parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
 
 		$pivot = new DatabaseEloquentPivotTestMutatorStub($parent, array('foo' => 'bar'), 'table', true);
@@ -35,7 +36,7 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 
 	public function testPropertiesUnchangedAreNotDirty()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
+		$parent = m::mock(Model::class.'[getConnectionName]');
 		$parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
 		$pivot = new Pivot($parent, array('foo' => 'bar', 'shimy' => 'shake'), 'table', true);
 
@@ -45,7 +46,7 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 
 	public function testPropertiesChangedAreDirty()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
+		$parent = m::mock(Model::class.'[getConnectionName]');
 		$parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
 		$pivot = new Pivot($parent, array('foo' => 'bar', 'shimy' => 'shake'), 'table', true);
 		$pivot->shimy = 'changed';
@@ -56,7 +57,7 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 
 	public function testTimestampPropertyIsSetIfCreatedAtInAttributes()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName,getDates]');
+		$parent = m::mock(Model::class.'[getConnectionName,getDates]');
 		$parent->shouldReceive('getConnectionName')->andReturn('connection');
 		$parent->shouldReceive('getDates')->andReturn(array());
 		$pivot = new DatabaseEloquentPivotTestDateStub($parent, array('foo' => 'bar', 'created_at' => 'foo'), 'table');
@@ -69,7 +70,7 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 
 	public function testKeysCanBeSetProperly()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
+		$parent = m::mock(Model::class.'[getConnectionName]');
 		$parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
 		$pivot = new Pivot($parent, array('foo' => 'bar'), 'table');
 		$pivot->setPivotKeys('foreign', 'other');
@@ -81,10 +82,10 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 
 	public function testDeleteMethodDeletesModelByKeys()
 	{
-		$parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
+		$parent = m::mock(Model::class.'[getConnectionName]');
 		$parent->guard(array());
 		$parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
-		$pivot = $this->getMock('Illuminate\Database\Eloquent\Relations\Pivot', array('newQuery'), array($parent, array('foo' => 'bar'), 'table'));
+		$pivot = $this->getMock(Pivot::class, array('newQuery'), array($parent, array('foo' => 'bar'), 'table'));
 		$pivot->setPivotKeys('foreign', 'other');
 		$pivot->foreign = 'foreign.value';
 		$pivot->other = 'other.value';
@@ -100,14 +101,14 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase {
 }
 
 
-class DatabaseEloquentPivotTestDateStub extends Illuminate\Database\Eloquent\Relations\Pivot {
+class DatabaseEloquentPivotTestDateStub extends Pivot {
 	public function getDates()
 	{
 		return array();
 	}
 }
 
-class DatabaseEloquentPivotTestMutatorStub extends Illuminate\Database\Eloquent\Relations\Pivot {
+class DatabaseEloquentPivotTestMutatorStub extends Pivot {
 	private $mutatorCalled = false;
 
 	public function setFooAttribute($value) {

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -1,7 +1,14 @@
 <?php
 
 use Mockery as m;
+use Carbon\Carbon;
+use Illuminate\Database\Grammar;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 
 class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
 
@@ -23,8 +30,8 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
 
 	public function testTouchMethodUpdatesRelatedTimestamps()
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
-		$parent = m::mock('Illuminate\Database\Eloquent\Model');
+		$builder = m::mock(EloquentBuilder::class);
+		$parent = m::mock(Model::class);
 		$parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
 		$builder->shouldReceive('getModel')->andReturn($related = m::mock('StdClass'));
 		$builder->shouldReceive('whereNotNull');
@@ -32,8 +39,8 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
 		$relation = new HasOne($builder, $parent, 'foreign_key', 'id');
 		$related->shouldReceive('getTable')->andReturn('table');
 		$related->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-		$related->shouldReceive('freshTimestampString')->andReturn(Carbon\Carbon::now());
-		$builder->shouldReceive('update')->once()->with(array('updated_at' => Carbon\Carbon::now()));
+		$related->shouldReceive('freshTimestampString')->andReturn(Carbon::now());
+		$builder->shouldReceive('update')->once()->with(array('updated_at' => Carbon::now()));
 
 		$relation->touch();
 	}
@@ -47,10 +54,10 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
 	public function testDonNotRunParentModelGlobalScopes()
 	{
 		/** @var Mockery\MockInterface $parent */
-		$eloquentBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
-		$queryBuilder = m::mock('Illuminate\Database\Query\Builder');
+		$eloquentBuilder = m::mock(EloquentBuilder::class);
+		$queryBuilder = m::mock(Builder::class);
 		$parent = m::mock('EloquentRelationResetModelStub')->makePartial();
-		$grammar = m::mock('\Illuminate\Database\Grammar');
+		$grammar = m::mock(Grammar::class);
 
 		$eloquentBuilder->shouldReceive('getModel')->andReturn($related = m::mock('StdClass'));
 		$eloquentBuilder->shouldReceive('getQuery')->andReturn($queryBuilder);
@@ -67,7 +74,7 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class EloquentRelationResetModelStub extends Illuminate\Database\Eloquent\Model {
+class EloquentRelationResetModelStub extends Model {
 	//Override method call which would normally go through __call()
 	public function getQuery()
 	{
@@ -76,10 +83,10 @@ class EloquentRelationResetModelStub extends Illuminate\Database\Eloquent\Model 
 }
 
 
-class EloquentRelationStub extends \Illuminate\Database\Eloquent\Relations\Relation {
+class EloquentRelationStub extends Relation {
 	public function addConstraints() {}
 	public function addEagerConstraints(array $models) {}
 	public function initRelation(array $models, $relation) {}
-	public function match(array $models, \Illuminate\Database\Eloquent\Collection $results, $relation) {}
+	public function match(array $models, Collection $results, $relation) {}
 	public function getResults() {}
 }

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\Migrations\MigrationCreator;
 
 class DatabaseMigrationCreatorTest extends PHPUnit_Framework_TestCase {
@@ -52,9 +53,9 @@ class DatabaseMigrationCreatorTest extends PHPUnit_Framework_TestCase {
 
 	protected function getCreator()
 	{
-		$files = m::mock('Illuminate\Filesystem\Filesystem');
+		$files = m::mock(Filesystem::class);
 
-		return $this->getMock('Illuminate\Database\Migrations\MigrationCreator', array('getDatePrefix'), array($files));
+		return $this->getMock(MigrationCreator::class, array('getDatePrefix'), array($files));
 	}
 
 }

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -1,6 +1,11 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Foundation\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Illuminate\Database\Console\Migrations\InstallCommand;
+use Illuminate\Database\Migrations\MigrationRepositoryInterface;
 
 class DatabaseMigrationInstallCommandTest extends PHPUnit_Framework_TestCase {
 
@@ -12,8 +17,8 @@ class DatabaseMigrationInstallCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testFireCallsRepositoryToInstall()
 	{
-		$command = new Illuminate\Database\Console\Migrations\InstallCommand($repo = m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'));
-		$command->setLaravel(new Illuminate\Foundation\Application);
+		$command = new InstallCommand($repo = m::mock(MigrationRepositoryInterface::class));
+		$command->setLaravel(new Application);
 		$repo->shouldReceive('setSource')->once()->with('foo');
 		$repo->shouldReceive('createRepository')->once();
 
@@ -23,7 +28,7 @@ class DatabaseMigrationInstallCommandTest extends PHPUnit_Framework_TestCase {
 
 	protected function runCommand($command, $options = array())
 	{
-		return $command->run(new Symfony\Component\Console\Input\ArrayInput($options), new Symfony\Component\Console\Output\NullOutput);
+		return $command->run(new ArrayInput($options), new NullOutput);
 	}
 
 }

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -1,6 +1,11 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Foundation\Composer;
+use Illuminate\Foundation\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 
 class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
@@ -13,11 +18,11 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 	public function testBasicCreateDumpsAutoload()
 	{
 		$command = new MigrateMakeCommand(
-			$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-			$composer = m::mock('Illuminate\Foundation\Composer'),
+			$creator = m::mock(MigrationCreator::class),
+			$composer = m::mock(Composer::class),
 			__DIR__.'/vendor'
 		);
-		$app = new Illuminate\Foundation\Application;
+		$app = new Application;
 		$app->useDatabasePath(__DIR__);
 		$command->setLaravel($app);
 		$creator->shouldReceive('create')->once()->with('create_foo', __DIR__.'/migrations', null, false);
@@ -29,11 +34,11 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 	public function testBasicCreateGivesCreatorProperArguments()
 	{
 		$command = new MigrateMakeCommand(
-			$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-			m::mock('Illuminate\Foundation\Composer')->shouldIgnoreMissing(),
+			$creator = m::mock(MigrationCreator::class),
+			m::mock(Composer::class)->shouldIgnoreMissing(),
 			__DIR__.'/vendor'
 		);
-		$app = new Illuminate\Foundation\Application;
+		$app = new Application;
 		$app->useDatabasePath(__DIR__);
 		$command->setLaravel($app);
 		$creator->shouldReceive('create')->once()->with('create_foo', __DIR__.'/migrations', null, false);
@@ -45,11 +50,11 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 	public function testBasicCreateGivesCreatorProperArgumentsWhenTableIsSet()
 	{
 		$command = new MigrateMakeCommand(
-			$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
-			m::mock('Illuminate\Foundation\Composer')->shouldIgnoreMissing(),
+			$creator = m::mock(MigrationCreator::class),
+			m::mock(Composer::class)->shouldIgnoreMissing(),
 			__DIR__.'/vendor'
 		);
-		$app = new Illuminate\Foundation\Application;
+		$app = new Application;
 		$app->useDatabasePath(__DIR__);
 		$command->setLaravel($app);
 		$creator->shouldReceive('create')->once()->with('create_foo', __DIR__.'/migrations', 'users', true);
@@ -60,7 +65,7 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase {
 
 	protected function runCommand($command, $input = array())
 	{
-		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+		return $command->run(new ArrayInput($input), new NullOutput);
 	}
 
 }

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -2,6 +2,9 @@
 
 use Mockery as m;
 use Illuminate\Foundation\Application;
+use Illuminate\Database\Migrations\Migrator;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 
 class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase {
@@ -14,7 +17,7 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testBasicMigrationsCallMigratorWithProperArguments()
 	{
-		$command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+		$command = new MigrateCommand($migrator = m::mock(Migrator::class), __DIR__.'/vendor');
 		$app = new ApplicationDatabaseMigrationStub(array('path.database' => __DIR__));
 		$app->useDatabasePath(__DIR__);
 		$command->setLaravel($app);
@@ -29,8 +32,8 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testMigrationRepositoryCreatedWhenNecessary()
 	{
-		$params = array($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
-		$command = $this->getMock('Illuminate\Database\Console\Migrations\MigrateCommand', array('call'), $params);
+		$params = array($migrator = m::mock(Migrator::class), __DIR__.'/vendor');
+		$command = $this->getMock(MigrateCommand::class, array('call'), $params);
 		$app = new ApplicationDatabaseMigrationStub(array('path.database' => __DIR__));
 		$app->useDatabasePath(__DIR__);
 		$command->setLaravel($app);
@@ -46,7 +49,7 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testTheCommandMayBePretended()
 	{
-		$command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+		$command = new MigrateCommand($migrator = m::mock(Migrator::class), __DIR__.'/vendor');
 		$app = new ApplicationDatabaseMigrationStub(array('path.database' => __DIR__));
 		$app->useDatabasePath(__DIR__);
 		$command->setLaravel($app);
@@ -61,7 +64,7 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testTheDatabaseMayBeSet()
 	{
-		$command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+		$command = new MigrateCommand($migrator = m::mock(Migrator::class), __DIR__.'/vendor');
 		$app = new ApplicationDatabaseMigrationStub(array('path.database' => __DIR__));
 		$app->useDatabasePath(__DIR__);
 		$command->setLaravel($app);
@@ -76,7 +79,7 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase {
 
 	protected function runCommand($command, $input = array())
 	{
-		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+		return $command->run(new ArrayInput($input), new NullOutput);
 	}
 
 }

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Migrations\DatabaseMigrationRepository;
 
 class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
@@ -15,7 +17,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 	{
 		$repo = $this->getRepository();
 		$query = m::mock('stdClass');
-		$connectionMock = m::mock('Illuminate\Database\Connection');
+		$connectionMock = m::mock(Connection::class);
 		$repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
 		$repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
 		$query->shouldReceive('lists')->once()->with('migration')->andReturn('bar');
@@ -26,12 +28,12 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetLastMigrationsGetsAllMigrationsWithTheLatestBatchNumber()
 	{
-		$repo = $this->getMock('Illuminate\Database\Migrations\DatabaseMigrationRepository', array('getLastBatchNumber'), array(
-			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'), 'migrations'
+		$repo = $this->getMock(DatabaseMigrationRepository::class, array('getLastBatchNumber'), array(
+			$resolver = m::mock(ConnectionResolverInterface::class), 'migrations'
 		));
 		$repo->expects($this->once())->method('getLastBatchNumber')->will($this->returnValue(1));
 		$query = m::mock('stdClass');
-		$connectionMock = m::mock('Illuminate\Database\Connection');
+		$connectionMock = m::mock(Connection::class);
 		$repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
 		$repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('batch', 1)->andReturn($query);
@@ -46,7 +48,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 	{
 		$repo = $this->getRepository();
 		$query = m::mock('stdClass');
-		$connectionMock = m::mock('Illuminate\Database\Connection');
+		$connectionMock = m::mock(Connection::class);
 		$repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
 		$repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
 		$query->shouldReceive('insert')->once()->with(array('migration' => 'bar', 'batch' => 1));
@@ -59,7 +61,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 	{
 		$repo = $this->getRepository();
 		$query = m::mock('stdClass');
-		$connectionMock = m::mock('Illuminate\Database\Connection');
+		$connectionMock = m::mock(Connection::class);
 		$repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
 		$repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
 		$query->shouldReceive('where')->once()->with('migration', 'foo')->andReturn($query);
@@ -72,8 +74,8 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetNextBatchNumberReturnsLastBatchNumberPlusOne()
 	{
-		$repo = $this->getMock('Illuminate\Database\Migrations\DatabaseMigrationRepository', array('getLastBatchNumber'), array(
-			m::mock('Illuminate\Database\ConnectionResolverInterface'), 'migrations'
+		$repo = $this->getMock(DatabaseMigrationRepository::class, array('getLastBatchNumber'), array(
+			m::mock(ConnectionResolverInterface::class), 'migrations'
 		));
 		$repo->expects($this->once())->method('getLastBatchNumber')->will($this->returnValue(1));
 
@@ -85,7 +87,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 	{
 		$repo = $this->getRepository();
 		$query = m::mock('stdClass');
-		$connectionMock = m::mock('Illuminate\Database\Connection');
+		$connectionMock = m::mock(Connection::class);
 		$repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
 		$repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
 		$query->shouldReceive('max')->once()->andReturn(1);
@@ -98,7 +100,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 	{
 		$repo = $this->getRepository();
 		$schema = m::mock('stdClass');
-		$connectionMock = m::mock('Illuminate\Database\Connection');
+		$connectionMock = m::mock(Connection::class);
 		$repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
 		$repo->getConnection()->shouldReceive('getSchemaBuilder')->once()->andReturn($schema);
 		$schema->shouldReceive('create')->once()->with('migrations', m::type('Closure'));
@@ -109,7 +111,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase {
 
 	protected function getRepository()
 	{
-		return new DatabaseMigrationRepository(m::mock('Illuminate\Database\ConnectionResolverInterface'), 'migrations');
+		return new DatabaseMigrationRepository(m::mock(ConnectionResolverInterface::class), 'migrations');
 	}
 
 }

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -1,6 +1,10 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Foundation\Application;
+use Illuminate\Database\Migrations\Migrator;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Illuminate\Database\Console\Migrations\ResetCommand;
 
 class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
@@ -13,7 +17,7 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testResetCommandCallsMigratorWithProperArguments()
 	{
-		$command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
+		$command = new ResetCommand($migrator = m::mock(Migrator::class));
 		$command->setLaravel(new AppDatabaseMigrationStub());
 		$migrator->shouldReceive('setConnection')->once()->with(null);
 		$migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
@@ -26,8 +30,8 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testResetCommandCanBePretended()
 	{
-		$command = new ResetCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
-		$command->setLaravel(new AppDatabaseMigrationStub());
+		$command = new ResetCommand($migrator = m::mock(Migrator::class));
+		$command->setLaravel(new AppDatabaseMigrationStub);
 		$migrator->shouldReceive('setConnection')->once()->with('foo');
 		$migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 		$migrator->shouldReceive('reset')->once()->with(true);
@@ -39,11 +43,11 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase {
 
 	protected function runCommand($command, $input = array())
 	{
-		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+		return $command->run(new ArrayInput($input), new NullOutput);
 	}
 
 }
 
-class AppDatabaseMigrationStub extends \Illuminate\Foundation\Application {
+class AppDatabaseMigrationStub extends Application {
 	public function environment() { return 'development'; }
 }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -2,6 +2,9 @@
 
 use Mockery as m;
 use Illuminate\Foundation\Application;
+use Illuminate\Database\Migrations\Migrator;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Illuminate\Database\Console\Migrations\RollbackCommand;
 
 class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase {
@@ -14,8 +17,8 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testRollbackCommandCallsMigratorWithProperArguments()
 	{
-		$command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
-		$command->setLaravel(new AppDatabaseMigrationRollbackStub());
+		$command = new RollbackCommand($migrator = m::mock(Migrator::class));
+		$command->setLaravel(new AppDatabaseMigrationRollbackStub);
 		$migrator->shouldReceive('setConnection')->once()->with(null);
 		$migrator->shouldReceive('rollback')->once()->with(false);
 		$migrator->shouldReceive('getNotes')->andReturn(array());
@@ -26,8 +29,8 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase {
 
 	public function testRollbackCommandCanBePretended()
 	{
-		$command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
-		$command->setLaravel(new AppDatabaseMigrationRollbackStub());
+		$command = new RollbackCommand($migrator = m::mock(Migrator::class));
+		$command->setLaravel(new AppDatabaseMigrationRollbackStub);
 		$migrator->shouldReceive('setConnection')->once()->with('foo');
 		$migrator->shouldReceive('rollback')->once()->with(true);
 		$migrator->shouldReceive('getNotes')->andReturn(array());
@@ -38,7 +41,7 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase {
 
 	protected function runCommand($command, $input = array())
 	{
-		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+		return $command->run(new ArrayInput($input), new NullOutput);
 	}
 
 }

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -1,6 +1,10 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Migrations\MigrationRepositoryInterface;
 
 class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 
@@ -12,10 +16,10 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 
 	public function testMigrationAreRunUpWhenOutstandingMigrationsExist()
 	{
-		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
-			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
-			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
-			m::mock('Illuminate\Filesystem\Filesystem'),
+		$migrator = $this->getMock(Migrator::class, array('resolve'), array(
+			m::mock(MigrationRepositoryInterface::class),
+			$resolver = m::mock(ConnectionResolverInterface::class),
+			m::mock(Filesystem::class),
 		));
 		$migrator->getFilesystem()->shouldReceive('glob')->once()->with(__DIR__.'/*_*.php')->andReturn(array(
 			__DIR__.'/2_bar.php',
@@ -46,10 +50,10 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 
 	public function testUpMigrationCanBePretended()
 	{
-		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
-			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
-			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
-			m::mock('Illuminate\Filesystem\Filesystem'),
+		$migrator = $this->getMock(Migrator::class, array('resolve'), array(
+			m::mock(MigrationRepositoryInterface::class),
+			$resolver = m::mock(ConnectionResolverInterface::class),
+			m::mock(Filesystem::class),
 		));
 		$migrator->getFilesystem()->shouldReceive('glob')->once()->with(__DIR__.'/*_*.php')->andReturn(array(
 			__DIR__.'/2_bar.php',
@@ -94,10 +98,10 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 
 	public function testNothingIsDoneWhenNoMigrationsAreOutstanding()
 	{
-		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
-			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
-			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
-			m::mock('Illuminate\Filesystem\Filesystem'),
+		$migrator = $this->getMock(Migrator::class, array('resolve'), array(
+			m::mock(MigrationRepositoryInterface::class),
+			$resolver = m::mock(ConnectionResolverInterface::class),
+			m::mock(Filesystem::class),
 		));
 		$migrator->getFilesystem()->shouldReceive('glob')->once()->with(__DIR__.'/*_*.php')->andReturn(array(
 			__DIR__.'/1_foo.php',
@@ -113,10 +117,10 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 
 	public function testLastBatchOfMigrationsCanBeRolledBack()
 	{
-		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
-			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
-			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
-			m::mock('Illuminate\Filesystem\Filesystem'),
+		$migrator = $this->getMock(Migrator::class, array('resolve'), array(
+			m::mock(MigrationRepositoryInterface::class),
+			$resolver = m::mock(ConnectionResolverInterface::class),
+			m::mock(Filesystem::class),
 		));
 		$migrator->getRepository()->shouldReceive('getLast')->once()->andReturn(array(
 			$fooMigration = new MigratorTestMigrationStub('foo'),
@@ -141,10 +145,10 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 
 	public function testRollbackMigrationsCanBePretended()
 	{
-		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
-			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
-			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
-			m::mock('Illuminate\Filesystem\Filesystem'),
+		$migrator = $this->getMock(Migrator::class, array('resolve'), array(
+			m::mock(MigrationRepositoryInterface::class),
+			$resolver = m::mock(ConnectionResolverInterface::class),
+			m::mock(Filesystem::class),
 		));
 		$migrator->getRepository()->shouldReceive('getLast')->once()->andReturn(array(
 			$fooMigration = new MigratorTestMigrationStub('foo'),
@@ -181,10 +185,10 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 
 	public function testNothingIsRolledBackWhenNothingInRepository()
 	{
-		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', array('resolve'), array(
-			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
-			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
-			m::mock('Illuminate\Filesystem\Filesystem'),
+		$migrator = $this->getMock(Migrator::class, array('resolve'), array(
+			m::mock(MigrationRepositoryInterface::class),
+			$resolver = m::mock(ConnectionResolverInterface::class),
+			m::mock(Filesystem::class),
 		));
 		$migrator->getRepository()->shouldReceive('getLast')->once()->andReturn(array());
 
@@ -194,10 +198,10 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 
 	public function testResettingMigrationsRollsBackAllMigrations()
 	{
-		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', ['resolve'], [
-			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
-			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
-			m::mock('Illuminate\Filesystem\Filesystem'),
+		$migrator = $this->getMock(Migrator::class, ['resolve'], [
+			m::mock(MigrationRepositoryInterface::class),
+			$resolver = m::mock(ConnectionResolverInterface::class),
+			m::mock(Filesystem::class),
 		]);
 
 		$fooMigration = (object) ['migration' => 'foo'];
@@ -233,10 +237,10 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 
 	public function testResetMigrationsCanBePretended()
 	{
-		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', ['resolve'], [
-			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
-			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
-			m::mock('Illuminate\Filesystem\Filesystem'),
+		$migrator = $this->getMock(Migrator::class, ['resolve'], [
+			m::mock(MigrationRepositoryInterface::class),
+			$resolver = m::mock(ConnectionResolverInterface::class),
+			m::mock(Filesystem::class),
 		]);
 
 		$fooMigration = (object) ['migration' => 'foo'];
@@ -289,10 +293,10 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase {
 
 	public function testNothingIsResetBackWhenNothingInRepository()
 	{
-		$migrator = $this->getMock('Illuminate\Database\Migrations\Migrator', ['resolve'], [
-			m::mock('Illuminate\Database\Migrations\MigrationRepositoryInterface'),
-			$resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
-			m::mock('Illuminate\Filesystem\Filesystem'),
+		$migrator = $this->getMock(Migrator::class, ['resolve'], [
+			m::mock(MigrationRepositoryInterface::class),
+			$resolver = m::mock(ConnectionResolverInterface::class),
+			m::mock(Filesystem::class),
 		]);
 		$migrator->getRepository()->shouldReceive('getRan')->once()->andReturn([]);
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1,7 +1,10 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 
 class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
@@ -305,7 +308,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('alter table `users` add `foo` varchar(100) null default \'bar\'', $statements[0]);
 
 		$blueprint = new Blueprint('users');
-		$blueprint->string('foo', 100)->nullable()->default(new Illuminate\Database\Query\Expression('CURRENT TIMESTAMP'));
+		$blueprint->string('foo', 100)->nullable()->default(new Expression('CURRENT TIMESTAMP'));
 		$statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
 		$this->assertEquals(1, count($statements));
@@ -609,13 +612,13 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 	protected function getConnection()
 	{
-		return m::mock('Illuminate\Database\Connection');
+		return m::mock(Connection::class);
 	}
 
 
 	public function getGrammar()
 	{
-		return new Illuminate\Database\Schema\Grammars\MySqlGrammar;
+		return new MySqlGrammar;
 	}
 
 }

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 
 class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
@@ -498,13 +500,13 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 	protected function getConnection()
 	{
-		return m::mock('Illuminate\Database\Connection');
+		return m::mock(Connection::class);
 	}
 
 
 	public function getGrammar()
 	{
-		return new Illuminate\Database\Schema\Grammars\PostgresGrammar;
+		return new PostgresGrammar;
 	}
 
 }

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Processors\Processor;
 
 class DatabaseProcessorTest extends PHPUnit_Framework_TestCase {
 
@@ -14,13 +17,12 @@ class DatabaseProcessorTest extends PHPUnit_Framework_TestCase {
 	{
 		$pdo = $this->getMock('ProcessorTestPDOStub');
 		$pdo->expects($this->once())->method('lastInsertId')->with($this->equalTo('id'))->will($this->returnValue('1'));
-		$connection = m::mock('Illuminate\Database\Connection');
+		$connection = m::mock(Connection::class);
 		$connection->shouldReceive('insert')->once()->with('sql', array('foo'));
 		$connection->shouldReceive('getPdo')->once()->andReturn($pdo);
-		$builder = m::mock('Illuminate\Database\Query\Builder');
+		$builder = m::mock(Builder::class);
 		$builder->shouldReceive('getConnection')->andReturn($connection);
-		$processor = new Illuminate\Database\Query\Processors\Processor;
-		$result = $processor->processInsertGetId($builder, 'sql', array('foo'), 'id');
+		$result = (new Processor)->processInsertGetId($builder, 'sql', array('foo'), 'id');
 		$this->assertSame(1, $result);
 	}
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2,7 +2,15 @@
 
 use Mockery as m;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Expression as Raw;
+use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Database\Query\Grammars\MySqlGrammar;
+use Illuminate\Database\Query\Grammars\SQLiteGrammar;
+use Illuminate\Database\Query\Grammars\PostgresGrammar;
+use Illuminate\Database\Query\Grammars\SqlServerGrammar;
+use Illuminate\Database\Query\Processors\MySqlProcessor;
 
 class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 
@@ -912,7 +920,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$builder = $this->getBuilder();
 		$builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email", "bar") values (?, bar)', array('foo'), 'id')->andReturn(1);
-		$result = $builder->from('users')->insertGetId(array('email' => 'foo', 'bar' => new Illuminate\Database\Query\Expression('bar')), 'id');
+		$result = $builder->from('users')->insertGetId(array('email' => 'foo', 'bar' => new Raw('bar')), 'id');
 		$this->assertEquals(1, $result);
 	}
 
@@ -1019,7 +1027,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 		$builder->getConnection()->shouldReceive('statement')->once()->with('truncate "users"', array());
 		$builder->from('users')->truncate();
 
-		$sqlite = new Illuminate\Database\Query\Grammars\SQLiteGrammar;
+		$sqlite = new SQLiteGrammar;
 		$builder = $this->getBuilder();
 		$builder->from('users');
 		$this->assertEquals(array(
@@ -1096,7 +1104,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$method     = 'whereFooBarAndBazOrQux';
 		$parameters = array('corge', 'waldo', 'fred');
-		$builder    = m::mock('Illuminate\Database\Query\Builder')->makePartial();
+		$builder    = m::mock(Builder::class)->makePartial();
 
 		$builder->shouldReceive('where')->with('foo_bar', '=', $parameters[0], 'and')->once()->andReturn($builder);
 		$builder->shouldReceive('where')->with('baz', '=', $parameters[1], 'and')->once()->andReturn($builder);
@@ -1110,7 +1118,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 	{
 		$method     = 'whereIosVersionAndAndroidVersionOrOrientation';
 		$parameters = array('6.1', '4.2', 'Vertical');
-		$builder    = m::mock('Illuminate\Database\Query\Builder')->makePartial();
+		$builder    = m::mock(Builder::class)->makePartial();
 
 		$builder->shouldReceive('where')->with('ios_version', '=', '6.1', 'and')->once()->andReturn($builder);
 		$builder->shouldReceive('where')->with('android_version', '=', '4.2', 'and')->once()->andReturn($builder);
@@ -1142,14 +1150,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 
 	public function setupCacheTestQuery($cache, $driver)
 	{
-		$connection = m::mock('Illuminate\Database\ConnectionInterface');
+		$connection = m::mock(ConnectionInterface::class);
 		$connection->shouldReceive('getName')->andReturn('connection_name');
 		$connection->shouldReceive('getCacheManager')->once()->andReturn($cache);
 		$cache->shouldReceive('driver')->once()->andReturn($driver);
-		$grammar = new Illuminate\Database\Query\Grammars\Grammar;
-		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
+		$grammar = new Grammar;
+		$processor = m::mock(Processor::class);
 
-		$builder = $this->getMock('Illuminate\Database\Query\Builder', array('getFresh'), array($connection, $grammar, $processor));
+		$builder = $this->getMock(Builder::class, array('getFresh'), array($connection, $grammar, $processor));
 		$builder->expects($this->once())->method('getFresh')->with($this->equalTo(array('*')))->will($this->returnValue(array('results')));
 		return $builder->select('*')->from('users')->where('email', 'foo@bar.com');
 	}
@@ -1279,49 +1287,49 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase {
 
 	protected function getBuilder()
 	{
-		$grammar = new Illuminate\Database\Query\Grammars\Grammar;
-		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
-		return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+		$grammar = new Grammar;
+		$processor = m::mock(Processor::class);
+		return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
 	}
 
 
 	protected function getPostgresBuilder()
 	{
-		$grammar = new Illuminate\Database\Query\Grammars\PostgresGrammar;
-		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
-		return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+		$grammar = new PostgresGrammar;
+		$processor = m::mock(Processor::class);
+		return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
 	}
 
 
 	protected function getMySqlBuilder()
 	{
-		$grammar = new Illuminate\Database\Query\Grammars\MySqlGrammar;
-		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
-		return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+		$grammar = new MySqlGrammar;
+		$processor = m::mock(Processor::class);
+		return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
 	}
 
 
 	protected function getSQLiteBuilder()
 	{
-		$grammar = new Illuminate\Database\Query\Grammars\SQLiteGrammar;
-		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
-		return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+		$grammar = new SQLiteGrammar;
+		$processor = m::mock(Processor::class);
+		return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
 	}
 
 
 	protected function getSqlServerBuilder()
 	{
-		$grammar = new Illuminate\Database\Query\Grammars\SqlServerGrammar;
-		$processor = m::mock('Illuminate\Database\Query\Processors\Processor');
-		return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+		$grammar = new SqlServerGrammar;
+		$processor = m::mock(Processor::class);
+		return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
 	}
 
 
 	protected function getMySqlBuilderWithProcessor()
 	{
-		$grammar = new Illuminate\Database\Query\Grammars\MySqlGrammar;
-		$processor = new Illuminate\Database\Query\Processors\MySqlProcessor;
-		return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
+		$grammar = new MySqlGrammar;
+		$processor = new MySqlProcessor;
+		return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
 	}
 
 }

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
 
 class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
@@ -455,13 +457,13 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 	protected function getConnection()
 	{
-		return m::mock('Illuminate\Database\Connection');
+		return m::mock(Connection::class);
 	}
 
 
 	public function getGrammar()
 	{
-		return new Illuminate\Database\Schema\Grammars\SQLiteGrammar;
+		return new SQLiteGrammar;
 	}
 
 }

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Grammars\MySqlGrammar;
 
 class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase {
 
@@ -13,11 +15,11 @@ class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase {
 
 	public function testToSqlRunsCommandsFromBlueprint()
 	{
-		$conn = m::mock('Illuminate\Database\Connection');
+		$conn = m::mock(Connection::class);
 		$conn->shouldReceive('statement')->once()->with('foo');
 		$conn->shouldReceive('statement')->once()->with('bar');
-		$grammar = m::mock('Illuminate\Database\Schema\Grammars\MySqlGrammar');
-		$blueprint = $this->getMock('Illuminate\Database\Schema\Blueprint', array('toSql'), array('users'));
+		$grammar = m::mock(MySqlGrammar::class);
+		$blueprint = $this->getMock(Blueprint::class, array('toSql'), array('users'));
 		$blueprint->expects($this->once())->method('toSql')->with($this->equalTo($conn), $this->equalTo($grammar))->will($this->returnValue(array('foo', 'bar')));
 
 		$blueprint->build($conn, $grammar);

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Builder;
 
 class DatabaseSchemaBuilderTest extends PHPUnit_Framework_TestCase {
@@ -13,7 +14,7 @@ class DatabaseSchemaBuilderTest extends PHPUnit_Framework_TestCase {
 
 	public function testHasTableCorrectlyCallsGrammar()
 	{
-		$connection = m::mock('Illuminate\Database\Connection');
+		$connection = m::mock(Connection::class);
 		$grammar = m::mock('StdClass');
 		$connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
 		$builder = new Builder($connection);
@@ -27,10 +28,10 @@ class DatabaseSchemaBuilderTest extends PHPUnit_Framework_TestCase {
 
 	public function testTableHasColumns()
     	{
-        	$connection = m::mock('Illuminate\Database\Connection');
+        	$connection = m::mock(Connection::class);
         	$grammar = m::mock('StdClass');
         	$connection->shouldReceive('getSchemaGrammar')->andReturn($grammar);
-        	$builder = m::mock('Illuminate\Database\Schema\Builder[getColumnListing]', array($connection));
+        	$builder = m::mock(Builder::class.'[getColumnListing]', array($connection));
         	$builder->shouldReceive('getColumnListing')->with('users')->twice()->andReturn(array('id', 'firstname'));
 
         	$this->assertTrue($builder->hasColumns('users', array('id', 'firstname')));

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -1,7 +1,10 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Console\Command;
 use Illuminate\Database\Seeder;
+use Illuminate\Container\Container;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class DatabaseSeederTest extends PHPUnit_Framework_TestCase {
 
@@ -14,10 +17,10 @@ class DatabaseSeederTest extends PHPUnit_Framework_TestCase {
 	public function testCallResolveTheClassAndCallsRun()
 	{
 		$seeder = new Seeder;
-		$seeder->setContainer($container = m::mock('Illuminate\Container\Container'));
-		$output = m::mock('Symfony\Component\Console\Output\OutputInterface');
+		$seeder->setContainer($container = m::mock(Container::class));
+		$output = m::mock(OutputInterface::class);
 		$output->shouldReceive('writeln')->once()->andReturn('foo');
-		$command = m::mock('Illuminate\Console\Command');
+		$command = m::mock(Command::class);
 		$command->shouldReceive('getOutput')->once()->andReturn($output);
 		$seeder->setCommand($command);
 		$container->shouldReceive('make')->once()->with('ClassName')->andReturn($child = m::mock('StdClass'));
@@ -32,7 +35,7 @@ class DatabaseSeederTest extends PHPUnit_Framework_TestCase {
 	public function testSetContainer()
 	{
 		$seeder = new Seeder;
-		$container = m::mock('Illuminate\Container\Container');
+		$container = m::mock(Container::class);
 		$this->assertEquals($seeder->setContainer($container), $seeder);
 	}
 
@@ -40,7 +43,7 @@ class DatabaseSeederTest extends PHPUnit_Framework_TestCase {
 	public function testSetCommand()
 	{
 		$seeder = new Seeder;
-		$command = m::mock('Illuminate\Console\Command');
+		$command = m::mock(Command::class);
 		$this->assertEquals($seeder->setCommand($command), $seeder);
 	}
 

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase {
 
@@ -12,9 +15,9 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase {
 
 	public function testApplyingScopeToABuilder()
 	{
-		$scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[extend]');
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
-		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$scope = m::mock(SoftDeletingScope::class.'[extend]');
+		$builder = m::mock(Builder::class);
+		$model = m::mock(Model::class);
 		$model->shouldReceive('getQualifiedDeletedAtColumn')->once()->andReturn('table.deleted_at');
 		$builder->shouldReceive('whereNull')->once()->with('table.deleted_at');
 		$scope->shouldReceive('extend')->once();
@@ -25,9 +28,9 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase {
 
 	public function testScopeCanRemoveDeletedAtConstraints()
 	{
-		$scope = new Illuminate\Database\Eloquent\SoftDeletingScope;
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
-		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$scope = new SoftDeletingScope;
+		$builder = m::mock(Builder::class);
+		$model = m::mock(Model::class);
 		$builder->shouldReceive('getModel')->andReturn($model);
 		$model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
 		$builder->shouldReceive('getQuery')->andReturn($query = m::mock('StdClass'));
@@ -40,12 +43,12 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase {
 
 	public function testForceDeleteExtension()
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(Builder::class);
 		$builder->shouldDeferMissing();
-		$scope = new Illuminate\Database\Eloquent\SoftDeletingScope;
+		$scope = new SoftDeletingScope;
 		$scope->extend($builder);
 		$callback = $builder->getMacro('forceDelete');
-		$givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$givenBuilder = m::mock(Builder::class);
 		$givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('StdClass'));
 		$query->shouldReceive('delete')->once();
 
@@ -55,12 +58,12 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase {
 
 	public function testRestoreExtension()
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(Builder::class);
 		$builder->shouldDeferMissing();
-		$scope = new Illuminate\Database\Eloquent\SoftDeletingScope;
+		$scope = new SoftDeletingScope;
 		$scope->extend($builder);
 		$callback = $builder->getMacro('restore');
-		$givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$givenBuilder = m::mock(Builder::class);
 		$givenBuilder->shouldReceive('withTrashed')->once();
 		$givenBuilder->shouldReceive('getModel')->once()->andReturn($model = m::mock('StdClass'));
 		$model->shouldReceive('getDeletedAtColumn')->once()->andReturn('deleted_at');
@@ -72,13 +75,13 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase {
 
 	public function testWithTrashedExtension()
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(Builder::class);
 		$builder->shouldDeferMissing();
-		$scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[remove]');
+		$scope = m::mock(SoftDeletingScope::class.'[remove]');
 		$scope->extend($builder);
 		$callback = $builder->getMacro('withTrashed');
-		$givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
-		$givenBuilder->shouldReceive('getModel')->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
+		$givenBuilder = m::mock(Builder::class);
+		$givenBuilder->shouldReceive('getModel')->andReturn($model = m::mock(Model::class));
 		$scope->shouldReceive('remove')->once()->with($givenBuilder, $model);
 		$result = $callback($givenBuilder);
 
@@ -88,14 +91,14 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase {
 
 	public function testOnlyTrashedExtension()
 	{
-		$builder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$builder = m::mock(Builder::class);
 		$builder->shouldDeferMissing();
-		$model = m::mock('Illuminate\Database\Eloquent\Model');
+		$model = m::mock(Model::class);
 		$model->shouldDeferMissing();
-		$scope = m::mock('Illuminate\Database\Eloquent\SoftDeletingScope[remove]');
+		$scope = m::mock(SoftDeletingScope::class.'[remove]');
 		$scope->extend($builder);
 		$callback = $builder->getMacro('onlyTrashed');
-		$givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
+		$givenBuilder = m::mock(Builder::class);
 		$scope->shouldReceive('remove')->once()->with($givenBuilder, $model);
 		$givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('StdClass'));
 		$givenBuilder->shouldReceive('getModel')->andReturn($model);

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DatabaseSoftDeletingTraitTest extends PHPUnit_Framework_TestCase {
 
@@ -19,7 +21,7 @@ class DatabaseSoftDeletingTraitTest extends PHPUnit_Framework_TestCase {
 		$query->shouldReceive('update')->once()->with(['deleted_at' => 'date-time']);
 		$model->delete();
 
-		$this->assertInstanceOf('Carbon\Carbon', $model->deleted_at);
+		$this->assertInstanceOf(Carbon::class, $model->deleted_at);
 	}
 
 
@@ -51,7 +53,7 @@ class DatabaseSoftDeletingTraitTest extends PHPUnit_Framework_TestCase {
 
 
 class DatabaseSoftDeletingTraitStub {
-	use Illuminate\Database\Eloquent\SoftDeletes;
+	use SoftDeletes;
 	public $deleted_at;
 	public function newQuery()
 	{
@@ -79,7 +81,7 @@ class DatabaseSoftDeletingTraitStub {
 	}
 	public function freshTimestamp()
 	{
-		return Carbon\Carbon::now();
+		return Carbon::now();
 	}
 	public function fromDateTime()
 	{

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 
 class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
@@ -479,13 +481,13 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase {
 
 	protected function getConnection()
 	{
-		return m::mock('Illuminate\Database\Connection');
+		return m::mock(Connection::class);
 	}
 
 
 	public function getGrammar()
 	{
-		return new Illuminate\Database\Schema\Grammars\SqlServerGrammar;
+		return new SqlServerGrammar;
 	}
 
 }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -2,6 +2,10 @@
 
 use Mockery as m;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Events\CallQueuedHandler;
+use Illuminate\Contracts\Queue\ShouldBeQueued;
 
 class EventsDispatcherTest extends PHPUnit_Framework_TestCase {
 
@@ -23,7 +27,7 @@ class EventsDispatcherTest extends PHPUnit_Framework_TestCase {
 
 	public function testContainerResolutionOfEventHandlers()
 	{
-		$d = new Dispatcher($container = m::mock('Illuminate\Container\Container'));
+		$d = new Dispatcher($container = m::mock(Container::class));
 		$container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('StdClass'));
 		$handler->shouldReceive('onFooEvent')->once()->with('foo', 'bar');
 		$d->listen('foo', 'FooHandler@onFooEvent');
@@ -33,7 +37,7 @@ class EventsDispatcherTest extends PHPUnit_Framework_TestCase {
 
 	public function testContainerResolutionOfEventHandlersWithDefaultMethods()
 	{
-		$d = new Dispatcher($container = m::mock('Illuminate\Container\Container'));
+		$d = new Dispatcher($container = m::mock(Container::class));
 		$container->shouldReceive('make')->once()->with('FooHandler')->andReturn($handler = m::mock('StdClass'));
 		$handler->shouldReceive('handle')->once()->with('foo', 'bar');
 		$d->listen('foo', 'FooHandler');
@@ -113,8 +117,8 @@ class EventsDispatcherTest extends PHPUnit_Framework_TestCase {
 	public function testQueuedEventHandlersAreQueued()
 	{
 		$d = new Dispatcher;
-		$queue = m::mock('Illuminate\Contracts\Queue\Queue');
-		$queue->shouldReceive('push')->once()->with('Illuminate\Events\CallQueuedHandler@call', [
+		$queue = m::mock(Queue::class);
+		$queue->shouldReceive('push')->once()->with(CallQueuedHandler::class.'@call', [
 			'class' => 'TestDispatcherQueuedHandler',
 			'method' => 'someMethod',
 			'data' => serialize(['foo', 'bar']),
@@ -129,8 +133,8 @@ class EventsDispatcherTest extends PHPUnit_Framework_TestCase {
 	public function testQueuedEventHandlersAreQueuedWithCustomHandlers()
 	{
 		$d = new Dispatcher;
-		$queue = m::mock('Illuminate\Contracts\Queue\Queue');
-		$queue->shouldReceive('push')->once()->with('Illuminate\Events\CallQueuedHandler@call', [
+		$queue = m::mock(Queue::class);
+		$queue->shouldReceive('push')->once()->with(CallQueuedHandler::class.'@call', [
 			'class' => 'TestDispatcherQueuedHandlerCustomQueue',
 			'method' => 'someMethod',
 			'data' => serialize(['foo', 'bar']),
@@ -143,11 +147,11 @@ class EventsDispatcherTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class TestDispatcherQueuedHandler implements Illuminate\Contracts\Queue\ShouldBeQueued {
+class TestDispatcherQueuedHandler implements ShouldBeQueued {
 	public function handle() {}
 }
 
-class TestDispatcherQueuedHandlerCustomQueue implements Illuminate\Contracts\Queue\ShouldBeQueued {
+class TestDispatcherQueuedHandlerCustomQueue implements ShouldBeQueued {
 	public function handle() {}
 	public function queue($queue, $handler, array $payload)
 	{

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\ServiceProvider;
 
 class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 
@@ -27,7 +28,7 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 
 	public function testServiceProvidersAreCorrectlyRegistered()
 	{
-		$provider = m::mock('Illuminate\Support\ServiceProvider');
+		$provider = m::mock(ServiceProvider::class);
 		$class = get_class($provider);
 		$provider->shouldReceive('register')->once();
 		$app = new Application;
@@ -135,7 +136,7 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class ApplicationDeferredSharedServiceProviderStub extends Illuminate\Support\ServiceProvider {
+class ApplicationDeferredSharedServiceProviderStub extends ServiceProvider {
 	protected $defer = true;
 	public function register()
 	{
@@ -145,7 +146,7 @@ class ApplicationDeferredSharedServiceProviderStub extends Illuminate\Support\Se
 	}
 }
 
-class ApplicationDeferredServiceProviderCountStub extends Illuminate\Support\ServiceProvider {
+class ApplicationDeferredServiceProviderCountStub extends ServiceProvider {
 	public static $count = 0;
 	protected $defer = true;
 	public function register()
@@ -155,7 +156,7 @@ class ApplicationDeferredServiceProviderCountStub extends Illuminate\Support\Ser
 	}
 }
 
-class ApplicationDeferredServiceProviderStub extends Illuminate\Support\ServiceProvider {
+class ApplicationDeferredServiceProviderStub extends ServiceProvider {
 	public static $initialized = false;
 	protected $defer = true;
 	public function register()
@@ -165,7 +166,7 @@ class ApplicationDeferredServiceProviderStub extends Illuminate\Support\ServiceP
 	}
 }
 
-class ApplicationFactoryProviderStub extends Illuminate\Support\ServiceProvider {
+class ApplicationFactoryProviderStub extends ServiceProvider {
 	protected $defer = true;
 	public function register()
 	{
@@ -176,7 +177,7 @@ class ApplicationFactoryProviderStub extends Illuminate\Support\ServiceProvider 
 	}
 }
 
-class ApplicationMultiProviderStub extends Illuminate\Support\ServiceProvider {
+class ApplicationMultiProviderStub extends ServiceProvider {
 	protected $defer = true;
 	public function register()
 	{

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Foundation\Composer;
+use Illuminate\Filesystem\Filesystem;
 
 class FoundationComposerTest extends PHPUnit_Framework_TestCase {
 
@@ -12,7 +14,7 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase {
 
 	public function testDumpAutoloadRunsTheCorrectCommand()
 	{
-		$composer = $this->getMock('Illuminate\Foundation\Composer', array('getProcess'), array($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__));
+		$composer = $this->getMock(Composer::class, array('getProcess'), array($files = m::mock(Filesystem::class), __DIR__));
 		$files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
 		$process = m::mock('stdClass');
 		$composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
@@ -25,7 +27,7 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase {
 
 	public function testDumpAutoloadRunsTheCorrectCommandWhenComposerIsntPresent()
 	{
-		$composer = $this->getMock('Illuminate\Foundation\Composer', array('getProcess'), array($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__));
+		$composer = $this->getMock(Composer::class, array('getProcess'), array($files = m::mock(Filesystem::class), __DIR__));
 		$files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(false);
 		$process = m::mock('stdClass');
 		$composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));

--- a/tests/Foundation/FoundationFormRequestTestCase.php
+++ b/tests/Foundation/FoundationFormRequestTestCase.php
@@ -1,7 +1,13 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Redirector;
 use Illuminate\Container\Container;
+use Illuminate\Validation\Validator;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Factory as ValidationFactory;
 
 class FoundationFormRequestTestCase extends PHPUnit_Framework_TestCase {
 
@@ -16,9 +22,9 @@ class FoundationFormRequestTestCase extends PHPUnit_Framework_TestCase {
 	{
 		$request = FoundationTestFormRequestStub::create('/', 'GET', ['name' => 'abigail']);
 		$request->setContainer(new Container);
-		$factory = m::mock('Illuminate\Validation\Factory');
+		$factory = m::mock(ValidationFactory::class);
 		$factory->shouldReceive('make')->once()->with(['name' => 'abigail'], ['name' => 'required'])->andReturn(
-			$validator = m::mock('Illuminate\Validation\Validator')
+			$validator = m::mock(Validator::class)
 		);
 		$validator->shouldReceive('fails')->once()->andReturn(false);
 
@@ -36,14 +42,14 @@ class FoundationFormRequestTestCase extends PHPUnit_Framework_TestCase {
 		$request = m::mock('FoundationTestFormRequestStub[response]');
 		$request->initialize(['name' => null]);
 		$request->setContainer(new Container);
-		$factory = m::mock('Illuminate\Validation\Factory');
+		$factory = m::mock(ValidationFactory::class);
 		$factory->shouldReceive('make')->once()->with(['name' => null], ['name' => 'required'])->andReturn(
-			$validator = m::mock('Illuminate\Validation\Validator')
+			$validator = m::mock(Validator::class)
 		);
 		$validator->shouldReceive('fails')->once()->andReturn(true);
 		$validator->shouldReceive('errors')->once()->andReturn($messages = m::mock('StdClass'));
 		$messages->shouldReceive('all')->once()->andReturn([]);
-		$request->shouldReceive('response')->once()->andReturn(new Illuminate\Http\Response);
+		$request->shouldReceive('response')->once()->andReturn(new Response);
 
 
 		$request->validate($factory);
@@ -58,12 +64,12 @@ class FoundationFormRequestTestCase extends PHPUnit_Framework_TestCase {
 		$request = m::mock('FoundationTestFormRequestForbiddenStub[forbiddenResponse]');
 		$request->initialize(['name' => null]);
 		$request->setContainer(new Container);
-		$factory = m::mock('Illuminate\Validation\Factory');
+		$factory = m::mock(ValidationFactory::class);
 		$factory->shouldReceive('make')->once()->with(['name' => null], ['name' => 'required'])->andReturn(
-			$validator = m::mock('Illuminate\Validation\Validator')
+			$validator = m::mock(Validator::class)
 		);
 		$validator->shouldReceive('fails')->once()->andReturn(false);
-		$request->shouldReceive('forbiddenResponse')->once()->andReturn(new Illuminate\Http\Response);
+		$request->shouldReceive('forbiddenResponse')->once()->andReturn(new Response);
 
 		$request->validate($factory);
 	}
@@ -72,8 +78,8 @@ class FoundationFormRequestTestCase extends PHPUnit_Framework_TestCase {
 	public function testRedirectResponseIsProperlyCreatedWithGivenErrors()
 	{
 		$request = FoundationTestFormRequestStub::create('/', 'GET');
-		$request->setRedirector($redirector = m::mock('Illuminate\Routing\Redirector'));
-		$redirector->shouldReceive('to')->once()->with('previous')->andReturn($response = m::mock('Illuminate\Http\RedirectResponse'));
+		$request->setRedirector($redirector = m::mock(Redirector::class));
+		$redirector->shouldReceive('to')->once()->with('previous')->andReturn($response = m::mock(RedirectResponse::class));
 		$redirector->shouldReceive('getUrlGenerator')->andReturn($url = m::mock('StdClass'));
 		$url->shouldReceive('previous')->once()->andReturn('previous');
 		$response->shouldReceive('withInput')->andReturn($response);
@@ -86,7 +92,7 @@ class FoundationFormRequestTestCase extends PHPUnit_Framework_TestCase {
 
 }
 
-class FoundationTestFormRequestStub extends Illuminate\Foundation\Http\FormRequest {
+class FoundationTestFormRequestStub extends FormRequest {
 	public function rules(StdClass $dep) {
 		return ['name' => 'required'];
 	}
@@ -98,7 +104,7 @@ class FoundationTestFormRequestStub extends Illuminate\Foundation\Http\FormReque
 	}
 }
 
-class FoundationTestFormRequestForbiddenStub extends Illuminate\Foundation\Http\FormRequest {
+class FoundationTestFormRequestForbiddenStub extends FormRequest {
 	public function rules() {
 		return ['name' => 'required'];
 	}

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -2,7 +2,12 @@
 
 use Mockery as m;
 use Illuminate\Http\Request;
+use Illuminate\Session\Store;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
 use Illuminate\Http\RedirectResponse;
+use Symfony\Component\HttpFoundation\Cookie;
+use Illuminate\Contracts\Support\MessageProvider;
 
 class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
 
@@ -28,7 +33,7 @@ class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
 {
 		$response = new RedirectResponse('foo.bar');
 		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
+		$response->setSession($session = m::mock(Store::class));
 		$session->shouldReceive('flash')->twice();
 		$response->with(array('name', 'age'));
 	}
@@ -38,7 +43,7 @@ class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
 	{
 		$response = new RedirectResponse('foo.bar');
 		$this->assertEquals(0, count($response->headers->getCookies()));
-		$this->assertEquals($response, $response->withCookie(new \Symfony\Component\HttpFoundation\Cookie('foo', 'bar')));
+		$this->assertEquals($response, $response->withCookie(new Cookie('foo', 'bar')));
 		$cookies = $response->headers->getCookies();
 		$this->assertEquals(1, count($cookies));
 		$this->assertEquals('foo', $cookies[0]->getName());
@@ -50,7 +55,7 @@ class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
 	{
 		$response = new RedirectResponse('foo.bar');
 		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
+		$response->setSession($session = m::mock(Store::class));
 		$session->shouldReceive('flashInput')->once()->with(array('name' => 'Taylor', 'age' => 26));
 		$response->withInput();
 	}
@@ -60,7 +65,7 @@ class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
 	{
 		$response = new RedirectResponse('foo.bar');
 		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
+		$response->setSession($session = m::mock(Store::class));
 		$session->shouldReceive('flashInput')->once()->with(array('name' => 'Taylor'));
 		$response->onlyInput('name');
 	}
@@ -70,7 +75,7 @@ class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
 	{
 		$response = new RedirectResponse('foo.bar');
 		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
+		$response->setSession($session = m::mock(Store::class));
 		$session->shouldReceive('flashInput')->once()->with(array('name' => 'Taylor'));
 		$response->exceptInput('age');
 	}
@@ -80,11 +85,11 @@ class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
 	{
 		$response = new RedirectResponse('foo.bar');
 		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
-		$session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new Illuminate\Support\ViewErrorBag);
-		$session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
-		$provider = m::mock('Illuminate\Contracts\Support\MessageProvider');
-		$provider->shouldReceive('getMessageBag')->once()->andReturn(new Illuminate\Support\MessageBag);
+		$response->setSession($session = m::mock(Store::class));
+		$session->shouldReceive('get')->with('errors', m::type(ViewErrorBag::class))->andReturn(new ViewErrorBag);
+		$session->shouldReceive('flash')->once()->with('errors', m::type(ViewErrorBag::class));
+		$provider = m::mock(MessageProvider::class);
+		$provider->shouldReceive('getMessageBag')->once()->andReturn(new MessageBag);
 		$response->withErrors($provider);
 	}
 
@@ -96,7 +101,7 @@ class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
 		$this->assertNull($response->getSession());
 
 		$request = Request::create('/', 'GET');
-		$session = m::mock('Illuminate\Session\Store');
+		$session = m::mock(Store::class);
 		$response->setRequest($request);
 		$response->setSession($session);
 		$this->assertSame($request, $response->getRequest());
@@ -108,9 +113,9 @@ class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
 	{
 		$response = new RedirectResponse('foo.bar');
 		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
-		$session->shouldReceive('get')->with('errors', m::type('Illuminate\Support\ViewErrorBag'))->andReturn(new Illuminate\Support\ViewErrorBag);
-		$session->shouldReceive('flash')->once()->with('errors', m::type('Illuminate\Support\ViewErrorBag'));
+		$response->setSession($session = m::mock(Store::class));
+		$session->shouldReceive('get')->with('errors', m::type(ViewErrorBag::class))->andReturn(new ViewErrorBag);
+		$session->shouldReceive('flash')->once()->with('errors', m::type(ViewErrorBag::class));
 		$provider = array('foo' => 'bar');
 		$response->withErrors($provider);
 	}
@@ -120,7 +125,7 @@ class HttpRedirectResponseTest extends PHPUnit_Framework_TestCase {
 	{
 		$response = new RedirectResponse('foo.bar');
 		$response->setRequest(Request::create('/', 'GET', array('name' => 'Taylor', 'age' => 26)));
-		$response->setSession($session = m::mock('Illuminate\Session\Store'));
+		$response->setSession($session = m::mock(Store::class));
 		$session->shouldReceive('flash')->once()->with('foo', 'bar');
 		$response->withFoo('bar');
 	}

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2,6 +2,8 @@
 
 use Mockery as m;
 use Illuminate\Http\Request;
+use Illuminate\Session\Store;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class HttpRequestTest extends PHPUnit_Framework_TestCase {
@@ -202,8 +204,8 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('Taylor', $request['name']);
 		$this->assertEquals('Bob', $request->input('foo', 'Bob'));
 
-		$request = Request::create('/', 'GET', [], [], ['file' => new Symfony\Component\HttpFoundation\File\UploadedFile(__FILE__, 'foo.php')]);
-		$this->assertInstanceOf('Symfony\Component\HttpFoundation\File\UploadedFile', $request['file']);
+		$request = Request::create('/', 'GET', [], [], ['file' => new UploadedFile(__FILE__, 'foo.php')]);
+		$this->assertInstanceOf(UploadedFile::class, $request['file']);
 	}
 
 
@@ -267,7 +269,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 			),
 		);
 		$request = Request::create('/', 'GET', array(), array(), $files);
-		$this->assertInstanceOf('Symfony\Component\HttpFoundation\File\UploadedFile', $request->file('foo'));
+		$this->assertInstanceOf(UploadedFile::class, $request->file('foo'));
 	}
 
 
@@ -358,7 +360,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 
 	public function testAllInputReturnsInputAndFiles()
 	{
-		$file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', null, array(__FILE__, 'photo.jpg'));
+		$file = $this->getMock(UploadedFile::class, null, array(__FILE__, 'photo.jpg'));
 		$request = Request::create('/?boom=breeze', 'GET', array('foo' => 'bar'), array(), array('baz' => $file));
 		$this->assertEquals(array('foo' => 'bar', 'baz' => $file, 'boom' => 'breeze'), $request->all());
 	}
@@ -366,7 +368,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 
 	public function testAllInputReturnsNestedInputAndFiles()
 	{
-		$file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', null, array(__FILE__, 'photo.jpg'));
+		$file = $this->getMock(UploadedFile::class, null, array(__FILE__, 'photo.jpg'));
 		$request = Request::create('/?boom=breeze', 'GET', array('foo' => array('bar' => 'baz')), array(), array('foo' => array('photo' => $file)));
 		$this->assertEquals(array('foo' => array('bar' => 'baz', 'photo' => $file), 'boom' => 'breeze'), $request->all());
 	}
@@ -413,7 +415,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	public function testOldMethodCallsSession()
 	{
 		$request = Request::create('/', 'GET');
-		$session = m::mock('Illuminate\Session\Store');
+		$session = m::mock(Store::class);
 		$session->shouldReceive('getOldInput')->once()->with('foo', 'bar')->andReturn('boom');
 		$request->setSession($session);
 		$this->assertEquals('boom', $request->old('foo', 'bar'));
@@ -423,7 +425,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase {
 	public function testFlushMethodCallsSession()
 	{
 		$request = Request::create('/', 'GET');
-		$session = m::mock('Illuminate\Session\Store');
+		$session = m::mock(Store::class);
 		$session->shouldReceive('flashInput')->once();
 		$request->setSession($session);
 		$request->flush();

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -1,7 +1,13 @@
 <?php
 
 use Mockery as m;
+use Monolog\Logger;
 use Illuminate\Log\Writer;
+use Illuminate\Events\Dispatcher;
+use Monolog\Handler\StreamHandler;
+use Monolog\Handler\ErrorLogHandler;
+use Monolog\Handler\RotatingFileHandler;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
 class LogWriterTest extends PHPUnit_Framework_TestCase {
 
@@ -13,31 +19,31 @@ class LogWriterTest extends PHPUnit_Framework_TestCase {
 
 	public function testFileHandlerCanBeAdded()
 	{
-		$writer = new Writer($monolog = m::mock('Monolog\Logger'));
-		$monolog->shouldReceive('pushHandler')->once()->with(m::type('Monolog\Handler\StreamHandler'));
+		$writer = new Writer($monolog = m::mock(Logger::class));
+		$monolog->shouldReceive('pushHandler')->once()->with(m::type(StreamHandler::class));
 		$writer->useFiles(__DIR__);
 	}
 
 
 	public function testRotatingFileHandlerCanBeAdded()
 	{
-		$writer = new Writer($monolog = m::mock('Monolog\Logger'));
-		$monolog->shouldReceive('pushHandler')->once()->with(m::type('Monolog\Handler\RotatingFileHandler'));
+		$writer = new Writer($monolog = m::mock(Logger::class));
+		$monolog->shouldReceive('pushHandler')->once()->with(m::type(RotatingFileHandler::class));
 		$writer->useDailyFiles(__DIR__, 5);
 	}
 
 
 	public function testErrorLogHandlerCanBeAdded()
 	{
-		$writer = new Writer($monolog = m::mock('Monolog\Logger'));
-		$monolog->shouldReceive('pushHandler')->once()->with(m::type('Monolog\Handler\ErrorLogHandler'));
+		$writer = new Writer($monolog = m::mock(Logger::class));
+		$monolog->shouldReceive('pushHandler')->once()->with(m::type(ErrorLogHandler::class));
 		$writer->useErrorLog();
 	}
 
 
 	public function testMethodsPassErrorAdditionsToMonolog()
 	{
-		$writer = new Writer($monolog = m::mock('Monolog\Logger'));
+		$writer = new Writer($monolog = m::mock(Logger::class));
 		$monolog->shouldReceive('error')->once()->with('foo', []);
 
 		$writer->error('foo');
@@ -46,7 +52,7 @@ class LogWriterTest extends PHPUnit_Framework_TestCase {
 
 	public function testWriterFiresEventsDispatcher()
 	{
-		$writer = new Writer($monolog = m::mock('Monolog\Logger'), $events = new Illuminate\Events\Dispatcher);
+		$writer = new Writer($monolog = m::mock(Logger::class), $events = new Dispatcher);
 		$monolog->shouldReceive('error')->once()->with('foo', array());
 
 		$events->listen('illuminate.log', function($level, $message, array $context = array())
@@ -74,14 +80,14 @@ class LogWriterTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testListenShortcutFailsWithNoDispatcher()
 	{
-		$writer = new Writer($monolog = m::mock('Monolog\Logger'));
+		$writer = new Writer($monolog = m::mock(Logger::class));
 		$writer->listen(function() {});
 	}
 
 
 	public function testListenShortcut()
 	{
-		$writer = new Writer($monolog = m::mock('Monolog\Logger'), $events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
+		$writer = new Writer($monolog = m::mock(Logger::class), $events = m::mock(DispatcherContract::class));
 
 		$callback = function() { return 'success'; };
 		$events->shouldReceive('listen')->with('illuminate.log', $callback)->once();

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Mail\Message;
 
 class MailMessageTest extends PHPUnit_Framework_TestCase {
 
@@ -13,7 +14,7 @@ class MailMessageTest extends PHPUnit_Framework_TestCase {
 	public function testBasicAttachment()
 	{
 		$swift = m::mock('StdClass');
-		$message = $this->getMock('Illuminate\Mail\Message', array('createAttachmentFromPath'), array($swift));
+		$message = $this->getMock(Message::class, array('createAttachmentFromPath'), array($swift));
 		$attachment = m::mock('StdClass');
 		$message->expects($this->once())->method('createAttachmentFromPath')->with($this->equalTo('foo.jpg'))->will($this->returnValue($attachment));
 		$swift->shouldReceive('attach')->once()->with($attachment);
@@ -26,7 +27,7 @@ class MailMessageTest extends PHPUnit_Framework_TestCase {
 	public function testDataAttachment()
 	{
 		$swift = m::mock('StdClass');
-		$message = $this->getMock('Illuminate\Mail\Message', array('createAttachmentFromData'), array($swift));
+		$message = $this->getMock(Message::class, array('createAttachmentFromData'), array($swift));
 		$attachment = m::mock('StdClass');
 		$message->expects($this->once())->method('createAttachmentFromData')->with($this->equalTo('foo'), $this->equalTo('name'))->will($this->returnValue($attachment));
 		$swift->shouldReceive('attach')->once()->with($attachment);

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use Aws\Ses\SesClient;
-use Illuminate\Foundation\Application;
-use Illuminate\Mail\TransportManager;
-use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\Support\Collection;
+use Illuminate\Mail\TransportManager;
+use Illuminate\Foundation\Application;
+use Illuminate\Mail\Transport\SesTransport;
 
 class MailSesTransportTest extends PHPUnit_Framework_TestCase {
 
@@ -39,7 +39,7 @@ class MailSesTransportTest extends PHPUnit_Framework_TestCase {
 		$message->setTo('me@example.com');
 		$message->setBcc('you@example.com');
 
-		$client = $this->getMockBuilder('Aws\Ses\SesClient')
+		$client = $this->getMockBuilder(SesClient::class)
 			->setMethods(['sendRawEmail'])
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -1,6 +1,10 @@
 <?php
 
 use Mockery as m;
+use Pheanstalk\Pheanstalk;
+use Illuminate\Container\Container;
+use Illuminate\Queue\Jobs\BeanstalkdJob;
+use Pheanstalk\Job as BeanstalkdBaseJob;
 
 class QueueBeanstalkdJobTest extends PHPUnit_Framework_TestCase {
 
@@ -44,7 +48,7 @@ class QueueBeanstalkdJobTest extends PHPUnit_Framework_TestCase {
 	public function testReleaseProperlyReleasesJobOntoBeanstalkd()
 	{
 		$job = $this->getJob();
-		$job->getPheanstalk()->shouldReceive('release')->once()->with($job->getPheanstalkJob(), Pheanstalk\Pheanstalk::DEFAULT_PRIORITY, 0);
+		$job->getPheanstalk()->shouldReceive('release')->once()->with($job->getPheanstalkJob(), Pheanstalk::DEFAULT_PRIORITY, 0);
 
 		$job->release();
 	}
@@ -61,10 +65,10 @@ class QueueBeanstalkdJobTest extends PHPUnit_Framework_TestCase {
 
 	protected function getJob()
 	{
-		return new Illuminate\Queue\Jobs\BeanstalkdJob(
-			m::mock('Illuminate\Container\Container'),
-			m::mock('Pheanstalk\Pheanstalk'),
-			m::mock('Pheanstalk\Job'),
+		return new BeanstalkdJob(
+			m::mock(Container::class),
+			m::mock(Pheanstalk::class),
+			m::mock(BeanstalkdBaseJob::class),
 			'default'
 		);
 	}

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -1,6 +1,11 @@
 <?php
 
 use Mockery as m;
+use Pheanstalk\Pheanstalk;
+use Illuminate\Container\Container;
+use Illuminate\Queue\BeanstalkdQueue;
+use Illuminate\Queue\Jobs\BeanstalkdJob;
+use Pheanstalk\Job as PheanstalkBaseJob;
 
 class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 
@@ -12,7 +17,7 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testPushProperlyPushesJobOntoBeanstalkd()
 	{
-		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
+		$queue = new BeanstalkdQueue(m::mock(Pheanstalk::class), 'default', 60);
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('useTube')->once()->with('stack')->andReturn($pheanstalk);
 		$pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
@@ -25,11 +30,11 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testDelayedPushProperlyPushesJobOntoBeanstalkd()
 	{
-		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
+		$queue = new BeanstalkdQueue(m::mock(Pheanstalk::class), 'default', 60);
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('useTube')->once()->with('stack')->andReturn($pheanstalk);
 		$pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
-		$pheanstalk->shouldReceive('put')->twice()->with(json_encode(array('job' => 'foo', 'data' => array('data'))), Pheanstalk\Pheanstalk::DEFAULT_PRIORITY, 5, Pheanstalk\Pheanstalk::DEFAULT_TTR);
+		$pheanstalk->shouldReceive('put')->twice()->with(json_encode(array('job' => 'foo', 'data' => array('data'))), Pheanstalk::DEFAULT_PRIORITY, 5, Pheanstalk::DEFAULT_TTR);
 
 		$queue->later(5, 'foo', array('data'), 'stack');
 		$queue->later(5, 'foo', array('data'));
@@ -38,22 +43,22 @@ class QueueBeanstalkdQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testPopProperlyPopsJobOffOfBeanstalkd()
 	{
-		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
-		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$queue = new BeanstalkdQueue(m::mock(Pheanstalk::class), 'default', 60);
+		$queue->setContainer(m::mock(Container::class));
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('watchOnly')->once()->with('default')->andReturn($pheanstalk);
-		$job = m::mock('Pheanstalk\Job');
+		$job = m::mock(PheanstalkBaseJob::class);
 		$pheanstalk->shouldReceive('reserve')->once()->andReturn($job);
 
 		$result = $queue->pop();
 
-		$this->assertInstanceOf('Illuminate\Queue\Jobs\BeanstalkdJob', $result);
+		$this->assertInstanceOf(BeanstalkdJob::class, $result);
 	}
 
 
 	public function testDeleteProperlyRemoveJobsOffBeanstalkd()
 	{
-		$queue = new Illuminate\Queue\BeanstalkdQueue(m::mock('Pheanstalk\Pheanstalk'), 'default', 60);
+		$queue = new BeanstalkdQueue(m::mock(Pheanstalk::class), 'default', 60);
 		$pheanstalk = $queue->getPheanstalk();
 		$pheanstalk->shouldReceive('useTube')->once()->with('default')->andReturn($pheanstalk);
 		$pheanstalk->shouldReceive('delete')->once()->with(1);

--- a/tests/Queue/QueueDatabaseQueueTest.php
+++ b/tests/Queue/QueueDatabaseQueueTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Queue\DatabaseQueue;
+use Illuminate\Database\Connection;
 
 class QueueDatabaseQueueTest extends PHPUnit_Framework_TestCase {
 
@@ -12,7 +14,7 @@ class QueueDatabaseQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testPushProperlyPushesJobOntoDatabase()
 	{
-		$queue = $this->getMock('Illuminate\Queue\DatabaseQueue', array('getTime'), array($database = m::mock('Illuminate\Database\Connection'), 'table', 'default'));
+		$queue = $this->getMock(DatabaseQueue::class, array('getTime'), array($database = m::mock(Connection::class), 'table', 'default'));
 		$queue->expects($this->any())->method('getTime')->will($this->returnValue('time'));
 		$database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
 		$query->shouldReceive('insertGetId')->once()->andReturnUsing(function($array) {
@@ -31,9 +33,9 @@ class QueueDatabaseQueueTest extends PHPUnit_Framework_TestCase {
 	public function testDelayedPushProperlyPushesJobOntoDatabase()
 	{
 		$queue = $this->getMock(
-			'Illuminate\Queue\DatabaseQueue',
+			DatabaseQueue::class,
 			array('getTime'),
-			array($database = m::mock('Illuminate\Database\Connection'), 'table', 'default')
+			array($database = m::mock(Connection::class), 'table', 'default')
 		);
 		$queue->expects($this->any())->method('getTime')->will($this->returnValue('time'));
 		$database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
@@ -52,8 +54,8 @@ class QueueDatabaseQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testBulkBatchPushesOntoDatabase()
 	{
-		$database = m::mock('Illuminate\Database\Connection');
-		$queue = $this->getMock('Illuminate\Queue\DatabaseQueue', ['getTime', 'getAvailableAt'], [$database, 'table', 'default']);
+		$database = m::mock(Connection::class);
+		$queue = $this->getMock(DatabaseQueue::class, ['getTime', 'getAvailableAt'], [$database, 'table', 'default']);
 		$queue->expects($this->any())->method('getTime')->will($this->returnValue('created'));
 		$queue->expects($this->any())->method('getAvailableAt')->will($this->returnValue('available'));
 		$database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));

--- a/tests/Queue/QueueIronJobTest.php
+++ b/tests/Queue/QueueIronJobTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Queue\IronQueue;
+use Illuminate\Queue\Jobs\IronJob;
+use Illuminate\Container\Container;
 
 class QueueIronJobTest extends PHPUnit_Framework_TestCase {
 
@@ -31,9 +34,9 @@ class QueueIronJobTest extends PHPUnit_Framework_TestCase {
 
 	public function testDeleteNoopsOnPushedQueues()
 	{
-		$job = new Illuminate\Queue\Jobs\IronJob(
-			m::mock('Illuminate\Container\Container'),
-			m::mock('Illuminate\Queue\IronQueue'),
+		$job = new IronJob(
+			m::mock(Container::class),
+			m::mock(IronQueue::class),
 			(object) array('id' => 1, 'body' => json_encode(array('job' => 'foo', 'data' => array('data'))), 'timeout' => 60, 'pushed' => true),
 			'default'
 		);
@@ -55,9 +58,9 @@ class QueueIronJobTest extends PHPUnit_Framework_TestCase {
 
 	protected function getJob()
 	{
-		return new Illuminate\Queue\Jobs\IronJob(
-			m::mock('Illuminate\Container\Container'),
-			m::mock('Illuminate\Queue\IronQueue'),
+		return new IronJob(
+			m::mock(Container::class),
+			m::mock(IronQueue::class),
 			(object) array('id' => 1, 'body' => json_encode(array('job' => 'foo', 'data' => array('data'), 'attempts' => 1, 'queue' => 'default')), 'timeout' => 60)
 		);
 	}

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Queue\Listener;
+use Symfony\Component\Process\Process;
 
 class QueueListenerTest extends PHPUnit_Framework_TestCase {
 
@@ -12,9 +14,9 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase {
 
 	public function testRunProcessCallsProcess()
 	{
-		$process = m::mock('Symfony\Component\Process\Process')->makePartial();
+		$process = m::mock(Process::class)->makePartial();
 		$process->shouldReceive('run')->once();
-		$listener = m::mock('Illuminate\Queue\Listener')->makePartial();
+		$listener = m::mock(Listener::class)->makePartial();
 		$listener->shouldReceive('memoryExceeded')->once()->with(1)->andReturn(false);
 
 		$listener->runProcess($process, 1);
@@ -23,9 +25,9 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase {
 
 	public function testListenerStopsWhenMemoryIsExceeded()
 	{
-		$process = m::mock('Symfony\Component\Process\Process')->makePartial();
+		$process = m::mock(Process::class)->makePartial();
 		$process->shouldReceive('run')->once();
-		$listener = m::mock('Illuminate\Queue\Listener')->makePartial();
+		$listener = m::mock(Listener::class)->makePartial();
 		$listener->shouldReceive('memoryExceeded')->once()->with(1)->andReturn(true);
 		$listener->shouldReceive('stop')->once();
 
@@ -35,10 +37,10 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase {
 
 	public function testMakeProcessCorrectlyFormatsCommandLine()
 	{
-		$listener = new Illuminate\Queue\Listener(__DIR__);
+		$listener = new Listener(__DIR__);
 		$process = $listener->makeProcess('connection', 'queue', 1, 2, 3);
 
-		$this->assertInstanceOf('Symfony\Component\Process\Process', $process);
+		$this->assertInstanceOf(Process::class, $process);
 		$this->assertEquals(__DIR__, $process->getWorkingDirectory());
 		$this->assertEquals(3, $process->getTimeout());
 		$this->assertEquals('"'.PHP_BINARY.'" artisan queue:work connection --queue="queue" --delay=1 --memory=2 --sleep=3 --tries=0', $process->getCommandLine());

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Queue\QueueManager;
+use Illuminate\Contracts\Encryption\Encrypter;
 
 class QueueManagerTest extends PHPUnit_Framework_TestCase {
 
@@ -18,7 +19,7 @@ class QueueManagerTest extends PHPUnit_Framework_TestCase {
 				'queue.default' => 'sync',
 				'queue.connections.sync' => array('driver' => 'sync'),
 			),
-			'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+			'encrypter' => $encrypter = m::mock(Encrypter::class),
 		);
 
 		$manager = new QueueManager($app);
@@ -40,7 +41,7 @@ class QueueManagerTest extends PHPUnit_Framework_TestCase {
 				'queue.default' => 'sync',
 				'queue.connections.foo' => array('driver' => 'bar'),
 			),
-			'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+			'encrypter' => $encrypter = m::mock(Encrypter::class),
 		);
 
 		$manager = new QueueManager($app);

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Queue\RedisQueue;
+use Illuminate\Container\Container;
+use Illuminate\Queue\Jobs\RedisJob;
 
 class QueueRedisJobTest extends PHPUnit_Framework_TestCase {
 
@@ -41,9 +44,9 @@ class QueueRedisJobTest extends PHPUnit_Framework_TestCase {
 
 	protected function getJob()
 	{
-		return new Illuminate\Queue\Jobs\RedisJob(
-			m::mock('Illuminate\Container\Container'),
-			m::mock('Illuminate\Queue\RedisQueue'),
+		return new RedisJob(
+			m::mock(Container::class),
+			m::mock(RedisQueue::class),
 			json_encode(array('job' => 'foo', 'data' => array('data'), 'attempts' => 1)),
 			'default'
 		);

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -1,6 +1,12 @@
 <?php
 
 use Mockery as m;
+use Carbon\Carbon;
+use Predis\Client;
+use Illuminate\Redis\Database;
+use Illuminate\Queue\RedisQueue;
+use Illuminate\Container\Container;
+use Illuminate\Queue\Jobs\RedisJob;
 
 class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 
@@ -12,7 +18,7 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testPushProperlyPushesJobOntoRedis()
 	{
-		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getRandomId'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
+		$queue = $this->getMock(RedisQueue::class, array('getRandomId'), array($redis = m::mock(Database::class), 'default'));
 		$queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
 		$redis->shouldReceive('connection')->once()->andReturn($redis);
 		$redis->shouldReceive('rpush')->once()->with('queues:default', json_encode(array('job' => 'foo', 'data' => array('data'), 'id' => 'foo', 'attempts' => 1)));
@@ -24,7 +30,7 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testDelayedPushProperlyPushesJobOntoRedis()
 	{
-		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getSeconds', 'getTime', 'getRandomId'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
+		$queue = $this->getMock(RedisQueue::class, array('getSeconds', 'getTime', 'getRandomId'), array($redis = m::mock(Database::class), 'default'));
 		$queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
 		$queue->expects($this->once())->method('getSeconds')->with(1)->will($this->returnValue(1));
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
@@ -43,8 +49,8 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis()
 	{
-		$date = Carbon\Carbon::now();
-		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getSeconds', 'getTime', 'getRandomId'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
+		$date = Carbon::now();
+		$queue = $this->getMock(RedisQueue::class, array('getSeconds', 'getTime', 'getRandomId'), array($redis = m::mock(Database::class), 'default'));
 		$queue->expects($this->once())->method('getRandomId')->will($this->returnValue('foo'));
 		$queue->expects($this->once())->method('getSeconds')->with($date)->will($this->returnValue(1));
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
@@ -62,8 +68,8 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testPopProperlyPopsJobOffOfRedis()
 	{
-		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime', 'migrateAllExpiredJobs'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
-		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$queue = $this->getMock(RedisQueue::class, array('getTime', 'migrateAllExpiredJobs'), array($redis = m::mock(Database::class), 'default'));
+		$queue->setContainer(m::mock(Container::class));
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
 		$queue->expects($this->once())->method('migrateAllExpiredJobs')->with($this->equalTo('queues:default'));
 
@@ -73,13 +79,13 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 
 		$result = $queue->pop();
 
-		$this->assertInstanceOf('Illuminate\Queue\Jobs\RedisJob', $result);
+		$this->assertInstanceOf(RedisJob::Class, $result);
 	}
 
 
 	public function testReleaseMethod()
 	{
-		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
+		$queue = $this->getMock(RedisQueue::class, array('getTime'), array($redis = m::mock(Database::class), 'default'));
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
 		$redis->shouldReceive('connection')->once()->andReturn($redis);
 		$redis->shouldReceive('zadd')->once()->with('queues:default:delayed', 2, json_encode(array('attempts' => 2)));
@@ -90,7 +96,7 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testMigrateExpiredJobs()
 	{
-		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime'), array($redis = m::mock('Illuminate\Redis\Database'), 'default'));
+		$queue = $this->getMock(RedisQueue::class, array('getTime'), array($redis = m::mock(Database::class), 'default'));
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
 		$transaction = m::mock('StdClass');
 		$redis->shouldReceive('connection')->once()->andReturn($redis);
@@ -109,9 +115,9 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testNotExpireJobsWhenExpireNull()
 	{
-		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime', 'migrateAllExpiredJobs'), array($redis = m::mock('Illuminate\Redis\Database'), 'default', null));
-		$redis->shouldReceive('connection')->andReturn($predis = m::mock('Predis\Client'));
-		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$queue = $this->getMock(RedisQueue::class, array('getTime', 'migrateAllExpiredJobs'), array($redis = m::mock(Database::class), 'default', null));
+		$redis->shouldReceive('connection')->andReturn($predis = m::mock(Client::class));
+		$queue->setContainer(m::mock(Container::class));
 		$queue->setExpire(null);
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
 		$queue->expects($this->never())->method('migrateAllExpiredJobs');
@@ -124,9 +130,9 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase {
 
 	public function testExpireJobsWhenExpireSet()
 	{
-		$queue = $this->getMock('Illuminate\Queue\RedisQueue', array('getTime', 'migrateAllExpiredJobs'), array($redis = m::mock('Illuminate\Redis\Database'), 'default', null));
-		$redis->shouldReceive('connection')->andReturn($predis = m::mock('Predis\Client'));
-		$queue->setContainer(m::mock('Illuminate\Container\Container'));
+		$queue = $this->getMock(RedisQueue::class, array('getTime', 'migrateAllExpiredJobs'), array($redis = m::mock(Database::class), 'default', null));
+		$redis->shouldReceive('connection')->andReturn($predis = m::mock(Client::class));
+		$queue->setContainer(m::mock(Container::class));
 		$queue->setExpire(30);
 		$queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
 		$queue->expects($this->once())->method('migrateAllExpiredJobs')->with($this->equalTo('queues:default'));

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -2,6 +2,9 @@
 
 use Mockery as m;
 use Illuminate\Queue\Worker;
+use Illuminate\Queue\QueueManager;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
 
 class QueueWorkerTest extends PHPUnit_Framework_TestCase {
 
@@ -13,10 +16,10 @@ class QueueWorkerTest extends PHPUnit_Framework_TestCase {
 
 	public function testJobIsPoppedOffQueueAndProcessed()
 	{
-		$worker = $this->getMock('Illuminate\Queue\Worker', array('process'), array($manager = m::mock('Illuminate\Queue\QueueManager')));
+		$worker = $this->getMock(Worker::class, array('process'), array($manager = m::mock(QueueManager::class)));
 		$manager->shouldReceive('connection')->once()->with('connection')->andReturn($connection = m::mock('StdClass'));
 		$manager->shouldReceive('getName')->andReturn('connection');
-		$job = m::mock('Illuminate\Contracts\Queue\Job');
+		$job = m::mock(Job::class);
 		$connection->shouldReceive('pop')->once()->with('queue')->andReturn($job);
 		$worker->expects($this->once())->method('process')->with($this->equalTo('connection'), $this->equalTo($job), $this->equalTo(0), $this->equalTo(0));
 
@@ -26,10 +29,10 @@ class QueueWorkerTest extends PHPUnit_Framework_TestCase {
 
 	public function testJobIsPoppedOffFirstQueueInListAndProcessed()
 	{
-		$worker = $this->getMock('Illuminate\Queue\Worker', array('process'), array($manager = m::mock('Illuminate\Queue\QueueManager')));
+		$worker = $this->getMock(Worker::class, array('process'), array($manager = m::mock(QueueManager::class)));
 		$manager->shouldReceive('connection')->once()->with('connection')->andReturn($connection = m::mock('StdClass'));
 		$manager->shouldReceive('getName')->andReturn('connection');
-		$job = m::mock('Illuminate\Contracts\Queue\Job');
+		$job = m::mock(Job::class);
 		$connection->shouldReceive('pop')->once()->with('queue1')->andReturn(null);
 		$connection->shouldReceive('pop')->once()->with('queue2')->andReturn($job);
 		$worker->expects($this->once())->method('process')->with($this->equalTo('connection'), $this->equalTo($job), $this->equalTo(0), $this->equalTo(0));
@@ -40,7 +43,7 @@ class QueueWorkerTest extends PHPUnit_Framework_TestCase {
 
 	public function testWorkerSleepsIfNoJobIsPresentAndSleepIsEnabled()
 	{
-		$worker = $this->getMock('Illuminate\Queue\Worker', array('process', 'sleep'), array($manager = m::mock('Illuminate\Queue\QueueManager')));
+		$worker = $this->getMock(Worker::class, array('process', 'sleep'), array($manager = m::mock(QueueManager::class)));
 		$manager->shouldReceive('connection')->once()->with('connection')->andReturn($connection = m::mock('StdClass'));
 		$connection->shouldReceive('pop')->once()->with('queue')->andReturn(null);
 		$worker->expects($this->never())->method('process');
@@ -52,8 +55,8 @@ class QueueWorkerTest extends PHPUnit_Framework_TestCase {
 
 	public function testWorkerLogsJobToFailedQueueIfMaxTriesHasBeenExceeded()
 	{
-		$worker = new Illuminate\Queue\Worker(m::mock('Illuminate\Queue\QueueManager'), $failer = m::mock('Illuminate\Queue\Failed\FailedJobProviderInterface'));
-		$job = m::mock('Illuminate\Contracts\Queue\Job');
+		$worker = new Worker(m::mock(QueueManager::class), $failer = m::mock(FailedJobProviderInterface::class));
+		$job = m::mock(Job::class);
 		$job->shouldReceive('attempts')->once()->andReturn(10);
 		$job->shouldReceive('getQueue')->once()->andReturn('queue');
 		$job->shouldReceive('getRawBody')->once()->andReturn('body');
@@ -70,8 +73,8 @@ class QueueWorkerTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testJobIsReleasedWhenExceptionIsThrown()
 	{
-		$worker = new Illuminate\Queue\Worker(m::mock('Illuminate\Queue\QueueManager'));
-		$job = m::mock('Illuminate\Contracts\Queue\Job');
+		$worker = new Worker(m::mock(QueueManager::class));
+		$job = m::mock(Job::class);
 		$job->shouldReceive('fire')->once()->andReturnUsing(function() { throw new RuntimeException; });
 		$job->shouldReceive('isDeleted')->once()->andReturn(false);
 		$job->shouldReceive('release')->once()->with(5);
@@ -85,8 +88,8 @@ class QueueWorkerTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testJobIsNotReleasedWhenExceptionIsThrownButJobIsDeleted()
 	{
-		$worker = new Illuminate\Queue\Worker(m::mock('Illuminate\Queue\QueueManager'));
-		$job = m::mock('Illuminate\Contracts\Queue\Job');
+		$worker = new Worker(m::mock(QueueManager::class));
+		$job = m::mock(Job::class);
 		$job->shouldReceive('fire')->once()->andReturnUsing(function() { throw new RuntimeException; });
 		$job->shouldReceive('isDeleted')->once()->andReturn(true);
 		$job->shouldReceive('release')->never();

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -1,7 +1,12 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Http\Request;
+use Illuminate\Session\Store;
 use Illuminate\Routing\Redirector;
+use Illuminate\Routing\UrlGenerator;
+use Illuminate\Http\RedirectResponse;
+use Symfony\Component\HttpFoundation\HeaderBag;
 
 class RoutingRedirectorTest extends PHPUnit_Framework_TestCase {
 
@@ -13,12 +18,12 @@ class RoutingRedirectorTest extends PHPUnit_Framework_TestCase {
 
 	public function setUp()
 	{
-		$this->headers = m::mock('Symfony\Component\HttpFoundation\HeaderBag');
+		$this->headers = m::mock(HeaderBag::class);
 
-		$this->request = m::mock('Illuminate\Http\Request');
+		$this->request = m::mock(Request::class);
 		$this->request->headers = $this->headers;
 
-		$this->url = m::mock('Illuminate\Routing\UrlGenerator');
+		$this->url = m::mock(UrlGenerator::class);
 		$this->url->shouldReceive('getRequest')->andReturn($this->request);
 		$this->url->shouldReceive('to')->with('bar', array(), null)->andReturn('http://foo.com/bar');
 		$this->url->shouldReceive('to')->with('bar', array(), true)->andReturn('https://foo.com/bar');
@@ -26,7 +31,7 @@ class RoutingRedirectorTest extends PHPUnit_Framework_TestCase {
 		$this->url->shouldReceive('to')->with('http://foo.com/bar', array(), null)->andReturn('http://foo.com/bar');
 		$this->url->shouldReceive('to')->with('/', array(), null)->andReturn('http://foo.com/');
 
-		$this->session = m::mock('Illuminate\Session\Store');
+		$this->session = m::mock(Store::class);
 
 		$this->redirect = new Redirector($this->url);
 		$this->redirect->setSession($this->session);
@@ -43,7 +48,7 @@ class RoutingRedirectorTest extends PHPUnit_Framework_TestCase {
 	{
 		$response = $this->redirect->to('bar');
 
-		$this->assertInstanceOf('Illuminate\Http\RedirectResponse', $response);
+		$this->assertInstanceOf(RedirectResponse::class, $response);
 		$this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
 		$this->assertEquals(302, $response->getStatusCode());
 		$this->assertEquals($this->session, $response->getSession());

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Session\EncryptedStore;
+use Illuminate\Contracts\Encryption\Encrypter;
 
 class EncryptedSessionStoreTest extends PHPUnit_Framework_TestCase {
 
@@ -41,7 +43,7 @@ class EncryptedSessionStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function getSession()
 	{
-		$reflection = new ReflectionClass('Illuminate\Session\EncryptedStore');
+		$reflection = new ReflectionClass(EncryptedStore::class);
 		return $reflection->newInstanceArgs($this->getMocks());
 	}
 
@@ -51,7 +53,7 @@ class EncryptedSessionStoreTest extends PHPUnit_Framework_TestCase {
 		return array(
 			$this->getSessionName(),
 			m::mock('SessionHandlerInterface'),
-			m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+			m::mock(Encrypter::class),
 			$this->getSessionId(),
 		);
 	}

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -1,6 +1,12 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Session\Store;
+use Illuminate\Cookie\CookieJar;
+use Illuminate\Session\CookieSessionHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 
 class SessionStoreTest extends PHPUnit_Framework_TestCase {
 
@@ -14,7 +20,7 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 	{
 		$session = $this->getSession();
 		$session->getHandler()->shouldReceive('read')->once()->with($this->getSessionId())->andReturn(serialize(array('foo' => 'bar', 'bagged' => array('name' => 'taylor'))));
-		$session->registerBag(new Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag('bagged'));
+		$session->registerBag(new AttributeBag('bagged'));
 		$session->start();
 
 		$this->assertEquals('bar', $session->get('foo'));
@@ -22,7 +28,7 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 		$this->assertTrue($session->has('foo'));
 		$this->assertFalse($session->has('bar'));
 		$this->assertEquals('taylor', $session->getBag('bagged')->get('name'));
-		$this->assertInstanceOf('Symfony\Component\HttpFoundation\Session\Storage\MetadataBag', $session->getMetadataBag());
+		$this->assertInstanceOf(MetadataBag::class, $session->getMetadataBag());
 		$this->assertTrue($session->isStarted());
 
 		$session->put('baz', 'boom');
@@ -222,7 +228,7 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 		$session = $this->getSession();
 		$session->set('foo', 'bar');
 
-		$bag = new Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag('bagged');
+		$bag = new AttributeBag('bagged');
 		$bag->set('qu', 'ux');
 		$session->registerBag($bag);
 
@@ -256,10 +262,10 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 		$this->assertFalse($session->handlerNeedsRequest());
 		$session->getHandler()->shouldReceive('setRequest')->never();
 
-		$session = new \Illuminate\Session\Store('test', m::mock(new \Illuminate\Session\CookieSessionHandler(new \Illuminate\Cookie\CookieJar(), 60)));
+		$session = new Store('test', m::mock(new CookieSessionHandler(new CookieJar, 60)));
 		$this->assertTrue($session->handlerNeedsRequest());
 		$session->getHandler()->shouldReceive('setRequest')->once();
-		$request = new \Symfony\Component\HttpFoundation\Request();
+		$request = new Request;
 		$session->setRequestOnHandler($request);
 	}
 
@@ -291,7 +297,7 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase {
 
 	public function getSession()
 	{
-		$reflection = new ReflectionClass('Illuminate\Session\Store');
+		$reflection = new ReflectionClass(Store::class);
 		return $reflection->newInstanceArgs($this->getMocks());
 	}
 

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -1,8 +1,13 @@
 <?php
 
-use Illuminate\Session\Console\SessionTableCommand;
-use Illuminate\Foundation\Application;
 use Mockery as m;
+use Illuminate\Foundation\Composer;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Illuminate\Session\Console\SessionTableCommand;
+use Illuminate\Database\Migrations\MigrationCreator;
 
 class SessionTableCommandTest extends PHPUnit_Framework_TestCase {
 
@@ -15,10 +20,10 @@ class SessionTableCommandTest extends PHPUnit_Framework_TestCase {
 	public function testCreateMakesMigration()
 	{
 		$command = new SessionTableCommandTestStub(
-			$files = m::mock('Illuminate\Filesystem\Filesystem'),
-			$composer = m::mock('Illuminate\Foundation\Composer')
+			$files = m::mock(Filesystem::class),
+			$composer = m::mock(Composer::class)
 		);
-		$creator = m::mock('Illuminate\Database\Migrations\MigrationCreator')->shouldIgnoreMissing();
+		$creator = m::mock(MigrationCreator::class)->shouldIgnoreMissing();
 
 		$app = new Application();
 		$app->useDatabasePath(__DIR__);
@@ -36,7 +41,7 @@ class SessionTableCommandTest extends PHPUnit_Framework_TestCase {
 
 	protected function runCommand($command, $input = array())
 	{
-		return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);
+		return $command->run(new ArrayInput($input), new NullOutput);
 	}
 
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4,6 +4,7 @@ use Mockery as m;
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 
@@ -111,9 +112,9 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testToArrayCallsToArrayOnEachItemInCollection()
 	{
-		$item1 = m::mock('Illuminate\Contracts\Support\Arrayable');
+		$item1 = m::mock(Arrayable::class);
 		$item1->shouldReceive('toArray')->once()->andReturn('foo.array');
-		$item2 = m::mock('Illuminate\Contracts\Support\Arrayable');
+		$item2 = m::mock(Arrayable::class);
 		$item2->shouldReceive('toArray')->once()->andReturn('bar.array');
 		$c = new Collection(array($item1, $item2));
 		$results = $c->toArray();
@@ -124,7 +125,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testToJsonEncodesTheToArrayResult()
 	{
-		$c = $this->getMock('Illuminate\Support\Collection', array('toArray'));
+		$c = $this->getMock(Collection::class, array('toArray'));
 		$c->expects($this->once())->method('toArray')->will($this->returnValue('foo'));
 		$results = $c->toJson();
 
@@ -134,7 +135,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 
 	public function testCastingToStringJsonEncodesTheToArrayResult()
 	{
-		$c = $this->getMock('Illuminate\Database\Eloquent\Collection', array('toArray'));
+		$c = $this->getMock(EloquentCollection::class, array('toArray'));
 		$c->expects($this->once())->method('toArray')->will($this->returnValue('foo'));
 
 		$this->assertEquals(json_encode('foo'), (string) $c);
@@ -390,8 +391,8 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$data = new Collection(array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 		$data = $data->chunk(3);
 
-		$this->assertInstanceOf('Illuminate\Support\Collection', $data);
-		$this->assertInstanceOf('Illuminate\Support\Collection', $data[0]);
+		$this->assertInstanceOf(Collection::class, $data);
+		$this->assertInstanceOf(Collection::class, $data[0]);
 		$this->assertEquals(4, $data->count());
 		$this->assertEquals(array(1, 2, 3), $data[0]->toArray());
 		$this->assertEquals(array(10), $data[3]->toArray());
@@ -447,7 +448,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 		$this->assertContains($random, $data->all());
 
 		$random = $data->random(3);
-		$this->assertInstanceOf('Illuminate\Support\Collection', $random);
+		$this->assertInstanceOf(Collection::class, $random);
 		$this->assertCount(3, $random);
 	}
 
@@ -795,10 +796,10 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase {
 	{
 		$c = new Collection([1, 2, 3]);
 		$c = $c->zip(new Collection([4, 5, 6]));
-		$this->assertInstanceOf('Illuminate\Support\Collection', $c);
-		$this->assertInstanceOf('Illuminate\Support\Collection', $c[0]);
-		$this->assertInstanceOf('Illuminate\Support\Collection', $c[1]);
-		$this->assertInstanceOf('Illuminate\Support\Collection', $c[2]);
+		$this->assertInstanceOf(Collection::class, $c);
+		$this->assertInstanceOf(Collection::class, $c[0]);
+		$this->assertInstanceOf(Collection::class, $c[1]);
+		$this->assertInstanceOf(Collection::class, $c[2]);
 		$this->assertEquals(3, $c->count());
 		$this->assertEquals([1, 4], $c[0]->all());
 		$this->assertEquals([2, 5], $c[1]->all());

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -1,12 +1,14 @@
 <?php
 
 use Mockery as m;
+use Mockery\MockInterface;
+use Illuminate\Support\Facades\Facade;
 
 class SupportFacadeTest extends PHPUnit_Framework_TestCase {
 
 	public function setUp()
 	{
-		Illuminate\Support\Facades\Facade::clearResolvedInstances();
+		Facade::clearResolvedInstances();
 		FacadeStub::setFacadeApplication(null);
 	}
 
@@ -33,7 +35,7 @@ class SupportFacadeTest extends PHPUnit_Framework_TestCase {
 		$app->setAttributes(array('foo' => new StdClass));
 		FacadeStub::setFacadeApplication($app);
 
-		$this->assertInstanceOf('Mockery\MockInterface', $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
+		$this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
 		$this->assertEquals('baz', $app['foo']->foo('bar'));
 	}
 
@@ -44,8 +46,8 @@ class SupportFacadeTest extends PHPUnit_Framework_TestCase {
 		$app->setAttributes(array('foo' => new StdClass));
 		FacadeStub::setFacadeApplication($app);
 
-		$this->assertInstanceOf('Mockery\MockInterface', $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
-		$this->assertInstanceOf('Mockery\MockInterface', $mock = FacadeStub::shouldReceive('foo2')->once()->with('bar2')->andReturn('baz2')->getMock());
+		$this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
+		$this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::shouldReceive('foo2')->once()->with('bar2')->andReturn('baz2')->getMock());
 		$this->assertEquals('baz', $app['foo']->foo('bar'));
 		$this->assertEquals('baz2', $app['foo']->foo2('bar2'));
 	}
@@ -59,7 +61,7 @@ class SupportFacadeTest extends PHPUnit_Framework_TestCase {
 
 }
 
-class FacadeStub extends Illuminate\Support\Facades\Facade {
+class FacadeStub extends Facade {
 
 	protected static function getFacadeAccessor()
 	{

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -9,7 +9,7 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 		$array  = array('name' => 'Taylor', 'age' => 25);
 		$fluent = new Fluent($array);
 
-		$refl = new \ReflectionObject($fluent);
+		$refl = new ReflectionObject($fluent);
 		$attributes = $refl->getProperty('attributes');
 		$attributes->setAccessible(true);
 
@@ -23,7 +23,7 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 		$array  = array('name' => 'Taylor', 'age' => 25);
 		$fluent = new Fluent((object) $array);
 
-		$refl = new \ReflectionObject($fluent);
+		$refl = new ReflectionObject($fluent);
 		$attributes = $refl->getProperty('attributes');
 		$attributes->setAccessible(true);
 
@@ -37,7 +37,7 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 		$array  = array('name' => 'Taylor', 'age' => 25);
 		$fluent = new Fluent(new FluentArrayIteratorStub($array));
 
-		$refl = new \ReflectionObject($fluent);
+		$refl = new ReflectionObject($fluent);
 		$attributes = $refl->getProperty('attributes');
 		$attributes->setAccessible(true);
 
@@ -68,7 +68,7 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('Taylor', $fluent->name);
 		$this->assertTrue($fluent->developer);
 		$this->assertEquals(25, $fluent->age);
-		$this->assertInstanceOf('Illuminate\Support\Fluent', $fluent->programmer());
+		$this->assertInstanceOf(Fluent::class, $fluent->programmer());
 	}
 
 
@@ -96,7 +96,7 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 
 	public function testToJsonEncodesTheToArrayResult()
 	{
-		$fluent = $this->getMock('Illuminate\Support\Fluent', array('toArray'));
+		$fluent = $this->getMock(Fluent::class, array('toArray'));
 		$fluent->expects($this->once())->method('toArray')->will($this->returnValue('foo'));
 		$results = $fluent->toJson();
 
@@ -106,7 +106,7 @@ class SupportFluentTest extends PHPUnit_Framework_TestCase {
 }
 
 
-class FluentArrayIteratorStub implements \IteratorAggregate {
+class FluentArrayIteratorStub implements IteratorAggregate {
 	protected $items = array();
 
 	public function __construct(array $items = array())
@@ -116,6 +116,6 @@ class FluentArrayIteratorStub implements \IteratorAggregate {
 
 	public function getIterator()
 	{
-		return new \ArrayIterator($this->items);
+		return new ArrayIterator($this->items);
 	}
 }

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Traits\Macroable;
+
 class SupportMacroableTest extends PHPUnit_Framework_TestCase {
 
 	private $macroable;
@@ -11,8 +13,7 @@ class SupportMacroableTest extends PHPUnit_Framework_TestCase {
 
 	private function createObjectForTrait()
 	{
-		$traitName = 'Illuminate\Support\Traits\Macroable';
-		return $this->getObjectForTrait($traitName);
+		return $this->getObjectForTrait(Macroable::class);
 	}
 
 
@@ -48,7 +49,7 @@ class SupportMacroableTest extends PHPUnit_Framework_TestCase {
 }
 
 class TestMacroable {
-	use Illuminate\Support\Traits\Macroable;
+	use Macroable;
 	protected $protectedVariable = 'instance';
 	protected static function getProtectedStatic()
 	{

--- a/tests/Support/SupportNamespacedItemResolverTest.php
+++ b/tests/Support/SupportNamespacedItemResolverTest.php
@@ -17,7 +17,7 @@ class SupportNamespacedItemResolverTest extends PHPUnit_Framework_TestCase {
 
 	public function testParsedItemsAreCached()
 	{
-		$r = $this->getMock('Illuminate\Support\NamespacedItemResolver', array('parseBasicSegments', 'parseNamespacedSegments'));
+		$r = $this->getMock(NamespacedItemResolver::class, array('parseBasicSegments', 'parseNamespacedSegments'));
 		$r->setParsedKey('foo.bar', array('foo'));
 		$r->expects($this->never())->method('parseBasicSegments');
 		$r->expects($this->never())->method('parseNamespacedSegments');

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -1,13 +1,14 @@
 <?php
 
-use Illuminate\Support\ServiceProvider;
 use Mockery as m;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\ServiceProvider;
 
 class SupportServiceProviderTest extends PHPUnit_Framework_TestCase {
 
 	public function setUp()
 	{
-		$app = m::mock('Illuminate\\Foundation\\Application')->makePartial();
+		$app = m::mock(Application::class)->makePartial();
 		$one = new ServiceProviderForTestingOne($app);
 		$one->boot();
 		$two = new ServiceProviderForTestingTwo($app);

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -14,7 +14,7 @@ class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase {
 
 	public function testLoadMethodWithoutNamespacesProperlyCallsLoader()
 	{
-		$loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+		$loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
 		$files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(true);
 		$files->shouldReceive('getRequire')->once()->with(__DIR__.'/en/foo.php')->andReturn(array('messages'));
 
@@ -24,7 +24,7 @@ class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase {
 
 	public function testLoadMethodWithNamespacesProperlyCallsLoader()
 	{
-		$loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+		$loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
 		$files->shouldReceive('exists')->once()->with('bar/en/foo.php')->andReturn(true);
 		$files->shouldReceive('exists')->once()->with(__DIR__.'/vendor/namespace/en/foo.php')->andReturn(false);
 		$files->shouldReceive('getRequire')->once()->with('bar/en/foo.php')->andReturn(array('foo' => 'bar'));
@@ -36,7 +36,7 @@ class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase {
 
 	public function testLoadMethodWithNamespacesProperlyCallsLoaderAndLoadsLocalOverrides()
 	{
-		$loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+		$loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
 		$files->shouldReceive('exists')->once()->with('bar/en/foo.php')->andReturn(true);
 		$files->shouldReceive('exists')->once()->with(__DIR__.'/vendor/namespace/en/foo.php')->andReturn(true);
 		$files->shouldReceive('getRequire')->once()->with('bar/en/foo.php')->andReturn(array('foo' => 'bar'));
@@ -49,7 +49,7 @@ class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase {
 
 	public function testEmptyArraysReturnedWhenFilesDontExist()
 	{
-		$loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+		$loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
 		$files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(false);
 		$files->shouldReceive('getRequire')->never();
 
@@ -59,7 +59,7 @@ class TranslationFileLoaderTest extends PHPUnit_Framework_TestCase {
 
 	public function testEmptyArraysReturnedWhenFilesDontExistForNamespacedItems()
 	{
-		$loader = new FileLoader($files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__);
+		$loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
 		$files->shouldReceive('getRequire')->never();
 
 		$this->assertEquals(array(), $loader->load('en', 'foo', 'bar'));

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -2,6 +2,8 @@
 
 use Mockery as m;
 use Illuminate\Translation\Translator;
+use Illuminate\Translation\LoaderInterface;
+use Symfony\Component\Translation\MessageSelector;
 
 class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 
@@ -13,11 +15,11 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 
 	public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
 	{
-		$t = $this->getMock('Illuminate\Translation\Translator', array('get'), array($this->getLoader(), 'en'));
+		$t = $this->getMock(Translator::class, array('get'), array($this->getLoader(), 'en'));
 		$t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(array()), $this->equalTo('bar'))->will($this->returnValue('foo'));
 		$this->assertFalse($t->has('foo', 'bar'));
 
-		$t = $this->getMock('Illuminate\Translation\Translator', array('get'), array($this->getLoader(), 'en', 'sp'));
+		$t = $this->getMock(Translator::class, array('get'), array($this->getLoader(), 'en', 'sp'));
 		$t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(array()), $this->equalTo('bar'))->will($this->returnValue('bar'));
 		$this->assertTrue($t->has('foo', 'bar'));
 	}
@@ -25,7 +27,7 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetMethodProperlyLoadsAndRetrievesItem()
 	{
-		$t = $this->getMock('Illuminate\Translation\Translator', null, array($this->getLoader(), 'en'));
+		$t = $this->getMock(Translator::class, null, array($this->getLoader(), 'en'));
 		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(array('foo' => 'foo', 'baz' => 'breeze :foo'));
 		$this->assertEquals('breeze bar', $t->get('foo::bar.baz', array('foo' => 'bar'), 'en'));
 		$this->assertEquals('foo', $t->get('foo::bar.foo'));
@@ -34,7 +36,7 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetMethodProperlyLoadsAndRetrievesItemWithLongestReplacementsFirst()
 	{
-		$t = $this->getMock('Illuminate\Translation\Translator', null, array($this->getLoader(), 'en'));
+		$t = $this->getMock(Translator::class, null, array($this->getLoader(), 'en'));
 		$t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(array('foo' => 'foo', 'baz' => 'breeze :foo :foobar'));
 		$this->assertEquals('breeze bar taylor', $t->get('foo::bar.baz', array('foo' => 'bar', 'foobar' => 'taylor'), 'en'));
 		$this->assertEquals('breeze foo bar baz taylor', $t->get('foo::bar.baz', array('foo' => 'foo bar baz', 'foobar' => 'taylor'), 'en'));
@@ -44,7 +46,7 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 
 	public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
 	{
-		$t = $this->getMock('Illuminate\Translation\Translator', null, array($this->getLoader(), 'en'));
+		$t = $this->getMock(Translator::class, null, array($this->getLoader(), 'en'));
 		$t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(array('bar' => 'breeze :foo'));
 		$this->assertEquals('breeze bar', $t->get('foo.bar', array('foo' => 'bar')));
 	}
@@ -52,9 +54,9 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 
 	public function testChoiceMethodProperlyLoadsAndRetrievesItem()
 	{
-		$t = $this->getMock('Illuminate\Translation\Translator', array('get'), array($this->getLoader(), 'en'));
+		$t = $this->getMock(Translator::class, array('get'), array($this->getLoader(), 'en'));
 		$t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(array('replace')), $this->equalTo('en'))->will($this->returnValue('line'));
-		$t->setSelector($selector = m::mock('Symfony\Component\Translation\MessageSelector'));
+		$t->setSelector($selector = m::mock(MessageSelector::class));
 		$selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
 
 		$t->choice('foo', 10, array('replace'));
@@ -63,7 +65,7 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase {
 
 	protected function getLoader()
 	{
-		return m::mock('Illuminate\Translation\LoaderInterface');
+		return m::mock(LoaderInterface::class);
 	}
 
 }

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Validation\DatabasePresenceVerifier;
+use Illuminate\Database\ConnectionResolverInterface;
 
 class ValidationDatabasePresenceVerifierTest extends PHPUnit_Framework_TestCase {
 
@@ -12,7 +14,7 @@ class ValidationDatabasePresenceVerifierTest extends PHPUnit_Framework_TestCase 
 
 	public function testBasicCount()
 	{
-		$verifier = new Illuminate\Validation\DatabasePresenceVerifier($db = m::mock('Illuminate\Database\ConnectionResolverInterface'));
+		$verifier = new DatabasePresenceVerifier($db = m::mock(ConnectionResolverInterface::class));
 		$verifier->setConnection('connection');
 		$db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock('StdClass'));
 		$conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock('StdClass'));

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -2,6 +2,9 @@
 
 use Mockery as m;
 use Illuminate\Validation\Factory;
+use Illuminate\Validation\Validator;
+use Illuminate\Validation\PresenceVerifierInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class ValidationFactoryTest extends PHPUnit_Framework_TestCase {
 
@@ -13,14 +16,14 @@ class ValidationFactoryTest extends PHPUnit_Framework_TestCase {
 
 	public function testMakeMethodCreatesValidValidator()
 	{
-		$translator = m::mock('Symfony\Component\Translation\TranslatorInterface');
+		$translator = m::mock(TranslatorInterface::class);
 		$factory = new Factory($translator);
 		$validator = $factory->make(array('foo' => 'bar'), array('baz' => 'boom'));
 		$this->assertEquals($translator, $validator->getTranslator());
 		$this->assertEquals(array('foo' => 'bar'), $validator->getData());
 		$this->assertEquals(array('baz' => array('boom')), $validator->getRules());
 
-		$presence = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+		$presence = m::mock(PresenceVerifierInterface::class);
 		$noop1 = function() {};
 		$noop2 = function() {};
 		$noop3 = function() {};
@@ -33,7 +36,7 @@ class ValidationFactoryTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(array('replacer' => $noop3), $validator->getReplacers());
 		$this->assertEquals($presence, $validator->getPresenceVerifier());
 
-		$presence = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+		$presence = m::mock(PresenceVerifierInterface::class);
 		$factory->extend('foo', $noop1, 'foo!');
 		$factory->extendImplicit('implicit', $noop2, 'implicit!');
 		$factory->setPresenceVerifier($presence);
@@ -47,12 +50,12 @@ class ValidationFactoryTest extends PHPUnit_Framework_TestCase {
 	public function testCustomResolverIsCalled()
 	{
 		unset($_SERVER['__validator.factory']);
-		$translator = m::mock('Symfony\Component\Translation\TranslatorInterface');
+		$translator = m::mock(TranslatorInterface::class);
 		$factory = new Factory($translator);
 		$factory->resolver(function($translator, $data, $rules)
 		{
 			$_SERVER['__validator.factory'] = true;
-			return new Illuminate\Validation\Validator($translator, $data, $rules);
+			return new Validator($translator, $data, $rules);
 		});
 		$validator = $factory->make(array('foo' => 'bar'), array('baz' => 'boom'));
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
 
 class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase {
@@ -628,7 +629,7 @@ empty
 
 	protected function getFiles()
 	{
-		return m::mock('Illuminate\Filesystem\Filesystem');
+		return m::mock(Filesystem::class);
 	}
 
 

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\View\Engines\CompilerEngine;
+use Illuminate\View\Compilers\CompilerInterface;
 
 class ViewCompilerEngineTest extends PHPUnit_Framework_TestCase {
 
@@ -39,7 +40,7 @@ class ViewCompilerEngineTest extends PHPUnit_Framework_TestCase {
 
 	protected function getEngine()
 	{
-		return new CompilerEngine(m::mock('Illuminate\View\Compilers\CompilerInterface'));
+		return new CompilerEngine(m::mock(CompilerInterface::class));
 	}
 
 }

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Illuminate\View\FileViewFinder;
+use Illuminate\Filesystem\Filesystem;
 
 class ViewFinderTest extends PHPUnit_Framework_TestCase {
 
@@ -152,7 +154,7 @@ class ViewFinderTest extends PHPUnit_Framework_TestCase {
 
 	protected function getFinder()
 	{
-		return new Illuminate\View\FileViewFinder(m::mock('Illuminate\Filesystem\Filesystem'), array(__DIR__));
+		return new FileViewFinder(m::mock(Filesystem::class), array(__DIR__));
 	}
 
 }

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -2,7 +2,11 @@
 
 use Mockery as m;
 use Illuminate\View\View;
+use Illuminate\View\Factory;
+use Illuminate\Support\MessageBag;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\View\Engines\EngineInterface;
 
 class ViewTest extends PHPUnit_Framework_TestCase {
 
@@ -14,13 +18,13 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 
 	public function testDataCanBeSetOnView()
 	{
-		$view = new View(m::mock('Illuminate\View\Factory'), m::mock('Illuminate\View\Engines\EngineInterface'), 'view', 'path', array());
+		$view = new View(m::mock(Factory::class), m::mock(EngineInterface::class), 'view', 'path', array());
 		$view->with('foo', 'bar');
 		$view->with(array('baz' => 'boom'));
 		$this->assertEquals(array('foo' => 'bar', 'baz' => 'boom'), $view->getData());
 
 
-		$view = new View(m::mock('Illuminate\View\Factory'), m::mock('Illuminate\View\Engines\EngineInterface'), 'view', 'path', array());
+		$view = new View(m::mock(Factory::class), m::mock(EngineInterface::class), 'view', 'path', array());
 		$view->withFoo('bar')->withBaz('boom');
 		$this->assertEquals(array('foo' => 'bar', 'baz' => 'boom'), $view->getData());
 	}
@@ -49,9 +53,9 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 
 	public function testRenderSectionsReturnsEnvironmentSections()
 	{
-		$view = m::mock('Illuminate\View\View[render]', array(
-			m::mock('Illuminate\View\Factory'),
-			m::mock('Illuminate\View\Engines\EngineInterface'),
+		$view = m::mock(View::class.'[render]', array(
+			m::mock(Factory::class),
+			m::mock(EngineInterface::class),
 			'view',
 			'path',
 			array(),
@@ -84,18 +88,18 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 		$view->getFactory()->shouldReceive('make')->once()->with('foo', array('data'));
 		$result = $view->nest('key', 'foo', array('data'));
 
-		$this->assertInstanceOf('Illuminate\View\View', $result);
+		$this->assertInstanceOf(View::class, $result);
 	}
 
 
 	public function testViewAcceptsArrayableImplementations()
 	{
-		$arrayable = m::mock('Illuminate\Contracts\Support\Arrayable');
+		$arrayable = m::mock(Arrayable::class);
 		$arrayable->shouldReceive('toArray')->once()->andReturn(array('foo' => 'bar', 'baz' => array('qux', 'corge')));
 
 		$view = new View(
-			m::mock('Illuminate\View\Factory'),
-			m::mock('Illuminate\View\Engines\EngineInterface'),
+			m::mock(Factory::class),
+			m::mock(EngineInterface::class),
 			'view',
 			'path',
 			$arrayable
@@ -163,7 +167,7 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 		$view->getFactory()->shouldReceive('decrementRender')->once()->ordered();
 		$view->getFactory()->shouldReceive('flushSectionsIfDoneRendering')->once();
 
-		$view->renderable = m::mock('Illuminate\Contracts\Support\Renderable');
+		$view->renderable = m::mock(Renderable::class);
 		$view->renderable->shouldReceive('render')->once()->andReturn('text');
 		$this->assertEquals('contents', $view->render());
 	}
@@ -191,13 +195,13 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 		$view = $this->getView();
 		$errors = array('foo' => 'bar', 'qu' => 'ux');
 		$this->assertSame($view, $view->withErrors($errors));
-		$this->assertInstanceOf('Illuminate\Support\MessageBag', $view->errors);
+		$this->assertInstanceOf(MessageBag::class, $view->errors);
 		$foo = $view->errors->get('foo');
 		$this->assertEquals($foo[0], 'bar');
 		$qu = $view->errors->get('qu');
 		$this->assertEquals($qu[0], 'ux');
 		$data = array('foo' => 'baz');
-		$this->assertSame($view, $view->withErrors(new \Illuminate\Support\MessageBag($data)));
+		$this->assertSame($view, $view->withErrors(new MessageBag($data)));
 		$foo = $view->errors->get('foo');
 		$this->assertEquals($foo[0], 'baz');
 	}
@@ -206,8 +210,8 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 	protected function getView()
 	{
 		return new View(
-			m::mock('Illuminate\View\Factory'),
-			m::mock('Illuminate\View\Engines\EngineInterface'),
+			m::mock(Factory::class),
+			m::mock(EngineInterface::class),
 			'view',
 			'path',
 			array('foo' => 'bar')


### PR DESCRIPTION
Makes it far less error-prone and infinitely more readable - especially in the tests.
