### PR TITLE
[5.1] Added prefix for index name

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -55,9 +55,9 @@ class Blueprint
     /**
      * Create a new schema blueprint.
      *
-     * @param  string        $table
-     * @param  \Closure|null $callback
-     * @param Connection     $connection
+     * @param  string  $table
+     * @param  \Closure|null  $callback
+     * @param  \Illuminate\Database\Connection  $connection
      */
     public function __construct($table, Closure $callback = null, Connection $connection = null)
     {

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -48,14 +48,20 @@ class Blueprint
     public $collation;
 
     /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
      * Create a new schema blueprint.
      *
      * @param  string  $table
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function __construct($table, Closure $callback = null)
+    public function __construct($table, Connection $connection, Closure $callback = null)
     {
+        $this->connection = $connection;
         $this->table = $table;
 
         if (!is_null($callback)) {
@@ -835,7 +841,8 @@ class Blueprint
      */
     protected function createIndexName($type, array $columns)
     {
-        $index = strtolower($this->table.'_'.implode('_', $columns).'_'.$type);
+        $prefix = $this->connection->getTablePrefix();
+        $index = strtolower($prefix.$this->table.'_'.implode('_', $columns).'_'.$type);
 
         return str_replace(['-', '.'], '_', $index);
     }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -48,18 +48,18 @@ class Blueprint
     public $collation;
 
     /**
-     * @var Connection
+     * @var \Illuminate\Database\Connection
      */
     private $connection;
 
     /**
      * Create a new schema blueprint.
      *
-     * @param  string  $table
-     * @param  \Closure|null  $callback
-     * @return void
+     * @param  string        $table
+     * @param  \Closure|null $callback
+     * @param Connection     $connection
      */
-    public function __construct($table, Connection $connection = null, Closure $callback = null)
+    public function __construct($table, Closure $callback = null, Connection $connection = null)
     {
         $this->connection = $connection;
         $this->table = $table;
@@ -841,7 +841,10 @@ class Blueprint
      */
     protected function createIndexName($type, array $columns)
     {
-        $prefix = $this->connection->getTablePrefix();
+        $prefix = '';
+        if ($this->connection) {
+            $prefix = $this->connection->getTablePrefix();
+        }
         $index = strtolower($prefix.$this->table.'_'.implode('_', $columns).'_'.$type);
 
         return str_replace(['-', '.'], '_', $index);

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -59,7 +59,7 @@ class Blueprint
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function __construct($table, Connection $connection, Closure $callback = null)
+    public function __construct($table, Connection $connection = null, Closure $callback = null)
     {
         $this->connection = $connection;
         $this->table = $table;

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -204,7 +204,7 @@ class Builder
             return call_user_func($this->resolver, $table, $callback);
         }
 
-        return new Blueprint($table, $this->connection, $callback);
+        return new Blueprint($table, $callback, $this->connection);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -204,7 +204,7 @@ class Builder
             return call_user_func($this->resolver, $table, $callback);
         }
 
-        return new Blueprint($table, $callback);
+        return new Blueprint($table, $this->connection, $callback);
     }
 
     /**


### PR DESCRIPTION
When migrating same table have foreign key with different prefix, it
will give error saying
<br>`Index name already exists.`

So, by adding prefix to index name, this problem can be solved.

@GrahamCampbell I hope this setup works. 

Last commit was failing tests, So made a small change in this commit. Probably should pass the tests now. 
