### PR TITLE
[5.1] key:generate command: support spaces around "=" in .env file

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -38,8 +38,9 @@ class KeyGenerateCommand extends Command
         $path = base_path('.env');
 
         if (file_exists($path)) {
-            file_put_contents($path, str_replace(
-                'APP_KEY='.$this->laravel['config']['app.key'], 'APP_KEY='.$key, file_get_contents($path)
+            $quoted_key = preg_quote($this->laravel['config']['app.key'], '/');
+            file_put_contents($path, preg_replace(
+                '/(APP_KEY[ \t]*=[ \t]*)'.$quoted_key.'/', '$1'.$key, file_get_contents($path)
             ));
         }
 


### PR DESCRIPTION
- Improves handling in case user have formatted their `.env` file.
- Adds support for https://github.com/laravel/laravel/pull/3490.
