### PR TITLE
[5.1] Fix code explanation in TaggedCache::rememberForever()

### DIFF
--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -199,7 +199,7 @@ class TaggedCache implements Store
     {
         // If the item exists in the cache we will just return this immediately
         // otherwise we will execute the given Closure and cache the result
-        // of that execution for the given number of minutes. It's easy.
+        // of that execution for an indefinite amount of time. It's easy.
         if (! is_null($value = $this->get($key))) {
             return $value;
         }


### PR DESCRIPTION
Since we are in the `rememberForever()` method, it is incorrect to say that data will be stored for a given amount of minutes. Instead, it will be stored for an indefinite amount of time.
