### PR TITLE
[5.1] Increase auth throttling from 3 fails to 5.

### DIFF
--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -17,7 +17,7 @@ trait ThrottlesLogins
     {
         $attempts = $this->getLoginAttempts($request);
 
-        if ($attempts > 3) {
+        if ($attempts > 5) {
             Cache::add($this->getLoginLockExpirationKey($request), time() + 60, 1);
 
             return true;


### PR DESCRIPTION
I've typed in a wrong password 3 times before, often because of my stupid fingers and/or phone keyboard.  It would be annoying to see lockout message after only 3 failed attempted.  Increasing to 5 would be a bit more lenient on user, but shouldn't affect security.  If a password is really safe, it should take thousands of thousands of attempts, so increasing to 5 fails per minute shouldn't matter.

TL;DR: Punish the malicious bot, not the real user.
