### PR TITLE
[5.1] Disable encryption for certain cookies

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -19,11 +19,11 @@ class EncryptCookies
     protected $encrypter;
 
     /**
-     * The names of all cookies that should not be encrypted.
+     * The names of all cookies for which encryption is disabled.
      *
      * @var array
      */
-    protected static $ignored = [];
+    protected static $disabled = [];
 
     /**
      * Create a new CookieGuard instance.
@@ -37,14 +37,14 @@ class EncryptCookies
     }
 
     /**
-     * Ignore the given cookie name(s) during encryption.
+     * Disable encryption for the given cookie name(s).
      *
      * @param string|array $cookieName
      * @return void
      */
-    public static function ignore($cookieName)
+    public static function disableFor($cookieName)
     {
-        static::$ignored[] = array_merge(static::$ignored, (array) $cookieName);
+        static::$disabled[] = array_merge(static::$disabled, (array) $cookieName);
     }
 
     /**
@@ -68,7 +68,7 @@ class EncryptCookies
     protected function decrypt(Request $request)
     {
         foreach ($request->cookies as $key => $c) {
-            if ($this->shouldBeIgnored($key)) {
+            if ($this->isDisabled($key)) {
                 continue;
             }
 
@@ -121,7 +121,7 @@ class EncryptCookies
     protected function encrypt(Response $response)
     {
         foreach ($response->headers->getCookies() as $key => $cookie) {
-            if ($this->shouldBeIgnored($key)) {
+            if ($this->isDisabled($key)) {
                 continue;
             }
 
@@ -149,13 +149,13 @@ class EncryptCookies
     }
 
     /**
-     * Determine whether the given cookie should not be encrypted.
+     * Determine whether encryption has been disabled for the given cookie.
      *
      * @param string $name
      * @return bool
      */
-    protected function shouldBeIgnored($name)
+    protected function isDisabled($name)
     {
-        return in_array($name, static::$ignored);
+        return in_array($name, static::$disabled);
     }
 }


### PR DESCRIPTION
This has been a long-requested feature (#3440, #4134, #6421, #6679), so I wanted to try to get this in before the 5.1 release.

For example, in my FluxBB auth bridge package, I could put this code in the service provider:

``` php
Illuminate\Cookie\Middleware\EncryptCookies::disableFor('fluxbb_cookie_1234');
```

After considering the options, I think a blacklist in the middleware is the best middle ground between small code changes, ease of use and keeping the concept to this contained in this middleware.

/cc @davejamesmiller @RomainLanz @raulp @maclof

Closes #6679.
