### PR TITLE
[5.1] $factory->raw() does not utilise $attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -135,7 +135,9 @@ class Factory implements ArrayAccess
      */
     public function raw($class, array $attributes = [], $name = 'default')
     {
-        return call_user_func($this->definitions[$class][$name], Faker::create());
+        $attrs = call_user_func($this->definitions[$class][$name], Faker::create());
+
+        return array_merge($attrs, $attributes);
     }
 
     /**


### PR DESCRIPTION
I love the new Factories when testing in L5.1!

However, I have noticed that whilst `raw` accepts an attributes array as a parameter, it does nothing with it when supplied. Assuming that the intention was to allow overriding of generated attributes (as per `make` and `create`) I've patched accordingly.

This is my first contribution to Laravel and so if I need to submit anything further please do let me know.
