### PR TITLE
[5.1] Fixes issue selecting name attribute containing brackets

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -578,7 +578,7 @@ trait CrawlerTrait
     {
         $name = str_replace('#', '', $name);
 
-        return $this->crawler->filter("{$element}#{$name}, {$element}[name={$name}]");
+        return $this->crawler->filter("{$element}#{$name}, {$element}[name='{$name}']");
     }
 
     /**


### PR DESCRIPTION
This should fix #9090 

If you are using the type method like this:

```
$this->type($faker->streetAddress, 'address[line_1]');
```

It will now generate a selection string like this:

```
*#email[address], *[name='email[address]']
```
