### PR TITLE
Added 'postJson' method to CrawlerTrait.php

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -93,6 +93,26 @@ trait CrawlerTrait
     }
 
     /**
+     * Visit the given URI with a POST request with content type of application/json
+     *
+     * @param string $uri
+     * @param array $data
+     * @param array $headers
+     * @return $this
+     */
+    public function postJson($uri, $data = [], $headers = [])
+    {
+        $headers['CONTENT_TYPE'] = 'application/json';
+        $headers['Accept'] = 'application/json';
+
+        $server = $this->transformHeadersToServerVars($headers);
+
+        $this->call('POST', $uri, [], [], [], $server, json_encode($data));
+
+        return $this;
+    }
+
+    /**
      * Visit the given URI with a PUT request.
      *
      * @param  string  $uri


### PR DESCRIPTION
A method to allow posting 'application/json' content to a URI. This
mimics how SPAs built on AngularJS send data to a URI.

A recent Laravel update made tests fail when data was sent as POST
parameters instead of POST body with the content type set to
'application/json', because the Request would no longer register
the POST parameters as variables (instead looking for POST body JSON)

This update allows tests to easily post JSON content in a format that
is expected by the Request.
