### PR TITLE
[5.1] Removed unused static property

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -21,13 +21,6 @@ use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 class Application extends Container implements ApplicationContract, HttpKernelInterface
 {
     /**
-     * The Laravel framework version.
-     *
-     * @var string
-     */
-    const VERSION = '5.1.8 (LTS)';
-
-    /**
      * The base path for the Laravel installation.
      *
      * @var string
@@ -158,7 +151,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function version()
     {
-        return static::VERSION;
+        return '5.1.8 (LTS)';
     }
 
     /**


### PR DESCRIPTION
Hi,

I saw on Lumen that the version is stored as a simple string. I think it's a good idea, so why not apply it directly on the Laravel framework ?

Or does it make sense to update Lumen Application class to use a constant to return the version ?
