### PR TITLE
[5.2] JSON Improvements

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -128,7 +128,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function response(array $errors)
     {
-        if ($this->ajax() || $this->wantsJson()) {
+        if ($this->ajax()) {
             return new JsonResponse($errors, 422);
         }
 

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -54,7 +54,7 @@ trait ValidatesRequests
      */
     protected function buildFailedValidationResponse(Request $request, array $errors)
     {
-        if ($request->ajax() || $request->wantsJson()) {
+        if ($request->ajax()) {
             return new JsonResponse($errors, 422);
         }
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -575,6 +575,8 @@ class Request extends SymfonyRequest implements ArrayAccess
     /**
      * Determine if the current request is asking for JSON in return.
      *
+     * @deprecated since version 5.2. Use acceptsJson().
+     *
      * @return bool
      */
     public function wantsJson()

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -569,7 +569,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      */
     public function isJson()
     {
-        return str_contains($this->header('CONTENT_TYPE'), '/json');
+        return $this->header('CONTENT_TYPE') === 'application/json';
     }
 
     /**


### PR DESCRIPTION
### 1

Firstly, when working out if we should return a json response, we need to correctly check if the client actually accepts json. I've changed the logic in the form request and the validates request trait.

Let me explain this new logic. What we're now checking is that the following things are true:
1. The client actually understands json.
2. The client doesn't understand html or made an ajax request.

If either one of these conditions are false, we assume `text/html` is the correct content type. If BOTH are true, then we make the conclusion that a response of content type `application/json` is what the client wants because it actually understands it, and has indicated some kind of preference towards it because it either said it doesn't understand html or made an ajax request, which is a common thing for people to do in their applications.
### 2

Secondly, I've deprecated the `wantsJson` method because it's total crap and doesn't actually work. If the client says it understands `application/*`, then it understands json, but that method doesn't understand that. The `acceptsJson` method actually correctly works out if the client understands json.
### 3

Finally, I've updated `isJson` to be more strict and correct.
# 
### EDIT:

Changed this stuff to just do an or for ajax or acceptsJson on Taylor's request.
