### PR TITLE
[5.1] Allow forceArray flag in Collection::random

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -524,11 +524,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Get one or more items randomly from the collection.
      *
      * @param  int  $amount
+     * @param  bool $forceArray
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
-    public function random($amount = 1)
+    public function random($amount = 1, $forceArray = false)
     {
         if ($amount > ($count = $this->count())) {
             throw new InvalidArgumentException("You requested {$amount} items, but there are only {$count} items in the collection");
@@ -536,11 +537,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $keys = array_rand($this->items, $amount);
 
-        if ($amount == 1) {
+        if (!$forceArray && $amount == 1) {
             return $this->items[$keys];
         }
 
-        return new static(array_intersect_key($this->items, array_flip($keys)));
+        return new static(array_intersect_key($this->items, array_flip((array) $keys)));
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -413,6 +413,10 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $random = $data->random(3);
         $this->assertInstanceOf('Illuminate\Support\Collection', $random);
         $this->assertCount(3, $random);
+
+        $random = $data->random(1, true);
+        $this->assertInstanceOf('Illuminate\Support\Collection', $random);
+        $this->assertCount(1, $random);
     }
 
     /**


### PR DESCRIPTION
Sometimes it is needed to always return array from random method.

E.g. getting random amount of random items

``` php
$collection->keys()->random(rand(1, $collection->count()))->all();
```

This code fails when we get a single item from collection.
