### PR TITLE
[5.1] Make migration path

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -98,6 +98,20 @@ class MigrateMakeCommand extends BaseCommand
     }
 
     /**
+     * Get migration path (either specified by '--path' option or default location).
+     *
+     * @return string
+     */
+    protected function getMigrationPath()
+    {
+        if (!is_null($targetPath = $this->input->getOption('path'))) {
+            return $this->laravel->basePath() . '/' . $targetPath;
+        }
+
+        return parent::getMigrationPath();
+    }
+
+    /**
      * Get the console command arguments.
      *
      * @return array
@@ -120,6 +134,8 @@ class MigrateMakeCommand extends BaseCommand
             ['create', null, InputOption::VALUE_OPTIONAL, 'The table to be created.'],
 
             ['table', null, InputOption::VALUE_OPTIONAL, 'The table to migrate.'],
+
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to create the migration file in.'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -3,18 +3,19 @@
 namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Foundation\Composer;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use Illuminate\Database\Migrations\MigrationCreator;
 
 class MigrateMakeCommand extends BaseCommand
 {
     /**
-     * The console command name.
+     * The console command signature.
      *
      * @var string
      */
-    protected $name = 'make:migration';
+    protected $signature = 'make:migration {name : The name of the migration.}
+        {--create= : The table to be created.}
+        {--table= : The table to migrate.}
+        {--path= : The path to create the migration file in.}';
 
     /**
      * The console command description.
@@ -111,31 +112,4 @@ class MigrateMakeCommand extends BaseCommand
         return parent::getMigrationPath();
     }
 
-    /**
-     * Get the console command arguments.
-     *
-     * @return array
-     */
-    protected function getArguments()
-    {
-        return [
-            ['name', InputArgument::REQUIRED, 'The name of the migration'],
-        ];
-    }
-
-    /**
-     * Get the console command options.
-     *
-     * @return array
-     */
-    protected function getOptions()
-    {
-        return [
-            ['create', null, InputOption::VALUE_OPTIONAL, 'The table to be created.'],
-
-            ['table', null, InputOption::VALUE_OPTIONAL, 'The table to migrate.'],
-
-            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to create the migration file in.'],
-        ];
-    }
 }

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -56,6 +56,20 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
     }
 
+    public function testCanSpecifyPathToCreateMigrationsIn()
+    {
+         $command = new MigrateMakeCommand(
+            $creator = m::mock('Illuminate\Database\Migrations\MigrationCreator'),
+            m::mock('Illuminate\Foundation\Composer')->shouldIgnoreMissing(),
+            __DIR__.'/vendor'
+        );
+        $app = new Illuminate\Foundation\Application;
+        $command->setLaravel($app);
+        $app->setBasePath('/home/laravel');
+        $creator->shouldReceive('create')->once()->with('create_foo', '/home/laravel/vendor/laravel-package/migrations', 'users', true);
+        $this->runCommand($command, ['name' => 'create_foo', '--path' => 'vendor/laravel-package/migrations', '--create' => 'users']);
+    }
+
     protected function runCommand($command, $input = [])
     {
         return $command->run(new Symfony\Component\Console\Input\ArrayInput($input), new Symfony\Component\Console\Output\NullOutput);


### PR DESCRIPTION
Following on from the `migrate` command where you can specify a path where migrations are RUN, this will allow you to specify a custom path where migrations are CREATED (useful for creating migrations for vendor packages). It operates in the same way. Also updated to new signature format.
