### PR TITLE
avoid matched route is compiled twice

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -497,9 +497,10 @@ class Route
      * @param  \Illuminate\Http\Request  $request
      * @return $this
      */
-    public function bind(Request $request)
+    public function bind(Request $request, $compile=false)
     {
-        $this->compileRoute();
+        if($compile)
+            $this->compileRoute();
 
         $this->bindParameters($request);
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -499,7 +499,7 @@ class Route
      */
     public function bind(Request $request, $compile=false)
     {
-        if($compile)
+        if ($compile)
             $this->compileRoute();
 
         $this->bindParameters($request);

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -182,7 +182,7 @@ class RouteCollection implements Countable, IteratorAggregate
             return (new Route('OPTIONS', $request->path(), function () use ($methods) {
                 return new Response('', 200, ['Allow' => implode(',', $methods)]);
 
-            }))->bind($request);
+            }))->bind($request, true);
         }
 
         $this->methodNotAllowed($methods);


### PR DESCRIPTION
Route::matches  execute  Route::compileRoute,  also do Route::bind .
