### PR TITLE
[5.1] Make AuthManager use Guard interface

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -20,11 +20,19 @@ class AuthManager extends Manager
         // When using the remember me functionality of the authentication services we
         // will need to be set the encryption instance of the guard, which allows
         // secure, encrypted cookie values to get generated for those cookies.
-        $guard->setCookieJar($this->app['cookie']);
+        if (method_exists($guard, 'setCookieJar')) {
+            $guard->setCookieJar($this->app['cookie']);
+        }
 
-        $guard->setDispatcher($this->app['events']);
+        if (method_exists($guard, 'setDispatcher')) {
+            $guard->setDispatcher($this->app['events']);
+        }
 
-        return $guard->setRequest($this->app->refresh('request', $guard, 'setRequest'));
+        if (method_exists($guard, 'setRequest')) {
+            $guard->setRequest($this->app->refresh('request', $guard, 'setRequest'));   
+        }
+        
+        return $guard;
     }
 
     /**

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -39,7 +39,7 @@ class AuthManager extends Manager
      * Call a custom driver creator.
      *
      * @param  string  $driver
-     * @return \Illuminate\Auth\Guard
+     * @return \Illuminate\Contracts\Auth\Guard
      */
     protected function callCustomCreator($driver)
     {

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Auth;
 
 use Illuminate\Support\Manager;
+use Illuminate\Contracts\Auth\Guard as GuardContract;
 
 class AuthManager extends Manager
 {
@@ -36,7 +37,7 @@ class AuthManager extends Manager
     {
         $custom = parent::callCustomCreator($driver);
 
-        if ($custom instanceof Guard) {
+        if ($custom instanceof GuardContract) {
             return $custom;
         }
 


### PR DESCRIPTION
AuthManager should make use of Illuminate\Contracts\Auth\Guard interface instead of concrete Illuminate\Auth\Guard class to allow replacement of Guard implementation with a custom guard class.

Closes #9597.
