### PR TITLE
Update Guard.php to support reminder cookie having secure flag

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -4,6 +4,7 @@ namespace Illuminate\Auth;
 
 use RuntimeException;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Auth\UserProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -529,7 +530,8 @@ class Guard implements GuardContract
      */
     protected function createRecaller($value)
     {
-        return $this->getCookieJar()->forever($this->getRecallerName(), $value);
+        $secure = Config::get('session.secure',false);
+        return $this->getCookieJar()->forever($this->getRecallerName(), $value, null, null, $secure);
     }
 
     /**


### PR DESCRIPTION
Laravel supports secure session cookies via the config session.secure. The reminder cookie is not sent securely even if session.secure = true

To better protect Laravel logins both the session and reminder cookies should use the same value for the cookie secure flag.
