### PR TITLE
[5.1] Performance improvement in database exists method

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -50,6 +50,8 @@ abstract class Grammar
     {
         if ($this->isExpression($value)) {
             return $this->getValue($value);
+        } elseif (is_int($value)) {
+            return $value;
         }
 
         // If the value being wrapped has a column alias we will need to separate out

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1563,7 +1563,7 @@ class Builder
     {
         $limit = $this->limit;
 
-        $result = $this->limit(1)->count() > 0;
+        $result = $this->limit(1)->aggregate(null, [1]) != null;
 
         $this->limit($limit);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -763,7 +763,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $results);
 
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from "users" limit 1', [], true)->andReturn([['aggregate' => 1]]);
+        $builder->getConnection()->shouldReceive('select')->once()->with('select (1) as aggregate from "users" limit 1', [], true)->andReturn([['aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) { return $results; });
         $results = $builder->from('users')->exists();
         $this->assertTrue($results);


### PR DESCRIPTION
As described in: https://github.com/laravel/framework/issues/9607.

Little performance improvement on the database exists method in the builder. Tested this with a table with 10.000 records. In mysql this was as twice as fast than before. In postgres it was a smaller difference but significant too.
