### PR TITLE
[5.1] Make acceptsJson return true if the accept type is for json-api

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -678,6 +678,8 @@ class Request extends SymfonyRequest implements ArrayAccess
     public function acceptsJson()
     {
         return $this->accepts('application/json');
+
+        return $this->accepts('application/vnd.api+json');
     }
 
     /**


### PR DESCRIPTION
This PR is pretty straightforward; it makes `Illuminate\Http\Request::acceptsjson()` return true if the accept header of the request is either `application/json` or `application/vnd.api+json` (as per [JSON API](http://jsonapi.org)).
