### PR TITLE
[5.1] Add support for localization in AuthenticatesUsers

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -81,7 +81,7 @@ trait AuthenticatesUsers
      */
     protected function getFailedLoginMessage()
     {
-        return 'These credentials do not match our records.';
+        return trans()->has('passwords.failed') ? trans('passwords.failed') : 'These credentials do not match our records.';
     }
 
     /**


### PR DESCRIPTION
Just suggestion, add lang support for failed login message, just like in ResetsPasswords, ThrottlesLogins traits.
With this, all the built-in Auth error messages will fully support localization.
