### PR TITLE
[5.1] [Proposal] Add WithoutCsrf trait for testing

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -46,7 +46,7 @@ class VerifyCsrfToken
      */
     public function handle($request, Closure $next)
     {
-        if ($this->isReading($request) || $this->shouldPassThrough($request) || $this->tokensMatch($request)) {
+        if ($this->isReading($request) || $this->shouldPassThrough($request) || $this->tokensMatch($request) || $this->isDisabled()) {
             return $this->addCookieToResponse($request, $next($request));
         }
 
@@ -117,5 +117,15 @@ class VerifyCsrfToken
     protected function isReading($request)
     {
         return in_array($request->method(), ['HEAD', 'GET', 'OPTIONS']);
+    }
+    
+    /**
+     * Determine if the CSRF check is disabled in our test.
+     *
+     * @return bool
+     */
+    protected function isDisabled()
+    {
+        return app()->bound('csrf.disable');
     }
 }

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -766,7 +766,7 @@ trait CrawlerTrait
      *
      * @return $this
      */
-    public function withoutCSRF()
+    public function withoutCsrf()
     {
         $this->app->instance('csrf.disable', true);
 

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -760,6 +760,18 @@ trait CrawlerTrait
 
         return $this;
     }
+    
+    /**
+     * Disable CSRF middleware for the test.
+     *
+     * @return $this
+     */
+    public function withoutCSRF()
+    {
+        $this->app->instance('csrf.disable', true);
+
+        return $this;
+    }
 
     /**
      * Dump the content from the last response.

--- a/src/Illuminate/Foundation/Testing/WithoutCsrf.php
+++ b/src/Illuminate/Foundation/Testing/WithoutCsrf.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Exception;
+
+trait WithoutCsrf
+{
+    /**
+     * @before
+     */
+    public function disableCsrfForAllTests()
+    {
+        if (method_exists($this, 'withoutCsrf')) {
+            $this->withoutCsrf();
+        } else {
+            throw new Exception('Unable to disable CSRF middleware. CrawlerTrait not used.');
+        }
+    }
+}


### PR DESCRIPTION
This allows you to disable just the CSRF middleware check on your tests, without having to disable all middleware. 

It is just a stripped down version of `withoutMiddleware` that already exists.

This can be useful when testing form submissions which may require aspects of your middleware to be used - but without having to include a csrf token in each of your tests.

If this is accepted, I'll submit a PR for the Docs.
