### PR TITLE
[5.1] Replace @parent with $default instead of nothing.

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -618,7 +618,7 @@ class Factory implements FactoryContract
         $sectionContent = str_replace('@@parent', '--parent--holder--', $sectionContent);
 
         return str_replace(
-            '--parent--holder--', '@parent', str_replace('@parent', '', $sectionContent)
+            '--parent--holder--', '@parent', str_replace('@parent', $default, $sectionContent)
         );
     }
 


### PR DESCRIPTION
Allow using the `@parent` directives when overwriting `@yield()` default content.

```
@yield('title', 'Learning-laravel.dev')
@section('title', 'Welcome - @parent')
```

Would display `Welcome - Learning-laravel.dev`
