### PR TITLE
[5.1] Password reset token generation simplified

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -168,7 +168,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      */
     public function createNewToken()
     {
-        return hash_hmac('sha256', Str::random(40), $this->hashKey);
+        return bin2hex(Str::randomBytes(32));
     }
 
     /**


### PR DESCRIPTION
Using HMAC for generating strong crypto nonces is not necessary in this scenario. This PR simplifies password reset token generation while preserving security. Closes #10112.
