### PR TITLE
[5.1] Add missing dependency

### DIFF
--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": ">=5.5.9",
         "illuminate/contracts": "5.1.*",
+        "illuminate/support": "5.1.*",
         "symfony/console": "2.7.*",
         "nesbot/carbon": "~1.19"
     },


### PR DESCRIPTION
We use Str:: functions in the Parser
