### PR TITLE
[5.2] Bump carbon version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",
-        "nesbot/carbon": "~1.19",
+        "nesbot/carbon": "~1.20",
         "psy/psysh": "0.4.*",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/console": "2.8.*",

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -19,7 +19,7 @@
         "illuminate/http": "5.2.*",
         "illuminate/session": "5.2.*",
         "illuminate/support": "5.2.*",
-        "nesbot/carbon": "~1.19"
+        "nesbot/carbon": "~1.20"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.5.9",
         "illuminate/contracts": "5.2.*",
         "illuminate/support": "5.2.*",
-        "nesbot/carbon": "~1.19"
+        "nesbot/carbon": "~1.20"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.5.9",
         "illuminate/contracts": "5.2.*",
         "symfony/console": "2.8.*",
-        "nesbot/carbon": "~1.19"
+        "nesbot/carbon": "~1.20"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -19,7 +19,7 @@
         "illuminate/container": "5.2.*",
         "illuminate/contracts": "5.2.*",
         "illuminate/support": "5.2.*",
-        "nesbot/carbon": "~1.19"
+        "nesbot/carbon": "~1.20"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -21,7 +21,7 @@
         "illuminate/http": "5.2.*",
         "illuminate/support": "5.2.*",
         "symfony/process": "2.8.*",
-        "nesbot/carbon": "~1.19"
+        "nesbot/carbon": "~1.20"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.5.9",
         "illuminate/contracts": "5.2.*",
         "illuminate/support": "5.2.*",
-        "nesbot/carbon": "~1.19",
+        "nesbot/carbon": "~1.20",
         "symfony/finder": "2.8.*",
         "symfony/http-foundation": "2.8.*"
     },


### PR DESCRIPTION
1.20 is the first version to support symfony 3.x (as well as 2.6+). We bumped the carbon version in 5.1 for 2.7.x support so it makes to bump it again here.
