### PR TITLE
[4.2] Escape escaped echos

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -249,13 +249,13 @@ class BladeCompiler extends Compiler implements CompilerInterface {
 	 */
 	protected function compileEscapedEchos($value)
 	{
-		$pattern = sprintf('/%s\s*(.+?)\s*%s(\r?\n)?/s', $this->escapedTags[0], $this->escapedTags[1]);
+		$pattern = sprintf('/(@)?%s\s*(.+?)\s*%s(\r?\n)?/s', $this->escapedTags[0], $this->escapedTags[1]);
 
 		$callback = function($matches)
 		{
-			$whitespace = empty($matches[2]) ? '' : $matches[2].$matches[2];
+			$whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
-			return '<?php echo e('.$this->compileEchoDefaults($matches[1]).'); ?>'.$whitespace;
+			return $matches[1] ? substr($matches[0], 1) : '<?php echo e('.$this->compileEchoDefaults($matches[2]).'); ?>'.$whitespace;
 		};
 
 		return preg_replace_callback($pattern, $callback, $value);


### PR DESCRIPTION
Using 4.2 version of Blade with

``` php
$compiler->setContentTags('{!!', '!!}');
$compiler->setEscapedContentTags('{{', '}}');
```

does not allow to escape double bracket echos: `@{{ anything }}`.

It’s not also possible to escape triple braced echos in case we do not change content and escaped content tags.

Similarly to https://github.com/laravel/framework/pull/9574 (for 5.1), this pull request adds possibility to escape escaped echos to the 4.2 branch.
