### PR TITLE
Allow SQLite unsupported integers as increments

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -20,7 +20,7 @@ class SQLiteGrammar extends Grammar
      *
      * @var array
      */
-    protected $serials = ['bigInteger', 'integer'];
+    protected $serials = ['bigInteger', 'integer', 'mediumInteger', 'smallInteger', 'tinyInteger'];
 
     /**
      * Compile the query to determine if a table exists.

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -224,6 +224,13 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->mediumInteger('foo', true);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
     public function testAddingTinyInteger()
@@ -234,6 +241,13 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->tinyInteger('foo', true);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
     public function testAddingSmallInteger()
@@ -244,6 +258,13 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->smallInteger('foo', true);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
     public function testAddingFloat()


### PR DESCRIPTION
Fixes #9057

The first commit shows that the bug is present.

All unsupported SQLite integer types are being converted to default integers anyway - so we can allow using them as increments.
