### PR TITLE
[5.1] Blade custom directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -272,6 +272,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
                 $match[0] = call_user_func($this->customDirectives[$match[1]], Arr::get($match, 3));
             }
 
+            if (isset($this->customDirectives[$method = 'custom'.ucfirst($match[1])])) {
+                $match = call_user_func($this->customDirectives[$method], $match);
+            }
+
             return isset($match[3]) ? $match[0] : $match[0].$match[2];
         };
 


### PR DESCRIPTION
This change allows prepending and appending some code before and after each directive. With this we can simply create customForeach and customEndforeach directives which will add code required for correct implementation of $_loop variable (more details here: https://github.com/laravel/framework/pull/9867/files - methods added in changes should be rewritten to directives).

Whole $match variable is passed and rewritten because in some cases we need to prevent double founction call modify (foo() as $bar) into ($_loop->collection as $bar) and some parts of statements need to be rewritten.
