### PR TITLE
[5.1] Encryption Fixes

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -122,11 +122,11 @@ class Encrypter implements EncrypterContract
         // assume it is invalid and bail out of the routine since we will not be able
         // to decrypt the given value. We'll also check the MAC for this encryption.
         if (!$payload || $this->invalidPayload($payload)) {
-            throw new DecryptException('Invalid data.');
+            throw new DecryptException('The payload is invalid.');
         }
 
         if (!$this->validMac($payload)) {
-            throw new DecryptException('MAC is invalid.');
+            throw new DecryptException('The MAC is invalid.');
         }
 
         return $payload;

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -42,16 +42,11 @@ class Encrypter implements EncrypterContract
     {
         $len = mb_strlen($key = (string) $key, '8bit');
 
-        if ($len === 16 || $len === 32) {
+        if (($cipher === 'AES-128-CBC' && ($len === 16 || $len === 32)) || ($cipher === 'AES-256-CBC' && $len === 32)) {
             $this->key = $key;
-        } else {
-            throw new RuntimeException('The only supported key lengths are 16 bytes and 32 bytes.');
-        }
-
-        if ($cipher === 'AES-128-CBC' || $cipher === 'AES-256-CBC') {
             $this->cipher = $cipher;
         } else {
-            throw new RuntimeException('The only supported ciphers are AES-128-CBC and AES-256-CBC.');
+            throw new RuntimeException('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
         }
     }
 

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -6,33 +6,75 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
 {
     public function testEncryption()
     {
-        $e = $this->getEncrypter();
-        $this->assertNotEquals('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $e->encrypt('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
-        $encrypted = $e->encrypt('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
-        $this->assertEquals('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $e->decrypt($encrypted));
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted = $e->encrypt('foo');
+        $this->assertNotEquals('foo', $encrypted);
+        $this->assertEquals('foo', $e->decrypt($encrypted));
     }
 
-    public function testEncryptionWithCustomCipher()
+    public function testWithCustomCipher()
     {
-        $e = new Encrypter(str_repeat('a', 32), 'AES-256-CBC');
-        $this->assertNotEquals('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $e->encrypt('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
-        $encrypted = $e->encrypt('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
-        $this->assertEquals('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $e->decrypt($encrypted));
+        $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
+        $encrypted = $e->encrypt('bar');
+        $this->assertNotEquals('bar', $encrypted);
+        $this->assertEquals('bar', $e->decrypt($encrypted));
+    }
+
+    public function testAllowLongerKeyForBC()
+    {
+        $e = new Encrypter(str_repeat('z', 32));
+        $encrypted = $e->encrypt('baz');
+        $this->assertNotEquals('baz', $encrypted);
+        $this->assertEquals('baz', $e->decrypt($encrypted));
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
+     */
+    public function testWithBadKeyLength()
+    {
+        $e = new Encrypter(str_repeat('a', 5));
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
+     */
+    public function testWithBadKeyLengthAlternativeCipher()
+    {
+        $e = new Encrypter(str_repeat('a', 16), 'AES-256-CFB8');
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
+     */
+    public function testWithUnsupportedCipher()
+    {
+        $e = new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
     }
 
     /**
      * @expectedException Illuminate\Contracts\Encryption\DecryptException
+     * @expectedExceptionMessage The payload is invalid.
      */
     public function testExceptionThrownWhenPayloadIsInvalid()
     {
-        $e = $this->getEncrypter();
+        $e = new Encrypter(str_repeat('a', 16));
         $payload = $e->encrypt('foo');
         $payload = str_shuffle($payload);
         $e->decrypt($payload);
     }
 
-    protected function getEncrypter()
+    /**
+     * @expectedException Illuminate\Contracts\Encryption\DecryptException
+     * @expectedExceptionMessage The MAC is invalid.
+     */
+    public function testExceptionThrownWithDifferentKey()
     {
-        return new Encrypter(str_repeat('a', 32));
+        $a = new Encrypter(str_repeat('a', 16));
+        $b = new Encrypter(str_repeat('b', 16));
+        $b->decrypt($a->encrypt('baz'));
     }
 }

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -18,7 +18,7 @@ class QueueSyncQueueTest extends PHPUnit_Framework_TestCase
          */
         $sync = new Illuminate\Queue\SyncQueue;
         $container = new Illuminate\Container\Container;
-        $encrypter = new Illuminate\Encryption\Encrypter(str_random(32));
+        $encrypter = new Illuminate\Encryption\Encrypter(str_repeat('b', 16));
         $container->instance('Illuminate\Contracts\Encryption\Encrypter', $encrypter);
         $sync->setContainer($container);
         $sync->setEncrypter($encrypter);
@@ -66,7 +66,7 @@ class QueueSyncQueueTest extends PHPUnit_Framework_TestCase
 
         $sync = new Illuminate\Queue\SyncQueue;
         $container = new Illuminate\Container\Container;
-        $encrypter = new Illuminate\Encryption\Encrypter(str_random(32));
+        $encrypter = new Illuminate\Encryption\Encrypter(str_repeat('c', 16));
         $container->instance('Illuminate\Contracts\Encryption\Encrypter', $encrypter);
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
         $events->shouldReceive('fire')->once();


### PR DESCRIPTION
Note that for `'AES-128-CBC'`, we MUST allow both 16 byte and 32 byte keys so that existing data can still be decrypted without issues with the MAC verification.
