### PR TITLE
[5.1] Fix #8987 str_random can return strings shorter than given length

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -222,19 +222,52 @@ class Str
      */
     public static function random($length = 16)
     {
-        if (function_exists('random_bytes')) {
-            $bytes = random_bytes($length * 2);
-        } elseif (function_exists('openssl_random_pseudo_bytes')) {
-            $bytes = openssl_random_pseudo_bytes($length * 2);
-        } else {
-            throw new RuntimeException('OpenSSL extension is required for PHP 5 users.');
+        $pool = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+        if (!function_exists('openssl_random_pseudo_bytes')) {
+            throw new RuntimeException('OpenSSL extension is required.');
         }
 
-        if ($bytes === false) {
-            throw new RuntimeException('Unable to generate random string.');
+        // can be replaced by random_int in  PHP 7: https://wiki.php.net/rfc/easy_userland_csprng
+        $random_int = function ($min, $max) {
+            $range = $max - $min;
+
+            // not so random...
+            if ($range < 0) {
+                return $min;
+            }
+
+            $log = log($range, 2);
+            // length in bytes
+            $bytes = (int)($log / 8) + 1;
+            // length in bits
+            $bits = (int)$log + 1;
+            // set all lower bits to 1
+            $filter = (int)(1 << $bits) - 1;
+
+            do {
+                $rnd = openssl_random_pseudo_bytes($bytes, $crypto_strong);
+
+                if ($crypto_strong === false || $rnd === false) {
+                    throw new RuntimeException('Unable to generate random string.');
+                }
+
+                $rnd = hexdec(bin2hex($rnd));
+
+                // discard irrelevant bits
+                $rnd = $rnd & $filter;
+            } while ($rnd >= $range);
+
+            return $min + $rnd;
+        };
+
+        $str = '';
+        $max = strlen($pool);
+        for ($i = 0; $i < $length; $i++) {
+            $str .= $pool[$random_int(0, $max)];
         }
 
-        return substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $length);
+        return $str;
     }
 
     /**


### PR DESCRIPTION
Hello again!
I raise the PR again for 5.1 as discussed in the old PR:  https://github.com/laravel/framework/pull/8991.

Seems that the only change in 5.1 so far was the usage of PHP 7's new `random_bytes` function. There is also a function for generating random integer (`random_int`) in PHP 7 that could be used here [1].

So far there is no release candidate for PHP 7 and it's not clear to me how this function will behave in an error case. Therefore I only added a comment that `$random_int` could be replaced by `random_int` as soon PHP 7 is available.

Greetings!

[1] https://wiki.php.net/rfc/easy_userland_csprng
