### PR TITLE
[5.0] Router group helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -272,6 +272,21 @@ if ( ! function_exists('get'))
 	}
 }
 
+if ( ! function_exists('group'))
+{
+	/**
+	 * Create a route group with shared attributes.
+	 *
+	 * @param  array     $attributes
+	 * @param  \Closure  $callback
+	 * @return void
+	 */
+	function group($attributes, $callback)
+	{
+		return app('router')->group($attributes, $callback);
+	}
+}
+
 if ( ! function_exists('info'))
 {
 	/**


### PR DESCRIPTION
Just adding the missing group helper.

```
group(['middleware' => 'auth'], function()
{

});
```
