### PR TITLE
Validate Password Reset Token On Reset Password Page

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -172,6 +172,25 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     }
 
     /**
+     * Get The Token Data From Database
+     *
+     * @param string $token
+     * @return array
+     */
+    public function validateTokenData($token)
+    {
+        $token = $this->getTable()->where('token', $token)->first();
+
+        if(empty($token))
+            return false;
+
+        $expiration_date = Carbon::parse($token->created_at)->addSeconds($this->expires)->toDateTimeString();
+        if($expiration_date->lt(Carbon::now()))
+            return false;
+
+        return true;
+    }
+    /**
      * Begin a new database query against the table.
      *
      * @return \Illuminate\Database\Query\Builder

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -190,6 +190,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
 
         return true;
     }
+
     /**
      * Begin a new database query against the table.
      *

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -172,7 +172,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     }
 
     /**
-     * Get The Token Data From Database
+     * Get & Validate Token Data From Database
      *
      * @param string $token
      * @return array

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Auth\Passwords;
 
-use Carbon\Carbon;
 use Closure;
 use UnexpectedValueException;
 use Illuminate\Contracts\Auth\UserProvider;

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -4,8 +4,6 @@ namespace Illuminate\Auth\Passwords;
 
 use Carbon\Carbon;
 use Closure;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\DB;
 use UnexpectedValueException;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
@@ -230,18 +228,7 @@ class PasswordBroker implements PasswordBrokerContract
      */
     public function validateToken($token)
     {
-        $token = DB::table(Config::get('auth.password.table'))->select('*')->where('token', '=', $token)->first();
-
-        // Return false If No Relevant Password Reset Token Data Found
-        if (empty($token))
-            return false;
-
-        // Calculating Expiration DateTime For Password Reset Token
-        $expiration_date = Carbon::parse($token->created_at)->addSeconds(Config::get('auth.password.expire'))->toDateTimeString();
-        if ($expiration_date->lt(Carbon::now()))
-            return false;
-
-        return true;
+        return $this->tokens->validateTokenData($token);
     }
 
     /**

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -230,15 +230,15 @@ class PasswordBroker implements PasswordBrokerContract
      */
     public function validateToken($token)
     {
-        $token = DB::table(Config::get('auth.password.table'))->select('*')->where('token','=',$token)->first();
+        $token = DB::table(Config::get('auth.password.table'))->select('*')->where('token', '=', $token)->first();
 
         // Return false If No Relevant Password Reset Token Data Found
-        if(empty($token))
+        if (empty($token))
             return false;
 
         // Calculating Expiration DateTime For Password Reset Token
         $expiration_date = Carbon::parse($token->created_at)->addSeconds(Config::get('auth.password.expire'))->toDateTimeString();
-        if($expiration_date->lt(Carbon::now()))
+        if ($expiration_date->lt(Carbon::now()))
             return false;
 
         return true;

--- a/src/Illuminate/Auth/Passwords/TokenRepositoryInterface.php
+++ b/src/Illuminate/Auth/Passwords/TokenRepositoryInterface.php
@@ -37,4 +37,12 @@ interface TokenRepositoryInterface
      * @return void
      */
     public function deleteExpired();
+
+    /**
+     * Get & Validate Token Data From Database
+     *
+     * @param string $token
+     * @return array
+     */
+    public function validateTokenData($token);
 }

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -65,6 +65,10 @@ trait ResetsPasswords
             throw new NotFoundHttpException;
         }
 
+        if(!Password::validateToken($token)) {
+            return redirect($this->redirectPath())->with('error',Lang::get(Password::INVALID_TOKEN));
+        }
+
         return view('auth.reset')->with('token', $token);
     }
 

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -5,7 +5,6 @@ namespace Illuminate\Foundation\Auth;
 use Illuminate\Http\Request;
 use Illuminate\Mail\Message;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Password;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -66,8 +65,8 @@ trait ResetsPasswords
             throw new NotFoundHttpException;
         }
 
-        if(! Password::validateToken($token)) {
-            return redirect($this->redirectPath())->with('error', Lang::get(Password::INVALID_TOKEN));
+        if (! Password::validateToken($token)) {
+            return redirect($this->redirectPath())->with('error', trans(Password::INVALID_TOKEN));
         }
 
         return view('auth.reset')->with('token', $token);

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Auth;
 use Illuminate\Http\Request;
 use Illuminate\Mail\Message;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Password;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -65,8 +66,8 @@ trait ResetsPasswords
             throw new NotFoundHttpException;
         }
 
-        if(!Password::validateToken($token)) {
-            return redirect($this->redirectPath())->with('error',Lang::get(Password::INVALID_TOKEN));
+        if(! Password::validateToken($token)) {
+            return redirect($this->redirectPath())->with('error', Lang::get(Password::INVALID_TOKEN));
         }
 
         return view('auth.reset')->with('token', $token);


### PR DESCRIPTION
Check Validity of The Password Reset Token when the user visits the Password Reset page.

By default, password reset is always shown regardless of whether the reset token is valid/invalid. In this pull request, i have modified the flow as follows:
- Checks Whether The Reset Token Exists in the Database.
- If token is found, then token expiration datetime is calculated. If expiration datetime is greater than the current datetime, then token is considered valid. Otherwise the token is invalid.
