### PR TITLE
[5.1] Fix Eloquent Builder paginate passing columns to count

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -267,7 +267,7 @@ class Builder
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page')
     {
-        $total = $this->query->getCountForPagination();
+        $total = $this->query->getCountForPagination($columns);
 
         $this->query->forPage(
             $page = Paginator::resolveCurrentPage($pageName),

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -214,6 +214,36 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['bar', 'baz'], $builder->lists('name')->all());
     }
 
+    public function testPaginatePassesColumnsToGetCountForPaginationMethod()
+    {
+        $totalItems = 100;
+        $itemsPerPage = 50;
+        $page = 1;
+        $database = 'SQLite';
+        $table = 'table';
+        $columns = [$table . '.column'];
+
+        $model = new EloquentBuilderTestNestedStub;
+
+        $this->mockConnectionForModel($model, $database);
+
+        $query = m::mock('Illuminate\Database\Query\Builder');
+        $query->shouldReceive('from')->once()->with($table);
+        $query->shouldReceive('forPage')->once()->with($page, $itemsPerPage)->andReturn($query);
+        $query->shouldReceive('get')->once()->andReturn($columns);
+
+        /**
+         * Add check that paginate method passes $columns param to getCountForPagination method
+         */
+        $query->shouldReceive('getCountForPagination')->once()->with($columns)->andReturn($totalItems);
+
+        $builder = new Builder($query);
+
+        $builder->setModel($model);
+
+        $builder->paginate($itemsPerPage, $columns);
+    }
+
     public function testMacrosAreCalledOnBuilder()
     {
         unset($_SERVER['__test.builder']);


### PR DESCRIPTION
At the moment $columns specified during paginate call as second parameter are not passed to count query of eloquent pagination.

This can be useful for example if one need to count distinct items.
