### PR TITLE
[5.2] Change compileEchoDefaults

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -342,7 +342,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function compileEchoDefaults($value)
     {
-        return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s', 'isset($1) ? $1 : $2', $value);
+        return preg_replace('/^(.+?)(?:\s+or\s+)(.+?)$/s', '$1 !== NULL ? $1 : $2', $value);
     }
 
     /**


### PR DESCRIPTION
As defined in the documentation (http://laravel.com/docs/5.1/blade#displaying-data) we currently can use "{{ $name or 'Default' }}" to echo data.

With this change we could also use functions (not only variables) with this feature. An example of this use could be "{{ old('name') or 'Default' }}"

Note: sending it to 5.2 as requested on pull request #9239 (https://github.com/laravel/framework/pull/9239)
