### PR TITLE
[5.1] Add Pre Task hook to Scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -690,9 +690,9 @@ class Event
      * @param  string  $url
      * @return $this
      */
-    public function beforePing($url)
+    public function firstPing($url)
     {
-        return $this->before(function () use ($url) { (new HttpClient)->get($url); });
+        return $this->first(function () use ($url) { (new HttpClient)->get($url); });
     }
 
     /**
@@ -701,7 +701,7 @@ class Event
      * @param  \Closure  $callback
      * @return $this
      */
-    public function before(Closure $callback)
+    public function first(Closure $callback)
     {
         $this->beforeCallbacks[] = $callback;
 

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -124,7 +124,7 @@ class Event
      */
     public function run(Container $container)
     {
-        if ((count($this->afterCallbacks) > 0) || (count($this->beforeCallbacks) > 0)) {
+        if (count($this->afterCallbacks) > 0 || count($this->beforeCallbacks) > 0) {
             $this->runCommandInForeground($container);
         } else {
             $this->runCommandInBackground();


### PR DESCRIPTION
Hi. There is currently a Post Task hook for the scheduler (using `then()`)

It would be nice if you could hook into the Pre Task, to run anything required before the command itself runs.

A specific use case for this is to Ping a monitoring service that your task is _about_ to start - so you can track/monitor the length of time the task took to run.

If this PR is accepted I'll do up a modification for the Docs to show it there as well.

p.s. I used the naming convention of `before()` and `beforePing()` - but it might be before to call it `now()` and `nowPing()` which is kind of the opposite of `then()`? Let me know if you want me to change it...
