### PR TITLE
[5.1] Preserve null in attributes array for JSON-castable attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2781,7 +2781,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $value = $this->fromDateTime($value);
         }
 
-        if ($this->isJsonCastable($key)) {
+        if ($this->isJsonCastable($key) && !is_null($value)) {
             $value = json_encode($value);
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1160,6 +1160,17 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model->seventh = null;
         $model->eighth = null;
 
+        $attributes = $model->getAttributes();
+
+        $this->assertNull($attributes['first']);
+        $this->assertNull($attributes['second']);
+        $this->assertNull($attributes['third']);
+        $this->assertNull($attributes['fourth']);
+        $this->assertNull($attributes['fifth']);
+        $this->assertNull($attributes['sixth']);
+        $this->assertNull($attributes['seventh']);
+        $this->assertNull($attributes['eighth']);
+
         $this->assertNull($model->first);
         $this->assertNull($model->second);
         $this->assertNull($model->third);


### PR DESCRIPTION
This change stores null values for JSON-castable attributes as `null` rather than `"null"` (string) in the underlying attributes array.

While storing `"null"` may work fine when retrieving the value through an Eloquent model (as Eloquent will attempt to cast it and `json_decode("null") === null`), the value stored in the database is `"null"` (string) which causes queries that check for null to return unexpected results (`$query->whereNull()`, `$query->whereNotNull()`, etc).
