### PR TITLE
[5.1] csrf_field helper returns a View Expression instead of string

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -204,7 +204,7 @@ if (!function_exists('csrf_field')) {
      */
     function csrf_field()
     {
-        return '<input type="hidden" name="_token" value="'.csrf_token().'">';
+        return new Illuminate\View\Expression('<input type="hidden" name="_token" value="'.csrf_token().'">');
     }
 }
 


### PR DESCRIPTION
This pull allows us to print `csrf_field()` in Blade templates without having to use the "unescape" tags, with the help of [View Expressions](https://github.com/laravel/framework/blob/5.1/src/Illuminate/View/Expression.php) added in 5.1.3.

```
<form action="/foo/bar" method="POST">
  {{ csrf_field() }}
</form>
```

Unescape tags still work, via Expression's `__toString` method, so no BC.

```
<form action="/foo/bar" method="POST">
  {!! csrf_field() !!}
</form>
```
