### PR TITLE
[5.1] Fix transactions rollback

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -507,7 +507,12 @@ class Connection implements ConnectionInterface
             $this->pdo->commit();
         }
 
-        --$this->transactions;
+        if ($this->transactions > 0) {
+            --$this->transactions;
+        }
+        else{
+            $this->transactions = 0;   
+        }
 
         $this->fireConnectionEvent('committed');
     }
@@ -524,7 +529,12 @@ class Connection implements ConnectionInterface
 
             $this->pdo->rollBack();
         } else {
-            --$this->transactions;
+            if ($this->transactions > 0) {
+                --$this->transactions;
+            }
+            else{
+                $this->transactions = 0;   
+            }
         }
 
         $this->fireConnectionEvent('rollingBack');


### PR DESCRIPTION
when combined with more than one transactions , the `$transactions` variable maybe under zero , and it maybe cause the rollback failed. 

such as below:

```
for($i = 0 ; $i < 2 ; $i++){
    DB::transaction(function() use($i){

        ActivityGift::saveData(['name' => 't3+'.$i]);  // save something into model

        DB::transaction(function() use($i){
            ActivityGift::saveData(['name' => 't4+'.$i]);  // save something into model
        });

        DB::rollback();

    });
}
```
