### PR TITLE
Allow configuring minimum logging level

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -61,9 +61,9 @@ class ConfigureLogging
      */
     protected function configureHandlers(Application $app, Writer $log)
     {
-        $method = 'configure'.ucfirst($app['config']['app.log']).'Handler';
-
-        $this->{$method}($app, $log);
+        $method = 'configure'.ucfirst($app['config']->get('app.log')).'Handler';
+        $level = $app['config']->get('app.level', 'debug');
+        $this->{$method}($app, $log, $level);
     }
 
     /**
@@ -71,11 +71,12 @@ class ConfigureLogging
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @param  \Illuminate\Log\Writer  $log
+     * @param  string  $level minimum level to be logged
      * @return void
      */
-    protected function configureSingleHandler(Application $app, Writer $log)
+    protected function configureSingleHandler(Application $app, Writer $log, $level = 'debug')
     {
-        $log->useFiles($app->storagePath().'/logs/laravel.log');
+        $log->useFiles($app->storagePath().'/logs/laravel.log', $level);
     }
 
     /**
@@ -83,13 +84,15 @@ class ConfigureLogging
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @param  \Illuminate\Log\Writer  $log
+     * @param  string  $level minimum level to be logged
      * @return void
      */
-    protected function configureDailyHandler(Application $app, Writer $log)
+    protected function configureDailyHandler(Application $app, Writer $log, $level = 'debug')
     {
         $log->useDailyFiles(
             $app->storagePath().'/logs/laravel.log',
-            $app->make('config')->get('app.log_max_files', 5)
+            $app->make('config')->get('app.log_max_files', 5),
+            $level
         );
     }
 
@@ -98,11 +101,12 @@ class ConfigureLogging
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @param  \Illuminate\Log\Writer  $log
+     * @param  string  $level minimum level to be logged
      * @return void
      */
-    protected function configureSyslogHandler(Application $app, Writer $log)
+    protected function configureSyslogHandler(Application $app, Writer $log, $level = 'debug')
     {
-        $log->useSyslog('laravel');
+        $log->useSyslog('laravel', $level);
     }
 
     /**
@@ -110,10 +114,11 @@ class ConfigureLogging
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @param  \Illuminate\Log\Writer  $log
+     * @param  string  $level minimum level to be logged
      * @return void
      */
-    protected function configureErrorlogHandler(Application $app, Writer $log)
+    protected function configureErrorlogHandler(Application $app, Writer $log, $level = 'debug')
     {
-        $log->useErrorLog();
+        $log->useErrorLog($level);
     }
 }


### PR DESCRIPTION
This allows to configure the minimum level of messages that should be saved in the log. 

All monolog handlers that Laravel uses support that, but that parameter is never passed from \Illuminate\Log\Writer that sets up the handlers. This PR reads the level from Config and passes it to handlers. The default logging level will be debug as it is now.
