### PR TITLE
Throw exception if paginator exceeds its maximum amount of pages.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -252,9 +252,18 @@ class Builder
     {
         $total = $this->query->getCountForPagination();
 
+        $page = Paginator::resolveCurrentPage($pageName);
+
+        $perPage = $perPage ?: $this->model->getPerPage();
+        $lastPage = ceil($total / $perPage);
+
+        if ($page > $lastPage) {
+            throw new PaginatorLastPageExceededException;
+        }
+
         $this->query->forPage(
-            $page = Paginator::resolveCurrentPage($pageName),
-            $perPage = $perPage ?: $this->model->getPerPage()
+            $page,
+            $perPage
         );
 
         return new LengthAwarePaginator($this->get($columns), $total, $perPage, $page, [

--- a/src/Illuminate/Database/Eloquent/PaginatorLastPageExceededException.php
+++ b/src/Illuminate/Database/Eloquent/PaginatorLastPageExceededException.php
@@ -1,0 +1,8 @@
+<?php namespace Illuminate\Database\Eloquent;
+
+use RuntimeException;
+
+class PaginatorLastPageExceededException extends RuntimeException
+{
+
+}

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -161,6 +161,19 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(3, $query->getCountForPagination());
     }
 
+    /**
+     * @expectedException Illuminate\Database\Eloquent\PaginatorLastPageExceededException
+     */
+    public function testPaginatedExceedingLastPage()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+
+        Paginator::currentPageResolver(function () { return 2; });
+        $models = EloquentTestUser::oldest('id')->paginate(1);
+
+        $this->assertInstanceIf('Illuminate\Database\Eloquent\PaginatorLastPageExceededException', $models);
+    }
+
     public function testListsRetrieval()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
If the paginator is on a page that does not exist throw an exception that can be handled by the user, BC for anyone expecting a blank page with no pagination results and a paginator that says it has 0 pages.
