### PR TITLE
Fix wrong class name in return docblock.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -143,7 +143,7 @@ class Factory implements ArrayAccess
      *
      * @param  string  $class
      * @param  string  $name
-     * @return \Illuminate\Database\Factory\Builder
+     * @return \Illuminate\Database\Eloquent\FactoryBuilder
      */
     public function of($class, $name = 'default')
     {


### PR DESCRIPTION
Method `of` in `Illuminate/Database/Eloquent/Factory` returns `Illuminate\Database\Eloquent\FactoryBuilder`, but the commentary suggests that is `Illuminate\Database\Factory\Builder`, and this class does not exists.
