### PR TITLE
[5.2] Added fix for last page on pagination query builder being ignored and…

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -261,9 +261,12 @@ class Builder {
 	{
 		$total = $this->query->getCountForPagination();
 
+		$perPage = $perPage ?: $this->model->getPerPage();
+		$lastPage = ceil($total / $perPage);
+
 		$this->query->forPage(
-			$page = Paginator::resolveCurrentPage($pageName),
-			$perPage = $perPage ?: $this->model->getPerPage()
+			$page = Paginator::resolveCurrentPage($pageName, 1, $lastPage),
+			$perPage
 		);
 
 		return new LengthAwarePaginator($this->get($columns), $total, $perPage, $page, [

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -306,14 +306,17 @@ abstract class AbstractPaginator {
 	 * Resolve the current page or return the default value.
 	 *
 	 * @param  string  $pageName
-	 * @param  int  $default
+	 * @param  int     $default
+	 * @param  int     $lastPage
 	 * @return int
 	 */
-	public static function resolveCurrentPage($pageName = 'page', $default = 1)
+	public static function resolveCurrentPage($pageName = 'page', $default = 1, $lastPage)
 	{
 		if (isset(static::$currentPageResolver))
 		{
-			return call_user_func(static::$currentPageResolver, $pageName);
+			$page = call_user_func(static::$currentPageResolver, $pageName);
+
+			return ($page > $lastPage) ? $lastPage : $page;
 		}
 
 		return $default;

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -305,12 +305,12 @@ abstract class AbstractPaginator {
 	/**
 	 * Resolve the current page or return the default value.
 	 *
-	 * @param  string  $pageName
-	 * @param  int     $default
-	 * @param  int     $lastPage
+	 * @param  string $pageName
+	 * @param  int $default
+	 * @param  int $lastPage
 	 * @return int
 	 */
-	public static function resolveCurrentPage($pageName = 'page', $default = 1, $lastPage)
+	public static function resolveCurrentPage($pageName = 'page', $default = 1, $lastPage = 1)
 	{
 		if (isset(static::$currentPageResolver))
 		{

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -305,9 +305,9 @@ abstract class AbstractPaginator {
 	/**
 	 * Resolve the current page or return the default value.
 	 *
-	 * @param  string $pageName
-	 * @param  int $default
-	 * @param  int $lastPage
+	 * @param  string  $pageName
+	 * @param  int  $default
+	 * @param  int  $lastPage
 	 * @return int
 	 */
 	public static function resolveCurrentPage($pageName = 'page', $default = 1, $lastPage = 1)


### PR DESCRIPTION
… current page being used.

I.e you have 61 items 30 per page, you have 3 pages, one user deletes an item now you have 2 pages of 60 items, another user refreshes on page 3 and they are stuck on a page without any results or pagination links.

Fixes #8252
