### PR TITLE
[5.2] Added the `current` method to the UrlGenerator. 

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -61,4 +61,11 @@ interface UrlGenerator
      * @return $this
      */
     public function setRootControllerNamespace($rootNamespace);
+
+    /**
+     * Get the current URL for the request.
+     *
+     * @return string
+     */
+    public function current();
 }


### PR DESCRIPTION
I am implementing a `Decorator` over the `UrlGenerator` in one package. My `Decorator` only implements methods defined in this contract.

One of my projects uses the mentioned package **and** `illuminate/html`. When my package rebinds the `UrlGenerator` contract to its `Decorator`, `Illuminate\Html\HtmlBuilder` and `Illuminate\Html\FormBuilder` fail because of hard-coded concrete dependencies.

I've checked both, and this is the only method missing from the interface so that `illuminate/html` may stop depending on the concrete `UrlGenerator` and depend on the contract.
