### PR TITLE
Partially fixes not being able to find indexes

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -1028,7 +1028,7 @@ trait CrawlerTrait
     {
         $name = str_replace('#', '', $name);
 
-        return $this->crawler->filter("{$element}#{$name}, {$element}[name='{$name}']");
+        return $this->crawler->filter("{$element}[name='{$name}']");
     }
 
     /**


### PR DESCRIPTION
I stumbled in a problem today: I was not able to find elements such as user[0][name], even when I escaped it. That was the cause and I made this little change so It could work. You won't be able to search for an element's ID, though.
Not a full fix, but will help some people.
