### PR TITLE
[5.1] array_sort_recursive() move to Arr class

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -398,6 +398,27 @@ class Arr
     }
 
     /**
+     * Recursively sort an array by keys and values.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function sortRecursive($array)
+    {
+        foreach ($array as &$value) {
+            if (is_array($value) && isset($value[0])) {
+                sort($value);
+            } elseif (is_array($value)) {
+                self::sortRecursive($value);
+            }
+        }
+
+        ksort($array);
+
+        return $array;
+    }
+
+    /**
      * Filter the array using the given callback.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -289,6 +289,19 @@ if (!function_exists('array_sort')) {
     }
 }
 
+if (!function_exists('array_sort_recursive')) {
+    /**
+     * Recursively sort an array by keys and values.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    function array_sort_recursive($array)
+    {
+        return Arr::sortRecursive($array);
+    }
+}
+
 if (!function_exists('array_where')) {
     /**
      * Filter the array using the given callback.
@@ -524,29 +537,6 @@ if (!function_exists('preg_replace_sub')) {
             }
 
         }, $subject);
-    }
-}
-
-if (!function_exists('array_sort_recursive')) {
-    /**
-     * Recursively sort an array by keys and values.
-     *
-     * @param  array  $array
-     * @return array
-     */
-    function array_sort_recursive($array)
-    {
-        foreach ($array as &$value) {
-            if (is_array($value) && isset($value[0])) {
-                sort($value);
-            } elseif (is_array($value)) {
-                array_sort_recursive($value);
-            }
-        }
-
-        ksort($array);
-
-        return $array;
     }
 }
 


### PR DESCRIPTION
Related to https://github.com/laravel/framework/commit/b9bddf5478788659441ab15716db2d5ab72d2572

Moving array related function helpers to Arr methods.
