### PR TITLE
[5.1] Use methods from contract

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
@@ -20,6 +20,6 @@ class RegisterFacades
 
         Facade::setFacadeApplication($app);
 
-        AliasLoader::getInstance($app['config']['app.aliases'])->register();
+        AliasLoader::getInstance($app->make('config')->get('app.aliases'))->register();
     }
 }

--- a/src/Illuminate/Foundation/Bootstrap/SetRequestForConsole.php
+++ b/src/Illuminate/Foundation/Bootstrap/SetRequestForConsole.php
@@ -15,7 +15,7 @@ class SetRequestForConsole
      */
     public function bootstrap(Application $app)
     {
-        $url = $app['config']->get('app.url', 'http://localhost');
+        $url = $app->make('config')->get('app.url', 'http://localhost');
 
         $app->instance('request', Request::create($url, 'GET', [], [], [], $_SERVER));
     }


### PR DESCRIPTION
The `Foundation\Application` interface is somewhat pointless, since methods outside of the contract are used througout Laravel.

But since it's so easy to follow the contract here, we may as well do so...
