### PR TITLE
[5.1] Validate Password Reset Token On Reset Password Page

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -172,6 +172,29 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     }
 
     /**
+     * Get and validate token data from database.
+     *
+     * @param  string  $token
+     * @return bool
+     */
+    public function validateToken($token)
+    {
+        $token = $this->getTable()->where('token', $token)->first();
+
+        if (empty($token)) {
+            return false;
+        }
+
+        $expirationDate = Carbon::parse($token->created_at)->addSeconds($this->expires);
+
+        if ($expirationDate->lt(Carbon::now())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Begin a new database query against the table.
      *
      * @return \Illuminate\Database\Query\Builder

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -220,6 +220,17 @@ class PasswordBroker implements PasswordBrokerContract
     }
 
     /**
+     * Validate reset password token.
+     *
+     * @param  string  $token
+     * @return bool
+     */
+    public function validateToken($token)
+    {
+        return $this->tokens->validateToken($token);
+    }
+
+    /**
      * Get the user for the given credentials.
      *
      * @param  array  $credentials

--- a/src/Illuminate/Auth/Passwords/TokenRepositoryInterface.php
+++ b/src/Illuminate/Auth/Passwords/TokenRepositoryInterface.php
@@ -37,4 +37,12 @@ interface TokenRepositoryInterface
      * @return void
      */
     public function deleteExpired();
+
+    /**
+     * Get and validate token data from database.
+     *
+     * @param  string  $token
+     * @return bool
+     */
+    public function validateToken($token);
 }

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -65,6 +65,12 @@ trait ResetsPasswords
             throw new NotFoundHttpException;
         }
 
+        if (! Password::validateToken($token)) {
+            return redirect(
+                ! empty($this->redirectError) ? $this->redirectError : '/password/email'
+            )->with('error', trans(Password::INVALID_TOKEN));
+        }
+
         return view('auth.reset')->with('token', $token);
     }
 


### PR DESCRIPTION
Check Validity of The Password Reset Token when the user visits the Password Reset page.

By default, password reset is always shown regardless of whether the reset token is valid/invalid. In this pull request, i have modified the flow as follows:
- Checks Whether The Reset Token Exists in the Database.
- If token is found, then token expiration datetime is calculated. If expiration datetime is less than the current datetime, then token is considered valid. Otherwise the token is invalid and user is redirected to the **/password/email** route by default.
