### PR TITLE
[5.1] Str::snake now trims whitespace

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -390,6 +390,7 @@ class Str
 
         if (!ctype_lower($value)) {
             $value = strtolower(preg_replace('/(.)(?=[A-Z])/', '$1'.$delimiter, $value));
+            $value = preg_replace('/\s+/', '', $value);
         }
 
         return static::$snakeCache[$key] = $value;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -138,5 +138,7 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));
         $this->assertEquals('laravel_php_framework', Str::snake('LaravelPhpFramework'));
+        $this->assertEquals('laravel_php_framework', Str::snake('Laravel Php Framework'));
+        $this->assertEquals('laravel_php_framework', Str::snake('Laravel    Php      Framework   '));
     }
 }


### PR DESCRIPTION
While using  `Str::snake`, I expected "Hello World" to become `hello_world`, not `hello _world`.
I'm not sure if that's deliberately not the case, but here's a fix.
