### PR TITLE
[5.1] Force one null default value when the tag is not set

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -54,7 +54,10 @@ class VendorPublishCommand extends Command
      */
     public function fire()
     {
-        foreach ($this->option('tag') as $tag) {
+        $tags = $this->option('tag');
+        $tags = $tags ?: [null];
+
+        foreach ($tags as $tag) {
             $this->publishTag($tag);
         }
     }


### PR DESCRIPTION
In the case no `tag` array option is not provided, we mimic the expected default value of a tag: `null`.
At the moment `\Illuminate\Console\Parser::parseOption` does not provide a way to set a default value when the option is of the type `InputOption::VALUE_IS_ARRAY`.

Fix #9469
