### PR TITLE
delete repeated register $request

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -231,8 +231,6 @@ class Kernel implements KernelContract
     protected function dispatchToRouter()
     {
         return function ($request) {
-            $this->app->instance('request', $request);
-
             return $this->router->dispatch($request);
         };
     }


### PR DESCRIPTION
I guess this line is unnecessary, because there is :

```
    protected function sendRequestThroughRouter($request)
    {
        $this->app->instance('request', $request);
        .....
    }
```
