### PR TITLE
[5.1] Moved max and min functions into general collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -97,32 +97,6 @@ class Collection extends BaseCollection
     }
 
     /**
-     * Get the max value of a given key.
-     *
-     * @param  string  $key
-     * @return mixed
-     */
-    public function max($key)
-    {
-        return $this->reduce(function ($result, $item) use ($key) {
-            return is_null($result) || $item->{$key} > $result ? $item->{$key} : $result;
-        });
-    }
-
-    /**
-     * Get the min value of a given key.
-     *
-     * @param  string  $key
-     * @return mixed
-     */
-    public function min($key)
-    {
-        return $this->reduce(function ($result, $item) use ($key) {
-            return is_null($result) || $item->{$key} < $result ? $item->{$key} : $result;
-        });
-    }
-
-    /**
      * Get the array of primary keys.
      *
      * @return array

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -406,6 +406,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the max value of a given key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function max($key)
+    {
+        return $this->reduce(function ($result, $item) use ($key) {
+            return is_null($result) || $item->{$key} > $result ? $item->{$key} : $result;
+        });
+    }
+
+    /**
      * Merge the collection with the given items.
      *
      * @param  mixed  $items
@@ -414,6 +427,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function merge($items)
     {
         return new static(array_merge($this->items, $this->getArrayableItems($items)));
+    }
+
+    /**
+     * Get the min value of a given key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function min($key)
+    {
+        return $this->reduce(function ($result, $item) use ($key) {
+            return is_null($result) || $item->{$key} < $result ? $item->{$key} : $result;
+        });
     }
 
     /**


### PR DESCRIPTION
Closes #9144 (and #2155 actually).

I put the functions in alphabetical order around the nearest functions, not sure what the order was otherwise.
