### PR TITLE
[5.1] Routes with Closure are cachable

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -17,6 +17,7 @@ use Illuminate\Routing\Matching\SchemeValidator;
 use Symfony\Component\Routing\Route as SymfonyRoute;
 use Illuminate\Http\Exception\HttpResponseException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use SuperClosure\SerializableClosure;
 
 class Route
 {
@@ -148,6 +149,9 @@ class Route
      */
     protected function runCallable(Request $request)
     {
+        if ($this->action['uses'] instanceof SerializableClosure) {
+            $this->action['uses'] = $this->action['uses']->getClosure();
+        }
         $parameters = $this->resolveMethodDependencies(
             $this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])
         );
@@ -971,7 +975,7 @@ class Route
     public function prepareForSerialization()
     {
         if ($this->action['uses'] instanceof Closure) {
-            throw new LogicException("Unable to prepare route [{$this->uri}] for serialization. Uses Closure.");
+            $this->action['uses'] = new SerializableClosure($this->action['uses']);
         }
 
         unset($this->container, $this->compiled);

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -23,7 +23,8 @@
         "illuminate/support": "5.1.*",
         "symfony/http-foundation": "2.7.*",
         "symfony/http-kernel": "2.7.*",
-        "symfony/routing": "2.7.*"
+        "symfony/routing": "2.7.*",
+        "jeremeamia/superclosure": "~2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This might not be a great idea because those closure might in turn contain something that are nasty and shouldn't be serialized. I am open to criticization and discussion.

However a simple example with nested closure did ok on local tests.

```
Route::any('/something', function () {
    $hello = function () {
        return "Hello";
    };

    return $hello();
});
```

**_Usuage**_

In several use-cases, we have routes that don't fit anywhere, like a redirection of `/shop` to `/s` or something like that. And having a dedicated controller to handle things like that sounds ugly. This change will allow us to have a closure as a route which is cachable.
