### PR TITLE
[5.2] Let git-archive ignore .editorconfig and .php_cs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,10 @@
 
 /build export-ignore
 /tests export-ignore
+.editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.php_cs export-ignore
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore
 phpunit.php export-ignore


### PR DESCRIPTION
Let git-archive ignore .editorconfig and .php_cs
