### PR TITLE
[5.2] Fix tests for collection reverse

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -345,12 +345,12 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $data = new Collection(['zaeed', 'alan']);
         $reversed = $data->reverse();
 
-        $this->assertEquals(['alan', 'zaeed'], array_values($reversed->all()));
+        $this->assertSame([1 => 'alan', 0 => 'zaeed'], $reversed->all());
 
-        $data = new Collection(['zaeed', 'alan']);
-        $reversed = $data->reverse(true);
+        $data = new Collection(['name' => 'taylor', 'framework' => 'laravel']);
+        $reversed = $data->reverse();
 
-        $this->assertEquals([1 => 'alan', 0 => 'zaeed'], $reversed->all());
+        $this->assertSame(['framework' => 'laravel', 'name' => 'taylor'], $reversed->all());
     }
 
     public function testFlip()


### PR DESCRIPTION
Related to #9950

Also `assertEquals` is too weak in this case.

``` php
$data = new Collection(['name' => 'taylor', 'framework' => 'laravel']);
$reversed = $data->reverse();

$this->assertEquals(['name' => 'taylor', 'framework' => 'laravel'], $reversed->all());
```

passes.
