### PR TITLE
[5.1] Added dynamic orderBy support

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -994,6 +994,44 @@ class Builder
     }
 
     /**
+     * Handles dynamic "orderBy" clauses to the query.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return $this
+     */
+    public function dynamicOrderBy($method, $parameters)
+    {
+        // $parameters, if any, will contain the ORDER BY direction. There are several cases:
+        // - Empty array: Default to 'asc'
+        // - Array of one direction string (asc|desc): Apply the same direction to all fields
+        // - Array of multiple direction strings: We match each field to the corresponding
+        // direction. If the number of fields and directions mismatch, throw an exception.
+
+        $fields = explode('And', substr($method, 7));
+
+        if (($directionCount = count($parameters)) > 1 && $directionCount !== count($fields)) {
+            throw new InvalidArgumentException('Number of fields and directions mismatch.');
+        }
+
+        for ($i = 0, $j = count($fields); $i < $j; ++$i) { 
+            if (!$fields[$i]) {
+                continue;
+            }
+
+            if (!$directionCount) {
+                $this->orderBy(Str::snake($fields[$i]), 'asc');
+            } elseif ($directionCount === 1) {
+                $this->orderBy(Str::snake($fields[$i]), $parameters[0]);
+            } else {
+                $this->orderBy(Str::snake($fields[$i]), $parameters[$i]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Add a single dynamic where clause statement to the query.
      *
      * @param  string  $segment
@@ -1313,21 +1351,6 @@ class Builder
         $result = (array) $this->first([$column]);
 
         return count($result) > 0 ? reset($result) : null;
-    }
-
-    /**
-     * Get a single column's value from the first result of a query.
-     *
-     * This is an alias for the "value" method.
-     *
-     * @param  string  $column
-     * @return mixed
-     *
-     * @deprecated since version 5.1.
-     */
-    public function pluck($column)
-    {
-        return $this->value($column);
     }
 
     /**
@@ -1996,6 +2019,10 @@ class Builder
     {
         if (Str::startsWith($method, 'where')) {
             return $this->dynamicWhere($method, $parameters);
+        }
+
+        if (Str::startsWith($method, 'orderBy')) {
+            return $this->dynamicOrderBy($method, $parameters);
         }
 
         $className = get_class($this);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1065,6 +1065,33 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertCount(2, $builder->wheres);
     }
 
+    public function testDynamicOrderBy()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByEmail();
+        $this->assertEquals('select * from "users" order by "email" asc', $builder->toSql());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByEmail('desc');
+        $this->assertEquals('select * from "users" order by "email" desc', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByEmailAndName();
+        $this->assertEquals('select * from "users" order by "email" asc, "name" asc', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByEmailAndName('desc');
+        $this->assertEquals('select * from "users" order by "email" desc, "name" desc', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByEmailAndName('asc', 'desc');
+        $this->assertEquals('select * from "users" order by "email" asc, "name" desc', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByEmailAndNameAndHomeAddress('desc', 'desc', 'asc');
+        $this->assertEquals('select * from "users" order by "email" desc, "name" desc, "home_address" asc', $builder->toSql());
+    }
+
     /**
      * @expectedException BadMethodCallException
      */


### PR DESCRIPTION
I really like Laravel's distinct dynamicWhere support, and thought it would make sense if we have something similar for `ORDER BY` clauses as well. Something like this:

``` php
$query->orderByName();
$query->orderByName('desc');
$query->orderByNameAndEmail('desc');
$query->orderByNameAndEmail('desc', 'asc');
```

By the way, the docblock for `dynamicWhere($method, $parameters)` appears to have a mistake for `$parameters` data type.
