### PR TITLE
[5.1] Suppress warnings in validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1268,7 +1268,7 @@ class Validator implements ValidatorContract
      */
     protected function validateAlpha($attribute, $value)
     {
-        return preg_match('/^[\pL\pM]+$/u', $value);
+        return @preg_match('/^[\pL\pM]+$/u', $value);
     }
 
     /**
@@ -1280,7 +1280,7 @@ class Validator implements ValidatorContract
      */
     protected function validateAlphaNum($attribute, $value)
     {
-        return preg_match('/^[\pL\pM\pN]+$/u', $value);
+        return @preg_match('/^[\pL\pM\pN]+$/u', $value);
     }
 
     /**
@@ -1292,7 +1292,7 @@ class Validator implements ValidatorContract
      */
     protected function validateAlphaDash($attribute, $value)
     {
-        return preg_match('/^[\pL\pM\pN_-]+$/u', $value);
+        return @preg_match('/^[\pL\pM\pN_-]+$/u', $value);
     }
 
     /**
@@ -1307,7 +1307,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(1, $parameters, 'regex');
 
-        return preg_match($parameters[0], $value);
+        return @preg_match($parameters[0], $value);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1149,6 +1149,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['x' => 'a,b'], ['x' => 'Regex:/^a,b$/i']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 3000], ['x' => 'Regex:/^([a-z0-9])+$/i']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => ['an', 'array', 'instead', 'of', 'a', 'string']], ['x' => 'Regex:/^a,b$/i']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateDateAndFormat()


### PR DESCRIPTION
Closes #9554

When something nasty (e.g. array or object) is passed to `preg_match` it raises an uncatchable exception in addition to returning `false`.
So it looks like a perfect use case for error suppression.

Phpunit crashes on the last new test without it.

For more info check the end of the issue.
