### PR TITLE
Add timestampsTz function to schema blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -712,6 +712,18 @@ class Blueprint
     }
 
     /**
+     * Add creation and update timestampTz columns to the table.
+     *
+     * @return void
+     */
+    public function timestampsTz()
+    {
+        $this->timestampTz('created_at');
+
+        $this->timestampTz('updated_at');
+    }
+
+    /**
      * Add a "deleted at" timestamp for the table.
      *
      * @return \Illuminate\Support\Fluent


### PR DESCRIPTION
This is just a time saver for people that want to use timestamp columns with a timezone. Exactly the same as `timestamps` but `timestampsTz` creates them as `timestampTz` fields.
