### PR TITLE
Allow UrlGenerator to fall back to root namespace

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -540,16 +540,18 @@ class UrlGenerator implements UrlGeneratorContract
     public function action($action, $parameters = [], $absolute = true)
     {
         if ($this->rootNamespace && !(strpos($action, '\\') === 0)) {
-            $action = $this->rootNamespace.'\\'.$action;
+            $amendedAction = $this->rootNamespace.'\\'.$action;
         } else {
-            $action = trim($action, '\\');
+            $amendedAction = trim($action, '\\');
         }
 
-        if (!is_null($route = $this->routes->getByAction($action))) {
-            return $this->toRoute($route, $parameters, $absolute);
+        if (is_null($route = $this->routes->getByAction($amendedAction))) {
+            if (is_null($route = $this->routes->getByAction($action))) {
+                throw new InvalidArgumentException("Action {$action} not defined.");
+            }
         }
 
-        throw new InvalidArgumentException("Action {$action} not defined.");
+        return $this->toRoute($route, $parameters, $absolute);
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -135,6 +135,21 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://www.foo.com/something/else', $url->action('\something\foo@bar'));
     }
 
+    public function testControllerRoutesOutsideOfDefaultNamespace()
+    {
+        $url = new UrlGenerator(
+            $routes = new Illuminate\Routing\RouteCollection,
+            $request = Illuminate\Http\Request::create('http://www.foo.com/')
+        );
+
+        $url->setRootControllerNamespace('namespace');
+
+        $route = new Illuminate\Routing\Route(['GET'], 'root/namespace', ['controller' => '\root\namespace@foo']);
+        $routes->add($route);
+
+        $this->assertEquals('http://www.foo.com/root/namespace', $url->action('\root\namespace@foo'));
+    }
+
     public function testRoutableInterfaceRouting()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
When using a default namespace for routing, you are able to route to controllers outside of the default namespace, like so:

```
//default namespace \App\Controllers

//Generates route to \App\Controllers\FooController    
Route::controller('foo','FooController');

//Generates route to \Bar\Controllers\BazController
Route::controller('bar','\Bar\Controllers\BazController');
```

This routing works, but in this situation the UrlGenerator simply will not generate urls for BazController, because it removes the leading slash in the FQN.

```
//default namespace \App\Controllers

//Searches for \App\Controllers\FooController
action('FooController@getIndex');

//Searches for \App\Controllers\Bar\Controllers\BazController
action('\Bar\Controllers\BazController@getIndex');
//With my addition, will then search for \Bar\Controllers\BazController, if first check fails to find a Controller.
```

This behaviour is strange, but it is what the current tests are set up to check.

I have updated the UrlGenerator to check in the root namespace, if the default namespace fails, allowing for both situations to work, and I have also added a unit test for the new functionality.
