### PR TITLE
[5.1] Add composite index to jobs migration

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -21,6 +21,7 @@ class CreateJobsTable extends Migration
             $table->unsignedInteger('reserved_at')->nullable();
             $table->unsignedInteger('available_at');
             $table->unsignedInteger('created_at');
+            $table->index(['queue', 'reserved', 'reserved_at']);
         });
     }
 


### PR DESCRIPTION
With a large number of jobs _(I tested with ~125K)_, a queue worker's `update` query to mark a job as 'reserved' causes CPU usage to spike and execution time to drag out. Indexing the columns used fixes this.
