### PR TITLE
[5.1] Add $alias to `morphTo` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -806,9 +806,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $name
      * @param  string  $type
      * @param  string  $id
+     * @param  array   $alias
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function morphTo($name = null, $type = null, $id = null)
+    public function morphTo($name = null, $type = null, $id = null, $alias = [])
     {
         // If no name is provided, we will use the backtrace to get the function name
         // since that is most likely the name of the polymorphic interface. We can
@@ -834,7 +835,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // as a belongs-to style relationship since morph-to extends that class and
         // we will pass in the appropriate values so that it behaves as expected.
         else {
-            $instance = new $class;
+            $instance = isset($alias[$class]) ? new $alias[$class] : new $class;
 
             return new MorphTo(
                 $instance->newQuery(), $this, $id, $instance->getKeyName(), $type, $name


### PR DESCRIPTION
This is to deal with Models that have custom `$morphClass`.

**Background:**
I've encountered the same problem with this: https://github.com/laravel/framework/issues/7347#issuecomment-73520940

I'm using one to many polymorphic and utilize the custom `$morphClass`. The problem is I can't query the morphed Models.

To describe the problem using example:

The models:

``` php
class Photo extends Model
{
    public function imageable()
    {
        return $this->morphTo();
    }
}

class Admin extends Model
{
    protected $morphClass = 'admin';

    public function photos()
    {
        return $this->morphMany('App\Photo', 'imageable');
    }
}
```

And in the database:

Table admins

| id | name |
| --- | --- |
| 1 | Administrator |

Table photos

| id | url | imageable_type | imageable_id |
| --- | --- | --- | --- |
| 1 | http://example.com/image.jpeg | admin | 1 |

When I'm querying `photos` from `Admin`, it's working fine:

``` php
$admin = \App\Admin::find(1);
var_dump($admin->photos); // dump the Photo object
```

But when I'm querying the inverse, it's broken:

``` php
$photo = \App\Photo::find(1);
var_dump($photo->imageable); // throws exception: Class 'admin' not found
```

That's because in `src/Illuminate/Database/Eloquent/Model.php` line 837, the `morphTo` method will initiate whatever value stored in the `imageable_type` column. If the value is the valid class name, it'll work, but since the value is a custom `$morphClass` it will throw the exception.

And since there's no way to lookup a Model's class name from its `$morphClass` value, and using the `AliasLoader` seems like an overkill, I propose to add another parameter to the `morphTo` method. The parameter is simply an array mapping the `$morphClass` to the model's name.

So the `Photo` model will be look like this:

``` php
class Photo extends Model
{
    public function imageable()
    {
        $alias = [
            'admin' => \App\Admin::class
        ];
        return $this->morphTo('imageable', 'imageable_type', 'imageable_id', $alias);
    }
}
```

This way when we're trying to look up the imageable value from a `Photo` it will initiate the correct `Admin` class name
