### PR TITLE
Add XSRF-TOKEN cookie with config settings

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -97,7 +97,7 @@ class VerifyCsrfToken
     protected function addCookieToResponse($request, $response)
     {
         $response->headers->setCookie(
-            new Cookie('XSRF-TOKEN', $request->session()->token(), time() + 60 * 120, '/', null, false, false)
+            new Cookie('XSRF-TOKEN', $request->session()->token(), time() + 60 * 120, config("session.path"), config("session.domain"), false, false)
         );
 
         return $response;


### PR DESCRIPTION
If we configure the "path" or "domain" on "session.php" configuration file, the XSRF-TOKEN cookie will have different values than the ones specified by the user.
I detected this, because if I specify a cookie domain, Laravel prepends it with a "." (dot) to allow the cookie on all sub-domains. If this config is set to NULL, Laravel sets the cookie domain without the "." (dot).

Is this the intended behavior?
