### PR TITLE
[5.1] Added all missing public methods from Router to Contracts\Routing\Registrar

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -61,6 +61,15 @@ interface Registrar
     public function options($uri, $action);
 
     /**
+     * Register a new route responding to all verbs.
+     *
+     * @param  string  $uri
+     * @param  \Closure|array|string  $action
+     * @return \Illuminate\Contracts\Routing\Registrar
+     */
+    public function any($uri, $action);
+
+    /**
      * Register a new route with the given verbs.
      *
      * @param  array|string  $methods
@@ -69,6 +78,32 @@ interface Registrar
      * @return void
      */
     public function match($methods, $uri, $action);
+
+    /**
+     * Register an array of controllers with wildcard routing.
+     *
+     * @param  array  $controllers
+     * @return void
+     */
+    public function controllers(array $controllers);
+
+    /**
+     * Route a controller to a URI with wildcard routing.
+     *
+     * @param  string  $uri
+     * @param  string  $controller
+     * @param  array   $names
+     * @return void
+     */
+    public function controller($uri, $controller, $names = []);
+
+    /**
+     * Register an array of resource controllers.
+     *
+     * @param  array  $resources
+     * @return void
+     */
+    public function resources(array $resources);
 
     /**
      * Route a resource to a controller.
@@ -88,6 +123,70 @@ interface Registrar
      * @return void
      */
     public function group(array $attributes, Closure $callback);
+
+    /**
+     * Merge the given array with the last group stack.
+     *
+     * @param  array  $new
+     * @return array
+     */
+    public function mergeWithLastGroup($new);
+
+    /**
+     * Merge the given group attributes.
+     *
+     * @param  array  $new
+     * @param  array  $old
+     * @return array
+     */
+    public static function mergeGroup($new, $old);
+
+    /**
+     * Get the prefix from the last group on the stack.
+     *
+     * @return string
+     */
+    public function getLastGroupPrefix();
+
+    /**
+     * Dispatch the request to the application.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function dispatch(\Illuminate\Http\Request $request);
+
+    /**
+     * Dispatch the request to a route and return the response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function dispatchToRoute(\Illuminate\Http\Request $request);
+
+    /**
+     * Gather the middleware for the given route.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return array
+     */
+    public function gatherRouteMiddlewares(\Illuminate\Routing\Route $route);
+
+    /**
+     * Resolve the middleware name to a class name preserving passed parameters.
+     *
+     * @param $name
+     * @return string
+     */
+    public function resolveMiddlewareClassName($name);
+
+    /**
+     * Register a route matched event listener.
+     *
+     * @param  string|callable  $callback
+     * @return void
+     */
+    public function matched($callback);
 
     /**
      * Register a new "before" filter with the router.
@@ -110,6 +209,22 @@ interface Registrar
     public function after($callback);
 
     /**
+     * Get all of the defined middleware short-hand names.
+     *
+     * @return array
+     */
+    public function getMiddleware();
+
+    /**
+     * Register a short-hand name for a middleware.
+     *
+     * @param  string  $name
+     * @param  string  $class
+     * @return $this
+     */
+    public function middleware($name, $class);
+
+    /**
      * Register a new filter with the router.
      *
      * @param  string  $name
@@ -119,4 +234,249 @@ interface Registrar
      * @deprecated since version 5.1
      */
     public function filter($name, $callback);
+
+    /**
+     * Register a pattern-based filter with the router.
+     *
+     * @param  string  $pattern
+     * @param  string  $name
+     * @param  array|null  $methods
+     * @return void
+     *
+     * @deprecated since version 5.1
+     */
+    public function when($pattern, $name, $methods = null);
+
+    /**
+     * Register a regular expression based filter with the router.
+     *
+     * @param  string     $pattern
+     * @param  string     $name
+     * @param  array|null $methods
+     * @return void
+     *
+     * @deprecated since version 5.1
+     */
+    public function whenRegex($pattern, $name, $methods = null);
+
+    /**
+     * Register a model binder for a wildcard.
+     *
+     * @param  string  $key
+     * @param  string  $class
+     * @param  \Closure|null  $callback
+     * @return void
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     */
+    public function model($key, $class, Closure $callback = null);
+
+    /**
+     * Add a new route parameter binder.
+     *
+     * @param  string  $key
+     * @param  string|callable  $binder
+     * @return void
+     */
+    public function bind($key, $binder);
+
+    /**
+     * Create a class based binding using the IoC container.
+     *
+     * @param  string    $binding
+     * @return \Closure
+     */
+    public function createClassBinding($binding);
+
+    /**
+     * Set a global where pattern on all routes.
+     *
+     * @param  string  $key
+     * @param  string  $pattern
+     * @return void
+     */
+    public function pattern($key, $pattern);
+
+    /**
+     * Set a group of global where patterns on all routes.
+     *
+     * @param  array  $patterns
+     * @return void
+     */
+    public function patterns($patterns);
+
+    /**
+     * Call the given route's before filters.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function callRouteBefore($route, $request);
+
+    /**
+     * Find the patterned filters matching a request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     *
+     * @deprecated since version 5.1
+     */
+    public function findPatternFilters($request);
+
+    /**
+     * Call the given route's after filters.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Response  $response
+     * @return mixed
+     *
+     * @deprecated since version 5.1
+     */
+    public function callRouteAfter($route, $request, $response);
+
+    /**
+     * Call the given route filter.
+     *
+     * @param  string  $filter
+     * @param  array  $parameters
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Response|null $response
+     * @return mixed
+     *
+     * @deprecated since version 5.1
+     */
+    public function callRouteFilter($filter, $parameters, $route, $request, $response = null);
+
+    /**
+     * Create a response instance from the given value.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  mixed  $response
+     * @return \Illuminate\Http\Response
+     */
+    public function prepareResponse($request, $response);
+
+    /**
+     * Determine if the router currently has a group stack.
+     *
+     * @return bool
+     */
+    public function hasGroupStack();
+
+    /**
+     * Get the current group stack for the router.
+     *
+     * @return array
+     */
+    public function getGroupStack();
+
+    /**
+     * Get a route parameter for the current route.
+     *
+     * @param  string  $key
+     * @param  string  $default
+     * @return mixed
+     */
+    public function input($key, $default = null);
+
+
+    /**
+     * Get the currently dispatched route instance.
+     *
+     * @return \Illuminate\Routing\Route
+     */
+    public function getCurrentRoute();
+
+    /**
+     * Get the currently dispatched route instance.
+     *
+     * @return \Illuminate\Routing\Route
+     */
+    public function current();
+
+    /**
+     * Check if a route with the given name exists.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function has($name);
+
+    /**
+     * Get the current route name.
+     *
+     * @return string|null
+     */
+    public function currentRouteName();
+
+    /**
+     * Alias for the "currentRouteNamed" method.
+     *
+     * @param  mixed  string
+     * @return bool
+     */
+    public function is();
+
+    /**
+     * Determine if the current route matches a given name.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function currentRouteNamed($name);
+
+    /**
+     * Get the current route action.
+     *
+     * @return string|null
+     */
+    public function currentRouteAction();
+
+    /**
+     * Alias for the "currentRouteUses" method.
+     *
+     * @param  mixed  string
+     * @return bool
+     */
+    public function uses();
+
+    /**
+     * Determine if the current route action matches a given action.
+     *
+     * @param  string  $action
+     * @return bool
+     */
+    public function currentRouteUses($action);
+
+    /**
+     * Get the request currently being dispatched.
+     *
+     * @return \Illuminate\Http\Request
+     */
+    public function getCurrentRequest();
+
+    /**
+     * Get the underlying route collection.
+     *
+     * @return \Illuminate\Routing\RouteCollection
+     */
+    public function getRoutes();
+
+    /**
+     * Set the route collection instance.
+     *
+     * @param  \Illuminate\Routing\RouteCollection  $routes
+     * @return void
+     */
+    public function setRoutes(\Illuminate\Routing\RouteCollection $routes);
+
+    /**
+     * Get the global "where" patterns.
+     *
+     * @return array
+     */
+    public function getPatterns();
 }


### PR DESCRIPTION
I've added the whole lot of them. I'm guessing this will probably be too much.

My suggestion would be to improve the public method's documentation with `@api` and / or `@internal` without leaving them out.

Also, some methods added now expose a dependency to implementations without contracts, such as `Illuminate\Http\Request`. `Illuminate\Routing\Route` and `Illuminate\Routing\RouteCollection`. I've left those hints as FQCN hints without moving them to a `use` clause, let me know if you'd rather move them up.

All docblocks were copied as-is from the implementation.

Cheers!
