### PR TITLE
[5.1] Collection::make empty array as default

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -38,7 +38,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  mixed  $items
      * @return static
      */
-    public static function make($items = null)
+    public static function make($items = [])
     {
         return new static($items);
     }


### PR DESCRIPTION
If we wish to make an empty collection, there is really no need that `getArrayableItems` is called in the contructor
