### PR TITLE
[5.1] Allow orderByRaw on a union

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1139,9 +1139,11 @@ class Builder
      */
     public function orderByRaw($sql, $bindings = [])
     {
+        $property = $this->unions ? 'unionOrders' : 'orders';
+        
         $type = 'raw';
 
-        $this->orders[] = compact('type', 'sql');
+        $this->{$property}[] = compact('type', 'sql');
 
         $this->addBinding($bindings, 'order');
 


### PR DESCRIPTION
Currently it's not possible to call orderByRaw() on a union. This change matches the behaviour of orderBy() in such cases.
