### PR TITLE
[5.1] Adding the missing seeOptionIsSelected and seeCheckboxIsChecked methods

### DIFF
--- a/tests/Foundation/FoundationCrawlerTraitIntegrationTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitIntegrationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Foundation\Testing\CrawlerTrait;
+use Symfony\Component\DomCrawler\Crawler;
+
+class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
+{
+    use CrawlerTrait;
+
+    public function testSeeInInput()
+    {
+        $this->crawler = new Crawler(
+            '<input type="text" name="framework" value="Laravel">'
+        );
+
+        $this->seeInField('framework', 'Laravel');
+    }
+
+    public function testSeeInTextarea()
+    {
+        $this->crawler = new Crawler(
+            '<textarea name="description">Laravel is awesome</textarea>'
+        );
+
+        $this->seeInField('description', 'Laravel is awesome');
+    }
+
+    public function testSeeOptionIsSelected()
+    {
+        $this->crawler = new Crawler(
+            ' <select name="availability">'
+            .'    <option value="partial_time">Partial time</option>'
+            .'    <option value="full_time" selected>Full time</option>'
+            .'</select>'
+        );
+
+        $this->seeIsSelected('availability', 'full_time');
+    }
+
+    public function testSeeRadioIsChecked()
+    {
+        $this->crawler = new Crawler(
+            ' <input type="radio" name="availability" value="partial_time">'
+            .'<input type="radio" name="availability" value="full_time" checked>'
+        );
+
+        $this->seeIsSelected('availability', 'full_time');
+    }
+
+    public function testSeeCheckboxIsChecked()
+    {
+        $this->crawler = new Crawler(
+            '<input type="checkbox" name="terms" checked>'
+        );
+
+        $this->seeIsChecked('terms');
+    }
+}

--- a/tests/Foundation/FoundationCrawlerTraitTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Foundation\Testing\CrawlerTrait;
+use Symfony\Component\DomCrawler\Crawler;
 
 class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
 {
@@ -67,6 +68,64 @@ class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
             ->andReturn($select);
 
         $this->seeInField('select', 'selected_value');
+    }
+
+    public function testSeeIsSelected()
+    {
+        $optionEmpty = m::mock(Crawler::class)->makePartial();
+        $optionEmpty->shouldReceive('hasAttribute')
+            ->withArgs(['selected'])
+            ->once()
+            ->andReturn(false);
+
+        $optionFullTime = m::mock(Crawler::class)->makePartial();
+        $optionFullTime->shouldReceive('hasAttribute')
+            ->withArgs(['selected'])
+            ->once()
+            ->andReturn(true);
+        $optionFullTime->shouldReceive('getAttribute')
+            ->withArgs(['value'])
+            ->once()
+            ->andReturn('full_time');
+
+        $select = m::mock(Crawler::class)->makePartial();
+        $select->shouldReceive('count')
+            ->once()
+            ->andReturn(1);
+        $select->shouldReceive('nodeName')
+            ->twice()
+            ->andReturn('select');
+        $select->shouldReceive('children')
+            ->once()
+            ->andReturn([$optionEmpty, $optionFullTime]);
+
+        $this->crawler = m::mock(Crawler::class)->makePartial();
+
+        $this->crawler->shouldReceive('filter')
+            ->withArgs(["*#availability, *[name='availability']"])
+            ->once()
+            ->andReturn($select);
+
+        $this->seeIsSelected('availability', 'full_time');
+    }
+
+    public function testSeeIsChecked()
+    {
+        $checkbox = m::mock(Crawler::class)->makePartial();
+        $checkbox->shouldReceive('count')->andReturn(1);
+        $checkbox->shouldReceive('attr')
+            ->withArgs(['checked'])
+            ->once()
+            ->andReturn('checked');
+
+        $this->crawler = m::mock(Crawler::class)->makePartial();
+
+        $this->crawler->shouldReceive('filter')
+            ->withArgs(["input[type='checkbox']#terms, input[type='checkbox'][name='terms']"])
+            ->once()
+            ->andReturn($checkbox);
+
+        $this->seeIsChecked('terms');
     }
 
     public function testExtractsRequestParametersFromForm()


### PR DESCRIPTION
These methods will allow developers to test selects, radio groups and checkboxes, along with seeInField that allow developers to test input texts and textareas.
