### PR TITLE
[5.1] Allow validateIn for type array

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -962,6 +962,10 @@ class Validator implements ValidatorContract
      */
     protected function validateIn($attribute, $value, $parameters)
     {
+        if (is_array($value) && in_array('array', $this->rules[$attribute])) {
+            return count(array_diff($value, $parameters)) == 0;
+        }
+
         return in_array((string) $value, $parameters);
     }
 


### PR DESCRIPTION
Allow for validation:

``` php
$inputs = [
    'values' => ['one']
];
$rules = [
    'values' => 'required|in:one,two'
];
$v = Validator::make($inputs, $rules);
var_dump(!$v->fails());
```
