### PR TITLE
[5.1] Removed deprecated methods from the registar contract

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -88,35 +88,4 @@ interface Registrar
      * @return void
      */
     public function group(array $attributes, Closure $callback);
-
-    /**
-     * Register a new "before" filter with the router.
-     *
-     * @param  string|callable  $callback
-     * @return void
-     *
-     * @deprecated since version 5.1
-     */
-    public function before($callback);
-
-    /**
-     * Register a new "after" filter with the router.
-     *
-     * @param  string|callable  $callback
-     * @return void
-     *
-     * @deprecated since version 5.1
-     */
-    public function after($callback);
-
-    /**
-     * Register a new filter with the router.
-     *
-     * @param  string  $name
-     * @param  string|callable  $callback
-     * @return void
-     *
-     * @deprecated since version 5.1
-     */
-    public function filter($name, $callback);
 }


### PR DESCRIPTION
Having them in there and not the middleware methods makes the contract "opinionated" anyway imo.
