### PR TITLE
[5.1] Fix basepath on chrooted environments

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -252,7 +252,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function setBasePath($basePath)
     {
-        $this->basePath = $basePath;
+        $this->basePath = rtrim($basePath, DIRECTORY_SEPARATOR);
 
         $this->bindPathsInContainer();
 


### PR DESCRIPTION
Fixes #9199

Configs are not properly loaded when environment is chrooted to laravel installation path.
In this case `config_path()` returns `//config` - so all configs are loaded with `config.` prefix.

See the issue for details.
