### PR TITLE
[5.1] Exists property is set to false on soft deleted eloquent model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1145,9 +1145,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $this->touchOwners();
 
             $this->performDeleteOnModel();
-
-            $this->exists = false;
-
+            
             // Once the model has been deleted, we will fire off the deleted event so that
             // the developers may hook into post-delete operations. We will then return
             // a boolean true as the delete is presumably successful on the database.
@@ -1177,6 +1175,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected function performDeleteOnModel()
     {
         $this->setKeysForSaveQuery($this->newQuery())->delete();
+        
+        $this->exists = false;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1145,7 +1145,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $this->touchOwners();
 
             $this->performDeleteOnModel();
-            
+
             // Once the model has been deleted, we will fire off the deleted event so that
             // the developers may hook into post-delete operations. We will then return
             // a boolean true as the delete is presumably successful on the database.
@@ -1175,7 +1175,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected function performDeleteOnModel()
     {
         $this->setKeysForSaveQuery($this->newQuery())->delete();
-        
+
         $this->exists = false;
     }
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -43,7 +43,11 @@ trait SoftDeletes
     protected function performDeleteOnModel()
     {
         if ($this->forceDeleting) {
-            return $this->withTrashed()->where($this->getKeyName(), $this->getKey())->forceDelete();
+            $res = $this->withTrashed()->where($this->getKeyName(), $this->getKey())->forceDelete();
+            
+            $this->exists = false;
+            
+            return $res;
         }
 
         return $this->runSoftDelete();

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -44,9 +44,9 @@ trait SoftDeletes
     {
         if ($this->forceDeleting) {
             $res = $this->withTrashed()->where($this->getKeyName(), $this->getKey())->forceDelete();
-            
+
             $this->exists = false;
-            
+
             return $res;
         }
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -123,6 +123,21 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         $this->assertCount(1, $users);
         $this->assertEquals(1, $users->first()->id);
     }
+    
+    public function testExistsPropertyOnDeletion()
+    {
+        $this->createUsers();
+        
+        $abigail = SoftDeletesTestUser::find(2);
+        $this->assertTrue($abigail->exists);
+        
+        $abigail->delete();
+        $this->assertTrue($abigail->exists);
+        
+        $abigail->forceDelete();
+        $this->assertFalse($abigail->exists);
+        $this->assertNull(SoftDeletesTestUser::find(2));
+    }
 
     /**
      * Helpers...

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -123,17 +123,17 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         $this->assertCount(1, $users);
         $this->assertEquals(1, $users->first()->id);
     }
-    
+
     public function testExistsPropertyOnDeletion()
     {
         $this->createUsers();
-        
+
         $abigail = SoftDeletesTestUser::find(2);
         $this->assertTrue($abigail->exists);
-        
+
         $abigail->delete();
         $this->assertTrue($abigail->exists);
-        
+
         $abigail->forceDelete();
         $this->assertFalse($abigail->exists);
         $this->assertNull(SoftDeletesTestUser::find(2));


### PR DESCRIPTION
If you soft delete a model the property _exists_ is set to false which may lead to problems.

Try the following code as a test:

```
$model->delete();
$model->forceDelete();
```

Surprisingly the model won't be hard deleted because the first _delete_ call will set the _exists_ property to _false_ thus the second call of _forceDelete_ won't perform anything and the model remains in the DB.

Soft deleting a model should prevent setting the _exists_ property to _false_ because otherwise the model object is in an inconsistent state and any logic relying on this property to check if a model was deleted will fail.
