### PR TITLE
Removed trailing period in `CrawlerTrait::seeLink`

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -300,7 +300,7 @@ trait CrawlerTrait
      */
     public function seeLink($text, $url = null)
     {
-        $message = "No links were found with expected text [{$text}].";
+        $message = "No links were found with expected text [{$text}]";
 
         if ($url) {
             $message .= " and URL [{$url}]";


### PR DESCRIPTION
The period was added in fb7b1f3219a9e160e0155af25f6f7df431cd894a. The method `dontSeeLink()` doesn't have it.
