### PR TITLE
[5.1] Improve compatibility of SoftDeletes with other Global Scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -43,7 +43,7 @@ trait SoftDeletes
     protected function performDeleteOnModel()
     {
         if ($this->forceDeleting) {
-            return $this->withTrashed()->where($this->getKeyName(), $this->getKey())->forceDelete();
+            return $this->newQueryWithoutScopes()->where($this->getKeyName(), $this->getKey())->forceDelete();
         }
 
         return $this->runSoftDelete();
@@ -56,7 +56,7 @@ trait SoftDeletes
      */
     protected function runSoftDelete()
     {
-        $query = $this->newQuery()->where($this->getKeyName(), $this->getKey());
+        $query = $this->newQueryWithoutScopes()->where($this->getKeyName(), $this->getKey());
 
         $this->{$this->getDeletedAtColumn()} = $time = $this->freshTimestamp();
 

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -13,7 +13,8 @@ class DatabaseSoftDeletingTraitTest extends PHPUnit_Framework_TestCase
     {
         $model = m::mock('DatabaseSoftDeletingTraitStub');
         $model->shouldDeferMissing();
-        $model->shouldReceive('newQuery')->andReturn($query = m::mock('StdClass'));
+        // $model->shouldReceive('newQuery')->andReturn($query = m::mock('StdClass'));
+        $model->shouldReceive('newQueryWithoutScopes')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('where')->once()->with('id', 1)->andReturn($query);
         $query->shouldReceive('update')->once()->with(['deleted_at' => 'date-time']);
         $model->delete();


### PR DESCRIPTION
Proposed changes to overcome this issue https://github.com/laravel/framework/issues/9349

I propose this change to the **SoftDeletes** trait to bring it in line with the expected behaviour, and reduce issues when additional **GlobalScopes** are applied.

While the `runSoftDelete()` method uses `newQuery()` the `restore()` method does not and simply directly sets the value 

``` php
$this->{$this->getDeletedAtColumn()} = null;
```

if the intention was to apply the scope in all queries is this not inconsistent? 

Also would it not be simpler and/or more efficent to directly apply set the value 

``` php
$this->{$this->getDeletedAtColumn()} = Carbon::now();
```
