### PR TITLE
[5.1] fix bug that causes failing migrations when using custom names for jobs tables

### DIFF
--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Composer;
 use Illuminate\Filesystem\Filesystem;
@@ -58,10 +59,12 @@ class FailedTableCommand extends Command
     {
         $table = $this->laravel['config']['queue.failed.table'];
 
+        $tableClassName = Str::studly($table);
+
         $fullPath = $this->createBaseMigration($table);
 
         $stub = str_replace(
-            '{{table}}', $table, $this->files->get(__DIR__.'/stubs/failed_jobs.stub')
+            ['{{table}}', '{{tableClassName}}'], [$table, $tableClassName], $this->files->get(__DIR__.'/stubs/failed_jobs.stub')
         );
 
         $this->files->put($fullPath, $stub);

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Composer;
 use Illuminate\Filesystem\Filesystem;
@@ -58,10 +59,12 @@ class TableCommand extends Command
     {
         $table = $this->laravel['config']['queue.connections.database.table'];
 
+        $tableClassName = Str::studly($table);
+
         $fullPath = $this->createBaseMigration($table);
 
         $stub = str_replace(
-            '{{table}}', $table, $this->files->get(__DIR__.'/stubs/jobs.stub')
+            ['{{table}}', '{{tableClassName}}'], [$table, $tableClassName], $this->files->get(__DIR__.'/stubs/jobs.stub')
         );
 
         $this->files->put($fullPath, $stub);

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateFailedJobsTable extends Migration
+class Create{{tableClassName}}Table extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateJobsTable extends Migration
+class Create{{tableClassName}}Table extends Migration
 {
     /**
      * Run the migrations.


### PR DESCRIPTION
Steps to recreate bug
- Change  `config/queue.php` to use the `database` driver
- Change the `config/queue.php` database array to use a custom table name such as `my_jobs` for the jobs table, or change the failed jobs table to use a custom table name such as `my_failed_jobs`
- run `php artisan queue:table` or `php artisan queue:failed-table` command
- attempt to run `php artisan migrate`

The migrations will fail after being unable to find the jobs table or failed-jobs table migration classes

---

Correcting the class names of the migrations to coincide with the filename created by the command resolves the issue.
