### PR TITLE
[5.1] Arr::expand method

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -100,6 +100,23 @@ class Arr
     }
 
     /**
+     * Expand dot-flattened array into a multi-dimensional associative array.
+     *
+     * @param  array $array
+     * @return array
+     */
+    public static function expand($array)
+    {
+        $results = [];
+
+        foreach ($array as $key => $value) {
+            static::set($results, $key, $value);
+        }
+
+        return $results;
+    }
+
+    /**
      * Get all of the given array except for a specified array of items.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -97,6 +97,19 @@ if (!function_exists('array_dot')) {
     }
 }
 
+if (!function_exists('array_expand')) {
+    /**
+     * Expand dot-flattened array into a multi-dimensional associative array.
+     *
+     * @param  array $array
+     * @return array
+     */
+    function array_expand($array)
+    {
+        return Arr::expand($array);
+    }
+}
+
 if (!function_exists('array_except')) {
     /**
      * Get all of the given array except for a specified array of items.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -15,6 +15,12 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($array, ['name' => 'taylor', 'languages.php' => true]);
     }
 
+    public function testArrayExpand()
+    {
+        $array = array_expand(['name' => 'taylor', 'languages' => false, 'languages.php' => true]);
+        $this->assertEquals($array, ['name' => 'taylor', 'languages' => ['php' => true]]);
+    }
+
     public function testArrayGet()
     {
         $array = ['names' => ['developer' => 'taylor']];


### PR DESCRIPTION
If we have an `Arr::dot` method which flattens array - why don't we have a method which does the opposite?
