### PR TITLE
Catch exceptions that might be thrown in the resolved class constructor

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue\Jobs;
 
 use DateTime;
+use Exception;
 use Illuminate\Support\Str;
 
 abstract class Job
@@ -200,10 +201,14 @@ abstract class Job
 
         list($class, $method) = $this->parseJob($payload['job']);
 
-        $this->instance = $this->resolve($class);
+        try {
+            $this->instance = $this->resolve($class);
 
-        if (method_exists($this->instance, 'failed')) {
-            $this->instance->failed($this->resolveQueueableEntities($payload['data']));
+            if (method_exists($this->instance, 'failed')) {
+                $this->instance->failed($this->resolveQueueableEntities($payload['data']));
+            }
+        } catch (Exception $e) {
+            //
         }
     }
 


### PR DESCRIPTION
Catch an uncaught Exception that may be thrown in the class instantiation.
See https://github.com/laravel/framework/issues/9473 for more details.
