### PR TITLE
[5.1] Use regex group to match both escaped and unescaped strings for see()

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -242,7 +242,10 @@ trait CrawlerTrait
     {
         $method = $negate ? 'assertNotRegExp' : 'assertRegExp';
 
-        $this->$method('/'.preg_quote($text, '/').'/i', $this->response->getContent());
+        $textPattern = preg_quote($text, '/');
+        $escapedPattern = preg_quote(e($text), '/');
+
+        $this->$method("/({$textPattern}|{$escapedPattern})/i", $this->response->getContent());
 
         return $this;
     }


### PR DESCRIPTION
See https://github.com/laracasts/Integrated/issues/61

For example `$this->see('Derick O'Reilly');` will fail because it is escaped to `Derick O&#039;Reilly`.

Using a regex group we can create a matcher like `/(Derick O'Reilly|Derick O&#039;Reilly)/i` that will match both the unescaped and escaped string. This is important because content escaped by blades `{{ }}` will be escaped but it is still possible for people to embed quotes in the blade templates as well.
