### PR TITLE
[5.1] Remove unused use statements.

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Encryption;
 
 use RuntimeException;
-use Illuminate\Support\Str;
 use Illuminate\Contracts\Encryption\EncryptException;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;

--- a/src/Illuminate/Encryption/McryptEncrypter.php
+++ b/src/Illuminate/Encryption/McryptEncrypter.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Encryption;
 
 use Exception;
-use Illuminate\Support\Str;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Http;
 
-use Symfony\Component\HttpFoundation\Cookie;
-
 trait ResponseTrait
 {
     /**


### PR DESCRIPTION
As in topic - imported classes are never used in code, so we can remove them from "use" statement.
