### PR TITLE
[5.1] `lists` method should be consistent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -231,7 +231,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $key
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
     public function lists($column, $key = null)
     {
@@ -248,7 +248,7 @@ class Builder
             }
         }
 
-        return $results;
+        return collect($results);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -180,7 +180,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'bar'])->andReturn(new EloquentBuilderTestListsStub(['name' => 'bar']));
         $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'baz'])->andReturn(new EloquentBuilderTestListsStub(['name' => 'baz']));
 
-        $this->assertEquals(['foo_bar', 'foo_baz'], $builder->lists('name'));
+        $this->assertEquals(['foo_bar', 'foo_baz'], $builder->lists('name')->all());
     }
 
     public function testListsWithoutModelGetterJustReturnTheAttributesFoundInDatabase()
@@ -190,7 +190,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasGetMutator')->with('name')->andReturn(false);
 
-        $this->assertEquals(['bar', 'baz'], $builder->lists('name'));
+        $this->assertEquals(['bar', 'baz'], $builder->lists('name')->all());
     }
 
     public function testMacrosAreCalledOnBuilder()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -166,8 +166,8 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
 
-        $simple = EloquentTestUser::oldest('id')->lists('users.email');
-        $keyed = EloquentTestUser::oldest('id')->lists('users.email', 'users.id');
+        $simple = EloquentTestUser::oldest('id')->lists('users.email')->all();
+        $keyed = EloquentTestUser::oldest('id')->lists('users.email', 'users.id')->all();
 
         $this->assertEquals(['taylorotwell@gmail.com', 'abigailotwell@gmail.com'], $simple);
         $this->assertEquals([1 => 'taylorotwell@gmail.com', 2 => 'abigailotwell@gmail.com'], $keyed);


### PR DESCRIPTION
When calling `lists` method on a collection it returns a new collection.
It would be great if they both return a `new Collection` and be
consistent.
