### PR TITLE
[5.1] Cannot create MySQL timestamps with default values

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -526,7 +526,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        if (!$column->nullable) {
+        if (!$column->nullable && $column->default === null) {
             return 'timestamp default 0';
         }
 
@@ -541,7 +541,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
-        if (!$column->nullable) {
+        if (!$column->nullable && $column->default === null) {
             return 'timestamp default 0';
         }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -558,6 +558,16 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('alter table `users` add `foo` timestamp default 0 not null', $statements[0]);
     }
 
+    public function testAddingTimeStampWithDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('foo')->default('2015-07-22 11:43:17');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('alter table `users` add `foo` timestamp not null default \'2015-07-22 11:43:17\'', $statements[0]);
+    }
+
     public function testAddingTimeStampTz()
     {
         $blueprint = new Blueprint('users');
@@ -566,6 +576,16 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` timestamp default 0 not null', $statements[0]);
+    }
+
+    public function testAddingTimeStampTzWithDefault()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('foo')->default('2015-07-22 11:43:17');;
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('alter table `users` add `foo` timestamp not null default \'2015-07-22 11:43:17\'', $statements[0]);
     }
 
     public function testAddingTimeStamps()


### PR DESCRIPTION
Attempting to add a timestamp column with a default value causes invalid SQL to be generated for MySQL.

`$blueprint->timestamp('col')->default('2015-07-22 11:43:17');`

yields the SQL `col TIMESTAMP DEFAULT 0 NOT NULL DEFAULT '2015-07-22 11:43:17'` which is invalid, having two `DEFAULT` clauses.

Presumably, the existing MySQL grammar adds the `DEFAULT 0` to non-null columns to deal with the older MySQL behaviour of silently adding `ON UPDATE CURRENT TIMESTAMP` to the first such column in a table.

However, we need to suppress this when a default has actually been supplied.

Unit tests, with failing cases included.
