### PR TITLE
[5.1] Use casts when getting dirty status

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3012,7 +3012,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         foreach ($this->attributes as $key => $value) {
             if (!array_key_exists($key, $this->original)) {
                 $dirty[$key] = $value;
-            } elseif ($value !== $this->original[$key] &&
+            } elseif ((($this->hasCast($key) && $value !== $this->castAttribute($key, $this->original[$key])) ||
+                       (!$this->hasCast($key) && $value !== $this->original[$key])) &&
                                  !$this->originalIsNumericallyEquivalent($key)) {
                 $dirty[$key] = $value;
             }


### PR DESCRIPTION
The $casts array on Model was not used when looking for changed fields. This led to getDirty() return true for fields casting tinyint as bool etc.
