### PR TITLE
Refactor `Database\Query\Builder::insert`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1705,39 +1705,18 @@ class Builder
         // Since every insert gets treated like a batch insert, we will make sure the
         // bindings are structured in a way that is convenient for building these
         // inserts statements by verifying the elements are actually an array.
-        if (! is_array(reset($values))) {
-            $values = [$values];
-        }
-
-        // Since every insert gets treated like a batch insert, we will make sure the
-        // bindings are structured in a way that is convenient for building these
-        // inserts statements by verifying the elements are actually an array.
-        else {
-            foreach ($values as $key => $value) {
-                ksort($value);
-                $values[$key] = $value;
-            }
-        }
+        $values = is_array(reset($values)) ? $values : [$values];
+        array_walk($values, 'ksort');
 
         // We'll treat every insert like a batch insert so we can easily insert each
         // of the records into the database consistently. This will make it much
         // easier on the grammars to just handle one type of record insertion.
-        $bindings = [];
-
-        foreach ($values as $record) {
-            foreach ($record as $value) {
-                $bindings[] = $value;
-            }
-        }
-
         $sql = $this->grammar->compileInsert($this, $values);
 
         // Once we have compiled the insert statement's SQL we can execute it on the
         // connection and return a result as a boolean success indicator as that
         // is the same type of result returned by the raw connection instance.
-        $bindings = $this->cleanBindings($bindings);
-
-        return $this->connection->insert($sql, $bindings);
+        return $this->connection->insert($sql, $this->cleanBindings(array_flatten($values)));
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -889,7 +889,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email", "name") select ? as "email", ? as "name" union all select ? as "email", ? as "name"', ['foo', 'taylor', 'bar', 'dayle'])->andReturn(true);
-        $result = $builder->from('users')->insert([['email' => 'foo', 'name' => 'taylor'], ['email' => 'bar', 'name' => 'dayle']]);
+        $result = $builder->from('users')->insert([['email' => 'foo', 'name' => 'taylor'], ['name' => 'dayle', 'email' => 'bar']]);
         $this->assertTrue($result);
     }
 


### PR DESCRIPTION
Originally I wanted to allow the `insert` method to accept either an `array` or a `Collection`, however, after refactoring it I found that allowing for something like that just makes the code look worse in the end.

This change is just a straight up refactor. I've used array methods to reduce indentation and added a ternary operator for the "make sure it's an array of arrays" part of the code. I've also eliminated the `$bindings` variable. All in all, I think it reads better, it's definitely shorter. 
