### PR TITLE
[5.1] Add HHVM >= 3.8.0 support in the artisan serve command

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Exception;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -38,8 +39,12 @@ class ServeCommand extends Command
 
         $this->info("Laravel development server started on http://{$host}:{$port}/");
         
-        if (defined('HHVM_VERSION') && HHVM_VERSION >= '3.8.0') {
-            passthru('"'.PHP_BINARY.'"'." -m server -v Server.Type=proxygen -v Server.SourceRoot=\"{$base}\"/ -v Server.IP={$host} -v Server.Port={$port} -v Server.DefaultDocument=server.php -v Server.ErrorDocument404=server.php");
+        if (defined('HHVM_VERSION')) {
+            if (HHVM_VERSION >= '3.8.0') {
+                passthru('"'.PHP_BINARY.'"'." -m server -v Server.Type=proxygen -v Server.SourceRoot=\"{$base}\"/ -v Server.IP={$host} -v Server.Port={$port} -v Server.DefaultDocument=server.php -v Server.ErrorDocument404=server.php");
+            } else {
+                throw new Exception("Requires HHVM >= 3.8.0");
+            }  
         } else {
             passthru('"'.PHP_BINARY.'"'." -S {$host}:{$port} \"{$base}\"/server.php");
         }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -37,8 +37,12 @@ class ServeCommand extends Command
         $base = $this->laravel->basePath();
 
         $this->info("Laravel development server started on http://{$host}:{$port}/");
-
-        passthru('"'.PHP_BINARY.'"'." -S {$host}:{$port} \"{$base}\"/server.php");
+        
+        if (defined('HHVM_VERSION') && HHVM_VERSION >= '3.8.0') {
+            passthru('"'.PHP_BINARY.'"'." -m server -v Server.Type=proxygen -v Server.SourceRoot=\"{$base}\"/ -v Server.IP={$host} -v Server.Port={$port} -v Server.DefaultDocument=server.php -v Server.ErrorDocument404=server.php");
+        } else {
+            passthru('"'.PHP_BINARY.'"'." -S {$host}:{$port} \"{$base}\"/server.php");
+        }
     }
 
     /**


### PR DESCRIPTION
With the help of the [Proxygen Web Server](https://code.facebook.com/posts/1503205539947302/introducing-proxygen-facebook-s-c-http-framework/).

Now we can run Laravel development server with [HHVM](http://hhvm.com), like this:
`hhvm artisan serve`
