### PR TITLE
[5.1] Call message builder after the message content has been added

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -172,12 +172,12 @@ class Mailer implements MailerContract, MailQueueContract
 
         $data['message'] = $message = $this->createMessage();
 
-        $this->callMessageBuilder($callback, $message);
-
         // Once we have retrieved the view content for the e-mail we will set the body
         // of this message using the HTML type, which will provide a simple wrapper
         // to creating view based emails that are able to receive arrays of data.
         $this->addContent($message, $view, $plain, $raw, $data);
+
+        $this->callMessageBuilder($callback, $message);
 
         if (isset($this->to['address'])) {
             $message->to($this->to['address'], $this->to['name'], true);


### PR DESCRIPTION
This allows the user to carry out additional operation on the message
like setting the content type of the email (and also the encoding perhaps) which otherwise would have been
overridden by addContent. An example would be something like this:

```
\Mail::send('example', array(), function($message) use($icalendar)
{
    $message->from('from@email.com', 'Name Here');
    $message->to('to@email.com')->subject('Test Calendar Event');

    $encoder = \Swift_Encoding::get7BitEncoding();
    $message->setEncoder($encoder);

    $message->addPart($icalendar, 'text/calendar; method=REQUEST', 'iso-8859-1');
});
```

which would otherwise have been replace by default content-type which in our case would be `text/plain`, because of this function in the same file:

```
/**
 * Add the content to a given message.
 *
 * @param  \Illuminate\Mail\Message  $message
 * @param  string  $view
 * @param  string  $plain
 * @param  string  $raw
 * @param  array   $data
 * @return void
 */
protected function addContent($message, $view, $plain, $raw, $data)
{
    if (isset($view))
    {
        $message->setBody($this->getView($view, $data), 'text/html');
    }

    if (isset($plain))
    {
        $message->addPart($this->getView($plain, $data), 'text/plain');
    }

    if (isset($raw))
    {
        $message->addPart($raw, 'text/plain');
    }
}
```
