### PR TITLE
[5.1] Use corresponding classes instead of helpers in Auth

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -5,7 +5,9 @@ namespace Illuminate\Foundation\Auth;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Redirect;
 
 trait AuthenticatesUsers
 {
@@ -18,11 +20,11 @@ trait AuthenticatesUsers
      */
     public function getLogin()
     {
-        if (view()->exists('auth.authenticate')) {
-            return view('auth.authenticate');
+        if (View::exists('auth.authenticate')) {
+            return View::make('auth.authenticate');
         }
 
-        return view('auth.login');
+        return View::make('auth.login');
     }
 
     /**
@@ -34,7 +36,8 @@ trait AuthenticatesUsers
     public function postLogin(Request $request)
     {
         $this->validate($request, [
-            $this->loginUsername() => 'required', 'password' => 'required',
+            $this->loginUsername() => 'required', 
+            'password' => 'required',
         ]);
 
         // If the class is using the ThrottlesLogins trait, we can automatically throttle
@@ -59,7 +62,7 @@ trait AuthenticatesUsers
             $this->incrementLoginAttempts($request);
         }
 
-        return redirect($this->loginPath())
+        return Redirect::to($this->loginPath())
             ->withInput($request->only($this->loginUsername(), 'remember'))
             ->withErrors([
                 $this->loginUsername() => $this->getFailedLoginMessage(),
@@ -83,7 +86,7 @@ trait AuthenticatesUsers
             return $this->authenticated($request, Auth::user());
         }
 
-        return redirect()->intended($this->redirectPath());
+        return Redirect::intended($this->redirectPath());
     }
 
     /**
@@ -118,7 +121,9 @@ trait AuthenticatesUsers
     {
         Auth::logout();
 
-        return redirect(property_exists($this, 'redirectAfterLogout') ? $this->redirectAfterLogout : '/');
+        return Redirect::to(
+            property_exists($this, 'redirectAfterLogout') ? $this->redirectAfterLogout : '/'
+        );
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -4,6 +4,8 @@ namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\Facades\Redirect;
 
 trait RegistersUsers
 {
@@ -12,11 +14,11 @@ trait RegistersUsers
     /**
      * Show the application registration form.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\View\View
      */
     public function getRegister()
     {
-        return view('auth.register');
+        return View::make('auth.register');
     }
 
     /**
@@ -37,6 +39,6 @@ trait RegistersUsers
 
         Auth::login($this->create($request->all()));
 
-        return redirect($this->redirectPath());
+        return Redirect::to($this->redirectPath());
     }
 }

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -5,7 +5,9 @@ namespace Illuminate\Foundation\Auth;
 use Illuminate\Http\Request;
 use Illuminate\Mail\Message;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Facades\Redirect;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 trait ResetsPasswords
@@ -13,11 +15,11 @@ trait ResetsPasswords
     /**
      * Display the form to request a password reset link.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\View\View
      */
     public function getEmail()
     {
-        return view('auth.password');
+        return View::make('auth.password');
     }
 
     /**
@@ -36,10 +38,10 @@ trait ResetsPasswords
 
         switch ($response) {
             case Password::RESET_LINK_SENT:
-                return redirect()->back()->with('status', trans($response));
+                return Redirect::back()->with('status', trans($response));
 
             case Password::INVALID_USER:
-                return redirect()->back()->withErrors(['email' => trans($response)]);
+                return Redirect::back()->withErrors(['email' => trans($response)]);
         }
     }
 
@@ -65,7 +67,7 @@ trait ResetsPasswords
             throw new NotFoundHttpException;
         }
 
-        return view('auth.reset')->with('token', $token);
+        return View::make('auth.reset')->with('token', $token);
     }
 
     /**
@@ -95,7 +97,7 @@ trait ResetsPasswords
                 return redirect($this->redirectPath());
 
             default:
-                return redirect()->back()
+                return Redirect::back()
                             ->withInput($request->only('email'))
                             ->withErrors(['email' => trans($response)]);
         }

--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -5,13 +5,14 @@ namespace Illuminate\Foundation\Auth;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Redirect;
 
 trait ThrottlesLogins
 {
     /**
      * Determine if the user has too many failed login attempts.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return bool
      */
     protected function hasTooManyLoginAttempts(Request $request)
@@ -21,7 +22,7 @@ trait ThrottlesLogins
         $lockedOut = Cache::has($this->getLoginLockExpirationKey($request));
 
         if ($attempts > 5 || $lockedOut) {
-            if (! $lockedOut) {
+            if (!$lockedOut) {
                 Cache::put($this->getLoginLockExpirationKey($request), time() + 60, 1);
             }
 
@@ -34,7 +35,7 @@ trait ThrottlesLogins
     /**
      * Get the login attempts for the user.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return int
      */
     protected function getLoginAttempts(Request $request)
@@ -45,7 +46,7 @@ trait ThrottlesLogins
     /**
      * Increment the login attempts for the user.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return int
      */
     protected function incrementLoginAttempts(Request $request)
@@ -58,7 +59,7 @@ trait ThrottlesLogins
     /**
      * Redirect the user after determining they are locked out.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return \Illuminate\Http\RedirectResponse
      */
     protected function sendLockoutResponse(Request $request)
@@ -69,7 +70,7 @@ trait ThrottlesLogins
                     ? Lang::get('auth.throttle', ['seconds' => $seconds])
                     : 'Too many login attempts. Please try again in '.$seconds.' seconds.';
 
-        return redirect($this->loginPath())
+        return Redirect::to($this->loginPath())
             ->withInput($request->only($this->loginUsername(), 'remember'))
             ->withErrors([
                 $this->loginUsername() => $message,
@@ -79,7 +80,7 @@ trait ThrottlesLogins
     /**
      * Clear the login locks for the given user credentials.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return void
      */
     protected function clearLoginAttempts(Request $request)
@@ -92,7 +93,7 @@ trait ThrottlesLogins
     /**
      * Get the login attempts cache key.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return string
      */
     protected function getLoginAttemptsKey(Request $request)
@@ -105,7 +106,7 @@ trait ThrottlesLogins
     /**
      * Get the login lock cache key.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return string
      */
     protected function getLoginLockExpirationKey(Request $request)


### PR DESCRIPTION
Replaced `view` and `redirect` helpers in the Auth module with the corresponding facades, following #9273, #9370 and the likes. IMO all of these helper calls should be removed from Laravel core itself – helpers are for users.
