### PR TITLE
Add a between function to the Str-class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -389,4 +389,41 @@ class Str {
 		return static::$studlyCache[$key] = str_replace(' ', '', $value);
 	}
 
+    /**
+     * Get the string between the given start and end in the given string.
+     *
+     * @param string $string
+     * @param string $start
+     * @param string $end
+     * @return string
+     */
+    public static function between($string, $start, $end)
+    {
+        if ($start == '' && $end == '') {
+            return $string;
+        }
+        
+        if ($start != '' && strpos($string, $start) === false) {
+            return '';
+        }
+        
+        if ($end != '' && strpos($string, $end) === false) {
+            return '';
+        }
+        
+        if ($start == '') {
+            return substr($string, 0, strpos($string, $end));
+        }
+
+        if ($end == '') {
+            return substr($string, strpos($string, $start) + strlen($start));
+        }
+
+        $stringWithoutStart = explode($start, $string)[1];
+        $middle = explode($end, $stringWithoutStart)[0];
+
+        return $middle;
+    }
+
+
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -155,4 +155,18 @@ class SupportStrTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals('laravel_php_framework', Str::snake('LaravelPhpFramework'));
 	}
 
+
+    public function testBetween()
+    {
+        $this->assertEquals('Middle', Str::between('StartMiddleEnd', 'Start', 'End'));
+        $this->assertEquals('', Str::between('MiddleEnd', 'Start', 'End'));
+        $this->assertEquals('', Str::between('StartMiddle', 'Start', 'End'));
+        $this->assertEquals('', Str::between('StartMiddleEnd', 'End', 'Start'));
+        $this->assertEquals('Middle', Str::between('StartMiddleStart', 'Start', 'Start'));
+        $this->assertEquals('MiddleEnd', Str::between('StartMiddleEnd', 'Start', ''));
+        $this->assertEquals('StartMiddle', Str::between('StartMiddleEnd', '', 'End'));
+        $this->assertEquals('StartMiddleEnd', Str::between('StartMiddleEnd', '', ''));
+    }
+
+
 }


### PR DESCRIPTION
This pull request adds a between function to the Str-class.

Example usage:

``` php
echo Str::between('StartMiddleEnd', 'Start', 'End'); //outputs "Middle"
```
