### PR TITLE
[5.2] Allow multiple `when`s and `skip`s on an Event

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -64,18 +64,18 @@ class Event
     public $withoutOverlapping = false;
 
     /**
-     * The filter callback.
+     * The array of filter callbacks.
      *
-     * @var \Closure
+     * @var array
      */
-    protected $filter;
+    protected $filters = [];
 
     /**
-     * The reject callback.
+     * The array of reject callbacks.
      *
-     * @var \Closure
+     * @var array
      */
-    protected $reject;
+    protected $rejects = [];
 
     /**
      * The location that output should be sent to.
@@ -264,9 +264,16 @@ class Event
      */
     protected function filtersPass(Application $app)
     {
-        if (($this->filter && ! $app->call($this->filter)) ||
-             $this->reject && $app->call($this->reject)) {
-            return false;
+        foreach ($this->filters as $callback) {
+            if(! $app->call($callback)) {
+                return false;
+            }
+        }
+
+        foreach ($this->rejects as $callback) {
+            if($app->call($callback)) {
+                return false;
+            }
         }
 
         return true;
@@ -616,7 +623,7 @@ class Event
      */
     public function when(Closure $callback)
     {
-        $this->filter = $callback;
+        $this->filters[] = $callback;
 
         return $this;
     }
@@ -629,7 +636,7 @@ class Event
      */
     public function skip(Closure $callback)
     {
-        $this->reject = $callback;
+        $this->rejects[] = $callback;
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -265,13 +265,13 @@ class Event
     protected function filtersPass(Application $app)
     {
         foreach ($this->filters as $callback) {
-            if(! $app->call($callback)) {
+            if (! $app->call($callback)) {
                 return false;
             }
         }
 
         foreach ($this->rejects as $callback) {
-            if($app->call($callback)) {
+            if ($app->call($callback)) {
                 return false;
             }
         }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -778,6 +778,16 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Is Doctrine available?
+     *
+     * @return bool
+     */
+    public function isDoctrineAvailable()
+    {
+        return class_exists('Doctrine\DBAL\Connection');
+    }
+
+    /**
      * Get a Doctrine Schema Column instance.
      *
      * @param  string  $table

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Grammar as BaseGrammar;
 use Doctrine\DBAL\Schema\AbstractSchemaManager as SchemaManager;
+use RuntimeException;
 
 abstract class Grammar extends BaseGrammar
 {
@@ -280,7 +281,7 @@ abstract class Grammar extends BaseGrammar
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
         if (! $connection->isDoctrineAvailable()) {
-            throw new \RuntimeException(sprintf(
+            throw new RuntimeException(sprintf(
                 'Changing columns for table "%s" requires Doctrine DBAL; install "doctrine/dbal".',
                 $blueprint->getTable()
             ));

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -279,6 +279,13 @@ abstract class Grammar extends BaseGrammar
      */
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
+        if (! $connection->isDoctrineAvailable()) {
+            throw new \RuntimeException(sprintf(
+                'Changing columns for table "%s" requires Doctrine DBAL; install "doctrine/dbal".',
+                $blueprint->getTable()
+            ));
+        }
+
         $schema = $connection->getDoctrineSchemaManager();
 
         $tableDiff = $this->getChangedDiff($blueprint, $schema);

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -439,7 +439,7 @@ class Str
      *
      * @param  string  $string
      * @param  int  $start
-     * @param  int  $length
+     * @param  int|null  $length
      * @return string
      */
     public static function substr($string, $start, $length = null)


### PR DESCRIPTION
This PR allows a Scheduling\Event to receive multiple when and skip callbacks, instead of just taking the last one and silently overwriting the previous ones.
