### PR TITLE
[5.1] In order to use subdomains, changes the 'localhost' for the localhost ip '127.0.0.1' in the ServeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -49,7 +49,7 @@ class ServeCommand extends Command
     protected function getOptions()
     {
         return [
-            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', 'localhost'],
+            ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', '127.0.0.1'],
 
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', 8000],
         ];


### PR DESCRIPTION
Because the `php artisan serve` command has the host hardcoded as `localhost`, we cannot get the app to load when going to `http://127.0.0.1:8000`, even though `localhost` points to `127.0.0.1`. 

If instead when running the command we specify the host as `127.0.0.1` (`php artisan serve --host 127.0.0.1`) we can access the app both from `http://localhost:8000` as well as `http://127.0.0.1:8000`.

Specifying the host as `127.0.0.1` also comes handy when working with subdomains locally and trying to use services such as `lvh.me` that directly point to `127.0.0.1`. 

With this small change, then by running `php artisan serve` we access and catch subdomains with ease. Example:

When going to: `http://client-name.lvh.me:8000/`

We can catch the subdomain just doing this:

```
Route::group(['domain' => '{subdomain}.lvh.me'], function(){

    Route::get('/', function($subdomain){
        dd($subdomain); // "client-name"
    }); 

});
```
