### PR TITLE
Added return value for Mail::send with log driver

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -398,6 +398,7 @@ class Mailer implements MailerContract, MailQueueContract
             return $this->swift->send($message, $this->failedRecipients);
         } elseif (isset($this->logger)) {
             $this->logMessage($message);
+            return true;
         }
     }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -399,7 +399,7 @@ class Mailer implements MailerContract, MailQueueContract
         } elseif (isset($this->logger)) {
             $this->logMessage($message);
 
-            return true;
+            return 1;
         }
     }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -398,6 +398,7 @@ class Mailer implements MailerContract, MailQueueContract
             return $this->swift->send($message, $this->failedRecipients);
         } elseif (isset($this->logger)) {
             $this->logMessage($message);
+
             return true;
         }
     }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -138,7 +138,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         $mailer->setLogger($logger);
         $mailer->pretend();
 
-        $this->assertTrue($mailer->send('foo', ['data'], function ($m) {}));
+        $this->assertEquals(1, $mailer->send('foo', ['data'], function ($m) {}));
     }
 
     public function testMailerCanResolveMailerClasses()

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -138,7 +138,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         $mailer->setLogger($logger);
         $mailer->pretend();
 
-        $mailer->send('foo', ['data'], function ($m) {});
+        $this->assertTrue($mailer->send('foo', ['data'], function ($m) {}));
     }
 
     public function testMailerCanResolveMailerClasses()


### PR DESCRIPTION
Mailer::send now returns `true` when using the log driver
fixed #9935
