### PR TITLE
[5.1] Fixed docblocs also on contract of ViewFactory

### DIFF
--- a/src/Illuminate/Contracts/View/Factory.php
+++ b/src/Illuminate/Contracts/View/Factory.php
@@ -35,9 +35,9 @@ interface Factory
     /**
      * Add a piece of shared data to the environment.
      *
-     * @param  string  $key
+     * @param  array|string  $key
      * @param  mixed  $value
-     * @return void
+     * @return mixed
      */
     public function share($key, $value = null);
 

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -138,7 +138,7 @@ class Factory implements FactoryContract
      * @param  string  $view
      * @param  array   $data
      * @param  array   $mergeData
-     * @return \Illuminate\View\View
+     * @return \Illuminate\Contracts\View\View
      */
     public function make($view, $data = [], $mergeData = [])
     {


### PR DESCRIPTION
As asked: https://github.com/laravel/framework/pull/9525#issuecomment-118628902
Now the docblocks are even for contract and Factory class.
