### PR TITLE
[5.1] Added MsSQL Azure connection lost message

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -677,6 +677,7 @@ class Connection implements ConnectionInterface
             'server has gone away',
             'no connection to the server',
             'Lost connection',
+            'is dead or not enabled',
         ]);
     }
 


### PR DESCRIPTION
Added Microsoft SQL Server message to lost connections, some references: 

https://social.msdn.microsoft.com/Forums/sqlserver/en-US/63bfcfb2-6cca-4cff-96df-216ad206881e/dbprocess-is-dead-or-not-enabled
http://www.sqlservercentral.com/Forums/Topic123601-92-1.aspx
http://forums.databasejournal.com/showthread.php?5260-DBPROCESS-is-dead-or-not-enabled

Bye.
