### PR TITLE
[5.1] Allow config['schema'] to be array for PostgresConnector

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -52,9 +52,9 @@ class PostgresConnector extends Connector implements ConnectorInterface
         // may have been specified on the connections. If that is the case we will
         // set the default schema search paths to the specified database schema.
         if (isset($config['schema'])) {
-            $schema = $config['schema'];
+            $schema = '"'.(is_array($config['schema']) ? implode('", "', $config['schema']) : $config['schema']).'"';
 
-            $connection->prepare("set search_path to \"{$schema}\"")->execute();
+            $connection->prepare("set search_path to {$schema}")->execute();
         }
 
         return $connection;

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -73,6 +73,24 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase
         $this->assertSame($result, $connection);
     }
 
+
+    public function testPostgresSearchPathArraySupported()
+	{
+		$dsn = 'pgsql:host=foo;dbname=bar';
+		$config = ['host' => 'foo', 'database' => 'bar', 'schema' => ['public', 'user'], 'charset' => 'utf8'];
+		$connector = $this->getMock('Illuminate\Database\Connectors\PostgresConnector', ['createConnection', 'getOptions'] );
+		$connection = m::mock('stdClass');
+		$connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
+		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
+		$connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
+		$connection->shouldReceive('prepare')->once()->with('set search_path to "public", "user"')->andReturn($connection);
+		$connection->shouldReceive('execute')->twice();
+		$result = $connector->connect($config);
+
+		$this->assertSame($result, $connection);
+	}
+
+
     public function testSQLiteMemoryDatabasesMayBeConnectedTo()
     {
         $dsn = 'sqlite::memory:';

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -73,7 +73,6 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase
         $this->assertSame($result, $connection);
     }
 
-
     public function testPostgresSearchPathArraySupported()
 	{
 		$dsn = 'pgsql:host=foo;dbname=bar';
@@ -89,7 +88,6 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase
 
 		$this->assertSame($result, $connection);
 	}
-
 
     public function testSQLiteMemoryDatabasesMayBeConnectedTo()
     {


### PR DESCRIPTION
Postgres allows several schemas in search_path. This PR will partially solve #8523. This is backwards compatible with what we have now.

http://www.postgresql.org/docs/9.4/static/ddl-schemas.html#DDL-SCHEMAS-PATH
