### PR TITLE
[5.1] Fix falsy dirty date

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3012,13 +3012,27 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         foreach ($this->attributes as $key => $value) {
             if (!array_key_exists($key, $this->original)) {
                 $dirty[$key] = $value;
-            } elseif ($value !== $this->original[$key] &&
-                                 !$this->originalIsNumericallyEquivalent($key)) {
+            } elseif (in_array($key, $this->getDates())) {
+                if (!$this->originalDateIsEquivalent($key)) {
+                    $dirty[$key] = $value;
+                }
+            } elseif ($value !== $this->original[$key] && !$this->originalIsNumericallyEquivalent($key)) {
                 $dirty[$key] = $value;
             }
         }
 
         return $dirty;
+    }
+
+    /**
+     * Determine if the new and old dates for a given key are equivalent.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function originalDateIsEquivalent($key)
+    {
+        return $this->attributes[$key] === $this->fromDateTime($this->original[$key]);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -44,6 +44,45 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($model->isDirty(['foo', 'bar']));
     }
 
+    public function testDirtyDatesAttributes()
+    {
+        $string = '2015-01-01 01:01:01';
+        $datetime = new DateTime($string);
+        $carbon = \Carbon\Carbon::instance($datetime);
+
+        $this->assertEquals($carbon->getTimestamp(), $carbon->getTimestamp());
+        $this->assertEquals($carbon->getTimezone(), $carbon->getTimezone());
+        $this->assertSame($string, $carbon->toDateTimeString());
+
+        $model = $this->getMock('EloquentDateModelStub', ['getDateFormat']);
+        $model->expects($this->any())->method('getDateFormat')->will($this->returnValue('Y-m-d H:i:s'));
+        $model->setRawAttributes([
+            'created_at' => $carbon,
+            'updated_at' => $datetime,
+        ]);
+        $model->syncOriginal();
+
+        $model->created_at = $datetime;
+        $model->updated_at = $carbon;
+        $this->assertFalse($model->isDirty());
+
+        $model->created_at = $string;
+        $model->updated_at = $string;
+        $this->assertFalse($model->isDirty());
+
+        $string = '2015-12-31 23:59:59';
+        $datetime = new DateTime($string);
+        $carbon = \Carbon\Carbon::instance($datetime);
+
+        $model->created_at = $datetime;
+        $model->updated_at = $carbon;
+        $this->assertTrue($model->isDirty());
+
+        $model->created_at = $string;
+        $model->updated_at = $string;
+        $this->assertTrue($model->isDirty());
+    }
+
     public function testCalculatedAttributes()
     {
         $model = new EloquentModelStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -48,7 +48,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     {
         $string = '2015-01-01 01:01:01';
         $datetime = new DateTime($string);
-        $carbon = \Carbon\Carbon::instance($datetime);
+        $carbon = Carbon\Carbon::instance($datetime);
 
         $this->assertEquals($carbon->getTimestamp(), $carbon->getTimestamp());
         $this->assertEquals($carbon->getTimezone(), $carbon->getTimezone());
@@ -72,7 +72,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
         $string = '2015-12-31 23:59:59';
         $datetime = new DateTime($string);
-        $carbon = \Carbon\Carbon::instance($datetime);
+        $carbon = Carbon\Carbon::instance($datetime);
 
         $model->created_at = $datetime;
         $model->updated_at = $carbon;


### PR DESCRIPTION
At the moment, if in my model an original date `mydate` is `2015-01-01 01:01:01`, setting as a new value with an equivalent `Carbon` or `Datetime` instance will result this date to be considered as dirty, which is not the correct.

This PR fixes that.
Without it, all the `isDirty` assertions of `testDirtyDatesAttributes` would fail.
