### PR TITLE
makes elixir helper respect app root

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -688,7 +688,7 @@ if (! function_exists('elixir')) {
         }
 
         if (isset($manifest[$file])) {
-            return '/build/'.$manifest[$file];
+            return app('url')->asset('/build/'.$manifest[$file]);
         }
 
         throw new InvalidArgumentException("File {$file} not defined in asset manifest.");


### PR DESCRIPTION
I apologize for not including a test; the Framework helpers do not appear to currently be tested, and I couldn't figure out how to create a test for this method from scratch. Please let me know if I need to do that!

Unlike the other URL-related helpers, the elixir() helper does not return URLs from the app root. Since the /build/ directory is by default (always?) put in the app root, the correct behavior seems to be that it _would_ return URLs from the app root.
