### PR TITLE
[5.1] Clarify documentation of Collection diff method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -86,7 +86,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-	 * Get the items in the collection that are not present in the given items.
+     * Get the items in the collection that are not present in the given items.
      *
      * @param  mixed  $items
      * @return static

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -86,7 +86,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Diff the collection with the given items.
+	 * Get the items in the collection that are not present in the given items.
      *
      * @param  mixed  $items
      * @return static


### PR DESCRIPTION
The documentation was previously not clear about whether diff computes the symmetric or asymmetric difference.

Other libraries sometimes call this method "without" or "removeAll", which is less prone to confusion.
See:
https://lodash.com/docs#without
http://docs.oracle.com/javase/7/docs/api/java/util/Set.html#removeAll

The underlying PHP method upon which diff is based is clear about the behaviour:
http://php.net/manual/en/function.array-diff.php
