### PR TITLE
[5.1] Throw exception when cannot exist field, mutator or relationship in model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2604,7 +2604,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this->getAttributeValue($key);
         }
 
-        return $this->getRelationValue($key);
+        $relationship = $this->getRelationValue($key);
+        if ($relationship !== false) {
+            return $relationship;
+        }
+
+        throw new LogicException("The field or relationship $key must be defined on model.");
     }
 
     /**
@@ -2664,6 +2669,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if (method_exists($this, $key)) {
             return $this->getRelationshipFromMethod($key);
         }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2604,9 +2604,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this->getAttributeValue($key);
         }
 
-        $relationship = $this->getRelationValue($key);
-        if ($relationship !== false) {
-            return $relationship;
+        $relationshipValue = $this->getRelationValue($key);
+        if ($relationshipValue !== false) {
+            return $relationshipValue;
         }
 
         throw new LogicException("The field or relationship $key must be defined on model.");


### PR DESCRIPTION
Now when a attribute $row->attribute cannot exist, this return null, but i think that should throw exception. Because this can lead to errors if you write bad some attribute, so i think this should not be a silent error.

Sorry for my bad english.
