### PR TITLE
Log Cc and Bcc addresses when pretending to mail

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -393,7 +393,13 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function logMessage($message)
     {
-        $emails = implode(', ', array_keys((array) $message->getTo()));
+        $recipients = array_merge(
+            (array) $message->getTo(),
+            (array) $message->getCc(),
+            (array) $message->getBcc()
+        );
+
+        $emails = implode(', ', array_keys($recipients));
 
         $this->logger->info("Pretending to mail message to: {$emails}");
     }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -131,10 +131,36 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         $message->shouldReceive('setFrom')->never();
         $this->setSwiftMailer($mailer);
         $message->shouldReceive('getTo')->once()->andReturn(['taylor@userscape.com' => 'Taylor']);
+        $message->shouldReceive('getCc')->once()->andReturn([]);
+        $message->shouldReceive('getBcc')->once()->andReturn([]);
         $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
         $mailer->getSwiftMailer()->shouldReceive('send')->never();
         $logger = m::mock('Psr\Log\LoggerInterface');
         $logger->shouldReceive('info')->once()->with('Pretending to mail message to: taylor@userscape.com');
+        $mailer->setLogger($logger);
+        $mailer->pretend();
+
+        $mailer->send('foo', ['data'], function ($m) {});
+    }
+
+    public function testMessageRecordsCcAndBccAddressesWhenLogged()
+    {
+        $mailer = $this->getMock('Illuminate\Mail\Mailer', ['createMessage'], $this->getMocks());
+        $message = m::mock('Swift_Mime_Message');
+        $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
+        $view = m::mock('StdClass');
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
+        $view->shouldReceive('render')->once()->andReturn('rendered.view');
+        $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
+        $message->shouldReceive('setFrom')->never();
+        $this->setSwiftMailer($mailer);
+        $message->shouldReceive('getTo')->once()->andReturn(['taylor@userscape.com' => 'Taylor']);
+        $message->shouldReceive('getCc')->once()->andReturn(['foo@bar.com' => 'Baz']);
+        $message->shouldReceive('getBcc')->once()->andReturn(['baz@foo.com' => 'Bar']);
+        $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
+        $mailer->getSwiftMailer()->shouldReceive('send')->never();
+        $logger = m::mock('Psr\Log\LoggerInterface');
+        $logger->shouldReceive('info')->once()->with('Pretending to mail message to: taylor@userscape.com, foo@bar.com, baz@foo.com');
         $mailer->setLogger($logger);
         $mailer->pretend();
 


### PR DESCRIPTION
Log Cc and Bcc addresses when pretending to mail.

'Pretending' to send mail messages now accurately logs the actual behaviour of a sent message.

Use case: Where the behaviour of emails is examined through logging and
where one is interested in the Cc and Bcc recipients.
