### PR TITLE
[5.1] Fix URL generator port check

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -495,7 +495,7 @@ class UrlGenerator implements UrlGeneratorContract
     {
         $secure = $this->request->isSecure();
 
-        $port = $this->request->getPort();
+        $port = (int) $this->request->getPort();
 
         if (($secure && $port === 443) || (!$secure && $port === 80)) {
             return $domain;

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -271,6 +271,21 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('https://sub.foo.com/foo/bar', $url->route('baz'));
     }
 
+    public function testRoutesWithDomainsThroughProxy()
+    {
+        Illuminate\Http\Request::setTrustedProxies(['10.0.0.1']);
+
+        $url = new UrlGenerator(
+            $routes = new Illuminate\Routing\RouteCollection,
+            $request = Illuminate\Http\Request::create('http://www.foo.com/', 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.1', 'HTTP_X_FORWARDED_PORT' => '80'])
+        );
+
+        $route = new Illuminate\Routing\Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'sub.foo.com']);
+        $routes->add($route);
+
+        $this->assertEquals('http://sub.foo.com/foo/bar', $url->route('foo'));
+    }
+
     public function testUrlGenerationForControllers()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
Replaces #9720. I've added a test to illustrate the bug (and confirm that it is fixed).  A strict comparison against a string does not work either as Symfony Request's `getPort()` can return a string OR an integer.  Therefore, I have chosen a loose comparison, as [used originally](https://github.com/laravel/framework/blob/0287dd65632fe77f7a0e403f4c2c5ecc763632b6/src/Illuminate/Routing/UrlGenerator.php#L501).

@GrahamCampbell If you use `===` to compare it to a string, it breaks other tests.
## 

Fixes the port from being added to generated URLs when unnecessary. [Symfony returns the port as a string](https://github.com/symfony/HttpFoundation/blob/v2.7.2/Request.php#L1007) and Laravel is doing a strict comparison with an integer.

[This change](https://github.com/laravel/framework/commit/a93053d46331a712dc449ca72959de351d6b6a0c) caused `:80` to appear in all of my generated URLs when the scheme was already `http`.

Edit: Digging more into the Symfony source code, it looks like `getPort()` can return an integer or a string.  The docblock specifies string, however.  I am using a proxy, which causes symfony to return `$this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_PORT])` (a string).
