### PR TITLE
[5.1] Skip unexisted classes files defined in config/compile.php

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -122,7 +122,8 @@ class OptimizeCommand extends Command
 
         $core = require __DIR__.'/Optimize/config.php';
 
-        $files = array_merge($core, $this->laravel['config']->get('compile.files', []));
+        $compileFiles = array_filter($this->laravel['config']->get('compile.files', []));
+        $files = array_merge($core, $compileFiles);
 
         foreach ($this->laravel['config']->get('compile.providers', []) as $provider) {
             $files = array_merge($files, forward_static_call([$provider, 'compiles']));


### PR DESCRIPTION
Given: unexisted class defined in `config/compile.php`:

![a](https://i.imgur.com/6cZHjbp.png)

When: run `php artisan optimize`, then getting excaption `Invalid filnema provided`:

![a](https://i.imgur.com/t7ylNJx.png)

Exception is thrown in `ClassPreloader.php` (line 105)

---

I discovered that when dumping `$this->laravel['config']->get('compile.files', [])` in `OptimizeCommand.php` (line 125)

![a](https://i.imgur.com/EQTSRJu.png)

Then there's an element having `false` value in that array:

![a](https://i.imgur.com/kLveoku.png)

And that's because `realpath()` method in `config/compile.php` returns `false` if file does not exist.

This PR fix this by removing empty array elements from `$this->laravel['config']->get('compile.files', [])` by using [array_filter](http://www.php.net/manual/en/function.array-filter.php).
