### PR TITLE
[5.1] Add validated() and unvalidated() method to Validator

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -390,7 +390,28 @@ class Validator implements ValidatorContract
 
         return array_intersect_key($this->data, $this->messages()->toArray());
     }
+    
+    /**
+     * Returns the data which was validated, and passed.
+     *
+     * @return array
+     */
+    public function validated()
+    {
+        $valid = $this->valid();
+        return array_intersect_key($valid, $this->rules);
+    }
 
+    /**
+     * Returns the data which was not at all validated.
+     *
+     * @return array
+     */
+    public function unvalidated()
+    {
+        return array_diff_key($this->data, $this->rules);
+    }
+    
     /**
      * Get the value of a given attribute.
      *

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -398,8 +398,7 @@ class Validator implements ValidatorContract
      */
     public function validated()
     {
-        $valid = $this->valid();
-        return array_intersect_key($valid, $this->rules);
+        return array_intersect_key($this->valid(), $this->rules);
     }
 
     /**
@@ -411,7 +410,7 @@ class Validator implements ValidatorContract
     {
         return array_diff_key($this->data, $this->rules);
     }
-    
+
     /**
      * Get the value of a given attribute.
      *

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -10,7 +10,35 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     {
         m::close();
     }
+    
+    public function testValidReturnsValidData()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => 'notEmpty','bar' => 'notNumeric','baz' => 'extra'], ['foo' => 'required|alpha', 'bar' => 'numeric']);
+        $this->assertEquals($v->valid(),['foo' => 'notEmpty','baz' => 'extra']);
+    }
+    
+    public function testInvalidReturnsInvalidData()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => 'notEmpty','bar' => 'notNumeric','baz' => 'extra'], ['foo' => 'required|alpha', 'bar' => 'numeric']);
+        $this->assertEquals($v->invalid(),['bar' => 'notNumeric']);
+    }
 
+    public function testValidatedReturnsValidatedDataOnly()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => 'notEmpty','bar' => 'notNumeric','baz' => 'extra'], ['foo' => 'required|alpha', 'bar' => 'numeric']);
+        $this->assertEquals($v->validated(),['foo' => 'notEmpty']);
+    }
+    
+    public function testUnvalidatedReturnsUnvalidatedDataOnly()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => 'notEmpty','bar' => 'notNumeric','baz' => 'extra'], ['foo' => 'required|alpha', 'bar' => 'numeric']);
+        $this->assertEquals($v->unvalidated(),['baz' => 'extra']);
+    }
+    
     public function testSometimesWorksOnNestedArrays()
     {
         $trans = $this->getRealTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -10,14 +10,14 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     {
         m::close();
     }
-    
+
     public function testValidReturnsValidData()
     {
         $trans = $this->getRealTranslator();
         $v = new Validator($trans, ['foo' => 'notEmpty','bar' => 'notNumeric','baz' => 'extra'], ['foo' => 'required|alpha', 'bar' => 'numeric']);
         $this->assertEquals($v->valid(),['foo' => 'notEmpty','baz' => 'extra']);
     }
-    
+
     public function testInvalidReturnsInvalidData()
     {
         $trans = $this->getRealTranslator();
@@ -31,14 +31,14 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['foo' => 'notEmpty','bar' => 'notNumeric','baz' => 'extra'], ['foo' => 'required|alpha', 'bar' => 'numeric']);
         $this->assertEquals($v->validated(),['foo' => 'notEmpty']);
     }
-    
+
     public function testUnvalidatedReturnsUnvalidatedDataOnly()
     {
         $trans = $this->getRealTranslator();
         $v = new Validator($trans, ['foo' => 'notEmpty','bar' => 'notNumeric','baz' => 'extra'], ['foo' => 'required|alpha', 'bar' => 'numeric']);
         $this->assertEquals($v->unvalidated(),['baz' => 'extra']);
     }
-    
+
     public function testSometimesWorksOnNestedArrays()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
This PR is a followup on #8195.

The `validated()` method will return the data that : 
1. Had a validation rule
2. Passed the validation rule 

The `unvalidated()` method will return the data that : 
1. Did not have a validation rule

The `valid()` returns the data that : 
1. Passed the validation rule OR there was no validation rule for the datum

The `invalid()` returns the data that : 
1. Failed the validation rule.

The `valid()` and `invalid()` methods always existed, and this PR adds tests for these two methods.
