### PR TITLE
[5.1] Fix validateAlpha logic and a few more tests

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1268,11 +1268,7 @@ class Validator implements ValidatorContract
      */
     protected function validateAlpha($attribute, $value)
     {
-        if (! is_string($value) && ! is_numeric($value)) {
-            return false;
-        }
-
-        return preg_match('/^[\pL\pM]+$/u', $value);
+        return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1082,6 +1082,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['x' => '❤'], ['x' => 'Alpha']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => '123'], ['x' => 'Alpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 123], ['x' => 'Alpha']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'abc123'], ['x' => 'Alpha']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateAlphaNum()
@@ -1148,6 +1157,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['x' => 'a,b'], ['x' => 'Regex:/^a,b$/i']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => '12'], ['x' => 'Regex:/^12$/i']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 123], ['x' => 'Regex:/^123$/i']);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
A numeric value doesn't pass in this regex validation, so it's waste of time validate it.
