### PR TITLE
[5.1]  Allow callbacks in Collection min and max method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -405,20 +405,29 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return new static(array_combine($keys, $items));
     }
 
-    /**
-     * Get the max value of a given key.
-     *
-     * @param  string|null  $key
-     * @return mixed
-     */
-    public function max($key = null)
-    {
-        return $this->reduce(function ($result, $item) use ($key) {
-            $value = data_get($item, $key);
+	/**
+	 * Get the max value of the given values.
+	 *
+	 * @param  callable|string|null  $callback
+	 * @return mixed
+	 */
+	public function max($callback = null)
+	{
+		if (is_null($callback)) {
+			if($this->count() == 0) {
+				return 0;
+			}
+			return max($this->items);
+		}
 
-            return is_null($result) || $value > $result ? $value : $result;
-        });
-    }
+		$callback = $this->valueRetriever($callback);
+
+		return $this->reduce(function ($result, $item) use ($callback) {
+			$value = $callback($item);
+
+			return is_null($result) || $value > $result ? $value : $result;
+		});
+	}
 
     /**
      * Merge the collection with the given items.
@@ -431,20 +440,29 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return new static(array_merge($this->items, $this->getArrayableItems($items)));
     }
 
-    /**
-     * Get the min value of a given key.
-     *
-     * @param  string|null  $key
-     * @return mixed
-     */
-    public function min($key = null)
-    {
-        return $this->reduce(function ($result, $item) use ($key) {
-            $value = data_get($item, $key);
+	/**
+	 * Get the min value of the given values.
+	 *
+	 * @param  callable|string|null  $callback
+	 * @return mixed
+	 */
+	public function min($callback = null)
+	{
+		if (is_null($callback)) {
+			if($this->count() == 0) {
+				return 0;
+			}
+			return min($this->items);
+		}
 
-            return is_null($result) || $value < $result ? $value : $result;
-        });
-    }
+		$callback = $this->valueRetriever($callback);
+
+		return $this->reduce(function ($result, $item) use ($callback) {
+			$value = $callback($item);
+
+			return is_null($result) || $value < $result ? $value : $result;
+		});
+	}
 
     /**
      * "Paginate" the collection by slicing it into a smaller collection.

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -414,7 +414,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function max($callback = null)
     {
         if (is_null($callback)) {
-            if($this->count() == 0) {
+            if ($this->count() == 0) {
                 return 0;
             }
             return max($this->items);
@@ -449,7 +449,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function min($callback = null)
     {
         if (is_null($callback)) {
-            if($this->count() == 0) {
+            if ($this->count() == 0) {
                 return 0;
             }
             return min($this->items);

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -405,29 +405,29 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return new static(array_combine($keys, $items));
     }
 
-	/**
-	 * Get the max value of the given values.
-	 *
-	 * @param  callable|string|null  $callback
-	 * @return mixed
-	 */
-	public function max($callback = null)
-	{
-		if (is_null($callback)) {
-			if($this->count() == 0) {
-				return 0;
-			}
-			return max($this->items);
-		}
+    /**
+     * Get the max value of the given values.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function max($callback = null)
+    {
+        if (is_null($callback)) {
+            if($this->count() == 0) {
+                return 0;
+            }
+            return max($this->items);
+        }
 
-		$callback = $this->valueRetriever($callback);
+        $callback = $this->valueRetriever($callback);
 
-		return $this->reduce(function ($result, $item) use ($callback) {
-			$value = $callback($item);
+        return $this->reduce(function ($result, $item) use ($callback) {
+            $value = $callback($item);
 
-			return is_null($result) || $value > $result ? $value : $result;
-		});
-	}
+            return is_null($result) || $value > $result ? $value : $result;
+        });
+    }
 
     /**
      * Merge the collection with the given items.
@@ -440,29 +440,29 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return new static(array_merge($this->items, $this->getArrayableItems($items)));
     }
 
-	/**
-	 * Get the min value of the given values.
-	 *
-	 * @param  callable|string|null  $callback
-	 * @return mixed
-	 */
-	public function min($callback = null)
-	{
-		if (is_null($callback)) {
-			if($this->count() == 0) {
-				return 0;
-			}
-			return min($this->items);
-		}
+    /**
+     * Get the min value of the given values.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function min($callback = null)
+    {
+        if (is_null($callback)) {
+            if($this->count() == 0) {
+                return 0;
+            }
+            return min($this->items);
+        }
 
-		$callback = $this->valueRetriever($callback);
+        $callback = $this->valueRetriever($callback);
 
-		return $this->reduce(function ($result, $item) use ($callback) {
-			$value = $callback($item);
+        return $this->reduce(function ($result, $item) use ($callback) {
+            $value = $callback($item);
 
-			return is_null($result) || $value < $result ? $value : $result;
-		});
-	}
+            return is_null($result) || $value < $result ? $value : $result;
+        });
+    }
 
     /**
      * "Paginate" the collection by slicing it into a smaller collection.

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -636,52 +636,52 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     {
         $c = new Collection();
         $this->assertEquals(0, $c->sum('foo'));
-	    $this->assertEquals(0, $c->sum());
+        $this->assertEquals(0, $c->sum());
     }
 
-	public function testGettingMaxFromCollection()
-	{
-		$c = new Collection([(object) ['foo' => 50], (object) ['foo' => 30]]);
-		$this->assertEquals(50, $c->max('foo'));
+    public function testGettingMaxFromCollection()
+    {
+        $c = new Collection([(object) ['foo' => 50], (object) ['foo' => 30]]);
+        $this->assertEquals(50, $c->max('foo'));
 
-		$c = new Collection([(object) ['foo' => 30], (object) ['foo' => 50]]);
-		$this->assertEquals(50, $c->max(function ($i) { return $i->foo; }));
-	}
+        $c = new Collection([(object) ['foo' => 30], (object) ['foo' => 50]]);
+        $this->assertEquals(50, $c->max(function ($i) { return $i->foo; }));
+    }
 
-	public function testCanMaxValuesWithoutACallback()
-	{
-		$c = new Collection([1, 2, 3, 4, 5]);
-		$this->assertEquals(5, $c->max());
-	}
+    public function testCanMaxValuesWithoutACallback()
+    {
+        $c = new Collection([1, 2, 3, 4, 5]);
+        $this->assertEquals(5, $c->max());
+    }
 
-	public function testGettingMaxFromEmptyCollection()
-	{
-		$c = new Collection();
-		$this->assertEquals(0, $c->max('foo'));
-		$this->assertEquals(0, $c->max());
-	}
+    public function testGettingMaxFromEmptyCollection()
+    {
+        $c = new Collection();
+        $this->assertEquals(0, $c->max('foo'));
+        $this->assertEquals(0, $c->max());
+    }
 
-	public function testGettingMinFromCollection()
-	{
-		$c = new Collection([(object) ['foo' => 50], (object) ['foo' => 30]]);
-		$this->assertEquals(30, $c->min('foo'));
+    public function testGettingMinFromCollection()
+    {
+        $c = new Collection([(object) ['foo' => 50], (object) ['foo' => 30]]);
+        $this->assertEquals(30, $c->min('foo'));
 
-		$c = new Collection([(object) ['foo' => 30], (object) ['foo' => 50]]);
-		$this->assertEquals(30, $c->min(function ($i) { return $i->foo; }));
-	}
+        $c = new Collection([(object) ['foo' => 30], (object) ['foo' => 50]]);
+        $this->assertEquals(30, $c->min(function ($i) { return $i->foo; }));
+    }
 
-	public function testCanMinValuesWithoutACallback()
-	{
-		$c = new Collection([1, 2, 3, 4, 5]);
-		$this->assertEquals(1, $c->min());
-	}
+    public function testCanMinValuesWithoutACallback()
+    {
+        $c = new Collection([1, 2, 3, 4, 5]);
+        $this->assertEquals(1, $c->min());
+    }
 
-	public function testGettingMinFromEmptyCollection()
-	{
-		$c = new Collection();
-		$this->assertEquals(0, $c->min('foo'));
-		$this->assertEquals(0, $c->min());
-	}
+    public function testGettingMinFromEmptyCollection()
+    {
+        $c = new Collection();
+        $this->assertEquals(0, $c->min('foo'));
+        $this->assertEquals(0, $c->min());
+    }
 
     public function testValueRetrieverAcceptsDotNotation()
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -636,7 +636,52 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     {
         $c = new Collection();
         $this->assertEquals(0, $c->sum('foo'));
+	    $this->assertEquals(0, $c->sum());
     }
+
+	public function testGettingMaxFromCollection()
+	{
+		$c = new Collection([(object) ['foo' => 50], (object) ['foo' => 30]]);
+		$this->assertEquals(50, $c->max('foo'));
+
+		$c = new Collection([(object) ['foo' => 30], (object) ['foo' => 50]]);
+		$this->assertEquals(50, $c->max(function ($i) { return $i->foo; }));
+	}
+
+	public function testCanMaxValuesWithoutACallback()
+	{
+		$c = new Collection([1, 2, 3, 4, 5]);
+		$this->assertEquals(5, $c->max());
+	}
+
+	public function testGettingMaxFromEmptyCollection()
+	{
+		$c = new Collection();
+		$this->assertEquals(0, $c->max('foo'));
+		$this->assertEquals(0, $c->max());
+	}
+
+	public function testGettingMinFromCollection()
+	{
+		$c = new Collection([(object) ['foo' => 50], (object) ['foo' => 30]]);
+		$this->assertEquals(30, $c->min('foo'));
+
+		$c = new Collection([(object) ['foo' => 30], (object) ['foo' => 50]]);
+		$this->assertEquals(30, $c->min(function ($i) { return $i->foo; }));
+	}
+
+	public function testCanMinValuesWithoutACallback()
+	{
+		$c = new Collection([1, 2, 3, 4, 5]);
+		$this->assertEquals(1, $c->min());
+	}
+
+	public function testGettingMinFromEmptyCollection()
+	{
+		$c = new Collection();
+		$this->assertEquals(0, $c->min('foo'));
+		$this->assertEquals(0, $c->min());
+	}
 
     public function testValueRetrieverAcceptsDotNotation()
     {
@@ -747,36 +792,6 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([1, 4, 7], $c[0]->all());
         $this->assertEquals([2, 5, null], $c[1]->all());
         $this->assertEquals([3, 6, null], $c[2]->all());
-    }
-
-    public function testGettingMaxItemsFromCollection()
-    {
-        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
-        $this->assertEquals(20, $c->max('foo'));
-
-        $c = new Collection([['foo' => 10], ['foo' => 20]]);
-        $this->assertEquals(20, $c->max('foo'));
-
-        $c = new Collection([1, 2, 3, 4, 5]);
-        $this->assertEquals(5, $c->max());
-
-        $c = new Collection();
-        $this->assertNull($c->max());
-    }
-
-    public function testGettingMinItemsFromCollection()
-    {
-        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
-        $this->assertEquals(10, $c->min('foo'));
-
-        $c = new Collection([['foo' => 10], ['foo' => 20]]);
-        $this->assertEquals(10, $c->min('foo'));
-
-        $c = new Collection([1, 2, 3, 4, 5]);
-        $this->assertEquals(1, $c->min());
-
-        $c = new Collection();
-        $this->assertNull($c->min());
     }
 }
 


### PR DESCRIPTION
The sum method on Collections allow the developer to pass a nothing, string and callable. This allow the developer to be more flexible to calculate the sum.

The max and min method's only allowed a key and the implementation was not the same as the sum method. I have implemented the sum method in the same way as the min and max methods.

Also changed the tests to reflect more closely to the sum methods.

Note: min and max in php will throw a warning on empty collection where array_sum doesn't. So extra check was required on the length of the array.
