### PR TITLE
[5.1] Use ellipsis character (&hellip;) instead of three dots (...)

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -621,7 +621,7 @@ if (!function_exists('str_limit')) {
      * @param  string  $end
      * @return string
      */
-    function str_limit($value, $limit = 100, $end = '...')
+    function str_limit($value, $limit = 100, $end = '&hellip;')
     {
         return Str::limit($value, $limit, $end);
     }


### PR DESCRIPTION
Use ellipsis character (&hellip;) instead of three dots (...) in str_limit() function.

This helps with HTML validation.
