### PR TITLE
[5.1] Adds array_walk functionality to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -870,6 +870,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Walk over each of the items.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function walk(callable $callback)
+    {
+        array_walk($this->items, $callback);
+        return new static($this->items);
+    }
+
+    /**
      * Zip the collection together with one or more arrays.
      *
      * e.g. new Collection([1, 2, 3])->zip([4, 5, 6]);

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -878,6 +878,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function walk(callable $callback)
     {
         array_walk($this->items, $callback);
+        
         return new static($this->items);
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -877,9 +877,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function walk(callable $callback)
     {
-        array_walk($this->items, $callback);
+        $items = $this->items;
 
-        return new static($this->items);
+        array_walk($items, $callback);
+
+        return new static($items);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -878,7 +878,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function walk(callable $callback)
     {
         array_walk($this->items, $callback);
-        
+
         return new static($this->items);
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -572,6 +572,14 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([['color' => 'red'],['color' => 'blue']], $data->all());
     }
 
+    public function testWalkDoesNotModifyOriginal()
+    {
+        $data = new Collection([['color' => 'red'],['color' => 'blue']]);
+        $modified = $data->walk(function (&$item) { $item['color'] = strrev($item['color']); });
+        $this->assertEquals([['color' => 'red'],['color' => 'blue']], $data->all());
+        $this->assertEquals([['color' => 'der'],['color' => 'eulb']], $modified->all());
+    }
+
     public function testTransform()
     {
         $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -571,7 +571,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $data = $data->walk(function ($item) { $item['color'] = strrev($item['color']); });
         $this->assertEquals([['color' => 'red'],['color' => 'blue']], $data->all());
     }
-    
+
     public function testTransform()
     {
         $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -558,6 +558,20 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
     }
 
+    public function testWalkWithModification()
+    {
+        $data = new Collection([['color' => 'red'],['color' => 'blue']]);
+        $data = $data->walk(function (&$item) { $item['color'] = strrev($item['color']); });
+        $this->assertEquals([['color' => 'der'],['color' => 'eulb']], $data->all());
+    }
+
+    public function testWalkWithoutModification()
+    {
+        $data = new Collection([['color' => 'red'],['color' => 'blue']]);
+        $data = $data->walk(function ($item) { $item['color'] = strrev($item['color']); });
+        $this->assertEquals([['color' => 'red'],['color' => 'blue']], $data->all());
+    }
+    
     public function testTransform()
     {
         $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -560,24 +560,24 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
     public function testWalkWithModification()
     {
-        $data = new Collection([['color' => 'red'],['color' => 'blue']]);
+        $data = new Collection([['color' => 'red'], ['color' => 'blue']]);
         $data = $data->walk(function (&$item) { $item['color'] = strrev($item['color']); });
-        $this->assertEquals([['color' => 'der'],['color' => 'eulb']], $data->all());
+        $this->assertEquals([['color' => 'der'], ['color' => 'eulb']], $data->all());
     }
 
     public function testWalkWithoutModification()
     {
-        $data = new Collection([['color' => 'red'],['color' => 'blue']]);
+        $data = new Collection([['color' => 'red'], ['color' => 'blue']]);
         $data = $data->walk(function ($item) { $item['color'] = strrev($item['color']); });
-        $this->assertEquals([['color' => 'red'],['color' => 'blue']], $data->all());
+        $this->assertEquals([['color' => 'red'], ['color' => 'blue']], $data->all());
     }
 
     public function testWalkDoesNotModifyOriginal()
     {
-        $data = new Collection([['color' => 'red'],['color' => 'blue']]);
+        $data = new Collection([['color' => 'red'], ['color' => 'blue']]);
         $modified = $data->walk(function (&$item) { $item['color'] = strrev($item['color']); });
-        $this->assertEquals([['color' => 'red'],['color' => 'blue']], $data->all());
-        $this->assertEquals([['color' => 'der'],['color' => 'eulb']], $modified->all());
+        $this->assertEquals([['color' => 'red'], ['color' => 'blue']], $data->all());
+        $this->assertEquals([['color' => 'der'], ['color' => 'eulb']], $modified->all());
     }
 
     public function testTransform()


### PR DESCRIPTION
Can iterate over items without modifying them or pass by reference to modify each item:

```
$collection->walk(function($item) {
      // Does not modify value
      $item->foo = $item->foo + 1;
});

$collection->walk(function(&$item) {
      // Does modify value
      $item->foo = $item->foo + 1;
});
```

Returns new Collection instance.
