### PR TITLE
[5.1] Add more error checking in key:generate command

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -38,15 +38,13 @@ class KeyGenerateCommand extends Command
         $path = base_path('.env');
 
         if (! file_exists($path)) {
-            $this->error('Missing '.$path.' file.');
-            return;
+            return $this->error("Missing {$path} file.");
         }
 
         $envContent = file_get_contents($path);
 
         if (strpos($envContent, 'APP_KEY=') === false) {
-            $this->error('Missing APP_KEY= in .env file.');
-            return;
+            return $this->error('Missing APP_KEY= in .env file.');
         }
 
         $envContent = str_replace('APP_KEY='.$this->laravel['config']['app.key'], 'APP_KEY='.$key, $envContent);

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -37,11 +37,21 @@ class KeyGenerateCommand extends Command
 
         $path = base_path('.env');
 
-        if (file_exists($path)) {
-            file_put_contents($path, str_replace(
-                'APP_KEY='.$this->laravel['config']['app.key'], 'APP_KEY='.$key, file_get_contents($path)
-            ));
+        if (! file_exists($path)) {
+            $this->error('Missing '.$path.' file.');
+            return;
         }
+
+        $envContent = file_get_contents($path);
+
+        if (strpos($envContent, 'APP_KEY=') === false) {
+            $this->error('Missing APP_KEY= in .env file.');
+            return;
+        }
+
+        $envContent = str_replace('APP_KEY='.$this->laravel['config']['app.key'], 'APP_KEY='.$key, $envContent);
+
+        file_put_contents($path, $envContent);
 
         $this->laravel['config']['app.key'] = $key;
 


### PR DESCRIPTION
- error message if .env does not exist
- error message if APP_KEY= does not exist in .env file

The reason for the fix is that I actually encountered this problem and was scratching my head for a few minutes why the key:generate command says:

`Application key XXX set successfully.`

 but nothing changed because APP_KEY= was missing.
