### PR TITLE
[5.1] Default scheduler output depending on the OS

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -82,7 +82,7 @@ class Event
      *
      * @var string
      */
-    public $output = null;
+    public $output = '/dev/null';
 
     /**
      * The array of callbacks to be run before the event is started.

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -82,7 +82,7 @@ class Event
      *
      * @var string
      */
-    public $output = '/dev/null';
+    public $output = null;
 
     /**
      * The array of callbacks to be run before the event is started.
@@ -114,6 +114,17 @@ class Event
     public function __construct($command)
     {
         $this->command = $command;
+        $this->output = $this->getDefaultOutput();
+    }
+
+    /**
+     * Get the default output depending on the OS.
+     *
+     * @return string
+     */
+    private function getDefaultOutput()
+    {
+        return (strpos(strtoupper(PHP_OS), 'WIN')===0) ? 'NUL' : '/dev/null';
     }
 
     /**
@@ -641,7 +652,7 @@ class Event
      */
     public function emailOutputTo($addresses)
     {
-        if (is_null($this->output) || $this->output == '/dev/null') {
+        if (is_null($this->output) || $this->output == $this->getDefaultOutput()) {
             throw new LogicException('Must direct output to a file in order to e-mail results.');
         }
 


### PR DESCRIPTION
Allows to run "php artisan schedule:run" also in Windows, not throwing errors and fix #9524.

Sorry, at this moment I only have access to Windows, I would appreciate if anyone can confirm that still works fine in Linux/Mac.

And about the code it's my first collaboration and any constructive criticism will be welcomed :)
