### PR TITLE
[5.1] Added command to make tests

### DIFF
--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class TestMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:test';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Test class for example FooTest';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Test';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        if ($this->option('database_migration')) {
+            return __DIR__.'/stubs/test.database_migration.stub';
+        }
+
+        return __DIR__.'/stubs/test.stub';
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $name = str_replace($this->laravel->getNamespace(), '', $name);
+
+        return $this->laravel['path.base'].'/tests/'.str_replace('\\', '/', $name).'.php';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['database_migration', 'd', InputOption::VALUE_NONE, 'Add DatabaseMigration Trait to your Test'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/test.database_migration.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.database_migration.stub
@@ -1,0 +1,10 @@
+<?php
+
+use \Illuminate\Foundation\Testing\DatabaseMigrations
+
+class DummyClass extends TestCase
+{
+    use DatabaseMigrations;
+
+    //
+}

--- a/src/Illuminate/Foundation/Console/stubs/test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.stub
@@ -1,0 +1,6 @@
+<?php
+
+class DummyClass extends TestCase
+{
+    //
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Foundation\Console\OptimizeCommand;
 use Illuminate\Foundation\Console\RouteListCommand;
 use Illuminate\Foundation\Console\EventMakeCommand;
 use Illuminate\Foundation\Console\ModelMakeCommand;
+use Illuminate\Foundation\Console\TestMakeCommand;
 use Illuminate\Foundation\Console\ViewClearCommand;
 use Illuminate\Foundation\Console\PolicyMakeCommand;
 use Illuminate\Foundation\Console\RouteCacheCommand;
@@ -71,6 +72,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'RouteClear' => 'command.route.clear',
         'RouteList' => 'command.route.list',
         'Serve' => 'command.serve',
+        'TestMake' => 'command.test.make',
         'Tinker' => 'command.tinker',
         'Up' => 'command.up',
         'VendorPublish' => 'command.vendor.publish',
@@ -282,6 +284,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.model.make', function ($app) {
             return new ModelMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerTestMakeCommand()
+    {
+        $this->app->singleton('command.test.make', function ($app) {
+            return new TestMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
So many great artisan commands to make Models, Controllers etc. I would like to make one to make a Test File.

For example 

```
php artisan make:test FooTest
```

Would make a default file to get going

``` php
<?php 

class FooTest extends \TestCase {

}
```

Or 

```
php artisan make:test FooTest --database_migration
```

``` php
<?php 

class FooTest extends \TestCase {
    use \Illuminate\Foundation\Testing\DatabaseMigrations;    

}
```
