### PR TITLE
[5.1] Fix "Call to undefined method Illuminate\Database\Query\Builder::getActualClassNameForMorph()"

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -886,7 +886,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string  $class
      * @return string
      */
-    protected function getActualClassNameForMorph($class)
+    public function getActualClassNameForMorph($class)
     {
         return array_get(Relation::morphMap(), $class, $class);
     }


### PR DESCRIPTION
The last tag changed a few things on morph to many relationships.

This method needs to be public to get it to work.
