### PR TITLE
[5.1] Allow a string to be passed into the Model::all() method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -643,6 +643,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public static function all($columns = ['*'])
     {
+        $columns = is_array($columns) ? $columns : func_get_args();
+
         $instance = new static;
 
         return $instance->newQuery()->get($columns);


### PR DESCRIPTION
I'm not sure if this is something that would be wanted throughout the database code or not. At the moment you can do something like `User::select('id')` or `User::select('id', 'name')` and they automatically be converted into an array (https://github.com/laravel/framework/blob/5.1/src/Illuminate/Database/Query/Builder.php#L217) however, doing something like `User::all('id')` won't work and will throw an `ErrorException` from `Illuminate\Database\Grammar::columnize()`.

This change just alters the `all()` call so that it works like select. This could be added to a number of other calls (`first`, `get`, `getFresh` and possibly others).
