### PR TITLE
[5.1] Create Gate Access Admission, so that a Policy can deny access with a reason

### DIFF
--- a/src/Illuminate/Auth/Access/Admission.php
+++ b/src/Illuminate/Auth/Access/Admission.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Illuminate\Auth\Access;
+
+class Admission
+{
+    /**
+     * Indicates whether admission was allowed.
+     *
+     * @var bool
+     */
+    protected $allowed;
+
+    /**
+     * The reason admission was allowed/denied.
+     *
+     * @var string|null
+     */
+    protected $reason;
+
+    /**
+     * Create a new admission instance.
+     *
+     * @return void
+     */
+    protected function __construct()
+    {
+        //
+    }
+
+    /**
+     * Create an allowed admission.
+     *
+     * @param  string|null  $reason
+     * @return static
+     */
+    public static function allow($reason = null)
+    {
+        $admission = new static;
+
+        $admission->allowed = true;
+        $admission->reason = $reason;
+
+        return $admission;
+    }
+
+    /**
+     * Create a denied admission.
+     *
+     * @param  string  $reason
+     * @return static
+     */
+    public static function deny($reason = 'This action is unauthorized.')
+    {
+        $admission = new static;
+
+        $admission->allowed = false;
+        $admission->reason = $reason;
+
+        return $admission;
+    }
+
+    /**
+     * Create a new admission from the given value.
+     *
+     * @param  mixed  $value
+     * @return static
+     */
+    public static function fromValue($value)
+    {
+        if ($value instanceof static) {
+            return $value;
+        }
+
+        return $value ? static::allow() : static::deny();
+    }
+
+    /**
+     * Gets the reason the admission was allowed/denied.
+     *
+     * @return string
+     */
+    public function reason()
+    {
+        return $this->reason;
+    }
+
+    /**
+     * Checks whether the admission was allowed.
+     *
+     * @return bool
+     */
+    public function allowed()
+    {
+        return $this->allowed;
+    }
+
+    /**
+     * Checks whether the admission was denied.
+     *
+     * @return bool
+     */
+    public function denied()
+    {
+        return ! $this->allowed;
+    }
+}

--- a/src/Illuminate/Auth/Access/CreatesAdmissions.php
+++ b/src/Illuminate/Auth/Access/CreatesAdmissions.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Auth\Access;
+
+trait CreatesAdmissions
+{
+    /**
+     * Create a denied addmission.
+     *
+     * @param  string  $reason
+     * @return \Illuminate\Auth\Access\Admission
+     */
+    protected function deny($reason = 'This action is unauthorized.')
+    {
+        return Admission::deny($reason);
+    }
+
+    /**
+     * Create an allowed admission.
+     *
+     * @param  string|null  $reason
+     * @return \Illuminate\Auth\Access\Admission
+     */
+    protected function allow($reason = null)
+    {
+        return Admission::allow($reason);
+    }
+}

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -170,6 +170,30 @@ class Gate implements GateContract
      */
     public function check($ability, $arguments = [])
     {
+        return $this->getAdmission($ability, $arguments)->allowed();
+    }
+
+    /**
+     * Get the admission for the given ability for the current user.
+     *
+     * @param  string  $ability
+     * @param  array|mixed  $arguments
+     * @return \Illuminate\Auth\Access\Admission
+     */
+    public function getAdmission($ability, $arguments = [])
+    {
+        return Admission::fromValue($this->raw($ability, $arguments));
+    }
+
+    /**
+     * Get the raw result for the given ability for the current user.
+     *
+     * @param  string  $ability
+     * @param  array|mixed  $arguments
+     * @return mixed
+     */
+    public function raw($ability, $arguments = [])
+    {
         if (! $user = $this->resolveUser()) {
             return false;
         }

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -2,8 +2,12 @@
 
 namespace DummyNamespace;
 
+use Illuminate\Auth\Access\CreatesAdmissions;
+
 class DummyClass
 {
+    use CreatesAdmissions;
+
     /**
      * Create a new policy instance.
      *

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Container\Container;
+use Illuminate\Auth\Access\Admission;
+use Illuminate\Auth\Access\CreatesAdmissions;
 
 class GateTest extends PHPUnit_Framework_TestCase
 {
@@ -113,7 +115,7 @@ class GateTest extends PHPUnit_Framework_TestCase
 
     public function test_policy_classes_can_be_defined_to_handle_checks_for_given_class_name()
     {
-        $gate = $this->getBasicGate();
+        $gate = $this->getBasicGate(true);
 
         $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
 
@@ -154,9 +156,67 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($gate->forUser((object) ['id' => 2])->check('foo'));
     }
 
-    protected function getBasicGate()
+    public function test_policy_returns_denied_admission()
     {
-        return new Gate(new Container, function () { return (object) ['id' => 1]; });
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $check = $gate->check('create', new AccessGateTestDummy);
+        $admission = $gate->getAdmission('create', new AccessGateTestDummy);
+
+        $this->assertInstanceOf(Admission::class, $admission);
+        $this->assertEquals('You are not an admin.', $admission->reason());
+        $this->assertFalse($check);
+        $this->assertTrue($admission->denied());
+    }
+
+    public function test_policy_returns_allowed_admission()
+    {
+        $gate = $this->getBasicGate(true);
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $check = $gate->check('create', new AccessGateTestDummy);
+        $admission = $gate->getAdmission('create', new AccessGateTestDummy);
+
+        $this->assertInstanceOf(Admission::class, $admission);
+        $this->assertNull($admission->reason());
+        $this->assertTrue($check);
+        $this->assertTrue($admission->allowed());
+    }
+
+    public function test_get_admission_returns_an_allowed_admission_for_a_truthy_return()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $admission = $gate->getAdmission('update', new AccessGateTestDummy);
+
+        $this->assertInstanceOf(Admission::class, $admission);
+        $this->assertTrue($admission->allowed());
+        $this->assertFalse($admission->denied());
+    }
+
+    public function test_get_admission_returns_a_denied_admission_for_a_falsy_return()
+    {
+        $gate = $this->getBasicGate(true);
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $admission = $gate->getAdmission('update', new AccessGateTestDummy);
+
+        $this->assertInstanceOf(Admission::class, $admission);
+        $this->assertFalse($admission->allowed());
+        $this->assertTrue($admission->denied());
+    }
+
+    protected function getBasicGate($isAdmin = false)
+    {
+        return new Gate(new Container, function () use ($isAdmin) {
+            return (object) ['id' => 1, 'isAdmin' => $isAdmin];
+        });
     }
 }
 
@@ -175,14 +235,16 @@ class AccessGateTestDummy
 
 class AccessGateTestPolicy
 {
+    use CreatesAdmissions;
+
     public function create($user)
     {
-        return true;
+        return $user->isAdmin ? $this->allow() : $this->deny('You are not an admin.');
     }
 
     public function update($user, AccessGateTestDummy $dummy)
     {
-        return $user instanceof StdClass;
+        return ! $user->isAdmin;
     }
 }
 


### PR DESCRIPTION
This would allow the policy to return with a reason for denying access, which would then be used in the 403 `HttpException` in the `AuthorizesRequests` trait:

``` php
use App\User;
use App\Post;
use Illumiante\Auth\Access\CreatesGrants;

class PostPolicy
{
    use CreatesGrants;

    public function update(User $user, Post $post)
    {
        if ($user->id !== $post->user_id) {
            return $this->deny('You are not the owner of this post.');
        }

        if ($post->isClosed()) {
            return $this->deny('Post is closed and cannot be updated.');
        }

        return $this->allow();
    }
}
```

---

I'm not entirely set on the `Admission` nomenclature. I've played with `Grant`, `Pass`, `Card`, `Passage`, `Token` and more, but have found `Admission` to be the most semantic in this case. I'm open to suggestions.
