### PR TITLE
append and prepend will create files if they do not exist

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -114,7 +114,11 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      */
     public function prepend($path, $data)
     {
-        return $this->put($path, $data.PHP_EOL.$this->get($path));
+        if ($this->exists($path)) {
+            return $this->put($path, $data.PHP_EOL.$this->get($path));
+        }
+
+        return $this->put($path, $data);
     }
 
     /**
@@ -126,7 +130,11 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      */
     public function append($path, $data)
     {
-        return $this->put($path, $this->get($path).PHP_EOL.$data);
+        if ($this->exists($path)) {
+            return $this->put($path, $this->get($path).PHP_EOL.$data);
+        }
+
+        return $this->put($path, $data);
     }
 
     /**


### PR DESCRIPTION
Mby it will be helpful to just use `append` (or `prepend`) methods without checking if file exists.

Right now you will get `FileNotFoundException`, because of `get` method.

For example `file_put_contents` works that way.
