### PR TITLE
[5.1] Make sure getRan() returns migrations in proper order

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -47,7 +47,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     public function getRan()
     {
-        return $this->table()->lists('migration');
+        return $this->table()->orderBy('batch', 'asc')->orderBy('migration', 'asc')->lists('migration');
     }
 
     /**

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -17,6 +17,8 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase
         $connectionMock = m::mock('Illuminate\Database\Connection');
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+        $query->shouldReceive('orderBy')->once()->with('batch', 'asc')->andReturn($query);
+        $query->shouldReceive('orderBy')->once()->with('migration', 'asc')->andReturn($query);
         $query->shouldReceive('lists')->once()->with('migration')->andReturn('bar');
 
         $this->assertEquals('bar', $repo->getRan());

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -24,6 +24,28 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $repo->getRan());
     }
 
+    public function testGetRanMigrationsWithBatchInCorrectOrder()
+    {
+        $repo = $this->getRepository();
+        require_once __DIR__.'/OrderByMock.php';
+        $order = new OrderByMock();
+        $expected = [
+            ['batch' => '1', 'migration' => '20100101_user_table'],
+            ['batch' => '1', 'migration' => '20100202_other_table'],
+            ['batch' => '2', 'migration' => '20100102_user_table'],
+            ['batch' => '2', 'migration' => '20100203_user_table'],
+            ['batch' => '3', 'migration' => '20100301_better_table'],
+        ];
+        $order->migrations = $expected;
+        shuffle($order->migrations);
+
+        $connectionMock = m::mock('Illuminate\Database\Connection');
+        $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
+        $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($order);
+
+        $this->assertEquals(array_pluck($expected, 'migration'), $repo->getRan());
+    }
+
     public function testGetLastMigrationsGetsAllMigrationsWithTheLatestBatchNumber()
     {
         $repo = $this->getMock('Illuminate\Database\Migrations\DatabaseMigrationRepository', ['getLastBatchNumber'], [

--- a/tests/Database/OrderByMock.php
+++ b/tests/Database/OrderByMock.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Class OrderByMock
+ *
+ * Class that mimics SQL-like orderBy function
+ */
+class OrderByMock
+{
+    public $migrations = [];
+    private $orderingColumns = [];
+
+    public function orderBy($column, $order)
+    {
+        $this->orderingColumns[] = $column;
+        usort($this->migrations, function ($a, $b) use ($order) {
+            $_a = $_b = '';
+            foreach ($this->orderingColumns as $column) {
+                $_a .= $a[$column];
+                $_b .= $b[$column];
+            }
+
+            if ($order === 'asc') {
+                return strcmp($_a, $_b);
+            } else {
+                return strcmp($_b, $_a);
+            }
+        });
+
+        return $this;
+    }
+
+    public function lists($column)
+    {
+        return array_pluck($this->migrations, $column);
+    }
+}


### PR DESCRIPTION
In the past I've fixed one issue with migrations order ( https://github.com/laravel/framework/pull/8532 ). Now I saw it failing again in 5.1. After investigation I've found out that the fix got reverted because it broke someones migrations. My bad - I did not take batches into account. This PR fixes the problems and keeps batches in order as well.
