### PR TITLE
[5.2] Removed unused imports

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -8,7 +8,6 @@ use Swift_Message;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use SuperClosure\Serializer;
-use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\Events\Dispatcher;

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Queue;
 
 use IronMQ\IronMQ;
-use Illuminate\Http\Response;
 use Illuminate\Queue\Jobs\IronJob;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -4,7 +4,6 @@ namespace Illuminate\Queue;
 
 use Closure;
 use DateTime;
-use RuntimeException;
 use Illuminate\Support\Arr;
 use SuperClosure\Serializer;
 use Illuminate\Container\Container;

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Routing;
 
 use BadMethodCallException;
-use Illuminate\Support\Str;
-use InvalidArgumentException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 abstract class Controller

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Routing;
 
-use Closure;
-use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Container\Container;


### PR DESCRIPTION
After applying this, StyleCI is now passing on both 5.1 and master, on my fork.
