### PR TITLE
[5.1] SES Mail Transport - Remove unnecessary logic

### DIFF
--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -34,31 +34,9 @@ class SesTransport extends Transport
 
         return $this->ses->sendRawEmail([
             'Source' => key($message->getSender() ?: $message->getFrom()),
-            'Destinations' => $this->getTo($message),
             'RawMessage' => [
                 'Data' => (string) $message,
             ],
         ]);
-    }
-
-    /**
-     * Get the "to" payload field for the API request.
-     *
-     * @param  \Swift_Mime_Message  $message
-     * @return array
-     */
-    protected function getTo(Swift_Mime_Message $message)
-    {
-        $destinations = [];
-
-        $contacts = array_merge(
-            (array) $message->getTo(), (array) $message->getCc(), (array) $message->getBcc()
-        );
-
-        foreach ($contacts as $address => $display) {
-            $destinations[] = $address;
-        }
-
-        return $destinations;
     }
 }

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -49,10 +49,6 @@ class MailSesTransportTest extends PHPUnit_Framework_TestCase
             ->method('sendRawEmail')
             ->with($this->equalTo([
                 'Source' => 'myself@example.com',
-                'Destinations' => [
-                    'me@example.com',
-                    'you@example.com',
-                ],
                 'RawMessage' => ['Data' => (string) $message],
             ]));
 


### PR DESCRIPTION
`"Destinations"` **optionally** defines the recipients to receive the message - **but** is used the To, Cc, and Bcc headers provided in the `"Data"` (that means, the `raw message` provided by `Swift_Mime_Message`).

Example of a raw message:

```
Message-ID: <ge69474z1595f592h3fd226224s431ba@www.app.dev>
Date: Fri, 07 Aug 2015 16:45:59 -0300
Subject: Test Subject
From: Kennedy1 <abc1@gmail.com>
To: Kennedy 2 <abc2@gmail.com>
Cc: Kennedy 3 <abc3@gmail.com>
MIME-Version: 1.0
Content-Type: text/html; charset=utf-8
Content-Transfer-Encoding: quoted-printable

<p>Test</p>
```

I have tested this change on my production app and all works fine.

Side note: http://docs.aws.amazon.com/ses/latest/APIReference/API_SendRawEmail.html
