### PR TITLE
[5.1] Fix nested route names with group that has no "as" option

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -398,8 +398,8 @@ class Router implements RegistrarContract
             isset($new['where']) ? $new['where'] : []
         );
 
-        if (isset($old['as']) && isset($new['as'])) {
-            $new['as'] = $old['as'].$new['as'];
+        if (isset($old['as'])) {
+            $new['as'] = $old['as'].(isset($new['as']) ? $new['as'] : '');
         }
 
         return array_merge_recursive(array_except($old, ['namespace', 'prefix', 'where', 'as']), $new);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -617,10 +617,15 @@ return 'foo!'; });
         $router = $this->getRouter();
         $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
             $router->get('bar', ['as' => 'bar', function () { return 'hello'; }]);
+            $router->group([], function () use ($router) {
+                $router->get('baz', ['as' => 'baz', function () { return 'hello'; }]);
+            });
         });
         $routes = $router->getRoutes();
         $route = $routes->getByName('Foo::bar');
         $this->assertEquals('foo/bar', $route->getPath());
+        $route = $routes->getByName('Foo::baz');
+        $this->assertEquals('foo/baz', $route->getPath());
     }
 
     public function testRoutePrefixing()


### PR DESCRIPTION
Fixes #9204
