### PR TITLE
[5.1] Dependency injection in model factories

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -66,7 +66,7 @@ class DatabaseServiceProvider extends ServiceProvider
         $this->app->singleton(EloquentFactory::class, function ($app) {
             $faker = $app->make(FakerGenerator::class);
 
-            return EloquentFactory::construct($faker, database_path('factories'));
+            return EloquentFactory::construct($app, $faker, database_path('factories'));
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -4,8 +4,8 @@ namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
 use Faker\Generator as Faker;
-use Illuminate\Contracts\Container\Container;
 use Symfony\Component\Finder\Finder;
+use Illuminate\Contracts\Container\Container;
 
 class Factory implements ArrayAccess
 {
@@ -26,7 +26,7 @@ class Factory implements ArrayAccess
     /**
      * Create a new factory instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container $container
+     * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  \Faker\Generator  $faker
      * @return void
      */
@@ -46,9 +46,9 @@ class Factory implements ArrayAccess
     /**
      * Create a new factory container.
      *
-     * @param  \Illuminate\Contracts\Container\Container $container
-     * @param  \Faker\Generator $faker
-     * @param  string|null $pathToFactories
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \Faker\Generator  $faker
+     * @param  string|null  $pathToFactories
      * @return static
      */
     public static function construct(Container $container, Faker $faker, $pathToFactories = null)

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -3,10 +3,19 @@
 namespace Illuminate\Database\Eloquent;
 
 use Faker\Generator as Faker;
+use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
 
 class FactoryBuilder
 {
+
+    /**
+     * The container instance.
+     *
+     * @var \Illuminate\Container\Container
+     */
+    protected $container;
+
     /**
      * The model definitions in the container.
      *
@@ -45,16 +54,17 @@ class FactoryBuilder
     /**
      * Create an new builder instance.
      *
-     * @param  string  $class
-     * @param  string  $name
-     * @param  array  $definitions
-     * @param  \Faker\Generator  $faker
-     * @return void
+     * @param  string $class
+     * @param  string $name
+     * @param  \Illuminate\Contracts\Container\Container $container
+     * @param  array $definitions
+     * @param  \Faker\Generator $faker
      */
-    public function __construct($class, $name, array $definitions, Faker $faker)
+    public function __construct($class, $name, Container $container, array $definitions, Faker $faker)
     {
         $this->name = $name;
         $this->class = $class;
+        $this->container = $container;
         $this->faker = $faker;
         $this->definitions = $definitions;
     }
@@ -127,7 +137,7 @@ class FactoryBuilder
                 throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}].");
             }
 
-            $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker, $attributes);
+            $definition = $this->container->call($this->definitions[$this->class][$this->name], [$this->faker, $attributes]);
 
             return new $this->class(array_merge($definition, $attributes));
         });

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Database\Eloquent;
 
 use Faker\Generator as Faker;
-use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
+use Illuminate\Contracts\Container\Container;
 
 class FactoryBuilder
 {
@@ -53,11 +53,11 @@ class FactoryBuilder
     /**
      * Create an new builder instance.
      *
-     * @param  string $class
-     * @param  string $name
-     * @param  \Illuminate\Contracts\Container\Container $container
-     * @param  array $definitions
-     * @param  \Faker\Generator $faker
+     * @param  string  $class
+     * @param  string  $name
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  array  $definitions
+     * @param  \Faker\Generator  $faker
      */
     public function __construct($class, $name, Container $container, array $definitions, Faker $faker)
     {

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -8,7 +8,6 @@ use InvalidArgumentException;
 
 class FactoryBuilder
 {
-
     /**
      * The container instance.
      *


### PR DESCRIPTION
It can be useful to inject some other classes to the factories, like some custom generators for data that is not included in `Faker`

example of use : 

```
$factory->define(App\User::class, function (App\CustomGenerator $customGenerator, $faker, $attributes) {

    return [
        'name' => $faker->name,
        'email' => $faker->email,
        'password' => str_random(10),
        'remember_token' => str_random(10),
        'custom_attribute' => $customGenerator->someValue()
    ];
});
```

Also, the function `Factory::raw()` was not compatible with the change in #9387, so it was fixed.
