### PR TITLE
[5.1] Use Illuminate\Support\Arr::first() instead of the alias array_first().

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 
 class Collection extends BaseCollection
@@ -19,7 +20,7 @@ class Collection extends BaseCollection
             $key = $key->getKey();
         }
 
-        return array_first($this->items, function ($itemKey, $model) use ($key) {
+        return Arr::first($this->items, function ($itemKey, $model) use ($key) {
             return $model->getKey() == $key;
 
         }, $default);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -8,6 +8,7 @@ use ArrayAccess;
 use Carbon\Carbon;
 use LogicException;
 use JsonSerializable;
+use Illuminate\Support\Arr;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
@@ -343,7 +344,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public static function getGlobalScope($scope)
     {
-        return array_first(static::$globalScopes[get_called_class()], function ($key, $value) use ($scope) {
+        return Arr::first(static::$globalScopes[get_called_class()], function ($key, $value) use ($scope) {
             return $scope instanceof $value;
         });
     }
@@ -1016,7 +1017,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $self = __FUNCTION__;
 
-        $caller = array_first(debug_backtrace(false), function ($key, $trace) use ($self) {
+        $caller = Arr::first(debug_backtrace(false), function ($key, $trace) use ($self) {
             $caller = $trace['function'];
 
             return !in_array($caller, Model::$manyMethods) && $caller != $self;

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation;
 
 use Closure;
 use RuntimeException;
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
@@ -527,7 +528,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $name = is_string($provider) ? $provider : get_class($provider);
 
-        return array_first($this->serviceProviders, function ($key, $value) use ($name) {
+        return Arr::first($this->serviceProviders, function ($key, $value) use ($name) {
             return $value instanceof $name;
         });
     }

--- a/src/Illuminate/Foundation/EnvironmentDetector.php
+++ b/src/Illuminate/Foundation/EnvironmentDetector.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation;
 
 use Closure;
+use Illuminate\Support\Arr;
 
 class EnvironmentDetector
 {
@@ -60,7 +61,7 @@ class EnvironmentDetector
      */
     protected function getEnvironmentArgument(array $args)
     {
-        return array_first($args, function ($k, $v) {
+        return Arr::first($args, function ($k, $v) {
             return starts_with($v, '--env');
         });
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -5,6 +5,7 @@ namespace Illuminate\Routing;
 use Closure;
 use LogicException;
 use ReflectionFunction;
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use UnexpectedValueException;
 use Illuminate\Container\Container;
@@ -635,7 +636,7 @@ class Route
      */
     protected function findCallable(array $action)
     {
-        return array_first($action, function ($key, $value) {
+        return Arr::first($action, function ($key, $value) {
             return is_callable($value) && is_numeric($key);
         });
     }

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Routing;
 use Countable;
 use ArrayIterator;
 use IteratorAggregate;
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -210,7 +211,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     protected function check(array $routes, $request, $includingMethod = true)
     {
-        return array_first($routes, function ($key, $value) use ($request, $includingMethod) {
+        return Arr::first($routes, function ($key, $value) use ($request, $includingMethod) {
             return $value->matches($request, $includingMethod);
         });
     }

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use ReflectionMethod;
+use Illuminate\Support\Arr;
 use ReflectionFunctionAbstract;
 
 trait RouteDependencyResolverTrait
@@ -74,7 +75,7 @@ trait RouteDependencyResolverTrait
      */
     protected function alreadyInParameters($class, array $parameters)
     {
-        return !is_null(array_first($parameters, function ($key, $value) use ($class) {
+        return !is_null(Arr::first($parameters, function ($key, $value) use ($class) {
             return $value instanceof $class;
         }));
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -182,7 +182,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return count($this->items) > 0 ? reset($this->items) : null;
         }
 
-        return array_first($this->items, $callback, $default);
+        return Arr::first($this->items, $callback, $default);
     }
 
     /**

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -3,6 +3,7 @@
 namespace Illuminate\View;
 
 use Closure;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\View\Engines\EngineResolver;
@@ -306,7 +307,7 @@ class Factory implements FactoryContract
     {
         $extensions = array_keys($this->extensions);
 
-        return array_first($extensions, function ($key, $value) use ($path) {
+        return Arr::first($extensions, function ($key, $value) use ($path) {
             return ends_with($path, $value);
         });
     }


### PR DESCRIPTION
![screen shot 2015-06-15 at 3 35 05 pm](https://cloud.githubusercontent.com/assets/172966/8155385/509f8434-1376-11e5-90c7-36b01d0eff1f.png)

46 calles to just pass through `array_first()` to `Arr::first()`.

Signed-off-by: crynobone crynobone@gmail.com
