### PR TITLE
[5.1] Add even() and odd() methods to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -114,6 +114,37 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Create a new collection consisting of even elements.
+     *
+     * @return static
+     */
+    public function even()
+    {
+        return $this->every(2);
+    }
+
+    /**
+     * Create a new collection consisting of every n-th element.
+     *
+     * @param  int  $step
+     * @param  int  $offset
+     * @return static
+     */
+    public function every($step, $offset = 0)
+    {
+        $new = [];
+        $position = 0;
+        foreach ($this->items as $key => $item) {
+            if ($position % $step === $offset) {
+                $new[] = $item;
+            }
+            $position++;
+        }
+
+        return new static($new);
+    }
+
+    /**
      * Fetch a nested element of the collection.
      *
      * @param  string  $key
@@ -444,6 +475,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
             return is_null($result) || $value < $result ? $value : $result;
         });
+    }
+
+    /**
+     * Create a new collection consisting of odd elements.
+     *
+     * @return static
+     */
+    public function odd()
+    {
+        return $this->every(2, 1);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -369,6 +369,37 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([10], $data[3]->toArray());
     }
 
+    public function testEven()
+    {
+        $data = new Collection(['a', 'b', 'c', 'd', 'e', 'f']);
+
+        $this->assertEquals(['a', 'c', 'e'], $data->even()->all());
+    }
+
+    public function testOdd()
+    {
+        $data = new Collection(['a', 'b', 'c', 'd', 'e', 'f']);
+
+        $this->assertEquals(['b', 'd', 'f'], $data->odd()->all());
+    }
+
+    public function testEvery()
+    {
+        $data = new Collection([
+            6 => 'a',
+            4 => 'b',
+            7 => 'c',
+            1 => 'd',
+            5 => 'e',
+            3 => 'f',
+        ]);
+
+        $this->assertEquals(['a', 'e'], $data->every(4)->all());
+        $this->assertEquals(['b', 'f'], $data->every(4, 1)->all());
+        $this->assertEquals(['c'], $data->every(4, 2)->all());
+        $this->assertEquals(['d'], $data->every(4, 3)->all());
+    }
+
     public function testPluckWithArrayAndObjectValues()
     {
         $data = new Collection([(object) ['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);


### PR DESCRIPTION
The tests pretty much describe what they do.

My use case is a little bit similar to the `chunk()`'s one: (Sorry for non-English texts)
https://i.gyazo.com/b3d0f673e957cf6abb1566aed24e9e1f.png

The files must be sorted like that
1 2
3 4
but I've got the following markup from frontend developer:

``` html
<ul class="left">
...
</ul>
<ul class="right">
...
</ul>
```

So, I would like to have a view like that:

``` html
<ul class="left">
     @foreach($files->even() as $file)
          <li>..</li>
     @endforeach
</ul>
<ul class="right">
     @foreach($files->odd() as $file)
          <li>..</li>
     @endforeach
</ul>
```

I know that it can be solved by extending the Collection, but I guess these methods make perfect sense in core since we tend to make collections more powerful adding stuff like `zip()`
