### PR TITLE
[5.1] Inject Request in update and store method

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -32,9 +32,10 @@ class DummyClass extends Controller
     /**
      * Store a newly created resource in storage.
      *
+     * @param Request $request
      * @return Response
      */
-    public function store()
+    public function store(Request $request)
     {
         //
     }
@@ -64,10 +65,11 @@ class DummyClass extends Controller
     /**
      * Update the specified resource in storage.
      *
+     * @param Request $request
      * @param  int  $id
      * @return Response
      */
-    public function update($id)
+    public function update(Request $request, $id)
     {
         //
     }


### PR DESCRIPTION
I think we always need a request object in update and store method (maybe it can help users to understand injection too)
