### PR TITLE
[5.1] Eloquent booted models reset

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -22,6 +22,8 @@ class DatabaseServiceProvider extends ServiceProvider
         Model::setConnectionResolver($this->app['db']);
 
         Model::setEventDispatcher($this->app['events']);
+
+        Model::resetBootedModels();
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3248,6 +3248,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * reset the booted models array
+     *
+     * @return void
+     */
+    public static function resetBootedModels()
+    {
+        self::$booted = [];
+    }
+
+    /**
      * Dynamically retrieve attributes on the model.
      *
      * @param  string  $key


### PR DESCRIPTION
When preforming unit test using the ApplicationTrait the Application is refreshed between each test function, but the Eloquent models boot function run only on the first test function. So on the following tests the models are already booted and the boot function is not running. 

This is create bugs while testing since the traits boot functions will run only on the firsts test.

For example, if one uses some validation layer that assigns a listener to the saving event inside a trait boot function, on the first test the validation will work, but after the application refresh the listener is destroyed, and on the following tests there will be no validation.

To fix it, the static booted property of the eloquent model should be reset, so when the application is refreshed between each test function the boot function will run.

a test case for the problem can be find here:
https://github.com/dan-har/laravel/commit/42cb3052d06889e2c72f58551047986baeb9ec5e
