### PR TITLE
[5.1] Updated wording on CheckForMaintenanceMode middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
@@ -16,7 +16,7 @@ class CheckForMaintenanceMode
     protected $app;
 
     /**
-     * Create a new filter instance.
+     * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void


### PR DESCRIPTION
Updated wording on CheckForMaintenanceMode middleware - the docblock used 'filter' where these have been replaced with 'middleware' now.
