### PR TITLE
[5.1] Add the ability to dump content from test responses.

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -694,4 +694,22 @@ trait CrawlerTrait
 
         return $this;
     }
+
+    /**
+     * Dump the content from the last response.
+     *
+     * @return void
+     */
+    public function dump()
+    {
+        $content = $this->response->getContent();
+
+        $json = json_decode($content);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            $content = $json;
+        }
+
+        dd($content);
+    }
 }


### PR DESCRIPTION
When writing functional tests, it's often handy to see what the test is seeing. This method helps by dumping the content of the last response. It does a check to see if the content is JSON, and if it is, it outputs the decoded values instead of the response string.

Example usage:

``` php
$this->visit('/home')->dump();
```
