### PR TITLE
[5.1] Parse multi-dimensional form fields to multi-dimensional array in Testing/CrawlerTrait submitForm() method.

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -170,6 +170,7 @@ trait CrawlerTrait
     protected function makeRequestParametersUsingForm(Form $form)
     {
         parse_str(http_build_query($form->getValues()), $parameters);
+
         return $parameters;
     }
 

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -157,8 +157,20 @@ trait CrawlerTrait
     protected function makeRequestUsingForm(Form $form)
     {
         return $this->makeRequest(
-            $form->getMethod(), $form->getUri(), $form->getValues(), [], $form->getFiles()
+            $form->getMethod(), $form->getUri(), $this->makeRequestParametersUsingForm($form), [], $form->getFiles()
         );
+    }
+
+    /**
+     * Make a request parameters using the given form.
+     *
+     * @param  \Symfony\Component\DomCrawler\Form  $form
+     * @return array
+     */
+    protected function makeRequestParametersUsingForm(Form $form)
+    {
+        parse_str(http_build_query($form->getValues()), $parameters);
+        return $parameters;
     }
 
     /**

--- a/tests/Foundation/FoundationCrawlerTraitTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Mockery as m;
+
+class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
+{
+    use Illuminate\Foundation\Testing\CrawlerTrait;
+
+    public function test_making_request_parameters_using_form()
+    {
+        $form = m::mock('\Symfony\Component\DomCrawler\Form');
+
+        $form->shouldReceive('getValues')->once()->andReturn([]);
+        $this->assertEquals([], $this->makeRequestParametersUsingForm($form));
+
+        $form->shouldReceive('getValues')->once()->andReturn(['name' => 'Laravel', 'license' => 'MIT']);
+        $this->assertEquals(['name' => 'Laravel', 'license' => 'MIT'], $this->makeRequestParametersUsingForm($form));
+
+        $form->shouldReceive('getValues')->once()->andReturn(['name' => 'Laravel', 'keywords[0]' => 'framework', 'keywords[1]' => 'laravel']);
+        $this->assertEquals(['name' => 'Laravel', 'keywords' => ['framework', 'laravel']], $this->makeRequestParametersUsingForm($form));
+    }
+}

--- a/tests/Foundation/FoundationCrawlerTraitTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Foundation\Testing\CrawlerTrait;
 
 class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
 {
-    use Illuminate\Foundation\Testing\CrawlerTrait;
+    use CrawlerTrait;
 
     public function test_making_request_parameters_using_form()
     {


### PR DESCRIPTION
Parse multi-dimensional form fields
['name' => 'Laravel', 'keywords[0]' => 'framework', 'keywords[1]' => 'laravel']

to multi-dimensional array
['name' => 'Laravel', 'keywords' => ['framework', 'laravel']]

in Testing/CrawlerTrait submitForm() method. Fixes issue #9052.
