### PR TITLE
[5.1] Fetch Depreciations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -88,6 +88,8 @@ class Collection extends BaseCollection
      *
      * @param  string  $key
      * @return static
+     *
+     * @deprecated since version 5.1. Use pluck instead.
      */
     public function fetch($key)
     {

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -296,8 +296,9 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     {
         return Collection::make($contents)
             ->where('type', $type)
-            ->fetch('path')
-            ->values()->all();
+            ->pluck('path')
+            ->values()
+            ->all();
     }
 
     /**


### PR DESCRIPTION
The fetch method in the main collection class is marked as depreciated, so the eloquent collection fetch method should be too. I've also made sure we're not using this depreciated fetch method within the framework core.
