### PR TITLE
vendor:publish Tag input is string explode it seperated by comma to c…

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -56,6 +56,10 @@ class VendorPublishCommand extends Command
     {
         $tags = $this->option('tag');
 
+        if (!is_array($tags)) {
+            $tags = explode(',', $tags);
+        }
+
         $tags = $tags ?: [null];
 
         foreach ($tags as $tag) {


### PR DESCRIPTION
When calling vendor:publish with the call method it is easy to create an array for tag(s). But raw on the commandline it is a bit harder.
If the parameter value is separated by a comma (like --tag=resources,public) it will now create an array with two items. 

```
$this->call('vendor:publish', ['--tag', => ['resources', 'public']]);
or 
$this->call('vendor:publish', ['--tag' => 'resources,public']);
```
