### PR TITLE
Passing $columns on Eloquent/Builder::getCountForPagination

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -270,7 +270,7 @@ class Builder
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
-        $total = $this->query->getCountForPagination();
+        $total = $this->query->getCountForPagination($columns);
 
         $this->query->forPage(
             $page = $page ?: Paginator::resolveCurrentPage($pageName),


### PR DESCRIPTION
On Illuminate/Database/Eloquent/Builder::getCountForPagination, passed the '$columns' parameter.

``` php
public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
{
    $total = $this->query->getCountForPagination($columns);
    // ...
```
