### PR TITLE
[5.1] Fix the missing Command class in App\Commands

### DIFF
--- a/src/Illuminate/Bus/Command.php
+++ b/src/Illuminate/Bus/Command.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Bus;
+
+abstract class Command
+{
+	
+}

--- a/src/Illuminate/Foundation/Console/stubs/command-queued-with-handler.stub
+++ b/src/Illuminate/Foundation/Console/stubs/command-queued-with-handler.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceCommands\Command;
+use Illuminate\Bus\Command;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/src/Illuminate/Foundation/Console/stubs/command-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/command-queued.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceCommands\Command;
+use Illuminate\Bus\Command;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Bus\SelfHandling;

--- a/src/Illuminate/Foundation/Console/stubs/command-with-handler.stub
+++ b/src/Illuminate/Foundation/Console/stubs/command-with-handler.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceCommands\Command;
+use Illuminate\Bus\Command;
 
 class DummyClass extends Command
 {

--- a/src/Illuminate/Foundation/Console/stubs/command.stub
+++ b/src/Illuminate/Foundation/Console/stubs/command.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceCommands\Command;
+use Illuminate\Bus\Command;
 use Illuminate\Contracts\Bus\SelfHandling;
 
 class DummyClass extends Command implements SelfHandling


### PR DESCRIPTION
In 5.0 there was a file in the app\Commands directory called Command.php
In 5.1 that file is missing but the generator stub uses it. I noticed it because i started a new project that uses commands and the first time that i run my application to test it said that the Command class was missing or not found.

My suggestion is creating a Command.php in the Framework (Illumninate\Bus) to prevent future users to notice the same issue that i did.
