### PR TITLE
[5.1] Keep the keys when adding an item to the stack with prepend

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -463,7 +463,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function prepend($value)
     {
-        $this->items = (array)$value + $this->items;
+        $this->items = (array) $value + $this->items;
 
         return $this;
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -463,7 +463,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function prepend($value)
     {
-        array_unshift($this->items, $value);
+        $this->items = (array)$value + $this->items;
 
         return $this;
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -463,9 +463,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function prepend($value)
     {
-        $this->items = (array) $value + $this->items;
-
-        return $this;
+        $this->items = array_merge([$value], $this->items);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -781,9 +781,9 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     
     public function testPrependWithArrayKeyValues()
     {
-        $collection = new Collection(['a'=>1, 'b'=>2, 'c'=>3]);
+        $collection = new Collection(['a' => 1, 'b' => 2, 'c' => 3]);
         $collection->prepend('test');
-        $this->assertSame([0=>'test', 'a'=>1, 'b'=>2, 'c'=>3], $collection->all());
+        $this->assertSame([0=>'test', 'a' => 1, 'b' => 2, 'c' => 3], $collection->all());
     }
     
     public function testPrependWithNumericKey()
@@ -795,10 +795,10 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 	
     public function testPrependWithObjectParameter()
     {
-        $collection = new Collection(['a'=>1, 'b'=>2, 'c'=>3]);
+        $collection = new Collection(['a' => 1, 'b' => 2, 'c' => 3]);
         $object = new \stdClass;
         $collection->prepend($object);
-        $this->assertSame([0=>$object, 'a'=>1, 'b'=>2, 'c'=>3], $collection->all());
+        $this->assertSame([0=>$object, 'a' => 1, 'b' => 2, 'c' => 3], $collection->all());
     }
     
     public function testPrependWithNumericKeyAndObjectParameter()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -779,12 +779,12 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertNull($c->min());
     }
     
-	public function testPrepend()
-	{
-	    $collection = new Collection(['a'=>1, 'b'=>2, 'c'=>3]);
-	    $collection->prepend('test');
-	    $this->assertSame([0=>'test', 'a'=>1, 'b'=>2, 'c'=>3], $collection->all());
-	}    
+    public function testPrepend()
+    {
+        $collection = new Collection(['a'=>1, 'b'=>2, 'c'=>3]);
+        $collection->prepend('test');
+        $this->assertSame([0=>'test', 'a'=>1, 'b'=>2, 'c'=>3], $collection->all());
+    }
 }
 
 class TestAccessorEloquentTestStub

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -778,6 +778,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $c = new Collection();
         $this->assertNull($c->min());
     }
+    
+	public function testPrepend()
+	{
+	    $collection = new Collection(['a'=>1, 'b'=>2, 'c'=>3]);
+	    $collection->prepend('test');
+	    $this->assertSame([0=>'test', 'a'=>1, 'b'=>2, 'c'=>3], $collection->all());
+	}    
 }
 
 class TestAccessorEloquentTestStub

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -779,11 +779,34 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertNull($c->min());
     }
     
-    public function testPrepend()
+    public function testPrependWithArrayKeyValues()
     {
         $collection = new Collection(['a'=>1, 'b'=>2, 'c'=>3]);
         $collection->prepend('test');
         $this->assertSame([0=>'test', 'a'=>1, 'b'=>2, 'c'=>3], $collection->all());
+    }
+    
+    public function testPrependWithNumericKey()
+    {
+        $collection = new Collection(['a', 'b', 'c']);
+        $collection->prepend('test');
+        $this->assertSame(['test', 'a', 'b', 'c'], $collection->all());
+    }
+	
+    public function testPrependWithObjectParameter()
+    {
+        $collection = new Collection(['a'=>1, 'b'=>2, 'c'=>3]);
+        $object = new \stdClass;
+        $collection->prepend($object);
+        $this->assertSame([0=>$object, 'a'=>1, 'b'=>2, 'c'=>3], $collection->all());
+    }
+    
+    public function testPrependWithNumericKeyAndObjectParameter()
+    {
+        $collection = new Collection(['a', 'b', 'c']);
+        $object = new \stdClass;
+        $collection->prepend($object);
+        $this->assertSame([0=>$object, 'a', 'b', 'c'], $collection->all());
     }
 }
 


### PR DESCRIPTION
array_unshift will wipe out the keys since it re-order the array. This will avoid loosing the keys.
