### PR TITLE
[5.1] Added morph map

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -870,12 +870,31 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // as a belongs-to style relationship since morph-to extends that class and
         // we will pass in the appropriate values so that it behaves as expected.
         else {
+            $class = $this->getActualClassName($class);
+
             $instance = new $class;
 
             return new MorphTo(
                 $instance->newQuery(), $this, $id, $instance->getKeyName(), $type, $name
             );
         }
+    }
+
+    /**
+     * Retrieve the fully qualified class name from a slug.
+     *
+     * @param  string  $class
+     * @return string
+     */
+    protected function getActualClassName($class)
+    {
+        $morphMap = Relation::morphMap();
+
+        if (isset($morphMap[$class])) {
+            return $morphMap[$class];
+        }
+
+        return $class;
     }
 
     /**
@@ -2054,7 +2073,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getMorphClass()
     {
-        return $this->morphClass ?: get_class($this);
+        $morphMap = Relation::morphMap();
+        $class = get_class($this);
+        if (! empty($morphMap) && in_array($class, $morphMap)) {
+            return array_flip($morphMap)[$class];
+        }
+
+        return $this->morphClass ?: $class;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2075,6 +2075,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $morphMap = Relation::morphMap();
         $class = get_class($this);
+
         if (! empty($morphMap) && in_array($class, $morphMap)) {
             return array_flip($morphMap)[$class];
         }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -213,7 +213,9 @@ class MorphTo extends BelongsTo
      */
     public function createModelByType($type)
     {
-        return new $type;
+        $class = $this->parent->getActualClassName($type);
+
+        return new $class;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -287,11 +287,11 @@ abstract class Relation
      */
     public static function morphMap($map = null)
     {
-        if (is_null($map)) {
-            return static::$morphMap;
+        if (is_array($map)) {
+            static::$morphMap = $map;
         }
 
-        static::$morphMap = $map;
+        return static::$morphMap;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -292,7 +292,7 @@ abstract class Relation
             if ($merge) {
                 array_merge(static::$morphMap, $map);
             } else {
-                static::$morphMap = $map
+                static::$morphMap = $map;
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -287,7 +287,7 @@ abstract class Relation
      */
     public static function morphMap($map = null)
     {
-        if (! $map) {
+        if (is_null($map)) {
             return static::$morphMap;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -39,6 +39,13 @@ abstract class Relation
     protected static $constraints = true;
 
     /**
+     * An array to map class names to their morph names in database.
+     *
+     * @var array
+     */
+    protected static $morphMap = [];
+
+    /**
      * Create a new relation instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -270,6 +277,21 @@ abstract class Relation
     public function wrap($value)
     {
         return $this->parent->newQueryWithoutScopes()->getQuery()->getGrammar()->wrap($value);
+    }
+
+    /**
+     * Set the morph map for polymorphic relations.
+     * 
+     * @param  array|null $map
+     * @return array
+     */
+    public static function morphMap($map = null)
+    {
+        if (! $map) {
+            return static::$morphMap;
+        }
+
+        static::$morphMap = $map;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -281,14 +281,19 @@ abstract class Relation
 
     /**
      * Set the morph map for polymorphic relations.
-     * 
+     *
      * @param  array|null $map
+     * @param  bool $merge
      * @return array
      */
-    public static function morphMap($map = null)
+    public static function morphMap($map = null, $merge = true)
     {
         if (is_array($map)) {
-            static::$morphMap = $map;
+            if ($merge) {
+                array_merge(static::$morphMap, $map);
+            } else {
+                static::$morphMap = $map
+            }
         }
 
         return static::$morphMap;

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -77,7 +77,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->schema()->drop('posts');
         $this->schema()->drop('photos');
 
-        \Illuminate\Database\Eloquent\Relations\Relation::morphMap([]);
+        Illuminate\Database\Eloquent\Relations\Relation::morphMap([]);
     }
 
     /**
@@ -344,7 +344,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testMorphMapIsUsedForCreatingAndFetchingThroughRelation()
     {
-        \Illuminate\Database\Eloquent\Relations\Relation::morphMap([
+        Illuminate\Database\Eloquent\Relations\Relation::morphMap([
             'user' => 'EloquentTestUser',
             'post' => 'EloquentTestPost',
         ]);
@@ -375,7 +375,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testMorphMapIsUsedWhenFetchingParent()
     {
-        \Illuminate\Database\Eloquent\Relations\Relation::morphMap([
+        Illuminate\Database\Eloquent\Relations\Relation::morphMap([
             'user' => 'EloquentTestUser',
             'post' => 'EloquentTestPost',
         ]);

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -77,7 +77,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->schema()->drop('posts');
         $this->schema()->drop('photos');
 
-        Illuminate\Database\Eloquent\Relations\Relation::morphMap([]);
+        Illuminate\Database\Eloquent\Relations\Relation::morphMap([], false);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -76,6 +76,8 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->schema()->drop('friends');
         $this->schema()->drop('posts');
         $this->schema()->drop('photos');
+
+        \Illuminate\Database\Eloquent\Relations\Relation::morphMap([]);
     }
 
     /**
@@ -338,6 +340,52 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('EloquentTestPost', $photos[2]->imageable);
         $this->assertEquals('taylorotwell@gmail.com', $photos[1]->imageable->email);
         $this->assertEquals('First Post', $photos[3]->imageable->name);
+    }
+
+    public function testMorphMapIsUsedForCreatingAndFetchingThroughRelation()
+    {
+        \Illuminate\Database\Eloquent\Relations\Relation::morphMap([
+            'user' => 'EloquentTestUser',
+            'post' => 'EloquentTestPost',
+        ]);
+
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        $user->photos()->create(['name' => 'Avatar 1']);
+        $user->photos()->create(['name' => 'Avatar 2']);
+        $post = $user->posts()->create(['name' => 'First Post']);
+        $post->photos()->create(['name' => 'Hero 1']);
+        $post->photos()->create(['name' => 'Hero 2']);
+
+        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $user->photos);
+        $this->assertInstanceOf('EloquentTestPhoto', $user->photos[0]);
+        $this->assertInstanceOf('Illuminate\Database\Eloquent\Collection', $post->photos);
+        $this->assertInstanceOf('EloquentTestPhoto', $post->photos[0]);
+        $this->assertEquals(2, $user->photos->count());
+        $this->assertEquals(2, $post->photos->count());
+        $this->assertEquals('Avatar 1', $user->photos[0]->name);
+        $this->assertEquals('Avatar 2', $user->photos[1]->name);
+        $this->assertEquals('Hero 1', $post->photos[0]->name);
+        $this->assertEquals('Hero 2', $post->photos[1]->name);
+
+        $this->assertEquals('user', $user->photos[0]->imageable_type);
+        $this->assertEquals('user', $user->photos[1]->imageable_type);
+        $this->assertEquals('post', $post->photos[0]->imageable_type);
+        $this->assertEquals('post', $post->photos[1]->imageable_type);
+    }
+
+    public function testMorphMapIsUsedWhenFetchingParent()
+    {
+        \Illuminate\Database\Eloquent\Relations\Relation::morphMap([
+            'user' => 'EloquentTestUser',
+            'post' => 'EloquentTestPost',
+        ]);
+
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        $user->photos()->create(['name' => 'Avatar 1']);
+
+        $photo = EloquentTestPhoto::first();
+        $this->assertEquals('user', $photo->imageable_type);
+        $this->assertInstanceOf('EloquentTestUser', $photo->imageable);
     }
 
     public function testEmptyMorphToRelationship()

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -165,6 +165,18 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($relation->updateOrCreate(['foo'], ['bar']) instanceof Model);
     }
 
+    public function testCreateFunctionOnNamespacedMorph()
+    {
+        $relation = $this->getNamespacedRelation('namespace');
+        $created = m::mock('Illuminate\Database\Eloquent\Model');
+        $created->shouldReceive('setAttribute')->once()->with('morph_id', 1);
+        $created->shouldReceive('setAttribute')->once()->with('morph_type', 'namespace');
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['name' => 'taylor'])->andReturn($created);
+        $created->shouldReceive('save')->once()->andReturn(true);
+
+        $this->assertEquals($created, $relation->create(['name' => 'taylor']));
+    }
+
     protected function getOneRelation()
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -193,6 +205,25 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
 
         return new MorphMany($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
+    }
+
+    protected function getNamespacedRelation($alias)
+    {
+        Illuminate\Database\Eloquent\Relations\Relation::morphMap([
+            $alias => 'Foo\Bar\EloquentModelNamespacedStub',
+        ]);
+
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
+        $builder->shouldReceive('whereNotNull')->once()->with('table.morph_id');
+        $builder->shouldReceive('where')->once()->with('table.morph_id', '=', 1);
+        $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $builder->shouldReceive('getModel')->andReturn($related);
+        $parent = m::mock('Foo\Bar\EloquentModelNamespacedStub');
+        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('getMorphClass')->andReturn($alias);
+        $builder->shouldReceive('where')->once()->with('table.morph_type', $alias);
+
+        return new MorphOne($builder, $parent, 'table.morph_type', 'table.morph_id', 'id');
     }
 }
 


### PR DESCRIPTION
Adds a morphMap array to the Eloquent Model which allows you to map the morphable type so that you don't have to pass a fully qualified namespace to aforementioned type.

Please see #9670 for complete details. This is simply another implementation of it, as suggested by @taylorotwell.

This allows you to globally declare a morph map for relations. The recommended place to do this would be in a service provider:

```
public function boot()
{
    Relation::$morphMap = [
        'user' => \Acme\User::class
    ];
}
```

The `$morphMap` array is to be set on the `Illuminate\Database\Eloquent\Relations\Relation` class.
