### PR TITLE
[5.1] Fix @return type for \Illuminate\Translation\Translator::getLine()

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -108,7 +108,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * @param  string  $locale
      * @param  string  $item
      * @param  array   $replace
-     * @return string|null
+     * @return string|array|null
      */
     protected function getLine($namespace, $group, $locale, $item, array $replace)
     {


### PR DESCRIPTION
As you can see from else-if condition, it can also return an array value.
