### PR TITLE
Make callback in Collection::filter optional

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -119,8 +119,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  callable  $callback
      * @return static
      */
-    public function filter(callable $callback)
+    public function filter(callable $callback = null)
     {
+        if ($callback === null) {
+            return new static(array_filter($this->items));
+        }
         return new static(array_filter($this->items, $callback));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -167,6 +167,9 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([1 => ['id' => 2, 'name' => 'World']], $c->filter(function ($item) {
             return $item['id'] == 2;
         })->all());
+
+        $c = new Collection(['', 'Hello', '', 'World']);
+        $this->assertEquals(['Hello', 'World'], $c->filter()->values()->toArray());
     }
 
     public function testWhere()


### PR DESCRIPTION
Standard behavior for `array_filter` is to filter out falsey values if you supply no callback. This PR lets you achieve the same behavior by passing no callback to the `filter` method on the `Collection` class.

PHP internal functions behave oddly in that passing `null` is not the same as not passing anything, so you specifically have to call `array_filter` without a second parameter if no parameter is passed to `Collection::filter`. Fun :/
