### PR TITLE
[5.1] Enable Router Switching

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Http;
 
 use Exception;
 use RuntimeException;
-use Illuminate\Routing\Router;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Contracts\Foundation\Application;

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -686,12 +686,9 @@ class Router implements RegistrarContract
     {
         $middleware = $this->gatherRouteMiddlewares($route);
 
-        $shouldSkipMiddleware = $this->container->bound('middleware.disable') &&
-                                $this->container->make('middleware.disable') === true;
-
         return (new Pipeline($this->container))
                         ->send($request)
-                        ->through($shouldSkipMiddleware ? [] : $middleware)
+                        ->through($middleware)
                         ->then(function ($request) use ($route) {
                             return $this->prepareResponse(
                                 $request,
@@ -843,6 +840,23 @@ class Router implements RegistrarContract
     public function middleware($name, $class)
     {
         $this->middleware[$name] = $class;
+
+        return $this;
+    }
+
+    /**
+     * Bulk register short-hand names for a set of middleware. Middlewares
+     * are passed through with the format [ 'name' => 'class', ... ]
+     *
+     * @param array $middlewares
+     * @return $this;
+     */
+
+    public function bulkRegisterMiddlewares($middlewares = [])
+    {
+        foreach ($middlewares as $key => $middleware) {
+            $this->middleware($key, $middleware);
+        }
 
         return $this;
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -845,13 +845,13 @@ class Router implements RegistrarContract
     }
 
     /**
-     * Bulk register short-hand names for a set of middleware. Middlewares
-     * are passed through with the format [ 'name' => 'class', ... ]
+     * Bulk register short-hand names for a set of middleware.
+     *
+     * Middlewares are passed through with the format [ 'name' => 'class', ... ]
      *
      * @param array $middlewares
      * @return $this;
      */
-
     public function bulkRegisterMiddlewares($middlewares = [])
     {
         foreach ($middlewares as $key => $middleware) {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -849,8 +849,8 @@ class Router implements RegistrarContract
      *
      * Middlewares are passed through with the format [ 'name' => 'class', ... ]
      *
-     * @param array $middlewares
-     * @return $this;
+     * @param  array  $middlewares
+     * @return $this
      */
     public function bulkRegisterMiddlewares($middlewares = [])
     {


### PR DESCRIPTION
Hi, 

I'm pretty early in my Laravel career - so I apologise if my contribution is not quite of the correct format. I'll be happy to amend as/if necessary.

I've proposed some modifications to Http Kernel, applying middleware after bootstrapping, and retrieving the router from the container later, therefore allowing a service provider to override the router.

This also enables a slight tidy up where the router no longer needs to be aware of the container settings for applying middleware - we just don't set up the middleware in the Kernel.
