### PR TITLE
[5.1] Improve validateRequired method 

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -535,7 +535,7 @@ class Validator implements ValidatorContract
             return false;
         } elseif (is_string($value) && trim($value) === '') {
             return false;
-        } elseif ((is_array($value) || $value instanceof Countable) && count($value) < 1) {
+        } elseif ((is_array($value) || $value instanceof Countable) && count(array_filter($value)) < 1) {
             return false;
         } elseif ($value instanceof File) {
             return (string) $value->getPath() != '';


### PR DESCRIPTION
The current implementation of the required check for arrays is only counting the elements in an array. If you pass an array with empty elements the validator will accept the values even if there aren't any values in the array. The suggestion removes all empty elements form the array and checks the size of the "filled"-elements-array.
