### PR TITLE
[5.1] Fixed A Load Of Issues With The Request Class

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -626,7 +626,7 @@ class Request extends SymfonyRequest implements ArrayAccess
         $types = (array) $contentTypes;
 
         foreach ($accepts as $accept) {
-            if ($accept === '*/*') {
+            if ($accept === '*/*' || $accept === '*') {
                 return true;
             }
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -619,7 +619,7 @@ class Request extends SymfonyRequest implements ArrayAccess
     {
         $acceptable = $this->getAcceptableContentTypes();
 
-        return isset($acceptable[0]) && strtok($acceptable[0], ';') === 'application/json';
+        return isset($acceptable[0]) && $acceptable[0] === 'application/json';
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -588,13 +588,26 @@ class Request extends SymfonyRequest implements ArrayAccess
         return false;
     }
 
+    /**
+     * Determine if the request is of the specified content type.
+     *
+     * @param string $type
+     *
+     * @return bool
+     */
+    public function isType($type)
+    {
+        return $this->matchesType($type, $this->header('CONTENT_TYPE'));
+    }
+
+    /**
      * Determine if the request is sending JSON.
      *
      * @return bool
      */
     public function isJson()
     {
-        return str_contains($this->header('CONTENT_TYPE'), '/json');
+        return $this->isType('application/json');
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -566,6 +566,28 @@ class Request extends SymfonyRequest implements ArrayAccess
     }
 
     /**
+     * Do the two content types match.
+     *
+     * If the first type is the same as the second type, or is a subset, then
+     * we're returning true, otherwise, false.
+     *
+     * @return bool
+     */
+    public function matchesType($actual, $type)
+    {
+        if ($actual === $type) {
+            return true;
+        }
+
+        $split = explode('/', $actual);
+
+        if (isset($split[1]) && preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type)) {
+            return true;
+        }
+
+        return false;
+    }
+
      * Determine if the request is sending JSON.
      *
      * @return bool
@@ -609,13 +631,7 @@ class Request extends SymfonyRequest implements ArrayAccess
             }
 
             foreach ($types as $type) {
-                if ($accept === $type || $accept === strtok('/', $type).'/*') {
-                    return true;
-                }
-
-                $split = explode('/', $accept);
-
-                if (isset($split[1]) && preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type)) {
+                if ($this->matchesType($accept, $type) || $accept === strtok('/', $type).'/*') {
                     return true;
                 }
             }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -597,7 +597,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      */
     public function isType($type)
     {
-        return $this->matchesType($type, $this->header('CONTENT_TYPE'));
+        return $this->matchesType($type, strtok($this->header('CONTENT_TYPE'), ';'));
     }
 
     /**
@@ -619,7 +619,7 @@ class Request extends SymfonyRequest implements ArrayAccess
     {
         $acceptable = $this->getAcceptableContentTypes();
 
-        return isset($acceptable[0]) && $acceptable[0] == 'application/json';
+        return isset($acceptable[0]) && strtok($acceptable[0], ';') === 'application/json';
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -342,6 +342,13 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertfalse(Request::create('/', 'GET', [], [], [], ['HTTP_CONTENT_TYPE' => 'application/*'])->isJson());
     }
 
+    public function testIsType()
+    {
+        $this->assertfalse(Request::create('/', 'GET', [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'])->isType('application/foo+json'));
+        $this->assertTrue(Request::create('/', 'GET', [], [], [], ['HTTP_CONTENT_TYPE' => 'text/plain'])->isType('text/plain'));
+        $this->assertTrue(Request::create('/', 'GET', [], [], [], ['HTTP_CONTENT_TYPE' => 'text/plain'])->isType('text/*'));
+    }
+
     public function testAllInputReturnsInputAndFiles()
     {
         $file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', null, [__FILE__, 'photo.jpg']);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -340,6 +340,12 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
         // false because application/* isn't a valid content type
         $this->assertfalse(Request::create('/', 'GET', [], [], [], ['HTTP_CONTENT_TYPE' => 'application/*'])->isJson());
+
+        // make sure we work with other info in the header
+        $this->assertTrue(Request::create('/', 'GET', [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json; charset=utf-8'])->isJson());
+
+        // make sure we still reject this with other info in the header
+        $this->assertFalse(Request::create('/', 'GET', [], [], [], ['HTTP_CONTENT_TYPE' => 'application/xml; charset=utf-8'])->isJson());
     }
 
     public function testIsType()
@@ -422,6 +428,10 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('json', $request->format());
         $this->assertTrue($request->wantsJson());
 
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8']);
+        $this->assertEquals('json', $request->format());
+        $this->assertTrue($request->wantsJson());
+
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/atom+xml']);
         $this->assertEquals('atom', $request->format());
         $this->assertFalse($request->wantsJson());
@@ -488,6 +498,16 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($request->accepts(['text/html', 'application/json']));
         $this->assertTrue($request->accepts('text/html'));
         $this->assertTrue($request->accepts('text/foo'));
+        $this->assertTrue($request->accepts('application/json'));
+        $this->assertTrue($request->accepts('application/baz+json'));
+    }
+
+    public function testFormatReturnsAcceptsCharset()
+    {
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8']);
+        $this->assertTrue($request->accepts(['text/html', 'application/json']));
+        $this->assertFalse($request->accepts('text/html'));
+        $this->assertFalse($request->accepts('text/foo'));
         $this->assertTrue($request->accepts('application/json'));
         $this->assertTrue($request->accepts('application/baz+json'));
     }


### PR DESCRIPTION
Added Robust REQUEST Content Type Parsing

This also fixes a small issues with the accept header, and abstracts some code both use.

Note that the accept header parsing code and the request content type parsing code call matchesType with paramaters in the reverse order.
