### PR TITLE
[5.1] Fix universal to and from of the mailer class when queuing using a serialized closure

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -200,6 +200,7 @@ class Mailer implements MailerContract, MailQueueContract
     public function queue($view, array $data, $callback, $queue = null)
     {
         $callback = $this->buildQueueCallable($callback);
+        $data = $this->buildQueueData($data);
 
         return $this->queue->push('mailer@handleQueuedMessage', compact('view', 'data', 'callback'), $queue);
     }
@@ -231,6 +232,7 @@ class Mailer implements MailerContract, MailQueueContract
     public function later($delay, $view, array $data, $callback, $queue = null)
     {
         $callback = $this->buildQueueCallable($callback);
+        $data = $this->buildQueueData($data);
 
         return $this->queue->later($delay, 'mailer@handleQueuedMessage', compact('view', 'data', 'callback'), $queue);
     }
@@ -263,6 +265,25 @@ class Mailer implements MailerContract, MailQueueContract
         }
 
         return (new Serializer)->serialize($callback);
+    }
+
+    /**
+     * Builds the data array passed to the queue
+     *
+     * @param  array  $callback
+     * @return array
+     */
+    protected function buildQueueData(array $data)
+    {
+        if (isset($this->from['address'])) {
+            $data['alwaysFrom'] = ['address' => $this->from['address'], 'name' => $this->from['name']];
+        }
+
+        if (isset($this->to['address'])) {
+            $data['alwaysTo'] = ['address' => $this->to['address'], 'name' => $this->to['name']];
+        }
+
+        return $data;
     }
 
     /**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -298,6 +298,19 @@ class Mailer implements MailerContract, MailQueueContract
      */
     public function handleQueuedMessage($job, $data)
     {
+        $metadata = $data['metadata'];
+        if (isset($metadata['alwaysTo'])) {
+            $address = $metadata['alwaysTo']['address'];
+            $name = isset($metadata['alwaysTo']['name']) ? $metadata['alwaysTo']['name'] : null;
+            $this->alwaysTo($address, $name);
+        }
+
+        if (isset($metadata['alwaysFrom'])) {
+            $address = $metadata['alwaysFrom']['address'];
+            $name = isset($metadata['alwaysFrom']['name']) ? $metadata['alwaysFrom']['name'] : null;
+            $this->alwaysFrom($address, $name);
+        }
+
         $this->send($data['view'], $data['data'], $this->getQueuedCallable($data));
 
         $job->delete();

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -200,9 +200,9 @@ class Mailer implements MailerContract, MailQueueContract
     public function queue($view, array $data, $callback, $queue = null)
     {
         $callback = $this->buildQueueCallable($callback);
-        $data = $this->buildQueueData($data);
+        $metadata = $this->queueMetadata();
 
-        return $this->queue->push('mailer@handleQueuedMessage', compact('view', 'data', 'callback'), $queue);
+        return $this->queue->push('mailer@handleQueuedMessage', compact('view', 'data', 'metadata', 'callback'), $queue);
     }
 
     /**
@@ -232,9 +232,9 @@ class Mailer implements MailerContract, MailQueueContract
     public function later($delay, $view, array $data, $callback, $queue = null)
     {
         $callback = $this->buildQueueCallable($callback);
-        $data = $this->buildQueueData($data);
+        $metadata = $this->queueMetadata();
 
-        return $this->queue->later($delay, 'mailer@handleQueuedMessage', compact('view', 'data', 'callback'), $queue);
+        return $this->queue->later($delay, 'mailer@handleQueuedMessage', compact('view', 'data', 'metadata', 'callback'), $queue);
     }
 
     /**
@@ -268,13 +268,16 @@ class Mailer implements MailerContract, MailQueueContract
     }
 
     /**
-     * Builds the data array passed to the queue
+     * If alwaysTo or alwaysFrom were called, returns an array containing
+     * $to and $from properties
      *
-     * @param  array  $callback
+     * @param  array  $data
      * @return array
      */
-    protected function buildQueueData(array $data)
+    protected function queueMetadata()
     {
+        $data = [];
+
         if (isset($this->from['address'])) {
             $data['alwaysFrom'] = ['address' => $this->from['address'], 'name' => $this->from['name']];
         }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -119,6 +119,63 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         $mailer->laterOn('queue', 10, 'foo', [1], 'callable');
     }
 
+    public function testQueuedMessagesDeleteJobs()
+    {
+        $mailer = $this->getMock('Illuminate\Mail\Mailer', ['send'], $this->getMocks());
+        $message = m::mock('Swift_Mime_Message');
+        $mailer->expects($this->once())->method('send');
+
+        $job = m::mock('Illuminate\Contracts\Queue\Job');
+        $job->shouldReceive('delete')->once();
+        $data = ['view' => 'foo', 'data' => [], 'metadata' => [], 'callback' => 'callable'];
+        $mailer->handleQueuedMessage($job, $data);
+    }
+
+    public function testQueuedMessagesUseAlwaysToMetadeta()
+    {
+        $mailer = $this->getMock('Illuminate\Mail\Mailer', ['send', 'alwaysTo'], $this->getMocks());
+        $message = m::mock('Swift_Mime_Message');
+        $mailer->expects($this->once())->method('send');
+        $mailer->expects($this->once())->method('alwaysTo')->with(
+            $this->equalTo('taylorotwell@gmail.com'),
+            $this->equalTo('Taylor Otwell')
+        );
+
+        $job = m::mock('Illuminate\Contracts\Queue\Job');
+        $job->shouldReceive('delete')->once();
+        $data = [
+            'view' => 'foo',
+            'data' => [],
+            'metadata' => ['alwaysTo' => ['address' => 'taylorotwell@gmail.com', 'name' => 'Taylor Otwell']],
+            'callback' => 'callable'
+        ];
+
+        $mailer->handleQueuedMessage($job, $data);
+    }
+
+    public function testQueuedMessagesUseAlwaysFromMetadeta()
+    {
+        $mailer = $this->getMock('Illuminate\Mail\Mailer', ['send', 'alwaysFrom'], $this->getMocks());
+        $message = m::mock('Swift_Mime_Message');
+        $mailer->expects($this->once())->method('send');
+        $mailer->expects($this->once())->method('alwaysFrom')->with(
+            $this->equalTo('taylorotwell@gmail.com'),
+            $this->equalTo('Taylor Otwell')
+        );
+
+        $job = m::mock('Illuminate\Contracts\Queue\Job');
+        $job->shouldReceive('delete')->once();
+        $data = [
+            'view' => 'foo',
+            'data' => [],
+            'metadata' => ['alwaysFrom' => ['address' => 'taylorotwell@gmail.com', 'name' => 'Taylor Otwell']],
+            'callback' => 'callable'
+        ];
+
+        $mailer->handleQueuedMessage($job, $data);
+    }
+
+
     public function testMessagesCanBeLoggedInsteadOfSent()
     {
         $mailer = $this->getMock('Illuminate\Mail\Mailer', ['createMessage'], $this->getMocks());

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -73,7 +73,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
         $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
-        $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'callback' => 'callable'], null);
+        $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'metadata' => [], 'callback' => 'callable'], null);
 
         $mailer->queue('foo', [1], 'callable');
     }
@@ -83,7 +83,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
         $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
-        $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'callback' => 'callable'], 'queue');
+        $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'metadata' => [], 'callback' => 'callable'], 'queue');
 
         $mailer->queueOn('queue', 'foo', [1], 'callable');
     }
@@ -94,7 +94,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
         $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
         $serialized = (new Serializer)->serialize($closure = function () {});
-        $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'callback' => $serialized], null);
+        $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'metadata' => [], 'callback' => $serialized], null);
 
         $mailer->queue('foo', [1], $closure);
     }
@@ -104,7 +104,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
         $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
-        $queue->shouldReceive('later')->once()->with(10, 'mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'callback' => 'callable'], null);
+        $queue->shouldReceive('later')->once()->with(10, 'mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'metadata' => [], 'callback' => 'callable'], null);
 
         $mailer->later(10, 'foo', [1], 'callable');
     }
@@ -114,7 +114,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
         $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
-        $queue->shouldReceive('later')->once()->with(10, 'mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'callback' => 'callable'], 'queue');
+        $queue->shouldReceive('later')->once()->with(10, 'mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'metadata' => [], 'callback' => 'callable'], 'queue');
 
         $mailer->laterOn('queue', 10, 'foo', [1], 'callable');
     }
@@ -188,7 +188,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         $mailer->alwaysTo('taylorotwell@gmail.com', 'Taylor Otwell');
         $queue->shouldReceive('push')->once()->with(
             'mailer@handleQueuedMessage',
-            ['view' => 'foo', 'data' => [1, 'alwaysTo' => ['address' => 'taylorotwell@gmail.com', 'name' => 'Taylor Otwell']], 'callback' => 'callable'],
+            ['view' => 'foo', 'data' => [1], 'metadata' => ['alwaysTo' => ['address' => 'taylorotwell@gmail.com', 'name' => 'Taylor Otwell']], 'callback' => 'callable'],
             null
         );
 
@@ -219,7 +219,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         $mailer->alwaysFrom('taylorotwell@gmail.com', 'Taylor Otwell');
         $queue->shouldReceive('push')->once()->with(
             'mailer@handleQueuedMessage',
-            ['view' => 'foo', 'data' => [1, 'alwaysFrom' => ['address' => 'taylorotwell@gmail.com', 'name' => 'Taylor Otwell']], 'callback' => 'callable'],
+            ['view' => 'foo', 'data' => [1], 'metadata' => ['alwaysFrom' => ['address' => 'taylorotwell@gmail.com', 'name' => 'Taylor Otwell']], 'callback' => 'callable'],
             null
         );
 


### PR DESCRIPTION
This pull request fixes a bug where the universal to and from settings of `Illuminate\Mail\Mailer` are lost when an email is send to the queue using a serialized closure.

I've added a `metadata` key to the data array that is send to the queue and is used when handling a queue message. Though it works, I don't really like my implementation so any feedback would be welcome.
