### PR TITLE
[5.1] Added setPrefix() to MemcachedStore

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -30,7 +30,7 @@ class MemcachedStore extends TaggableStore implements Store
     public function __construct($memcached, $prefix = '')
     {
         $this->memcached = $memcached;
-        $this->prefix = strlen($prefix) > 0 ? $prefix.':' : '';
+        $this->setPrefix($prefix);
     }
 
     /**
@@ -149,5 +149,16 @@ class MemcachedStore extends TaggableStore implements Store
     public function getPrefix()
     {
         return $this->prefix;
+    }
+
+    /**
+     * Set the cache key prefix.
+     *
+     * @param  string  $prefix
+     * @return void
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = ! empty($prefix) ? $prefix.':' : '';
     }
 }

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -59,4 +59,14 @@ class CacheMemcachedStoreTest extends PHPUnit_Framework_TestCase
         $store = new Illuminate\Cache\MemcachedStore($memcache);
         $store->forget('foo');
     }
+
+    public function testGetAndSetPrefix()
+    {
+        $store = new Illuminate\Cache\MemcachedStore(new Memcached(), 'bar');
+        $this->assertEquals('bar:', $store->getPrefix());
+        $store->setPrefix('foo');
+        $this->assertEquals('foo:', $store->getPrefix());
+        $store->setPrefix(null);
+        $this->assertSame('', $store->getPrefix());
+    }
 }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -85,9 +85,10 @@ class CacheRedisStoreTest extends PHPUnit_Framework_TestCase
     {
         $redis = $this->getRedis();
         $this->assertEquals('prefix:', $redis->getPrefix());
-
         $redis->setPrefix('foo');
         $this->assertEquals('foo:', $redis->getPrefix());
+        $redis->setPrefix(null);
+        $this->assertSame('', $redis->getPrefix());
     }
 
     protected function getRedis()


### PR DESCRIPTION
Testing here i'd realised that I have the same need of set a prefix in runtime with `MemcachedStore`. This also brings a bit more consistence between RedisStore and MemcachedStore apis.

```
$cache = Cache::store('memcached'); // or Cache::driver()
$cache->setPrefix('foo');
$cache->get('bar'); // key 'foo:bar'
```
