### PR TITLE
[4.2] Add hasMorph functionality (w/ accompanying methods) to Eloquent query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -710,6 +710,86 @@ class Builder {
 	}
 
 	/**
+	 * Add a polymorphic relationship count condition to the query.
+	 *
+	 * @param  string  $relation
+	 * @param  string  $model
+	 * @param  string  $operator
+	 * @param  int     $count
+	 * @param  string  $boolean
+	 * @param  \Closure|null  $callback
+	 * @return \Illuminate\Database\Eloquent\Builder|static
+	 */
+	public function hasMorph($relation, $model, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+	{
+		$relation = $this->getHasRelationQuery($relation);
+
+		$query = $relation->getRelationCountQuery((new $model)->newQuery(), $this);
+
+		if ($callback) call_user_func($callback, $query);
+
+		return $this->addHasWhere($query, $relation, $operator, $count, $boolean);
+	}
+
+	/**
+	 * Add a polymorphic relationship count condition to the query.
+	 *
+	 * @param  string  $relation
+	 * @param  string  $model
+	 * @param  string  $boolean
+	 * @param  \Closure|null  $callback
+	 * @return \Illuminate\Database\Eloquent\Builder|static
+	 */
+	public function doesntHaveMorph($relation, $model, $boolean = 'and', Closure $callback = null)
+	{
+		return $this->hasMorph($relation, $model, '<', 1, $boolean, $callback);
+	}
+
+	/**
+	 * Add a polymorphic relationship count condition to the query with where clauses.
+	 *
+	 * @param  string    $relation
+	 * @param  string    $model
+	 * @param  \Closure  $callback
+	 * @param  string    $operator
+	 * @param  int       $count
+	 * @return \Illuminate\Database\Eloquent\Builder|static
+	 */
+	public function whereHasMorph($relation, $model, Closure $callback, $operator = '>=', $count = 1)
+	{
+		return $this->hasMorph($relation, $model, $operator, $count, 'and', $callback);
+	}
+
+	/**
+	 * Add a polymorphic relationship count condition to the query with an "or".
+	 *
+	 * @param  string  $relation
+	 * @param  string  $model
+	 * @param  string  $operator
+	 * @param  int     $count
+	 * @return \Illuminate\Database\Eloquent\Builder|static
+	 */
+	public function orHasMorph($relation, $model, $operator = '>=', $count = 1)
+	{
+		return $this->hasMorph($relation, $model, $operator, $count, 'or');
+	}
+
+	/**
+	 * Add a polymorphic relationship count condition to the query with where clauses and an "or".
+	 *
+	 * @param  string    $relation
+	 * @param  string    $model
+	 * @param  \Closure  $callback
+	 * @param  string    $operator
+	 * @param  int       $count
+	 * @return \Illuminate\Database\Eloquent\Builder|static
+	 */
+	public function orWhereHasMorph($relation, $model, Closure $callback, $operator = '>=', $count = 1)
+	{
+		return $this->hasMorph($relation, $model, $operator, $count, 'or', $callback);
+	}
+
+	/**
 	 * Add the "has" condition where clause to the query.
 	 *
 	 * @param  \Illuminate\Database\Eloquent\Builder  $hasQuery

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -713,18 +713,18 @@ class Builder {
 	 * Add a polymorphic relationship count condition to the query.
 	 *
 	 * @param  string  $relation
-	 * @param  string  $model
+	 * @param  string  $morphClass
 	 * @param  string  $operator
 	 * @param  int     $count
 	 * @param  string  $boolean
 	 * @param  \Closure|null  $callback
 	 * @return \Illuminate\Database\Eloquent\Builder|static
 	 */
-	public function hasMorph($relation, $model, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+	public function hasMorph($relation, $morphClass, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
 	{
 		$relation = $this->getHasRelationQuery($relation);
 
-		$query = $relation->getRelationCountQuery((new $model)->newQuery(), $this);
+		$query = $relation->getRelationCountQuery((new $morphClass)->newQuery(), $this);
 
 		if ($callback) call_user_func($callback, $query);
 
@@ -735,58 +735,58 @@ class Builder {
 	 * Add a polymorphic relationship count condition to the query.
 	 *
 	 * @param  string  $relation
-	 * @param  string  $model
+	 * @param  string  $morphClass
 	 * @param  string  $boolean
 	 * @param  \Closure|null  $callback
 	 * @return \Illuminate\Database\Eloquent\Builder|static
 	 */
-	public function doesntHaveMorph($relation, $model, $boolean = 'and', Closure $callback = null)
+	public function doesntHaveMorph($relation, $morphClass, $boolean = 'and', Closure $callback = null)
 	{
-		return $this->hasMorph($relation, $model, '<', 1, $boolean, $callback);
+		return $this->hasMorph($relation, $morphClass, '<', 1, $boolean, $callback);
 	}
 
 	/**
 	 * Add a polymorphic relationship count condition to the query with where clauses.
 	 *
 	 * @param  string    $relation
-	 * @param  string    $model
+	 * @param  string    $morphClass
 	 * @param  \Closure  $callback
 	 * @param  string    $operator
 	 * @param  int       $count
 	 * @return \Illuminate\Database\Eloquent\Builder|static
 	 */
-	public function whereHasMorph($relation, $model, Closure $callback, $operator = '>=', $count = 1)
+	public function whereHasMorph($relation, $morphClass, Closure $callback, $operator = '>=', $count = 1)
 	{
-		return $this->hasMorph($relation, $model, $operator, $count, 'and', $callback);
+		return $this->hasMorph($relation, $morphClass, $operator, $count, 'and', $callback);
 	}
 
 	/**
 	 * Add a polymorphic relationship count condition to the query with an "or".
 	 *
 	 * @param  string  $relation
-	 * @param  string  $model
+	 * @param  string  $morphClass
 	 * @param  string  $operator
 	 * @param  int     $count
 	 * @return \Illuminate\Database\Eloquent\Builder|static
 	 */
-	public function orHasMorph($relation, $model, $operator = '>=', $count = 1)
+	public function orHasMorph($relation, $morphClass, $operator = '>=', $count = 1)
 	{
-		return $this->hasMorph($relation, $model, $operator, $count, 'or');
+		return $this->hasMorph($relation, $morphClass, $operator, $count, 'or');
 	}
 
 	/**
 	 * Add a polymorphic relationship count condition to the query with where clauses and an "or".
 	 *
 	 * @param  string    $relation
-	 * @param  string    $model
+	 * @param  string    $morphClass
 	 * @param  \Closure  $callback
 	 * @param  string    $operator
 	 * @param  int       $count
 	 * @return \Illuminate\Database\Eloquent\Builder|static
 	 */
-	public function orWhereHasMorph($relation, $model, Closure $callback, $operator = '>=', $count = 1)
+	public function orWhereHasMorph($relation, $morphClass, Closure $callback, $operator = '>=', $count = 1)
 	{
-		return $this->hasMorph($relation, $model, $operator, $count, 'or', $callback);
+		return $this->hasMorph($relation, $morphClass, $operator, $count, 'or', $callback);
 	}
 
 	/**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Collection as BaseCollection;
 
 class MorphTo extends BelongsTo {
@@ -51,6 +52,37 @@ class MorphTo extends BelongsTo {
 		$this->morphType = $type;
 
 		parent::__construct($query, $parent, $foreignKey, $otherKey, $relation);
+	}
+
+	/**
+	 * Add the constraints for a relationship count query.
+	 *
+	 * @param  \Illuminate\Database\Eloquent\Builder  $query
+	 * @param  \Illuminate\Database\Eloquent\Builder  $parent
+	 * @return \Illuminate\Database\Eloquent\Builder
+	 */
+	public function getRelationCountQuery(Builder $query, Builder $parent)
+	{
+		$query->select(new Expression('count(*)'));
+
+		$model = $query->getModel();
+
+		$otherKey = $this->wrap($model->getQualifiedKeyName());
+
+		return $query->where([
+			$this->getQualifiedForeignKey() => new Expression($otherKey),
+			$this->getQualifiedMorphType() => $model->getMorphClass()
+		]);
+	}
+
+	/**
+	 * Get the fully qualified morph type expression of the relationship.
+	 *
+	 * @return string
+	 */
+	protected function getQualifiedMorphType()
+	{
+		return $this->parent->getTable().'.'.$this->morphType;
 	}
 
 	/**


### PR DESCRIPTION
This provides an additional, slightly altered syntax in which to query polymorphic relations, like the already existing has/whereHas/orWhereHas/etc. methods. These methods do not work for polymorphic relations - where the target model is not explicit.

Example usage (using the Photo/Staff/Order/imageable example in the docs):
### Retrieve only photos tagged to staff members:

```
    Photo::hasMorph('imageable', 'Staff')->get();
```

Produces the following SQL:

`select * from "photos" where (select count(*) from "staffs" where ("photos"."imageable_id" = "staffs"."id" and "photos"."imageable_type" = "Staff")) >= 1`
### Retrieve only photos on orders less than a week old:

```
    Photo::whereHasMorph('imageable', 'Order', function($query)
    {
        $query->where('order_date', '>=', new DateTime('-1 week'));
    })->get();
```

Produces the following SQL:

`select * from "photos" where (select count(*) from "orders" where ("photos"."imageable_id" = "orders"."id" and "photos"."imageable_type" = "Order") and "order_date" >= ?) >= 1`
### Retrieve only photos belonging to orders less than week old, as well as photos belonging to a staff member with a last name ending in "own":

```
    Photo::whereHasMorph('imageable', 'Order', function($query)
    {
        $query->where('order_date', '>=', new DateTime('-1 week'));
    })->orWhereHasMorph('imageable', 'Staff', function($query)
    {
        $query->where('last_name', 'LIKE', '%own');
    })->get();
```

Produces the following SQL:

`select * from "photos" where (select count(*) from "orders" where ("photos"."imageable_id" = "orders"."id" and "photos"."imageable_type" = "Photo") and "order_date" >= ?) >= 1 or (select count(*) from "staffs" where ("photos"."imageable_id" = "staffs"."id" and "photos"."imageable_type" = "Staff") and "last_name" LIKE "%own") >= 1`
