### PR TITLE
[5.1] Remove double check of hidden relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2498,12 +2498,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $attributes = [];
 
-        $hidden = $this->getHidden();
-
         foreach ($this->getArrayableRelations() as $key => $value) {
-            if (in_array($key, $hidden)) {
-                continue;
-            }
 
             // If the values implements the Arrayable interface we can just call this
             // toArray method on the instances which will convert both models and

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -606,6 +606,23 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['name' => 'Taylor'], $array);
     }
 
+    public function testGetArrayableRelationsFunctionExcludeHiddenRelationships()
+    {
+        $model = new EloquentModelStub;
+
+        $class = new ReflectionClass($model);
+        $method = $class->getMethod('getArrayableRelations');
+        $method->setAccessible(true);
+
+        $model->setRelation('foo', ['bar']);
+        $model->setRelation('bam', ['boom']);
+        $model->setHidden(['foo']);
+
+        $array = $method->invokeArgs($model, []);
+
+        $this->assertSame(['bam' => ['boom']], $array);
+    }
+
     public function testToArraySnakeAttributes()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
Remove unnecessary check for hidden relation inside the `relationsToArray` function.
[The function](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Database/Eloquent/Model.php#L2564) `getArrayableItems` already checked for hidden relations and removed them from the array.
