### PR TITLE
[5.1] Fixes to the "accepts" method

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -610,7 +610,7 @@ class Request extends SymfonyRequest implements ArrayAccess
 
                 $split = explode('/', $accept);
 
-                if (preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type)) {
+                if (isset($split[1]) && preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type)) {
                     return true;
                 }
             }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -594,6 +594,10 @@ class Request extends SymfonyRequest implements ArrayAccess
     {
         $accepts = $this->getAcceptableContentTypes();
 
+        if (count($accepts) === 0) {
+            return true;
+        }
+
         foreach ($accepts as $accept) {
             if ($accept === '*/*') {
                 return true;

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -598,12 +598,14 @@ class Request extends SymfonyRequest implements ArrayAccess
             return true;
         }
 
+        $types = (array) $contentTypes;
+
         foreach ($accepts as $accept) {
             if ($accept === '*/*') {
                 return true;
             }
 
-            foreach ((array) $contentTypes as $type) {
+            foreach ($types as $type) {
                 if ($accept === $type || $accept === strtok('/', $type).'/*') {
                     return true;
                 }


### PR DESCRIPTION
If the client doesn't send an accept header, we should assume they understand everything. Also, I've added in a check to stop us fatal erroring if the client badly formatted accept header.
