### PR TITLE
[5.2] Encryption: Test the IV length in invalidPayload method

### DIFF
--- a/src/Illuminate/Encryption/BaseEncrypter.php
+++ b/src/Illuminate/Encryption/BaseEncrypter.php
@@ -60,7 +60,7 @@ abstract class BaseEncrypter
      */
     protected function invalidPayload($data)
     {
-        return ! is_array($data) || ! isset($data['iv']) || ! isset($data['value']) || ! isset($data['mac']);
+        return ! is_array($data) || ! isset($data['iv']) && strlen($data['iv']) === $this->getIvSize() || ! isset($data['value']) || ! isset($data['mac']);
     }
 
     /**
@@ -79,4 +79,11 @@ abstract class BaseEncrypter
 
         return Str::equals(hash_hmac('sha256', $payload['mac'], $bytes, true), $calcMac);
     }
+
+    /**
+     * Needs to be implemented by child class to be used in payload validation.
+     *
+     * @return int
+     */
+    abstract protected function getIvSize();
 }


### PR DESCRIPTION
Lately, I have upgraded my website from L 4.2.11 to the latest one. The Encryption cipher used before was MCRYPT_RIJNDAEL_128 which uses an IV with a length of 32. Since the payload in the cookies in users was encrypted using the old cipher, the EncryptCookies middleware threw an exception with this trace:

```
production.ERROR: exception 'ErrorException' with message 'openssl_decrypt(): IV passed is 32 bytes long which is longer than the 16 expected by selected cipher, truncating' in /home/www/MY/vendor/laravel/framework/src/Illuminate/Encryption/Encrypter.php:95
Stack trace:
#0 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(2, 'openssl_decrypt...', '/home/www/...', 95, Array)
#1 /home/www/MY/vendor/laravel/framework/src/Illuminate/Encryption/Encrypter.php(95): openssl_decrypt('Dbyr0401XlXcY6N...', 'AES-256-CBC', 'VyZn2WxfW9UgMrI...', 0, 'h\x82\x9Co\t\x9Fqx\\\x84\x8B\x16\x8B\x82P...')
#2 /home/www/MY/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php(95): Illuminate\Encryption\Encrypter->decrypt('eyJpdiI6ImFJS2N...')
#3 /home/www/MY/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php(76): Illuminate\Cookie\Middleware\EncryptCookies->decryptCookie('eyJpdiI6ImFJS2N...')
#4 /home/www/MY/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php(59): Illuminate\Cookie\Middleware\EncryptCookies->decrypt(Object(Illuminate\Http\Request))
#5 [internal function]: Illuminate\Cookie\Middleware\EncryptCookies->handle(Object(Illuminate\Http\Request), Object(Closure))
#6 /home/www/MY/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(124): call_user_func_array(Array, Array)
#7 [internal function]: Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
#8 /home/www/MY/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(103): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#9 /home/www/MY/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(122): Illuminate\Pipeline\Pipeline->then(Object(Closure))
#10 /home/www/MY/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(87): Illuminate\Foundation\Http\Kernel->sendRequestThroughRouter(Object(Illuminate\Http\Request))
#11 /home/www/MY/public/index.php(54): Illuminate\Foundation\Http\Kernel->handle(Object(Illuminate\Http\Request))
#12 {main} 
```

The obvious and simple trick would be to wrap the openssl_decrypt() in Encrypter.php:95 in a try catch block throwing a DecryptException exception, but this could be prevented since the beginning in the invalidPayload() method in the BaseEncrypter class by testing the length of the IV.

Since getIvSize() is used in the invalidPayload() method in the abstract invalidPayload() class, I declared it as an abstract method in it.
I would go ahead and define getIvSize() in the baseEnrypter class using openssl_cipher_iv_length() method, since the IV length might change in the future depending on the cipher declared in the config file.

At the end, I believe this might be considered as supporting an old version of laravel which is no longer done.
