### PR TITLE
[5.2] Allow validating against proper mime type, not just extension

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1256,7 +1256,16 @@ class Validator implements ValidatorContract {
 			return false;
 		}
 
-		return $value->getPath() != '' && in_array($value->guessExtension(), $parameters);
+		// If the parameters contain a slash, we assume it's a proper mime type,
+		// and do a comparison with the real mime type of the file.
+		if(count($parameters) > 0 && strpos($parameters[0], '/') !== false) {
+			$data = $value->getMimeType();
+		}
+		else {
+			$data = $value->guessExtension();
+		}
+
+		return $value->getPath() != '' && in_array($data, $parameters);
 	}
 
 	/**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1258,10 +1258,12 @@ class Validator implements ValidatorContract {
 
 		// If the parameters contain a slash, we assume it's a proper mime type,
 		// and do a comparison with the real mime type of the file.
-		if(count($parameters) > 0 && strpos($parameters[0], '/') !== false) {
+		if(count($parameters) > 0 && strpos($parameters[0], '/') !== false)
+		{
 			$data = $value->getMimeType();
 		}
-		else {
+		else
+		{
 			$data = $value->guessExtension();
 		}
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1258,7 +1258,7 @@ class Validator implements ValidatorContract {
 
 		// If the parameters contain a slash, we assume it's a proper mime type,
 		// and do a comparison with the real mime type of the file.
-		if(count($parameters) > 0 && strpos($parameters[0], '/') !== false)
+		if (count($parameters) > 0 && strpos($parameters[0], '/') !== false)
 		{
 			$data = $value->getMimeType();
 		}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1050,6 +1050,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, array(), array('x' => 'mimes:php'));
 		$v->setFiles(array('x' => $file2));
 		$this->assertFalse($v->passes());
+
+		$file3 = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', array('getMimeType'), $uploadedFile);
+		$file3->expects($this->any())->method('getMimeType')->will($this->returnValue('image/jpeg'));
+		$v = new Validator($trans, array(), array('x' => 'mimes:image/jpeg'));
+		$v->setFiles(array('x' => $file3));
+		$this->assertTrue($v->passes());
 	}
 
 


### PR DESCRIPTION
This commit allows a user to validate against the real mime type of the uploaded file.

It does this by looking for a '/' in the list of allowed mimes. If if finds a slash, it assumes the user wants the real mime type.
If not, it falls back to the old version which compares extensions.
