### PR TITLE
[5.1] addPortToDomain will not correctly add the port in some edgecases

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -491,11 +491,18 @@ class UrlGenerator implements UrlGeneratorContract
      */
     protected function addPortToDomain($domain)
     {
-        if (in_array($this->request->getPort(), ['80', '443'])) {
+        $is_secure = $this->request->isSecure();
+        $request_port = $this->request->getPort();
+
+        if ($is_secure && $request_port == 443) {
             return $domain;
         }
 
-        return $domain.':'.$this->request->getPort();
+        if (!$is_secure && $request_port == 80) {
+            return $domain;
+        }
+
+        return $domain.':'.$request_port;
     }
 
     /**


### PR DESCRIPTION
If the webserver has https listening on port 80, the port will not correctly get added to the URL.
