### PR TITLE
[5.1] Fews improvement to Routing component:

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -51,7 +51,7 @@ class ResourceRegistrar
         // We need to extract the base resource from the resource name. Nested resources
         // are supported in the framework, but we need to know what name to use for a
         // place-holder on the route wildcards, which should be the base resources.
-        $base = $this->getResourceWildcard(last(explode('.', $name)));
+        $base = $this->getResourceWildcard(end(explode('.', $name)));
 
         $defaults = $this->resourceDefaults;
 
@@ -137,7 +137,7 @@ class ResourceRegistrar
 
         $uri = $this->getNestedResourceUri($segments);
 
-        return str_replace('/{'.$this->getResourceWildcard(last($segments)).'}', '', $uri);
+        return str_replace('/{'.$this->getResourceWildcard(end($segments)).'}', '', $uri);
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -259,7 +259,7 @@ class Route
      */
     public function middleware()
     {
-        return (array) array_get($this->action, 'middleware', []);
+        return (array) isset($this->action['middleware']) ? $this->action['middleware'] : [];
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -357,7 +357,7 @@ class Router implements RegistrarContract
     protected function updateGroupStack(array $attributes)
     {
         if (!empty($this->groupStack)) {
-            $attributes = $this->mergeGroup($attributes, last($this->groupStack));
+            $attributes = $this->mergeGroup($attributes, end($this->groupStack));
         }
 
         $this->groupStack[] = $attributes;
@@ -371,7 +371,7 @@ class Router implements RegistrarContract
      */
     public function mergeWithLastGroup($new)
     {
-        return $this->mergeGroup($new, last($this->groupStack));
+        return $this->mergeGroup($new, end($this->groupStack));
     }
 
     /**
@@ -391,7 +391,10 @@ class Router implements RegistrarContract
             unset($old['domain']);
         }
 
-        $new['where'] = array_merge(array_get($old, 'where', []), array_get($new, 'where', []));
+        $new['where'] = array_merge(
+            isset($old['where']) ? $old['where'] : [],
+            isset($new['where']) ? $new['where'] : []
+        );
 
         return array_merge_recursive(array_except($old, ['namespace', 'prefix', 'where']), $new);
     }
@@ -406,12 +409,12 @@ class Router implements RegistrarContract
     protected static function formatUsesPrefix($new, $old)
     {
         if (isset($new['namespace']) && isset($old['namespace'])) {
-            return trim(array_get($old, 'namespace'), '\\').'\\'.trim($new['namespace'], '\\');
+            return trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\');
         } elseif (isset($new['namespace'])) {
             return trim($new['namespace'], '\\');
         }
 
-        return array_get($old, 'namespace');
+        return isset($old['namespace']) ? $old['namespace'] : null;
     }
 
     /**
@@ -423,11 +426,13 @@ class Router implements RegistrarContract
      */
     protected static function formatGroupPrefix($new, $old)
     {
+        $oldPrefix = isset($old['prefix']) ? $old['prefix'] : null;
+
         if (isset($new['prefix'])) {
-            return trim(array_get($old, 'prefix'), '/').'/'.trim($new['prefix'], '/');
+            return trim($oldPrefix, '/').'/'.trim($new['prefix'], '/');
         }
 
-        return array_get($old, 'prefix');
+        return $oldPrefix;
     }
 
     /**
@@ -524,9 +529,9 @@ class Router implements RegistrarContract
      */
     protected function addWhereClausesToRoute($route)
     {
-        $route->where(
-            array_merge($this->patterns, array_get($route->getAction(), 'where', []))
-        );
+        $where = isset($route->getAction()['where']) ? $route->getAction()['where'] : [];
+
+        $route->where(array_merge($this->patterns, $where));
 
         return $route;
     }
@@ -556,7 +561,7 @@ class Router implements RegistrarContract
             return false;
         }
 
-        return is_string($action) || is_string(array_get($action, 'uses'));
+        return is_string($action) || is_string(isset($action['uses']) ? $action['uses'] : null);
     }
 
     /**
@@ -594,7 +599,7 @@ class Router implements RegistrarContract
      */
     protected function prependGroupUses($uses)
     {
-        $group = last($this->groupStack);
+        $group = end($this->groupStack);
 
         return isset($group['namespace']) && strpos($uses, '\\') !== 0 ? $group['namespace'].'\\'.$uses : $uses;
     }
@@ -719,7 +724,7 @@ class Router implements RegistrarContract
 
         list($name, $parameters) = array_pad(explode(':', $name, 2), 2, null);
 
-        return array_get($map, $name, $name).($parameters ? ':'.$parameters : '');
+        return (isset($map[$name]) ? $map[$name] : $name).($parameters ? ':'.$parameters : '');
     }
 
     /**


### PR DESCRIPTION
- Avoid using `last()` since it's just an alias to `end()`
- Refactor `array_get()` to just use `isset($a) ? $a : null` when possible.
- Avoid using `array_get()` on middleware name to allow using '.' as route middleware name.

Signed-off-by: crynobone crynobone@gmail.com
