### PR TITLE
[5.1] Deprecate bindShared() method

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -283,6 +283,8 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string    $abstract
      * @param  \Closure  $closure
      * @return void
+     *
+     * @deprecated since version 5.1
      */
     public function bindShared($abstract, Closure $closure)
     {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -284,7 +284,8 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure  $closure
      * @return void
      *
-     * @deprecated since version 5.1
+     * @deprecated since version 5.1. Use singleton instead.
+     * @see singleton()
      */
     public function bindShared($abstract, Closure $closure)
     {

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -90,6 +90,7 @@ class Collection extends BaseCollection
      * @return static
      *
      * @deprecated since version 5.1. Use pluck instead.
+     * @see pluck()
      */
     public function fetch($key)
     {


### PR DESCRIPTION
Not part of the contract, `singleton()` is the recommended way.

See #6314 for reference.
