### PR TITLE
Execution path in delete method of Model class without return value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1155,6 +1155,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
             return true;
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
If one execution path returns a value in a method, all should. The delete method currently doesn't have a `return` if the `exists` property is `false`.

Even though PHP implicitly returns `null` if you omit the `return` statement you should explicitly add the return for a clear coding style and a well defined behavior.
In addition the doc block states `@return bool|null` while omitting the `return` would semantically rather be a `@return void`.

See also related discussion here: https://github.com/laravel/framework/pull/9806
