### PR TITLE
[5.1] Disable (as well as enable) MySQL strict mode

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -46,11 +46,15 @@ class MySqlConnector extends Connector implements ConnectorInterface
             )->execute();
         }
 
-        // If the "strict" option has been configured for the connection we'll enable
-        // strict mode on all of these tables. This enforces some extra rules when
+        // If the "strict" option has been configured for the connection we'll enable/disable
+        // strict mode for this session. Strict mode enforces some extra rules when
         // using the MySQL database system and is a quicker way to enforce them.
-        if (isset($config['strict']) && $config['strict']) {
-            $connection->prepare("set session sql_mode='STRICT_ALL_TABLES'")->execute();
+        if (isset($config['strict'])) {
+            if ($config['strict']) {
+                $connection->prepare("set session sql_mode='STRICT_ALL_TABLES'")->execute();
+            } else {
+                $connection->prepare("set session sql_mode=''")->execute();
+            }
         }
 
         return $connection;


### PR DESCRIPTION
The MySQL connector allows us to enable 'strict mode' using the config option `connections.mysql.strict = true`.

However, it does not allow us to **disable** strict mode.

This PR allows us to use `connections.mysql.strict = false` to achieve this.

Disabling strict mode is necessary when using MySQL 5.7 (which has it enabled by default, and which now includes `NO_ZERO_DATES`) and laravel's timestamp columns (which have a default of `0`).

If this setting is omitted, then the SQL mode is left unaltered.
