### PR TITLE
[5.1] Queue nice failed_jobs names

### DIFF
--- a/src/Illuminate/Queue/Console/ListFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ListFailedCommand.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Queue\Console;
 
-use Illuminate\Support\Arr;
 use Illuminate\Console\Command;
 
 class ListFailedCommand extends Command
@@ -70,9 +69,30 @@ class ListFailedCommand extends Command
     {
         $row = array_values(array_except($failed, ['payload']));
 
-        array_splice($row, 3, 0, Arr::get(json_decode($failed['payload'], true), 'job'));
+        array_splice($row, 3, 0, $this->setPayload($failed['payload']));
 
         return $row;
+    }
+
+    /**
+     * @param array $payload
+     *
+     * @return string
+     */
+    private function setPayload($payload)
+    {
+        $response = '';
+
+        $jsonDecode = json_decode($payload, true);
+
+        if ($jsonDecode && array_key_exists('data', $jsonDecode)) {
+            $data = unserialize($jsonDecode['data']['command']);
+            $name = (is_object($data) ? get_class($data) : substr(var_export($data, true), 0, 40));
+
+            $response .= $name;
+        }
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
Main problem: 

`php artisan queue:failed` command gives a to generic result. The Class column is not explain what was the failed job, just gives you `Illuminate\Queue\CallQueuedHandler@call`

It is annoying, when you have a lot of failed jobs and try to find what happened or just re-queue.

```
➜  laravel  artisan queue:failed
+----+------------+---------+-----------------------------------------+---------------------+
| ID | Connection | Queue   | Class                                   | Failed At           |
+----+------------+---------+-----------------------------------------+---------------------+
| 2  | database   | default | Illuminate\Queue\CallQueuedHandler@call | 2015-07-09 21:04:27 |
| 1  | database   | default | Illuminate\Queue\CallQueuedHandler@call | 2015-07-09 21:04:26 |
+----+------------+---------+-----------------------------------------+---------------------+
```

It's more familiar:

```
➜  laravel  artisan queue:failed
+----+------------+---------+----------------------------+---------------------+
| ID | Connection | Queue   | Class                      | Failed At           |
+----+------------+---------+----------------------------+---------------------+
| 2  | database   | default | App\Jobs\SendReminderEmail | 2015-07-09 21:04:27 |
| 1  | database   | default | App\Jobs\SendReminderEmail | 2015-07-09 21:04:26 |
+----+------------+---------+----------------------------+---------------------+
```
