### PR TITLE
[5.1] Container docblock

### DIFF
--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -63,7 +63,7 @@ interface Container
     /**
      * Register a shared binding in the container.
      *
-     * @param  string  $abstract
+     * @param  string|array  $abstract
      * @param  \Closure|string|null  $concrete
      * @return void
      */


### PR DESCRIPTION
Singleton method internally calls bind, so parameters should be equal.
