### PR TITLE
[5.1] Return regular collection from eloquent lists and pluck methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -235,4 +235,16 @@ class Collection extends BaseCollection
     {
         return new BaseCollection($this->items);
     }
+
+    /**
+     * Get an array with the values of a given key.
+     *
+     * @param  string  $value
+     * @param  string  $key
+     * @return static
+     */
+    public function pluck($value, $key = null)
+    {
+        return collect(Arr::pluck($this->items, $value, $key));
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -239,8 +239,8 @@ class Collection extends BaseCollection
     /**
      * Get an array with the values of a given key.
      *
-     * @param  string  $value
-     * @param  string  $key
+     * @param  string       $value
+     * @param  string|null  $key
      * @return static
      */
     public function pluck($value, $key = null)

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -221,4 +221,11 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(new Collection([$one, $three]), $c->except(2));
         $this->assertEquals(new Collection([$one]), $c->except([2, 3]));
     }
+
+    public function testPluckReturnsBaseCollection()
+    {
+        $c = new Collection([(object) ['foo' => 'bar'], (object) ['foo' => 'baz']]);
+
+        $this->assertEquals( collect(['bar', 'baz']), $c->pluck('foo') );
+    }
 }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -226,6 +226,6 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
     {
         $c = new Collection([(object) ['foo' => 'bar'], (object) ['foo' => 'baz']]);
 
-        $this->assertEquals( collect(['bar', 'baz']), $c->pluck('foo') );
+        $this->assertEquals(collect(['bar', 'baz']), $c->pluck('foo'));
     }
 }


### PR DESCRIPTION
This matches the eloquent builder's lists method, and makes sense, as the returned values are unlikely to be eloquent models (as described in #9412).
