### PR TITLE
[5.1] Add PSR-7 Http Message Bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "symfony/http-foundation": "2.7.*",
         "symfony/http-kernel": "2.7.*",
         "symfony/process": "2.7.*",
+        "symfony/psr-http-message-bridge": "0.1.x",
         "symfony/routing": "2.7.*",
         "symfony/security-core": "2.7.*",
         "symfony/translation": "2.7.*",
@@ -109,7 +110,8 @@
         "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (~3.0).",
         "predis/predis": "Required to use the redis cache and queue drivers (~1.0).",
-        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~2.0)."
+        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~2.0).",
+        "zendframework/zend-diactoros": "Required to use the PSR-7 Http Message Factory"
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
         "pda/pheanstalk": "Required to use the beanstalk queue driver (~3.0).",
         "predis/predis": "Required to use the redis cache and queue drivers (~1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~2.0).",
-        "zendframework/zend-diactoros": "Required to use the PSR-7 Http Message Factory"
+        "zendframework/zend-diactoros": "Required to use the PSR-7 Http Message Factory (~1.0)."
     },
     "minimum-stability": "dev"
 }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -13,5 +13,6 @@ class FoundationServiceProvider extends AggregateServiceProvider
      */
     protected $providers = [
         'Illuminate\Foundation\Providers\FormRequestServiceProvider',
+        'Illuminate\Foundation\Providers\HttpMessageServiceProvider',
     ];
 }

--- a/src/Illuminate/Foundation/Providers/HttpMessageServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/HttpMessageServiceProvider.php
@@ -1,10 +1,8 @@
 <?php namespace Illuminate\Foundation\Providers;
 
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 use Illuminate\Support\ServiceProvider;
-use Psr\Http\Message\HttpMessageInterface;
-use Illuminate\Contracts\Events\Dispatcher;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
@@ -17,7 +15,7 @@ class HttpMessageServiceProvider extends ServiceProvider
      *
      * @var bool
      */
-    protected $defer = false;
+    protected $defer = true;
 
     /**
      * Register the service provider.
@@ -38,7 +36,7 @@ class HttpMessageServiceProvider extends ServiceProvider
         });
 
         $this->app->alias(RequestInterface::class, ServerRequestInterface::class);
-        $this->app->alias(RequestInterface::class, HttpMessageInterface::class);
+        $this->app->alias(RequestInterface::class, MessageInterface::class);
     }
 
     public function registerHttpFoundationFactory()
@@ -52,18 +50,6 @@ class HttpMessageServiceProvider extends ServiceProvider
     {
         $this->app->bind('psr7.http_message_factory', function () {
             return new DiactorosFactory();
-        });
-    }
-
-    public function boot(Dispatcher $dispatcher)
-    {
-        $dispatcher->listen('router.prepare', function ($request, $response) {
-            if ($response instanceof ResponseInterface) {
-                $factory = $this->app->make('psr7.http_foundation_factory');
-                return $factory->createResponse($response);
-            }
-
-            return $response;
         });
     }
 
@@ -81,7 +67,7 @@ class HttpMessageServiceProvider extends ServiceProvider
             HttpMessageFactoryInterface::class,
             RequestInterface::class,
             ServerRequestInterface::class,
-            HttpMessageInterface::class,
+            MessageInterface::class,
         ];
     }
 }

--- a/src/Illuminate/Foundation/Providers/HttpMessageServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/HttpMessageServiceProvider.php
@@ -1,0 +1,87 @@
+<?php namespace Illuminate\Foundation\Providers;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Illuminate\Support\ServiceProvider;
+use Psr\Http\Message\HttpMessageInterface;
+use Illuminate\Contracts\Events\Dispatcher;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+
+class HttpMessageServiceProvider extends ServiceProvider
+{
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = false;
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->registerHttpFoundationFactory();
+        $this->registerHttpMessageFactory();
+
+        $this->app->alias('psr7.http_foundation_factory', HttpFoundationFactory::class);
+        $this->app->alias('psr7.http_message_factory', HttpMessageFactoryInterface::class);
+
+        $this->app->bind(RequestInterface::class, function ($app) {
+            $factory = $app->make('psr7.http_message_factory');
+            return $factory->createRequest($app['request']);
+        });
+
+        $this->app->alias(RequestInterface::class, ServerRequestInterface::class);
+        $this->app->alias(RequestInterface::class, HttpMessageInterface::class);
+    }
+
+    public function registerHttpFoundationFactory()
+    {
+        $this->app->bind('psr7.http_foundation_factory', function () {
+            return new HttpFoundationFactory();
+        });
+    }
+
+    public function registerHttpMessageFactory()
+    {
+        $this->app->bind('psr7.http_message_factory', function () {
+            return new DiactorosFactory();
+        });
+    }
+
+    public function boot(Dispatcher $dispatcher)
+    {
+        $dispatcher->listen('router.prepare', function ($request, $response) {
+            if ($response instanceof ResponseInterface) {
+                $factory = $this->app->make('psr7.http_foundation_factory');
+                return $factory->createResponse($response);
+            }
+
+            return $response;
+        });
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [
+            'psr7.http_foundation_factory',
+            'psr7.http_message_factory',
+            HttpFoundationFactory::class,
+            HttpMessageFactoryInterface::class,
+            RequestInterface::class,
+            ServerRequestInterface::class,
+            HttpMessageInterface::class,
+        ];
+    }
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1190,7 +1190,11 @@ class Router implements RegistrarContract
      */
     public function prepareResponse($request, $response)
     {
-        $response = $this->callFilter('prepare', $request, $response);
+        $filterResponse = $this->callFilter('prepare', $request, $response);
+
+        if (!is_null($filterResponse)) {
+            $response = $filterResponse;
+        }
 
         if (!$response instanceof SymfonyResponse) {
             $response = new Response($response);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1190,6 +1190,8 @@ class Router implements RegistrarContract
      */
     public function prepareResponse($request, $response)
     {
+        $response = $this->callFilter('prepare', $request, $response);
+
         if (!$response instanceof SymfonyResponse) {
             $response = new Response($response);
         }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Response;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
+use Psr\Http\Message\ResponseInterface;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Routing\Registrar as RegistrarContract;

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1190,13 +1190,10 @@ class Router implements RegistrarContract
      */
     public function prepareResponse($request, $response)
     {
-        $filterResponse = $this->callFilter('prepare', $request, $response);
-
-        if (!is_null($filterResponse)) {
-            $response = $filterResponse;
-        }
-
-        if (!$response instanceof SymfonyResponse) {
+        if ($response instanceof ResponseInterface) {
+            $factory = $this->container->make('psr7.http_foundation_factory');
+            $response = $factory->createResponse($response);
+        } elseif (!$response instanceof SymfonyResponse) {
             $response = new Response($response);
         }
 


### PR DESCRIPTION
Similar to [PSR-7 support in Symfony](http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html#psr-7-support) this implements [`symfony/psr-http-message-bridge`](https://github.com/symfony/psr-http-message-bridge). This SericeProvider makes it possible to:
- Inject PSR-7 RequestInterface in a controller by typehinting it. The `$app['request']` is converted to a PSR-7 request.
- Return a PSR-7 ResponseInterface object from a controller. It is converted to a SymfonyResponse.

Currently zend-diactoros is supported, but can easily be swapped out when more factories are provided. Also see this [Symfony blog post](http://symfony.com/blog/psr-7-support-in-symfony-is-here#requestinterface-and-responseinterface-in-the-symfony-framework).

The example from Symfony could be used the same in Laravel:

```
use Psr\Http\Message\ServerRequestInterface;
use Zend\Diactoros\Response;

class DefaultController extends Controller
{
    public function index(ServerRequestInterface $request)
    {
        // Interact with the PSR-7 request

        $response = new Response();
        // Interact with the PSR-7 response

        return $response;
    }
}
```

A new `router.prepare` event is added to catch the Response before forcing it to a Symfony response.

This would allow for PSR-7 controlles, that can be shared between frameworks and could speed up libraries for PSR-7 (which could handle requests or return psr-7 responses directly).

Todos:
- [ ] Discuss other options?
- [ ] Tests
- [ ] Docs
