### PR TITLE
[5.1] Pass $attributes through to factory definitions

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -126,7 +126,7 @@ class FactoryBuilder
                 throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}].");
             }
 
-            $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker);
+            $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker, $attributes);
 
             return new $this->class(array_merge($definition, $attributes));
         });


### PR DESCRIPTION
tl;dr

The factory builders are great but do have one bug, they create the entire factory (including defined relationships within the factory) first before merging the overriding attributes into the created factory. See https://github.com/laravel/framework/issues/9245 for a longer explanation of this.

This PR allows the factories to keep their existing behavior but also allows the factories more knowledge of what needs to be created.
