### PR TITLE
[5.1] Console Parser

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -24,48 +24,42 @@ class Parser
         preg_match('/[^\s]+/', $expression, $matches);
 
         if (isset($matches[0])) {
-            $name = trim($matches[0]);
+            $name = $matches[0];
         } else {
             throw new InvalidArgumentException('Unable to determine command name from signature.');
         }
 
-        preg_match_all('/\{.*?\}/', $expression, $matches);
+        preg_match_all('/\{\s*(.*?)\s*\}/', $expression, $matches);
 
-        $tokens = isset($matches[0]) ? $matches[0] : [];
+        $tokens = isset($matches[1]) ? $matches[1] : [];
 
-        return [
-            $name, static::arguments($tokens), static::options($tokens),
-        ];
+        if (count($tokens)) {
+            return array_merge([$name], static::parameters($tokens));
+        }
+
+        return [$name, [], []];
     }
 
     /**
-     * Extract all of the arguments from the tokens.
+     * Extract all of the parameters from the tokens.
      *
      * @param  array  $tokens
      * @return array
      */
-    protected static function arguments(array $tokens)
+    protected static function parameters(array $tokens)
     {
-        return array_values(array_filter(array_map(function ($token) {
-            if (Str::startsWith($token, '{') && !Str::startsWith($token, '{--')) {
-                return static::parseArgument(trim($token, '{}'));
-            }
-        }, $tokens)));
-    }
+        $arguments = [];
+        $options = [];
 
-    /**
-     * Extract all of the options from the tokens.
-     *
-     * @param  array  $tokens
-     * @return array
-     */
-    protected static function options(array $tokens)
-    {
-        return array_values(array_filter(array_map(function ($token) {
-            if (Str::startsWith($token, '{--')) {
-                return static::parseOption(ltrim(trim($token, '{}'), '-'));
+        foreach ($tokens as $token) {
+            if (!Str::startsWith($token, '--')) {
+                $arguments[] = static::parseArgument($token);
+            } else {
+                $options [] = static::parseOption(ltrim($token, '-'));
             }
-        }, $tokens)));
+        }
+
+        return [$arguments, $options];
     }
 
     /**


### PR DESCRIPTION
- When no tokens are found, no need to process them
- No need to loop twice the `$tokens` array, we can do that only once
- No need to trim `$name` as the spaces are not matched in the regular expression
- Update `$tokens` regular expression to avoid including the curly brackets and the spaces so that it's useless to trim them
- No need to filter/`array_filter` the return parameters (arguments/options) as `parseArgument` and `parseOption` cannot return an empty value
