### PR TITLE
[5.1] BelongsToMany: remove numerical id typecasting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -778,7 +778,7 @@ class BelongsToMany extends Relation
         if ($detaching && count($detach) > 0) {
             $this->detach($detach);
 
-            $changes['detached'] = (array) $detach;
+            $changes['detached'] = (array) array_map(function ($v) { return is_numeric($v) ? (int) $v : (string) $v; }, $detach);
         }
 
         // Now we are finally ready to attach the new records. Note that we'll disable
@@ -835,7 +835,7 @@ class BelongsToMany extends Relation
             if (! in_array($id, $current)) {
                 $this->attach($id, $attributes, $touch);
 
-                $changes['attached'][] = $id;
+                $changes['attached'][] = is_numeric($id) ? (int) $id : (string) $id;
             }
 
             // Now we'll try to update an existing pivot record with the attributes that were
@@ -843,7 +843,7 @@ class BelongsToMany extends Relation
             // list of updated pivot records so we return them back out to the consumer.
             elseif (count($attributes) > 0 &&
                 $this->updateExistingPivot($id, $attributes, $touch)) {
-                $changes['updated'][] = $id;
+                $changes['updated'][] = is_numeric($id) ? (int) $id : (string) $id;
             }
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -778,7 +778,7 @@ class BelongsToMany extends Relation
         if ($detaching && count($detach) > 0) {
             $this->detach($detach);
 
-            $changes['detached'] = (array) array_map(function ($v) { return (int) $v; }, $detach);
+            $changes['detached'] = (array) $detach;
         }
 
         // Now we are finally ready to attach the new records. Note that we'll disable
@@ -835,7 +835,7 @@ class BelongsToMany extends Relation
             if (! in_array($id, $current)) {
                 $this->attach($id, $attributes, $touch);
 
-                $changes['attached'][] = (int) $id;
+                $changes['attached'][] = $id;
             }
 
             // Now we'll try to update an existing pivot record with the attributes that were
@@ -843,7 +843,7 @@ class BelongsToMany extends Relation
             // list of updated pivot records so we return them back out to the consumer.
             elseif (count($attributes) > 0 &&
                 $this->updateExistingPivot($id, $attributes, $touch)) {
-                $changes['updated'][] = (int) $id;
+                $changes['updated'][] = $id;
             }
         }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -400,19 +400,19 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $query->shouldReceive('lists')->once()->with('role_id')->andReturn([1, 2, 3]);
-        $relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo([]), $this->equalTo(false));
+        $relation->expects($this->once())->method('attach')->with($this->equalTo('x'), $this->equalTo([]), $this->equalTo(false));
         $relation->expects($this->once())->method('detach')->with($this->equalTo([1]));
         $relation->getRelated()->shouldReceive('touches')->andReturn(false);
         $relation->getParent()->shouldReceive('touches')->andReturn(false);
 
-        $this->assertEquals(['attached' => [4], 'detached' => [1], 'updated' => []], $relation->sync($list));
+        $this->assertEquals(['attached' => ['x'], 'detached' => [1], 'updated' => []], $relation->sync($list));
     }
 
     public function syncMethodListProvider()
     {
         return [
-            [[2, 3, 4]],
-            [['2', '3', '4']],
+            [[2, 3, 'x']],
+            [['2', '3', 'x']],
         ];
     }
 


### PR DESCRIPTION
Updated for 5.1, older PR #4480 
