### PR TITLE
[5.1] Updated the test to confirm the url action generator bug.

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -541,8 +541,6 @@ class UrlGenerator implements UrlGeneratorContract
     {
         if ($this->rootNamespace && !(strpos($action, '\\') === 0)) {
             $action = $this->rootNamespace.'\\'.$action;
-        } else {
-            $action = trim($action, '\\');
         }
 
         if (!is_null($route = $this->routes->getByAction($action))) {

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -128,7 +128,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase
         $route = new Illuminate\Routing\Route(['GET'], 'foo/bar', ['controller' => 'namespace\foo@bar']);
         $routes->add($route);
 
-        $route = new Illuminate\Routing\Route(['GET'], 'something/else', ['controller' => 'something\foo@bar']);
+        $route = new Illuminate\Routing\Route(['GET'], 'something/else', ['controller' => '\something\foo@bar']);
         $routes->add($route);
 
         $this->assertEquals('http://www.foo.com/foo/bar', $url->action('foo@bar'));


### PR DESCRIPTION
By default laravel uses the root namespace of "App\Http\Controllers", to have a controller in another namespace we have to use "\My\Other\Namespace\Controller@foo".

The test wasn't adding the extra backslash, thus giving a false positive result.

See https://github.com/laravel/framework/issues/9206 for more details!
