### PR TITLE
Fix eloquent builder paginate columns for count

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -245,7 +245,7 @@ class Builder {
 	 */
 	public function paginate($perPage = null, $columns = ['*'])
 	{
-		$total = $this->query->getCountForPagination();
+		$total = $this->query->getCountForPagination($columns);
 
 		$this->query->forPage(
 			$page = Paginator::resolveCurrentPage(),


### PR DESCRIPTION
At the moment $columns specified during paginate call as second parameter are not passed to count query of eloquent pagination.

This can be useful for example if one need to count distinct items.
