### PR TITLE
[5.1] Ability to add custom configurations on index creation

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -348,12 +348,12 @@ class Blueprint
      * Specify an index for the table.
      *
      * @param  string|array  $columns
-     * @param  string  $name
+     * @param  string  $options
      * @return \Illuminate\Support\Fluent
      */
-    public function index($columns, $name = null)
+    public function index($columns, $options = null)
     {
-        return $this->indexCommand('index', $columns, $name);
+        return $this->indexCommand('index', $columns, $options);
     }
 
     /**
@@ -867,12 +867,18 @@ class Blueprint
      *
      * @param  string        $type
      * @param  string|array  $columns
-     * @param  string        $index
+     * @param  string|array  $options
      * @return \Illuminate\Support\Fluent
      */
-    protected function indexCommand($type, $columns, $index)
+    protected function indexCommand($type, $columns, $options = null)
     {
         $columns = (array) $columns;
+
+        $index = is_string($options) ? $options : null;
+
+        if (is_array($options) && isset($options['name'])) {
+             $index = $options['name'];
+        }
 
         // If no name was specified for this index, we will create one using a basic
         // convention of the table name, followed by the columns, followed by an
@@ -881,7 +887,7 @@ class Blueprint
             $index = $this->createIndexName($type, $columns);
         }
 
-        return $this->addCommand($type, compact('index', 'columns'));
+        return $this->addCommand($type, compact('index', 'columns', 'options'));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -877,7 +877,7 @@ class Blueprint
         $index = is_string($options) ? $options : null;
 
         if (is_array($options) && isset($options['name'])) {
-             $index = $options['name'];
+            $index = $options['name'];
         }
 
         // If no name was specified for this index, we will create one using a basic

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -710,7 +710,7 @@ class MySqlGrammar extends Grammar
     {
         $options = (array) $options;
 
-        $this->modifyUsingOption( $options );
+        $this->modifyUsingOption($options);
 
         return (object) $options;
     }

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -161,7 +161,9 @@ class MySqlGrammar extends Grammar
 
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} add {$type} {$command->index}($columns)";
+        $o = $this->formatIndexOptions($command->options);
+
+        return "alter table {$table} add {$type} {$command->index}($columns){$o->using}";
     }
 
     /**
@@ -696,5 +698,31 @@ class MySqlGrammar extends Grammar
         }
 
         return '`'.str_replace('`', '``', $value).'`';
+    }
+
+    /**
+     * Get the SQL for each index option.
+     *
+     * @param  string|array  $options
+     * @return stdObject
+     */
+    protected function formatIndexOptions($options)
+    {
+        $options = (array) $options;
+
+        $this->modifyUsingOption( $options );
+
+        return (object) $options;
+    }
+
+    /**
+     * Receives an array by reference and change its 'using' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyUsingOption(array &$options)
+    {
+        $options['using'] = isset($options['using']) ? ' using '.$options['using'] : '';
     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -113,7 +113,9 @@ class PostgresGrammar extends Grammar
     {
         $columns = $this->columnize($command->columns);
 
-        return "create index {$command->index} on ".$this->wrapTable($blueprint)." ({$columns})";
+        $o = $this->formatIndexOptions($command->options);
+
+        return "create index{$o->concurrently} {$command->index} on ".$this->wrapTable($blueprint)."{$o->using} ({$columns}){$o->with}{$o->tablespace}{$o->where}";
     }
 
     /**
@@ -539,5 +541,81 @@ class PostgresGrammar extends Grammar
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
             return ' primary key';
         }
+    }
+
+    /**
+     * Get the SQL for each index option.
+     *
+     * @param  string|array  $options
+     * @return stdObject
+     */
+    protected function formatIndexOptions($options)
+    {
+        $options = (array) $options;
+
+        $this->modifyConcurrentlyOption( $options );
+        $this->modifyTablespaceOption( $options );
+        $this->modifyUsingOption( $options );
+        $this->modifyWhereOption( $options );
+        $this->modifyWithOption( $options );
+
+        return (object) $options;
+    }
+
+    /**
+     * Receives an array by reference and change its 'concurrently' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyConcurrentlyOption(array &$options)
+    {
+        $options['concurrently'] = (isset($options['concurrently'])
+                                       && $options['concurrently'] === true) ? ' concurrently' : '';
+    }
+
+    /**
+     * Receives an array by reference and change its 'tablespace' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyTablespaceOption(array &$options)
+    {
+        $options['tablespace'] = isset($options['tablespace']) ? ' tablespace '.$options['tablespace'] : '';
+    }
+
+    /**
+     * Receives an array by reference and change its 'using' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyUsingOption(array &$options)
+    {
+        $options['using'] = isset($options['using']) ? ' using '.$options['using'] : '';
+    }
+
+    /**
+     * Receives an array by reference and change its 'where' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyWhereOption(array &$options)
+    {
+        $options['where'] = isset($options['where']) ? ' where '.$options['where'] : '';
+    }
+
+    /**
+     * Receives an array by reference and change its 'with' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyWithOption(array &$options)
+    {
+        $option = isset($options['with']) ? (array)$options['with'] : '';
+        $options['with'] = !empty($option) ? ' with ('.implode(', ',$option).')' : '';
     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -553,11 +553,11 @@ class PostgresGrammar extends Grammar
     {
         $options = (array) $options;
 
-        $this->modifyConcurrentlyOption( $options );
-        $this->modifyTablespaceOption( $options );
-        $this->modifyUsingOption( $options );
-        $this->modifyWhereOption( $options );
-        $this->modifyWithOption( $options );
+        $this->modifyConcurrentlyOption($options);
+        $this->modifyTablespaceOption($options);
+        $this->modifyUsingOption($options);
+        $this->modifyWhereOption($options);
+        $this->modifyWithOption($options);
 
         return (object) $options;
     }
@@ -615,7 +615,7 @@ class PostgresGrammar extends Grammar
      */
     protected function modifyWithOption(array &$options)
     {
-        $option = isset($options['with']) ? (array)$options['with'] : '';
-        $options['with'] = !empty($option) ? ' with ('.implode(', ',$option).')' : '';
+        $option = isset($options['with']) ? (array) $options['with'] : '';
+        $options['with'] = ! empty($option) ? ' with ('.implode(', ', $option).')' : '';
     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -84,11 +84,11 @@ class SQLiteGrammar extends Grammar
         foreach ($foreigns as $foreign) {
             $sql .= $this->getForeignKey($foreign);
 
-            if (!is_null($foreign->onDelete)) {
+            if (! is_null($foreign->onDelete)) {
                 $sql .= " on delete {$foreign->onDelete}";
             }
 
-            if (!is_null($foreign->onUpdate)) {
+            if (! is_null($foreign->onUpdate)) {
                 $sql .= " on update {$foreign->onUpdate}";
             }
         }
@@ -126,7 +126,7 @@ class SQLiteGrammar extends Grammar
     {
         $primary = $this->getCommandByName($blueprint, 'primary');
 
-        if (!is_null($primary)) {
+        if (! is_null($primary)) {
             $columns = $this->columnize($primary->columns);
 
             return ", primary key ({$columns})";
@@ -585,7 +585,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (!is_null($column->default)) {
+        if (! is_null($column->default)) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }
@@ -614,7 +614,7 @@ class SQLiteGrammar extends Grammar
     {
         $options = (array) $options;
 
-        $this->modifyWhereOption( $options );
+        $this->modifyWhereOption($options);
 
         return (object) $options;
     }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -84,11 +84,11 @@ class SQLiteGrammar extends Grammar
         foreach ($foreigns as $foreign) {
             $sql .= $this->getForeignKey($foreign);
 
-            if (! is_null($foreign->onDelete)) {
+            if (!is_null($foreign->onDelete)) {
                 $sql .= " on delete {$foreign->onDelete}";
             }
 
-            if (! is_null($foreign->onUpdate)) {
+            if (!is_null($foreign->onUpdate)) {
                 $sql .= " on update {$foreign->onUpdate}";
             }
         }
@@ -126,7 +126,7 @@ class SQLiteGrammar extends Grammar
     {
         $primary = $this->getCommandByName($blueprint, 'primary');
 
-        if (! is_null($primary)) {
+        if (!is_null($primary)) {
             $columns = $this->columnize($primary->columns);
 
             return ", primary key ({$columns})";
@@ -184,7 +184,9 @@ class SQLiteGrammar extends Grammar
 
         $table = $this->wrapTable($blueprint);
 
-        return "create index {$command->index} on {$table} ({$columns})";
+        $o = $this->formatIndexOptions($command->options);
+
+        return "create index {$command->index} on {$table} ({$columns}){$o->where}";
     }
 
     /**
@@ -583,7 +585,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->default)) {
+        if (!is_null($column->default)) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }
@@ -600,5 +602,31 @@ class SQLiteGrammar extends Grammar
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
             return ' primary key autoincrement';
         }
+    }
+
+    /**
+     * Get the SQL for each index option.
+     *
+     * @param  string|array  $options
+     * @return stdObject
+     */
+    protected function formatIndexOptions($options)
+    {
+        $options = (array) $options;
+
+        $this->modifyWhereOption( $options );
+
+        return (object) $options;
+    }
+
+    /**
+     * Receives an array by reference and change its 'where' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyWhereOption(array &$options)
+    {
+        $options['where'] = isset($options['where']) ? ' where '.$options['where'] : '';
     }
 }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -561,12 +561,12 @@ class SqlServerGrammar extends Grammar
     {
         $options = (array) $options;
 
-        $this->modifyFilestreamOption( $options );
-        $this->modifyClusteredOption( $options );
-        $this->modifyIncludeOption( $options );
-        $this->modifyWhereOption( $options );
-        $this->modifyWithOption( $options );
-        $this->modifyOnOption( $options );
+        $this->modifyFilestreamOption($options);
+        $this->modifyClusteredOption($options);
+        $this->modifyIncludeOption($options);
+        $this->modifyWhereOption($options);
+        $this->modifyWithOption($options);
+        $this->modifyOnOption($options);
 
         return (object) $options;
     }
@@ -602,8 +602,8 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyIncludeOption(array &$options)
     {
-        $option = isset($options['include']) ? (array)$options['include'] : '';
-        $options['include'] = !empty($option) ? ' include ('.implode(', ',$option).')' : '';
+        $option = isset($options['include']) ? (array) $options['include'] : '';
+        $options['include'] = ! empty($option) ? ' include ('.implode(', ', $option).')' : '';
     }
 
     /**
@@ -625,8 +625,8 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyWithOption(array &$options)
     {
-        $option = isset($options['with']) ? (array)$options['with'] : '';
-        $options['with'] = !empty($option) ? ' with ('.implode(', ',$option).')' : '';
+        $option = isset($options['with']) ? (array) $options['with'] : '';
+        $options['with'] = ! empty($option) ? ' with ('.implode(', ', $option).')' : '';
     }
 
     /**
@@ -639,5 +639,4 @@ class SqlServerGrammar extends Grammar
     {
         $options['on'] = isset($options['on']) ? ' on '.$options['on'] : '';
     }
-
 }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -119,7 +119,9 @@ class SqlServerGrammar extends Grammar
 
         $table = $this->wrapTable($blueprint);
 
-        return "create index {$command->index} on {$table} ({$columns})";
+        $o = $this->formatIndexOptions($command->options);
+
+        return "create{$o->clustered} index {$command->index} on {$table} ({$columns}){$o->include}{$o->where}{$o->with}{$o->on}{$o->filestream_on}";
     }
 
     /**
@@ -548,4 +550,94 @@ class SqlServerGrammar extends Grammar
             return ' identity primary key';
         }
     }
+
+    /**
+     * Get the SQL for each index option.
+     *
+     * @param  string|array  $options
+     * @return stdObject
+     */
+    protected function formatIndexOptions($options)
+    {
+        $options = (array) $options;
+
+        $this->modifyFilestreamOption( $options );
+        $this->modifyClusteredOption( $options );
+        $this->modifyIncludeOption( $options );
+        $this->modifyWhereOption( $options );
+        $this->modifyWithOption( $options );
+        $this->modifyOnOption( $options );
+
+        return (object) $options;
+    }
+
+    /**
+     * Receives an array by reference and change its 'filestream_on' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyFilestreamOption(array &$options)
+    {
+        $options['filestream_on'] = isset($options['filestream_on']) ? ' filestream_on '.$options['filestream_on'] : '';
+    }
+
+    /**
+     * Receives an array by reference and change its 'clustered' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyClusteredOption(array &$options)
+    {
+        $option = (isset($options['clustered']) && $options['clustered'] === true) ? ' clustered' : ' nonclustered';
+        $options['clustered'] = isset($options['clustered']) ? $option : '';
+    }
+
+    /**
+     * Receives an array by reference and change its 'include' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyIncludeOption(array &$options)
+    {
+        $option = isset($options['include']) ? (array)$options['include'] : '';
+        $options['include'] = !empty($option) ? ' include ('.implode(', ',$option).')' : '';
+    }
+
+    /**
+     * Receives an array by reference and change its 'where' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyWhereOption(array &$options)
+    {
+        $options['where'] = isset($options['where']) ? ' where '.$options['where'] : '';
+    }
+
+    /**
+     * Receives an array by reference and change its 'with' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyWithOption(array &$options)
+    {
+        $option = isset($options['with']) ? (array)$options['with'] : '';
+        $options['with'] = !empty($option) ? ' with ('.implode(', ',$option).')' : '';
+    }
+
+    /**
+     * Receives an array by reference and change its 'on' field to SQL.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function modifyOnOption(array &$options)
+    {
+        $options['on'] = isset($options['on']) ? ' on '.$options['on'] : '';
+    }
+
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -232,6 +232,26 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('alter table `users` add index baz(`foo`, `bar`)', $statements[0]);
     }
 
+    public function testAddingIndexWithOptions()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar'], ['name'=>'baz','using'=>'hash','invalid'=>'option']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('alter table `users` add index baz(`foo`, `bar`) using hash', $statements[0]);
+    }
+
+    public function testAddingIndexWithOptionsAndDefaultName()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar'], ['using'=>'hash']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('alter table `users` add index users_foo_bar_index(`foo`, `bar`) using hash', $statements[0]);
+    }
+
     public function testAddingForeignKey()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -235,7 +235,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
     public function testAddingIndexWithOptions()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->index(['foo', 'bar'], ['name'=>'baz','using'=>'hash','invalid'=>'option']);
+        $blueprint->index(['foo', 'bar'], ['name' => 'baz', 'using' => 'hash', 'invalid' => 'option']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
@@ -245,7 +245,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
     public function testAddingIndexWithOptionsAndDefaultName()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->index(['foo', 'bar'], ['using'=>'hash']);
+        $blueprint->index(['foo', 'bar'], ['using' => 'hash']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -177,7 +177,7 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
     public function testAddingIndexWithOptions()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->index(['foo', 'bar'], ['name'=>'baz','using'=>'gin','concurrently'=>true,'with'=>['fastupdate = off','fillfactor = 50'],'tablespace'=>'not_default','where'=>'foo = bar']);
+        $blueprint->index(['foo', 'bar'], ['name' => 'baz', 'using' => 'gin', 'concurrently' => true, 'with' => ['fastupdate = off', 'fillfactor = 50'], 'tablespace' => 'not_default', 'where' => 'foo = bar']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
@@ -187,7 +187,7 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
     public function testAddingIndexWithOptionsAndDefaultName()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->index(['foo', 'bar'], ['using'=>'hash']);
+        $blueprint->index(['foo', 'bar'], ['using' => 'hash']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -174,6 +174,26 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('create index baz on "users" ("foo", "bar")', $statements[0]);
     }
 
+    public function testAddingIndexWithOptions()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar'], ['name'=>'baz','using'=>'gin','concurrently'=>true,'with'=>['fastupdate = off','fillfactor = 50'],'tablespace'=>'not_default','where'=>'foo = bar']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('create index concurrently baz on "users" using gin ("foo", "bar") with (fastupdate = off, fillfactor = 50) tablespace not_default where foo = bar', $statements[0]);
+    }
+
+    public function testAddingIndexWithOptionsAndDefaultName()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar'], ['using'=>'hash']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('create index users_foo_bar_index on "users" using hash ("foo", "bar")', $statements[0]);
+    }
+
     public function testAddingIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -128,6 +128,26 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('create index baz on "users" ("foo", "bar")', $statements[0]);
     }
 
+    public function testAddingIndexWithOptions()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index('foo', ['name'=>'baz','where'=>'bar = baz']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('create index baz on "users" ("foo") where bar = baz', $statements[0]);
+    }
+
+    public function testAddingIndexWithOptionsAndDefaultName()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index('foo',['where'=>'bar = baz']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('create index users_foo_index on "users" ("foo") where bar = baz', $statements[0]);
+    }
+
     public function testAddingIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -131,7 +131,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
     public function testAddingIndexWithOptions()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->index('foo', ['name'=>'baz','where'=>'bar = baz']);
+        $blueprint->index('foo', ['name' => 'baz', 'where' => 'bar = baz']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
@@ -141,7 +141,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
     public function testAddingIndexWithOptionsAndDefaultName()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->index('foo',['where'=>'bar = baz']);
+        $blueprint->index('foo',['where' => 'bar = baz']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -141,7 +141,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
     public function testAddingIndexWithOptionsAndDefaultName()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->index('foo',['where' => 'bar = baz']);
+        $blueprint->index('foo', ['where' => 'bar = baz']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -167,7 +167,7 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
     public function testAddingIndexWithOptions()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->index(['foo', 'bar'], ['name'=>'baz','clustered'=>true,'filestream_on'=>'whatever','include'=>['something','else'],'with'=>['two','options'],'on'=>'top','where'=>'foo = bar']);
+        $blueprint->index(['foo', 'bar'], ['name' => 'baz', 'clustered' => true, 'filestream_on' => 'whatever', 'include' => ['something','else'], 'with' => ['two','options'], 'on' => 'top', 'where' => 'foo = bar']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
@@ -177,7 +177,7 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
     public function testAddingIndexWithOptionsAndDefaultName()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->index(['foo', 'bar'], ['clustered'=>false]);
+        $blueprint->index(['foo', 'bar'], ['clustered' => false]);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -164,6 +164,26 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('create index baz on "users" ("foo", "bar")', $statements[0]);
     }
 
+    public function testAddingIndexWithOptions()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar'], ['name'=>'baz','clustered'=>true,'filestream_on'=>'whatever','include'=>['something','else'],'with'=>['two','options'],'on'=>'top','where'=>'foo = bar']);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('create clustered index baz on "users" ("foo", "bar") include (something, else) where foo = bar with (two, options) on top filestream_on whatever', $statements[0]);
+    }
+
+    public function testAddingIndexWithOptionsAndDefaultName()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->index(['foo', 'bar'], ['clustered'=>false]);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('create nonclustered index users_foo_bar_index on "users" ("foo", "bar")', $statements[0]);
+    }
+
     public function testAddingIncrementingID()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
Ability to add custom configurations on index creation using $table->index('col',['key'=>'value', ...]). Resolves #9846.

It keeps the old behavior of setting a default index name if there is no second parameter. If the second parameter is a string, a custom index name will be given as usual. If it's an array, a custom name can still be given by passing 'name'=>'foo' as a field. 

This feature enables the developer to customize specific indexing options for all supported databases. I developed it because I needed to add GIN indexes to jsonb columns in Postgresql (and did not want to write raw queries for it), maybe someone will need this feature for other indexing scenarios with other database engines. ;)
