### PR TITLE
[5.1] Use {{table}} variable in queue table stubs

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -12,7 +12,7 @@ class CreateFailedJobsTable extends Migration
      */
     public function up()
     {
-        Schema::create('failed_jobs', function (Blueprint $table) {
+        Schema::create('{{table}}', function (Blueprint $table) {
             $table->increments('id');
             $table->text('connection');
             $table->text('queue');
@@ -28,6 +28,6 @@ class CreateFailedJobsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('failed_jobs');
+        Schema::drop('{{table}}');
     }
 }

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -12,7 +12,7 @@ class CreateJobsTable extends Migration
      */
     public function up()
     {
-        Schema::create('jobs', function (Blueprint $table) {
+        Schema::create('{{table}}', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('queue');
             $table->longText('payload');
@@ -31,6 +31,6 @@ class CreateJobsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('jobs');
+        Schema::drop('{{table}}');
     }
 }


### PR DESCRIPTION
Both [TableCommand](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Queue/Console/TableCommand.php#L63) and [FailedTableCommand](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Queue/Console/FailedTableCommand.php#L63) use `{{table}}` as a replacement in stubs. However stubs have hardcoded table names.
