### PR TITLE
[5.1] Server variables array can be set on a property of CrawlerTrait

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -49,6 +49,13 @@ trait CrawlerTrait
     protected $uploads = [];
 
     /**
+     * Additional server variables for all requests.
+     *
+     * @var array
+     */
+    protected $server = [];
+
+    /**
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri
@@ -1048,6 +1055,8 @@ trait CrawlerTrait
         $kernel = $this->app->make('Illuminate\Contracts\Http\Kernel');
 
         $this->currentUri = $this->prepareUrlForRequest($uri);
+
+        $server = array_replace($this->server, $server);
 
         $request = Request::create(
             $this->currentUri, $method, $parameters,


### PR DESCRIPTION
Minor feature -- fully backwards compatible

Synopsis:
In the TestCase setUp() callback for functional suite, we can 
define once a canonical set of values to mimic our production server.
This is done simply by setting $this->server = [ server vars ... ];

Explanation:
Many applications depend on data found in the server variables
found in the request. Laravel's functional testing depends on
symfony\http-foundation\Request, which provides an incomplete set
of default server variables when making a request. The only way
to specify additional values through the api was to forego use
of the visit(), get(), and other requesters and instead build
a long parameter list to call(). 

Now, test writers can optionally
set $this->server to an array of server variable key-value pairs.
The CrawlerTrait requests will all use these variables for all
requests.  Any values in the server array passed to call() will
override the values in the property.  No public interfaces or
parameters have changed, except for the addition of the protected
property, $server.
