### PR TITLE
[5.1] Make sure eloquent models are booted correctly

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -31,6 +31,8 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        Model::resetBootedModels();
+
         $this->registerEloquentFactory();
 
         $this->registerQueueableEntityResolver();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -316,6 +316,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Reset the list of booted models.
+     *
+     * @return void
+     */
+    public static function resetBootedModels()
+    {
+        static::$booted = [];
+    }
+
+    /**
      * Register a new global scope on the model.
      *
      * @param  \Illuminate\Database\Eloquent\ScopeInterface  $scope


### PR DESCRIPTION
Before this fix eloquent models were not booted in subsequent tests, forcing me to use process isolation as a work around.

---

Replaces #9667.
