### PR TITLE
[5.1] Add path for the database that we tried to load

### DIFF
--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -31,7 +31,7 @@ class SQLiteConnector extends Connector implements ConnectorInterface
         // as the developer probably wants to know if the database exists and this
         // SQLite driver will not throw any exception if it does not by default.
         if ($path === false) {
-            throw new InvalidArgumentException('Database does not exist.');
+            throw new InvalidArgumentException("Database (${config['database']}) does not exist.");
         }
 
         return $this->createConnection("sqlite:{$path}", $config, $options);


### PR DESCRIPTION
Without this information the exception isn't very helpful as the developer will have no idea where Illuminate was searching.

I was asked to send this to the 5.1 branch https://github.com/laravel/framework/pull/9295#event-332917172
