### PR TITLE
[5.1] Improving code reusability for login validation

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -55,6 +55,7 @@ trait AuthenticatesUsers
 
     /**
      * Get the validation rules for the request.
+     * 
      * @return array
      */
     protected function getValidationRules()
@@ -67,6 +68,7 @@ trait AuthenticatesUsers
 
     /**
      * Get the credentials that must not be sent back to input form.
+     * 
      * @return array
      */
     protected function getHiddenCredentials()

--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -57,7 +57,8 @@ trait AuthenticatesUsers
      * Get the validation rules for the request.
      * @return array
      */
-    protected function getValidationRules() {
+    protected function getValidationRules()
+    {
         return [
             'email' => 'required|email',
             'password'  =>  'required'
@@ -68,7 +69,8 @@ trait AuthenticatesUsers
      * Get the credentials that must not be sent back to input form.
      * @return array
      */
-    protected function getHiddenCredentials() {
+    protected function getHiddenCredentials()
+    {
         return [
             'password'
         ];

--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -27,9 +27,7 @@ trait AuthenticatesUsers
      */
     public function postLogin(Request $request)
     {
-        $this->validate($request, [
-            'email' => 'required|email', 'password' => 'required',
-        ]);
+        $this->validate($request, $this->getValidationRules());
 
         $credentials = $this->getCredentials($request);
 
@@ -38,9 +36,9 @@ trait AuthenticatesUsers
         }
 
         return redirect($this->loginPath())
-            ->withInput($request->only('email', 'remember'))
+            ->withInput($request->except($this->getHiddenCredentials()))
             ->withErrors([
-                'email' => $this->getFailedLoginMessage(),
+                'login' => $this->getFailedLoginMessage(),
             ]);
     }
 
@@ -53,6 +51,27 @@ trait AuthenticatesUsers
     protected function getCredentials(Request $request)
     {
         return $request->only('email', 'password');
+    }
+
+    /**
+     * Get the validation rules for the request.
+     * @return array
+     */
+    protected function getValidationRules() {
+        return [
+            'email' => 'required|email',
+            'password'  =>  'required'
+        ];
+    }
+
+    /**
+     * Get the credentials that must not be sent back to input form.
+     * @return array
+     */
+    protected function getHiddenCredentials() {
+        return [
+            'password'
+        ];
     }
 
     /**


### PR DESCRIPTION
Hi everyone.
I thought it was good idea to move validation rules and "hidden credentials" (all the credentials that can not be sent back to form if error occurs) into methods, so people can use as much as possibile code from AuthenticatesUsers trait using methods overriding.
