### PR TITLE
Added ability to edit messages by reference

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -376,10 +376,10 @@ class Mailer implements MailerContract, MailQueueContract
      *
      * @throws \InvalidArgumentException
      */
-    protected function callMessageBuilder($callback, $message)
+    protected function callMessageBuilder($callback, &$message)
     {
         if ($callback instanceof Closure) {
-            return call_user_func($callback, $message);
+            return call_user_func_array($callback, [&$message]);
         }
 
         if (is_string($callback)) {


### PR DESCRIPTION
I think there should be possibility of sending pre-prepared objects of Illuminate\Mail\Message. Useful for example in this case:

```
$ourMessage = $this->getMessage();
//return Illuminate\Mail\Message instance
\Mail::send($this->getTemplate(), $this->getData(), function (&$message) use ($ourMessage) 
 {
    $message = $ourMessage;
    //Here we can make additional changes to the $message
});
```
