### PR TITLE
[5.1] Bug fix in explodePluckParameters.

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -342,7 +342,7 @@ class Arr
      */
     protected static function explodePluckParameters($value, $key)
     {
-        $value = is_array($value) ? $value : explode('.', $value);
+        $value = is_null($value) || is_array($value) ? $value : explode('.', $value);
 
         $key = is_null($key) || is_array($key) ? $key : explode('.', $key);
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -99,6 +99,27 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['Taylor', 'Abigail'], $array);
     }
 
+    public function testPluckWithKeys()
+    {
+        $array = [
+            ['name' => 'Taylor', 'role' => 'developer'],
+            ['name' => 'Abigail', 'role' => 'developer'],
+        ];
+
+        $test1 = Arr::pluck($array, 'role', 'name');
+        $test2 = Arr::pluck($array, null, 'name');
+
+        $this->assertEquals([
+            'Taylor' => 'developer',
+            'Abigail' => 'developer',
+        ], $test1);
+
+        $this->assertEquals([
+            'Taylor' => ['name' => 'Taylor', 'role' => 'developer'],
+            'Abigail' => ['name' => 'Abigail', 'role' => 'developer'],
+        ], $test2);
+    }
+
     public function testPull()
     {
         $array = ['name' => 'Desk', 'price' => 100];


### PR DESCRIPTION
Allowing `null` as `$value` argument in `array_pluck` to return all values. This was possible before the new `explodePluckParameters` method and should still be at least for backward compatibility.
