### PR TITLE
[5.1] Prevent json_encode a json string when setting a castable attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2791,7 +2791,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $value = $this->fromDateTime($value);
         }
 
-        if ($this->isJsonCastable($key) && ! is_null($value)) {
+        if ($this->isJsonCastable($key) && ! is_null($value) && ! is_string($value)) {
             $value = json_encode($value);
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1192,6 +1192,20 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertNull($array['eighth']);
     }
 
+    public function testModelAttributeCastingPreventJsonEncodeFromJsonString()
+    {
+        $json_string = '{"foo":"bar"}';
+        $model = new EloquentModelCastingStub;
+        $model->sixth = $json_string;
+        $model->seventh = $json_string;
+        $model->eighth = $json_string;
+
+        $this->assertInternalType('object', $model->getAttribute('sixth'));
+        $this->assertInternalType('array', $model->getAttribute('seventh'));
+        $this->assertInternalType('array', $model->getAttribute('eighth'));
+        $this->assertEquals('{"foo":"bar"}', $model->eighthAttributeValue());
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));


### PR DESCRIPTION
This checks if the value is already a string when setting a castable attribute and prevents the call to `json_encode($value)` when `$value` is already a json string

The problem:

```
$model->casts = [ 'castableAttr' => 'array'];
$model->castableAttr; // will return [ 'foo' => 'bar'] for the value '{"foo":"bar"}' stored in the database

$model->fill([ 'castableAttr' => '{"foo":"bar2"}' ]);
$model->castableAttr; // now it will return `"{"foo":"bar"}"` (string) when it should return an array since the attribute is set to be castable
```
