### PR TITLE
[5.1] Moved failed so that it's triggered before failer log

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -224,11 +224,11 @@ class Worker
     protected function logFailedJob($connection, Job $job)
     {
         if ($this->failer) {
+            $job->failed();
+
             $this->failer->log($connection, $job->getQueue(), $job->getRawBody());
 
             $job->delete();
-
-            $job->failed();
 
             $this->raiseFailedJobEvent($connection, $job);
         }


### PR DESCRIPTION
I've had a situation recently where I needed to reload a model that was included within a constructor of a job. Using failed before storing the job to the database I would've been able to refresh the model before storing the failed job. Then when the failed job would be attempted to be executed again it'd be using a more up to date instance.
