### PR TITLE
[5.1] Return the result of pushing a job onto a queue in the dispatcher.

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -240,9 +240,9 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
         }
 
         if (method_exists($command, 'queue')) {
-            $command->queue($queue, $command);
+            return $command->queue($queue, $command);
         } else {
-            $this->pushCommandToQueue($queue, $command);
+            return $this->pushCommandToQueue($queue, $command);
         }
     }
 
@@ -267,7 +267,7 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
             return $queue->later($command->delay, $command);
         }
 
-        $queue->push($command);
+        return $queue->push($command);
     }
 
     /**


### PR DESCRIPTION
When dispatching a job onto a queue when using the database driver I wasn't receiving the job id as a return value. This adds the returns to the Dispatcher to return the queue push return value.

**Test**
In a controller:
`$this->dispatch(new Job()) !== null`
