### PR TITLE
Allow chunk to exit when the closure returns false

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -220,6 +220,10 @@ class Builder
             // On each chunk result set, we will pass them to the callback and then let the
             // developer take care of everything within the callback, which allows us to
             // keep the memory low for spinning through large result sets for working.
+            if (call_user_func($callback, $results) === false) {
+                break;
+            }
+
             call_user_func($callback, $results);
 
             $page++;

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -491,11 +491,18 @@ class UrlGenerator implements UrlGeneratorContract
      */
     protected function addPortToDomain($domain)
     {
-        if (in_array($this->request->getPort(), ['80', '443'])) {
+        $is_secure = $this->request->isSecure();
+        $request_port = $this->request->getPort();
+
+        if ($is_secure && $request_port == 443) {
             return $domain;
         }
 
-        return $domain.':'.$this->request->getPort();
+        if (!$is_secure && $request_port == 80) {
+            return $domain;
+        }
+
+        return $domain.':'.$request_port;
     }
 
     /**


### PR DESCRIPTION
When looping through all of the different rows returned by `Eloquent\Builder` using a chunk closure, you should be able to specify to Builder that you wish to no longer continue processing chunks by simply returning false inside the closure.
### Usage Example

```
  ExamplesModel::where('is_an_example', true)
        ->chunk(5000, function($urls) use (&$post, &$loop, $time_queries, $time_started) {

            foreach($urls as $url) {
                Lengthy::process($url->path, $url->filename);

                // only allow to run for 20 seconds...
                if ($time_started+20 > microtime(true)) {
                    return false;
                }
            }

        })
```
