### PR TITLE
[5.1] Fallback to Carbon::parse when converting dates in Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -6,6 +6,7 @@ use DateTime;
 use Exception;
 use ArrayAccess;
 use Carbon\Carbon;
+use InvalidArgumentException;
 use LogicException;
 use JsonSerializable;
 use Illuminate\Support\Arr;
@@ -2885,8 +2886,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return Carbon::createFromFormat('Y-m-d', $value)->startOfDay();
         }
 
-        // Finally, we will fallback to letting Carbon try to parse the string
-        return Carbon::parse($value);
+        try {
+            // We will just assume this date is in the format used by default on
+            // the database connection and use that format to create the Carbon object
+            // that is returned back out to the developers after we convert it here.
+            return Carbon::createFromFormat($this->getDateFormat(), $value);
+        } catch (InvalidArgumentException $e) {
+            // Finally, we will fallback to letting Carbon try to parse the string
+            return Carbon::parse($value);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2885,10 +2885,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return Carbon::createFromFormat('Y-m-d', $value)->startOfDay();
         }
 
-        // Finally, we will just assume this date is in the format used by default on
-        // the database connection and use that format to create the Carbon object
-        // that is returned back out to the developers after we convert it here.
-        return Carbon::createFromFormat($this->getDateFormat(), $value);
+        // Finally, we will fallback to letting Carbon try to parse the string
+        return Carbon::parse($value);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -311,6 +311,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model = new EloquentDateModelStub;
         $model->created_at = '2012-01-01';
         $this->assertInstanceOf('Carbon\Carbon', $model->created_at);
+
+        $model = new EloquentDateModelStub;
+        $model->created_at = '01/01/2012';
+        $this->assertInstanceOf('Carbon\Carbon', $model->created_at);
     }
 
     public function testFromDateTime()


### PR DESCRIPTION
Solves inconsistencies between Laravel's validators and Eloquent
where certain date formats (e.g. m/d/Y) pass the date validator but
throw an Exception when passed to a date field on an Eloquent model

resolves #9930
