### PR TITLE
[5.1] Skip further date format checks if DateTime passed to asDateTime()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2822,6 +2822,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function asDateTime($value)
     {
+        // If this value is already a Carbon instance, we shall just return it as is.
+        // This prevents us having to reinstantiate a Carbon instance when we know
+        // it already is one, which wouldn't be fulfilled by the DateTime check.
+        if ($value instanceof Carbon) {
+          return $value;
+        }
+
         // If the value is already a DateTime instance, we will just skip the rest of
         // these checks since they will be a waste of time, and hinder performance
         // when checking the field. We will just return the DateTime right away.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2826,7 +2826,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // these checks since they will be a waste of time, and hinder performance
         // when checking the field. We will just return the DateTime right away.
         if ($value instanceof DateTime) {
-            //
+            return Carbon::instance($value);
         }
 
         // If this value is an integer, we will assume it is a UNIX timestamp's value
@@ -2851,8 +2851,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
             return Carbon::createFromFormat($format, $value);
         }
-
-        return Carbon::instance($value);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2832,25 +2832,24 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // If this value is an integer, we will assume it is a UNIX timestamp's value
         // and format a Carbon object from this timestamp. This allows flexibility
         // when defining your date fields as they might be UNIX timestamps here.
-        elseif (is_numeric($value)) {
+        if (is_numeric($value)) {
             return Carbon::createFromTimestamp($value);
         }
 
         // If the value is in simply year, month, day format, we will instantiate the
         // Carbon instances from that format. Again, this provides for simple date
         // fields on the database, while still supporting Carbonized conversion.
-        elseif (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $value)) {
+        if (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $value)) {
             return Carbon::createFromFormat('Y-m-d', $value)->startOfDay();
         }
 
         // Finally, we will just assume this date is in the format used by default on
         // the database connection and use that format to create the Carbon object
         // that is returned back out to the developers after we convert it here.
-        elseif (!$value instanceof DateTime) {
-            $format = $this->getDateFormat();
+        $format = $this->getDateFormat();
 
-            return Carbon::createFromFormat($format, $value);
-        }
+        return Carbon::createFromFormat($format, $value);
+        
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2849,7 +2849,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $format = $this->getDateFormat();
 
         return Carbon::createFromFormat($format, $value);
-        
     }
 
     /**


### PR DESCRIPTION
Despite the comments within the `asDateTime()` method saying to skip further checks if the `$value` is a `DateTime` object, the actual logic does not skip them.
