### PR TITLE
[5.1] Pass the most recent response content to the Crawler.

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -137,13 +137,13 @@ trait CrawlerTrait
     {
         $uri = $this->prepareUrlForRequest($uri);
 
-        $response = $this->call($method, $uri, $parameters, $cookies, $files);
+        $this->call($method, $uri, $parameters, $cookies, $files);
 
         $this->clearInputs()->followRedirects()->assertPageLoaded($uri);
 
         $this->currentUri = $this->app->make('request')->fullUrl();
 
-        $this->crawler = new Crawler($response->getContent(), $uri);
+        $this->crawler = new Crawler($this->response->getContent(), $uri);
 
         return $this;
     }


### PR DESCRIPTION
This PR fixes a bug that causes the crawler to receive content of the first response instead of the most recent one. The problem appears when we are testing the page which has multiple redirections to it. In this case the response content which was passed to the Crawler turns out to be from the redirection, thus we are not able to assert against the target page.
