### PR TITLE
[5.1] Fix Translator::trans(), Translator::choice() and their common dependency Translator::get() for wrong return types

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -69,7 +69,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * @param  string  $key
      * @param  array   $replace
      * @param  string  $locale
-     * @return string
+     * @return string|array
      */
     public function get($key, array $replace = [], $locale = null)
     {
@@ -163,7 +163,8 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      */
     public function choice($key, $number, array $replace = [], $locale = null)
     {
-        $line = $this->get($key, $replace, $locale = $locale ?: $this->locale ?: $this->fallback);
+        $lines = $this->get($key, $replace, $locale = $locale ?: $this->locale ?: $this->fallback);
+        $line = is_array($lines) ? array_shift($lines) : $lines;
 
         $replace['count'] = $number;
 
@@ -181,7 +182,10 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      */
     public function trans($id, array $parameters = [], $domain = 'messages', $locale = null)
     {
-        return $this->get($id, $parameters, $locale);
+        $lines = $this->get($id, $parameters, $locale);
+        $line = is_array($lines) ? array_shift($lines) : $lines;
+        
+        return $line;
     }
 
     /**


### PR DESCRIPTION
Continuing on from #9610.

As you can see, `get()` method depends on the result of `getLine()` which may return array value. Hence the fix in its `@return` type.

From there on, `choice()` and `trans()` methods use `get()` method which actually can return an array value. However, logically these methods should rather return a translation string, not collection/array of those strings. The current modification I provide here returns the first element of such array, ensuring these methods always return a string value. My fix doesn't really look clean and I strongly believe we need to introduce separate method similar to `get()` which would return everything (strings and arrays, as `get()` does right now) and then make it so that `get()` always returns string, never an array. Ideas are welcome!
