### PR TITLE
[5.1] Allow the Broadcast Event job to be sent to a specific queue name.

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -254,8 +254,9 @@ class Dispatcher implements DispatcherContract
     {
         if ($this->queueResolver) {
             $connection = $event instanceof ShouldBroadcastNow ? 'sync' : null;
+            $queue = method_exists($event, 'queueOn') ? $event->queueOn() : null;
 
-            $this->resolveQueue()->connection($connection)->push('Illuminate\Broadcasting\BroadcastEvent', [
+            $this->resolveQueue()->connection($connection)->pushOn($queue, 'Illuminate\Broadcasting\BroadcastEvent', [
                 'event' => serialize($event),
             ]);
         }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -254,7 +254,7 @@ class Dispatcher implements DispatcherContract
     {
         if ($this->queueResolver) {
             $connection = $event instanceof ShouldBroadcastNow ? 'sync' : null;
-            $queue = method_exists($event, 'queueOn') ? $event->queueOn() : null;
+            $queue = method_exists($event, 'onQueue') ? $event->onQueue() : null;
 
             $this->resolveQueue()->connection($connection)->pushOn($queue, 'Illuminate\Broadcasting\BroadcastEvent', [
                 'event' => serialize($event),


### PR DESCRIPTION
Fixes: https://github.com/laravel/framework/issues/9750
### Summary
- Broadcast events need to be sent to a queue.
- Current code forces these jobs to be sent to queue as named in `config/queue.php` (usually 'default')
- This queue may already be full with other jobs. Therefore broadcast doesn't get sent until other jobs have been processed. Indeterminate delay.
- This PR allows the broadcast jobs to be sent to specified queue name allowing a dedicated worker to process them avoiding any delay.
### Why not use ShouldBroadcastNow Interface?

The `ShouldBroadcastNow` interface isn't well documented (that I could see). This can be used in the user's event class, instead of `ShouldBroadcast` but it forces SYNC mode instead of using a queue driver. My PR allows proper use of the queue system so Laravel isn't having to wait until the broadcast is sent.
### Why look for a onQueue method in the event class?

Initially I had used a property called `$queue` in the users event class to set the queue name to be used. However when an event is broadcast all properties get sent as the data payload [see docs](http://laravel.com/docs/5.1/events#broadcast-data). This meant that the queue name was being sent as a data as well as being used to determine the queue name. Something that didn't seem sensible.

By having an `onQueue` method this gets around the problem. It also remains consistent with trait `Queueable`
### Backwards Compatible

Yes, if there is no `onQueue` method, it returns `null`. 
When you `pushOn` to `null`, it uses the default queue name so there is no issues with this.
