### PR TITLE
[5.1] DB Query Builder Join Clause 'where in'

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -177,7 +177,17 @@ class Grammar extends BaseGrammar
     {
         $first = $this->wrap($clause['first']);
 
-        $second = $clause['where'] ? '?' : $this->wrap($clause['second']);
+        if ($clause['where']) {
+            if ($clause['operator'] === 'in' || $clause['operator'] === 'not in') {
+                // In case of `whereIn` operator.
+                $second = '(' . join(', ', array_fill(0, $clause['second'], '?')) . ')';
+            } else {
+                // In case of common `where` operator.
+                $second = '?';
+            }
+        } else {
+            $second = $this->wrap($clause['second']);
+        }
 
         return "{$clause['boolean']} $first {$clause['operator']} $second";
     }

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -57,11 +57,16 @@ class JoinClause
      */
     public function on($first, $operator, $second, $boolean = 'and', $where = false)
     {
-        $this->clauses[] = compact('first', 'operator', 'second', 'boolean', 'where');
-
         if ($where) {
             $this->bindings[] = $second;
         }
+
+        // In case of `whereIn`, store array count.
+        if ($where && ($operator === 'in' || $operator === 'not in') && is_array($second)) {
+            $second = count($second);
+        }
+
+        $this->clauses[] = compact('first', 'operator', 'second', 'boolean', 'where');
 
         return $this;
     }
@@ -150,5 +155,53 @@ class JoinClause
     public function orWhereNotNull($column)
     {
         return $this->whereNotNull($column, 'or');
+    }
+
+    /**
+     * Add an "on where in (...)" clause to the join.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @return \Illuminate\Database\Query\JoinClause
+     */
+    public function whereIn($column, array $values)
+    {
+        return $this->on($column, 'in', $values, 'and', true);
+    }
+
+    /**
+     * Add an "on where not in (...)" clause to the join.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @return \Illuminate\Database\Query\JoinClause
+     */
+    public function whereNotIn($column, array $values)
+    {
+        return $this->on($column, 'not in', $values, 'and', true);
+    }
+
+    /**
+     * Add an "or on where in (...)" clause to the join.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @return \Illuminate\Database\Query\JoinClause
+     */
+    public function orWhereIn($column, array $values)
+    {
+        return $this->on($column, 'in', $values, 'or', true);
+    }
+
+    /**
+     * Add an "or on where not in (...)" clause to the join.
+     *
+     * @param  string  $column
+     * @param  array  $values
+     * @return \Illuminate\Database\Query\JoinClause
+     */
+    public function orWhereNotIn($column, array $values)
+    {
+        return $this->on($column, 'not in', $values, 'or', true);
     }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -646,6 +646,40 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."deleted_at" is not null', $builder->toSql());
     }
 
+    public function testJoinWhereIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->join('contacts', function ($j) {
+            $j->on('users.id', '=', 'contacts.id')->whereIn('contacts.name', [48, 'baz', null]);
+        });
+        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."name" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([48, 'baz', null], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->join('contacts', function ($j) {
+            $j->on('users.id', '=', 'contacts.id')->orWhereIn('contacts.name', [48, 'baz', null]);
+        });
+        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."name" in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([48, 'baz', null], $builder->getBindings());
+    }
+
+    public function testJoinWhereNotIn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->join('contacts', function ($j) {
+            $j->on('users.id', '=', 'contacts.id')->whereNotIn('contacts.name', [48, 'baz', null]);
+        });
+        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."name" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([48, 'baz', null], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->join('contacts', function ($j) {
+            $j->on('users.id', '=', 'contacts.id')->orWhereNotIn('contacts.name', [48, 'baz', null]);
+        });
+        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."name" not in (?, ?, ?)', $builder->toSql());
+        $this->assertEquals([48, 'baz', null], $builder->getBindings());
+    }
+
     public function testRawExpressionsInSelect()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Added Join Clause methods:
- `whereIn`
- `whereNotIn`
- `orWhereIn`
- `orWhereNotIn`

[Issue discussion](https://github.com/laravel/framework/issues/4412)
[previously](https://github.com/laravel/framework/pull/9016)
