### PR TITLE
Namespace overriding in route groups.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -414,7 +414,7 @@ class Router implements RegistrarContract
      */
     protected static function formatUsesPrefix($new, $old)
     {
-        if (isset($new['namespace']) && isset($old['namespace'])) {
+        if (isset($new['namespace']) && isset($old['namespace']) && !(strpos($new['namespace'], '\\') === 0)) {
             return trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\');
         } elseif (isset($new['namespace'])) {
             return trim($new['namespace'], '\\');

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -672,11 +672,17 @@ return 'foo!'; });
             $router->group(['namespace' => 'Nested'], function () use ($router) {
                 $router->get('foo/bar', 'Controller@action');
             });
+            $router->group(['namespace' => '\Root'], function() use ($router) {
+                $router->get('baz/bam', 'Controller@action');
+            });
         });
         $routes = $router->getRoutes()->getRoutes();
         $action = $routes[0]->getAction();
 
         $this->assertEquals('Namespace\\Nested\\Controller@action', $action['controller']);
+
+        $rootAction = $routes[1]->getAction();
+        $this->assertEquals('Root\\Controller@action', $rootAction['controller']);
 
         $router = $this->getRouter();
         $router->group(['prefix' => 'baz'], function () use ($router) {


### PR DESCRIPTION
Allow route groups to specify a namespace with a leading slash to escape the current namespace, allowing you to choose whether to nest or not.

Other routing functions already work this way, and adding it to groups would make them consistent with the other functions.

Have also extended existing test to test this condition.
