### PR TITLE
[5.1] Fix PHPDoc typehint

### DIFF
--- a/src/Illuminate/Database/ConnectionResolverInterface.php
+++ b/src/Illuminate/Database/ConnectionResolverInterface.php
@@ -8,7 +8,7 @@ interface ConnectionResolverInterface
      * Get a database connection instance.
      *
      * @param  string  $name
-     * @return \Illuminate\Database\Connection
+     * @return \Illuminate\Database\ConnectionInterface
      */
     public function connection($name = null);
 


### PR DESCRIPTION
We should require the interface.

(This is already the case in the `ConnectionResolver` class.)
