### PR TITLE
[5.1] Missing public methods from Events\Dispatcher to Contracts\Events\Dispatcher

### DIFF
--- a/src/Illuminate/Contracts/Events/Dispatcher.php
+++ b/src/Illuminate/Contracts/Events/Dispatcher.php
@@ -23,6 +23,23 @@ interface Dispatcher
     public function hasListeners($eventName);
 
     /**
+     * Register an event and payload to be fired later.
+     *
+     * @param  string  $event
+     * @param  array  $payload
+     * @return void
+     */
+    public function push($event, $payload = []);
+
+    /**
+     * Register an event subscriber with the dispatcher.
+     *
+     * @param  object|string  $subscriber
+     * @return void
+     */
+    public function subscribe($subscriber);
+
+    /**
      * Fire an event until the first non-null response is returned.
      *
      * @param  string  $event
@@ -30,6 +47,14 @@ interface Dispatcher
      * @return mixed
      */
     public function until($event, $payload = []);
+
+    /**
+     * Flush a set of pushed events.
+     *
+     * @param  string  $event
+     * @return void
+     */
+    public function flush($event);
 
     /**
      * Fire an event and call the listeners.
@@ -40,6 +65,30 @@ interface Dispatcher
      * @return array|null
      */
     public function fire($event, $payload = [], $halt = false);
+
+    /**
+     * Get all of the listeners for a given event name.
+     *
+     * @param  string  $eventName
+     * @return array
+     */
+    public function getListeners($eventName);
+
+    /**
+     * Register an event listener with the dispatcher.
+     *
+     * @param  mixed  $listener
+     * @return mixed
+     */
+    public function makeListener($listener);
+
+    /**
+     * Create a class based listener using the IoC container.
+     *
+     * @param  mixed  $listener
+     * @return \Closure
+     */
+    public function createClassListener($listener);
 
     /**
      * Get the event that is currently firing.
@@ -62,4 +111,12 @@ interface Dispatcher
      * @return void
      */
     public function forgetPushed();
+
+    /**
+     * Set the queue resolver implementation.
+     *
+     * @param  callable  $resolver
+     * @return $this
+     */
+    public function setQueueResolver(callable $resolver);
 }


### PR DESCRIPTION
As with the `Router` / `Registrar`, I've added all missing methods.
Let me know if there's any changes needed, happy to help!

Cheers
