### PR TITLE
[5.1] Dynamic parameters for throttle login feature

### DIFF
--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -9,6 +9,18 @@ use Illuminate\Support\Facades\Cache;
 trait ThrottlesLogins
 {
     /**
+     * Amount of failed attempts a user can try before the login is locked out
+     * @var int
+     */
+    protected $throttleLimit = 5;
+
+    /**
+     * Time in minutes the login will be locked out after reaching the $throttleLimit
+     * @var int
+     */
+    protected $throttleTime = 1;
+
+    /**
      * Determine if the user has too many failed login attempts.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -20,9 +32,13 @@ trait ThrottlesLogins
 
         $lockedOut = Cache::has($this->getLoginLockExpirationKey($request));
 
-        if ($attempts > 5 || $lockedOut) {
+        if ($attempts > $this->throttleLimit || $lockedOut) {
             if (! $lockedOut) {
-                Cache::put($this->getLoginLockExpirationKey($request), time() + 60, 1);
+                Cache::put(
+                    $this->getLoginLockExpirationKey($request),
+                    time() + 60 * $this->throttleTime,
+                    1
+                );
             }
 
             return true;


### PR DESCRIPTION
Adding parameters as properties so users can change the default attempts limit or the locked out time

I also considered to put this in the auth config i.e. `Config::get('auth.throttle.limit')`, let me know if you want me to submit a new pull request.
