### PR TITLE
[5.1] Escape triple bracket echos

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -326,12 +326,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileEscapedEchos($value)
     {
-        $pattern = sprintf('/%s\s*(.+?)\s*%s(\r?\n)?/s', $this->escapedTags[0], $this->escapedTags[1]);
+        $pattern = sprintf('/(@)?%s\s*(.+?)\s*%s(\r?\n)?/s', $this->escapedTags[0], $this->escapedTags[1]);
 
         $callback = function ($matches) {
-            $whitespace = empty($matches[2]) ? '' : $matches[2].$matches[2];
+            $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-            return '<?php echo e('.$this->compileEchoDefaults($matches[1]).'); ?>'.$whitespace;
+            return $matches[1] ? $matches[0] : '<?php echo e('.$this->compileEchoDefaults($matches[2]).'); ?>'.$whitespace;
         };
 
         return preg_replace_callback($pattern, $callback, $value);


### PR DESCRIPTION
I came across a scenario using vue.js where I needed to return unescaped HTML from a data property (http://vuejs.org/guide/index.html#Mustache_Bindings), and to do so, I need to use the triple bracket syntax (`{{{ var }}}`), but since Blade also uses that syntax, it was an obvious clash.

Seeing as how the double bracket syntax (`{{ $var }}`) allows you to escape it by prefixing it with an `@` symbol, I thought we might as well allow it for the triple syntax for whenever the need arises. (Unless there is a specific reason for it not being allowed already?)

So, in short, this PR allows for the following syntaxes:
`{{{ $var }}}` outputs `<?php echo e($var); ?>`
`@{{{ $var }}}` outputs `{{{ $var }}}`
