### PR TITLE
Changed controllers wildcards from static {one?}{two?}{three?}... to dynamic by ReflectionAPI

### DIFF
--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -80,7 +80,7 @@ class ControllerInspector
     {
         $verb = $this->getVerb($name = $method->name);
 
-        $uri = $this->addUriWildcards($plain = $this->getPlainUri($name, $prefix));
+        $uri = $this->addUriWildcards($plain = $this->getPlainUri($name, $prefix), $method);
 
         return compact('verb', 'plain', 'uri');
     }
@@ -123,11 +123,16 @@ class ControllerInspector
     /**
      * Add wildcards to the given URI.
      *
-     * @param  string  $uri
+     * @param  string $uri
+     * @param ReflectionMethod $method
      * @return string
      */
-    public function addUriWildcards($uri)
+    public function addUriWildcards($uri, $method)
     {
-        return $uri.'/{one?}/{two?}/{three?}/{four?}/{five?}';
+        $parameters = [];
+        foreach ($method->getParameters() as $parameter) {
+            $parameters[] = $parameter->isOptional() ? "{{$parameter->getName()}?}" : "{{$parameter->getName()}}";
+        }
+        return $uri . '/' . implode('/', $parameters);
     }
 }


### PR DESCRIPTION
Now we can correctly use route model bindings and pattern filters for controllers in **_RouteServiceProvider_**.
When we registered a controller:

``` php
Route::controller('some', 'SomeController');
```

with action:

``` php
public function getAction($foo, $bar, $baz = 'World!')
{
    return 'Hello ' . $baz;
}
```

Laravel will register _/some/action/{one?}/{two?}/{three?}/{four?}/{five?}_ route
Now it will look like **/some/action/{foo}/{bar}/{baz?}**
After we can use:

``` php
public function boot(Router $router)
{
    $router->pattern('foo', '[0-9]+');
    //or
    $router->model('bar', \App\User::class);
    //or
    $router->bind('baz', function ($value) {
            return strtoupper($value);
    });
    parent::boot($router);
}
```
