### PR TITLE
[5.1] Fix routing outside of default namespace

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -106,7 +106,8 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     protected function addToActionList($action, $route)
     {
-        $this->actionList[$action['controller']] = $route;
+        $controllerName = trim($action['controller'], '\\');
+        $this->actionList[$controllerName] = $route;
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -135,6 +135,21 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://www.foo.com/something/else', $url->action('\something\foo@bar'));
     }
 
+    public function testControllerRoutesOutsideOfDefaultNamespace()
+    {
+        $url = new UrlGenerator(
+            $routes = new Illuminate\Routing\RouteCollection,
+            $request = Illuminate\Http\Request::create('http://www.foo.com/')
+        );
+
+        $url->setRootControllerNamespace('namespace');
+
+        $route = new Illuminate\Routing\Route(['GET'], 'root/namespace', ['controller' => '\root\namespace@foo']);
+        $routes->add($route);
+
+        $this->assertEquals('http://www.foo.com/root/namespace', $url->action('\root\namespace@foo'));
+    }
+
     public function testRoutableInterfaceRouting()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
Fix applied as per Taylor's comments in #9217 

URL generation fails for routing to controllers outside of default namespace.
Added a test for this eventuality and a fix so that the test passes.

Tests controller routing outside of default namespace, when a default namespace is set.
