### PR TITLE
[5.1] Fix #9969. Make $perPage optional again; throw same exception in simplePaginate()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -271,16 +271,15 @@ class Builder
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
+        $page = $page ?: Paginator::resolveCurrentPage($pageName);
+        $perPage = $perPage ?: $this->model->getPerPage();
+        $total = $this->query->getCountForPagination();
+
         if ($perPage <= 0) {
             throw new InvalidArgumentException("Negative 'perPage' value provided to 'paginate' method.");
         }
 
-        $total = $this->query->getCountForPagination();
-
-        $this->query->forPage(
-            $page = $page ?: Paginator::resolveCurrentPage($pageName),
-            $perPage = $perPage ?: $this->model->getPerPage()
-        );
+        $this->query->forPage($page, $perPage);
 
         return new LengthAwarePaginator($this->get($columns), $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),
@@ -301,6 +300,10 @@ class Builder
         $page = Paginator::resolveCurrentPage($pageName);
 
         $perPage = $perPage ?: $this->model->getPerPage();
+
+        if ($perPage <= 0) {
+            throw new InvalidArgumentException("Negative 'perPage' value provided to 'simplePaginate' method.");
+        }
 
         $this->skip(($page - 1) * $perPage)->take($perPage + 1);
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -131,6 +131,10 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
 
         Paginator::currentPageResolver(function () { return 1; });
+        $models = EloquentTestUser::oldest('id')->paginate();
+
+        $this->assertEquals(3, $models->count());
+
         $models = EloquentTestUser::oldest('id')->paginate(2);
 
         $this->assertEquals(2, $models->count());
@@ -147,6 +151,22 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Illuminate\Pagination\LengthAwarePaginator', $models);
         $this->assertInstanceOf('EloquentTestUser', $models[0]);
         $this->assertEquals('foo@gmail.com', $models[0]->email);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testPaginateWithNegativePerPageThrowsInvalidArgumentException()
+    {
+        EloquentTestUser::paginate(-3);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testSimplePaginateWithNegativePerPageThrowsInvalidArgumentException()
+    {
+        EloquentTestUser::simplePaginate(-3);
     }
 
     public function testCountForPaginationWithGrouping()


### PR DESCRIPTION
If we're going to throw an exception in `paginate()`, let's be consistent and throw it in `simplePaginate()` too.
#9969 is not implemented properly, preventing the following use of `paginate()`, effectively requiring a non-null, positive integer be passed to the method for `$perPage`.

``` php
App\Podcast::paginate()->all();
```

This PR makes `$perPage` optional while still enforcing a positive integer-like value when an argument _is_ passed. Integration tests included.
