### PR TITLE
Fixes #9937

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -205,6 +205,8 @@ class Arr
 
                 if (isset($array[$part]) && is_array($array[$part])) {
                     $array = &$array[$part];
+                } else {
+                    $parts =[];
                 }
             }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -206,7 +206,7 @@ class Arr
                 if (isset($array[$part]) && is_array($array[$part])) {
                     $array = &$array[$part];
                 } else {
-                    $parts =[];
+                    $parts = [];
                 }
             }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -70,4 +70,31 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($expect, Arr::sortRecursive($array));
     }
+
+    public function testForget()
+    {
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        Arr::forget($array, 'products.desk');
+        $this->assertEquals(['products' => []], $array);
+
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        Arr::forget($array, 'products.desk.price');
+        $this->assertEquals(['products' => ['desk' => []]], $array);
+
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        Arr::forget($array, 'products.final.price');
+        $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
+
+        $array = ['shop' => ['cart' => [150 => 0]]];
+        Arr::forget($array, 'shop.final.cart');
+        $this->assertEquals(['shop' => ['cart' => [150 => 0]]], $array);
+
+        $array = ['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]];
+        Arr::forget($array, 'products.desk.price.taxes');
+        $this->assertEquals(['products' => ['desk' => ['price' => ['original' => 50]]]], $array);
+
+        $array = ['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]];
+        Arr::forget($array, 'products.desk.final.taxes');
+        $this->assertEquals(['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]], $array);
+    }
 }


### PR DESCRIPTION
While looping through the provided array elements in dot notation, if the curreny element being inspected doesn't exist then exit out of the while loop and do not erase any array element.

When this didn't exist it was causing the issue in #9937.

Also added some tests.
