### PR TITLE
[5.1] Prevents exceptions when cookies are decrypted in the request

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Cookie\Middleware;
 
 use Closure;
+use Exception;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 
 class EncryptCookies
@@ -73,10 +73,12 @@ class EncryptCookies
             }
 
             try {
-                $request->cookies->set($key, $this->decryptCookie($c));
-            } catch (DecryptException $e) {
-                $request->cookies->set($key, null);
+                $value = $this->decryptCookie($c);
+            } catch (Exception $e) {
+                $value = null;
             }
+
+            $request->cookies->set($key, $value);
         }
 
         return $request;


### PR DESCRIPTION
This fix prevents exceptions when cookies are decrypted in the request. The exception occurs when the client has an old Cookie encrypted with different cipher than the one used by the application.

Example of this kind of exception:

```
ErrorException in Encrypter.php line 88
openssl_decrypt(): IV passed is 32 bytes long which is longer than the 16 expected by selected cipher, truncating
```
