### PR TITLE
[5.1] Paginator returns Htmlable

### DIFF
--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -103,7 +103,7 @@ interface Paginator
      * Render the paginator using a given Presenter.
      *
      * @param  \Illuminate\Contracts\Pagination\Presenter|null  $presenter
-     * @return string
+     * @return string|\Illuminate\Contracts\Support\Htmlable
      */
     public function render(Presenter $presenter = null);
 }

--- a/src/Illuminate/Pagination/Expression.php
+++ b/src/Illuminate/Pagination/Expression.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Pagination;
+
+use Illuminate\Contracts\Support\Htmlable;
+
+class Expression implements Htmlable
+{
+    /**
+     * The HTML string
+     *
+     * @var string
+     */
+    protected $html;
+
+    /**
+     * Create a new HTML string instance.
+     *
+     * @param  string  $html
+     * @return void
+     */
+    public function __construct($html)
+    {
+        $this->html = $html;
+    }
+
+    /**
+     * Get the the HTML string
+     *
+     * @return string
+     */
+    public function toHtml()
+    {
+        return $this->html;
+    }
+
+    /**
+     * Get the the HTML string
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toHtml();
+    }
+}

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -128,7 +128,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
 
         $presenter = $presenter ?: new BootstrapThreePresenter($this);
 
-        return $presenter->render();
+        return new Expression($presenter->render());
     }
 
     /**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -104,7 +104,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
 
         $presenter = $presenter ?: new SimpleBootstrapThreePresenter($this);
 
-        return $presenter->render();
+        return new Expression($presenter->render());
     }
 
     /**

--- a/tests/Pagination/PaginationExpressionTest.php
+++ b/tests/Pagination/PaginationExpressionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Pagination\Expression;
+
+class PaginationExpressionTest extends PHPUnit_Framework_TestCase
+{
+    public function testToHtml()
+    {
+        $str = '<h1>foo</h1>';
+        $html = new Expression('<h1>foo</h1>');
+        $this->assertEquals($str, $html->toHtml());
+    }
+
+    public function testToString()
+    {
+        $str = '<h1>foo</h1>';
+        $html = new Expression('<h1>foo</h1>');
+        $this->assertEquals($str, (string) $html);
+    }
+}


### PR DESCRIPTION
This pull is similar to #9440 in that it allows you to print rendered pagination with regular Blade tags.

```
{{ $pagination->render() }}
```

I decided to add an `Expression` class to the `Illuminate\Pagination` namespace so that `illuminate\pagination` didn't have to depend on `illuminate\view`.
