### PR TITLE
[5.1] Fix Model forceDelete return type doc

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1125,7 +1125,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      *
      * This method protects developers from running forceDelete when trait is missing.
      *
-     * @return void
+     * @return bool|null
+     * @throws \Exception
      */
     public function forceDelete()
     {


### PR DESCRIPTION
Applied same return type and throws doc as the `delete()` method.
