### PR TITLE
[5.2] `lists` method should be consistent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -214,7 +214,7 @@ class Builder {
 	 *
 	 * @param  string  $column
 	 * @param  string  $key
-	 * @return array
+	 * @return Illuminate\Support\Collection
 	 */
 	public function lists($column, $key = null)
 	{
@@ -233,7 +233,7 @@ class Builder {
 			}
 		}
 
-		return $results;
+		return collect($results);
 	}
 
 	/**


### PR DESCRIPTION
When calling `lists` method on a collection it returns a new collection.
It would be great if they both return a `new Collection` and be
consistent.
