### PR TITLE
[5.1] Remove storing child array as a variable

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -422,7 +422,7 @@ class Arr
     {
         foreach ($array as &$value) {
             if (is_array($value)) {
-                $value = self::sortRecursive($value);
+                self::sortRecursive($value);
             }
         }
 


### PR DESCRIPTION
My Lumen tests make use of `Laravel\Lumen\Testing\CrawlerTrait::seeJsonContains()`. I noticed after upgrading my composer dependencies that my tests began to fail. I tracked it down to this (`Illuminate\Support\Arr::sortRecursive()`) method, and replaced it with the previous version. This made my tests go green.

When comparing the logic of the two (previous vs current), I noticed that the older version called `self::sortRecursive($value);` on the value in the foreach loop, while the new version set the value to a variable `$value = self::sortRecursive($value);`. Once, I removed the `$value =` portion, my tests went green again.

I don't know the fine intricacies of how these references work, or why one would work over the other once you start throwing in static methods, etc.

The data I was passing in was an object that was type-casted into an array. The object contained several property types including arrays and objects.
