### PR TITLE
[5.1] Added setPrefix() to RedisStore

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -40,7 +40,7 @@ class RedisStore extends TaggableStore implements Store
     {
         $this->redis = $redis;
         $this->connection = $connection;
-        $this->prefix = strlen($prefix) > 0 ? $prefix.':' : '';
+        $this->setPrefix($prefix);
     }
 
     /**
@@ -172,6 +172,17 @@ class RedisStore extends TaggableStore implements Store
     public function getRedis()
     {
         return $this->redis;
+    }
+
+    /**
+     * Set the cache key prefix.
+     *
+     * @param  string  $prefix
+     * @return void
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = ! empty($prefix) ? $prefix.':' : '';
     }
 
     /**

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -81,6 +81,15 @@ class CacheRedisStoreTest extends PHPUnit_Framework_TestCase
         $redis->forget('foo');
     }
 
+    public function testGetAndSetPrefix()
+    {
+        $redis = $this->getRedis();
+        $this->assertEquals('prefix:', $redis->getPrefix());
+
+        $redis->setPrefix('foo');
+        $this->assertEquals('foo:', $redis->getPrefix());
+    }
+
     protected function getRedis()
     {
         return new Illuminate\Cache\RedisStore(m::mock('Illuminate\Redis\Database'), 'prefix');


### PR DESCRIPTION
This adds the ability to change the cache prefix in runtime:

```
$cache = Cache::store('redis'); // or Cache::driver()
$cache->setPrefix('foo');
$cache->get('bar');
```
