### PR TITLE
[5.1] Avoid Trailing Data error in datetime fields in postgres

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -160,7 +160,7 @@ abstract class Grammar
      */
     public function getDateFormat()
     {
-        return 'Y-m-d H:i:s';
+        return 'Y-m-d H:i:s+';
     }
 
     /**


### PR DESCRIPTION
Adding the "+" option to the date format avoid the Trailing data error when parsing dates coming from postgres with milliseconds.

http://php.net/manual/en/datetime.createfromformat.php
