### PR TITLE
[5.1] Encryption: Extract key length validation

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -42,27 +42,10 @@ class Encrypter implements EncrypterContract
     {
         $key = (string) $key;
 
-        if ($this->hasValidCipherAndKeyCombination($key, $cipher)) {
-            $this->key = $key;
-            $this->cipher = $cipher;
-        } else {
-            throw new RuntimeException('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
-        }
-    }
+        KeyLengths::ensureValid($cipher, $key);
 
-    /**
-     * Determine if the given key and cipher combination is valid.
-     *
-     * @param  string  $key
-     * @param  string  $cipher
-     * @return bool
-     */
-    protected function hasValidCipherAndKeyCombination($key, $cipher)
-    {
-        $length = mb_strlen($key, '8bit');
-
-        return ($cipher === 'AES-128-CBC' && ($length === 16 || $length === 32)) ||
-               ($cipher === 'AES-256-CBC' && $length === 32);
+        $this->key = $key;
+        $this->cipher = $cipher;
     }
 
     /**

--- a/src/Illuminate/Encryption/KeyLengths.php
+++ b/src/Illuminate/Encryption/KeyLengths.php
@@ -7,6 +7,8 @@ class KeyLengths
     /**
      * An array of supported ciphers with allowed key lengths.
      *
+     * Each element is an array of valid lengths, the first being preferred.
+     *
      * @var array
      */
     protected static $lengths = [

--- a/src/Illuminate/Encryption/KeyLengths.php
+++ b/src/Illuminate/Encryption/KeyLengths.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Encryption;
+
+class KeyLengths
+{
+    /**
+     * An array of supported ciphers with allowed key lengths.
+     *
+     * @var array
+     */
+    protected static $lengths = [
+        'AES-128-CBC' => [16, 32],
+        'AES-256-CBC' => [32],
+    ];
+
+    /**
+     * Throw an exception if the given key is invalid.
+     *
+     * This ensures that the given key has a valid length for the chosen cipher,
+     * while also taking into account backwards compatibility (v5.0 generated
+     * 32 byte keys for the AES-128-CBC-cipher).
+     *
+     * @param string $cipher
+     * @param string $key
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public static function ensureValid($cipher, $key)
+    {
+        $length = mb_strlen($key, '8bit');
+
+        if (isset(static::$lengths[$cipher]) && in_array($length, static::$lengths[$cipher])) {
+            return;
+        }
+
+        $validCiphers = implode(', ', array_keys(static::$lengths));
+        throw new \RuntimeException("The only supported ciphers are [$validCiphers] with the correct key lengths.");
+
+    }
+
+    /**
+     * Determine the preferred key length for the given cipher.
+     *
+     * @param string $cipher
+     * @return int
+     */
+    public static function of($cipher)
+    {
+        return isset(static::$lengths[$cipher]) ? static::$lengths[$cipher][0] : 32;
+    }
+}

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Encryption\KeyLengths;
 use Symfony\Component\Console\Input\InputOption;
 
 class KeyGenerateCommand extends Command
@@ -55,11 +56,7 @@ class KeyGenerateCommand extends Command
      */
     protected function getRandomKey($cipher)
     {
-        if ($cipher === 'AES-128-CBC') {
-            return str_random(16);
-        }
-
-        return str_random(32);
+        return str_random(KeyLengths::of($cipher));
     }
 
     /**

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -30,29 +30,29 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
+     * @expectedExceptionMessage The only supported ciphers are [AES-128-CBC, AES-256-CBC] with the correct key lengths.
      */
     public function testWithBadKeyLength()
     {
-        $e = new Encrypter(str_repeat('a', 5));
+        new Encrypter(str_repeat('a', 5));
     }
 
     /**
      * @expectedException RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
+     * @expectedExceptionMessage The only supported ciphers are [AES-128-CBC, AES-256-CBC] with the correct key lengths.
      */
     public function testWithBadKeyLengthAlternativeCipher()
     {
-        $e = new Encrypter(str_repeat('a', 16), 'AES-256-CFB8');
+        new Encrypter(str_repeat('a', 16), 'AES-256-CFB8');
     }
 
     /**
      * @expectedException RuntimeException
-     * @expectedExceptionMessage The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.
+     * @expectedExceptionMessage The only supported ciphers are [AES-128-CBC, AES-256-CBC] with the correct key lengths.
      */
     public function testWithUnsupportedCipher()
     {
-        $e = new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
+        new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
     }
 
     /**


### PR DESCRIPTION
This keeps the logic for determining and validating correct key lengths for a given cipher in one place.

> Keep things together that change for similar reasons.

Since encryption is so important, I thought it would be a nice idea.
