### PR TITLE
Use Opis Closure Serializer for better performance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "classpreloader/classpreloader": "~2.0",
         "danielstjules/stringy": "~1.8",
         "doctrine/inflector": "~1.0",
-        "jeremeamia/superclosure": "~2.0",
+        "opis/closure": "1.3.*",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -7,7 +7,7 @@ use Swift_Mailer;
 use Swift_Message;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use SuperClosure\Serializer;
+use Opis\Closure\SerializableClosure;
 use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
 use Illuminate\Contracts\View\Factory;
@@ -262,7 +262,7 @@ class Mailer implements MailerContract, MailQueueContract
             return $callback;
         }
 
-        return (new Serializer)->serialize($callback);
+        return serialize(new SerializableClosure($callback));
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -6,7 +6,7 @@ use Closure;
 use DateTime;
 use RuntimeException;
 use Illuminate\Support\Arr;
-use SuperClosure\Serializer;
+use Opis\Closure\SerializableClosure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\QueueableEntity;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
@@ -151,7 +151,7 @@ abstract class Queue
      */
     protected function createClosurePayload($job, $data)
     {
-        $closure = $this->crypt->encrypt((new Serializer)->serialize($job));
+        $closure = $this->crypt->encrypt(serialize(new SerializableClosure($job)));
 
         return ['job' => 'IlluminateQueueClosure', 'data' => compact('closure')];
     }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Mockery as m;
-use SuperClosure\Serializer;
+use Opis\Closure\SerializableClosure;
 
 class MailMailerTest extends PHPUnit_Framework_TestCase
 {
@@ -93,7 +93,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
         $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
-        $serialized = (new Serializer)->serialize($closure = function () {});
+        $serialized = serialize(new SerializableClosure($closure = function () {}));
         $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'callback' => $serialized], null);
 
         $mailer->queue('foo', [1], $closure);

--- a/tests/Queue/QueueIronQueueTest.php
+++ b/tests/Queue/QueueIronQueueTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Mockery as m;
-use SuperClosure\Serializer;
+use Opis\Closure\SerializableClosure;
 
 class QueueIronQueueTest extends PHPUnit_Framework_TestCase
 {
@@ -36,7 +36,7 @@ class QueueIronQueueTest extends PHPUnit_Framework_TestCase
         $crypt = m::mock('Illuminate\Contracts\Encryption\Encrypter');
         $queue->setEncrypter($crypt);
         $name = 'Foo';
-        $closure = (new Serializer)->serialize($innerClosure = function () use ($name) { return $name; });
+        $closure = serialize(new SerializableClosure($innerClosure = function () use ($name) { return $name; }));
         $crypt->shouldReceive('encrypt')->once()->with($closure)->andReturn('serial_closure');
         $crypt->shouldReceive('encrypt')->once()->with(json_encode([
             'job' => 'IlluminateQueueClosure', 'data' => ['closure' => 'serial_closure'], 'attempts' => 1, 'queue' => 'default',


### PR DESCRIPTION
**_Pros:**_
- Doesn't use eval to unserialize closures
- Almost 2x faster than jeremeamia's SuperClosure

**Cons:**
- This might break BC because developer might have decided to use the Serializer class bundled with Laravel installation to serialize other stuffs in their project but it is not something that cannot be fixed easily. Developers still wanting to use jeremeamia's SuperClosure can include in in their root project folder.
