### PR TITLE
[5.1] Remove mcrypt dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require": {
         "php": ">=5.5.9",
         "ext-openssl": "*",
-        "ext-mcrypt": "*",
         "ext-mbstring": "*",
         "classpreloader/classpreloader": "~1.2",
         "danielstjules/stringy": "~1.8",

--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -21,14 +21,6 @@ interface Encrypter
     public function decrypt($payload);
 
     /**
-     * Set the encryption mode.
-     *
-     * @param  string  $mode
-     * @return void
-     */
-    public function setMode($mode);
-
-    /**
      * Set the encryption cipher.
      *
      * @param  string  $cipher

--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -19,12 +19,4 @@ interface Encrypter
      * @return string
      */
     public function decrypt($payload);
-
-    /**
-     * Set the encryption cipher.
-     *
-     * @param  string  $cipher
-     * @return void
-     */
-    public function setCipher($cipher);
 }

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -113,7 +113,7 @@ class Encrypter implements EncrypterContract
         if ($decrypted === false) {
             throw new DecryptException('Could not decrypt data.');
         }
-        
+
         return $decrypted;
     }
 

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -262,19 +262,6 @@ class Encrypter implements EncrypterContract
     }
 
     /**
-     * Set the encryption mode.
-     *
-     * @param  string  $mode
-     * @return void
-     */
-    public function setMode($mode)
-    {
-        $this->cipher = $mode;
-
-        $this->updateBlockSize();
-    }
-
-    /**
      * Update the block size for the current cipher and mode.
      *
      * @return void

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -14,13 +14,7 @@ class EncryptionServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('encrypter', function ($app) {
-            $encrypter = new Encrypter($app['config']['app.key']);
-
-            if ($app['config']->has('app.cipher')) {
-                $encrypter->setCipher($app['config']['app.cipher']);
-            }
-
-            return $encrypter;
+            return new Encrypter($app['config']['app.key']);
         });
     }
 }

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -14,8 +14,7 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
 
     public function testEncryptionWithCustomCipher()
     {
-        $e = $this->getEncrypter();
-        $e->setCipher('AES-256-CBC');
+        $e = new Encrypter(str_repeat('a', 32), 'AES-256-CBC');
         $this->assertNotEquals('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $e->encrypt('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
         $encrypted = $e->encrypt('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
         $this->assertEquals('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $e->decrypt($encrypted));

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -15,7 +15,7 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
     public function testEncryptionWithCustomCipher()
     {
         $e = $this->getEncrypter();
-        $e->setCipher(MCRYPT_RIJNDAEL_256);
+        $e->setCipher('AES-256-CBC');
         $this->assertNotEquals('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $e->encrypt('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
         $encrypted = $e->encrypt('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
         $this->assertEquals('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $e->decrypt($encrypted));


### PR DESCRIPTION
To be honest, it's quite annoying to keep BC.

Can we implement a different encrypter for openssl, and keep the old one for BC?

Something like: If you have used the old encryptor, set 'app.encrypter' to 'mcrypt' to keep it working?

Also, can we remove or deprecate the `setMode()` method?
