### PR TITLE
[5.1] Use table name as default for morph map

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Relations;
 
 use Closure;
+use Illuminate\Support\Arr;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
@@ -288,11 +289,32 @@ abstract class Relation
      */
     public static function morphMap(array $map = null, $merge = true)
     {
+        $map = static::buildMorphMapFromModels($map);
+
         if (is_array($map)) {
             static::$morphMap = $merge ? array_merge(static::$morphMap, $map) : $map;
         }
 
         return static::$morphMap;
+    }
+
+    /**
+     * Builds a table-keyed array from model class names.
+     *
+     * @param  string[]|null  $models
+     * @return array|null
+     */
+    protected static function buildMorphMapFromModels(array $models = null)
+    {
+        if (is_null($models) || Arr::isAssoc($models)) {
+            return $models;
+        }
+
+        $tables = array_map(function ($model) {
+            return (new $model)->getTable();
+        }, $models);
+
+        return array_combine($tables, $models);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -280,7 +280,7 @@ abstract class Relation
     }
 
     /**
-     * Set the morph map for polymorphic relations.
+     * Set or get the morph map for polymorphic relations.
      *
      * @param  array|null  $map
      * @param  bool  $merge

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Model as Eloquent;
-use Illuminate\Pagination\AbstractPaginator as Paginator;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Pagination\AbstractPaginator as Paginator;
 
 class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
 {
@@ -78,7 +78,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->schema()->drop('posts');
         $this->schema()->drop('photos');
 
-        Illuminate\Database\Eloquent\Relations\Relation::morphMap([], false);
+        Relation::morphMap([], false);
     }
 
     /**
@@ -345,7 +345,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testMorphMapIsUsedForCreatingAndFetchingThroughRelation()
     {
-        Illuminate\Database\Eloquent\Relations\Relation::morphMap([
+        Relation::morphMap([
             'user' => 'EloquentTestUser',
             'post' => 'EloquentTestPost',
         ]);

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -3,6 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
@@ -209,7 +210,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
 
     protected function getNamespacedRelation($alias)
     {
-        Illuminate\Database\Eloquent\Relations\Relation::morphMap([
+        Relation::morphMap([
             $alias => 'Foo\Bar\EloquentModelNamespacedStub',
         ]);
 

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -10,6 +10,8 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
 {
     public function tearDown()
     {
+        Relation::morphMap([], false);
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -5,6 +5,7 @@ use Illuminate\Database\Grammar;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 
 class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase
@@ -41,6 +42,17 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase
         $relation->touch();
     }
 
+    public function testSettingMorphMapWithNumericArrayUsesTheTableNames()
+    {
+        Relation::morphMap([EloquentRelationResetModelStub::class]);
+
+        $this->assertEquals([
+            'reset' => 'EloquentRelationResetModelStub',
+        ], Relation::morphMap());
+
+        Relation::morphMap([], false);
+    }
+
     /**
      * Testing to ensure loop does not occur during relational queries in global scopes.
      *
@@ -71,7 +83,9 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase
 
 class EloquentRelationResetModelStub extends Model
 {
-    //Override method call which would normally go through __call()
+    protected $table = 'reset';
+
+    // Override method call which would normally go through __call()
 
     public function getQuery()
     {

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -1,7 +1,11 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Database\Grammar;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 
 class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase
 {
@@ -21,10 +25,10 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase
 
     public function testTouchMethodUpdatesRelatedTimestamps()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $builder = m::mock(Builder::class);
+        $parent = m::mock(Model::class);
         $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
-        $builder->shouldReceive('getModel')->andReturn($related = m::mock('StdClass'));
+        $builder->shouldReceive('getModel')->andReturn($related = m::mock(StdClass::class));
         $builder->shouldReceive('whereNotNull');
         $builder->shouldReceive('where');
         $relation = new HasOne($builder, $parent, 'foreign_key', 'id');
@@ -46,12 +50,12 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase
     public function testDonNotRunParentModelGlobalScopes()
     {
         /* @var Mockery\MockInterface $parent */
-        $eloquentBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $queryBuilder = m::mock('Illuminate\Database\Query\Builder');
-        $parent = m::mock('EloquentRelationResetModelStub')->makePartial();
-        $grammar = m::mock('\Illuminate\Database\Grammar');
+        $eloquentBuilder = m::mock(Builder::class);
+        $queryBuilder = m::mock(QueryBuilder::class);
+        $parent = m::mock(EloquentRelationResetModelStub::class)->makePartial();
+        $grammar = m::mock(Grammar::class);
 
-        $eloquentBuilder->shouldReceive('getModel')->andReturn($related = m::mock('StdClass'));
+        $eloquentBuilder->shouldReceive('getModel')->andReturn($related = m::mock(StdClass::class));
         $eloquentBuilder->shouldReceive('getQuery')->andReturn($queryBuilder);
         $queryBuilder->shouldReceive('getGrammar')->andReturn($grammar);
         $grammar->shouldReceive('wrap');
@@ -65,7 +69,7 @@ class DatabaseEloquentRelationTest extends PHPUnit_Framework_TestCase
     }
 }
 
-class EloquentRelationResetModelStub extends Illuminate\Database\Eloquent\Model
+class EloquentRelationResetModelStub extends Model
 {
     //Override method call which would normally go through __call()
 
@@ -75,7 +79,7 @@ class EloquentRelationResetModelStub extends Illuminate\Database\Eloquent\Model
     }
 }
 
-class EloquentRelationStub extends \Illuminate\Database\Eloquent\Relations\Relation
+class EloquentRelationStub extends Relation
 {
     public function addConstraints()
     {


### PR DESCRIPTION
So that you can set the morph map by simply passing in the model class names:

``` php
Relation::morphMap([
    App\User::class,
    App\Post::class,
    App\Comment::class,
]);
```
