### PR TITLE
[5.1] Fix bug with the KeyGenerateCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -38,7 +38,7 @@ class KeyGenerateCommand extends Command
 
         if (file_exists($path)) {
             file_put_contents($path, str_replace(
-                $this->laravel['config']['app.key'], $key, file_get_contents($path)
+                'APP_KEY=' . $this->laravel['config']['app.key'], 'APP_KEY=' . $key, file_get_contents($path)
             ));
         }
 


### PR DESCRIPTION
When trying to set an application key with Artisan, it will fail if the key is already empty.
