### PR TITLE
[5.1] Add dontSeeJson() to CrawlerTrait

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -125,4 +125,50 @@ class EloquentUserProvider implements UserProvider
 
         return new $class;
     }
+
+    /**
+     * Gets the hasher implementation.
+     *
+     * @return \Illuminate\Contracts\Hashing\Hasher
+     */
+    public function getHasher()
+    {
+        return $this->hasher;
+    }
+
+    /**
+     * Sets the hasher implementation.
+     *
+     * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
+     * @return $this
+     */
+    public function setHasher(HasherContract $hasher)
+    {
+        $this->hasher = $hasher;
+
+        return $this;
+    }
+
+    /**
+     * Gets the name of the Eloquent user model.
+     *
+     * @return string
+     */
+    public function getModel()
+    {
+        return $this->model;
+    }
+
+    /**
+     * Sets the name of the Eloquent user model.
+     *
+     * @param  string  $model
+     * @return $this
+     */
+    public function setModel($model)
+    {
+        $this->model = $model;
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Illuminate\Contracts\Foundation\Application as LaravelApplication;
 
 class Command extends SymfonyCommand
@@ -372,6 +373,19 @@ class Command extends SymfonyCommand
     public function error($string)
     {
         $this->output->writeln("<error>$string</error>");
+    }
+
+    /**
+     * Write a string as warning output.
+     *
+     * @param  string  $string
+     * @return void
+     */
+    public function warn($string)
+    {
+        $style = new OutputFormatterStyle('yellow');
+        $this->output->getFormatter()->setStyle('warning', $style);
+        $this->output->writeln("<warning>$string</warning>");
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -10,8 +10,8 @@ use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
-use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Illuminate\Contracts\Foundation\Application as LaravelApplication;
 
 class Command extends SymfonyCommand
@@ -384,7 +384,9 @@ class Command extends SymfonyCommand
     public function warn($string)
     {
         $style = new OutputFormatterStyle('yellow');
+
         $this->output->getFormatter()->setStyle('warning', $style);
+
         $this->output->writeln("<warning>$string</warning>");
     }
 

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -103,7 +103,7 @@ class CallbackEvent extends Event
      */
     protected function mutexPath()
     {
-        return storage_path().'/framework/schedule-'.md5($this->description);
+        return storage_path('framework/schedule-'.md5($this->description));
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -220,7 +220,7 @@ class Event
      */
     protected function mutexPath()
     {
-        return storage_path().'/framework/schedule-'.md5($this->expression.$this->command);
+        return storage_path('framework/schedule-'.md5($this->expression . $this->command));
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -220,7 +220,7 @@ class Event
      */
     protected function mutexPath()
     {
-        return storage_path('framework/schedule-'.md5($this->expression . $this->command));
+        return storage_path('framework/schedule-'.md5($this->expression.$this->command));
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -64,7 +64,7 @@ class Container implements ArrayAccess, ContainerContract
     protected $tags = [];
 
     /**
-     * The stack of concretions being currently built.
+     * The stack of concretions currently being built.
      *
      * @var array
      */

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -64,7 +64,7 @@ class Container implements ArrayAccess, ContainerContract
     protected $tags = [];
 
     /**
-     * The stack of concretions being current built.
+     * The stack of concretions being currently built.
      *
      * @var array
      */

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -247,7 +247,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Register a shared binding in the container.
      *
-     * @param  string  $abstract
+     * @param  string|array  $abstract
      * @param  \Closure|string|null  $concrete
      * @return void
      */

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1130,7 +1130,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function delete()
     {
-        if (is_null($this->primaryKey)) {
+        if (is_null($this->getKeyName())) {
             throw new Exception('No primary key defined on model.');
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -812,7 +812,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // the calling method's name and use that as the relationship name as most
         // of the time this will be what we desire to use for the relationships.
         if (is_null($relation)) {
-            list(, $caller) = debug_backtrace(false, 2);
+            list($current, $caller) = debug_backtrace(false, 2);
 
             $relation = $caller['function'];
         }
@@ -850,7 +850,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // since that is most likely the name of the polymorphic interface. We can
         // use that to get both the class and foreign key that will be utilized.
         if (is_null($name)) {
-            list(, $caller) = debug_backtrace(false, 2);
+            list($current, $caller) = debug_backtrace(false, 2);
 
             $name = Str::snake($caller['function']);
         }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -173,7 +173,7 @@ class Builder
 
     /**
      * The binding backups currently in use.
-     * 
+     *
      * @var array
      */
     protected $bindingBackups = [];
@@ -1395,17 +1395,19 @@ class Builder
      * @param  int  $perPage
      * @param  array  $columns
      * @param  string  $pageName
+     * @param  int|null  $page
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      */
-    public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page')
+    public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null)
     {
-        $page = Paginator::resolveCurrentPage($pageName);
-
         $total = $this->getCountForPagination($columns);
 
-        $results = $this->forPage($page, $perPage)->get($columns);
+        $this->forPage(
+            $page = $page ?: Paginator::resolveCurrentPage($pageName),
+            $perPage
+        );
 
-        return new LengthAwarePaginator($results, $total, $perPage, $page, [
+        return new LengthAwarePaginator($this->get($columns), $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
         ]);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -189,7 +189,7 @@ class Builder
         '&', '|', '^', '<<', '>>',
         'rlike', 'regexp', 'not regexp',
         '~', '~*', '!~', '!~*', 'similar to',
-                'not similar to',
+        'not similar to',
     ];
 
     /**
@@ -1400,14 +1400,13 @@ class Builder
      */
     public function paginate($perPage = 15, $columns = ['*'], $pageName = 'page', $page = null)
     {
+        $page = $page ?: Paginator::resolveCurrentPage($pageName);
+
         $total = $this->getCountForPagination($columns);
 
-        $this->forPage(
-            $page = $page ?: Paginator::resolveCurrentPage($pageName),
-            $perPage
-        );
+        $results = $this->forPage($page, $perPage)->get($columns);
 
-        return new LengthAwarePaginator($this->get($columns), $total, $perPage, $page, [
+        return new LengthAwarePaginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
         ]);

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -25,7 +25,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.1.9 (LTS)';
+    const VERSION = '5.1.10 (LTS)';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1106,7 +1106,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             return $this->namespace;
         }
 
-        $composer = json_decode(file_get_contents(base_path().'/composer.json'), true);
+        $composer = json_decode(file_get_contents(base_path('composer.json')), true);
 
         foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path) {
             foreach ((array) $path as $pathChoice) {

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -79,7 +79,7 @@ trait ResetsPasswords
         $this->validate($request, [
             'token' => 'required',
             'email' => 'required|email',
-            'password' => 'required|confirmed',
+            'password' => 'required|confirmed|min:6',
         ]);
 
         $credentials = $request->only(

--- a/src/Illuminate/Foundation/Inspiring.php
+++ b/src/Illuminate/Foundation/Inspiring.php
@@ -11,6 +11,8 @@ class Inspiring
      *
      * Taylor & Dayle made this commit from Jungfraujoch. (11,333 ft.)
      *
+     * May McGinnis always control the board. #LaraconUS2015
+     *
      * @return string
      */
     public static function quote()

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -309,6 +309,22 @@ trait CrawlerTrait
     }
 
     /**
+     * Assert that the given checkbox is selected.
+     *
+     * @param  string  $selector
+     * @return $this
+     */
+    public function seeIsChecked($selector)
+    {
+        $this->assertTrue(
+            $this->isChecked($selector),
+            "The checkbox [{$selector}] is not checked."
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the expected value is selected.
      *
      * @param  string  $selector
@@ -320,22 +336,6 @@ trait CrawlerTrait
         $this->assertSame(
             $expected, $this->getSelectedValue($selector),
             "The field [{$selector}] does not contain the selected value [{$expected}]."
-        );
-
-        return $this;
-    }
-
-    /**
-     * Assert that the given checkbox is selected.
-     *
-     * @param  string  $selector
-     * @return $this
-     */
-    public function seeIsChecked($selector)
-    {
-        $this->assertTrue(
-            $this->isChecked($selector),
-            "The checkbox [{$selector}] is not checked."
         );
 
         return $this;
@@ -410,7 +410,7 @@ trait CrawlerTrait
     protected function getSelectedValueFromSelect(Crawler $field)
     {
         if ($field->nodeName() !== 'select') {
-            throw new Exception('Given element is not a select.');
+            throw new Exception('Given element is not a select element.');
         }
 
         foreach ($field->children() as $option) {

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -384,9 +384,10 @@ trait CrawlerTrait
      * Assert that the response contains JSON.
      *
      * @param  array|null  $data
+     * @param  bool  $negate
      * @return $this
      */
-    public function seeJson(array $data = null)
+    public function seeJson(array $data = null, $negate = false)
     {
         if (is_null($data)) {
             $this->assertJson(
@@ -396,17 +397,31 @@ trait CrawlerTrait
             return $this;
         }
 
-        return $this->seeJsonContains($data);
+        return $this->seeJsonContains($data, $negate);
+    }
+
+    /**
+     * Assert that the response doesn't contain JSON.
+     *
+     * @param  array|null  $data
+     * @return $this
+     */
+    public function dontSeeJson(array $data = null)
+    {
+        return $this->seeJson($data, true);
     }
 
     /**
      * Assert that the response contains the given JSON.
      *
      * @param  array  $data
+     * @param  bool  $negate
      * @return $this
      */
-    protected function seeJsonContains(array $data)
+    protected function seeJsonContains(array $data, $negate = false)
     {
+        $method = $negate ? 'assertFalse' : 'assertTrue';
+
         $actual = json_encode(array_sort_recursive(
             json_decode($this->response->getContent(), true)
         ));
@@ -414,9 +429,9 @@ trait CrawlerTrait
         foreach (array_sort_recursive($data) as $key => $value) {
             $expected = $this->formatToExpectedJson($key, $value);
 
-            $this->assertTrue(
+            $this->{$method}(
                 Str::contains($actual, $this->formatToExpectedJson($key, $value)),
-                "Unable to find JSON fragment [{$expected}] within [{$actual}]."
+                ($negate ? 'Found' : 'Unable to find')." JSON fragment [{$expected}] within [{$actual}]."
             );
         }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -684,7 +684,7 @@ if (! function_exists('elixir')) {
         static $manifest = null;
 
         if (is_null($manifest)) {
-            $manifest = json_decode(file_get_contents(public_path().'/build/rev-manifest.json'), true);
+            $manifest = json_decode(file_get_contents(public_path('build/rev-manifest.json')), true);
         }
 
         if (isset($manifest[$file])) {

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Composer;
 use Illuminate\Filesystem\Filesystem;
@@ -58,10 +59,12 @@ class FailedTableCommand extends Command
     {
         $table = $this->laravel['config']['queue.failed.table'];
 
+        $tableClassName = Str::studly($table);
+
         $fullPath = $this->createBaseMigration($table);
 
         $stub = str_replace(
-            '{{table}}', $table, $this->files->get(__DIR__.'/stubs/failed_jobs.stub')
+            ['{{table}}', '{{tableClassName}}'], [$table, $tableClassName], $this->files->get(__DIR__.'/stubs/failed_jobs.stub')
         );
 
         $this->files->put($fullPath, $stub);

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Composer;
 use Illuminate\Filesystem\Filesystem;
@@ -58,10 +59,12 @@ class TableCommand extends Command
     {
         $table = $this->laravel['config']['queue.connections.database.table'];
 
+        $tableClassName = Str::studly($table);
+
         $fullPath = $this->createBaseMigration($table);
 
         $stub = str_replace(
-            '{{table}}', $table, $this->files->get(__DIR__.'/stubs/jobs.stub')
+            ['{{table}}', '{{tableClassName}}'], [$table, $tableClassName], $this->files->get(__DIR__.'/stubs/jobs.stub')
         );
 
         $this->files->put($fullPath, $stub);

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateFailedJobsTable extends Migration
+class Create{{tableClassName}}Table extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateJobsTable extends Migration
+class Create{{tableClassName}}Table extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -205,6 +205,8 @@ class Arr
 
                 if (isset($array[$part]) && is_array($array[$part])) {
                     $array = &$array[$part];
+                } else {
+                    $parts =[];
                 }
             }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -206,7 +206,7 @@ class Arr
                 if (isset($array[$part]) && is_array($array[$part])) {
                     $array = &$array[$part];
                 } else {
-                    $parts =[];
+                    $parts = [];
                 }
             }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -114,16 +114,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Create a new collection consisting of even elements.
-     *
-     * @return static
-     */
-    public function even()
-    {
-        return $this->every(2);
-    }
-
-    /**
      * Create a new collection consisting of every n-th element.
      *
      * @param  int  $step
@@ -133,11 +123,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function every($step, $offset = 0)
     {
         $new = [];
+
         $position = 0;
+
         foreach ($this->items as $key => $item) {
             if ($position % $step === $offset) {
                 $new[] = $item;
             }
+
             $position++;
         }
 
@@ -475,16 +468,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
             return is_null($result) || $value < $result ? $value : $result;
         });
-    }
-
-    /**
-     * Create a new collection consisting of odd elements.
-     *
-     * @return static
-     */
-    public function odd()
-    {
-        return $this->every(2, 1);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -671,7 +671,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $items = $this->items;
 
-        $callback ? uasort($items, $callback) : natcasesort($items);
+        $callback ? uasort($items, $callback) : uasort($items, function ($a, $b) {
+
+            if ($a == $b) {
+                return 0;
+            }
+
+            return ($a < $b) ? -1 : 1;
+        });
 
         return new static($items);
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -114,6 +114,37 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Create a new collection consisting of even elements.
+     *
+     * @return static
+     */
+    public function even()
+    {
+        return $this->every(2);
+    }
+
+    /**
+     * Create a new collection consisting of every n-th element.
+     *
+     * @param  int  $step
+     * @param  int  $offset
+     * @return static
+     */
+    public function every($step, $offset = 0)
+    {
+        $new = [];
+        $position = 0;
+        foreach ($this->items as $key => $item) {
+            if ($position % $step === $offset) {
+                $new[] = $item;
+            }
+            $position++;
+        }
+
+        return new static($new);
+    }
+
+    /**
      * Fetch a nested element of the collection.
      *
      * @param  string  $key
@@ -444,6 +475,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
             return is_null($result) || $value < $result ? $value : $result;
         });
+    }
+
+    /**
+     * Create a new collection consisting of odd elements.
+     *
+     * @return static
+     */
+    public function odd()
+    {
+        return $this->every(2, 1);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -166,7 +166,7 @@ class Str
      */
     public static function lower($value)
     {
-        return mb_strtolower($value, 'UTF-8');
+        return mb_strtolower($value);
     }
 
     /**
@@ -323,7 +323,7 @@ class Str
      */
     public static function upper($value)
     {
-        return mb_strtoupper($value, 'UTF-8');
+        return mb_strtoupper($value);
     }
 
     /**
@@ -444,7 +444,7 @@ class Str
      */
     public static function substr($string, $start, $length = null)
     {
-        return mb_substr($string, $start, $length, 'UTF-8');
+        return mb_substr($string, $start, $length);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -166,7 +166,7 @@ class Str
      */
     public static function lower($value)
     {
-        return mb_strtolower($value);
+        return mb_strtolower($value, 'UTF-8');
     }
 
     /**
@@ -323,7 +323,7 @@ class Str
      */
     public static function upper($value)
     {
-        return mb_strtoupper($value);
+        return mb_strtoupper($value, 'UTF-8');
     }
 
     /**
@@ -444,7 +444,7 @@ class Str
      */
     public static function substr($string, $start, $length = null)
     {
-        return mb_substr($string, $start, $length);
+        return mb_substr($string, $start, $length, 'UTF-8');
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -442,7 +442,8 @@ class Str
      * @param  int  $length
      * @return string
      */
-    public static function substr($string, $start, $length = null) {
+    public static function substr($string, $start, $length = null)
+    {
         return mb_substr($string, $start, $length, 'UTF-8');
     }
 
@@ -452,7 +453,8 @@ class Str
      * @param  string  $string
      * @return string
      */
-    public static function ucfirst($string) {
+    public static function ucfirst($string)
+    {
         return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -166,7 +166,7 @@ class Str
      */
     public static function lower($value)
     {
-        return mb_strtolower($value);
+        return mb_strtolower($value, 'UTF-8');
     }
 
     /**
@@ -323,7 +323,7 @@ class Str
      */
     public static function upper($value)
     {
-        return mb_strtoupper($value);
+        return mb_strtoupper($value, 'UTF-8');
     }
 
     /**
@@ -432,5 +432,27 @@ class Str
         $value = ucwords(str_replace(['-', '_'], ' ', $value));
 
         return static::$studlyCache[$key] = str_replace(' ', '', $value);
+    }
+
+    /**
+     * Returns the portion of string specified by the start and length parameters.
+     *
+     * @param  string  $string
+     * @param  int  $start
+     * @param  int  $length
+     * @return string
+     */
+    public static function substr($string, $start, $length = null) {
+        return mb_substr($string, $start, $length, 'UTF-8');
+    }
+
+    /**
+     * Make a string's first character uppercase.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function ucfirst($string) {
+        return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
     }
 }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -968,7 +968,7 @@ class Validator implements ValidatorContract
             return count(array_diff($value, $parameters)) == 0;
         }
 
-        return in_array((string) $value, $parameters);
+        return !is_array($value) && in_array((string) $value, $parameters);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -998,7 +998,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(1, $parameters, 'unique');
 
-        list($connection, $table) = $this->parseUniqueTable($parameters[0]);
+        list($connection, $table) = $this->parseTable($parameters[0]);
 
         // The second parameter position holds the name of the column that needs to
         // be verified as unique. If this parameter isn't specified we will just
@@ -1034,12 +1034,12 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Parse the connection / table for the unique rule.
+     * Parse the connection / table for the unique / exists rules.
      *
      * @param  string  $table
      * @return array
      */
-    protected function parseUniqueTable($table)
+    protected function parseTable($table)
     {
         return Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
     }
@@ -1084,7 +1084,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(1, $parameters, 'exists');
 
-        $table = $parameters[0];
+        list($connection, $table) = $this->parseTable($parameters[0]);
 
         // The second parameter position holds the name of the column that should be
         // verified as existing. If this parameter is not specified we will guess
@@ -1093,21 +1093,26 @@ class Validator implements ValidatorContract
 
         $expected = (is_array($value)) ? count($value) : 1;
 
-        return $this->getExistCount($table, $column, $value, $parameters) >= $expected;
+        return $this->getExistCount($connection, $table, $column, $value, $parameters) >= $expected;
     }
 
     /**
      * Get the number of records that exist in storage.
      *
+     * @param  mixed   $connection
      * @param  string  $table
      * @param  string  $column
      * @param  mixed   $value
      * @param  array   $parameters
      * @return int
      */
-    protected function getExistCount($table, $column, $value, $parameters)
+    protected function getExistCount($connection, $table, $column, $value, $parameters)
     {
         $verifier = $this->getPresenceVerifier();
+
+        if (! is_null($connection)) {
+            $verifier->setConnection($connection);
+        }
 
         $extra = $this->getExtraExistConditions($parameters);
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -837,12 +837,7 @@ class Validator implements ValidatorContract
      */
     protected function validateJson($attribute, $value)
     {
-        $object = json_decode($value);
-        if ($object === null) {
-            return false;
-        }
-
-        return true;
+        return ! is_null(json_decode($value));
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -968,7 +968,7 @@ class Validator implements ValidatorContract
             return count(array_diff($value, $parameters)) == 0;
         }
 
-        return !is_array($value) && in_array((string) $value, $parameters);
+        return ! is_array($value) && in_array((string) $value, $parameters);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -838,7 +838,7 @@ class Validator implements ValidatorContract
     protected function validateJson($attribute, $value)
     {
         $object = json_decode($value);
-        if($object === null) {
+        if ($object === null) {
             return false;
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -838,6 +838,7 @@ class Validator implements ValidatorContract
     protected function validateJson($attribute, $value)
     {
         json_decode($value);
+
         return json_last_error() === JSON_ERROR_NONE;
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -837,7 +837,8 @@ class Validator implements ValidatorContract
      */
     protected function validateJson($attribute, $value)
     {
-        return ! is_null(json_decode($value));
+        json_decode($value);
+        return json_last_error() === JSON_ERROR_NONE;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -829,6 +829,23 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Validate the attribute is a valid JSON string.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    protected function validateJson($attribute, $value)
+    {
+        $object = json_decode($value);
+        if($object === null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Validate that an attribute has a given number of digits.
      *
      * @param  string  $attribute

--- a/tests/Foundation/FoundationCrawlerTraitIntegrationTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitIntegrationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Foundation\Testing\CrawlerTrait;
+use Symfony\Component\DomCrawler\Crawler;
+
+class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
+{
+    use CrawlerTrait;
+
+    public function testSeeInInput()
+    {
+        $this->crawler = new Crawler(
+            '<input type="text" name="framework" value="Laravel">'
+        );
+
+        $this->seeInField('framework', 'Laravel');
+    }
+
+    public function testSeeInTextarea()
+    {
+        $this->crawler = new Crawler(
+            '<textarea name="description">Laravel is awesome</textarea>'
+        );
+
+        $this->seeInField('description', 'Laravel is awesome');
+    }
+
+    public function testSeeOptionIsSelected()
+    {
+        $this->crawler = new Crawler(
+            ' <select name="availability">'
+            .'    <option value="partial_time">Partial time</option>'
+            .'    <option value="full_time" selected>Full time</option>'
+            .'</select>'
+        );
+
+        $this->seeIsSelected('availability', 'full_time');
+    }
+
+    public function testSeeRadioIsChecked()
+    {
+        $this->crawler = new Crawler(
+            ' <input type="radio" name="availability" value="partial_time">'
+            .'<input type="radio" name="availability" value="full_time" checked>'
+        );
+
+        $this->seeIsSelected('availability', 'full_time');
+    }
+
+    public function testSeeCheckboxIsChecked()
+    {
+        $this->crawler = new Crawler(
+            '<input type="checkbox" name="terms" checked>'
+        );
+
+        $this->seeIsChecked('terms');
+    }
+}

--- a/tests/Foundation/FoundationCrawlerTraitTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Foundation\Testing\CrawlerTrait;
+use Symfony\Component\DomCrawler\Crawler;
 
 class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
 {
@@ -67,6 +68,64 @@ class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
             ->andReturn($select);
 
         $this->seeInField('select', 'selected_value');
+    }
+
+    public function testSeeIsSelected()
+    {
+        $optionEmpty = m::mock(Crawler::class)->makePartial();
+        $optionEmpty->shouldReceive('hasAttribute')
+            ->withArgs(['selected'])
+            ->once()
+            ->andReturn(false);
+
+        $optionFullTime = m::mock(Crawler::class)->makePartial();
+        $optionFullTime->shouldReceive('hasAttribute')
+            ->withArgs(['selected'])
+            ->once()
+            ->andReturn(true);
+        $optionFullTime->shouldReceive('getAttribute')
+            ->withArgs(['value'])
+            ->once()
+            ->andReturn('full_time');
+
+        $select = m::mock(Crawler::class)->makePartial();
+        $select->shouldReceive('count')
+            ->once()
+            ->andReturn(1);
+        $select->shouldReceive('nodeName')
+            ->twice()
+            ->andReturn('select');
+        $select->shouldReceive('children')
+            ->once()
+            ->andReturn([$optionEmpty, $optionFullTime]);
+
+        $this->crawler = m::mock(Crawler::class)->makePartial();
+
+        $this->crawler->shouldReceive('filter')
+            ->withArgs(["*#availability, *[name='availability']"])
+            ->once()
+            ->andReturn($select);
+
+        $this->seeIsSelected('availability', 'full_time');
+    }
+
+    public function testSeeIsChecked()
+    {
+        $checkbox = m::mock(Crawler::class)->makePartial();
+        $checkbox->shouldReceive('count')->andReturn(1);
+        $checkbox->shouldReceive('attr')
+            ->withArgs(['checked'])
+            ->once()
+            ->andReturn('checked');
+
+        $this->crawler = m::mock(Crawler::class)->makePartial();
+
+        $this->crawler->shouldReceive('filter')
+            ->withArgs(["input[type='checkbox']#terms, input[type='checkbox'][name='terms']"])
+            ->once()
+            ->andReturn($checkbox);
+
+        $this->seeIsChecked('terms');
     }
 
     public function testExtractsRequestParametersFromForm()

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -54,6 +54,17 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Illuminate\Queue\Jobs\SqsJob', $result);
     }
 
+    public function testPopProperlyPopsJobOffOfSqsWithCustomJobCreator()
+    {
+        $queue = $this->getMock('Illuminate\Queue\SqsQueue', ['getQueue'], [$this->sqs, $this->queueName, $this->account]);
+        $queue->createJobsUsing(function () { return 'job!'; });
+        $queue->setContainer(m::mock('Illuminate\Container\Container'));
+        $queue->expects($this->once())->method('getQueue')->with($this->queueName)->will($this->returnValue($this->queueUrl));
+        $this->sqs->shouldReceive('receiveMessage')->once()->with(['QueueUrl' => $this->queueUrl, 'AttributeNames' => ['ApproximateReceiveCount']])->andReturn($this->mockedReceiveMessageResponseModel);
+        $result = $queue->pop($this->queueName);
+        $this->assertEquals('job!', $result);
+    }
+
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoSqs()
     {
         $now = Carbon\Carbon::now();

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -70,4 +70,31 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expect, Arr::sortRecursive($array));
     }
+
+    public function testForget()
+    {
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        Arr::forget($array, 'products.desk');
+        $this->assertEquals(['products' => []], $array);
+
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        Arr::forget($array, 'products.desk.price');
+        $this->assertEquals(['products' => ['desk' => []]], $array);
+
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        Arr::forget($array, 'products.final.price');
+        $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
+
+        $array = ['shop' => ['cart' => [150 => 0]]];
+        Arr::forget($array, 'shop.final.cart');
+        $this->assertEquals(['shop' => ['cart' => [150 => 0]]], $array);
+
+        $array = ['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]];
+        Arr::forget($array, 'products.desk.price.taxes');
+        $this->assertEquals(['products' => ['desk' => ['price' => ['original' => 50]]]], $array);
+
+        $array = ['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]];
+        Arr::forget($array, 'products.desk.final.taxes');
+        $this->assertEquals(['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]], $array);
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -369,20 +369,6 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([10], $data[3]->toArray());
     }
 
-    public function testEven()
-    {
-        $data = new Collection(['a', 'b', 'c', 'd', 'e', 'f']);
-
-        $this->assertEquals(['a', 'c', 'e'], $data->even()->all());
-    }
-
-    public function testOdd()
-    {
-        $data = new Collection(['a', 'b', 'c', 'd', 'e', 'f']);
-
-        $this->assertEquals(['b', 'd', 'f'], $data->odd()->all());
-    }
-
     public function testEvery()
     {
         $data = new Collection([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -369,6 +369,37 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([10], $data[3]->toArray());
     }
 
+    public function testEven()
+    {
+        $data = new Collection(['a', 'b', 'c', 'd', 'e', 'f']);
+
+        $this->assertEquals(['a', 'c', 'e'], $data->even()->all());
+    }
+
+    public function testOdd()
+    {
+        $data = new Collection(['a', 'b', 'c', 'd', 'e', 'f']);
+
+        $this->assertEquals(['b', 'd', 'f'], $data->odd()->all());
+    }
+
+    public function testEvery()
+    {
+        $data = new Collection([
+            6 => 'a',
+            4 => 'b',
+            7 => 'c',
+            1 => 'd',
+            5 => 'e',
+            3 => 'f',
+        ]);
+
+        $this->assertEquals(['a', 'e'], $data->every(4)->all());
+        $this->assertEquals(['b', 'f'], $data->every(4, 1)->all());
+        $this->assertEquals(['c'], $data->every(4, 2)->all());
+        $this->assertEquals(['d'], $data->every(4, 3)->all());
+    }
+
     public function testPluckWithArrayAndObjectValues()
     {
         $data = new Collection([(object) ['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -302,6 +302,9 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $data = (new Collection([5, 3, 1, 2, 4]))->sort();
         $this->assertEquals([1, 2, 3, 4, 5], $data->values()->all());
 
+        $data = (new Collection([-1, -3, -2, -4, -5, 0, 5, 3, 1, 2, 4]))->sort();
+        $this->assertEquals([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5], $data->values()->all());
+
         $data = (new Collection(['foo', 'bar-10', 'bar-1']))->sort();
         $this->assertEquals(['bar-1', 'bar-10', 'foo'], $data->values()->all());
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -157,4 +157,27 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('laravelPhPFramework', Str::camel('Laravel-phP-framework'));
         $this->assertEquals('laravelPhpFramework', Str::camel('Laravel  -_-  php   -_-   framework   '));
     }
+
+    public function testSubstr()
+    {
+        $this->assertEquals('Ё', Str::substr('БГДЖИЛЁ', -1));
+        $this->assertEquals('ЛЁ', Str::substr('БГДЖИЛЁ', -2));
+        $this->assertEquals('И', Str::substr('БГДЖИЛЁ', -3, 1));
+        $this->assertEquals('ДЖИЛ', Str::substr('БГДЖИЛЁ', 2, -1));
+        $this->assertEquals(false, Str::substr('БГДЖИЛЁ', 4, -4));
+        $this->assertEquals('ИЛ', Str::substr('БГДЖИЛЁ', -3, -1));
+        $this->assertEquals('ГДЖИЛЁ', Str::substr('БГДЖИЛЁ', 1));
+        $this->assertEquals('ГДЖ', Str::substr('БГДЖИЛЁ', 1, 3));
+        $this->assertEquals('БГДЖ', Str::substr('БГДЖИЛЁ', 0, 4));
+        $this->assertEquals('Ё', Str::substr('БГДЖИЛЁ', -1, 1));
+        $this->assertEquals(false, Str::substr('Б', 2));
+    }
+
+    public function testUcfirst()
+    {
+        $this->assertEquals('Laravel', Str::ucfirst('laravel'));
+        $this->assertEquals('Laravel framework', Str::ucfirst('laravel framework'));
+        $this->assertEquals('Мама', Str::ucfirst('мама'));
+        $this->assertEquals('Мама мыла раму', Str::ucfirst('мама мыла раму'));
+    }
 }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -141,4 +141,20 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('laravel_php_framework', Str::snake('Laravel Php Framework'));
         $this->assertEquals('laravel_php_framework', Str::snake('Laravel    Php      Framework   '));
     }
+
+    public function testStudly()
+    {
+        $this->assertEquals('LaravelPHPFramework', Str::studly('laravel_p_h_p_framework'));
+        $this->assertEquals('LaravelPhpFramework', Str::studly('laravel_php_framework'));
+        $this->assertEquals('LaravelPhPFramework', Str::studly('laravel-phP-framework'));
+        $this->assertEquals('LaravelPhpFramework', Str::studly('laravel  -_-  php   -_-   framework   '));
+    }
+
+    public function testCamel()
+    {
+        $this->assertEquals('laravelPHPFramework', Str::camel('Laravel_p_h_p_framework'));
+        $this->assertEquals('laravelPhpFramework', Str::camel('Laravel_php_framework'));
+        $this->assertEquals('laravelPhPFramework', Str::camel('Laravel-phP-framework'));
+        $this->assertEquals('laravelPhpFramework', Str::camel('Laravel  -_-  php   -_-   framework   '));
+    }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -902,6 +902,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $mock3->shouldReceive('getMultiCount')->once()->with('users', 'email_addr', ['foo'], [])->andReturn(false);
         $v->setPresenceVerifier($mock3);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:connection.users']);
+        $mock5 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock5->shouldReceive('setConnection')->once()->with('connection');
+        $mock5->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(true);
+        $v->setPresenceVerifier($mock5);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidationExistsIsNotCalledUnnecessarily()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -824,6 +824,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['name' => ['foo', 'qux']], ['name' => 'Array|In:foo,baz,qux']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ['foo', 'bar']], ['name' => 'Alpha|In:foo,bar']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateNotIn()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -544,6 +544,21 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateJson()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => 'aslksd'], ['foo' => 'json']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => '[]'], ['foo' => 'json']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => '{"name":"John","age":"34"}'], ['foo' => 'json']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateBoolean()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
Following up from #9893, this PR is made against the 5.1 branch.

Sometimes it's great to test that the JSON response doesn't contain certain content, for example if an API endpoint is meant to filter by a given constraint. I've based this upon the approach used by the see()/dontSee() methods.
