### PR TITLE
fixing mongodb duplicate key error

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -75,7 +75,7 @@ class EloquentUserProvider implements UserProvider
     {
         $user->setRememberToken($token);
 
-        $user->save();
+        $user->update();
     }
 
     /**


### PR DESCRIPTION
Error occurs when a user tries to logout $this->auth->logout(). The updateRememberToken() function uses  save() on user model what causes duplicate key error in mongodb. Changing it to update() fixes the issue. 

On the record.
Why do you use save function in the first place. When the business logic (or a use case) is about an update ?

Cheers!
