### PR TITLE
[5.1] Add new $filePermission property to Log\Writer

### DIFF
--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -50,6 +50,13 @@ class Writer implements LogContract, PsrLoggerInterface
     ];
 
     /**
+     * The permission mode for for new log files.
+     *
+     * @var int|null
+     */
+    protected $filePermission;
+
+    /**
      * Create a new log writer instance.
      *
      * @param  \Monolog\Logger  $monolog
@@ -211,7 +218,7 @@ class Writer implements LogContract, PsrLoggerInterface
      */
     public function useFiles($path, $level = 'debug')
     {
-        $this->monolog->pushHandler($handler = new StreamHandler($path, $this->parseLevel($level)));
+        $this->monolog->pushHandler($handler = new StreamHandler($path, $this->parseLevel($level), true, $this->filePermission));
 
         $handler->setFormatter($this->getDefaultFormatter());
     }
@@ -227,7 +234,7 @@ class Writer implements LogContract, PsrLoggerInterface
     public function useDailyFiles($path, $days = 0, $level = 'debug')
     {
         $this->monolog->pushHandler(
-            $handler = new RotatingFileHandler($path, $days, $this->parseLevel($level))
+            $handler = new RotatingFileHandler($path, $days, $this->parseLevel($level), true, $this->filePermission)
         );
 
         $handler->setFormatter($this->getDefaultFormatter());
@@ -343,7 +350,7 @@ class Writer implements LogContract, PsrLoggerInterface
     }
 
     /**
-     * Get a defaut Monolog formatter instance.
+     * Get a default Monolog formatter instance.
      *
      * @return \Monolog\Formatter\LineFormatter
      */
@@ -371,5 +378,26 @@ class Writer implements LogContract, PsrLoggerInterface
     public function setEventDispatcher(Dispatcher $dispatcher)
     {
         $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * Get the file permission for creating files
+     *
+     * @return int|null
+     */
+    public function getFilePermission()
+    {
+        return $this->filePermission;
+    }
+
+    /**
+     * Set the file permission for newly created files
+     *
+     * @param  int|null  $filePermission
+     * @return void
+     */
+    public function setFilePermission($filePermission)
+    {
+        $this->filePermission = $filePermission;
     }
 }


### PR DESCRIPTION
`StreamHandler` log writers accept a parameter for setting new file permissions (i.e. created during rotation), but there is no way to modify the argument without sub-classing or a lot of weird configuration stuff I've yet to discover. 

The easiest solution was to add a new property that could be ignored completely, or set, then passed to `StreamHandler` constructors. My change defaults the value to `null`, which is the default already being passed. A getter and setter are provided as well.

P.S. I fixed a typo as well.
