### PR TITLE
[5.2] Add `when` statement to Blade

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -705,6 +705,22 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Compile the when statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileWhen($expression)
+    {
+        preg_match('/\(\s*(\$.+),\s*[\'"](.*)[\'"]\s*\)/', $expression, $matches);
+
+        $formattedString = str_replace(':value', "{{$matches[1]}}", $matches[2]);
+        $formattedString = str_replace('"', '\"', $formattedString);
+
+        return "<?php echo isset({$matches[1]}) ? \"{$formattedString}\" : ''; ?>";
+    }
+
+    /**
     * Get the extensions used by the compiler.
     *
     * @return array

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -488,6 +488,16 @@ empty
         $this->assertEquals('<?php $__env->appendSection(); ?>', $compiler->compileString('@append'));
     }
 
+    public function testWhenStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertEquals('<?php echo isset($foo) ? "<p>Here\'s the value: {$foo}</p>" : \'\'; ?>', $compiler->compileString("@when(\$foo, '<p>Here's the value: :value</p>')"));
+        $this->assertEquals('<?php echo isset($foo) ? "<p>Here\'s the value: {$foo}</p>" : \'\'; ?>', $compiler->compileString("@when(\$foo, \"<p>Here's the value: :value</p>\")"));
+        $this->assertEquals('<?php echo isset($foo) ? "<p>Here\'s the value: {$foo}</p>" : \'\'; ?>', $compiler->compileString("@when( \$foo, \"<p>Here's the value: :value</p>\")"));
+        $this->assertEquals('<?php echo isset($foo) ? "<p>Here\'s the value: {$foo}</p>" : \'\'; ?>', $compiler->compileString("@when(\$foo,\"<p>Here's the value: :value</p>\")"));
+        $this->assertEquals('<?php echo isset($foo) ? "<p>Here\'s the value: {$foo}</p>" : \'\'; ?>', $compiler->compileString("@when(\$foo, \"<p>Here's the value: :value</p>\" )"));
+    }
+
     public function testCustomPhpCodeIsCorrectlyHandled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
The `when` statement allows you to format a variable if it passes an
`isset` check, otherwise nothing is rendered.

It works much like the formatting feature of the `MessageBag`.

For example:

```
@when($foo, '<p class="bar">:value</p>')
```

...is functionality equivalent to:

```
@if (isset($foo)
    <p class="bar">$foo</p>
@endif
```

Just throwing it out there to see if people think it's a good fit for the framework, if not it's super easy to bring in via a package, so no hurt feelings :blush: 
