### PR TITLE
[5.1] Name for grouped resource incorrect

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -209,7 +209,7 @@ class ResourceRegistrar
      */
     protected function getGroupResourceName($prefix, $resource, $method)
     {
-        $group = trim(str_replace('/', '.', $this->router->getLastGroupPrefix()), '.');
+        $group = !empty($this->router->getLastGroupName()) ? '' : trim(str_replace('/', '.', $this->router->getLastGroupPrefix()), '.');
 
         if (empty($group)) {
             return trim("{$prefix}{$resource}.{$method}", '.');

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -458,6 +458,22 @@ class Router implements RegistrarContract
     }
 
     /**
+     * Get the alias from the last group on the stack.
+     *
+     * @return string
+     */
+    public function getLastGroupName()
+    {
+        if (!empty($this->groupStack)) {
+            $last = end($this->groupStack);
+
+            return isset($last['as']) ? $last['as'] : '';
+        }
+
+        return '';
+    }
+    
+    /**
      * Add a route to the underlying route collection.
      *
      * @param  array|string  $methods

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -775,6 +775,17 @@ return 'foo!'; });
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar'));
     }
 
+    public function testResourceRouteNamingInGroup()
+    {
+        $router = $this->getRouter();
+        $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
+            $router->resource('foo', 'FooController');
+        });
+        $routes = $router->getRoutes();
+
+        $this->assertTrue($routes->hasNamedRoute('Foo::foo.index'));
+    }
+
     public function testRouterFiresRoutedEvent()
     {
         $events = new Illuminate\Events\Dispatcher();


### PR DESCRIPTION
In my routes.php file I have the following routes set up:

```
Route::group(['prefix' => 'api/v1', 'namespace' => 'Api', 'as' => 'api::'], function() {
    Route::resource('customers', 'CustomersController', ['only' => ['index']]);
    Route::get('customers2', ['as' => 'customers.index', 'uses' => 'CustomersController@index']);
});
```

Then in both cases I expect the route's name to be api::customers.index, however the index action for the customers resource is named api::api.v1.customers.index. I don't think this is expected behavior. I've also added a testcase.

Hope this helps :)
