### PR TITLE
[5.1] Fix eloquent pagination count column

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -267,7 +267,7 @@ class Builder
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page')
     {
-        $total = $this->query->getCountForPagination();
+        $total = $this->query->getCountForPagination($columns);
 
         $this->query->forPage(
             $page = Paginator::resolveCurrentPage($pageName),

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1433,7 +1433,12 @@ class Builder
     {
         $this->backupFieldsForCount();
 
-        $this->aggregate = ['function' => 'count', 'columns' => $columns];
+        $columnToCountBy = reset($columns);
+        if (!$columnToCountBy) {
+            $columnToCountBy = '*';
+        }
+
+        $this->aggregate = ['function' => 'count', 'columns' => [$columnToCountBy]];
 
         $results = $this->get();
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -214,6 +214,36 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['bar', 'baz'], $builder->lists('name')->all());
     }
 
+    public function testPaginatePassesColumnsToGetCountForPaginationMethod()
+    {
+        $totalItems = 100;
+        $itemsPerPage = 50;
+        $page = 1;
+        $database = 'SQLite';
+        $table = 'table';
+        $columns = [$table . '.column'];
+
+        $model = new EloquentBuilderTestNestedStub;
+
+        $this->mockConnectionForModel($model, $database);
+
+        $query = m::mock('Illuminate\Database\Query\Builder');
+        $query->shouldReceive('from')->once()->with($table);
+        $query->shouldReceive('forPage')->once()->with($page, $itemsPerPage)->andReturn($query);
+        $query->shouldReceive('get')->once()->andReturn($columns);
+
+        /**
+         * Add check that paginate method passes $columns param to getCountForPagination method
+         */
+        $query->shouldReceive('getCountForPagination')->once()->with($columns)->andReturn($totalItems);
+
+        $builder = new Builder($query);
+
+        $builder->setModel($model);
+
+        $builder->paginate($itemsPerPage, $columns);
+    }
+
     public function testMacrosAreCalledOnBuilder()
     {
         unset($_SERVER['__test.builder']);

--- a/tests/Database/DatabaseEloquentIntegrationWithPdoExceptionTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithPdoExceptionTest.php
@@ -38,11 +38,15 @@ class DatabaseEloquentIntegrationWithPdoErrModeExceptionTest extends DatabaseElo
     {
         $columns = ['id', 'email'];
 
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
+
         $query = EloquentTestUser::oldest('id')->getQuery();
 
-        $this->setExpectedException('Illuminate\Database\QueryException');
+        $total = $query->getCountForPagination($columns);
 
-        $query->getCountForPagination($columns);
+        $this->assertEquals(3, $total);
     }
 
     public function testEmptyMorphToRelationship()

--- a/tests/Database/DatabaseEloquentIntegrationWithPdoExceptionTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithPdoExceptionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+class DatabaseEloquentIntegrationWithPdoErrModeExceptionTest extends DatabaseEloquentIntegrationTest
+{
+    /**
+     * Bootstrap Eloquent.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        $resolver = new DatabaseIntegrationTestConnectionResolver;
+        $resolver->connection()->getPdo()->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        Eloquent::setConnectionResolver($resolver);
+
+        Eloquent::setEventDispatcher(
+            new Illuminate\Events\Dispatcher
+        );
+    }
+
+    public function testCountForPaginationWithGrouping()
+    {
+        $this->setExpectedException('Illuminate\Database\QueryException');
+
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
+        EloquentTestUser::create(['id' => 4, 'email' => 'foo@gmail.com']);
+
+        $query = EloquentTestUser::groupBy('email')->getQuery();
+
+        $this->assertEquals(3, $query->getCountForPagination());
+    }
+
+    public function testCountForPaginationWithPassingColumns()
+    {
+        $columns = ['id', 'email'];
+
+        $query = EloquentTestUser::oldest('id')->getQuery();
+
+        $this->setExpectedException('Illuminate\Database\QueryException');
+
+        $query->getCountForPagination($columns);
+    }
+
+    public function testEmptyMorphToRelationship()
+    {
+        $this->setExpectedException('Illuminate\Database\QueryException');
+
+        $photo = EloquentTestPhoto::create(['name' => 'Avatar 1']);
+
+        $this->assertNull($photo->imageable);
+    }
+}


### PR DESCRIPTION
Added fix for #9385 along with test to reproduce bug ocured with those changes.

Also added fix as proposed by @zot24 in https://github.com/laravel/framework/pull/9385#issuecomment-118385042.

Inside \Illuminate\Database\Query\Builder::getCountForPagination  method only first column will be used for counting total and if columns have not been passed - default $columns value will be used ['*'].
