### PR TITLE
[5.1] Added Missing "connectors" Variable

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -31,6 +31,7 @@ class QueueManager implements FactoryContract, MonitorContract
 +     */
 +    protected $connectors = [];
 
+
     /**
      * Create a new queue manager instance.
      *

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -22,6 +22,14 @@ class QueueManager implements FactoryContract, MonitorContract
      * @var array
      */
     protected $connections = [];
+    
+    +    
++    /**
++     * The array of resolved queue connectors.
++     *
++     * @var array
++     */
++    protected $connectors = [];
 
     /**
      * Create a new queue manager instance.

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -23,13 +23,12 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     protected $connections = [];
     
-    +    
-+    /**
-+     * The array of resolved queue connectors.
-+     *
-+     * @var array
-+     */
-+    protected $connectors = [];
+    /**
+     * The array of resolved queue connectors.
+     *
+     * @var array
+     */
+    protected $connectors = [];
 
 
     /**


### PR DESCRIPTION
otherwise it will show "Undefined property: Illuminate\Queue\QueueManager::$connectors" when execute "php artisan"
