### PR TITLE
[5.1] Fix has() on self referencing relationship with table prefix

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -107,9 +107,7 @@ class BelongsTo extends Relation
     {
         $query->select(new Expression('count(*)'));
 
-        $tablePrefix = $this->query->getQuery()->getConnection()->getTablePrefix();
-
-        $query->from($query->getModel()->getTable().' as '.$tablePrefix.$hash = $this->getRelationCountHash());
+        $query->from($query->getModel()->getTable().' as '.$hash = $this->getRelationCountHash());
 
         $key = $this->wrap($this->getQualifiedForeignKey());
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -325,9 +325,7 @@ class BelongsToMany extends Relation
     {
         $query->select(new Expression('count(*)'));
 
-        $tablePrefix = $this->query->getQuery()->getConnection()->getTablePrefix();
-
-        $query->from($this->table.' as '.$tablePrefix.$hash = $this->getRelationCountHash());
+        $query->from($this->table.' as '.$hash = $this->getRelationCountHash());
 
         $key = $this->wrap($this->getQualifiedParentKeyName());
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -81,9 +81,7 @@ abstract class HasOneOrMany extends Relation
     {
         $query->select(new Expression('count(*)'));
 
-        $tablePrefix = $this->query->getQuery()->getConnection()->getTablePrefix();
-
-        $query->from($query->getModel()->getTable().' as '.$tablePrefix.$hash = $this->getRelationCountHash());
+        $query->from($query->getModel()->getTable().' as '.$hash = $this->getRelationCountHash());
 
         $key = $this->wrap($this->getQualifiedParentKeyName());
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -52,6 +52,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->schema()->create('posts', function ($table) {
             $table->increments('id');
             $table->integer('user_id');
+            $table->integer('parent_id')->nullable();
             $table->string('name');
             $table->timestamps();
         });
@@ -262,6 +263,28 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
     }
 
+    public function testHasOnSelfReferencingBelongsToRelationship()
+    {
+        $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'user_id' => 1]);
+        $childPost = EloquentTestPost::create(['name' => 'Child Post', 'parent_id' => $parentPost->id, 'user_id' => 2]);
+
+        $results = EloquentTestPost::has('parentPost')->get();
+
+        $this->assertEquals(1, count($results));
+        $this->assertEquals('Child Post', $results->first()->name);
+    }
+
+    public function testHasOnSelfReferencingHasManyRelationship()
+    {
+        $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'user_id' => 1]);
+        $childPost = EloquentTestPost::create(['name' => 'Child Post', 'parent_id' => $parentPost->id, 'user_id' => 2]);
+
+        $results = EloquentTestPost::has('childPosts')->get();
+
+        $this->assertEquals(1, count($results));
+        $this->assertEquals('Parent Post', $results->first()->name);
+    }
+
     public function testBelongsToManyRelationshipModelsAreProperlyHydratedOverChunkedRequest()
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
@@ -426,6 +449,14 @@ class EloquentTestUser extends Eloquent
     public function photos()
     {
         return $this->morphMany('EloquentTestPhoto', 'imageable');
+    }
+    public function childPosts()
+    {
+        return $this->hasMany('EloquentTestPost', 'parent_id');
+    }
+    public function parentPost()
+    {
+        return $this->belongsTo('EloquentTestPost', 'parent_id');
     }
 }
 

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class DatabaseEloquentIntegrationWithTablePrefixTest extends DatabaseEloquentIntegrationTest
+{
+    /**
+     * Bootstrap Eloquent.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        $resolver = new DatabaseIntegrationTestConnectionResolver;
+        $resolver->connection()->setTablePrefix('prefix_');
+        Eloquent::setConnectionResolver($resolver);
+
+        Eloquent::setEventDispatcher(
+            new Illuminate\Events\Dispatcher
+        );
+    }
+
+    public function testBasicModelHydration()
+    {
+        EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['email' => 'abigailotwell@gmail.com']);
+
+        $models = EloquentTestUser::hydrateRaw(
+            'SELECT * FROM prefix_users WHERE email = ?', ['abigailotwell@gmail.com'], 'foo_connection'
+        );
+
+        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $models);
+        $this->assertInstanceOf('EloquentTestUser', $models[0]);
+        $this->assertEquals('abigailotwell@gmail.com', $models[0]->email);
+        $this->assertEquals('foo_connection', $models[0]->getConnectionName());
+        $this->assertEquals(1, $models->count());
+    }
+}


### PR DESCRIPTION
This is a port of #8859 that was merged into 5.0, for 5.1.
