### PR TITLE
[5.1] Add global `request` helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -442,6 +442,24 @@ if (! function_exists('redirect')) {
     }
 }
 
+if (! function_exists('request')) {
+    /**
+     * Get an instance of the current request or an input item from the request.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return \Illuminate\Http\Request|string|array
+     */
+    function request($key = null, $default = null)
+    {
+        if (is_null($key)) {
+            return app('request');
+        }
+
+        return app('request')->input($key, $default);
+    }
+}
+
 if (! function_exists('resource')) {
     /**
      * Route a resource to a controller.


### PR DESCRIPTION
Allows quick access to the current request via `request()`, or access
to an input item in the request via `request($key, $default = null)`.

Saves the namespace importing if you prefer to user facade-style access
to the request, much like the other Foundation helpers.

``` php
// 1. Injecting the request

use Illuminate\Http\Request;

public function postRegister(Request $request)
{
    $this->validate($request, [
        'email' => ['required', 'email'],
        'password' => 'required',
    ]);

    User::create([
        'email' => $request->email,
        'password' => bcrypt($request->password),
    ]);

    // ...
}


// 2. Using the `Request` facade

use Illuminate\Support\Facades\Request;

public function postRegister()
{
    $this->validate(Request::instance(), [
        'email' => ['required', 'email'],
        'password' => 'required',
    ]);

    User::create([
        'email' => Request::input('email'),
        'password' => bcrypt(Request::input('password')),
    ]);

    // ...
}


// 3. Using the `request` helper

public function postRegister()
{
    $this->validate(request(), [
        'email' => ['required', 'email'],
        'password' => 'required',
    ]);

    User::create([
        'email' => request('email'),
        'password' => bcrypt(request('password')),
    ]);

    // ...
}
```
