### PR TITLE
[5.1] Minor Eloquent\Model refactoring

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -10,6 +10,7 @@ use LogicException;
 use JsonSerializable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Type;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
@@ -2737,29 +2738,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $value;
         }
 
-        switch ($this->getCastType($key)) {
-            case 'int':
-            case 'integer':
-                return (int) $value;
-            case 'real':
-            case 'float':
-            case 'double':
-                return (float) $value;
-            case 'string':
-                return (string) $value;
-            case 'bool':
-            case 'boolean':
-                return (bool) $value;
-            case 'object':
-                return json_decode($value);
-            case 'array':
-            case 'json':
-                return json_decode($value, true);
-            case 'collection':
-                return new BaseCollection(json_decode($value, true));
-            default:
-                return $value;
+        $method = 'cast'.Str::studly($this->getCastType($key));
+
+        if (method_exists(Type::class, $method)) {
+            return call_user_func([Type::class, $method], $value);
         }
+        return $value;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -22,7 +22,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
-use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Query\Builder as QueryBuilder;

--- a/src/Illuminate/Support/Type.php
+++ b/src/Illuminate/Support/Type.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Illuminate\Support;
+
+class Type
+{
+    /**
+     * Cast value to integer.
+     *
+     * @param  mixed  $value
+     * @return int
+     */
+    public static function castInteger($value)
+    {
+        return (int) $value;
+    }
+
+    /**
+     * Cast value to integer.
+     *
+     * @param  mixed  $value
+     * @return int
+     */
+    public static function castInt($value)
+    {
+        return self::castInteger($value);
+    }
+
+    /**
+     * Cast value to float.
+     *
+     * @param  mixed  $value
+     * @return float
+     */
+    public static function castFloat($value)
+    {
+        return (float) $value;
+    }
+
+    /**
+     * Cast value to float.
+     *
+     * @param  mixed  $value
+     * @return float
+     */
+    public static function castDouble($value)
+    {
+        return self::castFloat($value);
+    }
+
+    /**
+     * Cast value to float.
+     *
+     * @param  mixed  $value
+     * @return float
+     */
+    public static function castReal($value)
+    {
+        return self::castFloat($value);
+    }
+
+    /**
+     * Cast value to string.
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    public static function castString($value)
+    {
+        return (string) $value;
+    }
+
+    /**
+     * Cast value to boolean.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function castBoolean($value)
+    {
+        return (bool) $value;
+    }
+
+    /**
+     * Cast value to boolean.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function castBool($value)
+    {
+        return self::castBoolean($value);
+    }
+
+    /**
+     * Cast value to object.
+     *
+     * @param  string  $value
+     * @param  bool    $assoc
+     * @return object
+     */
+    public static function castObject($value, $assoc = false)
+    {
+        return json_decode($value, $assoc);
+    }
+
+    /**
+     * Cast value to array.
+     *
+     * @param  string  $value
+     * @return array
+     */
+    public static function castArray($value)
+    {
+        return self::castObject($value, true);
+    }
+
+    /**
+     * Cast value to array.
+     *
+     * @param  string  $value
+     * @return array
+     */
+    public static function castJson($value)
+    {
+        return self::castArray($value);
+    }
+
+    /**
+     * Cast value to collection.
+     *
+     * @param  string  $value
+     * @return \Illuminate\Support\Collection
+     */
+    public static function castCollection($value)
+    {
+        return new Collection(self::castArray($value));
+    }
+}

--- a/tests/Support/SupportTypeTest.php
+++ b/tests/Support/SupportTypeTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Support\Type;
+use Illuminate\Support\Collection;
+
+class SupportTypeTest extends PHPUnit_Framework_TestCase
+{
+    public function testCastInteger()
+    {
+        $this->assertInternalType('integer', Type::castInteger('123'));
+    }
+
+    public function testCastInt()
+    {
+        $this->assertInternalType('integer', Type::castInt('12.3'));
+    }
+
+    public function testCastFloat()
+    {
+        $this->assertInternalType('float', Type::castFloat('1.23'));
+    }
+
+    public function testCastReal()
+    {
+        $this->assertInternalType('float', Type::castFloat('12.3'));
+    }
+
+    public function testCastDouble()
+    {
+        $this->assertInternalType('float', Type::castFloat('123'));
+    }
+
+    public function testCastString()
+    {
+        $this->assertInternalType('string', Type::castString(123));
+    }
+
+    public function testCastBoolean()
+    {
+        $this->assertInternalType('boolean', Type::castBoolean('1'));
+    }
+
+    public function testCastBool()
+    {
+        $this->assertInternalType('boolean', Type::castBoolean(''));
+    }
+
+    public function testCastObject()
+    {
+        $this->assertInstanceOf(stdClass::class, Type::castObject('{"test":"test"}'));
+    }
+
+    public function testCastArray()
+    {
+        $this->assertInternalType('array', Type::castArray('{"test":"test"}'));
+    }
+
+    public function testCastJson()
+    {
+        $this->assertInternalType('array', Type::castJson('{"test":"test"}'));
+    }
+
+    public function testCastCollection()
+    {
+        $this->assertInstanceOf(Collection::class, Type::castCollection('[{"test":"test"}]'));
+    }
+}


### PR DESCRIPTION
I have refactored 5 lowest rated methods(by Scrutinizer-CI) in Eloquent Model class. Building relation objects is extracted to separate methods to remove duplication. Also, I have added a support class responsible for type-casting. Using static methods is not a good practice in my opinion, but it has been done this way in Arr and Str classes, so I just followed the pattern. This increased Scrutinizer rating by 0.02 to 8.18, relation methods are now rated A(were D), castAttribute is rated A as well(was C). The changes should be 100% backward compatible.
