### PR TITLE
[5.1] Fix nested parenthesis on multiple unions

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -51,8 +51,9 @@ class MySqlGrammar extends Grammar
     protected function compileUnion(array $union)
     {
         $joiner = $union['all'] ? ' union all ' : ' union ';
+        $sql    = $union['query']->toSql();
 
-        return $joiner.'('.$union['query']->toSql().')';
+		return $joiner.(preg_match( '/^\(.*\)$/', $sql ) ? $sql : "($sql)" );
     }
 
     /**


### PR DESCRIPTION
multiple unions were failing due to nested parenthesis.  Builder was producing SQL like this:
    ( SELECT... ) UNION ( ( SELECT... ) UNION ( SELECT... ) )

When it should be like this:
    ( SELECT... ) UNION ( SELECT... ) UNION ( SELECT... )
