### PR TITLE
[5.1] Allow calling of whereHas without callback closure.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -632,7 +632,7 @@ class Builder
      * Add a relationship count condition to the query with where clauses.
      *
      * @param  string    $relation
-     * @param  \Closure  $callback
+     * @param  \Closure|null  $callback
      * @param  string    $operator
      * @param  int       $count
      * @return \Illuminate\Database\Eloquent\Builder|static

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -632,12 +632,12 @@ class Builder
      * Add a relationship count condition to the query with where clauses.
      *
      * @param  string    $relation
-     * @param  \Closure  $callback
+     * @param  \Closure|null  $callback
      * @param  string    $operator
      * @param  int       $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereHas($relation, Closure $callback, $operator = '>=', $count = 1)
+    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'and', $callback);
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -637,7 +637,7 @@ class Builder
      * @param  int       $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
-    public function whereHas($relation, Closure $callback, $operator = '>=', $count = 1)
+    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'and', $callback);
     }


### PR DESCRIPTION
It would be nice to use whereHas without the need for passing a callback, to the model has at least one relation. eg:  `$family->whereHas('children')` would return all families that have children. 

At the moment I get fatal error _"Argument 2 passed to Illuminate\Database\Eloquent\Builder::whereHas() must be an instance of Closure"_
I see other methods like `whereDoesntHave` and `doesntHave` do allow empty callbacks..
