### PR TITLE
[5.1] Fix json validator

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -838,6 +838,7 @@ class Validator implements ValidatorContract
     protected function validateJson($attribute, $value)
     {
         json_decode($value);
+
         return json_last_error() === JSON_ERROR_NONE;
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -837,7 +837,8 @@ class Validator implements ValidatorContract
      */
     protected function validateJson($attribute, $value)
     {
-        return ! is_null(json_decode($value));
+        json_decode($value);
+        return json_last_error() === JSON_ERROR_NONE;
     }
 
     /**


### PR DESCRIPTION
`json_decode()` can return `null` if json contains it. We have to look for errors.
