### PR TITLE
[5.1] Allow multi-dimentional arrays in pagination

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -128,7 +128,7 @@ abstract class AbstractPaginator
         }
 
         return $this->path.'?'
-                        .url_decode(http_build_query($parameters, null, '&'))
+                        .urldecode(http_build_query($parameters, null, '&'))
                         .$this->buildFragment();
     }
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -128,7 +128,7 @@ abstract class AbstractPaginator
         }
 
         return $this->path.'?'
-                        .http_build_query($parameters, null, '&')
+                        .url_decode(http_build_query($parameters, null, '&'))
                         .$this->buildFragment();
     }
 


### PR DESCRIPTION
This isn't really a solution as much as a demonstration of a bug I found.

In the abstract paginator a http_build_query is run to encode the parameters, but after the user is redirected to that page, the url is encoded again. This isn't an issue unless you have multi-dimentional arrays that you might have for a input checkbox.

I found this when I wanted to add existing parameters to the paginator, and found 

``` PHP
$paginatedProducts->appends(Input::get())
```

With a query string of

```
?sub-category%5bAccessories%5d=on&page=1
```

Would have the % re-encoded to

```
?sub-category%255BAccessories%255D=on&page=1
```

This continues to be re-encoded every time a new link is clicked.
