### PR TITLE
[5.1] Custom pivot models when using polymorphic relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
@@ -1922,6 +1923,20 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function newPivot(Model $parent, array $attributes, $table, $exists)
     {
         return new Pivot($parent, $attributes, $table, $exists);
+    }
+
+    /**
+     * Create a new MorphPivot model instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  array   $attributes
+     * @param  string  $table
+     * @param  bool    $exists
+     * @return \Illuminate\Database\Eloquent\Relations\MorphPivot
+     */
+    public function newMorphPivot(Model $parent, array $attributes, $table, $exists)
+    {
+        return new MorphPivot($parent, $attributes, $table, $exists);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1929,9 +1929,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * Create a new MorphPivot model instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @param  array   $attributes
+     * @param  array  $attributes
      * @param  string  $table
-     * @param  bool    $exists
+     * @param  bool  $exists
      * @return \Illuminate\Database\Eloquent\Relations\MorphPivot
      */
     public function newMorphPivot(Model $parent, array $attributes, $table, $exists)

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -129,7 +129,7 @@ class MorphToMany extends BelongsToMany
      */
     public function newPivot(array $attributes = [], $exists = false)
     {
-        $pivot = new MorphPivot($this->parent, $attributes, $this->table, $exists);
+        $pivot = $this->related->newMorphPivot($this->parent, $attributes, $this->table, $exists);
 
         $pivot->setPivotKeys($this->foreignKey, $this->otherKey)
               ->setMorphType($this->morphType)


### PR DESCRIPTION
See https://github.com/laravel/framework/issues/9805

Example of use:

``` php
use Illuminate\Database\Eloquent\Relations\MorphPivot;

class ContactablePivot extends MorphPivot
{
    protected $casts=[
        "isactive" => "bool"
    ];
}
```

``` php
class Contact extends Model
{
    ...

    public function bonnen()
    {
        return $this->morphedByMany(Bon::class, "contactable", "contactables", "contact_id", "contactable_id")->withPivot("isactive");
    }

    public function newMorphPivot(Model $parent, array $attributes, $table, $exists)
    {
        if($parent instanceof Bon) return new ContactablePivot($parent, $attributes, $table, $exists);
        return parent::newMorphPivot($parent, $attributes, $table, $exists);
    }
}
```

and vice versa in the related model.
