### PR TITLE
[5.2] Add dynamic array input support on Validator

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -229,6 +229,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('require it please!', $v->messages()->first('name'));
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['name' => ['', 'foo']], ['name[]' => 'Required'], ['name[].required' => 'require it please!']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('require it please!', $v->messages()->first('name.0'));
     }
 
     public function testValidateRequired()
@@ -242,6 +248,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['name' => 'foo'], ['name' => 'Required']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ['Foo', 'Bar']], ['name[]' => 'Required']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ['', 'Bar']], ['name[]' => 'Required']);
+        $this->assertFalse($v->passes());
 
         $file = new File('', false);
         $v = new Validator($trans, ['name' => $file], ['name' => 'Required']);


### PR DESCRIPTION
Hi guys, I have a proposal.
I had a case where I had to validate an array input with Validator, and normally we validate it like this:

``` php
public function rules()
{
  $rules = [
    'itemname.0' => 'required',
    'itemname.1' => 'required',
    ...
  ];

  return $rules;
}
```

and so on, and if the input is **dynamic**, we can use loop like this:

``` php
public function rules()
{
  $rules = [
    'name' => 'required|max:255',
  ];

  foreach($this->request->get('items') as $key => $val)
  {
    $rules['items.'.$key] = 'required|max:10';
  }

  return $rules;
}

```

It'll be really dirty if we had about 3-5 array input and we need to loop the **rules** and **messages**.

This PR enables us to only write it as follows:

``` php
public function rules()
{
        return [
            'food[]' => 'required|min:3',
            'drink[]' => 'required',
            'name' => 'required',
        ];
}

```

PS: If the code can still be improved, then please help!

Thank you.
