### PR TITLE
[5.1] Check if the primary key is overwritten, regardless of the value of "$incrementing"

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1546,12 +1546,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $this->updateTimestamps();
         }
 
-        // If the model has an incrementing key, we can use the "insertGetId" method on
+        // If the model's primary key is not set manually, we can use the "insertGetId" method on
         // the query builder, which will give us back the final inserted ID for this
         // table from the database. Not all tables have to be incrementing though.
         $attributes = $this->attributes;
 
-        if ($this->incrementing) {
+        if ($this->hasAutoIncrementingKey()) {
             $this->insertAndSetId($query, $attributes);
         }
 
@@ -1570,6 +1570,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->fireModelEvent('created', false);
 
         return true;
+    }
+
+    /**
+     * Determines if the developer has manually set the primary key on the model.
+     *
+     * @return bool
+     */
+    protected function hasAutoIncrementingKey()
+    {
+        return $this->incrementing && ! isset($this->attributes[$this->getKeyName()]);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1181,6 +1181,18 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertNull($array['eighth']);
     }
 
+    public function testPrimaryKeyNotOverwrittenIfManuallySet()
+    {
+        $model = new EloquentTestPrimaryKeyPreserveStub();
+
+        $tempId = 99999999; // ID that is not used elsewhere, and is not PDO's next insert ID
+
+        $model->id = $tempId;
+        $model->save();
+
+        $this->assertEquals($model->id, $tempId);
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
@@ -1275,6 +1287,17 @@ class EloquentModelSaveStub extends Model
     public function setIncrementing($value)
     {
         $this->incrementing = $value;
+    }
+}
+
+class EloquentTestPrimaryKeyPreserveStub extends EloquentModelSaveStub
+{
+    protected $primaryKey = 'id';
+    public $incrementing = true;
+
+    public function setIncrementing($value)
+    {
+        $this->incrementing = true;
     }
 }
 


### PR DESCRIPTION
Basically I had this problem, where I have a freshly created User, whos primary key is overwritten. If I wanted to log this user in, the last inserted ID that PDO gave me was not the ID that matches the user. This commit makes it so that the model checks if the primary key is set, before overwriting the primary key with what PDO thinks is the primary key.
