### PR TITLE
[5.1] Ability to specify a custom artisan binary path

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -138,7 +138,7 @@ class Event
      */
     protected function runCommandInBackground()
     {
-        chdir(base_path());
+        chdir(bin_path());
 
         exec($this->buildCommand());
     }
@@ -154,7 +154,7 @@ class Event
         $this->callBeforeCallbacks($container);
 
         (new Process(
-            trim($this->buildCommand(), '& '), base_path(), null, null, null
+            trim($this->buildCommand(), '& '), bin_path(), null, null, null
         ))->run();
 
         $this->callAfterCallbacks($container);

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -36,7 +36,9 @@ class Schedule
      */
     public function command($command, array $parameters = [])
     {
-        return $this->exec(PHP_BINARY.' artisan '.$command, $parameters);
+        $artisan = (defined('ARTISAN_BINARY')) ? ARTISAN_BINARY : 'artisan';
+
+        return $this->exec(PHP_BINARY.' '.$artisan.' '.$command, $parameters);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -126,6 +126,13 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected $environmentFile = '.env';
 
     /**
+     * The custom path to the artisan binary defined by the developer.
+     *
+     * @var string
+     */
+    protected $binPath;
+
+    /**
      * The application namespace.
      *
      * @var string
@@ -472,6 +479,29 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $args = isset($_SERVER['argv']) ? $_SERVER['argv'] : null;
 
         return $this['env'] = (new EnvironmentDetector())->detect($callback, $args);
+    }
+
+    /**
+     * Get the path to the directory containing the artisan binary.
+     *
+     * @return string
+     */
+    public function binPath()
+    {
+        return $this->binPath ?: $this->basePath;
+    }
+
+    /**
+     * Set the directory for the artisan binary.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function useBinPath($path)
+    {
+        $this->binPath = $path;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -106,6 +106,19 @@ if (!function_exists('base_path')) {
     }
 }
 
+if (!function_exists('bin_path')) {
+    /**
+     * Get the path to the directory containing the artisan binary.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function bin_path($path = '')
+    {
+        return app()->binPath().($path ? DIRECTORY_SEPARATOR.$path : $path);
+    }
+}
+
 if (!function_exists('back')) {
     /**
      * Create a new redirect response to the previous location.


### PR DESCRIPTION
This PR lets us set a custom location for the `artisan` file and falls back to the base path.

It also lets you use a different filename for artisan obviously falling back to `artisan`.

The use case: our app requires moving the Laravel directory. The artisan file might not be where Laravel currently assumes it will be.

The only place I ran into the need for this so far is in `Event.php`, when running scheduled commands. It may need to be adjusted elsewhere, I'm not sure.
