### PR TITLE
Ability to specify a custom environment path

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -111,6 +111,13 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected $storagePath;
 
     /**
+     * The custom environment path defined by the developer.
+     *
+     * @var string
+     */
+    protected $environmentPath;
+
+    /**
      * The environment file to load during bootstrapping.
      *
      * @var string
@@ -370,6 +377,31 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->storagePath = $path;
 
         $this->instance('path.storage', $path);
+
+        return $this;
+    }
+
+    /**
+     * Get the path to the environment file directory.
+     *
+     * @return string
+     */
+    public function environmentPath()
+    {
+        return $this->environmentPath ?: $this->basePath;
+    }
+
+    /**
+     * Set the directory for the environment file.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function useEnvironmentPath($path)
+    {
+        $this->environmentPath = $path;
+
+        $this->instance('path.environment', $path);
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -401,8 +401,6 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $this->environmentPath = $path;
 
-        $this->instance('path.environment', $path);
-
         return $this;
     }
 

--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -17,7 +17,7 @@ class DetectEnvironment
     public function bootstrap(Application $app)
     {
         try {
-            Dotenv::load($app->basePath(), $app->environmentFile());
+            Dotenv::load($app->environmentPath(), $app->environmentFile());
         } catch (InvalidArgumentException $e) {
             //
         }


### PR DESCRIPTION
This PR lets us set a custom location for the `.env` file and falls back to the base path.

The use case: our app requires moving the Laravel directory. The .env file might not be where Laravel currently assumes it will be.
