### PR TITLE
Store.php breaks when using session.driver 'array'

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -283,7 +283,9 @@ class Store implements SessionInterface
     protected function addBagDataToSession()
     {
         foreach (array_merge($this->bags, [$this->metaBag]) as $bag) {
-            $this->put($bag->getStorageKey(), $this->bagData[$bag->getStorageKey()]);
+            if(isset($this->bagData[$bag->getStorageKey()])){
+                $this->put($bag->getStorageKey(), $this->bagData[$bag->getStorageKey()]);
+            }
         }
     }
 


### PR DESCRIPTION
Breaks when using session.driver 'array' in some occasions, it returns:

ErrorException in Store.php line 287:
Undefined index: _sf2_meta
