### PR TITLE
[5.1] Decrypting cookies encrypted with a different Cipher

### DIFF
--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Cookie\Middleware;
 
 use Closure;
+use Exception;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 
 class EncryptCookies
@@ -74,7 +74,7 @@ class EncryptCookies
 
             try {
                 $request->cookies->set($key, $this->decryptCookie($c));
-            } catch (DecryptException $e) {
+            } catch (Exception $e) {
                 $request->cookies->set($key, null);
             }
         }


### PR DESCRIPTION
Lately, I have upgraded my website from L 4.2.11 to the latest one. The Encryption cipher used before was MCRYPT_RIJNDAEL_256 which uses an IV with a length of 32. Since the payload in the cookies in users was encrypted using the old cipher, the EncryptCookies middleware threw an exception with this trace:

```
production.ERROR: exception 'ErrorException' with message 'openssl_decrypt(): IV passed is 32 bytes long which is longer than the 16 expected by selected cipher, truncating' in /home/www/MY/vendor/laravel/framework/src/Illuminate/Encryption/Encrypter.php:95
Stack trace:
#0 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(2, 'openssl_decrypt...', '/home/www/...', 95, Array)
#1 /home/www/MY/vendor/laravel/framework/src/Illuminate/Encryption/Encrypter.php(95): openssl_decrypt('Dbyr0401XlXcY6N...', 'AES-256-CBC', 'VyZn2WxfW9UgMrI...', 0, 'h\x82\x9Co\t\x9Fqx\\\x84\x8B\x16\x8B\x82P...')
#2 /home/www/MY/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php(95): Illuminate\Encryption\Encrypter->decrypt('eyJpdiI6ImFJS2N...')
#3 /home/www/MY/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php(76): Illuminate\Cookie\Middleware\EncryptCookies->decryptCookie('eyJpdiI6ImFJS2N...')
#4 /home/www/MY/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php(59): Illuminate\Cookie\Middleware\EncryptCookies->decrypt(Object(Illuminate\Http\Request))
#5 [internal function]: Illuminate\Cookie\Middleware\EncryptCookies->handle(Object(Illuminate\Http\Request), Object(Closure))
#6 /home/www/MY/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(124): call_user_func_array(Array, Array)
#7 [internal function]: Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
#8 /home/www/MY/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(103): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#9 /home/www/MY/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(122): Illuminate\Pipeline\Pipeline->then(Object(Closure))
#10 /home/www/MY/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(87): Illuminate\Foundation\Http\Kernel->sendRequestThroughRouter(Object(Illuminate\Http\Request))
#11 /home/www/MY/public/index.php(54): Illuminate\Foundation\Http\Kernel->handle(Object(Illuminate\Http\Request))
#12 {main} 
```

This commit will allow the the decrypt method to handle non `Illuminate\Contracts\Encryption\DecryptException` exceptions. Since sometimes that class can't cover all the decryption issues since cookies can be set from other third parties in the browser.
