### PR TITLE
[5.1] Support php 7 throwables

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -6,6 +6,7 @@ use PDO;
 use Closure;
 use DateTime;
 use Exception;
+use Throwable;
 use LogicException;
 use RuntimeException;
 use Illuminate\Support\Arr;
@@ -450,7 +451,7 @@ class Connection implements ConnectionInterface
     /**
      * Execute a Closure within a transaction.
      *
-     * @param  \Closure  $callback
+     * @param  \Throwable  $callback
      * @return mixed
      *
      * @throws \Exception
@@ -472,6 +473,10 @@ class Connection implements ConnectionInterface
         // up in the database. Then we'll re-throw the exception so it can
         // be handled how the developer sees fit for their applications.
         catch (Exception $e) {
+            $this->rollBack();
+
+            throw $e;
+        } catch (Throwable $e) {
             $this->rollBack();
 
             throw $e;

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -107,7 +107,7 @@ interface ConnectionInterface
      * @param  \Closure  $callback
      * @return mixed
      *
-     * @throws \Exception
+     * @throws \Throwable
      */
     public function transaction(Closure $callback);
 

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database;
 
 use Closure;
 use Exception;
+use Throwable;
 use Doctrine\DBAL\Driver\PDOSqlsrv\Driver as DoctrineDriver;
 use Illuminate\Database\Query\Processors\SqlServerProcessor;
 use Illuminate\Database\Query\Grammars\SqlServerGrammar as QueryGrammar;
@@ -17,7 +18,7 @@ class SqlServerConnection extends Connection
      * @param  \Closure  $callback
      * @return mixed
      *
-     * @throws \Exception
+     * @throws \Throwable
      */
     public function transaction(Closure $callback)
     {
@@ -40,6 +41,10 @@ class SqlServerConnection extends Connection
         // up in the database. Then we'll re-throw the exception so it can
         // be handled how the developer sees fit for their applications.
         catch (Exception $e) {
+            $this->pdo->exec('ROLLBACK TRAN');
+
+            throw $e;
+        } catch (Throwable $e) {
             $this->pdo->exec('ROLLBACK TRAN');
 
             throw $e;

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -2,10 +2,12 @@
 
 namespace Illuminate\Foundation\Bootstrap;
 
+use Exception;
 use ErrorException;
 use Illuminate\Contracts\Foundation\Application;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Debug\Exception\FatalErrorException;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 class HandleExceptions
 {
@@ -65,11 +67,15 @@ class HandleExceptions
      * the HTTP and Console kernels. But, fatal error exceptions must
      * be handled differently since they are not normal exceptions.
      *
-     * @param  \Exception  $e
+     * @param  \Throwable  $e
      * @return void
      */
     public function handleException($e)
     {
+        if (!$e instanceof Exception) {
+            $e = new FatalThrowableError($e);
+        }
+
         $this->getExceptionHandler()->report($e);
 
         if ($this->app->runningInConsole()) {

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -3,11 +3,13 @@
 namespace Illuminate\Foundation\Console;
 
 use Exception;
+use Throwable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Console\Kernel as KernelContract;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 class Kernel implements KernelContract
 {
@@ -97,6 +99,14 @@ class Kernel implements KernelContract
 
             return $this->getArtisan()->run($input, $output);
         } catch (Exception $e) {
+            $this->reportException($e);
+
+            $this->renderException($output, $e);
+
+            return 1;
+        } catch (Throwable $e) {
+            $e = new FatalThrowableError($e);
+
             $this->reportException($e);
 
             $this->renderException($output, $e);

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -3,12 +3,14 @@
 namespace Illuminate\Foundation\Http;
 
 use Exception;
+use Throwable;
 use RuntimeException;
 use Illuminate\Routing\Router;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 class Kernel implements KernelContract
 {
@@ -85,6 +87,12 @@ class Kernel implements KernelContract
 
             $response = $this->sendRequestThroughRouter($request);
         } catch (Exception $e) {
+            $this->reportException($e);
+
+            $response = $this->renderException($request, $e);
+        } catch (Throwable $e) {
+            $e = new FatalThrowableError($e);
+
             $this->reportException($e);
 
             $response = $this->renderException($request, $e);

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue;
 
 use Exception;
+use Throwable;
 use Illuminate\Queue\Jobs\SyncJob;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
@@ -16,7 +17,7 @@ class SyncQueue extends Queue implements QueueContract
      * @param  mixed   $data
      * @param  string  $queue
      * @return mixed
-     * @throws \Exception
+     * @throws \Throwable
      */
     public function push($job, $data = '', $queue = null)
     {
@@ -25,6 +26,10 @@ class SyncQueue extends Queue implements QueueContract
         try {
             $queueJob->fire();
         } catch (Exception $e) {
+            $this->handleFailedJob($queueJob);
+
+            throw $e;
+        } catch (Throwable $e) {
             $this->handleFailedJob($queueJob);
 
             throw $e;

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -3,11 +3,13 @@
 namespace Illuminate\Queue;
 
 use Exception;
+use Throwable;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Queue\Failed\FailedJobProviderInterface;
-use Illuminate\Contracts\Cache\Repository as CacheContract;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Illuminate\Contracts\Cache\Repository as CacheContract;
 
 class Worker
 {
@@ -111,6 +113,10 @@ class Worker
             if ($this->exceptions) {
                 $this->exceptions->report($e);
             }
+        } catch (Throwable $e) {
+            if ($this->exceptions) {
+                $this->exceptions->report(new FatalThrowableError($e));
+            }
         }
     }
 
@@ -187,7 +193,7 @@ class Worker
      * @param  int  $delay
      * @return void
      *
-     * @throws \Exception
+     * @throws \Throwable
      */
     public function process($connection, Job $job, $maxTries = 0, $delay = 0)
     {
@@ -206,6 +212,12 @@ class Worker
             // If we catch an exception, we will attempt to release the job back onto
             // the queue so it is not lost. This will let is be retried at a later
             // time by another listener (or the same one). We will do that here.
+            if (!$job->isDeleted()) {
+                $job->release($delay);
+            }
+
+            throw $e;
+        } catch (Throwable $e) {
             if (!$job->isDeleted()) {
                 $job->release($delay);
             }

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -3,6 +3,8 @@
 namespace Illuminate\View\Engines;
 
 use Exception;
+use Throwable;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 class PhpEngine implements EngineInterface
 {
@@ -40,6 +42,8 @@ class PhpEngine implements EngineInterface
             include $__path;
         } catch (Exception $e) {
             $this->handleViewException($e, $obLevel);
+        } catch (Throwable $e) {
+            $this->handleViewException(new FatalThrowableError($e), $obLevel);
         }
 
         return ltrim(ob_get_clean());


### PR DESCRIPTION
This backports my changes from 5.2 now that we're happy with them.

NB, we ended up adding a few missing Exception typehints in the process on 5.2, but I've not brought those changes back.
