### PR TITLE
[5.1] Add verbosity levels to OutputStyle

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -7,7 +7,6 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
@@ -33,7 +32,7 @@ class Command extends SymfonyCommand
     /**
      * The output interface implementation.
      *
-     * @var \Symfony\Component\Console\Style\SymfonyStyle
+     * @var \Illuminate\Console\OutputStyle
      */
     protected $output;
 
@@ -131,7 +130,7 @@ class Command extends SymfonyCommand
     {
         $this->input = $input;
 
-        $this->output = new SymfonyStyle($input, $output);
+        $this->output = new OutputStyle($input, $output);
 
         return parent::run($input, $output);
     }

--- a/src/Illuminate/Console/OutputStyle.php
+++ b/src/Illuminate/Console/OutputStyle.php
@@ -8,14 +8,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class OutputStyle extends SymfonyStyle
 {
-    /** @var OutputInterface */
+    /**
+     * The output instance.
+     *
+     * @var \Symfony\Component\Console\Output\OutputInterface
+     */
     private $output;
 
     /**
      * Create a new Console OutputStyle instance.
      *
-     * @param  InputInterface $input
-     * @param  OutputInterface $output
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return void
      */
     public function __construct(InputInterface $input, OutputInterface $output)
@@ -26,9 +30,9 @@ class OutputStyle extends SymfonyStyle
     }
 
     /**
-     * Returns whether verbosity is quiet (-q)
+     * Returns whether verbosity is quiet (-q).
      *
-     * @return bool true if verbosity is set to VERBOSITY_QUIET, false otherwise
+     * @return bool
      */
     public function isQuiet()
     {
@@ -36,9 +40,9 @@ class OutputStyle extends SymfonyStyle
     }
 
     /**
-     * Returns whether verbosity is verbose (-v)
+     * Returns whether verbosity is verbose (-v).
      *
-     * @return bool true if verbosity is set to VERBOSITY_VERBOSE, false otherwise
+     * @return bool
      */
     public function isVerbose()
     {
@@ -46,9 +50,9 @@ class OutputStyle extends SymfonyStyle
     }
 
     /**
-     * Returns whether verbosity is very verbose (-vv)
+     * Returns whether verbosity is very verbose (-vv).
      *
-     * @return bool true if verbosity is set to VERBOSITY_VERY_VERBOSE, false otherwise
+     * @return bool
      */
     public function isVeryVerbose()
     {
@@ -56,9 +60,9 @@ class OutputStyle extends SymfonyStyle
     }
 
     /**
-     * Returns whether verbosity is debug (-vvv)
+     * Returns whether verbosity is debug (-vvv).
      *
-     * @return bool true if verbosity is set to VERBOSITY_DEBUG, false otherwise
+     * @return bool
      */
     public function isDebug()
     {

--- a/src/Illuminate/Console/OutputStyle.php
+++ b/src/Illuminate/Console/OutputStyle.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Illuminate\Console;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class OutputStyle extends SymfonyStyle
+{
+    /** @var OutputInterface */
+    private $output;
+
+    /**
+     * Create a new Console OutputStyle instance.
+     *
+     * @param  InputInterface $input
+     * @param  OutputInterface $output
+     * @return void
+     */
+    public function __construct(InputInterface $input, OutputInterface $output)
+    {
+        $this->output = $output;
+
+        parent::__construct($input, $output);
+    }
+
+    /**
+     * Returns whether verbosity is quiet (-q)
+     *
+     * @return bool true if verbosity is set to VERBOSITY_QUIET, false otherwise
+     */
+    public function isQuiet()
+    {
+        return $this->output->isQuiet();
+    }
+
+    /**
+     * Returns whether verbosity is verbose (-v)
+     *
+     * @return bool true if verbosity is set to VERBOSITY_VERBOSE, false otherwise
+     */
+    public function isVerbose()
+    {
+        return $this->output->isVerbose();
+    }
+
+    /**
+     * Returns whether verbosity is very verbose (-vv)
+     *
+     * @return bool true if verbosity is set to VERBOSITY_VERY_VERBOSE, false otherwise
+     */
+    public function isVeryVerbose()
+    {
+        return $this->output->isVeryVerbose();
+    }
+
+    /**
+     * Returns whether verbosity is debug (-vvv)
+     *
+     * @return bool true if verbosity is set to VERBOSITY_DEBUG, false otherwise
+     */
+    public function isDebug()
+    {
+        return $this->output->isDebug();
+    }
+}


### PR DESCRIPTION
In 5.1, we switched to the Symfony OutputStyle, which implements the OutputInterface, but not all methods that the regular Output has, like `isVerbose()`. Users might be expecting those methods. 

This PR adds a OutputStyle which extends the SymfonyStyle and adds those methods.

Note: They will be back in Symfony 3.0, because they are added in the OutputInterface there (see https://github.com/symfony/symfony/commit/9ff47b846ca791f3f397c09c4049461d1fd655f1). But this doesn't fix the current problem.
