### PR TITLE
[5.2] Improve blade @endsection, overwrite by default.

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -421,7 +421,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileEndsection($expression)
     {
-        return "<?php \$__env->stopSection(); ?>";
+        return "<?php \$__env->stopSection(true); ?>";
     }
 
     /**

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -520,7 +520,7 @@ class Factory implements FactoryContract
                 $this->sectionStack[] = $section;
             }
         } else {
-            $this->extendSection($section, $content);
+            $this->overwriteSection($section, $content);
         }
     }
 
@@ -596,6 +596,18 @@ class Factory implements FactoryContract
             $content = str_replace('@parent', $content, $this->sections[$section]);
         }
 
+        $this->sections[$section] = $content;
+    }
+
+    /**
+     * Overwrite content to a given section.
+     *
+     * @param  string  $section
+     * @param  string  $content
+     * @return void
+     */
+    protected function overwriteSection($section, $content)
+    {
         $this->sections[$section] = $content;
     }
 

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -479,7 +479,7 @@ empty
     public function testEndSectionsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
-        $this->assertEquals('<?php $__env->stopSection(); ?>', $compiler->compileString('@endsection'));
+        $this->assertEquals('<?php $__env->stopSection(true); ?>', $compiler->compileString('@endsection'));
     }
 
     public function testAppendSectionsAreCompiled()

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -234,6 +234,15 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('hi', $factory->yieldContent('foo'));
     }
 
+    public function testStartSectionWithInlineContentOverwrites()
+    {
+        $factory = $this->getFactory();
+        $factory->startSection('foo', 'bar');
+        $this->assertEquals('bar', $factory->yieldContent('foo'));
+        $factory->startSection('foo', 'baz');
+        $this->assertEquals('baz', $factory->yieldContent('foo'));
+    }
+
     public function testSectionExtending()
     {
         $factory = $this->getFactory();


### PR DESCRIPTION
This addresses my concerns in issue #8970, regarding reusing and nesting `@extend @yield @section` directives within partials.

TL;DR...

``` php
@endsection // overwrite=false, does not allow multiple instances of section name.
```

``` php
@stop       // overwrite=false, does not allow multiple instances of section name.
```

``` php
@overwrite  // overwrite=true, allows multiple instances by overwriting at compile time.
```

I think most users would benefit from being able to use reuse and nest `@extend @yield @section` directives throughout an app, even if sections reuse common names like 'title' or 'body' in their partials.

We already have this functionality if we force the compiler to overwrite the section in memory by using `@overwrite` instead of `@endsection`.  However, default `@endsection` functionality disallows this, because it duplicates `@stop` functionality.  I think the issue here is in the naming of `@endsection`, and confusion around it's default behaviour.  Sure, using `@overwrite` solves #8970 functionally, but the terminology of 'overwrite' is misleading for this use case; I'm not trying to 'overwrite' the last title section, I'm trying to define a new title section in a totally separate partial.  I'm not doing the overwriting, the compiler is just overwriting the last instance at compile time.

Unfortunately, this IS a breaking change, even if it doesn't affect many users.  If merged, any users who need original functionality can `@stop` their sections.  However, I think allowing `@extend @yield @section` with `@endsection` everywhere throughout an app is much more intuitive, so I'm proposing this PR for 5.2.

Thank you for considering this.
