### PR TITLE
[5.1] Fix see in CrawlerTrait

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -240,9 +240,17 @@ trait CrawlerTrait
      */
     protected function see($text, $negate = false)
     {
-        $method = $negate ? 'assertNotRegExp' : 'assertRegExp';
+        $method = $negate ?'assertNotRegExp' : 'assertRegExp';
 
-        $this->$method('/'.preg_quote(e($text), '/').'/i', $this->response->getContent());
+        $escaped = e($text);
+        $text = preg_quote($text, '/');
+
+        if (preg_match('/\&[^\s]*;/', $escaped)) {
+            $escaped = preg_quote($escaped, '/');
+            $text = "$escaped|$text";
+        }
+
+        $this->$method("/$text/i", $this->response->getContent());
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -242,7 +242,7 @@ trait CrawlerTrait
     {
         $method = $negate ? 'assertNotRegExp' : 'assertRegExp';
 
-        $this->$method('/'.preg_quote($text, '/').'/i', $this->response->getContent());
+        $this->$method('/'.preg_quote(e($text), '/').'/i', $this->response->getContent());
 
         return $this;
     }


### PR DESCRIPTION
method `see` fail when search something without HTML entities convert

``` php
$this->see('café');
```

should search `caf&eacute`
