### PR TITLE
Adding getter methods for raw tags and extensions

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -395,7 +395,8 @@ class Container implements ArrayAccess, ContainerContract {
 	{
 		$results = [];
 
-		if (isset($this->tags[$tag])) {
+		if (isset($this->tags[$tag]))
+		{
 			foreach ($this->tags[$tag] as $abstract)
 			{
 				$results[] = $this->make($abstract);

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -395,9 +395,11 @@ class Container implements ArrayAccess, ContainerContract {
 	{
 		$results = [];
 
-		foreach ($this->tags[$tag] as $abstract)
-		{
-			$results[] = $this->make($abstract);
+		if (isset($this->tags[$tag])) {
+			foreach ($this->tags[$tag] as $abstract)
+			{
+				$results[] = $this->make($abstract);
+			}
 		}
 
 		return $results;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -107,9 +107,7 @@ class BelongsTo extends Relation {
 	{
 		$query->select(new Expression('count(*)'));
 
-		$tablePrefix = $this->query->getQuery()->getConnection()->getTablePrefix();
-
-		$query->from($query->getModel()->getTable().' as '.$tablePrefix.$hash = $this->getRelationCountHash());
+		$query->from($query->getModel()->getTable().' as '.$hash = $this->getRelationCountHash());
 
 		$key = $this->wrap($this->getQualifiedForeignKey());
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -324,9 +324,7 @@ class BelongsToMany extends Relation {
 	{
 		$query->select(new Expression('count(*)'));
 
-		$tablePrefix = $this->query->getQuery()->getConnection()->getTablePrefix();
-
-		$query->from($this->table.' as '.$tablePrefix.$hash = $this->getRelationCountHash());
+		$query->from($this->table.' as '.$hash = $this->getRelationCountHash());
 
 		$key = $this->wrap($this->getQualifiedParentKeyName());
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -81,9 +81,7 @@ abstract class HasOneOrMany extends Relation {
 	{
 		$query->select(new Expression('count(*)'));
 
-		$tablePrefix = $this->query->getQuery()->getConnection()->getTablePrefix();
-
-		$query->from($query->getModel()->getTable().' as '.$tablePrefix.$hash = $this->getRelationCountHash());
+		$query->from($query->getModel()->getTable().' as '.$hash = $this->getRelationCountHash());
 
 		$key = $this->wrap($this->getQualifiedParentKeyName());
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -49,7 +49,11 @@ class WorkCommand extends Command {
 	 */
 	public function fire()
 	{
-		if ($this->downForMaintenance() && ! $this->option('daemon')) return;
+        if ($this->downForMaintenance() && ! $this->option('daemon'))
+        {
+            $this->worker->sleep($this->option('sleep'));
+            return;
+        }
 
 		$queue = $this->option('queue');
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -51,8 +51,7 @@ class WorkCommand extends Command {
 	{
 		if ($this->downForMaintenance() && ! $this->option('daemon'))
 		{
-			$this->worker->sleep($this->option('sleep'));
-			return;
+			return $this->worker->sleep($this->option('sleep'));
 		}
 
 		$queue = $this->option('queue');

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -49,11 +49,11 @@ class WorkCommand extends Command {
 	 */
 	public function fire()
 	{
-        if ($this->downForMaintenance() && ! $this->option('daemon'))
-        {
-            $this->worker->sleep($this->option('sleep'));
-            return;
-        }
+		if ($this->downForMaintenance() && ! $this->option('daemon'))
+		{
+			$this->worker->sleep($this->option('sleep'));
+			return;
+		}
 
 		$queue = $this->option('queue');
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -225,7 +225,14 @@ class Str {
 			throw new RuntimeException('Unable to generate random string.');
 		}
 
-		return substr(str_replace(array('/', '+', '='), '', base64_encode($bytes)), 0, $length);
+		$string = substr(str_replace(array('/', '+', '='), '', base64_encode($bytes)), 0, $length);
+
+		while (($len = strlen($string)) < $length)
+		{
+			$string .= static::random($length - $len);
+		}
+
+		return $string;
 	}
 
 	/**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -213,26 +213,46 @@ class Str {
 	 */
 	public static function random($length = 16)
 	{
-		if ( ! function_exists('openssl_random_pseudo_bytes'))
-		{
-			throw new RuntimeException('OpenSSL extension is required.');
-		}
-
-		$bytes = openssl_random_pseudo_bytes($length * 2, $strong);
-
-		if ($bytes === false || $strong === false)
-		{
-			throw new RuntimeException('Unable to generate random string.');
-		}
-
-		$string = substr(str_replace(array('/', '+', '='), '', base64_encode($bytes)), 0, $length);
+		$string = '';
 
 		while (($len = strlen($string)) < $length)
 		{
-			$string .= static::random($length - $len);
+			$size = $length - $len;
+			$bytes = static::randomBytes($size * 2);
+			$string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
 		}
 
 		return $string;
+	}
+
+	/**
+	 * Generate a more truly "random" bytes.
+	 *
+	 * @param  int  $length
+	 * @return string
+	 *
+	 * @throws \RuntimeException
+	 */
+	public static function randomBytes($length = 16)
+	{
+		if (function_exists('random_bytes'))
+		{
+			$bytes = random_bytes($length);
+		}
+		elseif (function_exists('openssl_random_pseudo_bytes'))
+		{
+			$bytes = openssl_random_pseudo_bytes($length, $strong);
+			if ($bytes === false || $strong === false)
+			{
+				throw new RuntimeException('Unable to generate random string.');
+			}
+		}
+		else
+		{
+			throw new RuntimeException('OpenSSL extension is required for PHP 5 users.');
+		}
+
+		return $bytes;
 	}
 
 	/**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -218,9 +218,9 @@ class Str {
 			throw new RuntimeException('OpenSSL extension is required.');
 		}
 
-		$bytes = openssl_random_pseudo_bytes($length * 2);
+		$bytes = openssl_random_pseudo_bytes($length * 2, $strong);
 
-		if ($bytes === false)
+		if ($bytes === false || $strong === false)
 		{
 			throw new RuntimeException('Unable to generate random string.');
 		}

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -218,7 +218,7 @@ class Str {
 		while (($len = strlen($string)) < $length)
 		{
 			$size = $length - $len;
-			$bytes = static::randomBytes($size * 2);
+			$bytes = static::randomBytes($size);
 			$string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
 		}
 

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -808,5 +808,25 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	{
 		$this->echoFormat = $format;
 	}
+	
+	/**
+	* Gets the raw tags used for the compiler.
+	*
+	* @return string
+	*/
+	public function getRawTags()
+	{
+		return $this->rawTags;
+	}
+
+	/**
+	* Gets the extensions used for the compiler.
+	*
+	* @return string
+	*/
+	public function getExtensions()
+	{
+		return $this->extensions;
+	}
 
 }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -497,6 +497,8 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(2, count($container->tagged('foo')));
 		$this->assertInstanceOf('ContainerImplementationStub', $container->tagged('foo')[0]);
 		$this->assertInstanceOf('ContainerImplementationStubTwo', $container->tagged('foo')[1]);
+
+		$this->assertEmpty($container->tagged('this_tag_does_not_exist'));
 	}
 
 }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -54,6 +54,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 		$this->schema()->create('posts', function($table) {
 			$table->increments('id');
 			$table->integer('user_id');
+			$table->integer('parent_id')->nullable();
 			$table->string('name');
 			$table->timestamps();
 		});
@@ -279,6 +280,30 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+	public function testHasOnSelfReferencingBelongsToRelationship()
+	{
+		$parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'user_id' => 1]);
+		$childPost = EloquentTestPost::create(['name' => 'Child Post', 'parent_id' => $parentPost->id, 'user_id' => 2]);
+
+		$results = EloquentTestPost::has('parentPost')->get();
+
+		$this->assertEquals(1, count($results));
+		$this->assertEquals('Child Post', $results->first()->name);
+	}
+
+
+	public function testHasOnSelfReferencingHasManyRelationship()
+	{
+		$parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'user_id' => 1]);
+		$childPost = EloquentTestPost::create(['name' => 'Child Post', 'parent_id' => $parentPost->id, 'user_id' => 2]);
+
+		$results = EloquentTestPost::has('childPosts')->get();
+
+		$this->assertEquals(1, count($results));
+		$this->assertEquals('Parent Post', $results->first()->name);
+	}
+
+
 	public function testBelongsToManyRelationshipModelsAreProperlyHydratedOverChunkedRequest()
 	{
 		$user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
@@ -428,6 +453,12 @@ class EloquentTestPost extends Eloquent {
 	}
 	public function photos() {
 		return $this->morphMany('EloquentTestPhoto', 'imageable');
+	}
+	public function childPosts() {
+		return $this->hasMany('EloquentTestPost', 'parent_id');
+	}
+	public function parentPost() {
+		return $this->belongsTo('EloquentTestPost', 'parent_id');
 	}
 }
 

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class DatabaseEloquentIntegrationWithTablePrefixTest extends DatabaseEloquentIntegrationTest {
+
+	/**
+	 * Bootstrap Eloquent.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(){
+		$resolver = new DatabaseIntegrationTestConnectionResolver;
+		$resolver->connection()->setTablePrefix('prefix_');
+		Eloquent::setConnectionResolver($resolver);
+
+		Eloquent::setEventDispatcher(
+			new Illuminate\Events\Dispatcher
+		);
+	}
+
+	public function testBasicModelHydration()
+	{
+		EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+		EloquentTestUser::create(['email' => 'abigailotwell@gmail.com']);
+
+		$models = EloquentTestUser::hydrateRaw('SELECT * FROM prefix_users WHERE email = ?', ['abigailotwell@gmail.com'], 'foo_connection');
+
+		$this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $models);
+		$this->assertInstanceOf('EloquentTestUser', $models[0]);
+		$this->assertEquals('abigailotwell@gmail.com', $models[0]->email);
+		$this->assertEquals('foo_connection', $models[0]->getConnectionName());
+		$this->assertEquals(1, $models->count());
+	}
+}


### PR DESCRIPTION
We need them when we want to extend BladeCompiler and we want to use global settings of Blade that usually we write them in a custom provider for examples: extend blade or 
public function register()
        {
        Blade::setRawTags('{{', '}}');
        Blade::setContentTags('{{{', '}}}');
        Blade::setEscapedContentTags('{{{', '}}}');
        }
Please accept, thanks.
