### PR TITLE
[5.1] Allow for setting an "as" prefix for an entire group.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -398,6 +398,10 @@ class Router implements RegistrarContract
             isset($new['where']) ? $new['where'] : []
         );
 
+        if (isset($old['as_prefix']) && isset($new['as'])) {
+            $new['as'] = $old['as_prefix'].$new['as'];
+        }
+
         return array_merge_recursive(array_except($old, ['namespace', 'prefix', 'where']), $new);
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -398,11 +398,11 @@ class Router implements RegistrarContract
             isset($new['where']) ? $new['where'] : []
         );
 
-        if (isset($old['as_prefix']) && isset($new['as'])) {
-            $new['as'] = $old['as_prefix'].$new['as'];
+        if (isset($old['as']) && isset($new['as'])) {
+            $new['as'] = $old['as'].$new['as'];
         }
 
-        return array_merge_recursive(array_except($old, ['namespace', 'prefix', 'where']), $new);
+        return array_merge_recursive(array_except($old, ['namespace', 'prefix', 'where', 'as']), $new);
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -612,6 +612,17 @@ return 'foo!'; });
         $this->assertEquals('foo', $routes[0]->getPrefix());
     }
 
+    public function testRouteGroupingWithAasPrefix()
+    {
+        $router = $this->getRouter();
+        $router->group(['prefix' => 'foo', 'as_prefix' => 'Foo::'], function () use ($router) {
+            $router->get('bar', ['as' => 'bar', function () { return 'hello'; }]);
+        });
+        $routes = $router->getRoutes();
+        $route = $routes->getByName('Foo::bar');
+        $this->assertEquals('foo/bar', $route->getPath());
+    }
+
     public function testRoutePrefixing()
     {
         /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -612,10 +612,10 @@ return 'foo!'; });
         $this->assertEquals('foo', $routes[0]->getPrefix());
     }
 
-    public function testRouteGroupingWithAasPrefix()
+    public function testRouteGroupingWithAs()
     {
         $router = $this->getRouter();
-        $router->group(['prefix' => 'foo', 'as_prefix' => 'Foo::'], function () use ($router) {
+        $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->get('bar', ['as' => 'bar', function () { return 'hello'; }]);
         });
         $routes = $router->getRoutes();


### PR DESCRIPTION
Example usage:

``` php
// assessment_routes.php
$router->get('widgets', ['as' => 'widgets', function () {
    return view('Assessment::widgets');
}]);

$router->get('gizmos', ['as' => 'gizmos', function () {
    return view('Assessment::gizmos');
}]);
```

``` php
<?php
// RouteProvider.php
Route::group(['prefix' => '/skills', 'as' => 'assessment.'], function (Router $router) {
    require __DIR__.'/assessment_routes.php';
});
```

``` html
<ul>
    <li><a href="{{ route('assessment.widgets') }}">My Widgets</a></li>
    <li><a href="{{ route('assessment.gizmos') }}">My Gizmos</a></li>
</ul>
```

The following might be more consistent with the way that View namespaces work:

``` php
<?php
// RouteProvider.php
Route::group(['prefix' => '/skills', 'as' => 'Assessment::'], function (Router $router) {
    require __DIR__.'/assessment_routes.php';
});
```

``` html
<ul>
    <li><a href="{{ route('Assessment::widgets') }}">My Widgets</a></li>
    <li><a href="{{ route('Assessment::gizmos') }}">My Gizmos</a></li>
</ul>
```

---

**Update:** Edited example usage to better match the final implementation.
