### PR TITLE
[5.1] Depreciate Routing Filters

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -94,6 +94,8 @@ interface Registrar
      *
      * @param  string|callable  $callback
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function before($callback);
 
@@ -102,6 +104,8 @@ interface Registrar
      *
      * @param  string|callable  $callback
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function after($callback);
 
@@ -111,6 +115,8 @@ interface Registrar
      * @param  string  $name
      * @param  string|callable  $callback
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function filter($name, $callback);
 }

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -55,6 +55,8 @@ abstract class Controller
      * @param  \Closure|string  $filter
      * @param  array  $options
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function beforeFilter($filter, array $options = [])
     {
@@ -67,6 +69,8 @@ abstract class Controller
      * @param  \Closure|string  $filter
      * @param  array  $options
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function afterFilter($filter, array $options = [])
     {
@@ -149,6 +153,8 @@ abstract class Controller
      *
      * @param  string  $filter
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function forgetBeforeFilter($filter)
     {
@@ -160,6 +166,8 @@ abstract class Controller
      *
      * @param  string  $filter
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function forgetAfterFilter($filter)
     {
@@ -194,6 +202,8 @@ abstract class Controller
      * Get the registered "before" filters.
      *
      * @return array
+     *
+     * @deprecated since version 5.1
      */
     public function getBeforeFilters()
     {
@@ -204,6 +214,8 @@ abstract class Controller
      * Get the registered "after" filters.
      *
      * @return array
+     *
+     * @deprecated since version 5.1
      */
     public function getAfterFilters()
     {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -266,6 +266,8 @@ class Route
      * Get the "before" filters for the route.
      *
      * @return array
+     *
+     * @deprecated since version 5.1
      */
     public function beforeFilters()
     {
@@ -280,6 +282,8 @@ class Route
      * Get the "after" filters for the route.
      *
      * @return array
+     *
+     * @deprecated since version 5.1
      */
     public function afterFilters()
     {
@@ -295,6 +299,8 @@ class Route
      *
      * @param  string  $filters
      * @return array
+     *
+     * @deprecated since version 5.1
      */
     public static function parseFilters($filters)
     {
@@ -340,6 +346,8 @@ class Route
      *
      * @param  string  $filter
      * @return array
+     *
+     * @deprecated since version 5.1
      */
     public static function parseFilter($filter)
     {
@@ -648,6 +656,8 @@ class Route
      *
      * @param  string  $filters
      * @return $this
+     *
+     * @deprecated since version 5.1
      */
     public function before($filters)
     {
@@ -659,6 +669,8 @@ class Route
      *
      * @param  string  $filters
      * @return $this
+     *
+     * @deprecated since version 5.1
      */
     public function after($filters)
     {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -783,6 +783,8 @@ class Router implements RegistrarContract
      *
      * @param  string|callable  $callback
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function before($callback)
     {
@@ -794,6 +796,8 @@ class Router implements RegistrarContract
      *
      * @param  string|callable  $callback
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function after($callback)
     {
@@ -842,6 +846,8 @@ class Router implements RegistrarContract
      * @param  string  $name
      * @param  string|callable  $callback
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function filter($name, $callback)
     {
@@ -870,6 +876,8 @@ class Router implements RegistrarContract
      * @param  string  $name
      * @param  array|null  $methods
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function when($pattern, $name, $methods = null)
     {
@@ -887,6 +895,8 @@ class Router implements RegistrarContract
      * @param  string     $name
      * @param  array|null $methods
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function whenRegex($pattern, $name, $methods = null)
     {
@@ -1047,6 +1057,8 @@ class Router implements RegistrarContract
      *
      * @param  \Illuminate\Http\Request  $request
      * @return array
+     *
+     * @deprecated since version 5.1
      */
     public function findPatternFilters($request)
     {
@@ -1143,6 +1155,8 @@ class Router implements RegistrarContract
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Http\Response  $response
      * @return mixed
+     *
+     * @deprecated since version 5.1
      */
     public function callRouteAfter($route, $request, $response)
     {
@@ -1160,6 +1174,8 @@ class Router implements RegistrarContract
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Http\Response|null $response
      * @return mixed
+     *
+     * @deprecated since version 5.1
      */
     public function callRouteFilter($filter, $parameters, $route, $request, $response = null)
     {


### PR DESCRIPTION
I've marked all public methods associated with filtering as depreciated.
