### PR TITLE
[5.2] Namespace overriding in route groups

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -400,7 +400,7 @@ class Router implements RegistrarContract
      */
     protected static function formatUsesPrefix($new, $old)
     {
-        if (isset($new['namespace']) && isset($old['namespace'])) {
+        if (isset($new['namespace']) && isset($old['namespace']) && !(strpos($new['namespace'], '\\') === 0)) {
             return trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\');
         } elseif (isset($new['namespace'])) {
             return trim($new['namespace'], '\\');

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -480,11 +480,17 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
             $router->group(['namespace' => 'Nested'], function () use ($router) {
                 $router->get('foo/bar', 'Controller@action');
             });
+            $router->group(['namespace' => '\Root'], function() use ($router) {
+                $router->get('baz/bam', 'Controller@action');
+            });
         });
         $routes = $router->getRoutes()->getRoutes();
         $action = $routes[0]->getAction();
 
         $this->assertEquals('Namespace\\Nested\\Controller@action', $action['controller']);
+
+        $rootAction = $routes[1]->getAction();
+        $this->assertEquals('Root\\Controller@action', $rootAction['controller']);
 
         $router = $this->getRouter();
         $router->group(['prefix' => 'baz'], function () use ($router) {


### PR DESCRIPTION
Allow route groups to specify a namespace with a leading slash to escape the current namespace.

Other routing already functions work this way, and adding it to groups makes them consistent with other functions.

Have also extended existing test to test this condition.
