### PR TITLE
[5.1] Add seeJsonContainsPath() method to CrawlerTrait

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\DomCrawler\Crawler;
@@ -358,8 +359,9 @@ trait CrawlerTrait
     /**
      * Asserts that the response JSON contains the given path.
      *
-     * @param  string $path
+     * @param  string  $path
      * @return $this
+     * @throws PHPUnitException
      */
     protected function seeJsonMatchesPath($path)
     {
@@ -369,7 +371,7 @@ trait CrawlerTrait
         $search = ltrim($path, '$.');
 
         // Using random string to protect against null values
-        $notFoundString = str_random(6);
+        $notFoundString = Str::quickRandom(6);
 
         try {
             $this->assertNotEquals(
@@ -377,9 +379,7 @@ trait CrawlerTrait
                 $notFoundString
             );
         } catch (PHPUnitException $e) {
-            $message = "Unable to find provided path [{$path}] in received JSON [{$this->response->getContent()}].";
-
-            throw new PHPUnitException($message);
+            throw new PHPUnitException("Unable to find provided path [{$path}] in received JSON [{$this->response->getContent()}].");
         }
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -356,6 +356,36 @@ trait CrawlerTrait
     }
 
     /**
+     * Asserts that the response JSON contains the given path.
+     *
+     * @param  string $path
+     * @return $this
+     */
+    protected function seeJsonMatchesPath($path)
+    {
+        $response = json_decode($this->response->getContent(), true);
+
+        // Remove heading $. symbols
+        $search = ltrim($path, '$.');
+
+        // Using random string to protect against null values
+        $notFoundString = str_random(6);
+
+        try {
+            $this->assertNotEquals(
+                array_get($response, $search, $notFoundString),
+                $notFoundString
+            );
+        } catch (PHPUnitException $e) {
+            $message = "Unable to find provided path [{$path}] in received JSON [{$this->response->getContent()}].";
+
+            throw new PHPUnitException($message);
+        }
+
+        return $this;
+    }
+
+    /**
      * Asserts that the status code of the response matches the given code.
      *
      * @param  int  $status


### PR DESCRIPTION
Sometimes when you test JSON API you don't need to check the exact value of the JSON key, you just need to be sure that you receive this key. Or the value of the key can be random.

For this situation I implemented `seeJsonContainsPath($path)` method that matches received data with requested path from the root element ($) down to the searched one. 

Example JSON:

``` json
{
     "user": {
        "login": "john.doe",
        "email": "john.doe@email.com",
        "name": "John Doe"
     },
     "meta": {
         "foo": "random string"
     }
}
```

Check if we received email:

``` php
$this->seeJsonContainsPath('$.user.login');
```

Or check if we received something random in metadata:

``` php
$this->seeJsonContainsPath('$.meta.foo');
```

Implemented via Laravel `array_get()` helper, so we don't need any additional dependences such as `flow/jsonpath`.
