### PR TITLE
[5.1] Fix execution of terminable middleware in combination with WithoutMiddleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -135,9 +135,15 @@ class Kernel implements KernelContract
      */
     public function terminate($request, $response)
     {
-        $routeMiddlewares = $this->gatherRouteMiddlewares($request);
+        $shouldSkipMiddleware = $this->app->bound('middleware.disable') &&
+                                $this->app->make('middleware.disable') === true;
 
-        foreach (array_merge($routeMiddlewares, $this->middleware) as $middleware) {
+        $middlewares = $shouldSkipMiddleware ? [] : array_merge(
+            $this->gatherRouteMiddlewares($request),
+            $this->middleware
+        );
+
+        foreach ($middlewares as $middleware) {
             list($name, $parameters) = $this->parseMiddleware($middleware);
 
             $instance = $this->app->make($name);


### PR DESCRIPTION
If a test uses the WithoutMiddleware trait, all middleware (including terminable
middleware) should be skipped over.

This PR builds on top of #9659.

To clarify: Before #9659 terminable middleware was never executed in tests. After #9659 terminable middleware was always executed in tests, even if the `WithoutMiddleware` trait is used by the test.

This PR fixes that behavior. Middleware should always be executed in tests if there is no `WithoutMiddleware` trait, and never be executed in tests if `WithoutMiddleware` is used.

Regarding backwards compatibility: This fix would break any tests that falsely rely on the execution of terminable middleware in tests that use `WithoutMiddleware`. Please take this into consideration.
