### PR TITLE
Enhance the checks in Encrypter constructor

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -11,6 +11,16 @@ use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 class Encrypter implements EncrypterContract
 {
     /**
+     * The list of supported ciphers. Values are supported key lengths.
+     *
+     * @var array
+     */
+    protected $supportedCiphers = [
+        'AES-128-CBC' => 16,
+        'AES-256-CBC' => 32,
+    ];
+
+    /**
      * The encryption key.
      *
      * @var string
@@ -40,19 +50,20 @@ class Encrypter implements EncrypterContract
      */
     public function __construct($key, $cipher = 'AES-128-CBC')
     {
-        $len = mb_strlen($key = (string) $key, '8bit');
-
-        if ($len === 16 || $len === 32) {
-            $this->key = $key;
-        } else {
-            throw new RuntimeException('The only supported key lengths are 16 bytes and 32 bytes.');
-        }
-
-        if ($cipher === 'AES-128-CBC' || $cipher === 'AES-256-CBC') {
-            $this->cipher = $cipher;
-        } else {
+        if (!isset($this->supportedCiphers[$cipher])) {
             throw new RuntimeException('The only supported ciphers are AES-128-CBC and AES-256-CBC.');
         }
+
+        $this->cipher = $cipher;
+
+        $supportedKeyLength = $this->supportedCiphers[$cipher];
+        $keyLen = mb_strlen($key = (string) $key, '8bit');
+
+        if ($keyLen != $supportedKeyLength) {
+            throw new RuntimeException('Unsupported key length for '.$cipher.'. Use a '.$supportedKeyLength.' bytes key.');
+        }
+
+        $this->key = $key;
     }
 
     /**

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -60,7 +60,7 @@ class Encrypter implements EncrypterContract
         $keyLen = mb_strlen($key = (string) $key, '8bit');
 
         if ($keyLen != $supportedKeyLength) {
-            throw new RuntimeException('Unsupported key length for '.$cipher.'. Use a '.$supportedKeyLength.' bytes key.');
+            throw new RuntimeException("Unsupported key length for $cipher. Use a $supportedKeyLength bytes key.");
         }
 
         $this->key = $key;

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": ">=5.5.9",
         "ext-openssl": "*",
+        "ext-mbstring": "*",
         "illuminate/contracts": "5.1.*",
         "illuminate/support": "5.1.*"
     },

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -14,7 +14,7 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
 
     public function testEncryptionWithCustomCipher()
     {
-        $e = new Encrypter(str_repeat('a', 32), 'AES-256-CBC');
+        $e = new Encrypter(str_random(32), 'AES-256-CBC');
         $this->assertNotEquals('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $e->encrypt('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
         $encrypted = $e->encrypt('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
         $this->assertEquals('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $e->decrypt($encrypted));
@@ -33,6 +33,6 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
 
     protected function getEncrypter()
     {
-        return new Encrypter(str_repeat('a', 32));
+        return new Encrypter(str_random(16));
     }
 }

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -18,7 +18,7 @@ class QueueSyncQueueTest extends PHPUnit_Framework_TestCase
          */
         $sync = new Illuminate\Queue\SyncQueue;
         $container = new Illuminate\Container\Container;
-        $encrypter = new Illuminate\Encryption\Encrypter(str_random(32));
+        $encrypter = new Illuminate\Encryption\Encrypter(str_random(16));
         $container->instance('Illuminate\Contracts\Encryption\Encrypter', $encrypter);
         $sync->setContainer($container);
         $sync->setEncrypter($encrypter);
@@ -66,7 +66,7 @@ class QueueSyncQueueTest extends PHPUnit_Framework_TestCase
 
         $sync = new Illuminate\Queue\SyncQueue;
         $container = new Illuminate\Container\Container;
-        $encrypter = new Illuminate\Encryption\Encrypter(str_random(32));
+        $encrypter = new Illuminate\Encryption\Encrypter(str_random(16));
         $container->instance('Illuminate\Contracts\Encryption\Encrypter', $encrypter);
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
         $events->shouldReceive('fire')->once();


### PR DESCRIPTION
One issue I see with the length enforced checks is that if someone was using an invalid key (shorter or longer than they should) this would break BC for them. This applies to @GrahamCampbell RP https://github.com/laravel/framework/pull/9063 too

What do you think @taylorotwell ?

cc/ @ircmaxell @paragonie-scott
