### PR TITLE
[5.1] Added only some missing public methods from Routing\Router to Contracts\Routing\Registrar

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -61,6 +61,15 @@ interface Registrar
     public function options($uri, $action);
 
     /**
+     * Register a new route responding to all verbs.
+     *
+     * @param  string  $uri
+     * @param  \Closure|array|string  $action
+     * @return \Illuminate\Contracts\Routing\Registrar
+     */
+    public function any($uri, $action);
+
+    /**
      * Register a new route with the given verbs.
      *
      * @param  array|string  $methods
@@ -69,6 +78,32 @@ interface Registrar
      * @return void
      */
     public function match($methods, $uri, $action);
+
+    /**
+     * Register an array of controllers with wildcard routing.
+     *
+     * @param  array  $controllers
+     * @return void
+     */
+    public function controllers(array $controllers);
+
+    /**
+     * Route a controller to a URI with wildcard routing.
+     *
+     * @param  string  $uri
+     * @param  string  $controller
+     * @param  array   $names
+     * @return void
+     */
+    public function controller($uri, $controller, $names = []);
+
+    /**
+     * Register an array of resource controllers.
+     *
+     * @param  array  $resources
+     * @return void
+     */
+    public function resources(array $resources);
 
     /**
      * Route a resource to a controller.
@@ -88,6 +123,39 @@ interface Registrar
      * @return void
      */
     public function group(array $attributes, Closure $callback);
+
+    /**
+     * Merge the given array with the last group stack.
+     *
+     * @param  array  $new
+     * @return array
+     */
+    public function mergeWithLastGroup($new);
+
+    /**
+     * Merge the given group attributes.
+     *
+     * @param  array  $new
+     * @param  array  $old
+     * @return array
+     */
+    public static function mergeGroup($new, $old);
+
+    /**
+     * Resolve the middleware name to a class name preserving passed parameters.
+     *
+     * @param $name
+     * @return string
+     */
+    public function resolveMiddlewareClassName($name);
+
+    /**
+     * Register a route matched event listener.
+     *
+     * @param  string|callable  $callback
+     * @return void
+     */
+    public function matched($callback);
 
     /**
      * Register a new "before" filter with the router.
@@ -110,6 +178,15 @@ interface Registrar
     public function after($callback);
 
     /**
+     * Register a short-hand name for a middleware.
+     *
+     * @param  string  $name
+     * @param  string  $class
+     * @return $this
+     */
+    public function middleware($name, $class);
+
+    /**
      * Register a new filter with the router.
      *
      * @param  string  $name
@@ -119,4 +196,32 @@ interface Registrar
      * @deprecated since version 5.1
      */
     public function filter($name, $callback);
+
+    /**
+     * Register a model binder for a wildcard.
+     *
+     * @param  string  $key
+     * @param  string  $class
+     * @param  \Closure|null  $callback
+     * @return void
+     *
+     */
+    public function model($key, $class, Closure $callback = null);
+
+    /**
+     * Add a new route parameter binder.
+     *
+     * @param  string  $key
+     * @param  string|callable  $binder
+     * @return void
+     */
+    public function bind($key, $binder);
+
+    /**
+     * Create a class based binding using the IoC container.
+     *
+     * @param  string    $binding
+     * @return \Closure
+     */
+    public function createClassBinding($binding);
 }


### PR DESCRIPTION
As requested, only added methods with the following criteria:
- **NOT** getters/setters _(may have missed some methods here)_
- **NOT** deprecated
- arguments do **NOT** hint concrete classes
- return type is **NOT** a concrete class
