### PR TITLE
Add support for \Illuminate\Validation\Validator::each() to be passed a string as $rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -274,6 +274,8 @@ class Validator implements ValidatorContract {
 			throw new InvalidArgumentException('Attribute for each() must be an array.');
 		}
 
+		$rules = is_array($rules) ? $rules : [$rules];
+
 		foreach ($data as $dataKey => $dataValue)
 		{
 			foreach ($rules as $ruleKey => $ruleValue)

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1388,6 +1388,10 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase {
 		$v = new Validator($trans, $data, ['foo' => 'Array']);
 		$v->each('foo', ['numeric|min:4|max:16']);
 		$this->assertTrue($v->passes());
+
+		$v = new Validator($trans, $data, ['foo' => 'Array']);
+		$v->each('foo', 'numeric|min:4|max:16');
+		$this->assertTrue($v->passes());
 	}
 
 	public function testValidateEachWithNonIndexedArray()


### PR DESCRIPTION
`\Illuminate\Validation\Validator::each()` function documents `$rules` to be either array or string. But currently only array is supported. This PR fixes this behaviour. Fixes #7145.

```
    /**
     * Define a set of rules that apply to each element in an array attribute.
     *
     * @param  string  $attribute
     * @param  string|array  $rules
     * @return void
     *
     * @throws \InvalidArgumentException
     */
    public function each($attribute, $rules)
```
