### PR TITLE
[5.1] Fix sending headers in tests during HTTP calls

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -771,7 +771,9 @@ trait CrawlerTrait
         $server = [];
 
         foreach ($headers as $name => $value) {
-            $name = 'HTTP_'.strtr(strtoupper($name), '-', '_');
+            if (!starts_with($name, 'HTTP_')) {
+                $name = 'HTTP_'.strtr(strtoupper($name), '-', '_');
+            }
 
             $server[$name] = $value;
         }

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -59,7 +59,9 @@ trait CrawlerTrait
      */
     public function get($uri, array $headers = [])
     {
-        $this->call('GET', $uri, [], [], [], $headers);
+        $server = $this->transformHeadersToServerVars($headers);
+
+        $this->call('GET', $uri, [], [], [], $server);
 
         return $this;
     }
@@ -74,7 +76,9 @@ trait CrawlerTrait
      */
     public function post($uri, array $data = [], array $headers = [])
     {
-        $this->call('POST', $uri, $data, [], [], $headers);
+        $server = $this->transformHeadersToServerVars($headers);
+        
+        $this->call('POST', $uri, $data, [], [], $server);
 
         return $this;
     }
@@ -89,7 +93,9 @@ trait CrawlerTrait
      */
     public function put($uri, array $data = [], array $headers = [])
     {
-        $this->call('PUT', $uri, $data, [], [], $headers);
+        $server = $this->transformHeadersToServerVars($headers);
+        
+        $this->call('PUT', $uri, $data, [], [], $server);
 
         return $this;
     }
@@ -104,7 +110,9 @@ trait CrawlerTrait
      */
     public function patch($uri, array $data = [], array $headers = [])
     {
-        $this->call('PATCH', $uri, $data, [], [], $headers);
+        $server = $this->transformHeadersToServerVars($headers);
+        
+        $this->call('PATCH', $uri, $data, [], [], $server);
 
         return $this;
     }
@@ -119,7 +127,9 @@ trait CrawlerTrait
      */
     public function delete($uri, array $data = [], array $headers = [])
     {
-        $this->call('DELETE', $uri, $data, [], [], $headers);
+        $server = $this->transformHeadersToServerVars($headers);
+        
+        $this->call('DELETE', $uri, $data, [], [], $server);
 
         return $this;
     }
@@ -748,6 +758,25 @@ trait CrawlerTrait
         }
 
         return trim($uri, '/');
+    }
+
+    /**
+     * Transform headers array to array of $_SERVER vars with HTTP_* format.
+     *
+     * @param  array  $headers
+     * @return array
+     */
+    protected function transformHeadersToServerVars(array $headers)
+    {
+        $server = [];
+
+        foreach ($headers as $name => $value) {
+            $name = 'HTTP_'.strtr(strtoupper($name), '-', '_');
+
+            $server[$name] = $value;
+        }
+
+        return $server;
     }
 
     /**


### PR DESCRIPTION
Fixing https://github.com/laravel/framework/issues/9368
Updating PR https://github.com/laravel/framework/pull/9376

Problem is that Symfony `Request::create` method expects sixth parameter as a prepared `$_SERVER` array, but `get()`, `post()`, etc methods are sending there a raw array of headers. That's why if you are trying to test http call with headers they won't come.

Fixed via transforming array of headers to array of `$_SERVER` vars.
