### PR TITLE
[5.1] Fix URL generator port check

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -497,7 +497,7 @@ class UrlGenerator implements UrlGeneratorContract
 
         $port = $this->request->getPort();
 
-        if (($secure && $port === 443) || (!$secure && $port === 80)) {
+        if (($secure && $port == 443) || (!$secure && $port == 80)) {
             return $domain;
         }
 


### PR DESCRIPTION
Fixes the port from being added to generated URLs when unnecessary. [Symfony returns the port as a string](https://github.com/symfony/HttpFoundation/blob/v2.7.2/Request.php#L1007) and Laravel is doing a strict comparison with an integer.

[This change](https://github.com/laravel/framework/commit/a93053d46331a712dc449ca72959de351d6b6a0c) caused `:80` to appear in all of my generated URLs when the scheme was already `http`.

Edit: Digging more into the Symfony source code, it looks like `getPort()` can return an integer or a string.  The docblock specifies string, however.  I am using a proxy, which causes symfony to return `$this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_PORT])` (a string).
