### PR TITLE
[5.1] Prevent repeated calls to the same function

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -415,7 +415,7 @@ trait CrawlerTrait
             $expected = $this->formatToExpectedJson($key, $value);
 
             $this->assertTrue(
-                Str::contains($actual, $this->formatToExpectedJson($key, $value)),
+                Str::contains($actual, $expected),
                 "Unable to find JSON fragment [{$expected}] within [{$actual}]."
             );
         }


### PR DESCRIPTION
Remove unnecessary repeated call to formatToExpectedJson().
