### PR TITLE
SES transport throws exception if sender not provided

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -57,7 +57,7 @@ class SesTransport implements Swift_Transport
     public function send(Swift_Mime_Message $message, &$failedRecipients = null)
     {
         return $this->ses->sendRawEmail([
-            'Source' => key($message->getSender()),
+            'Source' => key(is_null($message->getSender()) ? $message->getFrom() : $message->getSender()),
             'Destinations' => $this->getTo($message),
             'RawMessage' => [
                 'Data' => (string) $message,

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -57,7 +57,7 @@ class SesTransport implements Swift_Transport
     public function send(Swift_Mime_Message $message, &$failedRecipients = null)
     {
         return $this->ses->sendRawEmail([
-            'Source' => key(is_null($message->getSender()) ? $message->getFrom() : $message->getSender()),
+            'Source' => key($message->getSender() ?: $message->getFrom()),
             'Destinations' => $this->getTo($message),
             'RawMessage' => [
                 'Data' => (string) $message,


### PR DESCRIPTION
Most users following the docs will send mail specifying $mail->from('me@example.com').

When using the SES transport this will throw  'key() expects parameter 1 to be array, null given' as sender is not specified

This patch will check if sender is null and replace it with the 'from' variable
