### PR TITLE
[5.1] Added public function getCustomDirectives to BladeCompiler

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -741,7 +741,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
-     * Get the list of custom directives.gs
+     * Get the list of custom directives.
      *
      * @return array
      */

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -741,6 +741,16 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Get the list of custom directives.gs
+     *
+     * @return array
+     */
+    public function getCustomDirectives()
+    {
+        return $this->customDirectives;
+    }
+
+    /**
     * Gets the raw tags used by the compiler.
     *
     * @return array

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -487,9 +487,11 @@ empty
     public function testCustomStatements()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertEquals(0, count($compiler->getCustomDirectives()));
         $compiler->directive('customControl', function ($expression) {
             return "<?php echo custom_control{$expression}; ?>";
         });
+        $this->assertEquals(1, count($compiler->getCustomDirectives()));
 
         $string = '@if($foo)
 @customControl(10, $foo, \'bar\')

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -487,11 +487,11 @@ empty
     public function testCustomStatements()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
-        $this->assertEquals(0, count($compiler->getCustomDirectives()));
+        $this->assertCount(0, $compiler->getCustomDirectives());
         $compiler->directive('customControl', function ($expression) {
             return "<?php echo custom_control{$expression}; ?>";
         });
-        $this->assertEquals(1, count($compiler->getCustomDirectives()));
+        $this->assertCount(1, $compiler->getCustomDirectives());
 
         $string = '@if($foo)
 @customControl(10, $foo, \'bar\')


### PR DESCRIPTION
I need to get all custom directives in this component:
https://github.com/xinax/laravel-gettext

More details here:
https://github.com/xinax/laravel-gettext/issues/34
