### PR TITLE
[5.1] Use Illuminate\Support\Arr::x() instead of the alias array_x()

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Broadcasting;
 
 use Pusher;
 use Closure;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Broadcasting\Broadcasters\LogBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\RedisBroadcaster;
@@ -133,7 +134,7 @@ class BroadcastManager implements FactoryContract
     protected function createRedisDriver(array $config)
     {
         return new RedisBroadcaster(
-            $this->app->make('redis'), array_get($config, 'connection')
+            $this->app->make('redis'), Arr::get($config, 'connection')
         );
     }
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Cache;
 
 use Closure;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Contracts\Cache\Factory as FactoryContract;
@@ -199,7 +200,7 @@ class CacheManager implements FactoryContract
     {
         $redis = $this->app['redis'];
 
-        $connection = array_get($config, 'connection', 'default') ?: 'default';
+        $connection = Arr::get($config, 'connection', 'default') ?: 'default';
 
         return $this->repository(new RedisStore($redis, $this->getPrefix($config), $connection));
     }
@@ -212,7 +213,7 @@ class CacheManager implements FactoryContract
      */
     protected function createDatabaseDriver(array $config)
     {
-        $connection = $this->app['db']->connection(array_get($config, 'connection'));
+        $connection = $this->app['db']->connection(Arr::get($config, 'connection'));
 
         return $this->repository(
             new DatabaseStore(
@@ -248,7 +249,7 @@ class CacheManager implements FactoryContract
      */
     protected function getPrefix(array $config)
     {
-        return array_get($config, 'prefix') ?: $this->app['config']['cache.prefix'];
+        return Arr::get($config, 'prefix') ?: $this->app['config']['cache.prefix'];
     }
 
     /**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Cache;
 
 use Exception;
+use Illuminate\Support\Arr;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Contracts\Cache\Store;
 
@@ -43,7 +44,7 @@ class FileStore implements Store
      */
     public function get($key)
     {
-        return array_get($this->getPayload($key), 'data');
+        return Arr::get($this->getPayload($key), 'data');
     }
 
     /**

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Config;
 
 use ArrayAccess;
+use Illuminate\Support\Arr;
 use Illuminate\Contracts\Config\Repository as ConfigContract;
 
 class Repository implements ArrayAccess, ConfigContract
@@ -33,7 +34,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function has($key)
     {
-        return array_has($this->items, $key);
+        return Arr::has($this->items, $key);
     }
 
     /**
@@ -45,7 +46,7 @@ class Repository implements ArrayAccess, ConfigContract
      */
     public function get($key, $default = null)
     {
-        return array_get($this->items, $key, $default);
+        return Arr::get($this->items, $key, $default);
     }
 
     /**
@@ -59,10 +60,10 @@ class Repository implements ArrayAccess, ConfigContract
     {
         if (is_array($key)) {
             foreach ($key as $innerKey => $innerValue) {
-                array_set($this->items, $innerKey, $innerValue);
+                Arr::set($this->items, $innerKey, $innerValue);
             }
         } else {
-            array_set($this->items, $key, $value);
+            Arr::set($this->items, $key, $value);
         }
     }
 

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Cookie;
 
+use Illuminate\Support\Arr;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Contracts\Cookie\QueueingFactory as JarContract;
 
@@ -98,7 +99,7 @@ class CookieJar implements JarContract
      */
     public function queued($key, $default = null)
     {
-        return array_get($this->queued, $key, $default);
+        return Arr::get($this->queued, $key, $default);
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -8,6 +8,7 @@ use DateTime;
 use Exception;
 use LogicException;
 use RuntimeException;
+use Illuminate\Support\Arr;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Query\Processors\Processor;
@@ -896,7 +897,7 @@ class Connection implements ConnectionInterface
      */
     public function getConfig($option)
     {
-        return array_get($this->config, $option);
+        return Arr::get($this->config, $option);
     }
 
     /**

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Connectors;
 
 use PDO;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\SQLiteConnection;
@@ -150,7 +151,7 @@ class ConnectionFactory
      */
     protected function parseConfig(array $config, $name)
     {
-        return array_add(array_add($config, 'prefix', ''), 'name', $name);
+        return Arr::add(Arr::add($config, 'prefix', ''), 'name', $name);
     }
 
     /**

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Connectors;
 
 use PDO;
+use Illuminate\Support\Arr;
 
 class Connector
 {
@@ -27,7 +28,7 @@ class Connector
      */
     public function getOptions(array $config)
     {
-        $options = array_get($config, 'options', []);
+        $options = Arr::get($config, 'options', []);
 
         return array_diff_key($this->options, $options) + $options;
     }
@@ -42,9 +43,9 @@ class Connector
      */
     public function createConnection($dsn, array $config, array $options)
     {
-        $username = array_get($config, 'username');
+        $username = Arr::get($config, 'username');
 
-        $password = array_get($config, 'password');
+        $password = Arr::get($config, 'password');
 
         return new PDO($dsn, $username, $password, $options);
     }

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Connectors;
 
 use PDO;
+use Illuminate\Support\Arr;
 
 class SqlServerConnector extends Connector implements ConnectorInterface
 {
@@ -63,7 +64,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
         ];
 
         $arguments = array_merge(
-            $arguments, array_only($config, ['appname', 'charset'])
+            $arguments, Arr::only($config, ['appname', 'charset'])
         );
 
         return $this->buildConnectString('dblib', $arguments);

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Database\Connectors\ConnectionFactory;
@@ -233,7 +234,7 @@ class DatabaseManager implements ConnectionResolverInterface
         // If the configuration doesn't exist, we'll throw an exception and bail.
         $connections = $this->app['config']['database.connections'];
 
-        if (is_null($config = array_get($connections, $name))) {
+        if (is_null($config = Arr::get($connections, $name))) {
             throw new InvalidArgumentException("Database [$name] not configured.");
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent;
 
 use Closure;
+use Illuminate\Support\Arr;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -355,7 +356,7 @@ class Builder
 
         $column = $this->model->getUpdatedAtColumn();
 
-        return array_add($values, $column, $this->model->freshTimestampString());
+        return Arr::add($values, $column, $this->model->freshTimestampString());
     }
 
     /**
@@ -915,7 +916,7 @@ class Builder
      */
     public function getMacro($name)
     {
-        return array_get($this->macros, $name);
+        return Arr::get($this->macros, $name);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -94,7 +94,7 @@ class Collection extends BaseCollection
      */
     public function fetch($key)
     {
-        return new static(array_fetch($this->toArray(), $key));
+        return new static(Arr::fetch($this->toArray(), $key));
     }
 
     /**
@@ -189,7 +189,7 @@ class Collection extends BaseCollection
      */
     public function only($keys)
     {
-        $dictionary = array_only($this->getDictionary(), $keys);
+        $dictionary = Arr::only($this->getDictionary(), $keys);
 
         return new static(array_values($dictionary));
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -356,7 +356,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getGlobalScopes()
     {
-        return array_get(static::$globalScopes, get_class($this), []);
+        return Arr::get(static::$globalScopes, get_class($this), []);
     }
 
     /**
@@ -1477,7 +1477,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $this->syncOriginal();
 
-        if (array_get($options, 'touch', true)) {
+        if (Arr::get($options, 'touch', true)) {
             $this->touchOwners();
         }
     }
@@ -1504,7 +1504,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             // First we need to create a fresh query instance and touch the creation and
             // update timestamp on the model which are maintained by us for developer
             // convenience. Then we will just continue saving the model instances.
-            if ($this->timestamps && array_get($options, 'timestamps', true)) {
+            if ($this->timestamps && Arr::get($options, 'timestamps', true)) {
                 $this->updateTimestamps();
             }
 
@@ -1539,7 +1539,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // First we'll need to create a fresh query instance and touch the creation and
         // update timestamps on this model, which are maintained by us for developer
         // convenience. After, we will just continue saving these model instances.
-        if ($this->timestamps && array_get($options, 'timestamps', true)) {
+        if ($this->timestamps && Arr::get($options, 'timestamps', true)) {
             $this->updateTimestamps();
         }
 
@@ -2944,7 +2944,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getOriginal($key = null, $default = null)
     {
-        return array_get($this->original, $key, $default);
+        return Arr::get($this->original, $key, $default);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Support\Arr;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
@@ -564,7 +565,7 @@ class BelongsToMany extends Relation
     public function saveMany(array $models, array $joinings = [])
     {
         foreach ($models as $key => $model) {
-            $this->save($model, (array) array_get($joinings, $key), false);
+            $this->save($model, (array) Arr::get($joinings, $key), false);
         }
 
         $this->touchIfTouching();
@@ -712,7 +713,7 @@ class BelongsToMany extends Relation
         $instances = [];
 
         foreach ($records as $key => $record) {
-            $instances[] = $this->create($record, (array) array_get($joinings, $key), false);
+            $instances[] = $this->create($record, (array) Arr::get($joinings, $key), false);
         }
 
         $this->touchIfTouching();

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Support\Arr;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -104,7 +105,7 @@ class MorphToMany extends BelongsToMany
     {
         $record = parent::createAttachRecord($id, $timed);
 
-        return array_add($record, $this->morphType, $this->morphClass);
+        return Arr::add($record, $this->morphType, $this->morphClass);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Query;
 
 use Closure;
 use BadMethodCallException;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Support\Collection;
 use Illuminate\Pagination\Paginator;
@@ -1512,7 +1513,7 @@ class Builder
 
         $results = new Collection($this->get($columns));
 
-        return $results->pluck($columns[0], array_get($columns, 1))->all();
+        return $results->pluck($columns[0], Arr::get($columns, 1))->all();
     }
 
     /**
@@ -1860,7 +1861,7 @@ class Builder
      */
     public function getBindings()
     {
-        return array_flatten($this->bindings);
+        return Arr::flatten($this->bindings);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -5,6 +5,7 @@ namespace Illuminate\Filesystem;
 use Closure;
 use Aws\S3\S3Client;
 use OpenCloud\Rackspace;
+use Illuminate\Support\Arr;
 use League\Flysystem\FilesystemInterface;
 use League\Flysystem\Filesystem as Flysystem;
 use League\Flysystem\Adapter\Ftp as FtpAdapter;
@@ -135,7 +136,7 @@ class FilesystemManager implements FactoryContract
      */
     public function createFtpDriver(array $config)
     {
-        $ftpConfig = array_only($config, ['host', 'username', 'password', 'port', 'root', 'passive', 'ssl', 'timeout']);
+        $ftpConfig = Arr::only($config, ['host', 'username', 'password', 'port', 'root', 'passive', 'ssl', 'timeout']);
 
         return $this->adapt(new Flysystem(new FtpAdapter($ftpConfig)));
     }
@@ -149,7 +150,7 @@ class FilesystemManager implements FactoryContract
     public function createS3Driver(array $config)
     {
         $config += [
-            'credentials' => array_only($config, ['key', 'secret']),
+            'credentials' => Arr::only($config, ['key', 'secret']),
             'version'     => 'latest',
         ];
 
@@ -186,7 +187,7 @@ class FilesystemManager implements FactoryContract
      */
     protected function getRackspaceContainer(Rackspace $client, array $config)
     {
-        $urlType = array_get($config, 'url_type');
+        $urlType = Arr::get($config, 'url_type');
 
         $store = $client->objectStoreService('cloudFiles', $config['region'], $urlType);
 

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
@@ -174,7 +175,7 @@ class RouteListCommand extends Command
 
         foreach ($controller->getMiddleware() as $name => $options) {
             if (!$this->methodExcludedByOptions($method, $options)) {
-                $results[] = array_get($middleware, $name, $name);
+                $results[] = Arr::get($middleware, $name, $name);
             }
         }
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -6,6 +6,7 @@ use Closure;
 use ArrayAccess;
 use SplFileInfo;
 use RuntimeException;
+use Illuminate\Support\Arr;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
@@ -127,7 +128,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      */
     public function segment($index, $default = null)
     {
-        return array_get($this->segments(), $index - 1, $default);
+        return Arr::get($this->segments(), $index - 1, $default);
     }
 
     /**
@@ -283,7 +284,7 @@ class Request extends SymfonyRequest implements ArrayAccess
     {
         $input = $this->getInputSource()->all() + $this->query->all();
 
-        return array_get($input, $key, $default);
+        return Arr::get($input, $key, $default);
     }
 
     /**
@@ -301,7 +302,7 @@ class Request extends SymfonyRequest implements ArrayAccess
         $input = $this->all();
 
         foreach ($keys as $key) {
-            array_set($results, $key, array_get($input, $key));
+            Arr::set($results, $key, Arr::get($input, $key));
         }
 
         return $results;
@@ -319,7 +320,7 @@ class Request extends SymfonyRequest implements ArrayAccess
 
         $results = $this->all();
 
-        array_forget($results, $keys);
+        Arr::forget($results, $keys);
 
         return $results;
     }
@@ -368,7 +369,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      */
     public function file($key = null, $default = null)
     {
-        return array_get($this->files->all(), $key, $default);
+        return Arr::get($this->files->all(), $key, $default);
     }
 
     /**
@@ -545,7 +546,7 @@ class Request extends SymfonyRequest implements ArrayAccess
             return $this->json;
         }
 
-        return array_get($this->json->all(), $key, $default);
+        return Arr::get($this->json->all(), $key, $default);
     }
 
     /**
@@ -799,7 +800,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      */
     public function offsetGet($offset)
     {
-        return array_get($this->all(), $offset);
+        return Arr::get($this->all(), $offset);
     }
 
     /**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -5,6 +5,7 @@ namespace Illuminate\Mail;
 use Closure;
 use Swift_Mailer;
 use Swift_Message;
+use Illuminate\Support\Arr;
 use SuperClosure\Serializer;
 use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
@@ -355,9 +356,9 @@ class Mailer implements MailerContract, MailQueueContract
         // named keys instead, allowing the developers to use one or the other.
         if (is_array($view)) {
             return [
-                array_get($view, 'html'),
-                array_get($view, 'text'),
-                array_get($view, 'raw'),
+                Arr::get($view, 'html'),
+                Arr::get($view, 'text'),
+                Arr::get($view, 'raw'),
             ];
         }
 

--- a/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
+++ b/src/Illuminate/Queue/Connectors/BeanstalkdConnector.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue\Connectors;
 
 use Pheanstalk\Pheanstalk;
+use Illuminate\Support\Arr;
 use Pheanstalk\PheanstalkInterface;
 use Illuminate\Queue\BeanstalkdQueue;
 
@@ -16,10 +17,10 @@ class BeanstalkdConnector implements ConnectorInterface
      */
     public function connect(array $config)
     {
-        $pheanstalk = new Pheanstalk($config['host'], array_get($config, 'port', PheanstalkInterface::DEFAULT_PORT));
+        $pheanstalk = new Pheanstalk($config['host'], Arr::get($config, 'port', PheanstalkInterface::DEFAULT_PORT));
 
         return new BeanstalkdQueue(
-            $pheanstalk, $config['queue'], array_get($config, 'ttr', Pheanstalk::DEFAULT_TTR)
+            $pheanstalk, $config['queue'], Arr::get($config, 'ttr', Pheanstalk::DEFAULT_TTR)
         );
     }
 }

--- a/src/Illuminate/Queue/Connectors/DatabaseConnector.php
+++ b/src/Illuminate/Queue/Connectors/DatabaseConnector.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Connectors;
 
+use Illuminate\Support\Arr;
 use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Database\ConnectionResolverInterface;
 
@@ -34,10 +35,10 @@ class DatabaseConnector implements ConnectorInterface
     public function connect(array $config)
     {
         return new DatabaseQueue(
-            $this->connections->connection(array_get($config, 'connection')),
+            $this->connections->connection(Arr::get($config, 'connection')),
             $config['table'],
             $config['queue'],
-            array_get($config, 'expire', 60)
+            Arr::get($config, 'expire', 60)
         );
     }
 }

--- a/src/Illuminate/Queue/Connectors/RedisConnector.php
+++ b/src/Illuminate/Queue/Connectors/RedisConnector.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Connectors;
 
+use Illuminate\Support\Arr;
 use Illuminate\Redis\Database;
 use Illuminate\Queue\RedisQueue;
 
@@ -43,10 +44,10 @@ class RedisConnector implements ConnectorInterface
     public function connect(array $config)
     {
         $queue = new RedisQueue(
-            $this->redis, $config['queue'], array_get($config, 'connection', $this->connection)
+            $this->redis, $config['queue'], Arr::get($config, 'connection', $this->connection)
         );
 
-        $queue->setExpire(array_get($config, 'expire', 60));
+        $queue->setExpire(Arr::get($config, 'expire', 60));
 
         return $queue;
     }

--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Console;
 
+use Illuminate\Support\Arr;
 use Illuminate\Console\Command;
 
 class ListFailedCommand extends Command
@@ -69,7 +70,7 @@ class ListFailedCommand extends Command
     {
         $row = array_values(array_except($failed, ['payload']));
 
-        array_splice($row, 3, 0, array_get(json_decode($failed['payload'], true), 'job'));
+        array_splice($row, 3, 0, Arr::get(json_decode($failed['payload'], true), 'job'));
 
         return $row;
     }

--- a/src/Illuminate/Queue/Jobs/IronJob.php
+++ b/src/Illuminate/Queue/Jobs/IronJob.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Jobs;
 
+use Illuminate\Support\Arr;
 use Illuminate\Queue\IronQueue;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Job as JobContract;
@@ -112,7 +113,7 @@ class IronJob extends Job implements JobContract
     {
         $payload = json_decode($this->job->body, true);
 
-        array_set($payload, 'attempts', array_get($payload, 'attempts', 1) + 1);
+        Arr::set($payload, 'attempts', Arr::get($payload, 'attempts', 1) + 1);
 
         $this->iron->recreate(json_encode($payload), $this->getQueue(), $delay);
     }
@@ -124,7 +125,7 @@ class IronJob extends Job implements JobContract
      */
     public function attempts()
     {
-        return array_get(json_decode($this->job->body, true), 'attempts', 1);
+        return Arr::get(json_decode($this->job->body, true), 'attempts', 1);
     }
 
     /**
@@ -174,6 +175,6 @@ class IronJob extends Job implements JobContract
      */
     public function getQueue()
     {
-        return array_get(json_decode($this->job->body, true), 'queue');
+        return Arr::get(json_decode($this->job->body, true), 'queue');
     }
 }

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Jobs;
 
+use Illuminate\Support\Arr;
 use Illuminate\Queue\RedisQueue;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Job as JobContract;
@@ -93,7 +94,7 @@ class RedisJob extends Job implements JobContract
      */
     public function attempts()
     {
-        return array_get(json_decode($this->job, true), 'attempts');
+        return Arr::get(json_decode($this->job, true), 'attempts');
     }
 
     /**
@@ -103,7 +104,7 @@ class RedisJob extends Job implements JobContract
      */
     public function getJobId()
     {
-        return array_get(json_decode($this->job, true), 'id');
+        return Arr::get(json_decode($this->job, true), 'id');
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Closure;
 use DateTime;
 use RuntimeException;
+use Illuminate\Support\Arr;
 use SuperClosure\Serializer;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\QueueableEntity;
@@ -167,7 +168,7 @@ abstract class Queue
     {
         $payload = json_decode($payload, true);
 
-        return json_encode(array_set($payload, $key, $value));
+        return json_encode(Arr::set($payload, $key, $value));
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue;
 
+use Illuminate\Support\Arr;
 use Illuminate\Redis\Database;
 use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
@@ -76,7 +77,7 @@ class RedisQueue extends Queue implements QueueContract
     {
         $this->getConnection()->rpush($this->getQueue($queue), $payload);
 
-        return array_get(json_decode($payload, true), 'id');
+        return Arr::get(json_decode($payload, true), 'id');
     }
 
     /**
@@ -96,7 +97,7 @@ class RedisQueue extends Queue implements QueueContract
 
         $this->getConnection()->zadd($this->getQueue($queue).':delayed', $this->getTime() + $delay, $payload);
 
-        return array_get(json_decode($payload, true), 'id');
+        return Arr::get(json_decode($payload, true), 'id');
     }
 
     /**

--- a/src/Illuminate/Redis/Database.php
+++ b/src/Illuminate/Redis/Database.php
@@ -4,6 +4,7 @@ namespace Illuminate\Redis;
 
 use Closure;
 use Predis\Client;
+use Illuminate\Support\Arr;
 use Illuminate\Contracts\Redis\Database as DatabaseContract;
 
 class Database implements DatabaseContract
@@ -23,9 +24,9 @@ class Database implements DatabaseContract
      */
     public function __construct(array $servers = [])
     {
-        $cluster = array_pull($servers, 'cluster');
+        $cluster = Arr::pull($servers, 'cluster');
 
-        $options = (array) array_pull($servers, 'options');
+        $options = (array) Arr::pull($servers, 'options');
 
         if ($cluster) {
             $this->clients = $this->createAggregateClient($servers, $options);
@@ -72,7 +73,7 @@ class Database implements DatabaseContract
      */
     public function connection($name = 'default')
     {
-        return array_get($this->clients, $name ?: 'default');
+        return Arr::get($this->clients, $name ?: 'default');
     }
 
     /**

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Closure;
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Container\Container;
@@ -266,7 +267,7 @@ class ControllerDispatcher
      */
     protected function filterFailsOn($filter, $request, $method)
     {
-        $on = array_get($filter, 'options.on');
+        $on = Arr::get($filter, 'options.on');
 
         if (is_null($on)) {
             return false;

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -261,7 +261,7 @@ class Route
      */
     public function middleware()
     {
-        return (array) array_get($this->action, 'middleware', []);
+        return (array) Arr::get($this->action, 'middleware', []);
     }
 
     /**
@@ -306,7 +306,7 @@ class Route
      */
     public static function parseFilters($filters)
     {
-        return array_build(static::explodeFilters($filters), function ($key, $value) {
+        return Arr::build(static::explodeFilters($filters), function ($key, $value) {
             return Route::parseFilter($value);
         });
     }
@@ -405,7 +405,7 @@ class Route
      */
     public function parameter($name, $default = null)
     {
-        return array_get($this->parameters(), $name, $default);
+        return Arr::get($this->parameters(), $name, $default);
     }
 
     /**
@@ -589,7 +589,7 @@ class Route
     protected function replaceDefaults(array $parameters)
     {
         foreach ($parameters as $key => &$value) {
-            $value = isset($value) ? $value : array_get($this->defaults, $key);
+            $value = isset($value) ? $value : Arr::get($this->defaults, $key);
         }
 
         return $parameters;

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -228,7 +228,7 @@ class RouteCollection implements Countable, IteratorAggregate
             return $this->getRoutes();
         }
 
-        return array_get($this->routes, $method, []);
+        return Arr::get($this->routes, $method, []);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Closure;
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Pipeline\Pipeline;
@@ -280,7 +281,7 @@ class Router implements RegistrarContract
         // If a given controller method has been named, we will assign the name to the
         // controller action array, which provides for a short-cut to method naming
         // so you don't have to define an individual route for these controllers.
-        $action['as'] = array_get($names, $method);
+        $action['as'] = Arr::get($names, $method);
 
         $this->{$route['verb']}($route['uri'], $action);
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
 use Illuminate\Contracts\Routing\UrlRoutable;
@@ -339,7 +340,7 @@ class UrlGenerator implements UrlGeneratorContract
     protected function replaceNamedParameters($path, &$parameters)
     {
         return preg_replace_callback('/\{(.*?)\??\}/', function ($m) use (&$parameters) {
-            return isset($parameters[$m[1]]) ? array_pull($parameters, $m[1]) : $m[0];
+            return isset($parameters[$m[1]]) ? Arr::pull($parameters, $m[1]) : $m[0];
 
         }, $path);
     }
@@ -434,7 +435,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     protected function getStringParameters(array $parameters)
     {
-        return array_where($parameters, function ($k, $v) { return is_string($k); });
+        return Arr::where($parameters, function ($k, $v) { return is_string($k); });
     }
 
     /**
@@ -445,7 +446,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     protected function getNumericParameters(array $parameters)
     {
-        return array_where($parameters, function ($k, $v) { return is_numeric($k); });
+        return Arr::where($parameters, function ($k, $v) { return is_numeric($k); });
     }
 
     /**

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -4,6 +4,7 @@ namespace Illuminate\Session\Middleware;
 
 use Closure;
 use Carbon\Carbon;
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Session\SessionManager;
 use Illuminate\Session\SessionInterface;
@@ -177,7 +178,7 @@ class StartSession
         if ($this->sessionIsPersistent($config = $this->manager->getSessionConfig())) {
             $response->headers->setCookie(new Cookie(
                 $session->getName(), $session->getId(), $this->getCookieExpirationDate(),
-                $config['path'], $config['domain'], array_get($config, 'secure', false)
+                $config['path'], $config['domain'], Arr::get($config, 'secure', false)
             ));
         }
     }
@@ -189,7 +190,7 @@ class StartSession
      */
     protected function getSessionLifetimeInSeconds()
     {
-        return array_get($this->manager->getSessionConfig(), 'lifetime') * 60;
+        return Arr::get($this->manager->getSessionConfig(), 'lifetime') * 60;
     }
 
     /**
@@ -211,7 +212,7 @@ class StartSession
      */
     protected function sessionConfigured()
     {
-        return !is_null(array_get($this->manager->getSessionConfig(), 'driver'));
+        return !is_null(Arr::get($this->manager->getSessionConfig(), 'driver'));
     }
 
     /**

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Session;
 
+use Illuminate\Support\Arr;
 use SessionHandlerInterface;
 use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
@@ -314,7 +315,7 @@ class Store implements SessionInterface
      */
     public function get($name, $default = null)
     {
-        return array_get($this->attributes, $name, $default);
+        return Arr::get($this->attributes, $name, $default);
     }
 
     /**
@@ -326,7 +327,7 @@ class Store implements SessionInterface
      */
     public function pull($key, $default = null)
     {
-        return array_pull($this->attributes, $key, $default);
+        return Arr::pull($this->attributes, $key, $default);
     }
 
     /**
@@ -356,7 +357,7 @@ class Store implements SessionInterface
         // Input that is flashed to the session can be easily retrieved by the
         // developer, making repopulating old forms and the like much more
         // convenient, since the request's previous input is available.
-        return array_get($input, $key, $default);
+        return Arr::get($input, $key, $default);
     }
 
     /**
@@ -364,7 +365,7 @@ class Store implements SessionInterface
      */
     public function set($name, $value)
     {
-        array_set($this->attributes, $name, $value);
+        Arr::set($this->attributes, $name, $value);
     }
 
     /**
@@ -500,7 +501,7 @@ class Store implements SessionInterface
      */
     public function remove($name)
     {
-        return array_pull($this->attributes, $name);
+        return Arr::pull($this->attributes, $name);
     }
 
     /**
@@ -511,7 +512,7 @@ class Store implements SessionInterface
      */
     public function forget($key)
     {
-        array_forget($this->attributes, $key);
+        Arr::forget($this->attributes, $key);
     }
 
     /**
@@ -557,7 +558,7 @@ class Store implements SessionInterface
      */
     public function getBag($name)
     {
-        return array_get($this->bags, $name, function () {
+        return Arr::get($this->bags, $name, function () {
             throw new InvalidArgumentException('Bag not registered.');
         });
     }
@@ -578,7 +579,7 @@ class Store implements SessionInterface
      */
     public function getBagData($name)
     {
-        return array_get($this->bagData, $name, []);
+        return Arr::get($this->bagData, $name, []);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -192,7 +192,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function flatten()
     {
-        return new static(array_flatten($this->items));
+        return new static(Arr::flatten($this->items));
     }
 
     /**

--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -90,7 +90,7 @@ class ViewErrorBag implements Countable
      */
     public function __get($key)
     {
-        return array_get($this->bags, $key, new MessageBag);
+        return Arr::get($this->bags, $key, new MessageBag);
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Translation;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\NamespacedItemResolver;
 use Symfony\Component\Translation\MessageSelector;
@@ -111,7 +112,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      */
     protected function getLine($namespace, $group, $locale, $item, array $replace)
     {
-        $line = array_get($this->loaded[$namespace][$group][$locale], $item);
+        $line = Arr::get($this->loaded[$namespace][$group][$locale], $item);
 
         if (is_string($line)) {
             return $this->makeReplacements($line, $replace);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -8,6 +8,7 @@ use Countable;
 use Exception;
 use DateTimeZone;
 use RuntimeException;
+use Illuminate\Support\Arr;
 use BadMethodCallException;
 use InvalidArgumentException;
 use Illuminate\Support\Fluent;
@@ -258,7 +259,7 @@ class Validator implements ValidatorContract
      */
     public function each($attribute, $rules)
     {
-        $data = array_get($this->data, $attribute);
+        $data = Arr::get($this->data, $attribute);
 
         if (!is_array($data)) {
             if ($this->hasRule($attribute, 'Array')) {
@@ -398,9 +399,9 @@ class Validator implements ValidatorContract
      */
     protected function getValue($attribute)
     {
-        if (!is_null($value = array_get($this->data, $attribute))) {
+        if (!is_null($value = Arr::get($this->data, $attribute))) {
             return $value;
-        } elseif (!is_null($value = array_get($this->files, $attribute))) {
+        } elseif (!is_null($value = Arr::get($this->files, $attribute))) {
             return $value;
         }
     }
@@ -442,7 +443,7 @@ class Validator implements ValidatorContract
     protected function passesOptionalCheck($attribute)
     {
         if ($this->hasRule($attribute, ['Sometimes'])) {
-            return array_key_exists($attribute, array_dot($this->data))
+            return array_key_exists($attribute, Arr::dot($this->data))
                 || in_array($attribute, array_keys($this->data))
                 || array_key_exists($attribute, $this->files);
         }
@@ -672,7 +673,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(2, $parameters, 'required_if');
 
-        $data = array_get($this->data, $parameters[0]);
+        $data = Arr::get($this->data, $parameters[0]);
 
         $values = array_slice($parameters, 1);
 
@@ -694,7 +695,7 @@ class Validator implements ValidatorContract
         $count = 0;
 
         foreach ($attributes as $key) {
-            if (array_get($this->data, $key) || array_get($this->files, $key)) {
+            if (Arr::get($this->data, $key) || Arr::get($this->files, $key)) {
                 $count++;
             }
         }
@@ -726,7 +727,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(1, $parameters, 'same');
 
-        $other = array_get($this->data, $parameters[0]);
+        $other = Arr::get($this->data, $parameters[0]);
 
         return isset($other) && $value == $other;
     }
@@ -743,7 +744,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(1, $parameters, 'different');
 
-        $other = array_get($this->data, $parameters[0]);
+        $other = Arr::get($this->data, $parameters[0]);
 
         return isset($other) && $value != $other;
     }
@@ -942,7 +943,7 @@ class Validator implements ValidatorContract
         // is the size. If it is a file, we take kilobytes, and for a string the
         // entire length of the string will be considered the attribute size.
         if (is_numeric($value) && $hasNumeric) {
-            return array_get($this->data, $attribute);
+            return Arr::get($this->data, $attribute);
         } elseif (is_array($value)) {
             return count($value);
         } elseif ($value instanceof File) {
@@ -1905,7 +1906,7 @@ class Validator implements ValidatorContract
      */
     protected function replaceRequiredIf($message, $attribute, $rule, $parameters)
     {
-        $parameters[1] = $this->getDisplayableValue($parameters[0], array_get($this->data, $parameters[0]));
+        $parameters[1] = $this->getDisplayableValue($parameters[0], Arr::get($this->data, $parameters[0]));
 
         $parameters[0] = $this->getAttribute($parameters[0]);
 
@@ -2045,7 +2046,7 @@ class Validator implements ValidatorContract
      */
     protected function parseArrayRule(array $rules)
     {
-        return [studly_case(trim(array_get($rules, 0))), array_slice($rules, 1)];
+        return [studly_case(trim(Arr::get($rules, 0))), array_slice($rules, 1)];
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\View\Compilers;
 
+use Illuminate\Support\Arr;
+
 class BladeCompiler extends Compiler implements CompilerInterface
 {
     /**
@@ -264,9 +266,9 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $callback = function ($match) {
             if (method_exists($this, $method = 'compile'.ucfirst($match[1]))) {
-                $match[0] = $this->$method(array_get($match, 3));
+                $match[0] = $this->$method(Arr::get($match, 3));
             } elseif (isset($this->customDirectives[$match[1]])) {
-                $match[0] = call_user_func($this->customDirectives[$match[1]], array_get($match, 3));
+                $match[0] = call_user_func($this->customDirectives[$match[1]], Arr::get($match, 3));
             }
 
             return isset($match[3]) ? $match[0] : $match[0].$match[2];

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -824,7 +824,7 @@ class Factory implements FactoryContract
      */
     public function shared($key, $default = null)
     {
-        return array_get($this->shared, $key, $default);
+        return Arr::get($this->shared, $key, $default);
     }
 
     /**


### PR DESCRIPTION
Fixes for https://github.com/laravel/framework/pull/9294

Use Illuminate\Support\Arr::x() instead of the alias array_x()
