### PR TITLE
[5.1] Prevent creation of new Collection

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -394,6 +394,9 @@ class Arr
      */
     public static function sort($array, callable $callback)
     {
+        if($array instanceof Collection)
+            return $array->sortBy($callback)->all();
+
         return Collection::make($array)->sortBy($callback)->all();
     }
 


### PR DESCRIPTION
If `Arr::sort` is used in generic methods which both have to deal with arrays and Collections it can happen that a Collection is passed into `Arr::sort`. This works perfectly but a new Collection will be created while it's not needed.
