### PR TITLE
[5.1] Fixes Terminable Middleware During Tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -672,14 +672,19 @@ trait CrawlerTrait
      */
     public function call($method, $uri, $parameters = [], $cookies = [], $files = [], $server = [], $content = null)
     {
+        $kernel = $this->app->make('Illuminate\Contracts\Http\Kernel');
         $this->currentUri = $this->prepareUrlForRequest($uri);
 
         $request = Request::create(
             $this->currentUri, $method, $parameters,
             $cookies, $files, $server, $content
         );
+        
+        $response = $kernel->handle($request);
 
-        return $this->response = $this->app->make('Illuminate\Contracts\Http\Kernel')->handle($request);
+        $kernel->terminate($request, $response);
+
+        return $this->response = $response;
     }
 
     /**


### PR DESCRIPTION
Resolves bug #9357:  [5.1] Terminable Middleware not called during integration tests
