### PR TITLE
[5.1] Incorrect behaviour of "in" validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -968,7 +968,7 @@ class Validator implements ValidatorContract
             return count(array_diff($value, $parameters)) == 0;
         }
 
-        return in_array((string) $value, $parameters);
+        return !is_array($value) && in_array((string) $value, $parameters);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -968,7 +968,7 @@ class Validator implements ValidatorContract
             return count(array_diff($value, $parameters)) == 0;
         }
 
-        return !is_array($value) && in_array((string) $value, $parameters);
+        return ! is_array($value) && in_array((string) $value, $parameters);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -824,6 +824,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['name' => ['foo', 'qux']], ['name' => 'Array|In:foo,baz,qux']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'Alpha|In:foo,bar']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateNotIn()


### PR DESCRIPTION
When validating a field which is not explicitly defined as an "array" field; "in" validation would still fail whenever the input over that value was an array. Even though previously a specific (non array) type was defined (i.e. alpha, alphanum etc.)  as a rule.

Example:
POST/PUT-ing a JSON object, having property: "test". Define a rule on "test" that it is of type "alpha" and that it's values have to be either "a" or "b", then submitting the JSON but instead of submitting a string for "test" submit an array will fail.

The proposed fix is to add an array check before the actual "in" check and let the rule fail whenever this is the case, since know for sure that it is **not** the desired value. I though about having it fail "silently" or in this case having the rule pass as long as it is an array. But then you would get undesirable behaviour since the validator would mark the request as valid while it actually is not.
