### PR TITLE
Use View in artisan make:controller stubs.

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/controller.plain.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.plain.stub
@@ -2,6 +2,7 @@
 
 namespace DummyNamespace;
 
+use Illuminate\View\View;
 use Illuminate\Http\Request;
 
 use DummyRootNamespaceHttp\Requests;

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -2,6 +2,7 @@
 
 namespace DummyNamespace;
 
+use Illuminate\View\View;
 use Illuminate\Http\Request;
 
 use DummyRootNamespaceHttp\Requests;


### PR DESCRIPTION
Small thing, but it seems View is almost certainly to be used in a controller. Tad bit more efficient to include it by default.

...although one can use view(), it's handy to have the class formally included.
