### PR TITLE
[5.1] Key sorting and sort options in Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -665,13 +665,30 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Sort through each item with a callback.
      *
      * @param  callable|null  $callback
+     * @param  int|null       $options
      * @return static
      */
-    public function sort(callable $callback = null)
+    public function sort(callable $callback = null, $options = null)
     {
         $items = $this->items;
 
-        $callback ? uasort($items, $callback) : natcasesort($items);
+        $callback ? uasort($items, $callback) : ($options ? sort($items, $options) : natcasesort($items));
+
+        return new static($items);
+    }
+
+    /**
+     * Sort through each item by keys with a callback.
+     *
+     * @param  callable|null  $callback
+     * @param  int            $options
+     * @return static
+     */
+    public function ksort(callable $callback = null, $options = SORT_REGULAR)
+    {
+        $items = $this->items;
+
+        $callback ? uksort($items, $callback) : ksort($items, $options);
 
         return new static($items);
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -304,6 +304,15 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
         $data = (new Collection(['foo', 'bar-10', 'bar-1']))->sort();
         $this->assertEquals(['bar-1', 'bar-10', 'foo'], $data->values()->all());
+
+        $data = (new Collection(['foo', 'Bar-2', 'bar-1']))->sort(null, SORT_NATURAL);
+        $this->assertEquals(['Bar-2', 'bar-1', 'foo'], $data->values()->all());
+    }
+
+    public function testKsort()
+    {
+        $data = (new Collection([2 => 'b', 4 => 'd', 1 => 'a', 3 => 'c', 5 => 'e']))->sort();
+        $this->assertEquals(['a', 'b', 'c', 'd', 'e'], $data->values()->all());
     }
 
     public function testSortWithCallback()


### PR DESCRIPTION
Currently there is no shorthand method for sorting collections by keys (except providing a callback to sortBy method).

In addition I provided support for options in default sort method (E. g. natural case-sensitive sorting currently requires providing callback either)
