### PR TITLE
[5.1] Moved max and min functions into general collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -97,32 +97,6 @@ class Collection extends BaseCollection
     }
 
     /**
-     * Get the max value of a given key.
-     *
-     * @param  string  $key
-     * @return mixed
-     */
-    public function max($key)
-    {
-        return $this->reduce(function ($result, $item) use ($key) {
-            return is_null($result) || $item->{$key} > $result ? $item->{$key} : $result;
-        });
-    }
-
-    /**
-     * Get the min value of a given key.
-     *
-     * @param  string  $key
-     * @return mixed
-     */
-    public function min($key)
-    {
-        return $this->reduce(function ($result, $item) use ($key) {
-            return is_null($result) || $item->{$key} < $result ? $item->{$key} : $result;
-        });
-    }
-
-    /**
      * Get the array of primary keys.
      *
      * @return array

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -406,6 +406,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get the max value of a given key.
+     *
+     * @param  string|null  $key
+     * @return mixed
+     */
+    public function max($key = null)
+    {
+        return $this->reduce(function ($result, $item) use ($key) {
+            $value = data_get($item, $key);
+
+            return is_null($result) || $value > $result ? $value : $result;
+        });
+    }
+
+    /**
      * Merge the collection with the given items.
      *
      * @param  mixed  $items
@@ -414,6 +429,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function merge($items)
     {
         return new static(array_merge($this->items, $this->getArrayableItems($items)));
+    }
+
+    /**
+     * Get the min value of a given key.
+     *
+     * @param  string|null  $key
+     * @return mixed
+     */
+    public function min($key = null)
+    {
+        return $this->reduce(function ($result, $item) use ($key) {
+            $value = data_get($item, $key);
+
+            return is_null($result) || $value < $result ? $value : $result;
+        });
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -743,6 +743,36 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([2, 5, null], $c[1]->all());
         $this->assertEquals([3, 6, null], $c[2]->all());
     }
+
+    public function testGettingMaxItemsFromCollection()
+    {
+        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
+        $this->assertEquals(20, $c->max('foo'));
+
+        $c = new Collection([['foo' => 10], ['foo' => 20]]);
+        $this->assertEquals(20, $c->max('foo'));
+
+        $c = new Collection([1, 2, 3, 4, 5]);
+        $this->assertEquals(5, $c->max());
+
+        $c = new Collection();
+        $this->assertNull($c->max());
+    }
+
+    public function testGettingMinItemsFromCollection()
+    {
+        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
+        $this->assertEquals(10, $c->min('foo'));
+
+        $c = new Collection([['foo' => 10], ['foo' => 20]]);
+        $this->assertEquals(10, $c->min('foo'));
+
+        $c = new Collection([1, 2, 3, 4, 5]);
+        $this->assertEquals(1, $c->min());
+
+        $c = new Collection();
+        $this->assertNull($c->min());
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
The only issue I see right now is that it no longer enforces the `$key` as required in `Eloquent\Collection`. A possible solution to that is to throw an `\InvalidArgumentException` in the overwritten method when `$key === null`, or leave as is and let the result speak for it self.

Use cases:
- Converting an array to a collection for manipulation.
- Collections that are not from eloquent queries after `->toBase()`.
- Component usage outside of the framework (this is the Support component after all).

Worked off of #9166 and looked at #5257.
