### PR TITLE
[5.1] PostgresConnector set application_name for a connection

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -57,6 +57,14 @@ class PostgresConnector extends Connector implements ConnectorInterface
             $connection->prepare("set search_path to {$schema}")->execute();
         }
 
+        // In Postgres the name of the application can be set by the user.
+        // This is useful for monitoring.
+        if (isset($config['application_name'])) {
+            $applicationName = $config['application_name'];
+
+            $connection->prepare("set application_name to '$applicationName'")->execute();
+        }
+
         return $connection;
     }
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -89,6 +89,22 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase
         $this->assertSame($result, $connection);
     }
 
+    public function testPostgresApplicationNameIsSet()
+    {
+        $dsn = 'pgsql:host=foo;dbname=bar';
+        $config = ['host' => 'foo', 'database' => 'bar', 'charset' => 'utf8', 'application_name' => 'Larvel App'];
+        $connector = $this->getMock('Illuminate\Database\Connectors\PostgresConnector', ['createConnection', 'getOptions']);
+        $connection = m::mock('stdClass');
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
+        $connection->shouldReceive('prepare')->once()->with('set names \'utf8\'')->andReturn($connection);
+        $connection->shouldReceive('prepare')->once()->with('set application_name to \'Larvel App\'')->andReturn($connection);
+        $connection->shouldReceive('execute')->twice();
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
     public function testSQLiteMemoryDatabasesMayBeConnectedTo()
     {
         $dsn = 'sqlite::memory:';


### PR DESCRIPTION
In PostgresSql you can set the application name of a connection, the name is shown in monitoring through `pg_stat_activity` and logs. Useful for monitoring and debugging.

Added optional `application_name` configuration to PostgresConnector which when provided will be used to the the application name for the connection. 
