### PR TITLE
[5.2] Add some fluent methods to routes (again)

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -29,6 +29,12 @@ class RouteServiceProvider extends ServiceProvider
         } else {
             $this->loadRoutes();
         }
+
+        // We still want name look-ups to be fast, even if names were specified fluently
+        // on the route itself. This will update the name look-up table just in case.
+        $this->app->booted(function () use ($router) {
+            $router->getRoutes()->refreshNameLookup();
+        });
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -266,6 +266,24 @@ class Route
     }
 
     /**
+     * Attach middleware(s) to the route.
+     *
+     * @param $middleware
+     *
+     * @return $this
+     */
+    public function withMiddleware($middleware)
+    {
+        if (is_string($middleware)) {
+            $middleware = [$middleware];
+        }
+
+        $this->action['middleware'] = array_merge($this->action['middleware'], $middleware);
+
+        return $this;
+    }
+
+    /**
      * Determine a given parameter exists from the route.
      *
      * @param  string $name
@@ -746,6 +764,20 @@ class Route
     public function getName()
     {
         return isset($this->action['as']) ? $this->action['as'] : null;
+    }
+
+    /**
+     * Add or change the route name.
+     *
+     * @param $name
+     *
+     * @return $this
+     */
+    public function withName($name)
+    {
+        $this->action['as'] = $name;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -99,6 +99,22 @@ class RouteCollection implements Countable, IteratorAggregate
     }
 
     /**
+     * Refresh the name look-up table, in case any names have been defined fluently.
+     *
+     * @return void
+     */
+    public function refreshNameLookup()
+    {
+        $this->nameList = [];
+
+        foreach ($this->allRoutes as $route) {
+            if ($route->getName()) {
+                $this->nameList[$route->getName()] = $route;
+            }
+        }
+    }
+
+    /**
      * Add a route to the controller action dictionary.
      *
      * @param  array  $action


### PR DESCRIPTION
I'm back!

This is another attempt at #5859, now with new and improved name lookups.

This enables us instead of doing this:

``` php
$router->get('/', ['uses' => 'Controller@method', 'as' => 'route.name', 'middleware' => ['SomeMiddleware']]);
```

to do this:

``` php
$router->get('/', 'Controller@method')->withName('route.name')->withMiddleware('SomeMiddleware');
```

Which the folks in #5859 all seemed to agree is much nicer.

This time I've added a one time refresh of the name look-up table in `RouteCollection`, to ensure that it's up-to-date and still blazingly fast, even if some routes had names defined fluently. This refresh, in my testing, adds ~0.7ms, or ~0.0007 of a second, for 1,000 routes.
