### PR TITLE
PHP-CS-Fixer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor
 composer.phar
 composer.lock
+.php_cs.cache
 .DS_Store
 Thumbs.db

--- a/.php_cs
+++ b/.php_cs
@@ -58,4 +58,5 @@ $fixers = [
 return Symfony\CS\Config\Config::create()
     ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
     ->fixers($fixers)
-    ->finder($finder);
+    ->finder($finder)
+    ->setUsingCache(true);

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Console\Scheduling;
 
-use Exception;
 use LogicException;
 use InvalidArgumentException;
 use Illuminate\Contracts\Container\Container;


### PR DESCRIPTION
- Add a basic .editorconfig file
- Use the cache feature so that we only try to fix files that I've changed since the last fix
- Ensure this .php_cs.cache files is not commited
