### PR TITLE
[5.1] Add string representations of boolean values

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -787,7 +787,7 @@ class Validator implements ValidatorContract
      */
     protected function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [true, false, 'true', 'false', 0, 1, '0', '1'];
 
         return in_array($value, $acceptable, true);
     }


### PR DESCRIPTION
true/false values from ajax request get cast to string so validateBoolean() currently returns false for these values.
