### PR TITLE
Change delete() function on model to allow primary key method override

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1130,7 +1130,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function delete()
     {
-        if (is_null($this->primaryKey)) {
+        if (is_null($this->getKeyName())) {
             throw new Exception('No primary key defined on model.');
         }
 


### PR DESCRIPTION
This will allow getKeyName() method override in inherited models.
For my use case, I dynamically generate a primary key, based on several
conditions, which I achieve by overriding getKeyName().
