### PR TITLE
Dependency injection model factories

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -125,4 +125,50 @@ class EloquentUserProvider implements UserProvider
 
         return new $class;
     }
+
+    /**
+     * Gets the hasher implementation.
+     *
+     * @return \Illuminate\Contracts\Hashing\Hasher
+     */
+    public function getHasher()
+    {
+        return $this->hasher;
+    }
+
+    /**
+     * Sets the hasher implementation.
+     *
+     * @param  \Illuminate\Contracts\Hashing\Hasher  $hasher
+     * @return $this
+     */
+    public function setHasher(HasherContract $hasher)
+    {
+        $this->hasher = $hasher;
+
+        return $this;
+    }
+
+    /**
+     * Gets the name of the Eloquent user model.
+     *
+     * @return string
+     */
+    public function getModel()
+    {
+        return $this->model;
+    }
+
+    /**
+     * Sets the name of the Eloquent user model.
+     *
+     * @param  string  $model
+     * @return $this
+     */
+    public function setModel($model)
+    {
+        $this->model = $model;
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -64,7 +64,7 @@ class Container implements ArrayAccess, ContainerContract
     protected $tags = [];
 
     /**
-     * The stack of concretions being currently built.
+     * The stack of concretions currently being built.
      *
      * @var array
      */

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -64,7 +64,7 @@ class Container implements ArrayAccess, ContainerContract
     protected $tags = [];
 
     /**
-     * The stack of concretions being current built.
+     * The stack of concretions being currently built.
      *
      * @var array
      */

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -247,7 +247,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Register a shared binding in the container.
      *
-     * @param  string  $abstract
+     * @param  string|array  $abstract
      * @param  \Closure|string|null  $concrete
      * @return void
      */

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -66,7 +66,7 @@ class DatabaseServiceProvider extends ServiceProvider
         $this->app->singleton(EloquentFactory::class, function ($app) {
             $faker = $app->make(FakerGenerator::class);
 
-            return EloquentFactory::construct($faker, database_path('factories'));
+            return EloquentFactory::construct($app, $faker, database_path('factories'));
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -4,8 +4,8 @@ namespace Illuminate\Database\Eloquent;
 
 use ArrayAccess;
 use Faker\Generator as Faker;
-use Illuminate\Contracts\Container\Container;
 use Symfony\Component\Finder\Finder;
+use Illuminate\Contracts\Container\Container;
 
 class Factory implements ArrayAccess
 {
@@ -26,7 +26,7 @@ class Factory implements ArrayAccess
     /**
      * Create a new factory instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container $container
+     * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  \Faker\Generator  $faker
      * @return void
      */
@@ -46,9 +46,9 @@ class Factory implements ArrayAccess
     /**
      * Create a new factory container.
      *
-     * @param  \Illuminate\Contracts\Container\Container $container
-     * @param  \Faker\Generator $faker
-     * @param  string|null $pathToFactories
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \Faker\Generator  $faker
+     * @param  string|null  $pathToFactories
      * @return static
      */
     public static function construct(Container $container, Faker $faker, $pathToFactories = null)

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -3,10 +3,19 @@
 namespace Illuminate\Database\Eloquent;
 
 use Faker\Generator as Faker;
+use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
 
 class FactoryBuilder
 {
+
+    /**
+     * The container instance.
+     *
+     * @var \Illuminate\Container\Container
+     */
+    protected $container;
+
     /**
      * The model definitions in the container.
      *
@@ -45,16 +54,17 @@ class FactoryBuilder
     /**
      * Create an new builder instance.
      *
-     * @param  string  $class
-     * @param  string  $name
-     * @param  array  $definitions
-     * @param  \Faker\Generator  $faker
-     * @return void
+     * @param  string $class
+     * @param  string $name
+     * @param  \Illuminate\Contracts\Container\Container $container
+     * @param  array $definitions
+     * @param  \Faker\Generator $faker
      */
-    public function __construct($class, $name, array $definitions, Faker $faker)
+    public function __construct($class, $name, Container $container, array $definitions, Faker $faker)
     {
         $this->name = $name;
         $this->class = $class;
+        $this->container = $container;
         $this->faker = $faker;
         $this->definitions = $definitions;
     }
@@ -127,7 +137,7 @@ class FactoryBuilder
                 throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}].");
             }
 
-            $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker, $attributes);
+            $definition = $this->container->call($this->definitions[$this->class][$this->name], [$this->faker, $attributes]);
 
             return new $this->class(array_merge($definition, $attributes));
         });

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Database\Eloquent;
 
 use Faker\Generator as Faker;
-use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
+use Illuminate\Contracts\Container\Container;
 
 class FactoryBuilder
 {
@@ -53,11 +53,11 @@ class FactoryBuilder
     /**
      * Create an new builder instance.
      *
-     * @param  string $class
-     * @param  string $name
-     * @param  \Illuminate\Contracts\Container\Container $container
-     * @param  array $definitions
-     * @param  \Faker\Generator $faker
+     * @param  string  $class
+     * @param  string  $name
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  array  $definitions
+     * @param  \Faker\Generator  $faker
      */
     public function __construct($class, $name, Container $container, array $definitions, Faker $faker)
     {

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -8,7 +8,6 @@ use InvalidArgumentException;
 
 class FactoryBuilder
 {
-
     /**
      * The container instance.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1130,7 +1130,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function delete()
     {
-        if (is_null($this->primaryKey)) {
+        if (is_null($this->getKeyName())) {
             throw new Exception('No primary key defined on model.');
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -812,7 +812,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // the calling method's name and use that as the relationship name as most
         // of the time this will be what we desire to use for the relationships.
         if (is_null($relation)) {
-            list(, $caller) = debug_backtrace(false, 2);
+            list($current, $caller) = debug_backtrace(false, 2);
 
             $relation = $caller['function'];
         }
@@ -850,7 +850,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // since that is most likely the name of the polymorphic interface. We can
         // use that to get both the class and foreign key that will be utilized.
         if (is_null($name)) {
-            list(, $caller) = debug_backtrace(false, 2);
+            list($current, $caller) = debug_backtrace(false, 2);
 
             $name = Str::snake($caller['function']);
         }

--- a/src/Illuminate/Foundation/Inspiring.php
+++ b/src/Illuminate/Foundation/Inspiring.php
@@ -11,6 +11,8 @@ class Inspiring
      *
      * Taylor & Dayle made this commit from Jungfraujoch. (11,333 ft.)
      *
+     * May McGinnis always control the board. #LaraconUS2015
+     *
      * @return string
      */
     public static function quote()

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -671,7 +671,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $items = $this->items;
 
-        $callback ? uasort($items, $callback) : natcasesort($items);
+        $callback ? uasort($items, $callback) : uasort($items, function ($a, $b) {
+
+            if ($a == $b) {
+                return 0;
+            }
+
+            return ($a < $b) ? -1 : 1;
+        });
 
         return new static($items);
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -998,7 +998,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(1, $parameters, 'unique');
 
-        list($connection, $table) = $this->parseUniqueTable($parameters[0]);
+        list($connection, $table) = $this->parseTable($parameters[0]);
 
         // The second parameter position holds the name of the column that needs to
         // be verified as unique. If this parameter isn't specified we will just
@@ -1034,12 +1034,12 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Parse the connection / table for the unique rule.
+     * Parse the connection / table for the unique / exists rules.
      *
      * @param  string  $table
      * @return array
      */
-    protected function parseUniqueTable($table)
+    protected function parseTable($table)
     {
         return Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
     }
@@ -1084,7 +1084,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(1, $parameters, 'exists');
 
-        $table = $parameters[0];
+        list($connection, $table) = $this->parseTable($parameters[0]);
 
         // The second parameter position holds the name of the column that should be
         // verified as existing. If this parameter is not specified we will guess
@@ -1093,21 +1093,26 @@ class Validator implements ValidatorContract
 
         $expected = (is_array($value)) ? count($value) : 1;
 
-        return $this->getExistCount($table, $column, $value, $parameters) >= $expected;
+        return $this->getExistCount($connection, $table, $column, $value, $parameters) >= $expected;
     }
 
     /**
      * Get the number of records that exist in storage.
      *
+     * @param  mixed   $connection
      * @param  string  $table
      * @param  string  $column
      * @param  mixed   $value
      * @param  array   $parameters
      * @return int
      */
-    protected function getExistCount($table, $column, $value, $parameters)
+    protected function getExistCount($connection, $table, $column, $value, $parameters)
     {
         $verifier = $this->getPresenceVerifier();
+
+        if (! is_null($connection)) {
+            $verifier->setConnection($connection);
+        }
 
         $extra = $this->getExtraExistConditions($parameters);
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -302,6 +302,9 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $data = (new Collection([5, 3, 1, 2, 4]))->sort();
         $this->assertEquals([1, 2, 3, 4, 5], $data->values()->all());
 
+        $data = (new Collection([-1, -3, -2, -4, -5, 0, 5, 3, 1, 2, 4]))->sort();
+        $this->assertEquals([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5], $data->values()->all());
+
         $data = (new Collection(['foo', 'bar-10', 'bar-1']))->sort();
         $this->assertEquals(['bar-1', 'bar-10', 'foo'], $data->values()->all());
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -141,4 +141,20 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('laravel_php_framework', Str::snake('Laravel Php Framework'));
         $this->assertEquals('laravel_php_framework', Str::snake('Laravel    Php      Framework   '));
     }
+
+    public function testStudly()
+    {
+        $this->assertEquals('LaravelPHPFramework', Str::studly('laravel_p_h_p_framework'));
+        $this->assertEquals('LaravelPhpFramework', Str::studly('laravel_php_framework'));
+        $this->assertEquals('LaravelPhPFramework', Str::studly('laravel-phP-framework'));
+        $this->assertEquals('LaravelPhpFramework', Str::studly('laravel  -_-  php   -_-   framework   '));
+    }
+
+    public function testCamel()
+    {
+        $this->assertEquals('laravelPHPFramework', Str::camel('Laravel_p_h_p_framework'));
+        $this->assertEquals('laravelPhpFramework', Str::camel('Laravel_php_framework'));
+        $this->assertEquals('laravelPhPFramework', Str::camel('Laravel-phP-framework'));
+        $this->assertEquals('laravelPhpFramework', Str::camel('Laravel  -_-  php   -_-   framework   '));
+    }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -902,6 +902,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $mock3->shouldReceive('getMultiCount')->once()->with('users', 'email_addr', ['foo'], [])->andReturn(false);
         $v->setPresenceVerifier($mock3);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:connection.users']);
+        $mock5 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock5->shouldReceive('setConnection')->once()->with('connection');
+        $mock5->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(true);
+        $v->setPresenceVerifier($mock5);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidationExistsIsNotCalledUnnecessarily()


### PR DESCRIPTION
It can be useful to inject some other classes to the factories, like some custom generators for data that is not included in `Faker`

example of use : 

```
$factory->define(App\User::class, function (App\CustomGenerator $customGenerator, $faker, $attributes) {

    return [
        'name' => $faker->name,
        'email' => $faker->email,
        'password' => str_random(10),
        'remember_token' => str_random(10),
        'custom_attribute' => $customGenerator->someValue()
    ];
});
```

Also, the function `Factory::raw()` was not compatible with the change in #9387, so it was fixed.
