### PR TITLE
Allow string class names like dispatchFrom... methods.

### DIFF
--- a/src/Illuminate/Foundation/Bus/DispatchesJobs.php
+++ b/src/Illuminate/Foundation/Bus/DispatchesJobs.php
@@ -14,7 +14,11 @@ trait DispatchesJobs
      */
     protected function dispatch($job)
     {
-        return app('Illuminate\Contracts\Bus\Dispatcher')->dispatch($job);
+        if (is_string($job)) {
+            return app('Illuminate\Contracts\Bus\Dispatcher')->dispatch(app($job));
+        } else {
+            return app('Illuminate\Contracts\Bus\Dispatcher')->dispatch($job);
+        }
     }
 
     /**


### PR DESCRIPTION
It may be more appropriate to address this in Illuminate\Bus\Dispatcher. But this was a simpler.
