### PR TITLE
[5.2] We need to work on URL validation

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -986,7 +986,17 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function validUrls()
     {
         return [
+            ['http://a.pl'],
+            ['http://localhost/url.php'],
+            ['http://local.dev'],
+            ['http://google.com'],
             ['http://www.google.com'],
+            ['https://google.com'],
+            ['http://illuminate.dev'],
+            ['http://localhost'],
+            ['http://президент.рф/'],
+            ['http://스타벅스코리아.com'],
+            ['http://xn--d1abbgf6aiiy.xn--p1ai/'],
         ];
     }
 
@@ -994,6 +1004,20 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     {
         return [
             ['aslsdlks'],
+            ['google.com'],
+            ['://google.com'],
+            ['http ://google.com'],
+            ['http:/google.com'],
+            ['http://goog_le.com'],
+            ['http://google.com::aa'],
+            ['http://google.com:aa'],
+            ['http://laravel.com?'],
+            ['http://laravel.com/?'],
+            ['http://laravel.com#'],
+            ['http://127.0.0.1:aa'],
+            ['http://[::1'],
+            ['foo://bar'],
+            ['javascript://test%0Aalert(321)'],
         ];
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -963,14 +963,38 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testValidateUrl()
+    /**
+     * @dataProvider validUrls
+     */
+    public function testValidateUrlWithValidUrls($validUrl)
     {
         $trans = $this->getRealTranslator();
-        $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'Url']);
-        $this->assertFalse($v->passes());
-
-        $v = new Validator($trans, ['x' => 'http://google.com'], ['x' => 'Url']);
+        $v = new Validator($trans, ['x' => $validUrl], ['x' => 'Url']);
         $this->assertTrue($v->passes());
+    }
+
+    /**
+     * @dataProvider invalidUrls
+     */
+    public function testValidateUrlWithInvalidUrls($invalidUrl)
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['x' => $invalidUrl], ['x' => 'Url']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function validUrls()
+    {
+        return [
+            ['http://www.google.com'],
+        ];
+    }
+
+    public function invalidUrls()
+    {
+        return [
+            ['aslsdlks'],
+        ];
     }
 
     public function testValidateActiveUrl()


### PR DESCRIPTION
I've brought this up a long time ago, but we never did something about it.

URL validation in Laravel is rather broken; some perfectly valid URLs are not validated, and some invalid (and quite dangerous ones) are let through, like this good boy:

> javascript://test%0Aalert(321)

Some more information on why filter_var() is not the best way to do URL validation:
http://www.d-mueller.de/blog/why-url-validation-with-filter_var-might-not-be-a-good-idea/

I only added some new tests, which prove that something should be done about this.

Some of our options:
- Using Symfony's regex: https://github.com/symfony/Validator/blob/master/Constraints/UrlValidator.php
- I think we have a rather complete one in FluxBB: https://github.com/fluxbb/fluxbb/blob/207d7e4a12938857d3c0b4d7a01da382e3873603/include/functions.php#L1910-L2017
- I'm sure there are packages for this purpose.

/cc @willrowe @borys-p You guys may be interested in this
/ref #10088 and #10103 
