### PR TITLE
Add aviability to inject new engines

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -311,6 +311,16 @@ class Factory implements FactoryContract
             return Str::endsWith($path, $value);
         });
     }
+    
+    /**
+     * Bind view engine alias with a given extension
+     * @param $extension
+     * @param $engineAlias
+     */
+    public function bindEngine($extension, $engineAlias)
+    {
+        $this->extensions[$extension] = $engineAlias;
+    }
 
     /**
      * Add a piece of shared data to the environment.

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -311,9 +311,9 @@ class Factory implements FactoryContract
             return Str::endsWith($path, $value);
         });
     }
-    
+
     /**
-     * Bind view engine alias with a given extension
+     * Bind view engine alias with a given extension.
      * @param $extension
      * @param $engineAlias
      */


### PR DESCRIPTION
Hi. Without this method you can't inject a new view engine into a view factory.
For example, we want add a new engine:

```
       $finder = $app['view.finder'];
       $finder->addExtension('html');
        $resolver->register('handlebars', function(){
            return new HandlebarsEngine();
        });

        $env = new Factory($resolver, $finder, $app['events']);
        $env->setContainer($app);
        $env->share('app', $app);
```

This code will not work correctly, but if we add $env->bindEngine('html', 'handlebars'); everything will be ok :)
