### PR TITLE
[5.2] Upgrade to Stringy 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "classpreloader/classpreloader": "~2.0",
-        "danielstjules/stringy": "~1.8",
+        "danielstjules/stringy": "~2.0",
         "doctrine/inflector": "~1.0",
         "jeremeamia/superclosure": "~2.0",
         "league/flysystem": "~1.0",

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support;
 
 use RuntimeException;
-use Stringy\StaticStringy;
+use Stringy\Stringy;
 use Illuminate\Support\Traits\Macroable;
 
 class Str
@@ -39,7 +39,7 @@ class Str
      */
     public static function ascii($value)
     {
-        return StaticStringy::toAscii($value);
+        return (string) Stringy::create($value)->toAscii();
     }
 
     /**


### PR DESCRIPTION
Stringy has released 2.0.0, which breaks backwards compatibility in ways that don't effect the Laravel framework other than the removal of the StaticStringy class.

This PR inlines the removed-in-2.0.0 `StaticStringy::toAscii()` function to allow us to move to the 2.0.0 branch.

To ease review, here is a copy of Stringy 1.8's static function which I inlined in this patch.

``` php
    // StaticStringy::toAscii()
    public static function toAscii($str, $removeUnsupported = true)
    {
        return (string) Stringy::create($str)->toAscii($removeUnsupported);
    }
```
