### PR TITLE
[5.1] Use Str class instead of string helper functions

### DIFF
--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth;
 
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
@@ -103,7 +104,7 @@ class DatabaseUserProvider implements UserProvider
         $query = $this->conn->table($this->table);
 
         foreach ($credentials as $key => $value) {
-            if (!str_contains($key, 'password')) {
+            if (!Str::contains($key, 'password')) {
                 $query->where($key, $value);
             }
         }

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth;
 
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
@@ -91,7 +92,7 @@ class EloquentUserProvider implements UserProvider
         $query = $this->createModel()->newQuery();
 
         foreach ($credentials as $key => $value) {
-            if (!str_contains($key, 'password')) {
+            if (!Str::contains($key, 'password')) {
                 $query->where($key, $value);
             }
         }

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Auth;
 
 use RuntimeException;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Auth\UserProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -237,7 +238,7 @@ class Guard implements GuardContract
      */
     protected function validRecaller($recaller)
     {
-        if (!is_string($recaller) || !str_contains($recaller, '|')) {
+        if (!is_string($recaller) || !Str::contains($recaller, '|')) {
             return false;
         }
 
@@ -583,7 +584,7 @@ class Guard implements GuardContract
      */
     protected function refreshRememberToken(UserContract $user)
     {
-        $user->setRememberToken($token = str_random(60));
+        $user->setRememberToken($token = Str::random(60));
 
         $this->provider->updateRememberToken($user, $token);
     }

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Auth\Passwords;
 
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 
@@ -167,7 +168,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      */
     public function createNewToken()
     {
-        return hash_hmac('sha256', str_random(40), $this->hashKey);
+        return hash_hmac('sha256', Str::random(40), $this->hashKey);
     }
 
     /**

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -86,11 +87,11 @@ abstract class GeneratorCommand extends Command
     {
         $rootNamespace = $this->laravel->getNamespace();
 
-        if (starts_with($name, $rootNamespace)) {
+        if (Str::startsWith($name, $rootNamespace)) {
             return $name;
         }
 
-        if (str_contains($name, '/')) {
+        if (Str::contains($name, '/')) {
             $name = str_replace('/', '\\', $name);
         }
 

--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console;
 
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -46,7 +47,7 @@ class Parser
     protected static function arguments(array $tokens)
     {
         return array_values(array_filter(array_map(function ($token) {
-            if (starts_with($token, '{') && !starts_with($token, '{--')) {
+            if (Str::startsWith($token, '{') && !Str::startsWith($token, '{--')) {
                 return static::parseArgument(trim($token, '{}'));
             }
         }, $tokens)));
@@ -61,7 +62,7 @@ class Parser
     protected static function options(array $tokens)
     {
         return array_values(array_filter(array_map(function ($token) {
-            if (starts_with($token, '{--')) {
+            if (Str::startsWith($token, '{--')) {
                 return static::parseOption(ltrim(trim($token, '{}'), '-'));
             }
         }, $tokens)));
@@ -77,7 +78,7 @@ class Parser
     {
         $description = null;
 
-        if (str_contains($token, ' : ')) {
+        if (Str::contains($token, ' : ')) {
             list($token, $description) = explode(' : ', $token, 2);
 
             $token = trim($token);
@@ -113,7 +114,7 @@ class Parser
     {
         $description = null;
 
-        if (str_contains($token, ' : ')) {
+        if (Str::contains($token, ' : ')) {
             list($token, $description) = explode(' : ', $token);
 
             $token = trim($token);

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -9,6 +9,7 @@ use Exception;
 use LogicException;
 use RuntimeException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Query\Processors\Processor;
@@ -667,7 +668,7 @@ class Connection implements ConnectionInterface
     {
         $message = $e->getPrevious()->getMessage();
 
-        return str_contains($message, [
+        return Str::contains($message, [
             'server has gone away',
             'no connection to the server',
             'Lost connection',

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -516,9 +517,9 @@ class Builder
      */
     protected function isNested($name, $relation)
     {
-        $dots = str_contains($name, '.');
+        $dots = Str::contains($name, '.');
 
-        return $dots && starts_with($name, $relation.'.');
+        return $dots && Str::startsWith($name, $relation.'.');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -9,6 +9,7 @@ use Carbon\Carbon;
 use LogicException;
 use JsonSerializable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
@@ -782,7 +783,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // foreign key name by using the name of the relationship function, which
         // when combined with an "_id" should conventionally match the columns.
         if (is_null($foreignKey)) {
-            $foreignKey = snake_case($relation).'_id';
+            $foreignKey = Str::snake($relation).'_id';
         }
 
         $instance = new $related;
@@ -813,7 +814,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if (is_null($name)) {
             list(, $caller) = debug_backtrace(false, 2);
 
-            $name = snake_case($caller['function']);
+            $name = Str::snake($caller['function']);
         }
 
         list($type, $id) = $this->getMorphs($name, $type, $id);
@@ -978,7 +979,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // appropriate query constraints then entirely manages the hydrations.
         $query = $instance->newQuery();
 
-        $table = $table ?: str_plural($name);
+        $table = $table ?: Str::plural($name);
 
         return new MorphToMany(
             $query, $this, $name, $table, $foreignKey,
@@ -1037,9 +1038,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // The joining table name, by convention, is simply the snake cased models
         // sorted alphabetically and concatenated with an underscore, so we can
         // just sort the models and join them together to get the table name.
-        $base = snake_case(class_basename($this));
+        $base = Str::snake(class_basename($this));
 
-        $related = snake_case(class_basename($related));
+        $related = Str::snake(class_basename($related));
 
         $models = [$related, $base];
 
@@ -1893,7 +1894,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this->table;
         }
 
-        return str_replace('\\', '', snake_case(str_plural(class_basename($this))));
+        return str_replace('\\', '', Str::snake(Str::plural(class_basename($this))));
     }
 
     /**
@@ -2043,7 +2044,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getForeignKey()
     {
-        return snake_case(class_basename($this)).'_id';
+        return Str::snake(class_basename($this)).'_id';
     }
 
     /**
@@ -2246,7 +2247,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return false;
         }
 
-        return empty($this->fillable) && !starts_with($key, '_');
+        return empty($this->fillable) && !Str::startsWith($key, '_');
     }
 
     /**
@@ -2278,7 +2279,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function removeTableFromKey($key)
     {
-        if (!str_contains($key, '.')) {
+        if (!Str::contains($key, '.')) {
             return $key;
         }
 
@@ -2481,7 +2482,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             // key so that the relation attribute is snake cased in this returned
             // array to the developers, making this consistent with attributes.
             if (static::$snakeAttributes) {
-                $key = snake_case($key);
+                $key = Str::snake($key);
             }
 
             // If the relation value has been set, we will set it on this attributes
@@ -2637,7 +2638,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function hasGetMutator($key)
     {
-        return method_exists($this, 'get'.studly_case($key).'Attribute');
+        return method_exists($this, 'get'.Str::studly($key).'Attribute');
     }
 
     /**
@@ -2649,7 +2650,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function mutateAttribute($key, $value)
     {
-        return $this->{'get'.studly_case($key).'Attribute'}($value);
+        return $this->{'get'.Str::studly($key).'Attribute'}($value);
     }
 
     /**
@@ -2756,7 +2757,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // which simply lets the developers tweak the attribute as it is set on
         // the model, such as "json_encoding" an listing of data for storage.
         if ($this->hasSetMutator($key)) {
-            $method = 'set'.studly_case($key).'Attribute';
+            $method = 'set'.Str::studly($key).'Attribute';
 
             return $this->{$method}($value);
         }
@@ -2783,7 +2784,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function hasSetMutator($key)
     {
-        return method_exists($this, 'set'.studly_case($key).'Attribute');
+        return method_exists($this, 'set'.Str::studly($key).'Attribute');
     }
 
     /**
@@ -3233,7 +3234,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             if (strpos($method, 'Attribute') !== false &&
                         preg_match('/^get(.+)Attribute$/', $method, $matches)) {
                 if (static::$snakeAttributes) {
-                    $matches[1] = snake_case($matches[1]);
+                    $matches[1] = Str::snake($matches[1]);
                 }
 
                 $mutatedAttributes[] = lcfirst($matches[1]);

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
@@ -1047,7 +1048,7 @@ class BelongsToMany extends Relation
      */
     protected function guessInverseRelation()
     {
-        return camel_case(str_plural(class_basename($this->getParent())));
+        return Str::camel(Str::plural(class_basename($this->getParent())));
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Migrations;
 
 use Closure;
+use Illuminate\Support\Str;
 use Illuminate\Filesystem\Filesystem;
 
 class MigrationCreator
@@ -110,7 +111,7 @@ class MigrationCreator
      */
     protected function getClassName($name)
     {
-        return studly_case($name);
+        return Str::studly($name);
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Migrations;
 
+use Illuminate\Support\Str;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
@@ -318,7 +319,7 @@ class Migrator
     {
         $file = implode('_', array_slice(explode('_', $file), 4));
 
-        $class = studly_case($file);
+        $class = Str::studly($file);
 
         return new $class;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Query;
 use Closure;
 use BadMethodCallException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Support\Collection;
 use Illuminate\Pagination\Paginator;
@@ -1008,7 +1009,7 @@ class Builder
         // clause on the query. Then we'll increment the parameter index values.
         $bool = strtolower($connector);
 
-        $this->where(snake_case($segment), '=', $parameters[$index], $bool);
+        $this->where(Str::snake($segment), '=', $parameters[$index], $bool);
     }
 
     /**
@@ -1984,7 +1985,7 @@ class Builder
      */
     public function __call($method, $parameters)
     {
-        if (starts_with($method, 'where')) {
+        if (Str::startsWith($method, 'where')) {
             return $this->dynamicWhere($method, $parameters);
         }
 

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -4,6 +4,7 @@ namespace Illuminate\Events;
 
 use Exception;
 use ReflectionClass;
+use Illuminate\Support\Str;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
@@ -76,7 +77,7 @@ class Dispatcher implements DispatcherContract
     public function listen($events, $listener, $priority = 0)
     {
         foreach ((array) $events as $event) {
-            if (str_contains($event, '*')) {
+            if (Str::contains($event, '*')) {
                 $this->setupWildcardListen($event, $listener);
             } else {
                 $this->listeners[$event][$priority][] = $this->makeListener($listener);
@@ -288,7 +289,7 @@ class Dispatcher implements DispatcherContract
         $wildcards = [];
 
         foreach ($this->wildcards as $key => $listeners) {
-            if (str_is($key, $eventName)) {
+            if (Str::is($key, $eventName)) {
                 $wildcards = array_merge($wildcards, $listeners);
             }
         }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation;
 use Closure;
 use RuntimeException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
@@ -439,7 +440,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             $patterns = is_array(func_get_arg(0)) ? func_get_arg(0) : func_get_args();
 
             foreach ($patterns as $pattern) {
-                if (str_is($pattern, $this['env'])) {
+                if (Str::is($pattern, $this['env'])) {
                     return true;
                 }
             }

--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 
 class EventGenerateCommand extends Command
@@ -32,7 +33,7 @@ class EventGenerateCommand extends Command
         );
 
         foreach ($provider->listens() as $event => $listeners) {
-            if (!str_contains($event, '\\')) {
+            if (!Str::contains($event, '\\')) {
                 continue;
             }
 

--- a/src/Illuminate/Foundation/Console/HandlerEventCommand.php
+++ b/src/Illuminate/Foundation/Console/HandlerEventCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -40,7 +41,7 @@ class HandlerEventCommand extends GeneratorCommand
 
         $event = $this->option('event');
 
-        if (!starts_with($event, $this->laravel->getNamespace())) {
+        if (!Str::startsWith($event, $this->laravel->getNamespace())) {
             $event = $this->laravel->getNamespace().'Events\\'.$event;
         }
 

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -56,10 +57,10 @@ class KeyGenerateCommand extends Command
     protected function getRandomKey($cipher)
     {
         if ($cipher === 'AES-128-CBC') {
-            return str_random(16);
+            return Str::random(16);
         }
 
-        return str_random(32);
+        return Str::random(32);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -40,7 +41,7 @@ class ListenerMakeCommand extends GeneratorCommand
 
         $event = $this->option('event');
 
-        if (!starts_with($event, $this->laravel->getNamespace())) {
+        if (!Str::startsWith($event, $this->laravel->getNamespace())) {
             $event = $this->laravel->getNamespace().'Events\\'.$event;
         }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -37,7 +38,7 @@ class ModelMakeCommand extends GeneratorCommand
     {
         if (parent::fire() !== false) {
             if ($this->option('migration')) {
-                $table = str_plural(snake_case(class_basename($this->argument('name'))));
+                $table = Str::plural(Str::snake(class_basename($this->argument('name'))));
 
                 $this->call('make:migration', ['name' => "create_{$table}_table", '--create' => $table]);
             }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
@@ -239,8 +240,8 @@ class RouteListCommand extends Command
      */
     protected function filterRoute(array $route)
     {
-        if (($this->option('name') && !str_contains($route['name'], $this->option('name'))) ||
-             $this->option('path') && !str_contains($route['uri'], $this->option('path'))) {
+        if (($this->option('name') && !Str::contains($route['name'], $this->option('name'))) ||
+             $this->option('path') && !Str::contains($route['uri'], $this->option('path'))) {
             return;
         }
 

--- a/src/Illuminate/Foundation/EnvironmentDetector.php
+++ b/src/Illuminate/Foundation/EnvironmentDetector.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation;
 
 use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class EnvironmentDetector
 {
@@ -62,7 +63,7 @@ class EnvironmentDetector
     protected function getEnvironmentArgument(array $args)
     {
         return Arr::first($args, function ($k, $v) {
-            return starts_with($v, '--env');
+            return Str::startsWith($v, '--env');
         });
     }
 }

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
 use Symfony\Component\DomCrawler\Form;
@@ -325,7 +326,7 @@ trait CrawlerTrait
             $expected = $this->formatToExpectedJson($key, $value);
 
             $this->assertTrue(
-                str_contains($actual, $this->formatToExpectedJson($key, $value)),
+                Str::contains($actual, $this->formatToExpectedJson($key, $value)),
                 "Unable to find JSON fragment [{$expected}] within [{$actual}]."
             );
         }
@@ -344,7 +345,7 @@ trait CrawlerTrait
     {
         $expected = json_encode([$key => $value]);
 
-        if (starts_with($expected, '{')) {
+        if (Str::startsWith($expected, '{')) {
             $expected = substr($expected, 1);
         }
 
@@ -738,11 +739,11 @@ trait CrawlerTrait
      */
     protected function prepareUrlForRequest($uri)
     {
-        if (starts_with($uri, '/')) {
+        if (Str::startsWith($uri, '/')) {
             $uri = substr($uri, 1);
         }
 
-        if (!starts_with($uri, 'http')) {
+        if (!Str::startsWith($uri, 'http')) {
             $uri = $this->baseUrl.'/'.$uri;
         }
 

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http;
 
 use BadMethodCallException;
+use Illuminate\Support\Str;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\Session\Store as SessionStore;
@@ -190,8 +191,8 @@ class RedirectResponse extends BaseRedirectResponse
      */
     public function __call($method, $parameters)
     {
-        if (starts_with($method, 'with')) {
-            return $this->with(snake_case(substr($method, 4)), $parameters[0]);
+        if (Str::startsWith($method, 'with')) {
+            return $this->with(Str::snake(substr($method, 4)), $parameters[0]);
         }
 
         throw new BadMethodCallException("Method [$method] does not exist on Redirect.");

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -7,6 +7,7 @@ use ArrayAccess;
 use SplFileInfo;
 use RuntimeException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
@@ -152,7 +153,7 @@ class Request extends SymfonyRequest implements ArrayAccess
     public function is()
     {
         foreach (func_get_args() as $pattern) {
-            if (str_is($pattern, urldecode($this->path()))) {
+            if (Str::is($pattern, urldecode($this->path()))) {
                 return true;
             }
         }
@@ -572,7 +573,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      */
     public function isJson()
     {
-        return str_contains($this->header('CONTENT_TYPE'), '/json');
+        return Str::contains($this->header('CONTENT_TYPE'), '/json');
     }
 
     /**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -6,6 +6,7 @@ use Closure;
 use Swift_Mailer;
 use Swift_Message;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use SuperClosure\Serializer;
 use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
@@ -286,7 +287,7 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function getQueuedCallable(array $data)
     {
-        if (str_contains($data['callback'], 'SerializableClosure')) {
+        if (Str::contains($data['callback'], 'SerializableClosure')) {
             return unserialize($data['callback'])->getClosure();
         }
 

--- a/src/Illuminate/Queue/Console/SubscribeCommand.php
+++ b/src/Illuminate/Queue/Console/SubscribeCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue\Console;
 
 use Exception;
 use RuntimeException;
+use Illuminate\Support\Str;
 use Illuminate\Queue\IronQueue;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
@@ -96,7 +97,7 @@ class SubscribeCommand extends Command
 
         $url = $this->argument('url');
 
-        if (!starts_with($url, ['http://', 'https://'])) {
+        if (!Str::startsWith($url, ['http://', 'https://'])) {
             $url = $this->laravel['url']->to($url);
         }
 

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue\Jobs;
 
 use DateTime;
+use Illuminate\Support\Str;
 
 abstract class Job
 {
@@ -179,7 +180,7 @@ abstract class Job
      */
     protected function resolveQueueableEntity($value)
     {
-        if (is_string($value) && starts_with($value, '::entity::')) {
+        if (is_string($value) && Str::startsWith($value, '::entity::')) {
             list($marker, $type, $id) = explode('|', $value, 3);
 
             return $this->getEntityResolver()->resolve($type, $id);

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Redis\Database;
 use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
@@ -261,7 +262,7 @@ class RedisQueue extends Queue implements QueueContract
      */
     protected function getRandomId()
     {
-        return str_random(32);
+        return Str::random(32);
     }
 
     /**

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Closure;
 use BadMethodCallException;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -137,7 +138,7 @@ abstract class Controller
      */
     protected function isInstanceFilter($filter)
     {
-        if (is_string($filter) && starts_with($filter, '@')) {
+        if (is_string($filter) && Str::startsWith($filter, '@')) {
             if (method_exists($this, substr($filter, 1))) {
                 return true;
             }

--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use ReflectionClass;
 use ReflectionMethod;
+use Illuminate\Support\Str;
 
 class ControllerInspector
 {
@@ -65,7 +66,7 @@ class ControllerInspector
             return false;
         }
 
-        return starts_with($method->name, $this->verbs);
+        return Str::startsWith($method->name, $this->verbs);
     }
 
     /**
@@ -104,7 +105,7 @@ class ControllerInspector
      */
     public function getVerb($name)
     {
-        return head(explode('_', snake_case($name)));
+        return head(explode('_', Str::snake($name)));
     }
 
     /**
@@ -116,7 +117,7 @@ class ControllerInspector
      */
     public function getPlainUri($name, $prefix)
     {
-        return $prefix.'/'.implode('-', array_slice(explode('_', snake_case($name)), 1));
+        return $prefix.'/'.implode('-', array_slice(explode('_', Str::snake($name)), 1));
     }
 
     /**

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Support\Str;
+
 class ResourceRegistrar
 {
     /**
@@ -42,7 +44,7 @@ class ResourceRegistrar
         // If the resource name contains a slash, we will assume the developer wishes to
         // register these resource routes with a prefix so we will set that up out of
         // the box so they don't have to mess with it. Otherwise, we will continue.
-        if (str_contains($name, '/')) {
+        if (Str::contains($name, '/')) {
             $this->prefixedResource($name, $controller, $options);
 
             return;
@@ -126,7 +128,7 @@ class ResourceRegistrar
      */
     public function getResourceUri($resource)
     {
-        if (!str_contains($resource, '.')) {
+        if (!Str::contains($resource, '.')) {
             return $resource;
         }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -6,6 +6,7 @@ use Closure;
 use LogicException;
 use ReflectionFunction;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use UnexpectedValueException;
 use Illuminate\Container\Container;
@@ -353,7 +354,7 @@ class Route
      */
     public static function parseFilter($filter)
     {
-        if (!str_contains($filter, ':')) {
+        if (!Str::contains($filter, ':')) {
             return [$filter, []];
         }
 
@@ -619,7 +620,7 @@ class Route
             $action['uses'] = $this->findCallable($action);
         }
 
-        if (is_string($action['uses']) && ! str_contains($action['uses'], '@')) {
+        if (is_string($action['uses']) && ! Str::contains($action['uses'], '@')) {
             throw new UnexpectedValueException(sprintf(
                 'Invalid route action: [%s]', $action['uses']
             ));

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Pipeline\Pipeline;
@@ -874,7 +875,7 @@ class Router implements RegistrarContract
      */
     protected function parseFilter($callback)
     {
-        if (is_string($callback) && !str_contains($callback, '@')) {
+        if (is_string($callback) && !Str::contains($callback, '@')) {
             return $callback.'@filter';
         }
 
@@ -1082,7 +1083,7 @@ class Router implements RegistrarContract
             // To find the patterned middlewares for a request, we just need to check these
             // registered patterns against the path info for the current request to this
             // applications, and when it matches we will merge into these middlewares.
-            if (str_is($pattern, $path)) {
+            if (Str::is($pattern, $path)) {
                 $merge = $this->patternsByMethod($method, $filters);
 
                 $results = array_merge($results, $merge);
@@ -1309,7 +1310,7 @@ class Router implements RegistrarContract
     public function is()
     {
         foreach (func_get_args() as $pattern) {
-            if (str_is($pattern, $this->currentRouteName())) {
+            if (Str::is($pattern, $this->currentRouteName())) {
                 return true;
             }
         }
@@ -1353,7 +1354,7 @@ class Router implements RegistrarContract
     public function uses()
     {
         foreach (func_get_args() as $pattern) {
-            if (str_is($pattern, $this->currentRouteAction())) {
+            if (Str::is($pattern, $this->currentRouteAction())) {
                 return true;
             }
         }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
 use Illuminate\Contracts\Routing\UrlRoutable;
@@ -212,7 +213,7 @@ class UrlGenerator implements UrlGeneratorContract
     {
         $i = 'index.php';
 
-        return str_contains($root, $i) ? str_replace('/'.$i, '', $root) : $root;
+        return Str::contains($root, $i) ? str_replace('/'.$i, '', $root) : $root;
     }
 
     /**
@@ -574,7 +575,7 @@ class UrlGenerator implements UrlGeneratorContract
             $root = $this->cachedRoot;
         }
 
-        $start = starts_with($root, 'http://') ? 'http://' : 'https://';
+        $start = Str::startsWith($root, 'http://') ? 'http://' : 'https://';
 
         return preg_replace('~'.$start.'~', $scheme, $root, 1);
     }
@@ -599,7 +600,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function isValidUrl($path)
     {
-        if (starts_with($path, ['#', '//', 'mailto:', 'tel:', 'http://', 'https://'])) {
+        if (Str::startsWith($path, ['#', '//', 'mailto:', 'tel:', 'http://', 'https://'])) {
             return true;
         }
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Session;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use SessionHandlerInterface;
 use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
@@ -193,7 +194,7 @@ class Store implements SessionInterface
      */
     protected function generateSessionId()
     {
-        return sha1(uniqid('', true).str_random(25).microtime(true));
+        return sha1(uniqid('', true).Str::random(25).microtime(true));
     }
 
     /**
@@ -609,7 +610,7 @@ class Store implements SessionInterface
      */
     public function regenerateToken()
     {
-        $this->put('_token', str_random(40));
+        $this->put('_token', Str::random(40));
     }
 
     /**

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation;
 
 use Closure;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Container\Container;
 use Symfony\Component\Translation\TranslatorInterface;
 use Illuminate\Contracts\Validation\Factory as FactoryContract;
@@ -163,7 +164,7 @@ class Factory implements FactoryContract
         $this->extensions[$rule] = $extension;
 
         if ($message) {
-            $this->fallbackMessages[snake_case($rule)] = $message;
+            $this->fallbackMessages[Str::snake($rule)] = $message;
         }
     }
 
@@ -180,7 +181,7 @@ class Factory implements FactoryContract
         $this->implicitExtensions[$rule] = $extension;
 
         if ($message) {
-            $this->fallbackMessages[snake_case($rule)] = $message;
+            $this->fallbackMessages[Str::snake($rule)] = $message;
         }
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -9,6 +9,7 @@ use Exception;
 use DateTimeZone;
 use RuntimeException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use BadMethodCallException;
 use InvalidArgumentException;
 use Illuminate\Support\Fluent;
@@ -1040,7 +1041,7 @@ class Validator implements ValidatorContract
      */
     protected function parseUniqueTable($table)
     {
-        return str_contains($table, '.') ? explode('.', $table, 2) : [null, $table];
+        return Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
     }
 
     /**
@@ -1503,7 +1504,7 @@ class Validator implements ValidatorContract
      */
     protected function getMessage($attribute, $rule)
     {
-        $lowerRule = snake_case($rule);
+        $lowerRule = Str::snake($rule);
 
         $inlineMessage = $this->getInlineMessage($attribute, $lowerRule);
 
@@ -1579,7 +1580,7 @@ class Validator implements ValidatorContract
      */
     protected function getSizeMessage($attribute, $rule)
     {
-        $lowerRule = snake_case($rule);
+        $lowerRule = Str::snake($rule);
 
         // There are three different types of size validations. The attribute may be
         // either a number, file, or string so we will check a few things to know
@@ -1626,8 +1627,8 @@ class Validator implements ValidatorContract
     {
         $message = str_replace(':attribute', $this->getAttribute($attribute), $message);
 
-        if (isset($this->replacers[snake_case($rule)])) {
-            $message = $this->callReplacer($message, $attribute, snake_case($rule), $parameters);
+        if (isset($this->replacers[Str::snake($rule)])) {
+            $message = $this->callReplacer($message, $attribute, Str::snake($rule), $parameters);
         } elseif (method_exists($this, $replacer = "replace{$rule}")) {
             $message = $this->$replacer($message, $attribute, $rule, $parameters);
         }
@@ -1682,7 +1683,7 @@ class Validator implements ValidatorContract
         // If no language line has been specified for the attribute all of the
         // underscores are removed from the attribute name and that will be
         // used as default versions of the attribute's displayable names.
-        return str_replace('_', ' ', snake_case($attribute));
+        return str_replace('_', ' ', Str::snake($attribute));
     }
 
     /**
@@ -2046,7 +2047,7 @@ class Validator implements ValidatorContract
      */
     protected function parseArrayRule(array $rules)
     {
-        return [studly_case(trim(Arr::get($rules, 0))), array_slice($rules, 1)];
+        return [Str::studly(trim(Arr::get($rules, 0))), array_slice($rules, 1)];
     }
 
     /**
@@ -2068,7 +2069,7 @@ class Validator implements ValidatorContract
             $parameters = $this->parseParameters($rules, $parameter);
         }
 
-        return [studly_case(trim($rules)), $parameters];
+        return [Str::studly(trim($rules)), $parameters];
     }
 
     /**
@@ -2106,7 +2107,7 @@ class Validator implements ValidatorContract
     public function addExtensions(array $extensions)
     {
         if ($extensions) {
-            $keys = array_map('snake_case', array_keys($extensions));
+            $keys = array_map('\Illuminate\Support\Str::snake', array_keys($extensions));
 
             $extensions = array_combine($keys, array_values($extensions));
         }
@@ -2125,7 +2126,7 @@ class Validator implements ValidatorContract
         $this->addExtensions($extensions);
 
         foreach ($extensions as $rule => $extension) {
-            $this->implicitRules[] = studly_case($rule);
+            $this->implicitRules[] = Str::studly($rule);
         }
     }
 
@@ -2138,7 +2139,7 @@ class Validator implements ValidatorContract
      */
     public function addExtension($rule, $extension)
     {
-        $this->extensions[snake_case($rule)] = $extension;
+        $this->extensions[Str::snake($rule)] = $extension;
     }
 
     /**
@@ -2152,7 +2153,7 @@ class Validator implements ValidatorContract
     {
         $this->addExtension($rule, $extension);
 
-        $this->implicitRules[] = studly_case($rule);
+        $this->implicitRules[] = Str::studly($rule);
     }
 
     /**
@@ -2174,7 +2175,7 @@ class Validator implements ValidatorContract
     public function addReplacers(array $replacers)
     {
         if ($replacers) {
-            $keys = array_map('snake_case', array_keys($replacers));
+            $keys = array_map('\Illuminate\Support\Str::snake', array_keys($replacers));
 
             $replacers = array_combine($keys, array_values($replacers));
         }
@@ -2191,7 +2192,7 @@ class Validator implements ValidatorContract
      */
     public function addReplacer($rule, $replacer)
     {
-        $this->replacers[snake_case($rule)] = $replacer;
+        $this->replacers[Str::snake($rule)] = $replacer;
     }
 
     /**
@@ -2574,7 +2575,7 @@ class Validator implements ValidatorContract
      */
     public function __call($method, $parameters)
     {
-        $rule = snake_case(substr($method, 8));
+        $rule = Str::snake(substr($method, 8));
 
         if (isset($this->extensions[$rule])) {
             return $this->callExtension($rule, $parameters);

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -3,6 +3,7 @@
 namespace Illuminate\View\Compilers;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class BladeCompiler extends Compiler implements CompilerInterface
 {
@@ -647,7 +648,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileExtends($expression)
     {
-        if (starts_with($expression, '(')) {
+        if (Str::startsWith($expression, '(')) {
             $expression = substr($expression, 1, -1);
         }
 
@@ -666,7 +667,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileInclude($expression)
     {
-        if (starts_with($expression, '(')) {
+        if (Str::startsWith($expression, '(')) {
             $expression = substr($expression, 1, -1);
         }
 

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -4,6 +4,7 @@ namespace Illuminate\View;
 
 use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\View\Engines\EngineResolver;
@@ -268,7 +269,7 @@ class Factory implements FactoryContract
         // view. Alternatively, the "empty view" could be a raw string that begins
         // with "raw|" for convenience and to let this know that it is a string.
         else {
-            if (starts_with($empty, 'raw|')) {
+            if (Str::startsWith($empty, 'raw|')) {
                 $result = substr($empty, 4);
             } else {
                 $result = $this->make($empty)->render();
@@ -476,11 +477,11 @@ class Factory implements FactoryContract
      */
     protected function parseClassEvent($class, $prefix)
     {
-        if (str_contains($class, '@')) {
+        if (Str::contains($class, '@')) {
             return explode('@', $class);
         }
 
-        $method = str_contains($prefix, 'composing') ? 'compose' : 'create';
+        $method = Str::contains($prefix, 'composing') ? 'compose' : 'create';
 
         return [$class, $method];
     }

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -5,6 +5,7 @@ namespace Illuminate\View;
 use Closure;
 use ArrayAccess;
 use BadMethodCallException;
+use Illuminate\Support\Str;
 use Illuminate\Support\MessageBag;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\View\Engines\EngineInterface;
@@ -375,8 +376,8 @@ class View implements ArrayAccess, ViewContract
      */
     public function __call($method, $parameters)
     {
-        if (starts_with($method, 'with')) {
-            return $this->with(snake_case(substr($method, 4)), $parameters[0]);
+        if (Str::startsWith($method, 'with')) {
+            return $this->with(Str::snake(substr($method, 4)), $parameters[0]);
         }
 
         throw new BadMethodCallException("Method [$method] does not exist on view.");

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Str;
 use Illuminate\Encryption\Encrypter;
 
 class EncrypterTest extends PHPUnit_Framework_TestCase
@@ -81,7 +82,7 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
 
     public function testOpenSslEncrypterCanDecryptMcryptedData()
     {
-        $key = str_random(32);
+        $key = Str::random(32);
         $encrypter = new Illuminate\Encryption\McryptEncrypter($key);
         $encrypted = $encrypter->encrypt('foo');
         $openSslEncrypter = new Illuminate\Encryption\Encrypter($key, 'AES-256-CBC');

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Support\Str;
 
 class SupportHelpersTest extends PHPUnit_Framework_TestCase
 {
@@ -170,32 +171,32 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
 
     public function testStrIs()
     {
-        $this->assertTrue(str_is('*.dev', 'localhost.dev'));
-        $this->assertTrue(str_is('a', 'a'));
-        $this->assertTrue(str_is('/', '/'));
-        $this->assertTrue(str_is('*dev*', 'localhost.dev'));
-        $this->assertTrue(str_is('foo?bar', 'foo?bar'));
-        $this->assertFalse(str_is('*something', 'foobar'));
-        $this->assertFalse(str_is('foo', 'bar'));
-        $this->assertFalse(str_is('foo.*', 'foobar'));
-        $this->assertFalse(str_is('foo.ar', 'foobar'));
-        $this->assertFalse(str_is('foo?bar', 'foobar'));
-        $this->assertFalse(str_is('foo?bar', 'fobar'));
+        $this->assertTrue(Str::is('*.dev', 'localhost.dev'));
+        $this->assertTrue(Str::is('a', 'a'));
+        $this->assertTrue(Str::is('/', '/'));
+        $this->assertTrue(Str::is('*dev*', 'localhost.dev'));
+        $this->assertTrue(Str::is('foo?bar', 'foo?bar'));
+        $this->assertFalse(Str::is('*something', 'foobar'));
+        $this->assertFalse(Str::is('foo', 'bar'));
+        $this->assertFalse(Str::is('foo.*', 'foobar'));
+        $this->assertFalse(Str::is('foo.ar', 'foobar'));
+        $this->assertFalse(Str::is('foo?bar', 'foobar'));
+        $this->assertFalse(Str::is('foo?bar', 'fobar'));
     }
 
     public function testStrRandom()
     {
-        $result = str_random(20);
+        $result = Str::random(20);
         $this->assertTrue(is_string($result));
         $this->assertEquals(20, strlen($result));
     }
 
     public function testStartsWith()
     {
-        $this->assertTrue(starts_with('jason', 'jas'));
-        $this->assertTrue(starts_with('jason', ['jas']));
-        $this->assertFalse(starts_with('jason', 'day'));
-        $this->assertFalse(starts_with('jason', ['day']));
+        $this->assertTrue(Str::startsWith('jason', 'jas'));
+        $this->assertTrue(Str::startsWith('jason', ['jas']));
+        $this->assertFalse(Str::startsWith('jason', 'day'));
+        $this->assertFalse(Str::startsWith('jason', ['day']));
     }
 
     public function testE()
@@ -217,36 +218,36 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
 
     public function testStrContains()
     {
-        $this->assertTrue(str_contains('taylor', 'ylo'));
-        $this->assertTrue(str_contains('taylor', ['ylo']));
-        $this->assertFalse(str_contains('taylor', 'xxx'));
-        $this->assertFalse(str_contains('taylor', ['xxx']));
-        $this->assertTrue(str_contains('taylor', ['xxx', 'taylor']));
+        $this->assertTrue(Str::contains('taylor', 'ylo'));
+        $this->assertTrue(Str::contains('taylor', ['ylo']));
+        $this->assertFalse(Str::contains('taylor', 'xxx'));
+        $this->assertFalse(Str::contains('taylor', ['xxx']));
+        $this->assertTrue(Str::contains('taylor', ['xxx', 'taylor']));
     }
 
     public function testStrFinish()
     {
-        $this->assertEquals('test/string/', str_finish('test/string', '/'));
-        $this->assertEquals('test/string/', str_finish('test/string/', '/'));
-        $this->assertEquals('test/string/', str_finish('test/string//', '/'));
+        $this->assertEquals('test/string/', Str::finish('test/string', '/'));
+        $this->assertEquals('test/string/', Str::finish('test/string/', '/'));
+        $this->assertEquals('test/string/', Str::finish('test/string//', '/'));
     }
 
     public function testSnakeCase()
     {
-        $this->assertEquals('foo_bar', snake_case('fooBar'));
-        $this->assertEquals('foo_bar', snake_case('fooBar')); // test cache
+        $this->assertEquals('foo_bar', Str::snake('fooBar'));
+        $this->assertEquals('foo_bar', Str::snake('fooBar')); // test cache
     }
 
     public function testStrLimit()
     {
         $string = 'The PHP framework for web artisans.';
-        $this->assertEquals('The PHP...', str_limit($string, 7));
-        $this->assertEquals('The PHP', str_limit($string, 7, ''));
-        $this->assertEquals('The PHP framework for web artisans.', str_limit($string, 100));
+        $this->assertEquals('The PHP...', Str::limit($string, 7));
+        $this->assertEquals('The PHP', Str::limit($string, 7, ''));
+        $this->assertEquals('The PHP framework for web artisans.', Str::limit($string, 100));
 
         $nonAsciiString = '这是一段中文';
-        $this->assertEquals('这是一...', str_limit($nonAsciiString, 6));
-        $this->assertEquals('这是一', str_limit($nonAsciiString, 6, ''));
+        $this->assertEquals('这是一...', Str::limit($nonAsciiString, 6));
+        $this->assertEquals('这是一', Str::limit($nonAsciiString, 6, ''));
     }
 
     public function testCamelCase()
@@ -260,11 +261,11 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
 
     public function testStudlyCase()
     {
-        $this->assertEquals('FooBar', studly_case('fooBar'));
-        $this->assertEquals('FooBar', studly_case('foo_bar'));
-        $this->assertEquals('FooBar', studly_case('foo_bar')); // test cache
-        $this->assertEquals('FooBarBaz', studly_case('foo-barBaz'));
-        $this->assertEquals('FooBarBaz', studly_case('foo-bar_baz'));
+        $this->assertEquals('FooBar', Str::studly('fooBar'));
+        $this->assertEquals('FooBar', Str::studly('foo_bar'));
+        $this->assertEquals('FooBar', Str::studly('foo_bar')); // test cache
+        $this->assertEquals('FooBarBaz', Str::studly('foo-barBaz'));
+        $this->assertEquals('FooBarBaz', Str::studly('foo-bar_baz'));
     }
 
     public function testClassBasename()

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -1,36 +1,38 @@
 <?php
 
+use Illuminate\Support\Str;
+
 class SupportPluralizerTest extends PHPUnit_Framework_TestCase
 {
     public function testBasicSingular()
     {
-        $this->assertEquals('child', str_singular('children'));
+        $this->assertEquals('child', Str::singular('children'));
     }
 
     public function testBasicPlural()
     {
-        $this->assertEquals('children', str_plural('child'));
+        $this->assertEquals('children', Str::plural('child'));
     }
 
     public function testCaseSensitiveSingularUsage()
     {
-        $this->assertEquals('Child', str_singular('Children'));
-        $this->assertEquals('CHILD', str_singular('CHILDREN'));
-        $this->assertEquals('Test', str_singular('Tests'));
+        $this->assertEquals('Child', Str::singular('Children'));
+        $this->assertEquals('CHILD', Str::singular('CHILDREN'));
+        $this->assertEquals('Test', Str::singular('Tests'));
     }
 
     public function testCaseSensitiveSingularPlural()
     {
-        $this->assertEquals('Children', str_plural('Child'));
-        $this->assertEquals('CHILDREN', str_plural('CHILD'));
-        $this->assertEquals('Tests', str_plural('Test'));
+        $this->assertEquals('Children', Str::plural('Child'));
+        $this->assertEquals('CHILDREN', Str::plural('CHILD'));
+        $this->assertEquals('Tests', Str::plural('Test'));
     }
 
     public function testIfEndOfWordPlural()
     {
-        $this->assertEquals('VortexFields', str_plural('VortexField'));
-        $this->assertEquals('MatrixFields', str_plural('MatrixField'));
-        $this->assertEquals('IndexFields', str_plural('IndexField'));
-        $this->assertEquals('VertexFields', str_plural('VertexField'));
+        $this->assertEquals('VortexFields', Str::plural('VortexField'));
+        $this->assertEquals('MatrixFields', Str::plural('MatrixField'));
+        $this->assertEquals('IndexFields', Str::plural('IndexField'));
+        $this->assertEquals('VertexFields', Str::plural('VertexField'));
     }
 }


### PR DESCRIPTION
Avoid useless calls to an helper function which will call the Str function

---

Also related to #9273, #9310 and #9011 
