### PR TITLE
[5.1] Fix EncryptCookies middleware not disabling encryption for queued cookies defined in the $except property

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -120,7 +120,7 @@ class EncryptCookies
      */
     protected function encrypt(Response $response)
     {
-        foreach ($response->headers->getCookies() as $key => $cookie) {
+        foreach ($response->headers->getCookies() as $cookie) {
             if ($this->isDisabled($cookie->getName())) {
                 continue;
             }

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -121,7 +121,7 @@ class EncryptCookies
     protected function encrypt(Response $response)
     {
         foreach ($response->headers->getCookies() as $key => $cookie) {
-            if ($this->isDisabled($key)) {
+            if ($this->isDisabled($cookie->getName())) {
                 continue;
             }
 

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -3,16 +3,20 @@
 use Illuminate\Http\Response;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
+use Illuminate\Routing\Controller;
 use Illuminate\Container\Container;
 use Illuminate\Encryption\Encrypter;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Cookie\CookieJar;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Symfony\Component\HttpFoundation\Cookie;
 
 class EncryptCookiesTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var Illuminate\Routing\Router
+     * @var Router
      */
     protected $router;
 
@@ -24,11 +28,11 @@ class EncryptCookiesTest extends PHPUnit_Framework_TestCase
         parent::setUp();
 
         $container = new Container;
-        $container->singleton('Illuminate\Contracts\Encryption\Encrypter', function () {
+        $container->singleton(EncrypterContract::class, function () {
             return new Encrypter(str_repeat('a', 16));
         });
 
-        $this->router = new Router(new Illuminate\Events\Dispatcher, $container);
+        $this->router = new Router(new Dispatcher, $container);
     }
 
     public function testSetCookieEncryption()
@@ -66,7 +70,7 @@ class EncryptCookiesTest extends PHPUnit_Framework_TestCase
     }
 }
 
-class EncryptCookiesTestController extends Illuminate\Routing\Controller
+class EncryptCookiesTestController extends Controller
 {
     public function setCookies()
     {
@@ -94,7 +98,7 @@ class AddQueuedCookiesToResponseTestMiddleware extends AddQueuedCookiesToRespons
 {
     public function __construct()
     {
-        $cookie = new Illuminate\Cookie\CookieJar;
+        $cookie = new CookieJar;
         $cookie->queue(new Cookie('encrypted_cookie', 'value'));
         $cookie->queue(new Cookie('unencrypted_cookie', 'value'));
 

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Http\Response;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
+use Illuminate\Container\Container;
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Symfony\Component\HttpFoundation\Cookie;
+
+class EncryptCookiesTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Illuminate\Routing\Router
+     */
+    protected $router;
+
+    protected $setCookiePath = 'cookie/set';
+    protected $queueCookiePath = 'cookie/queue';
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $container = new Container;
+        $container->singleton('Illuminate\Contracts\Encryption\Encrypter', function () {
+            return new Encrypter(str_repeat('a', 16));
+        });
+
+        $this->router = new Router(new Illuminate\Events\Dispatcher, $container);
+    }
+    public function testSetCookieEncryption()
+    {
+        $this->router->get($this->setCookiePath, [
+            'middleware' => 'EncryptCookiesTestMiddleware',
+            'uses'=>'EncryptCookiesTestController@setCookies'
+        ]);
+
+        $response = $this->router->dispatch(Request::create($this->setCookiePath, 'GET'));
+
+        $cookies = $response->headers->getCookies();
+        $this->assertEquals(2, count($cookies));
+        $this->assertEquals('encrypted_cookie', $cookies[0]->getName());
+        $this->assertNotEquals('value', $cookies[0]->getValue());
+        $this->assertEquals('unencrypted_cookie', $cookies[1]->getName());
+        $this->assertEquals('value', $cookies[1]->getValue());
+    }
+    public function testQueuedCookieEncryption()
+    {
+        $this->router->get($this->queueCookiePath, [
+            'middleware' => ['EncryptCookiesTestMiddleware', 'AddQueuedCookiesToResponseTestMiddleware'],
+            'uses'=>'EncryptCookiesTestController@queueCookies'
+        ]);
+
+        $response = $this->router->dispatch(Request::create($this->queueCookiePath, 'GET'));
+
+        $cookies = $response->headers->getCookies();
+        $this->assertEquals(2, count($cookies));
+        $this->assertEquals('encrypted_cookie', $cookies[0]->getName());
+        $this->assertNotEquals('value', $cookies[0]->getValue());
+        $this->assertEquals('unencrypted_cookie', $cookies[1]->getName());
+        $this->assertEquals('value', $cookies[1]->getValue());
+    }
+}
+
+class EncryptCookiesTestController extends Illuminate\Routing\Controller
+{
+    public function setCookies()
+    {
+        $response = new Response();
+        $response->headers->setCookie(new Cookie('encrypted_cookie', 'value'));
+        $response->headers->setCookie(new Cookie('unencrypted_cookie', 'value'));
+
+        return $response;
+    }
+    public function queueCookies()
+    {
+        return new Response();
+    }
+}
+
+class EncryptCookiesTestMiddleware extends EncryptCookies
+{
+    protected $except = [
+        'unencrypted_cookie',
+    ];
+}
+
+class AddQueuedCookiesToResponseTestMiddleware extends AddQueuedCookiesToResponse
+{
+    public function __construct()
+    {
+        $cookie = new Illuminate\Cookie\CookieJar;
+        $cookie->queue(new Cookie('encrypted_cookie', 'value'));
+        $cookie->queue(new Cookie('unencrypted_cookie', 'value'));
+
+        $this->cookies = $cookie;
+    }
+}

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -30,11 +30,12 @@ class EncryptCookiesTest extends PHPUnit_Framework_TestCase
 
         $this->router = new Router(new Illuminate\Events\Dispatcher, $container);
     }
+
     public function testSetCookieEncryption()
     {
         $this->router->get($this->setCookiePath, [
             'middleware' => 'EncryptCookiesTestMiddleware',
-            'uses'=>'EncryptCookiesTestController@setCookies'
+            'uses' => 'EncryptCookiesTestController@setCookies'
         ]);
 
         $response = $this->router->dispatch(Request::create($this->setCookiePath, 'GET'));
@@ -46,11 +47,12 @@ class EncryptCookiesTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('unencrypted_cookie', $cookies[1]->getName());
         $this->assertEquals('value', $cookies[1]->getValue());
     }
+
     public function testQueuedCookieEncryption()
     {
         $this->router->get($this->queueCookiePath, [
             'middleware' => ['EncryptCookiesTestMiddleware', 'AddQueuedCookiesToResponseTestMiddleware'],
-            'uses'=>'EncryptCookiesTestController@queueCookies'
+            'uses' => 'EncryptCookiesTestController@queueCookies'
         ]);
 
         $response = $this->router->dispatch(Request::create($this->queueCookiePath, 'GET'));
@@ -74,6 +76,7 @@ class EncryptCookiesTestController extends Illuminate\Routing\Controller
 
         return $response;
     }
+
     public function queueCookies()
     {
         return new Response();


### PR DESCRIPTION
PR related to issue #9317.
