### PR TITLE
[5.1] Fix app namespace determination

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation;
 
 use Closure;
+use RuntimeException;
 use Illuminate\Http\Request;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
@@ -1054,6 +1055,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      * Get the application namespace.
      *
      * @return string
+     *
+     * @ throws \RuntimeException
      */
     public function getNamespace()
     {
@@ -1061,8 +1064,16 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             return $this->namespace;
         }
 
-        $this->namespace = strtok(get_class($this->getKernel()), '\\').'\\';
+        $composer = json_decode(file_get_contents(base_path().'/composer.json'), true);
 
-        return $this->namespace;
+        foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path) {
+            foreach ((array) $path as $pathChoice) {
+                if (realpath(app_path()) == realpath(base_path().'/'.$pathChoice)) {
+                    return $this->namespace = $namespace;
+                }
+            }
+        }
+
+        throw new RuntimeException('Unable to detect application namespace.');
     }
 }


### PR DESCRIPTION
Closes #8997

There are some problems with app namespace determination that was introduced in #8084
1. Nested namespaces doesn't work atm, but in L5.0 they work fine.
2. In some rare cases kernel classes can be overwriten since they are bound into the container in laravel/laravel https://github.com/laravel/laravel/blob/develop/bootstrap/app.php

So I guess it's better to return to the code we have in 5.0, sorry.
