### PR TITLE
[5.1] Fix route:list sorting, use host instead of domain

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -272,7 +272,7 @@ class RouteListCommand extends Command
 
             ['reverse', 'r', InputOption::VALUE_NONE, 'Reverse the ordering of the routes.'],
 
-            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (domain, method, uri, name, action, middleware) to sort by.', 'uri'],
+            ['sort', null, InputOption::VALUE_OPTIONAL, 'The column (host, method, uri, name, action, middleware) to sort by.', 'uri'],
         ];
     }
 }


### PR DESCRIPTION
route:list command's help documentation incorrectly listed 'domain' as a sort option. This wasn't a valid index.
