### PR TITLE
[5.1] Add Request::wants()

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -616,6 +616,45 @@ class Request extends SymfonyRequest implements ArrayAccess
     }
 
     /**
+     * Determines whether the current requests accepts a given content type
+     * based on content negotiation.
+     *
+     * @param  string|array  $contentTypes
+     * @return string|null
+     */
+    public function wants($contentTypes)
+    {
+        $accepts = $this->getAcceptableContentTypes();
+
+        foreach ($accepts as $accept) {
+            foreach ((array) $contentTypes as $contentType) {
+                $type = $contentType;
+
+                if (!is_null($mimeType = $this->getMimeType($contentType))) {
+                    $type = $mimeType;
+                }
+
+                if ($accept === $type) {
+                    return $contentType;
+                }
+
+                $split = explode('/', $accept);
+
+                if (preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type)) {
+                    return $contentType;
+                }
+
+            }
+
+            if ($accept === '*/*') {
+                return is_array($contentTypes) ? $contentTypes[0] : $contentTypes;
+            }
+        }
+
+        return ;
+    }
+
+    /**
      * Determines whether a request accepts JSON.
      *
      * @return bool

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -326,6 +326,19 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($payload, $data);
     }
 
+    public function testWants()
+    {
+        $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json'])->wants(['json']));
+        $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json'])->wants(['html', 'json']));
+        $this->assertEquals('application/foo+json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/foo+json'])->wants('application/foo+json'));
+        $this->assertEquals('html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.5, text/html;q=1.0'])->wants(['json', 'html']));
+        $this->assertEquals('txt', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.5, text/plain;q=1.0, text/html;q=1.0'])->wants(['json', 'txt', 'html']));
+        $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->wants('json'));
+        $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8'])->wants('json'));
+        $this->assertEquals('application/json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8'])->wants('application/json'));
+        $this->assertNull(Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/xml; charset=utf-8'])->wants(['html', 'json']));
+    }
+
     public function testAllInputReturnsInputAndFiles()
     {
         $file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', null, [__FILE__, 'photo.jpg']);


### PR DESCRIPTION
Determines whether the current requests accepts a given content type based on content negotiation.

This would allow us to serve different content-types for same endpoints based on the `Accept` header.

``` php
switch ($request->wants(['html', 'json']) {
   case 'html' :
      return view('users.index', $users);
   case 'json' :
      return $users->toJson();
   default :
      throw new NotSupportedException();
} 
```

Signed-off-by: crynobone crynobone@gmail.com
