### PR TITLE
[5.1] Add support for localization in ThrottlesLogins

### DIFF
--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -59,11 +59,11 @@ trait ThrottlesLogins
     protected function sendLockoutResponse(Request $request)
     {
         $seconds = (int) Cache::get($this->getLoginLockExpirationKey($request)) - time();
-
+        $key = 'passwords.throttle';
         return redirect($this->loginPath())
             ->withInput($request->only($this->loginUsername(), 'remember'))
             ->withErrors([
-                $this->loginUsername() => 'Too many login attempts. Please try again in '.$seconds.' seconds.',
+                $this->loginUsername() => trans()->has($key) ? trans($key, ['seconds' => $seconds]) : 'Too many login attempts. Please try again in '.$seconds.' seconds.',
             ]);
     }
 


### PR DESCRIPTION
Just suggestion, and it assumes we use the existing passwords.php file in resources/lang/en

Usage in laravel/laravel -> resources/lang/en/passwords.php (just like validation messages)

``` php
[
    "throttle" => "Too many login attempts. Please try again in :seconds seconds.",
];
```

Here is the PR for [laravel/laravel for lang](https://github.com/laravel/laravel/pull/3444)

Thank you.
