### PR TITLE
[5.1] Move BindingResolutionException

### DIFF
--- a/src/Illuminate/Container/BindingResolutionException.php
+++ b/src/Illuminate/Container/BindingResolutionException.php
@@ -4,6 +4,9 @@ namespace Illuminate\Container;
 
 use Exception;
 
+/**
+ * @deprecated since version 5.1. Use Illuminate\Contracts\Container\BindingResolutionException.
+ */
 class BindingResolutionException extends Exception
 {
 }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -10,6 +10,7 @@ use ReflectionFunction;
 use ReflectionParameter;
 use InvalidArgumentException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
+use Illuminate\Contracts\Container\BindingResolutionException as BindingResolutionContractException;
 
 class Container implements ArrayAccess, ContainerContract
 {
@@ -721,7 +722,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  array   $parameters
      * @return mixed
      *
-     * @throws BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function build($concrete, array $parameters = [])
     {
@@ -740,7 +741,7 @@ class Container implements ArrayAccess, ContainerContract
         if (!$reflector->isInstantiable()) {
             $message = "Target [$concrete] is not instantiable.";
 
-            throw new BindingResolutionException($message);
+            throw new BindingResolutionContractException($message);
         }
 
         $this->buildStack[] = $concrete;
@@ -809,7 +810,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \ReflectionParameter  $parameter
      * @return mixed
      *
-     * @throws BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function resolveNonClass(ReflectionParameter $parameter)
     {
@@ -819,7 +820,7 @@ class Container implements ArrayAccess, ContainerContract
 
         $message = "Unresolvable dependency resolving [$parameter] in class {$parameter->getDeclaringClass()->getName()}";
 
-        throw new BindingResolutionException($message);
+        throw new BindingResolutionContractException($message);
     }
 
     /**
@@ -828,7 +829,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \ReflectionParameter  $parameter
      * @return mixed
      *
-     * @throws BindingResolutionException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function resolveClass(ReflectionParameter $parameter)
     {
@@ -839,7 +840,7 @@ class Container implements ArrayAccess, ContainerContract
         // If we can not resolve the class instance, we will check to see if the value
         // is optional, and if it is we will return the optional parameter value as
         // the value of the dependency, similarly to how we do this with scalars.
-        catch (BindingResolutionException $e) {
+        catch (BindingResolutionContractException $e) {
             if ($parameter->isOptional()) {
                 return $parameter->getDefaultValue();
             }

--- a/src/Illuminate/Contracts/Container/BindingResolutionException.php
+++ b/src/Illuminate/Contracts/Container/BindingResolutionException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Contracts\Container;
+
+use Illuminate\Container\BindingResolutionException as BaseException;
+
+class BindingResolutionException extends BaseException
+{
+}

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -321,7 +321,7 @@ return $obj; });
 
     public function testInternalClassWithDefaultParameters()
     {
-        $this->setExpectedException('Illuminate\Container\BindingResolutionException', 'Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class ContainerMixedPrimitiveStub');
+        $this->setExpectedException('Illuminate\Contracts\Container\BindingResolutionException', 'Unresolvable dependency resolving [Parameter #0 [ <required> $first ]] in class ContainerMixedPrimitiveStub');
         $container = new Container;
         $parameters = [];
         $container->make('ContainerMixedPrimitiveStub', $parameters);


### PR DESCRIPTION
To be deleted in 5.2. For now, old catch blocks will still work.
