### PR TITLE
[5.1] Fix failing unit test for BladeCompiler

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -147,7 +147,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         // add them here at the end of the template. This gets used mainly for the
         // template inheritance via the extends keyword that should be appended.
         if (count($this->footer) > 0) {
-            $result = ltrim($result, PHP_EOL)
+            $result = ltrim($result)
                     .PHP_EOL.implode(PHP_EOL, array_reverse($this->footer));
         }
 


### PR DESCRIPTION
The unit tests are failing for me on php 5.6.10:

```
There were 2 failures:

1) ViewBladeCompilerTest::testExtendsAreCompiled
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'test
+'
+test
 <?php echo $__env->make('foo', array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>'

/home/vagrant/laravel-framework/tests/View/ViewBladeCompilerTest.php:191
/home/vagrant/.composer/vendor/phpunit/phpunit/src/TextUI/Command.php:147
/home/vagrant/.composer/vendor/phpunit/phpunit/src/TextUI/Command.php:99

2) ViewBladeCompilerTest::testSequentialCompileStringCalls
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'test
+'
+test
 <?php echo $__env->make('foo', array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>'

/home/vagrant/laravel-framework/tests/View/ViewBladeCompilerTest.php:600
/home/vagrant/.composer/vendor/phpunit/phpunit/src/TextUI/Command.php:147
/home/vagrant/.composer/vendor/phpunit/phpunit/src/TextUI/Command.php:99

FAILURES!
Tests: 1527, Assertions: 3388, Failures: 2.
```

It's an issue in the BladeCompiler. The problem is a new line which is introduced on this line: 

```
$result = ltrim($result, PHP_EOL)
                    .PHP_EOL.implode(PHP_EOL, array_reverse($this->footer));
```

The `ltrim()` isn't doing it's job. The easiest way is to skip the `PHP_EOL`. It doesn't matter because `ltrim` without  params will trim blank lines. Furthermore removing tabs etc is welcome in this situation.
