### PR TITLE
[5.1] Write compiled class cache to a tmp file before overwriting the old cache

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -82,7 +82,9 @@ class OptimizeCommand extends Command
     {
         $preloader = new ClassPreloader(new PrettyPrinter, new Parser(new Lexer), $this->getTraverser());
 
-        $handle = $preloader->prepareOutput($this->laravel->getCachedCompilePath());
+        $compilePath = $this->laravel->getCachedCompilePath();
+
+        $handle = $preloader->prepareOutput($compilePath.'.tmp');
 
         foreach ($this->getClassFiles() as $file) {
             try {
@@ -93,6 +95,8 @@ class OptimizeCommand extends Command
         }
 
         fclose($handle);
+
+        rename($compilePath.'.tmp', $compilePath);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -82,13 +82,13 @@ class OptimizeCommand extends Command
     {
         $preloader = new ClassPreloader(new PrettyPrinter, new Parser(new Lexer), $this->getTraverser());
 
-        $compilePath = $this->laravel->getCachedCompilePath();
+        $path = $this->laravel->getCachedCompilePath();
 
-        if (file_exists($compilePath)) {
-            unlink($compilePath);
+        if (file_exists($path)) {
+            unlink($path);
         }
 
-        $handle = $preloader->prepareOutput($compilePath.'.tmp');
+        $handle = $preloader->prepareOutput($path.'.tmp');
 
         foreach ($this->getClassFiles() as $file) {
             try {
@@ -100,7 +100,7 @@ class OptimizeCommand extends Command
 
         fclose($handle);
 
-        rename($compilePath.'.tmp', $compilePath);
+        rename($path.'.tmp', $path);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -84,6 +84,10 @@ class OptimizeCommand extends Command
 
         $compilePath = $this->laravel->getCachedCompilePath();
 
+        if (file_exists($compilePath)) {
+            unlink($compilePath);
+        }
+
         $handle = $preloader->prepareOutput($compilePath.'.tmp');
 
         foreach ($this->getClassFiles() as $file) {


### PR DESCRIPTION
This way a website in production won't throw exceptions because classes couldn't be found or because of other errors that occur because of an incomplete compiled.php.

Especially handy for continuous integration where a project can be optimized several times a day. With this little change the website will stay online for a few seconds longer.
