### PR TITLE
[5.1] Improve performance of exists() query

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1561,11 +1561,18 @@ class Builder
      */
     public function exists()
     {
-        $limit = $this->limit;
+        // Backup limit, select columns and select bindings
+        $previousLimit = $this->limit;
+        $previousColumns = $this->columns;
+        $previousSelectBindings = $this->bindings['select'];
+        $this->bindings['select'] = [];
 
-        $result = $this->limit(1)->count() > 0;
+        $result = $this->selectRaw('1')->first() !== null;
 
-        $this->limit($limit);
+        // Restore limit, select columns and select bindings
+        $this->limit($previousLimit);
+        $this->columns = $previousColumns;
+        $this->bindings['select'] = $previousSelectBindings;
 
         return $result;
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -763,7 +763,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $results);
 
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from "users" limit 1', [], true)->andReturn([['aggregate' => 1]]);
+        $builder->getConnection()->shouldReceive('select')->once()->with('select 1 from "users" limit 1', [], true)->andReturn([['aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) { return $results; });
         $results = $builder->from('users')->exists();
         $this->assertTrue($results);


### PR DESCRIPTION
Related: #9614
Original Issue: #9607

Instead of using `count(*)` this query just checks if there is at least one matching record, which can save quite some time. The compiled SQL looks like this:

```
select 1 from `table` limit 1
```
