### PR TITLE
[5.1] Add the possibility to set an option shortcut

### DIFF
--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -117,18 +117,25 @@ class Parser
             $description = trim($description);
         }
 
+        $shortcut = null;
+        $matches = preg_split('/\s*\|\s*/', $token, 2);
+        if (isset($matches[1])) {
+            $shortcut = $matches[0];
+            $token = $matches[1];
+        }
+
         switch (true) {
             case Str::endsWith($token, '='):
-                return new InputOption(trim($token, '='), null, InputOption::VALUE_OPTIONAL, $description);
+                return new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description);
 
             case Str::endsWith($token, '=*'):
-                return new InputOption(trim($token, '=*'), null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description);
+                return new InputOption(trim($token, '=*'), $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description);
 
             case (preg_match('/(.+)\=(.+)/', $token, $matches)):
-                return new InputOption($matches[1], null, InputOption::VALUE_OPTIONAL, $description, $matches[2]);
+                return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]);
 
             default:
-                return new InputOption($token, null, InputOption::VALUE_NONE, $description);
+                return new InputOption($token, $shortcut, InputOption::VALUE_NONE, $description);
         }
     }
 }

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -62,4 +62,46 @@ class ConsoleParserTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($results[2][0]->acceptValue());
         $this->assertTrue($results[2][0]->isArray());
     }
+
+    public function testShortcutNameParsing()
+    {
+        $results = Parser::parse('command:name {--o|option}');
+
+        $this->assertEquals('o', $results[2][0]->getShortcut());
+        $this->assertEquals('option', $results[2][0]->getName());
+        $this->assertFalse($results[2][0]->acceptValue());
+
+        $results = Parser::parse('command:name {--o|option=}');
+
+        $this->assertEquals('o', $results[2][0]->getShortcut());
+        $this->assertEquals('option', $results[2][0]->getName());
+        $this->assertTrue($results[2][0]->acceptValue());
+
+        $results = Parser::parse('command:name {--o|option=*}');
+
+        $this->assertEquals('command:name', $results[0]);
+        $this->assertEquals('o', $results[2][0]->getShortcut());
+        $this->assertEquals('option', $results[2][0]->getName());
+        $this->assertTrue($results[2][0]->acceptValue());
+        $this->assertTrue($results[2][0]->isArray());
+
+        $results = Parser::parse('command:name {--o|option=* : The option description.}');
+
+        $this->assertEquals('command:name', $results[0]);
+        $this->assertEquals('o', $results[2][0]->getShortcut());
+        $this->assertEquals('option', $results[2][0]->getName());
+        $this->assertEquals('The option description.', $results[2][0]->getDescription());
+        $this->assertTrue($results[2][0]->acceptValue());
+        $this->assertTrue($results[2][0]->isArray());
+
+        $results = Parser::parse('command:name
+            {--o|option=* : The option description.}');
+
+        $this->assertEquals('command:name', $results[0]);
+        $this->assertEquals('o', $results[2][0]->getShortcut());
+        $this->assertEquals('option', $results[2][0]->getName());
+        $this->assertEquals('The option description.', $results[2][0]->getDescription());
+        $this->assertTrue($results[2][0]->acceptValue());
+        $this->assertTrue($results[2][0]->isArray());
+    }
 }


### PR DESCRIPTION
Update `\Illuminate\Console\Parser::parseOption` to provide the possibility to get options shortcut.
Proposed syntax is `--o|option(...)` with a pipe `|` as separator.
