### PR TITLE
[5.1] Use signature format in make migration command & allow specifing path to create migration file in

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -98,6 +98,20 @@ class MigrateMakeCommand extends BaseCommand
     }
 
     /**
+     * Get migration path (either specified by '--path' option or default location).
+     *
+     * @return string
+     */
+    protected function getMigrationPath()
+    {
+        if (is_null($path = $this->input->getOption('path'))) {
+            $path = parent::getMigrationPath();
+        }
+        
+        return $path;
+    }
+
+    /**
      * Get the console command arguments.
      *
      * @return array
@@ -120,6 +134,8 @@ class MigrateMakeCommand extends BaseCommand
             ['create', null, InputOption::VALUE_OPTIONAL, 'The table to be created.'],
 
             ['table', null, InputOption::VALUE_OPTIONAL, 'The table to migrate.'],
+
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to create the migration file in.'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -3,18 +3,19 @@
 namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Foundation\Composer;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use Illuminate\Database\Migrations\MigrationCreator;
 
 class MigrateMakeCommand extends BaseCommand
 {
     /**
-     * The console command name.
+     * The console command signature.
      *
      * @var string
      */
-    protected $name = 'make:migration';
+    protected $signature = 'make:migration {name : The name of the migration.}
+        {--create= : The table to be created.}
+        {--table= : The table to migrate.}
+        {--path= : The path to create the migration file in.}';
 
     /**
      * The console command description.
@@ -111,31 +112,4 @@ class MigrateMakeCommand extends BaseCommand
         return $path;
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
-    {
-        return [
-            ['name', InputArgument::REQUIRED, 'The name of the migration'],
-        ];
-    }
-
-    /**
-     * Get the console command options.
-     *
-     * @return array
-     */
-    protected function getOptions()
-    {
-        return [
-            ['create', null, InputOption::VALUE_OPTIONAL, 'The table to be created.'],
-
-            ['table', null, InputOption::VALUE_OPTIONAL, 'The table to migrate.'],
-
-            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to create the migration file in.'],
-        ];
-    }
 }

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -56,6 +56,19 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
     }
 
+    public function testCanSpecifyPathToCreateMigrationsIn()
+    {
+         $command = new MigrateMakeCommand(
+            $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
+            m::mock('Illuminate\Foundation\Composer')->shouldIgnoreMissing(),
+            __DIR__.'/vendor'
+        );
+        $app = new Illuminate\Foundation\Application;
+        $command->setLaravel($app);
+        $creator->shouldReceive('create')->once()->with('create_foo', 'vendor/laravel-package/migrations', 'users', true);
+        $this->runCommand($command, ['name' => 'create_foo', '--path' => 'vendor/laravel-package/migrations', '--create' => 'users']);
+    }
+
     protected function runCommand($command, $input = [])
     {
         return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);


### PR DESCRIPTION
- Use new signature format for make:migration command
- Allow specifying a path to create migration file in. Useful for developing packages and being able to do `make:migration create_users_table --path=vendor/package/migrations`
