### PR TITLE
[5.1] Fix negative validation for pagination

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent;
 
 use Closure;
+use InvalidArgumentException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Pagination\Paginator;
@@ -265,9 +266,15 @@ class Builder
      * @param  string  $pageName
      * @param  int|null  $page
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     *
+     * @throws InvalidArgumentException
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
+        if( $perPage <= 0) {
+            throw new InvalidArgumentException("Negative values can't be used to query results");
+        }
+
         $total = $this->query->getCountForPagination();
 
         $this->query->forPage(
@@ -291,6 +298,8 @@ class Builder
      */
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page')
     {
+
+
         $page = Paginator::resolveCurrentPage($pageName);
 
         $perPage = $perPage ?: $this->model->getPerPage();

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -271,7 +271,7 @@ class Builder
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
-        if( $perPage <= 0) {
+        if ($perPage <= 0) {
             throw new InvalidArgumentException("Negative values can't be used to query results");
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -298,8 +298,6 @@ class Builder
      */
     public function simplePaginate($perPage = null, $columns = ['*'], $pageName = 'page')
     {
-
-
         $page = Paginator::resolveCurrentPage($pageName);
 
         $perPage = $perPage ?: $this->model->getPerPage();

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Database\Eloquent;
 
 use Closure;
-use InvalidArgumentException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -267,7 +267,7 @@ class Builder
      * @param  int|null  $page
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
      *
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {


### PR DESCRIPTION
$user = Model::paginate(-8);

$user returns a vague error description about offset from the sql query. 

This fixes and throws an appropriate exception `Negative values can't be used to query results`
