### PR TITLE
[5.1] Update Guard.php - remove "isset" (always TRUE)

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -457,7 +457,7 @@ class Guard implements GuardContract
      */
     protected function fireLoginEvent($user, $remember = false)
     {
-        if (isset($this->events)) {
+        if ($this->events) {
             $this->events->fire('auth.login', [$user, $remember]);
         }
     }


### PR DESCRIPTION
As the `$events` property is declared in the class, `if (isset($this->events))` will always return a boolean `true`.

I would personally prefer `if (!empty($this->events))`, but since all other `if` in the class do `if ($this->events)`, I just did the same.
