### PR TITLE
[5.1] Added cached compile and service path methods to the Application interface

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -83,4 +83,18 @@ interface Application extends Container
      * @return void
      */
     public function booted($callback);
+
+    /**
+     * Get the path to the cached "compiled.php" file.
+     *
+     * @return string
+     */
+    public function getCachedCompilePath();
+
+    /**
+     * Get the path to the cached services.json file.
+     *
+     * @return string
+     */
+    public function getCachedServicesPath();
 }


### PR DESCRIPTION
Fixes #8229 and requested by @GrahamCampbell 
