### PR TITLE
[5.1] Improve artisan make:listener feedback

### DIFF
--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -30,6 +30,20 @@ class ListenerMakeCommand extends GeneratorCommand
     protected $type = 'Listener';
 
     /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        if (!$this->option('event')) {
+            return $this->error("Missing required --event option");
+        }
+
+        parent::fire();
+    }
+
+    /**
      * Build the class with the given name.
      *
      * @param  string  $name

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -37,7 +37,7 @@ class ListenerMakeCommand extends GeneratorCommand
     public function fire()
     {
         if (!$this->option('event')) {
-            return $this->error("Missing required --event option");
+            return $this->error('Missing required --event option');
         }
 
         parent::fire();


### PR DESCRIPTION
Closes #9576

As you can see people tend to use this command without required `--event` option. 
I find the fact that the generator creates a broken listener class with syntax errors in this case pretty confusing.
