### PR TITLE
[5.1] Add missing getters on HasManyThrough

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -343,4 +343,24 @@ class HasManyThrough extends Relation
     {
         return $this->farParent->getQualifiedKeyName();
     }
+
+    /**
+     * Get the qualified foreign key on the related model.
+     *
+     * @return string
+     */
+    public function getForeignKey()
+    {
+        return $this->related->getTable().'.'.$this->secondKey;
+    }
+
+    /**
+     * Get the qualified foreign key on the "through" model.
+     *
+     * @return string
+     */
+    public function getThroughKey()
+    {
+        return $this->parent->getTable().'.'.$this->firstKey;
+    }
 }


### PR DESCRIPTION
Currently it is impossible to reliably get the `foreign keys` of the `hasManyThrough` relation.

It's OK if you follow the conventions:

```
// Category Model
public function comments() {
  $this->hasManyThrough(Comment::class, Post::class); // category_id, post_id
}

// then this will be true:
$this->comments()->parent()->getForeignKey() // post_id
$this->getForeignKey() // category_id
```

but if you don't:

```
public function comments() {
  $this->hasManyThrough(Comment::class, Post::class, 'CategoryID', 'PostID');
}
```

then there is no way to get the `CategoryID` & `PostID` from the relation.
