### PR TITLE
Mailgun transport uses 6.0 version of Guzzle

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Mail\Transport\LogTransport;
 use Illuminate\Mail\Transport\MailgunTransport;
 use Illuminate\Mail\Transport\MandrillTransport;
 use Swift_SendmailTransport as SendmailTransport;
+use GuzzleHttp\Client as HttpClient;
 
 class MailServiceProvider extends ServiceProvider {
 
@@ -214,7 +215,7 @@ class MailServiceProvider extends ServiceProvider {
 
 		$this->app->bindShared('swift.transport', function() use ($mailgun)
 		{
-			return new MailgunTransport($mailgun['secret'], $mailgun['domain']);
+			return new MailgunTransport(new HttpClient, $mailgun['secret'], $mailgun['domain']);
 		});
 	}
 

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -3,7 +3,6 @@
 use Swift_Transport;
 use GuzzleHttp\ClientInterface;
 use Swift_Mime_Message;
-use GuzzleHttp\Post\PostFile;
 use Swift_Events_EventListener;
 
 class MailgunTransport implements Swift_Transport {

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -2,6 +2,7 @@
 
 use Swift_Transport;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Post\PostFile;
 use Swift_Mime_Message;
 use Swift_Events_EventListener;
 


### PR DESCRIPTION
I updated the MailgunTransport class (and the service provider) to use the newer 6.0 version of Guzzle. Similar to the way the 5.1 branch does.

This is the first time I've ever contributed to any open source lib...I probably didn't do something right. If my changes aren't accepted, could we at least make them the 'right' way and release a patch to 4.2.17 (or a 4.2.18?) so I can use the Mailgun driver without downgrading to Guzzle 4 (or using my own fork of Laravel 4)?
