### PR TITLE
[5.2] Dependency injection in model factories

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -66,7 +66,7 @@ class DatabaseServiceProvider extends ServiceProvider
         $this->app->singleton(EloquentFactory::class, function ($app) {
             $faker = $app->make(FakerGenerator::class);
 
-            return EloquentFactory::construct($faker, database_path('factories'));
+            return EloquentFactory::construct($app, $faker, database_path('factories'));
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -5,9 +5,17 @@ namespace Illuminate\Database\Eloquent;
 use ArrayAccess;
 use Faker\Generator as Faker;
 use Symfony\Component\Finder\Finder;
+use Illuminate\Contracts\Container\Container;
 
 class Factory implements ArrayAccess
 {
+    /**
+     * The container instance.
+     *
+     * @var Illuminate\Contracts\Container\Container;
+     */
+    protected $container;
+
     /**
      * The Faker instance for the builder.
      *
@@ -18,11 +26,13 @@ class Factory implements ArrayAccess
     /**
      * Create a new factory instance.
      *
+     * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  \Faker\Generator  $faker
      * @return void
      */
-    public function __construct(Faker $faker)
+    public function __construct(Container $container, Faker $faker)
     {
+        $this->container = $container;
         $this->faker = $faker;
     }
 
@@ -36,15 +46,16 @@ class Factory implements ArrayAccess
     /**
      * Create a new factory container.
      *
+     * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  \Faker\Generator  $faker
      * @param  string|null  $pathToFactories
      * @return static
      */
-    public static function construct(Faker $faker, $pathToFactories = null)
+    public static function construct(Container $container, Faker $faker, $pathToFactories = null)
     {
         $pathToFactories = $pathToFactories ?: database_path('factories');
 
-        $factory = new static($faker);
+        $factory = new static($container, $faker);
 
         if (is_dir($pathToFactories)) {
             foreach (Finder::create()->files()->in($pathToFactories) as $file) {
@@ -154,7 +165,7 @@ class Factory implements ArrayAccess
      */
     public function raw($class, array $attributes = [], $name = 'default')
     {
-        $raw = call_user_func($this->definitions[$class][$name], $this->faker);
+        $raw = $this->container->call($this->definitions[$class][$name], [$this->faker, $attributes]);
 
         return array_merge($raw, $attributes);
     }
@@ -168,7 +179,7 @@ class Factory implements ArrayAccess
      */
     public function of($class, $name = 'default')
     {
-        return new FactoryBuilder($class, $name, $this->definitions, $this->faker);
+        return new FactoryBuilder($class, $name, $this->container, $this->definitions, $this->faker);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -12,7 +12,7 @@ class Factory implements ArrayAccess
     /**
      * The container instance.
      *
-     * @var Illuminate\Contracts\Container\Container;
+     * @var \Illuminate\Contracts\Container\Container
      */
     protected $container;
 

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -179,7 +179,7 @@ class Factory implements ArrayAccess
      */
     public function of($class, $name = 'default')
     {
-        return new FactoryBuilder($class, $name, $this->container, $this->definitions, $this->faker);
+        return new FactoryBuilder($this->container, $this->faker, $this->definitions, $class, $name);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -4,9 +4,17 @@ namespace Illuminate\Database\Eloquent;
 
 use Faker\Generator as Faker;
 use InvalidArgumentException;
+use Illuminate\Contracts\Container\Container;
 
 class FactoryBuilder
 {
+    /**
+     * The container instance.
+     *
+     * @var Illuminate\Contracts\Container\Container;
+     */
+    protected $container;
+
     /**
      * The model definitions in the container.
      *
@@ -47,14 +55,16 @@ class FactoryBuilder
      *
      * @param  string  $class
      * @param  string  $name
+     * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  array  $definitions
      * @param  \Faker\Generator  $faker
      * @return void
      */
-    public function __construct($class, $name, array $definitions, Faker $faker)
+    public function __construct($class, $name, Container $container, array $definitions, Faker $faker)
     {
         $this->name = $name;
         $this->class = $class;
+        $this->container = $container;
         $this->faker = $faker;
         $this->definitions = $definitions;
     }
@@ -127,7 +137,7 @@ class FactoryBuilder
                 throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}].");
             }
 
-            $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker, $attributes);
+            $definition = $this->container->call($this->definitions[$this->class][$this->name], [$this->faker, $attributes]);
 
             return new $this->class(array_merge($definition, $attributes));
         });

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -11,7 +11,7 @@ class FactoryBuilder
     /**
      * The container instance.
      *
-     * @var Illuminate\Contracts\Container\Container;
+     * @var \Illuminate\Contracts\Container\Container
      */
     protected $container;
 
@@ -53,20 +53,20 @@ class FactoryBuilder
     /**
      * Create an new builder instance.
      *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \Faker\Generator  $faker
+     * @param  array  $definitions
      * @param  string  $class
      * @param  string  $name
-     * @param  \Illuminate\Contracts\Container\Container  $container
-     * @param  array  $definitions
-     * @param  \Faker\Generator  $faker
      * @return void
      */
-    public function __construct($class, $name, Container $container, array $definitions, Faker $faker)
+    public function __construct(Container $container, Faker $faker, array $definitions, $class, $name)
     {
-        $this->name = $name;
-        $this->class = $class;
         $this->container = $container;
         $this->faker = $faker;
         $this->definitions = $definitions;
+        $this->class = $class;
+        $this->name = $name;
     }
 
     /**


### PR DESCRIPTION
It can be useful to inject some other classes to the factories, like some custom generators for data that is not included in `Faker`

example of use : 

```
$factory->define(App\User::class, function (App\CustomGenerator $customGenerator, $faker, $attributes) {

    return [
        'name' => $faker->name,
        'email' => $faker->email,
        'password' => str_random(10),
        'remember_token' => str_random(10),
        'custom_attribute' => $customGenerator->someValue()
    ];
});
```

Also, the function `Factory::raw()` was not compatible with the change in #9387, so it was fixed.
