### PR TITLE
[5.1] Add a morphMap for polymorphic relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -801,6 +801,20 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Alias for morphTo with the morph map as first argument
+     *
+     * @param  array $morphMap
+     * @param  string $name
+     * @param  string $type
+     * @param  string $id
+     * @return MorphTo
+     */
+    public function morphToMap(array $morphMap = [], $name = null, $type = null, $id = null)
+    {
+        return $this->morphTo($name, $type, $id, $morphMap);
+    }
+
+    /**
      * Define a polymorphic, inverse one-to-one or many relationship.
      *
      * @param  string $name

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -801,13 +801,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Alias for morphTo with the morph map as first argument
+     * Alias for morphTo with the morph map as first argument.
      *
      * @param  array $morphMap
      * @param  string $name
      * @param  string $type
      * @param  string $id
-     * @return MorphTo
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
     public function morphToMap(array $morphMap = [], $name = null, $type = null, $id = null)
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -180,8 +180,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $morphClass;
 
     /**
-     * An array mapping the morphable type saved to the database
-     * to the actual class
+     * A map between the morphable type saved to database and the actual class.
      *
      * @var array
      */
@@ -842,7 +841,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // as a belongs-to style relationship since morph-to extends that class and
         // we will pass in the appropriate values so that it behaves as expected.
         else {
-
             $class = $this->getActualClassName($class);
 
             $instance = new $class;
@@ -854,8 +852,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Fetch the class name from the morph map, or return the original if it's not defined
-     * It has been declared public so that it can be used by the MorphTo relation class for eager loading
+     * Fetch the class name from the morph map if it exists.
      *
      * @param $class
      * @return string

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -180,13 +180,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $morphClass;
 
     /**
-     * A map between the morphable type saved to database and the actual class.
-     *
-     * @var array
-     */
-    protected $morphMap = [];
-
-    /**
      * Indicates if the model exists.
      *
      * @var bool
@@ -810,12 +803,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Define a polymorphic, inverse one-to-one or many relationship.
      *
-     * @param  string  $name
-     * @param  string  $type
-     * @param  string  $id
-     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     * @param  string $name
+     * @param  string $type
+     * @param  string $id
+     * @param  array $morphMap
+     * @return MorphTo
      */
-    public function morphTo($name = null, $type = null, $id = null)
+    public function morphTo($name = null, $type = null, $id = null, array $morphMap = [])
     {
         // If no name is provided, we will use the backtrace to get the function name
         // since that is most likely the name of the polymorphic interface. We can
@@ -841,7 +835,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // as a belongs-to style relationship since morph-to extends that class and
         // we will pass in the appropriate values so that it behaves as expected.
         else {
-            $class = $this->getActualClassName($class);
+            $class = $this->getActualClassName($class, $morphMap);
 
             $instance = new $class;
 
@@ -854,12 +848,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Fetch the class name from the morph map if it exists.
      *
-     * @param $class
+     * @param  $class
+     * @param  array $morphMap
      * @return string
      */
-    public function getActualClassName($class)
+    public function getActualClassName($class, array $morphMap = [])
     {
-        if (array_key_exists($class, $this->morphMap)) {
+        if (array_key_exists($class, $morphMap)) {
             return $this->morphMap[$class];
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -180,6 +180,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $morphClass;
 
     /**
+     * An array mapping the morphable type saved to the database
+     * to the actual class
+     *
+     * @var array
+     */
+    protected $morphMap = [];
+
+    /**
      * Indicates if the model exists.
      *
      * @var bool
@@ -834,12 +842,31 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // as a belongs-to style relationship since morph-to extends that class and
         // we will pass in the appropriate values so that it behaves as expected.
         else {
+
+            $class = $this->getActualClassName($class);
+
             $instance = new $class;
 
             return new MorphTo(
                 $instance->newQuery(), $this, $id, $instance->getKeyName(), $type, $name
             );
         }
+    }
+
+    /**
+     * Fetch the class name from the morph map, or return the original if it's not defined
+     * It has been declared public so that it can be used by the MorphTo relation class for eager loading
+     *
+     * @param $class
+     * @return string
+     */
+    public function getActualClassName($class)
+    {
+        if (array_key_exists($class, $this->morphMap)) {
+            return $this->morphMap[$class];
+        }
+
+        return $class;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -827,7 +827,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // there are multiple types in the morph and we can't use single queries.
         if (is_null($class = $this->$type)) {
             return new MorphTo(
-                $this->newQuery(), $this, $id, null, $type, $name
+                $this->newQuery(), $this, $id, null, $type, $morphMap
             );
         }
 
@@ -840,7 +840,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $instance = new $class;
 
             return new MorphTo(
-                $instance->newQuery(), $this, $id, $instance->getKeyName(), $type, $name
+                $instance->newQuery(), $this, $id, $instance->getKeyName(), $type, $morphMap
             );
         }
     }
@@ -849,13 +849,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * Fetch the class name from the morph map if it exists.
      *
      * @param  $class
-     * @param  array $morphMap
+     * @param  array $morph
      * @return string
      */
-    public function getActualClassName($class, array $morphMap = [])
+    public function getActualClassName($class, array $morph = [])
     {
-        if (array_key_exists($class, $morphMap)) {
-            return $this->morphMap[$class];
+        if (array_key_exists($class, $morph)) {
+            return $morph[$class];
         }
 
         return $class;
@@ -974,15 +974,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Define a polymorphic many-to-many relationship.
      *
-     * @param  string  $related
-     * @param  string  $name
-     * @param  string  $table
-     * @param  string  $foreignKey
-     * @param  string  $otherKey
-     * @param  bool    $inverse
-     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
+     * @param  string $related
+     * @param  string $name
+     * @param  string $table
+     * @param  string $foreignKey
+     * @param  string $otherKey
+     * @param  bool $inverse
+     * @param  array $morphMap
+     * @return MorphToMany
      */
-    public function morphToMany($related, $name, $table = null, $foreignKey = null, $otherKey = null, $inverse = false)
+    public function morphToMany($related, $name, $table = null, $foreignKey = null, $otherKey = null, $inverse = false, $morphMap = [])
     {
         $caller = $this->getBelongsToManyCaller();
 
@@ -1004,7 +1005,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         return new MorphToMany(
             $query, $this, $name, $table, $foreignKey,
-            $otherKey, $caller, $inverse
+            $otherKey, $caller, $inverse, $morphMap
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -214,6 +214,7 @@ class MorphTo extends BelongsTo
     public function createModelByType($type)
     {
         $class = $this->parent->getActualClassName($type);
+
         return new $class;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -213,7 +213,8 @@ class MorphTo extends BelongsTo
      */
     public function createModelByType($type)
     {
-        return new $type;
+        $class = $this->parent->getActualClassName($type);
+        return new $class;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -46,13 +46,14 @@ class MorphTo extends BelongsTo
     /**
      * Create a new morph to relationship instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder $query
-     * @param  \Illuminate\Database\Eloquent\Model $parent
-     * @param  string $foreignKey
-     * @param  string $otherKey
-     * @param  string $type
-     * @param  string $relation
-     * @param  array $morphMap
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  string  $foreignKey
+     * @param  string  $otherKey
+     * @param  string  $type
+     * @param  string  $relation
+     * @param  array   $morphMap
+     * @return void
      */
     public function __construct(Builder $query, Model $parent, $foreignKey, $otherKey, $type, $relation, array $morphMap = [])
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -16,6 +16,13 @@ class MorphTo extends BelongsTo
     protected $morphType;
 
     /**
+     * A map between the morphable type saved to database and the actual class.
+     *
+     * @var array
+     */
+    protected $morphMap = [];
+
+    /**
      * The models whose relations are being eager loaded.
      *
      * @var \Illuminate\Database\Eloquent\Collection
@@ -39,17 +46,19 @@ class MorphTo extends BelongsTo
     /**
      * Create a new morph to relationship instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
-     * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @param  string  $foreignKey
-     * @param  string  $otherKey
-     * @param  string  $type
-     * @param  string  $relation
-     * @return void
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @param  \Illuminate\Database\Eloquent\Model $parent
+     * @param  string $foreignKey
+     * @param  string $otherKey
+     * @param  string $type
+     * @param  string $relation
+     * @param  array $morphMap
      */
-    public function __construct(Builder $query, Model $parent, $foreignKey, $otherKey, $type, $relation)
+    public function __construct(Builder $query, Model $parent, $foreignKey, $otherKey, $type, $relation, array $morphMap)
     {
         $this->morphType = $type;
+
+        $this->morphMap = $morphMap;
 
         parent::__construct($query, $parent, $foreignKey, $otherKey, $relation);
     }
@@ -213,7 +222,7 @@ class MorphTo extends BelongsTo
      */
     public function createModelByType($type)
     {
-        $class = $this->parent->getActualClassName($type);
+        $class = $this->parent->getActualClassName($type, $this->morphMap);
 
         return new $class;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -54,7 +54,7 @@ class MorphTo extends BelongsTo
      * @param  string $relation
      * @param  array $morphMap
      */
-    public function __construct(Builder $query, Model $parent, $foreignKey, $otherKey, $type, $relation, array $morphMap)
+    public function __construct(Builder $query, Model $parent, $foreignKey, $otherKey, $type, $relation, array $morphMap = [])
     {
         $this->morphType = $type;
 


### PR DESCRIPTION
_Should resolve #9407 and #3090_

Adds a `morphMap` array to the Eloquent Model which allows you to map the `morphable type` so that you don't have to pass a fully qualified namespace to aforementioned type.

**Reasons:**
- Makes refactoring, including namespace changes, easy as the database does not need to be altered if a model is moved to another namespace
- allows you to use a shorthand/alias instead of the fully qualified class name

**Example**

We use the same tables as in the [Laravel docs for polymorphic relations](http://laravel.com/docs/5.1/eloquent-relationships#polymorphic-relations), with the modification of the name of the staff table.

```
employees – App\Modules\Users\Domain\Employee
+---------+------------------+
| id(int) |   name(string)   |
+---------+------------------+
|       1 | John Doe         |
|       2 | Angelia Cendejas |
+---------+------------------+

products – App\Modules\Shop\Domain\Product
+---------+----------------+
| id(int) | price(integer) |
+---------+----------------+
|       1 |            900 |
|       2 |            700 |
+---------+----------------+

photos – App\Modules\Resources\Domain\Photo
+---------+--------------+--------------+----------------+
| id(int) | path(string) | imageable_id | imageable_type |
+---------+--------------+--------------+----------------+
|       1 | /foo/bar.png |            1 | staff          |
|       2 | /foo/baz.png |            1 | product        |
+---------+--------------+--------------+----------------+
```

In our `Photo` model, we can then define the relationship and morphMap as following:

```
public function imageable()
{
    $morphMap = [
        'staff' => App\Modules\Users\Domain\Employee::class,
        'product' => App\Modules\Shop\Domain\Product::class
    ];
    return $this->morphTo(null, null, null, $morphMap);
}
```

Or even easier:

```
public function imageable()
{
    return $this->morphToMap([
        'staff' => App\Modules\Users\Domain\Employee::class,
        'product' => App\Modules\Shop\Domain\Product::class
    ]);
}
```

The `Product` and `Employee` models will then have to define the `protected $morphClass` to whatever is stored in the database. So for the `Product`, this would be `product`, and for the `Employee` this would be `staff`.
