### PR TITLE
Adding getter methods for raw tags and extensions

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -808,5 +808,25 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	{
 		$this->echoFormat = $format;
 	}
+	
+	/**
+	* Gets the raw tags used for the compiler.
+	*
+	* @return string
+	*/
+	public function getRawTags()
+	{
+		return $this->rawTags;
+	}
+
+	/**
+	* Gets the extensions used for the compiler.
+	*
+	* @return string
+	*/
+	public function getExtensions()
+	{
+		return $this->extensions;
+	}
 
 }


### PR DESCRIPTION
We need them when we want to extend BladeCompiler and we want to use global settings of Blade that usually we write them in a custom provider for examples: extend blade or 
public function register()
        {
        Blade::setRawTags('{{', '}}');
        Blade::setContentTags('{{{', '}}}');
        Blade::setEscapedContentTags('{{{', '}}}');
        }
Please accept it, thanks
