### PR TITLE
[5.1] Add dontSee() to CrawlerTrait.

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -237,6 +237,17 @@ trait CrawlerTrait
     }
 
     /**
+     * Assert that a given string is not seen on the page.
+     *
+     * @param  string  $text
+     * @return $this
+     */
+    protected function dontSee($text)
+    {
+        return $this->see($text, true);
+    }
+
+    /**
      * Assert that the response contains JSON.
      *
      * @param  array|null  $data


### PR DESCRIPTION
Usage example:

``` php
$this->visit("/cart");
$this->see("cart is empty");

// add item to cart

$this->visit("/cart");
$this->notSee("cart is empty");
```
