### PR TITLE
[5.1] Adding seeLink and dontSeeLink methods

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -292,6 +292,94 @@ trait CrawlerTrait
     }
 
     /**
+     * Assert that a given link is seen on the page.
+     *
+     * @param  string  $text
+     * @param  string|null  $url
+     * @return $this
+     */
+    public function seeLink($text, $url = null)
+    {
+        $message = "No links were found with the text [$text]";
+        if ($url) {
+            $message .= " and the URL [$url]";
+        }
+
+        $this->assertTrue($this->hasLink($text, $url), $message);
+
+        return $this;
+    }
+
+    /**
+     * Assert that a given link is not seen on the page.
+     *
+     * @param  string  $text
+     * @param  string|null  $url
+     * @return $this
+     */
+    public function dontSeeLink($text, $url = null)
+    {
+        $message = "A link was found with the text [$text]";
+        if ($url) {
+            $message .= " and the URL [$url]";
+        }
+
+        $this->assertFalse($this->hasLink($text, $url), $message);
+
+        return $this;
+    }
+
+    /**
+     * Add a root if the URL is relative (helper method of the hasLink function).
+     *
+     * @param  string  $url
+     * @return string
+     */
+    protected function addRootToRelativeUrl($url)
+    {
+        if (! Str::startsWith($url, ['http', 'https'])) {
+            $url = $this->app->make('url')->to($url);
+
+            return $url;
+        }
+
+        return $url;
+    }
+
+    /**
+     * Check if the page has a link with the given $text and optional $url.
+     *
+     * @param  string  $text
+     * @param  string|null  $url
+     * @return bool
+     */
+    protected function hasLink($text, $url = null)
+    {
+        $links = $this->crawler->selectLink($text);
+
+        if ($links->count() == 0) {
+            return false;
+        }
+
+        // If the URL is null, we assume the developer only wants to
+        // find a link with the given $text regardless of the URL
+        // and since at least one was found we'll return true.
+        if ($url == null) {
+            return true;
+        }
+
+        $url = $this->addRootToRelativeUrl($url);
+
+        foreach ($links as $link) {
+            if ($link->getAttribute('href') == $url) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Assert that an input field contains the given value.
      *
      * @param  string  $selector

--- a/tests/Foundation/FoundationCrawlerTraitIntegrationTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitIntegrationTest.php
@@ -7,6 +7,26 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 {
     use CrawlerTrait;
 
+    public function testSeeLink()
+    {
+        $this->crawler = new Crawler(
+            '<a href="https://laravel.com">Laravel</a>'
+        );
+
+        $this->seeLink('Laravel');
+        $this->seeLink('Laravel', 'https://laravel.com');
+    }
+
+    public function testDontSeeLink()
+    {
+        $this->crawler = new Crawler(
+            '<a href="https://laravel.com">Laravel</a>'
+        );
+
+        $this->dontSeeLink('Symfony');
+        $this->dontSeeLink('Symfony', 'https://symfonyc.com');
+    }
+
     protected function getInputHtml()
     {
         return '<input type="text" name="framework" value="Laravel">';


### PR DESCRIPTION
Adding two more methods for the Integration test package.

You can pass only a $text to check if the page has a link with the given $text or you can also pass an URL to check if the page has (or doesn't have) a link with the corresponding $text+$url

the parameter $url accepts relative URLs (i.e. 'home' instead of http://localhost/home)
