### PR TITLE
[5.1] Fix for chunk()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -222,7 +222,7 @@ class Builder
         $offset = is_null($originalOffset) ? 0 : $originalOffset;
         $limit = is_null($originalLimit) ? $count : min($count, $originalLimit);
 
-        $resultsFetched = 0;
+        $totalResultsFetched = 0;
         $results = $this->skip($offset)->take($limit)->get();
 
         while (count($results) > 0) {
@@ -233,11 +233,11 @@ class Builder
                 break;
             }
 
-            $resultsFetched += count($results);
+            $totalResultsFetched += count($results);
             $offset += $limit;
 
             if (!is_null($originalLimit)) {
-                $resultsLeft = $originalLimit - $resultsFetched;
+                $resultsLeft = $originalLimit - $totalResultsFetched;
                 if ($resultsLeft === 0) {
                     break;
                 }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1168,6 +1168,18 @@ class Builder
     }
 
     /**
+     * Get the current "offset" value of the query.
+     *
+     * @return int|null
+     */
+    public function getOffset()
+    {
+        $property = $this->unions ? 'unionOffset' : 'offset';
+
+        return $this->$property;
+    }
+
+    /**
      * Alias to set the "offset" value of the query.
      *
      * @param  int  $value
@@ -1193,6 +1205,18 @@ class Builder
         }
 
         return $this;
+    }
+
+    /**
+     * Get the current "limit" value of the query.
+     *
+     * @return int|null
+     */
+    public function getLimit()
+    {
+        $property = $this->unions ? 'unionLimit' : 'limit';
+
+        return $this->$property;
     }
 
     /**


### PR DESCRIPTION
Closes #9649

This one is relatively hard to review. Sorry about that.

As you can see in the issue limits and offsets are completely ignored if `chunk()` is used instead of `get()`.
This happens because chunk overrides those properties internally.

Although it's a rare usecase, in my opinion it's a bug and should be fixed in 5.1 therefore.
