### PR TITLE
[5.1] Adding CrawlerTrait::getResponse() method

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -694,6 +694,16 @@ trait CrawlerTrait
 
         return $this;
     }
+    
+    /**
+     * Returns the last response.
+     * 
+     * @return \Illuminate\Http\Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
 
     /**
      * Dump the content from the last response.


### PR DESCRIPTION
Whereas there is `CrawlerTrait::dump()` method which actually is rarely useful (especially if one already is developing with XDebug or similar tool), I believe an accessor for the last response object is much needed. I myself have a need for it in my unit-tests to check against certain values returned from my crawlers or check on headers returned etc.
