### PR TITLE
[5.1] CrawlerTrait allows specifying server vars for request

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -49,6 +49,13 @@ trait CrawlerTrait
     protected $uploads = [];
 
     /**
+     * Additional server variables for all requests.
+     *
+     * @var array
+     */
+    protected $server = [];
+
+    /**
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri
@@ -1048,6 +1055,8 @@ trait CrawlerTrait
         $kernel = $this->app->make('Illuminate\Contracts\Http\Kernel');
 
         $this->currentUri = $this->prepareUrlForRequest($uri);
+
+        $server = array_replace($this->server, $server);
 
         $request = Request::create(
             $this->currentUri, $method, $parameters,


### PR DESCRIPTION
The contents of Request::server() values can now be configured to match the production server's variables when running tests.

Simply set the server property with the server variables of the real server, and the crawler will use them when generating test requests.

---

Replaces #10163.
