### PR TITLE
[5.1] Add the ability to fill a collection with a range of data

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -138,6 +138,29 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Fills a collection with items.
+     *
+     * @param  int  $amount
+     * @param  mixed  $value
+     * @param  bool  $append
+     * @return $this
+     */
+    public function fill($amount, $value = null, $append = true)
+    {
+        $items = ($amount - $this->count()) - 1;
+
+        foreach (range(0, $items) as $range) {
+            if ($append) {
+                $this->push($value);
+            } else {
+                $this->prepend($value);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Fetch a nested element of the collection.
      *
      * @param  string  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -386,6 +386,37 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['d'], $data->every(4, 3)->all());
     }
 
+    public function testFillEmpty()
+    {
+        $data = new Collection();
+        $data->fill(2);
+
+        $this->assertEquals([null, null], $data->all());
+        $this->assertEquals([null, null, null, null], $data->fill(2)->all());
+    }
+
+    public function testFillExisting()
+    {
+        $data = new Collection([
+            0 => 'foo',
+            1 => 'bar',
+        ]);
+
+        $this->assertEquals(['foo', 'bar'], $data->all());
+        $this->assertEquals(['foo', 'bar', 'baz'], $data->fill(3, 'baz')->all());
+    }
+
+    public function testFillPrepend()
+    {
+        $data = new Collection([
+            0 => 'foo',
+            1 => 'bar',
+        ]);
+
+        $this->assertEquals(['foo', 'bar'], $data->all());
+        $this->assertEquals(['baz', 'foo', 'bar'], $data->fill(3, 'baz', false)->all());
+    }
+
     public function testPluckWithArrayAndObjectValues()
     {
         $data = new Collection([(object) ['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);


### PR DESCRIPTION
This adds a new method to `Collection` which allows us to fill it with data, for a given range. This can either be prepended or appended.

My given use case for this is with an Eloquent query. I may take 30 results but due to a lack of data, have 0/1 row(s). If my UI requires 30 steps of data, I could loop it and fill the void, but this is a much cleaner, integrated solution.
