### PR TITLE
[5.1] Added seeInField method

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing;
 
+use Exception;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
@@ -660,6 +661,52 @@ trait CrawlerTrait
         $this->inputs[$element] = $text;
 
         return $this;
+    }
+
+    /**
+     * Assert that an input field contains the given value.
+     *
+     * @param  string  $selector
+     * @param  string  $expected
+     * @return $this
+     */
+    public function seeInField($selector, $expected)
+    {
+        $this->assertSame(
+            $this->getInputOrTextareaValue($selector),
+            $expected,
+            "The input [{$selector}] has not the value [{$expected}]."
+        );
+
+        return $this;
+    }
+
+    /**
+     * Get an input or textarea value.
+     *
+     * @param  string  $selector
+     * @return string
+     * @throws Exception
+     */
+    protected function getInputOrTextareaValue($selector)
+    {
+        $field = $this->filterByNameOrId($selector);
+
+        if ($field->count() == 0) {
+            throw new Exception("There are no elements with the name or ID [$selector]");
+        }
+
+        $element = $field->nodeName();
+
+        if ($element == 'input') {
+            return $field->attr('value');
+        }
+
+        if ($element == 'textarea') {
+            return $field->text();
+        }
+
+        throw new Exception("[$selector] is neither an input nor a textarea");
     }
 
     /**

--- a/tests/Foundation/FoundationCrawlerTraitTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitTest.php
@@ -12,6 +12,63 @@ class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
         m::close();
     }
 
+    public function testSeeInFieldInput()
+    {
+        $input = m::mock(Crawler::class)->makePartial();
+        $input->shouldReceive('count')->andReturn(1);
+        $input->shouldReceive('nodeName')->once()->andReturn('input');
+        $input->shouldReceive('attr')
+            ->withArgs(['value'])
+            ->once()
+            ->andReturn('Laravel');
+
+        $this->crawler = m::mock(Crawler::class)->makePartial();
+
+        $this->crawler->shouldReceive('filter')
+            ->withArgs(["*#framework, *[name='framework']"])
+            ->once()
+            ->andReturn($input);
+
+        $this->seeInField('framework', 'Laravel');
+    }
+
+    public function testSeeInFieldTextarea()
+    {
+        $textarea = m::mock(Crawler::class)->makePartial();
+        $textarea->shouldReceive('count')->andReturn(1);
+        $textarea->shouldReceive('nodeName')->once()->andReturn('textarea');
+        $textarea->shouldReceive('text')->once()->andReturn('Laravel is awesome');
+
+        $this->crawler = m::mock(Crawler::class)->makePartial();
+
+        $this->crawler->shouldReceive('filter')
+            ->withArgs(["*#description, *[name='description']"])
+            ->once()
+            ->andReturn($textarea);
+
+        $this->seeInField('description', 'Laravel is awesome');
+    }
+
+    /**
+     * @expectedException        Exception
+     * @expectedExceptionMessage [select] is neither an input nor a textarea
+     */
+    public function testSeeInFieldWrongElementException()
+    {
+        $select = m::mock(Crawler::class)->makePartial();
+        $select->shouldReceive('count')->andReturn(1);
+        $select->shouldReceive('nodeName')->once()->andReturn('select');
+
+        $this->crawler = m::mock(Crawler::class)->makePartial();
+
+        $this->crawler->shouldReceive('filter')
+            ->withArgs(["*#select, *[name='select']"])
+            ->once()
+            ->andReturn($select);
+
+        $this->seeInField('select', 'selected_value');
+    }
+
     public function testExtractsRequestParametersFromForm()
     {
         $form = m::mock('\Symfony\Component\DomCrawler\Form');


### PR DESCRIPTION
Adding a proposal for the **seeInField** method, that will allow developers to check if a input or textarea contain the expected value.

Usage:

```
$this->seeInField('name', 'Taylor');
```
