### PR TITLE
Request::isJson() to allow JSON Content-Type variations.

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -572,7 +572,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      */
     public function isJson()
     {
-        return str_contains($this->header('CONTENT_TYPE'), '/json');
+        return str_contains($this->header('CONTENT_TYPE'), 'json');
     }
 
     /**


### PR DESCRIPTION
If a 3rd party is sending JSON requests using jsonapi.org spec, or something like HAL, Siren, etc., then Content-Type might vary from `application/json`.  

For example: ([Source](http://jsonapi.org/format/))

> Clients MUST send all JSON API data in request documents with the header Content-Type: **application/vnd.api+json** without any media type parameters.

Some Content-Type possibilities:

```
application/vnd.api+json`
application/hal+json
application/vnd.siren+json`
```

Would it make sense if `Request::isJson()` were changed to check for 'json' instead of '/json'?

UPDATE: For the record, @GrahamCampbell has a much better PR for this at #9340. Anyone interested can continue conversation there.
