### PR TITLE
Changed the Validator::validateUrl method to use the Symfony regex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "symfony/process": "2.7.*",
         "symfony/routing": "2.7.*",
         "symfony/translation": "2.7.*",
+        "symfony/validator": "2.7.*",
         "symfony/var-dumper": "2.7.*",
         "vlucas/phpdotenv": "~1.0"
     },

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -18,6 +18,7 @@ use Illuminate\Contracts\Container\Container;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Validator\Constraints\UrlValidator;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 
 class Validator implements ValidatorContract
@@ -1200,7 +1201,13 @@ class Validator implements ValidatorContract
      */
     protected function validateUrl($attribute, $value)
     {
-        return filter_var($value, FILTER_VALIDATE_URL) !== false;
+        foreach (['http', 'https', 'ftp'] as $protocol) {
+            if (preg_match(sprintf(UrlValidator::PATTERN, $protocol), $value) == 1) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
This is in response to #10149, with this the PR from @franzliedke should pass based on @taylorotwell suggestion to use the Symphony regex for URL validation.

This is my first PR to Laravel, so I'm not sure I did this 100% correctly... apologies if it's wrong.
