### PR TITLE
add more fully-featured iterator

### DIFF
--- a/src/Illuminate/Support/ArrayIterator.php
+++ b/src/Illuminate/Support/ArrayIterator.php
@@ -46,7 +46,7 @@ class ArrayIterator extends BaseArrayIterator
 
     public function isLast($returnIfTrue = true, $returnIfFalse = false)
     {
-        if($this->count() == $this->i + 1) {
+        if($this->count() === $this->i + 1) {
 
             return $returnIfTrue;
         }

--- a/src/Illuminate/Support/ArrayIterator.php
+++ b/src/Illuminate/Support/ArrayIterator.php
@@ -8,22 +8,22 @@ class ArrayIterator extends BaseArrayIterator
 {
     private $i = 0;
 
-    public function rewind() {
-
+    public function rewind()
+    {
         $this->i = 0;
 
         return parent::rewind();
     }
 
-    public function next() {
-
+    public function next()
+    {
         $this->i++;
 
         return parent::next();
     }
 
-    public function prev() {
-
+    public function prev()
+    {
         $this->i--;
 
         return parent::prev();

--- a/src/Illuminate/Support/ArrayIterator.php
+++ b/src/Illuminate/Support/ArrayIterator.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Illuminate\Support;
+
+use ArrayIterator as BaseArrayIterator;
+
+class ArrayIterator extends BaseArrayIterator
+{
+    private $i = 0;
+
+    public function rewind() {
+
+        $this->i = 0;
+
+        return parent::rewind();
+    }
+
+    public function next() {
+
+        $this->i++;
+
+        return parent::next();
+    }
+
+    public function prev() {
+
+        $this->i--;
+
+        return parent::prev();
+    }
+
+    public function alternator($even = 'even', $odd = 'odd')
+    {
+        return $this->i === 0 || $this->i % 2 === 0 ? $even : $odd;
+    }
+
+    public function isFirst($returnIfTrue = true, $returnIfFalse = false)
+    {
+        if($this->i === 0) {
+
+            return $returnIfTrue;
+        }
+
+        return $returnIfFalse;
+    }
+
+    public function isLast($returnIfTrue = true, $returnIfFalse = false)
+    {
+        if($this->count() == $this->i + 1) {
+
+            return $returnIfTrue;
+        }
+
+        return $returnIfFalse;
+    }
+
+    public function currentIndex()
+    {
+        return $this->i;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->i;
+    }
+}

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -4,7 +4,6 @@ namespace Illuminate\Support;
 
 use Countable;
 use ArrayAccess;
-use ArrayIterator;
 use CachingIterator;
 use JsonSerializable;
 use IteratorAggregate;


### PR DESCRIPTION
It would be nice to have a more fully-featured iterator for laravel collections.  This would add support for common needs when iterating in a view.  For example:

```
<ul>
    @foreach($i = $items->getIterator() as $item)

         <li class="{{ $i->alternator() }} {{ $i->isFirst('is-first') }} {{ $i->isLast('is-last') }}" data-position="{{ $i }}">

             {{ $item }}

        </li>

    @endforeach
</ul>
```

```
Route::get('/', function () {

    $items = collect([
        'result-1' => 'Result 1',
        'result-2' => 'Result 2',
        'result-3' => 'Result 3',
        'result-4' => 'Result 4',
        'result-5' => 'Result 5',
    ]);

    return view('welcome', compact('items'));
});
```
