### PR TITLE
[5.2] Index bindings by clause key to facilitate binding removal

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1990,7 +1990,7 @@ class Builder
         $var = ($type == 'select') ? 'columns' : "{$type}s";
 
         $array = $this->$var;
-        if (!$array) {
+        if ( !$array) {
             return 0;
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1990,7 +1990,7 @@ class Builder
         $var = ($type == 'select') ? 'columns' : "{$type}s";
 
         $array = $this->$var;
-        if ( !$array) {
+        if (! $array) {
             return 0;
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1892,7 +1892,7 @@ class Builder
     }
 
     /**
-     * Get the raw array of bindings.
+     * Get the raw indexed array of bindings.
      *
      * @return array
      */
@@ -1926,6 +1926,7 @@ class Builder
      *
      * @param  mixed   $value
      * @param  string  $type
+     * @param  int $key
      * @return $this
      *
      * @throws \InvalidArgumentException
@@ -1936,14 +1937,16 @@ class Builder
             throw new InvalidArgumentException("Invalid binding type: {$type}.");
         }
 
-        if(is_null($key)) $key = $this->getLastKeyOfType($type);
+        if (is_null($key)) {
+            $key = $this->getLastKeyOfType($type);
+        }
         $this->bindings[$type][$key][] = $value;
 
         return $this;
     }
 
     /**
-     * Remove a binding from the query
+     * Remove a binding from the query.
      *
      * @param  string  $type
      * @param  int $key
@@ -1952,11 +1955,12 @@ class Builder
     public function removeBinding($type, $key)
     {
         unset($this->bindings[$type][$key]);
+
         return $this;
     }
 
     /**
-     * Remove a clause and corresponding binding from the query
+     * Remove a clause and corresponding binding from the query.
      *
      * @param  string  $type
      * @param  int $key
@@ -1964,7 +1968,7 @@ class Builder
      */
     public function removeClause($type, $key)
     {
-        $var = ($type == 'select') ? "columns" : "{$type}s";
+        $var = ($type == 'select') ? 'columns' : "{$type}s";
 
         $clauses = $this->$var;
         unset($clauses[$key]);
@@ -1976,17 +1980,19 @@ class Builder
     }
 
     /**
-     * Return the key for the last inserted clause
+     * Return the key for the last inserted clause.
      *
      * @param  string  $type
      * @return int
      */
     public function getLastKeyOfType($type)
     {
-        $var = ($type == 'select') ? "columns" : "{$type}s";
-        
+        $var = ($type == 'select') ? 'columns' : "{$type}s";
+
         $array = $this->$var;
-        if(is_null($array) || empty($array)) return 0;
+        if (!$array) {
+            return 0;
+        }
 
         end($array);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1184,7 +1184,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
         // extra clause removed
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->join('othertable', function ($join) { $join->where('bar', '=', 'foo'); })->where('registered', 1)->where('foo', '=', 'qux')->groupBy('city')->having('population', '>', 3)->orderByRaw('match ("foo") against(?)', ['bar']); 
+        $builder->select('*')->from('users')->join('othertable', function ($join) { $join->where('bar', '=', 'foo'); })->where('registered', 1)->where('foo', '=', 'qux')->groupBy('city')->having('population', '>', 3)->orderByRaw('match ("foo") against(?)', ['bar']);
         $builder->removeClause('where', 1);
         $this->assertEquals($expectedSql, $builder->toSql());
         $this->assertEquals($expectedBindings, $builder->getBindings());
@@ -1229,24 +1229,24 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
     public function testBindingIndexMatchesWhere()
     {
-		$expectedBindings = [
-			0 => [0 => 'bar'],
-			2 => [0 => ['baz', 'qux']]
-		];
+        $expectedBindings = [
+            0 => [0 => 'bar'],
+            2 => [0 => ['baz', 'qux']],
+        ];
 
         $builder = $this->getBuilder();
         $builder->where('foo', '=', 'bar');
         $builder->whereNull('foo');
         $builder->whereBetween('foo', ['baz', 'qux']);
 
-        $this->assertEquals($expectedBindings, $builder->getRawIndexedBindings()['where'] );
+        $this->assertEquals($expectedBindings, $builder->getRawIndexedBindings()['where']);
     }
 
     public function testBindingAndClauseRemoval()
     {
         $expectedBindings = [
             0 => [0 => 'bar'],
-            2 => [0 => ['baz', 'qux']]
+            2 => [0 => ['baz', 'qux']],
         ];
 
         $builder = $this->getBuilder();
@@ -1256,7 +1256,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
         $builder->removeClause('where', 1);
 
-        $this->assertEquals($expectedBindings, $builder->getRawIndexedBindings()['where'] );
+        $this->assertEquals($expectedBindings, $builder->getRawIndexedBindings()['where']);
     }
 
     public function testSubSelect()


### PR DESCRIPTION
Index bindings by the key for the corresponding query clause, and add functions to 
remove clauses and/or binding.

This will simplify removing global scope(s) with binding(s), and make it more robust
