### PR TITLE
[5.1] Paginator causes superfluous redirect

### DIFF
--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -37,7 +37,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
 
         $this->perPage = $perPage;
         $this->currentPage = $this->setCurrentPage($currentPage);
-        $this->path = $this->path != '/' ? rtrim($this->path, '/').'/' : $this->path;
+        $this->path = $this->path != '/' ? rtrim($this->path, '/') : $this->path;
         $this->items = $items instanceof Collection ? $items : Collection::make($items);
 
         $this->checkForMorePages();

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -181,4 +181,11 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
     }
+
+    public function testPaginatorRemovesTrailingSlashes()
+    {
+        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2, ['path' => 'http://website.com/test/']);
+
+        $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
+    }
 }

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -174,4 +174,11 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase
             'prev_page_url' => '/?page=1', 'from' => 3, 'to' => 4, 'data' => ['item3', 'item4'],
         ], $p->toArray());
     }
+
+    public function testPaginatorGeneratesUrlsWithoutTrailingSlash()
+    {
+        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2, ['path' => 'http://website.com/test']);
+
+        $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
+    }
 }


### PR DESCRIPTION
Currently, the paginator appends a trailing slash. However, the `.htaccess` currently does 301 redirects to the URL without trailing slash (see https://github.com/laravel/laravel/blob/master/public/.htaccess#L10). Hence, the added trailing slash is seemingly pointless.
