### PR TITLE
[5.1] Move generating SymfonyDisplayer to a separate method to make it easier to replace the generic exception page.

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -90,7 +90,7 @@ class Handler implements ExceptionHandlerContract
         if ($this->isHttpException($e)) {
             return $this->toIlluminateResponse($this->renderHttpException($e), $e);
         } else {
-            return $this->toIlluminateResponse((new SymfonyDisplayer(config('app.debug')))->createResponse($e), $e);
+            return $this->toIlluminateResponse($this->getBasicHttpExceptionDisplayer($e), $e);
         }
     }
 
@@ -135,8 +135,19 @@ class Handler implements ExceptionHandlerContract
         if (view()->exists("errors.{$status}")) {
             return response()->view("errors.{$status}", ['exception' => $e], $status);
         } else {
-            return (new SymfonyDisplayer(config('app.debug')))->createResponse($e);
+            return $this->getBasicHttpExceptionDisplayer($e);
         }
+    }
+
+    /**
+     * Get generic HTTP exception displayer/view.
+     *
+     * @param  \Exception  $e
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function getBasicHttpExceptionDisplayer(Exception $e)
+    {
+        return (new SymfonyDisplayer(config('app.debug')))->createResponse($e);
     }
 
     /**


### PR DESCRIPTION
This is useful for application that intent to avoid using SymfonyDisplayer for generic exception (avoid seeing the basic "Whoops" page).

With this change, it would be easier to do the following (instead of manually overriding both `render` and `rendeHttpException` method):

``` php
    /**
     * Get generic HTTP exception displayer/view.
     *
     * @param  \Exception  $e
     * @return \Symfony\Component\HttpFoundation\Response
     */
    protected function getBasicHttpExceptionDisplayer(Exception $e)
    {
        $debug = config('app.debug', false);

        if (!! $debug) {
            return (new SymfonyDisplayer($debug))->createResponse($e);
        }

        return response()->view("errors.error", ['exception' => $e], 500);
    }
```

Signed-off-by: crynobone crynobone@gmail.com
