### PR TITLE
[5.1] Allow nested Route::group to override parent namespace

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -414,14 +414,18 @@ class Router implements RegistrarContract
      * @param  array  $old
      * @return string|null
      */
+          
     protected static function formatUsesPrefix($new, $old)
     {
         if (isset($new['namespace'])) {
+            if (isset($old['namespace']) && $new['namespace'][0] === '\\') {
+                return trim($new['namespace']);
+            }
+            
             return isset($old['namespace'])
                     ? trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\')
                     : trim($new['namespace'], '\\');
         }
-
         return isset($old['namespace']) ? $old['namespace'] : null;
     }
 


### PR DESCRIPTION
Currently if namespace is defined in nested Route::group, the namespace is appended with the parent.
It will be good if namespace can be overwritten in child if it start with `'\'`.

```
Route::group([
    'namespace' => 'Admin\Controllers',
], function () {
    ...
    Route::group([
        'namespace' => '\Admin\Submodules\Controllers',
    ], function () {

   });
    ...
});
```
