### PR TITLE
[5.1] Allow pagination without URL

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -260,10 +260,10 @@ class Builder
     /**
      * Paginate the given query.
      *
-     * @param  int $perPage
-     * @param  array $columns
-     * @param  string $pageName
-     * @param  null $page
+     * @param  int  $perPage
+     * @param  array  $columns
+     * @param  string  $pageName
+     * @param  int  $page
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -263,12 +263,13 @@ class Builder
      * @param  int  $perPage
      * @param  array  $columns
      * @param  string  $pageName
-     * @param  int  $page
+     * @param  int|null  $page
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
         $total = $this->query->getCountForPagination();
+
         $this->query->forPage(
             $page = $page ?: Paginator::resolveCurrentPage($pageName),
             $perPage = $perPage ?: $this->model->getPerPage()

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -260,17 +260,17 @@ class Builder
     /**
      * Paginate the given query.
      *
-     * @param  int  $perPage
-     * @param  array  $columns
-     * @param  string  $pageName
+     * @param  int $perPage
+     * @param  array $columns
+     * @param  string $pageName
+     * @param  null $page
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page')
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
         $total = $this->query->getCountForPagination();
-
         $this->query->forPage(
-            $page = Paginator::resolveCurrentPage($pageName),
+            $page = $page ?: Paginator::resolveCurrentPage($pageName),
             $perPage = $perPage ?: $this->model->getPerPage()
         );
 


### PR DESCRIPTION
This addition will allow users to pass in a page number to the Eloquent Builder `paginate()` method rather than relying on a URL variable. The change is non-breaking and can be used in the following way:

```
$page3 = Model::paginate(null, ['*'], 'page', 3);
```

This is by no means a major modification, but it allows for more flexibility in pagination by removing the URI dependence of the paginate method.
