### PR TITLE
[5.1] Add first() modifier for MySql

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -13,7 +13,7 @@ class MySqlGrammar extends Grammar
      *
      * @var array
      */
-    protected $modifiers = ['Unsigned', 'Charset', 'Collate', 'Nullable', 'Default', 'Increment', 'Comment', 'After'];
+    protected $modifiers = ['Unsigned', 'Charset', 'Collate', 'Nullable', 'Default', 'Increment', 'Comment', 'After', 'First'];
 
     /**
      * The possible column serials.
@@ -638,6 +638,20 @@ class MySqlGrammar extends Grammar
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
             return ' auto_increment primary key';
+        }
+    }
+
+    /**
+     * Get the SQL for a "first" column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyFirst(Blueprint $blueprint, Fluent $column)
+    {
+        if (!is_null($column->first)) {
+            return ' first';
         }
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -252,6 +252,16 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
     }
 
+    public function testAddingColumnInTableFirst()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('name')->first();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('alter table `users` add `name` varchar(255) not null first', $statements[0]);
+    }
+
     public function testAddingColumnAfterAnotherColumn()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
This allows a column to be added 'first' in MySql (http://dev.mysql.com/doc/refman/5.1/en/alter-table.html). 

I'll open a pull request on laravel/docs for this change as well.
