### PR TITLE
[5.1] [Proposal] [Blade] Add Htmlable contract, HtmlString helper class

### DIFF
--- a/src/Illuminate/Contracts/Support/Htmlable.php
+++ b/src/Illuminate/Contracts/Support/Htmlable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface Htmlable
+{
+    /**
+     * Get content as a string of HTML
+     *
+     * @return string
+     */
+    public function toHtml();
+}

--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Contracts\Support\Htmlable;
+
+class HtmlString implements Htmlable
+{
+    /**
+     * The HTML string
+     *
+     * @var string
+     */
+    protected $html;
+
+    /**
+     * Create a new HTML string instance.
+     *
+     * @param  string  $html
+     * @return void
+     */
+    public function __construct($html)
+    {
+        $this->html = $html;
+    }
+
+    /**
+     * Get the the HTML string
+     *
+     * @return string
+     */
+    public function toHtml()
+    {
+        return $this->html;
+    }
+
+    /**
+     * Get the the HTML string
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toHtml();
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -426,11 +426,15 @@ if (!function_exists('e')) {
     /**
      * Escape HTML entities in a string.
      *
-     * @param  string  $value
+     * @param  \Illuminate\Support\Htmlable|string  $value
      * @return string
      */
     function e($value)
     {
+        if ($value instanceof Illuminate\Contracts\Support\Htmlable) {
+            return $value->toHtml();
+        }
+
         return htmlentities($value, ENT_QUOTES, 'UTF-8', false);
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1,7 +1,14 @@
 <?php
 
+use Mockery as m;
+
 class SupportHelpersTest extends PHPUnit_Framework_TestCase
 {
+    public function tearDown()
+    {
+        m::close();
+    }
+
     public function testArrayBuild()
     {
         $this->assertEquals(['foo' => 'bar'], array_build(['foo' => 'bar'], function ($key, $value) {
@@ -189,6 +196,15 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(starts_with('jason', ['jas']));
         $this->assertFalse(starts_with('jason', 'day'));
         $this->assertFalse(starts_with('jason', ['day']));
+    }
+
+    public function testE()
+    {
+        $str = 'A \'quote\' is <b>bold</b>';
+        $this->assertEquals('A &#039;quote&#039; is &lt;b&gt;bold&lt;/b&gt;', e($str));
+        $html = m::mock('Illuminate\Support\HtmlString');
+        $html->shouldReceive('toHtml')->andReturn($str);
+        $this->assertEquals($str, e($html));
     }
 
     public function testEndsWith()

--- a/tests/Support/SupportHtmlStringTest.php
+++ b/tests/Support/SupportHtmlStringTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Support\HtmlString;
+
+class SupportHtmlStringTest extends PHPUnit_Framework_TestCase
+{
+    public function testToHtml()
+    {
+        $str = '<h1>foo</h1>';
+        $html = new HtmlString('<h1>foo</h1>');
+        $this->assertEquals($str, $html->toHtml());
+    }
+
+    public function testToString()
+    {
+        $str = '<h1>foo</h1>';
+        $html = new HtmlString('<h1>foo</h1>');
+        $this->assertEquals($str, (string) $html);
+    }
+}


### PR DESCRIPTION
This is an attempt to add something like Handlebars' [`SafeString`](http://handlebarsjs.com/reference.html#base-SafeString) to Blade.

This patch adds the following:
1. An `Htmlable` contract with a single method, `toHtml()`
2. A concrete implementation of `Htmlable` called `HtmlString`, which simply accepts an HTML string in the constructor and gives it back when `toHtml()` is called
3. An update to the `e()` helper which detects the presence of an `Htmlable` instance and returns the output of its `toHtml()` method rather than pass the value to `htmlentities`.
# Why?

This is a way to have data objects which represent UI components, by serializing to HTML. An example of this is the FormBuilder from `Illuminate/Html`. Presently, you'd use Blade's `{!! $unescaped !!}` syntax for such a scenario. With this proposed patch, we can dispense with using Blade unescape syntax for helpers that render HTML, making our Blade templates just a bit cleaner and easier to read.

Sent to current stable branch since there are no backwards compatibility issues here.

My personal use case is iterating over a set of decorated properties (this is what I have to do now):

```
@foreach ($properties as $property)
    @if ($property instanceof MyOwn\ImplementationOf\Htmlable)
        <td>{!! $property !!}</td>
    @else
        <td>{{ $property }}</td>
    @endif
@endforeach
```

With this patch it'd simply be:

```
@foreach ($properties as $property)
    <td>{{ $property }}</td>
@endforeach
```

If the Form helper returned `Htmlable` objects, for instance, you could use plain old Blade tags to print an input:

```
{{ Form::text('foo') }}
```
# Usage

Using the built-in `HtmlString` class:

```
use Illuminate\Support\HtmlString;

class MyController
{
    public function index()
    {
        $posts = [];

        foreach (Post::get() as $post) {
            $posts[] = [
                'name' => $post->name,
                'buttons' => [
                    new HtmlString('<a class="btn btn-default" href="/posts/'.$post->id.'">View Post</a>'),
                    new HtmlString('<a class="btn btn-info" href="/posts/edit'.$post->id.'">Edit Post</a>'),
                ],
            ];
        }

        return view('posts', compact('posts'));
    }
}
```

```
@foreach ($posts as $post)
    <div class="post">
        <h2>{{ $post['name'] }}</h2>
        <ul>
        @foreach ($buttons as $button)
            <li>{{ $button }}</li>
        @endforeach
@endforeach
```

Using the `Htmlable` contract for your own helper:

```
namespace App\UI\Bootstrap;

use Illuminate\Contracts\Support\Htmlable;

class Button implements Htmlable
{
    public function __construct($url, $label, $type = 'default')
    {
        $this->url = $url;
        $this->label = $label;
        $this->type = $type;
    }

    public function toHtml()
    {
        return '<a class="btn btn-'.e($this->type).'" href="'.e($this->url).'">'.e($this->label).'</a>';
    }
}
```

```
use App\UI\Bootstrap\Button;

class MyController
{
    public function index()
    {
        $posts = [];

        foreach (Post::get() as $post) {
            $posts[] = [
                'name' => $post->name,
                'buttons' => [
                    new Button(url('posts', $post->id), 'View Post'),
                    new Button(url('posts/edit', $post->id), 'Edit Post'),
                ],
            ];
        }

        return view('posts', compact('posts'));
    }
}
```

I've added tests for the new `HtmlString` class and also added a test for the `e()` helper (which previously had no test).

I'm very open to suggestions regarding class/method names and the overall implementation itself.

Curious if others would find this useful, or if I'm out on a limb.
