### PR TITLE
'null' cast type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2741,6 +2741,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 return json_decode($value, true);
             case 'collection':
                 return new BaseCollection(json_decode($value, true));
+            case 'null':
+                return $value ?: null;
             default:
                 return $value;
         }
@@ -2773,6 +2775,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         if ($this->isJsonCastable($key)) {
             $value = json_encode($value);
+        }
+        
+        if ($this->getCastType($key) == 'null') {
+            $value = $value ?: null;
         }
 
         $this->attributes[$key] = $value;


### PR DESCRIPTION
Added 'null' cast type to cause any falsy values to be set to null (i.e. instead of 0 in an integer database field).
