### PR TITLE
[5.1] Cleanup the encryptor

### DIFF
--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -14,7 +14,7 @@ class EncryptionServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('encrypter', function ($app) {
-            return new Encrypter($app['config']['app.key']);
+            return new Encrypter($app['config']['app.key'], $app['config']['app.cipher']);
         });
     }
 }


### PR DESCRIPTION
I've cleaned up the class, and removed the excess functions (like padding and base64_encodeing) that OpenSSL can accomplish.

I also removed the `setKey()`, since it's make much since to use the same encrypter with different keys. Just create a new instance if you need a different key.

Also, I restored the app.cipher configuration incase someone still needs this. If it's `null` then nothing it falls back to the default.

What do you think?
