### PR TITLE
[5.1] Give appropriate warning when changing columns if Doctrine DBAL is not available.

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -778,6 +778,16 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Is Doctrine available?
+     *
+     * @return bool
+     */
+    public function isDoctrineAvailable()
+    {
+        return class_exists('Doctrine\DBAL\Connection');
+    }
+
+    /**
      * Get a Doctrine Schema Column instance.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Doctrine\DBAL\Schema\AbstractSchemaManager as SchemaManager;
+use RuntimeException;
 
 abstract class Grammar extends BaseGrammar
 {
@@ -280,7 +281,7 @@ abstract class Grammar extends BaseGrammar
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
         if (! $connection->isDoctrineAvailable()) {
-            throw new \RuntimeException(sprintf(
+            throw new RuntimeException(sprintf(
                 'Changing columns for table "%s" requires Doctrine DBAL; install "doctrine/dbal".',
                 $blueprint->getTable()
             ));

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -279,6 +279,13 @@ abstract class Grammar extends BaseGrammar
      */
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
+        if (! $connection->isDoctrineAvailable()) {
+            throw new \RuntimeException(sprintf(
+                'Changing columns for table "%s" requires Doctrine DBAL; install "doctrine/dbal".',
+                $blueprint->getTable()
+            ));
+        }
+
         $schema = $connection->getDoctrineSchemaManager();
 
         $tableDiff = $this->getChangedDiff($blueprint, $schema);


### PR DESCRIPTION
Obvious in the docs is one thing. Obvious when writing code and you hadn't seen it in the docs is another. Somewhat related to #590, I thought it would have been super helpful if the exception I was shown in the console output had told me more about what was wrong than just fatalling because `Class 'Doctrine\DBAL\Driver\PDOMySql\Driver' not found`.

I could have put the exception in `getDoctrineConnection` (and still could, probably) but I thought that adding `isDoctrineAvailable` would let things further out do more meaningful messages when something requires Doctrine but it is not available. For example, I now see `Changing columns for table "lesson_templates" requires Doctrine DBAL; install "doctrine/dbal".` which tells me exactly _why_ Doctrine is required, not just that it needs to be installed.

Happy to adjust this as needed. Happy to throw a more general exception in `getDoctrineConnection` as well, either as a part of this PR or in a follow-up PR.
