### PR TITLE
[5.1] Improvements to Arr::sortRecursive

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -273,6 +273,20 @@ class Arr
     }
 
     /**
+     * Determines if an array is associative.
+     * An array is "associative" if it doesn't have sequential numerical keys starting with 0.
+     * 
+     * @param  array  $array
+     * @return bool
+     */
+    public static function isAssoc(array $array)
+    {
+        $keys = array_keys($array);
+
+        return array_keys($keys) !== $keys;
+    }
+
+    /**
      * Get a subset of the items from the given array.
      *
      * @param  array  $array
@@ -403,17 +417,20 @@ class Arr
      * @param  array  $array
      * @return array
      */
-    public static function sortRecursive($array)
+    public static function sortRecursive(&$array)
     {
         foreach ($array as &$value) {
-            if (is_array($value) && isset($value[0])) {
-                sort($value);
-            } elseif (is_array($value)) {
+            if (is_array($value)) {
                 self::sortRecursive($value);
             }
         }
-
-        ksort($array);
+        if (self::isAssoc($array)) {
+            // sort associative array
+            ksort($array);
+        } else {
+            // sort regular array
+            sort($array);
+        }
 
         return $array;
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use Illuminate\Support\Arr;
+
+class SupportArrTest extends PHPUnit_Framework_TestCase
+{
+    public function testIsAssoc()
+    {
+        $this->assertTrue(Arr::isAssoc(['a' => 'a', 0 => 'b']));
+
+        $this->assertTrue(Arr::isAssoc([1 => 'a', 0 => 'b']));
+
+        $this->assertTrue(Arr::isAssoc([1 => 'a', 2 => 'b']));
+
+        $this->assertFalse(Arr::isAssoc([0 => 'a', 1 => 'b']));
+
+        $this->assertFalse(Arr::isAssoc(['a', 'b']));
+    }
+
+    public function testSortRecursive()
+    {
+        $array = [
+            'users' => [
+                [
+                    // should sort associative arrays by keys
+                    'name' => 'joe',
+                    'mail' => 'joe@example.com',
+                    // should sort deeply nested arrays
+                    'numbers' => [2, 1, 0],
+                ],
+                [
+                    'name' => 'jane',
+                    'age' => 25,
+                ],
+            ],
+            'repositories' => [
+                // should use weird `sort()` behavior on arrays of arrays
+                ['id' => 1],
+                ['id' => 0],
+            ],
+            // should sort non-associative arrays by value
+            20 => [2, 1, 0],
+            30 => [
+                // should sort non-incrementing numerical keys by keys
+                2 => 'a',
+                1 => 'b',
+                0 => 'c',
+            ],
+        ];
+
+        $expect = [
+            20 => [0, 1, 2],
+            30 => [
+                0 => 'c',
+                1 => 'b',
+                2 => 'a',
+            ],
+            'repositories' => [
+                ['id' => 0],
+                ['id' => 1],
+            ],
+            'users' => [
+                [
+                    'age' => 25,
+                    'name' => 'jane',
+                ],
+                [
+                    'mail' => 'joe@example.com',
+                    'name' => 'joe',
+                    'numbers' => [0, 1, 2],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expect, Arr::sortRecursive($array));
+    }
+}


### PR DESCRIPTION
I've recently encountered a few issues with `Arr::sortRecursive` so I'd like to propose some improvements to this function. These issues were:

**Recursion stops if an array containing the key `0` is encountered:**

| Array | Expected result | Actual result |
| --- | --- | --- |
| `[['b' => 'x', 'a' => 'x']]` | `[['a' => 'x', 'b' => 'x']]` | `[['b' => 'x', 'a' => 'x']]` |

**Flat arrays were not sorted:**

| Array | Expected result | Actual result |
| --- | --- | --- |
| `['b', 'a']` | `['a', 'b']` | `['b', 'a']` |

To improve recognizing of "non-associative" arrays (having incrementing numerical keys starting with 0), I've added an `Arr::isAssoc` method.

The general behavior is now as follows:
Every "non-associative" array (like `[3, 2, 1]`) is sorted by values using `sort()`. Every "associative" array (like `['b' => 1, 'a' => 5]`) is sorted by keys using `ksort()`. The array is now passed by reference (to be consistent with functions like `sort` or `ksort`; also for the recursion to work properly) but the sorted array is returned, too (for compatibility reasons).

**Edit:** The test fails with PHP 7; I'll look into it.
