### PR TITLE
[5.1] Added the first three missing public methods from Events\Dispatcher to Contracts\Events\Dispatcher

### DIFF
--- a/src/Illuminate/Contracts/Events/Dispatcher.php
+++ b/src/Illuminate/Contracts/Events/Dispatcher.php
@@ -23,6 +23,23 @@ interface Dispatcher
     public function hasListeners($eventName);
 
     /**
+     * Register an event and payload to be fired later.
+     *
+     * @param  string  $event
+     * @param  array  $payload
+     * @return void
+     */
+    public function push($event, $payload = []);
+
+    /**
+     * Register an event subscriber with the dispatcher.
+     *
+     * @param  object|string  $subscriber
+     * @return void
+     */
+    public function subscribe($subscriber);
+
+    /**
      * Fire an event until the first non-null response is returned.
      *
      * @param  string  $event
@@ -30,6 +47,14 @@ interface Dispatcher
      * @return mixed
      */
     public function until($event, $payload = []);
+
+    /**
+     * Flush a set of pushed events.
+     *
+     * @param  string  $event
+     * @return void
+     */
+    public function flush($event);
 
     /**
      * Fire an event and call the listeners.


### PR DESCRIPTION
As requested, only the first three methods were added.
