### PR TITLE
[5.1] Fixed docblocks

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -27,7 +27,7 @@ abstract class Grammar
     /**
      * Wrap a table in keyword identifiers.
      *
-     * @param  string  $table
+     * @param  string|\Illuminate\Database\Query\Expression  $table
      * @return string
      */
     public function wrapTable($table)
@@ -42,7 +42,7 @@ abstract class Grammar
     /**
      * Wrap a value in keyword identifiers.
      *
-     * @param  string  $value
+     * @param  string|\Illuminate\Database\Query\Expression  $value
      * @param  bool    $prefixAlias
      * @return string
      */


### PR DESCRIPTION
`$value` in `wrap` and `$table` in `wrapTable` can be `\Illuminate\Database\Query\Expression` or `string`
