### PR TITLE
[5.1] Distinction between real @parent and echoed content

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -708,6 +708,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Compile the parent statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileParent($expression)
+    {
+        return "<?php \$__env->appendParent(); ?>";
+    }
+
+    /**
      * Compile the push statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -715,7 +715,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileParent($expression)
     {
-        return "<?php \$__env->appendParent(); ?>";
+        return '<?php $__env->appendParent(); ?>';
     }
 
     /**

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -92,7 +92,7 @@ class Factory implements FactoryContract
     protected $sectionStack = [];
 
     /**
-     * The marks for @parent section embedding
+     * The marks for @parent section embedding.
      *
      * @var array
      */
@@ -557,7 +557,7 @@ class Factory implements FactoryContract
             $this->parentMarks[$last] = [];
         }
 
-        array_unshift($this->parentMarks[$last], ob_get_length());
+        array_push($this->parentMarks[$last], ob_get_length());
 
         $this->sectionStack[] = $last;
     }
@@ -619,10 +619,9 @@ class Factory implements FactoryContract
     protected function extendSection($section, $content)
     {
         if (isset($this->sections[$section])) {
-            foreach ($this->parentMarks[$section] as $mark) {
+            while ($mark = array_pop($this->parentMarks[$section])) {
                 $this->sections[$section] = substr_replace($this->sections[$section], $content, $mark, 0);
             }
-            $this->parentMarks[$section] = [];
         } else {
             $this->sections[$section] = $content;
         }

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -619,8 +619,10 @@ class Factory implements FactoryContract
     protected function extendSection($section, $content)
     {
         if (isset($this->sections[$section])) {
-            while ($mark = array_pop($this->parentMarks[$section])) {
-                $this->sections[$section] = substr_replace($this->sections[$section], $content, $mark, 0);
+            if (isset($this->parentMarks[$section])) {
+                while ($mark = array_pop($this->parentMarks[$section])) {
+                    $this->sections[$section] = substr_replace($this->sections[$section], $content, $mark, 0);
+                }
             }
         } else {
             $this->sections[$section] = $content;

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -471,6 +471,12 @@ empty
         $this->assertEquals('<?php $__env->stopSection(); ?>', $compiler->compileString('@endsection'));
     }
 
+    public function testParentsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertEquals('<?php $__env->appendParent(); ?>', $compiler->compileString('@parent'));
+    }
+
     public function testAppendSectionsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -247,6 +247,18 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('hi there', $factory->yieldContent('foo'));
     }
 
+    public function testParentKeywordEscaping()
+    {
+        $factory = $this->getFactory();
+        $factory->startSection('foo');
+        echo 'hi @parent';
+        $factory->stopSection();
+        $factory->startSection('foo');
+        echo 'there';
+        $factory->stopSection();
+        $this->assertEquals('hi @parent', $factory->yieldContent('foo'));
+    }
+
     public function testSingleStackPush()
     {
         $factory = $this->getFactory();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -238,7 +238,8 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
-        echo 'hi @parent';
+        echo 'hi ';
+        $factory->appendParent();
         $factory->stopSection();
         $factory->startSection('foo');
         echo 'there';


### PR DESCRIPTION
This PR fixes security issue: `@parent` from view data was treated as real `@parent`.
This is an idea for non-breaking approach without restructuring everything. Needs review and tests.

---

Closes #10068.
