### PR TITLE
Fixes error message, when status code doesn't match expected value

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -352,7 +352,7 @@ trait CrawlerTrait
      */
     protected function seeStatusCode($status)
     {
-        $this->assertEquals($this->response->getStatusCode(), $status);
+        $this->assertEquals($status, $this->response->getStatusCode());
 
         return $this;
     }


### PR DESCRIPTION
In assertEquals(), the expected value should be passed in as the first
parameter. The second parameter is the actual value.
