### PR TITLE
[5.1] Fix transformHeadersToServerVars method

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -795,10 +795,12 @@ trait CrawlerTrait
     protected function transformHeadersToServerVars(array $headers)
     {
         $server = [];
+        $prefix = 'HTTP_';
 
         foreach ($headers as $name => $value) {
-            if (!starts_with($name, 'HTTP_')) {
-                $name = 'HTTP_'.strtr(strtoupper($name), '-', '_');
+            $name = strtr(strtoupper($name), '-', '_');
+            if (!starts_with($name, $prefix) && $name != 'CONTENT_TYPE') {
+                $name = $prefix . $name;
             }
 
             $server[$name] = $value;


### PR DESCRIPTION
That's because CONTENT_TYPE not transform to HTTP_CONTENT_TYPE in Symfony bundle.
If you have any proposal, let me know. Thank you!
