### PR TITLE
[5.1] #9970 $request->get() now includes json content

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -728,7 +728,7 @@ class Request extends SymfonyRequest implements ArrayAccess
             $request->cookies->all(), $request->files->all(), $request->server->all()
         );
 
-        // ensure that json is empty
+        // if this isn't explicitly unset, json content will not be read from the body content
         unset($request->json);
 
         $request->content = $content;
@@ -886,17 +886,15 @@ class Request extends SymfonyRequest implements ArrayAccess
      *
      * Order of precedence: GET, PATH, POST, JSON
      *
-     * Avoid using this method in controllers:
-     *
-     *  * slow
-     *  * prefer to get from a "named" source
+     * Avoid using this method in controllers as it may be slow.
      *
      * It is better to explicitly get request parameters from the appropriate
-     * public property instead (query, attributes, request, json).
+     * public property instead (query, attributes, request) or from the appropriate
+     * function (input(), json())
      *
      * @param  string  $key
-     * @param  mixed   $default
-     * @param  bool    $deep
+     * @param  mixed  $default
+     * @param  bool  $deep
      * @return mixed
      */
     public function get($key, $default = null, $deep = false)

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -728,6 +728,9 @@ class Request extends SymfonyRequest implements ArrayAccess
             $request->cookies->all(), $request->files->all(), $request->server->all()
         );
 
+        // ensure that json is empty
+        unset($request->json);
+
         $request->content = $content;
 
         $request->request = $request->getInputSource();
@@ -876,6 +879,37 @@ class Request extends SymfonyRequest implements ArrayAccess
     public function offsetUnset($offset)
     {
         return $this->getInputSource()->remove($offset);
+    }
+
+    /**
+     * Gets a "parameter" value.
+     *
+     * Order of precedence: GET, PATH, POST, JSON
+     *
+     * Avoid using this method in controllers:
+     *
+     *  * slow
+     *  * prefer to get from a "named" source
+     *
+     * It is better to explicitly get request parameters from the appropriate
+     * public property instead (query, attributes, request, json).
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @param  bool    $deep
+     * @return mixed
+     */
+    public function get($key, $default = null, $deep = false)
+    {
+        if ($this !== $result = parent::get($key, $this, $deep)) {
+            return $result;
+        }
+
+        if ($this !== $result = $this->json()->get($key, $this, $deep)) {
+            return $result;
+        }
+
+        return $default;
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -537,4 +537,22 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($request->request->all(), $body);
     }
+
+    public function testJsonContent()
+    {
+        $body = [
+            'foo' => 'bar',
+            'baz' => ['qux'],
+        ];
+
+        $server = [
+            'CONTENT_TYPE' => 'application/json',
+        ];
+
+        $request = Request::create('/', 'GET', [], [], [], $server, json_encode($body));
+
+        $this->assertEquals($request->all(), $body);
+        $this->assertEquals($request->get('foo'), 'bar');
+        $this->assertEquals($request->get('baz'), ['qux']);
+    }
 }


### PR DESCRIPTION
`$request->get()` wouldn't include json body content but `$request->input()` would (because it internally uses `getInputSource()` which actually responds to `isJson()`).

The result is that `$request->all()` would return content that is passed through the request body with the header `CONTENT_TYPE=application/json`, but won't return anything that is passed as a parameter, while `$request->get()` was unaware of any data passed through the request body.

This pull request modifies the `get` method to allow access to json content (if it exists), which will make the `Request` object behave correctly when `CONTENT_TYPE=application/json` is set.
