### PR TITLE
[5.1] Import Diactoros response class

### DIFF
--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Zend\Diactoros\Response as PsrResponse;
 
 class RoutingServiceProvider extends ServiceProvider
 {
@@ -130,7 +131,7 @@ class RoutingServiceProvider extends ServiceProvider
     protected function registerPsrResponse()
     {
         $this->app->bind('Psr\Http\Message\ResponseInterface', function ($app) {
-            return new Zend\Diactoros\Response();
+            return new PsrResponse();
         });
     }
 


### PR DESCRIPTION
An `ErrorException` is raised when requesting the `Psr\Http\Message\ResponseInterface` abstract instance from the Laravel container. The class is not found because it is not imported into the file scope. Add a `use` statement to import the class into this file.
