### PR TITLE
[5.1] Added seeJsonKeys and dontSeeJsonKeys to CrawlerTrait

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -528,6 +528,82 @@ trait CrawlerTrait
     }
 
     /**
+     * Assert that the response contains the given JSON keys.
+     *
+     * Keys can be formatted with dot notation, or as nested arrays:
+     *   $keys = [ 'key1', 'key2' => ['subkey1'], 'key3.subkey2' ]
+     *
+     * Would match this json reponse:
+     *   {"key1": "data", "key2": {"subkey1": "data"}, "key3": {"subkey2": "data"}}
+     *
+     * @param  array|null  $data A list of JSON keys to look for
+     * @param  bool|false  $strict If strict, look for exact paths - if not, look for key anywhere in response
+     * @return $this
+     */
+    public function seeJsonKeys(array $data = null, $strict = false)
+    {
+        if (is_null($data)) {
+            $this->assertJson(
+                $this->response->getContent(), "Failed asserting that JSON returned [{$this->currentUri}]."
+            );
+
+            return $this;
+        }
+
+        return $this->seeJsonKeysContain($data, $strict, false);
+    }
+
+    /**
+     * Assert that the response does not contain the given JSON keys.
+     *
+     * @param  array|null  $data A list of JSON keys to look for
+     * @param  bool|false  $strict If strict, look for exact paths - if not, look for key anywhere in response
+     * @return $this
+     */
+    public function dontSeeJsonKeys(array $data = null, $strict = false)
+    {
+        if (is_null($data)) {
+            $this->assertJson(
+                $this->response->getContent(), "Failed asserting that JSON returned [{$this->currentUri}]."
+            );
+
+            return $this;
+        }
+
+        return $this->seeJsonKeysContain($data, $strict, true);
+    }
+
+    /**
+     * Assert that the response contains the given JSON keys.
+     *
+     * @param  array|null  $data A list of JSON keys to look for
+     * @param  bool|false  $strict If strict, look for exact paths - if not, look for key anywhere in response
+     * @param  bool  $negate
+     * @return $this
+     */
+    protected function seeJsonKeysContain(array $data, $strict = false, $negate = false)
+    {
+        $method = $negate ? 'assertFalse' : 'assertTrue';
+
+        // Normalise the values to dot notation
+        $data = array_flatten_values(array_sort_recursive($data));
+
+        // Get all array keys in a flat array with dot notation
+        $actual = array_sort_recursive(json_decode($this->response->getContent(), true));
+        $actualKeys = array_flatten_keys($actual, true, $strict);
+        $actual = json_encode($actual);
+
+        foreach ($data as $expected) {
+            $this->$method(
+                in_array($expected, $actualKeys),
+                ($negate ? 'Found unexpected' : 'Unable to find')." JSON key [{$expected}] within [{$actual}]."
+            );
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the response doesn't contain JSON.
      *
      * @param  array|null  $data

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -772,3 +772,76 @@ if (! function_exists('with')) {
         return $object;
     }
 }
+
+if (! function_exists('array_flatten_values')) {
+    /**
+     * Normalise values using dot notation to signify sub-arrays
+     *
+     * The following array:
+     *   $array = [ 'foo', 'bar' => ['baz'], 'fizz' => ['buzz' => ['bing'], 'bang' => 'boom']]
+     *
+     * Would pre transformed into:
+     *   ['foo', 'bar.baz', 'fizz.buzz.bing', 'fizz.boom']
+     *
+     * @param  array  $array The array to normalise
+     * @return array
+     */
+    function array_flatten_values(array $array = [])
+    {
+        $vals = [];
+
+        foreach ($array as $k => $v) {
+            if (is_array($v)) {
+                $vals = array_merge($vals, array_map(function ($val) use ($k) { return $k.'.'.strval($val); }, array_flatten_values($v)));
+            } else {
+                $vals[] = $v;
+            }
+        }
+
+        return array_unique($vals);
+    }
+}
+
+if (! function_exists('array_flatten_keys')) {
+    /**
+     * Find all keys in the array and normalise into an array with dot notation
+     *
+     * The following array would be transformed with the function like this:
+     *   $array = ["key1" => "data", "key2" => ["subkey1" => "data"], "key3" => ["subkey2": "data"]]
+     *
+     * array_flatten_keys($array, false):
+     *   ["key1", "key2", "key3"]
+     *
+     * array_flatten_keys($array, true, true):
+     *   ["key1", "key2", "key2.subkey1", "key3", "key3.subkey2"]
+     *
+     * array_flatten_keys($array, true, false):
+     *   ["key1", "key2", "subkey1", "key2.subkey1", "key3", "subkey2", "key3.subkey2"]
+     *
+     * @param  array  $array The array to find keys for
+     * @param  bool|false  $deep Find keys for sub-arrays
+     * @param  bool|false  $strict If strict only include full key paths. If not, include all keys
+     * @return array
+     */
+    function array_flatten_keys(array $array = [], $deep = true, $strict = false)
+    {
+        $keys = array_keys($array);
+
+        if ($deep) {
+            foreach ($array as $k => $v) {
+                if (is_array($v)) {
+                    $sub = array_flatten_keys($v, $deep, $strict);
+
+                    if (! $strict) {
+                        $keys = array_unique(array_merge($keys, $sub));
+                    }
+
+                    // add dot-notation keys
+                    $keys = array_unique(array_merge($keys, array_map(function ($v) use ($k) { return $k.'.'.$v; }, $sub)));
+                }
+            }
+        }
+
+        return $keys;
+    }
+}


### PR DESCRIPTION
Added methods to the CrawlerTrait which allow you to search
for json keys without caring about content.

This is useful if returned data is long, or the exact value doesn't
really matter.
