### PR TITLE
[5.1] clean up database.stub file to be consistent with other migrations

### DIFF
--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 class CreateSessionTable extends Migration
@@ -11,10 +12,10 @@ class CreateSessionTable extends Migration
      */
     public function up()
     {
-        Schema::create('sessions', function ($t) {
-            $t->string('id')->unique();
-            $t->text('payload');
-            $t->integer('last_activity');
+        Schema::create('sessions', function (Blueprint $table) {
+            $table->string('id')->unique();
+            $table->text('payload');
+            $table->integer('last_activity');
         });
     }
 


### PR DESCRIPTION
Fixed database.stub to create migration file consistent with other migrations.
