### PR TITLE
[5.1] Fix bindings on unions by added a new binding type

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -640,7 +640,7 @@ class Builder
 
             $this->wheres[] = compact('type', 'query', 'boolean');
 
-            $this->mergeBindings($query);
+            $this->addBinding($query->getBindings(), 'where');
         }
 
         return $this;
@@ -668,7 +668,7 @@ class Builder
 
         $this->wheres[] = compact('type', 'column', 'operator', 'query', 'boolean');
 
-        $this->mergeBindings($query);
+        $this->addBinding($query->getBindings(), 'where');
 
         return $this;
     }
@@ -694,7 +694,7 @@ class Builder
 
         $this->wheres[] = compact('type', 'operator', 'query', 'boolean');
 
-        $this->mergeBindings($query);
+        $this->addBinding($query, 'where');
 
         return $this;
     }
@@ -822,7 +822,7 @@ class Builder
 
         $this->wheres[] = compact('type', 'column', 'query', 'boolean');
 
-        $this->mergeBindings($query);
+        $this->addBinding($query->getBindings(), 'where');
 
         return $this;
     }
@@ -1234,7 +1234,9 @@ class Builder
 
         $this->unions[] = compact('query', 'all');
 
-        return $this->addBinding($query->bindings, 'union');
+        $this->addBinding($query->bindings, 'union');
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -49,6 +49,7 @@ class Builder
         'where'  => [],
         'having' => [],
         'order'  => [],
+        'union'  => [],
     ];
 
     /**
@@ -1233,7 +1234,7 @@ class Builder
 
         $this->unions[] = compact('query', 'all');
 
-        return $this->mergeBindings($query);
+        return $this->addBinding($query->bindings, 'union');
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -310,6 +310,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->union($this->getMySqlBuilder()->select('*')->from('users')->where('id', '=', 2));
         $this->assertEquals('(select * from `users` where `id` = ?) union (select * from `users` where `id` = ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
+
+        $builder = $this->getMysqlBuilder();
+        $second = $this->getMysqlBuilder()->select('*')->from('users')->orderByRaw('id = ?', 2);
+        $third = $this->getMysqlBuilder()->select('*')->from('users')->where('id', 3)->groupBy('id')->having('id', '!=', 4);
+        $builder->groupBy('a')->having('a', '=', 1)->union($second)->union($third);
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3, 3 => 4], $builder->getBindings());
     }
 
     public function testUnionAlls()


### PR DESCRIPTION
Fixes #9777.

The query was not able to know which union query had which binding. We need to add a new binding type `union` that takes the subquery bindings instead of merging them.
