### PR TITLE
[5.2] Fixed the exception handler

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -5,9 +5,12 @@ namespace Illuminate\Foundation\Exceptions;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Illuminate\Http\Response;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\Debug\ExceptionHandler as SymfonyDisplayer;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\Debug\ExceptionHandler as SymfonyExceptionHandler;
 use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 
 class Handler implements ExceptionHandlerContract
@@ -90,7 +93,7 @@ class Handler implements ExceptionHandlerContract
         if ($this->isHttpException($e)) {
             return $this->toIlluminateResponse($this->renderHttpException($e), $e);
         } else {
-            return $this->toIlluminateResponse((new SymfonyDisplayer(config('app.debug')))->createResponse($e), $e);
+            return $this->toIlluminateResponse($this->createSymfonyResponse($e), $e);
         }
     }
 
@@ -108,6 +111,51 @@ class Handler implements ExceptionHandlerContract
         $response->exception = $e;
 
         return $response;
+    }
+
+    /**
+     * Create a symfony response for the given exception.
+     *
+     * @param  \Exception  $e
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function createSymfonyResponse(Exception $e)
+    {
+        $e = FlattenException::create($e);
+        $handler = new SymfonyExceptionHandler(config('app.debug'));
+        $dectorated = $this->decorate($handler->getContent($e), $handler->getStylesheet($e));
+
+        return SymfonyResponse::create($dectorated, $e->getStatusCode(), $e->getHeaders());
+    }
+
+    /**
+     * Get the html response content.
+     *
+     * @param  string  $content
+     * @param  string  $css
+     * @return string
+     */
+    protected function decorate($content, $css)
+    {
+        return <<<EOF
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="robots" content="noindex,nofollow" />
+        <style>
+            /* Copyright (c) 2010, Yahoo! Inc. All rights reserved. Code licensed under the BSD License: http://developer.yahoo.com/yui/license.html */
+            html{color:#000;background:#FFF;}body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,textarea,p,blockquote,th,td{margin:0;padding:0;}table{border-collapse:collapse;border-spacing:0;}fieldset,img{border:0;}address,caption,cite,code,dfn,em,strong,th,var{font-style:normal;font-weight:normal;}li{list-style:none;}caption,th{text-align:left;}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:normal;}q:before,q:after{content:'';}abbr,acronym{border:0;font-variant:normal;}sup{vertical-align:text-top;}sub{vertical-align:text-bottom;}input,textarea,select{font-family:inherit;font-size:inherit;font-weight:inherit;}input,textarea,select{*font-size:100%;}legend{color:#000;}
+            html { background: #eee; padding: 10px }
+            img { border: 0; }
+            #sf-resetcontent { width:970px; margin:0 auto; }
+            $css
+        </style>
+    </head>
+    <body>
+        $content
+    </body>
+</html>
+EOF;
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -123,9 +123,9 @@ class Handler implements ExceptionHandlerContract
     {
         $e = FlattenException::create($e);
         $handler = new SymfonyExceptionHandler(config('app.debug'));
-        $dectorated = $this->decorate($handler->getContent($e), $handler->getStylesheet($e));
+        $decorated = $this->decorate($handler->getContent($e), $handler->getStylesheet($e));
 
-        return SymfonyResponse::create($dectorated, $e->getStatusCode(), $e->getHeaders());
+        return SymfonyResponse::create($decorated, $e->getStatusCode(), $e->getHeaders());
     }
 
     /**


### PR DESCRIPTION
2 days ago, symfony broke our exception handler by deleting their createResponse method.

This PR is somewhat simelar to the one I did for Lumen: https://github.com/laravel/lumen-framework/pull/212.
