### PR TITLE
[5.1] Allow relationships in factory builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -128,8 +128,6 @@ class FactoryBuilder
 
             $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker);
             
-            foreach($definition as $key => $attribute)
-            {
                 try {
                     $class = app($attribute);
                     if($class instanceof Model)

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -4,6 +4,8 @@ namespace Illuminate\Database\Eloquent;
 
 use Faker\Factory as Faker;
 use InvalidArgumentException;
+use ReflectionException;
+use ReflectionClass;
 
 class FactoryBuilder
 {
@@ -130,7 +132,7 @@ class FactoryBuilder
             
             foreach ($definition as $key => $attribute) {
                 try {
-                    $class = app($attribute);
+                    $class = new ReflectionException($attribute);
                     if ($class instanceof Model) {
                         $definition[$key] = $class::orderByRaw('RAND()')->first()->id;
                     }

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -132,9 +132,9 @@ class FactoryBuilder
                 try {
                     $class = app($attribute);
                     if ($class instanceof Model) {
-                        $definition[$key] = $class::orderByRaw('RAND()')->get()->id;
+                        $definition[$key] = $class::orderByRaw('RAND()')->first()->id;
                     }
-                } catch (Exception $e) {
+                } catch (\ReflectionException $e) {
                 }
             }
 

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -127,6 +127,16 @@ class FactoryBuilder
             }
 
             $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker);
+            
+            foreach($definition as $key => $attribute)
+            {
+                try {
+                    $class = app($attribute);
+                    if($class instanceof Model)
+                        $definition[$key] = $class::orderByRaw("RAND()")->get()->id;
+                } 
+                catch(Exception $e) {   }
+            }
 
             return new $this->class(array_merge($definition, $attributes));
         });

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -132,7 +132,7 @@ class FactoryBuilder
             
             foreach ($definition as $key => $attribute) {
                 try {
-                    $class = new ReflectionException($attribute);
+                    $class = new ReflectionClass($attribute);
                     if ($class instanceof Model) {
                         $definition[$key] = $class::orderByRaw('RAND()')->first()->id;
                     }

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -128,12 +128,14 @@ class FactoryBuilder
 
             $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker);
             
+            foreach ($definition as $key => $attribute) {
                 try {
                     $class = app($attribute);
-                    if($class instanceof Model)
-                        $definition[$key] = $class::orderByRaw("RAND()")->get()->id;
-                } 
-                catch(Exception $e) {   }
+                    if ($class instanceof Model) {
+                        $definition[$key] = $class::orderByRaw('RAND()')->get()->id;
+                    }
+                } catch (Exception $e) {
+                }
             }
 
             return new $this->class(array_merge($definition, $attributes));


### PR DESCRIPTION
(I'm pretty sure I didn't do this perfectly but I hope that someone who is better than me at this gets the idea.) :)
Basically I can put something like this in my FactoryBuilder.php file:

'user_id' => App\User::class

and it will take the id of the user and set it as the attribute. I like this better than 'factory:User' because it will allow me to click through to the User model. If there's any way to make this cleaner or faster just tell me and I'll fix it ASAP! Especially the try catch because I feel like it's kind of hacky. Also comment if you think I should export this to its own function
