### PR TITLE
[5.0] Fix reapplying scopes in whereHas callback

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -563,6 +563,8 @@ class Builder {
 
 		$query = $relation->getRelationCountQuery($relation->getRelated()->newQuery(), $this);
 
+		$this->mergeWheresToHas($query, $relation);
+
 		if ($callback) call_user_func($callback, $query);
 
 		return $this->addHasWhere($query, $relation, $operator, $count, $boolean);
@@ -678,8 +680,6 @@ class Builder {
 	 */
 	protected function addHasWhere(Builder $hasQuery, Relation $relation, $operator, $count, $boolean)
 	{
-		$this->mergeWheresToHas($hasQuery, $relation);
-
 		if (is_numeric($count))
 		{
 			$count = new Expression($count);


### PR DESCRIPTION
This fixes the problem of reapplying global scopes constraints if you try to remove them in the `whereHas` callback - take `SoftDeletes` as an example:

```
// Basic has call - 'deleted_at is null' applied by default
>>> User::has('posts')->toSql()
=> "select * from `users` where (select count(*) from `posts` where `posts`.`user_id` = `users`.`id` and `posts`.`deleted_at` is null) >= 1"

// Now let's remove the 'deleted_at is null' constraint in the callback
>>> User::whereHas('posts', function ($q) { $q->withTrashed(); })->toSql()
=> "select * from `users` where (select count(*) from `posts` where `posts`.`user_id` = `users`.`id` 
and `posts`.`deleted_at` is null // it shouldn't be here anymore
) >= 1"
>>> 
```

This happens because `mergeWheresToHas` is applied **after** user-provided callback.
