### PR TITLE
[5.1] Make the route of a request available to global middlewares

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -117,6 +117,8 @@ class Kernel implements KernelContract
 
         $this->bootstrap();
 
+        $this->router->matchRoute($request);
+		
         return (new Pipeline($this->app))
                     ->send($request)
                     ->through($this->app->shouldSkipMiddleware() ? [] : $this->middleware)

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -649,16 +649,11 @@ class Router implements RegistrarContract
      */
     public function dispatchToRoute(Request $request)
     {
-        // First we will find a route that matches this request. We will also set the
-        // route resolver on the request so middlewares assigned to the route will
-        // receive access to this route instance for checking of the parameters.
-        $route = $this->findRoute($request);
-
-        $request->setRouteResolver(function () use ($route) {
-            return $route;
-        });
-
-        $this->events->fire('router.matched', [$route, $request]);
+        // Check if the request has already been matched to a route. If not perform
+        // the route matching now.
+        if (is_null($route = $request->route())) {
+            $route = $this->matchRoute($request);
+        }
 
         // Once we have successfully matched the incoming request to a given route we
         // can call the before filters on that route. This works similar to global
@@ -679,6 +674,28 @@ class Router implements RegistrarContract
         $this->callRouteAfter($route, $request, $response);
 
         return $response;
+    }
+
+    /**
+     * Match the request to its route.
+     * 
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Routing\Route
+     */
+    public function matchRoute(Request $request)
+    {
+        // First we will find a route that matches this request. We will also set the
+        // route resolver on the request so middlewares assigned to the route will
+        // receive access to this route instance for checking of the parameters.
+        $route = $this->findRoute($request);
+
+        $request->setRouteResolver(function () use ($route) {
+            return $route;
+        });
+
+        $this->events->fire('router.matched', [$route, $request]);
+        
+        return $route;
     }
 
     /**


### PR DESCRIPTION
This change should be fully backwards compatible and performs the request to route matching before the global middlewares are being executed instead of after all global middlewares have finished.

This gives global middlewares the opportunity to get the route for a request inside their _handle_ method via `$request->route()` to e.g. adapt their behavior for specific routes.

One scenario for which this change would be helpful: [Disabling the CSRF Middleware in Laravel 5 ](http://laravel.io/forum/11-14-2014-disabling-the-csrf-middleware-in-laravel-5?page=2#reply-26261)
