### PR TITLE
[5.1] Change getConfigurationNesting to protected

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -82,7 +82,7 @@ class LoadConfiguration
      * @param  \Symfony\Component\Finder\SplFileInfo  $file
      * @return string
      */
-    private function getConfigurationNesting(SplFileInfo $file)
+    protected function getConfigurationNesting(SplFileInfo $file)
     {
         $directory = dirname($file->getRealPath());
 


### PR DESCRIPTION
I don't see any reason `getConfigurationNesting` should be private which makes overloading `getConfigurationFiles` annoying.
