### PR TITLE
[5.1] Fixed small typo

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -221,7 +221,7 @@ class Gate implements GateContract
     }
 
     /**
-     * Get a guard instance for the given uer.
+     * Get a guard instance for the given user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|mixed  $user
      * @return static


### PR DESCRIPTION
Just a small typo on method documentation.
