### PR TITLE
[5.1] Add cookies to http call methods in CrawlerTrait

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -54,14 +54,15 @@ trait CrawlerTrait
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri
-     * @param  array  $headers
+     * @param  array   $headers
+     * @param  array   $cookies
      * @return $this
      */
-    public function get($uri, array $headers = [])
+    public function get($uri, array $headers = [], array $cookies = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
 
-        $this->call('GET', $uri, [], [], [], $server);
+        $this->call('GET', $uri, [], $cookies, [], $server);
 
         return $this;
     }
@@ -70,15 +71,16 @@ trait CrawlerTrait
      * Visit the given URI with a POST request.
      *
      * @param  string  $uri
-     * @param  array  $data
-     * @param  array  $headers
+     * @param  array   $data
+     * @param  array   $headers
+     * @param  array   $cookies
      * @return $this
      */
-    public function post($uri, array $data = [], array $headers = [])
+    public function post($uri, array $data = [], array $headers = [], array $cookies = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
-        
-        $this->call('POST', $uri, $data, [], [], $server);
+
+        $this->call('POST', $uri, $data, $cookies, [], $server);
 
         return $this;
     }
@@ -87,15 +89,16 @@ trait CrawlerTrait
      * Visit the given URI with a PUT request.
      *
      * @param  string  $uri
-     * @param  array  $data
-     * @param  array  $headers
+     * @param  array   $data
+     * @param  array   $headers
+     * @param  array   $cookies
      * @return $this
      */
-    public function put($uri, array $data = [], array $headers = [])
+    public function put($uri, array $data = [], array $headers = [], array $cookies = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
-        
-        $this->call('PUT', $uri, $data, [], [], $server);
+
+        $this->call('PUT', $uri, $data, $cookies, [], $server);
 
         return $this;
     }
@@ -104,15 +107,16 @@ trait CrawlerTrait
      * Visit the given URI with a PATCH request.
      *
      * @param  string  $uri
-     * @param  array  $data
-     * @param  array  $headers
+     * @param  array   $data
+     * @param  array   $headers
+     * @param  array   $cookies
      * @return $this
      */
-    public function patch($uri, array $data = [], array $headers = [])
+    public function patch($uri, array $data = [], array $headers = [], array $cookies = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
-        
-        $this->call('PATCH', $uri, $data, [], [], $server);
+
+        $this->call('PATCH', $uri, $data, $cookies, [], $server);
 
         return $this;
     }
@@ -121,15 +125,16 @@ trait CrawlerTrait
      * Visit the given URI with a DELETE request.
      *
      * @param  string  $uri
-     * @param  array  $data
-     * @param  array  $headers
+     * @param  array   $data
+     * @param  array   $headers
+     * @param  array   $cookies
      * @return $this
      */
-    public function delete($uri, array $data = [], array $headers = [])
+    public function delete($uri, array $data = [], array $headers = [], array $cookies = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
-        
-        $this->call('DELETE', $uri, $data, [], [], $server);
+
+        $this->call('DELETE', $uri, $data, $cookies, [], $server);
 
         return $this;
     }
@@ -139,9 +144,9 @@ trait CrawlerTrait
      *
      * @param  string  $method
      * @param  string  $uri
-     * @param  array  $parameters
-     * @param  array  $cookies
-     * @param  array  $files
+     * @param  array   $parameters
+     * @param  array   $cookies
+     * @param  array   $files
      * @return $this
      */
     protected function makeRequest($method, $uri, $parameters = [], $cookies = [], $files = [])

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -54,8 +54,8 @@ trait CrawlerTrait
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri
-     * @param  array   $headers
-     * @param  array   $cookies
+     * @param  array  $headers
+     * @param  array  $cookies
      * @return $this
      */
     public function get($uri, array $headers = [], array $cookies = [])
@@ -71,9 +71,9 @@ trait CrawlerTrait
      * Visit the given URI with a POST request.
      *
      * @param  string  $uri
-     * @param  array   $data
-     * @param  array   $headers
-     * @param  array   $cookies
+     * @param  array  $data
+     * @param  array  $headers
+     * @param  array  $cookies
      * @return $this
      */
     public function post($uri, array $data = [], array $headers = [], array $cookies = [])
@@ -89,9 +89,9 @@ trait CrawlerTrait
      * Visit the given URI with a PUT request.
      *
      * @param  string  $uri
-     * @param  array   $data
-     * @param  array   $headers
-     * @param  array   $cookies
+     * @param  array  $data
+     * @param  array  $headers
+     * @param  array  $cookies
      * @return $this
      */
     public function put($uri, array $data = [], array $headers = [], array $cookies = [])
@@ -107,9 +107,9 @@ trait CrawlerTrait
      * Visit the given URI with a PATCH request.
      *
      * @param  string  $uri
-     * @param  array   $data
-     * @param  array   $headers
-     * @param  array   $cookies
+     * @param  array  $data
+     * @param  array  $headers
+     * @param  array  $cookies
      * @return $this
      */
     public function patch($uri, array $data = [], array $headers = [], array $cookies = [])
@@ -125,9 +125,9 @@ trait CrawlerTrait
      * Visit the given URI with a DELETE request.
      *
      * @param  string  $uri
-     * @param  array   $data
-     * @param  array   $headers
-     * @param  array   $cookies
+     * @param  array  $data
+     * @param  array  $headers
+     * @param  array  $cookies
      * @return $this
      */
     public function delete($uri, array $data = [], array $headers = [], array $cookies = [])
@@ -144,9 +144,9 @@ trait CrawlerTrait
      *
      * @param  string  $method
      * @param  string  $uri
-     * @param  array   $parameters
-     * @param  array   $cookies
-     * @param  array   $files
+     * @param  array  $parameters
+     * @param  array  $cookies
+     * @param  array  $files
      * @return $this
      */
     protected function makeRequest($method, $uri, $parameters = [], $cookies = [], $files = [])


### PR DESCRIPTION
CrawlerTrait's `call()` method can accept `$cookies` array, but all http methods such as `get()`, `post()`, etc that utilise this method don't use it. So it becomes quite tricky to send cookies in test HTTP calls.

I added an optional `$cookie` parameter to all this http methods. This change doesn't break anything, just extends current functionality and makes http calls with cookies easier and more readable.
