### PR TITLE
[5.1] Fix for Query Builder not clearing the select bindings before an aggregate.

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1641,7 +1641,9 @@ class Builder
         $this->aggregate = compact('function', 'columns');
 
         $previousColumns = $this->columns;
-
+        $previousSelectBindings = $this->bindings['select'];
+        $this->bindings['select'] = [];
+        
         $results = $this->get($columns);
 
         // Once we have executed the query, we will reset the aggregate property so
@@ -1650,6 +1652,7 @@ class Builder
         $this->aggregate = null;
 
         $this->columns = $previousColumns;
+        $this->bindings['select'] = $previousSelectBindings;
 
         if (isset($results[0])) {
             $result = array_change_key_case((array) $results[0]);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1643,7 +1643,7 @@ class Builder
         $previousColumns = $this->columns;
         $previousSelectBindings = $this->bindings['select'];
         $this->bindings['select'] = [];
-        
+
         $results = $this->get($columns);
 
         // Once we have executed the query, we will reset the aggregate property so

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -795,6 +795,16 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([['column2' => 'foo', 'column3' => 'bar']], $result);
     }
 
+    public function testAggregateWithSubSelect()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from "users"', [], true)->andReturn([['aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) { return $results; });
+        $builder->from('users')->selectSub(function($query) { $query->from('posts')->select('foo')->where('title', 'foo'); }, 'post');
+        $count = $builder->count();
+        $this->assertEquals(1, $count);
+    }
+
     public function testInsertMethod()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -803,6 +803,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->from('users')->selectSub(function($query) { $query->from('posts')->select('foo')->where('title', 'foo'); }, 'post');
         $count = $builder->count();
         $this->assertEquals(1, $count);
+        $this->assertEquals(['foo'], $builder->getBindings());
     }
 
     public function testInsertMethod()


### PR DESCRIPTION
Currently, before running an aggregate function, the Query Builder clears and resets the columns, but not the select bindings. This is an issue when the query contains a sub-select query with bindings, since the aggregate query will have extraneous bindings.

The use case that caused me to run into this was pagination, which uses count() internally.
