### PR TITLE
[5.1] Added $_loop variable support

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -512,7 +512,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileFor($expression)
     {
-        return "<?php for{$expression}: ?>";
+        return '<?php '.$this->beforeStartLoop($expression, false)." for{$expression}: ".$this->afterStartLoop().' ?>';
     }
 
     /**
@@ -523,7 +523,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileForeach($expression)
     {
-        return "<?php foreach{$expression}: ?>";
+        return '<?php '.$this->beforeStartLoop($expression)." foreach{$expression}: ".$this->afterStartLoop().' ?>';
     }
 
     /**
@@ -536,7 +536,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $empty = '$__empty_'.++$this->forelseCounter;
 
-        return "<?php {$empty} = true; foreach{$expression}: {$empty} = false; ?>";
+        return "<?php {$empty} = true; ".$this->beforeStartLoop($expression)." foreach{$expression}: {$empty} = false; ".$this->afterStartLoop().' ?>';
     }
 
     /**
@@ -571,7 +571,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $empty = '$__empty_'.$this->forelseCounter--;
 
-        return "<?php endforeach; if ({$empty}): ?>";
+        return '<?php '.$this->beforeEndLoop().' endforeach; '.$this->afterEndLoop()." if ({$empty}): ?>";
     }
 
     /**
@@ -582,7 +582,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileWhile($expression)
     {
-        return "<?php while{$expression}: ?>";
+        return '<?php '.$this->beforeStartLoop($expression, false)." while{$expression}: ".$this->afterStartLoop().' ?>';
     }
 
     /**
@@ -593,7 +593,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileEndwhile($expression)
     {
-        return '<?php endwhile; ?>';
+        return '<?php '.$this->beforeEndLoop().' endwhile; '.$this->afterEndLoop().' ?>';
     }
 
     /**
@@ -604,7 +604,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileEndfor($expression)
     {
-        return '<?php endfor; ?>';
+        return '<?php '.$this->beforeEndLoop().' endfor; '.$this->afterEndLoop().' ?>';
     }
 
     /**
@@ -615,7 +615,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileEndforeach($expression)
     {
-        return '<?php endforeach; ?>';
+        return '<?php '.$this->beforeEndLoop().' endforeach; '.$this->afterEndLoop().' ?>';
     }
 
     /**
@@ -841,5 +841,69 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function setEchoFormat($format)
     {
         $this->echoFormat = $format;
+    }
+
+    /**
+     * Set $_loop object default properties before loop.
+     *
+     * @param  string  $expression
+     * @param  bool    $count
+     * @return string
+     */
+    protected function beforeStartLoop(&$expression, $count = true)
+    {
+        // when counted replace collection variable with stored one
+        if ($count) {
+            $collection = substr($expression, 1, strpos(strtolower($expression), ' as '));
+            $expression = str_replace($collection, '$_loop->collection ', $expression);
+        }
+
+        return 'if (isset($_loop)) {
+            $__loopParent = $_loop;
+        } else {
+            $__loopParent = null;
+        }
+        $_loop = new \stdClass();
+        $_loop->parent = $__loopParent;
+        $_loop->index = 0;
+        $_loop->num = 0;
+        $_loop->first = true;
+        $_loop->total = '.($count ? 'count($_loop->collection = '.$collection.')' : 'null').';';
+    }
+
+    /**
+     * Update $_loop index, num and last properties.
+     *
+     * @return string
+     */
+    protected function afterStartLoop()
+    {
+        return '$_loop->num++;
+        $_loop->last = $_loop->num == $_loop->total;';
+    }
+
+    /**
+     * Update $_loop first and index properties.
+     *
+     * @return string
+     */
+    protected function beforeEndLoop()
+    {
+        return '$_loop->first = false;
+        $_loop->index++;';
+    }
+
+    /**
+     * Cleanup $_loop variable.
+     *
+     * @return string
+     */
+    protected function afterEndLoop()
+    {
+        return 'if ($_loop->parent) {
+            $_loop = $_loop->parent;
+        } else {
+            unset($_loop);
+        }';
     }
 }


### PR DESCRIPTION
I was really missing Twig's loop variable feature so I wrote an implementation for Blade.

Fix creates $_loop variable with properties which are set before and after each loop and iterance:
- index (zero-indexed)
- num (one-indexed)
- first (true on first iterance)
- last (true on last iterance)
- total (set only in foreach and forelse loop)
- parent (if any)

Usage is simple, $_loop variable can be used in same way as any other variable:

```
                @foreach(range(1,3) as $i)
                    <div data-1index="{{ $_loop->num }}">
                        @foreach(range(1,3) as $j)
                            <div data-parent-0index="{{ $_loop->parent->index }}">
                                @if($_loop->first)
                                    First child
                                @elseif($_loop->last)
                                    Last child
                                @endif

                                {{ $_loop->parent->num }} / {{ $_loop->num }}
                            </div>
                        @endforeach
                    </div>
                @endforeach
```

It also prevents double method call, for example: @foreach($foo->bar() as $row) will first save result of $foo->bar() in $_loop->all and then output PHP code foreach($_loop->all as $row).

Note that any pre-existent $_loop variable will be overwritten, so this is only backwards compatibility issue.
