### PR TITLE
[5.1] Fixes filesystem, mail, and queue AWS drivers' config

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -149,12 +149,12 @@ class FilesystemManager implements FactoryContract
      */
     public function createS3Driver(array $config)
     {
-        $config += [
-            'credentials' => Arr::only($config, ['key', 'secret']),
-            'version'     => 'latest',
-        ];
+        $config += ['version' => 'latest'];
 
-        unset($config['key'], $config['secret']);
+        // Move 'key' and 'secret' under 'credentials', if present.
+        if ($config['key'] && $config['secret']) {
+            $config['credentials'] = Arr::only($config, ['key', 'secret']);
+        }
 
         return $this->adapt(
             new Flysystem(new S3Adapter(new S3Client($config), $config['bucket']))

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Mail;
 
 use Aws\Ses\SesClient;
 use Illuminate\Support\Manager;
+use Illuminate\Support\Arr;
 use GuzzleHttp\Client as HttpClient;
 use Swift_SmtpTransport as SmtpTransport;
 use Swift_MailTransport as MailTransport;
@@ -70,14 +71,13 @@ class TransportManager extends Manager
 
         $config += [
             'version' => 'latest',
-            'service' => 'email',
-            'credentials' => [
-                'key'    => $config['key'],
-                'secret' => $config['secret'],
-            ],
+            'service' => 'email', // Fixes issue with SDK versions < 3.0.2
         ];
 
-        unset($config['key'], $config['secret']);
+        // Move 'key' and 'secret' under 'credentials', if present.
+        if ($config['key'] && $config['secret']) {
+            $config['credentials'] = Arr::only($config, ['key', 'secret']);
+        }
 
         return new SesTransport(new SesClient($config));
     }

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue\Connectors;
 
 use Aws\Sqs\SqsClient;
 use Illuminate\Queue\SqsQueue;
+use Illuminate\Support\Arr;
 
 class SqsConnector implements ConnectorInterface
 {
@@ -15,15 +16,12 @@ class SqsConnector implements ConnectorInterface
      */
     public function connect(array $config)
     {
-        $config += [
-            'version' => 'latest',
-            'credentials' => [
-                'key'    => $config['key'],
-                'secret' => $config['secret'],
-            ],
-        ];
+        $config += ['version' => 'latest'];
 
-        unset($config['key'], $config['secret']);
+        // Move 'key' and 'secret' under 'credentials', if present.
+        if ($config['key'] && $config['secret']) {
+            $config['credentials'] = Arr::only($config, ['key', 'secret']);
+        }
 
         return new SqsQueue(new SqsClient($config), $config['queue']);
     }


### PR DESCRIPTION
Implicitly provided credentials (via environment variables or IAM instance profile credentials) are now read correctly when `key` and `secret` are not explicitly provided. This fixes #9309.
