### PR TITLE
[5.1] Adjustment to allow setContentTags to handle escaping of tags

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -61,7 +61,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $escapedTags = ['{{{', '}}}'];
 
     /**
-     * To keep track of if content tag are escaped
+     * Switch to track escape setting for contentTags.
      *
      * @var bool
      */
@@ -804,11 +804,11 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
-    * Set if content tags should be escaped
-    *
-    * @param  bool  $escaped
-    * @return void
-    */
+     * Enable/Disable escape setting for contentTags.
+     *
+     * @param  bool  $escaped
+     * @return void
+     */
     public function setContentTagsEscaped($escaped = true) {
         $this->contentTagsEscaped = $escaped;
     }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -61,11 +61,11 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $escapedTags = ['{{{', '}}}'];
 
     /**
-     * The "regular" / legacy echo string format.
+     * To keep track of if content tag are escaped
      *
-     * @var string
+     * @var bool
      */
-    protected $echoFormat = 'e(%s)';
+    protected $contentTagsEscaped = true;
 
     /**
      * Array of footer lines to be added to template.
@@ -307,7 +307,11 @@ class BladeCompiler extends Compiler implements CompilerInterface
         $callback = function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-            $wrapped = sprintf($this->echoFormat, $this->compileEchoDefaults($matches[2]));
+            if ($this->contentTagsEscaped) {
+                $wrapped = sprintf('e(%s)', $this->compileEchoDefaults($matches[2]));
+            } else {
+                $wrapped = sprintf('%s', $this->compileEchoDefaults($matches[2]));
+            }
 
             return $matches[1] ? substr($matches[0], 1) : '<?php echo '.$wrapped.'; ?>'.$whitespace;
         };
@@ -747,11 +751,11 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @param  bool    $escaped
      * @return void
      */
-    public function setContentTags($openTag, $closeTag, $escaped = false)
+    public function setContentTags($openTag, $closeTag, $escaped = true)
     {
-        $property = ($escaped === true) ? 'escapedTags' : 'contentTags';
+        $this->setContentTagsEscaped($escaped);
 
-        $this->{$property} = [preg_quote($openTag), preg_quote($closeTag)];
+        $this->contentTags = [preg_quote($openTag), preg_quote($closeTag)];
     }
 
     /**
@@ -763,7 +767,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function setEscapedContentTags($openTag, $closeTag)
     {
-        $this->setContentTags($openTag, $closeTag, true);
+        $this->escapedTags = array(preg_quote($openTag), preg_quote($closeTag));
     }
 
     /**
@@ -800,13 +804,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
-     * Set the echo format to be used by the compiler.
-     *
-     * @param  string  $format
-     * @return void
-     */
-    public function setEchoFormat($format)
-    {
-        $this->echoFormat = $format;
+    * Set if content tags should be escaped
+    *
+    * @param  bool  $escaped
+    * @return void
+    */
+    public function setContentTagsEscaped($escaped = true) {
+        $this->contentTagsEscaped = $escaped;
     }
 }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -809,7 +809,8 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @param  bool  $escaped
      * @return void
      */
-    public function setContentTagsEscaped($escaped = true) {
+    public function setContentTagsEscaped($escaped = true) 
+    {
         $this->contentTagsEscaped = $escaped;
     }
 }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -551,7 +551,7 @@ empty
     public function testRawTagsCanBeSetToLegacyValues()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
-        $compiler->setEchoFormat('%s');
+        $compiler->setContentTagsEscaped(false);
 
         $this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{{ $name }}}'));
         $this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{ $name }}'));


### PR DESCRIPTION
updated to use 5.1 version
- removed setEchoFormat function and $echoFormat variable
- adjusted compileRegularEchos function
- adjusted setContentTags function
- adjusted setEscapedContentTags function

I could find no other use in the existing code for the setEchoFormat, so I'm assuming it was in to allow to change to support the old way content tags were being escaped or not.

This fixes the setContentTags to support setting tags to be escaped or not.

In the function setContentTags($openTag, $closeTag, $escaped) the original $escaped flag only changed the tag name, nothing to really do with if the specified tag is escaped or not.

Default in setContentTags function for $escaped is true, this keeps the default of the content tags being escaped.

This change allows the developer to set the standard content tags to be escaped or not and makes the function more in line with how it reads.

Example:
setContentTags('[[', ']]') - would work just like the default tags, they would be escaped
setContentTags('[[', ']]', false) - would set the tags to not be escaped
