### PR TITLE
[5.0] Validate Password Reset Token On Password Reset Page

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -169,6 +169,28 @@ class DatabaseTokenRepository implements TokenRepositoryInterface {
 		return hash_hmac('sha256', str_random(40), $this->hashKey);
 	}
 
+    /**
+     * Get and validate token data from database.
+     *
+     * @param string $token
+     * @return bool
+     */
+    public function validateToken($token)
+    {
+        $token = $this->getTable()->where('token', $token)->first();
+
+        if (empty($token)) {
+            return false;
+        }
+
+        $expirationDate = Carbon::parse($token->created_at)->addSeconds($this->expires);
+        if ($expirationDate->lt(Carbon::now())) {
+            return false;
+        }
+
+        return true;
+    }
+
 	/**
 	 * Begin a new database query against the table.
 	 *

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -225,6 +225,17 @@ class PasswordBroker implements PasswordBrokerContract {
 		return $password === $confirm && mb_strlen($password) >= 6;
 	}
 
+    /**
+     * Validate reset password token.
+     *
+     * @param  string  $token
+     * @return bool
+     */
+    public function validateToken($token)
+    {
+        return $this->tokens->validateToken($token);
+    }
+
 	/**
 	 * Get the user for the given credentials.
 	 *

--- a/src/Illuminate/Auth/Passwords/TokenRepositoryInterface.php
+++ b/src/Illuminate/Auth/Passwords/TokenRepositoryInterface.php
@@ -36,4 +36,12 @@ interface TokenRepositoryInterface {
 	 */
 	public function deleteExpired();
 
+    /**
+     * Get and validate token data from database.
+     *
+     * @param string $token
+     * @return bool
+     */
+    public function validateToken($token);
+
 }

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -73,4 +73,12 @@ interface PasswordBroker {
 	 */
 	public function validateNewPassword(array $credentials);
 
+    /**
+     * Validate reset password token.
+     *
+     * @param  string  $token
+     * @return bool
+     */
+    public function validateToken($token);
+
 }

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -79,6 +79,10 @@ trait ResetsPasswords {
 			throw new NotFoundHttpException;
 		}
 
+        if (! $this->passwords->validateToken($token)) {
+            return redirect($this->redirectPath())->with('error', trans(PasswordBroker::INVALID_TOKEN));
+        }
+
 		return view('auth.reset')->with('token', $token);
 	}
 


### PR DESCRIPTION
Check Validity of The Password Reset Token when the user visits the Password Reset page.

By default, password reset is always shown regardless of whether the reset token is valid/invalid. In this pull request, i have modified the flow as follows:
- Checks Whether The Reset Token Exists in the Database.
- If token is found, then token expiration datetime is calculated. If expiration datetime is greater than the current datetime, then token is considered valid. Otherwise the token is invalid.
