### PR TITLE
[5.1] Allow passing class name for Gate policy calls

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -233,8 +233,15 @@ class Gate implements GateContract
      */
     protected function firstArgumentCorrespondsToPolicy(array $arguments)
     {
-        return isset($arguments[0]) && is_object($arguments[0]) &&
-               isset($this->policies[get_class($arguments[0])]);
+        if (! isset($arguments[0])) {
+            return false;
+        }
+
+        if (is_object($arguments[0])) {
+            return isset($this->policies[get_class($arguments[0])]);
+        }
+
+        return is_string($arguments[0]) && isset($this->policies[$arguments[0]]);
     }
 
     /**
@@ -248,9 +255,7 @@ class Gate implements GateContract
     protected function resolvePolicyCallback($user, $ability, array $arguments)
     {
         return function () use ($user, $ability, $arguments) {
-            $instance = $this->resolvePolicy(
-                $this->policies[get_class($arguments[0])]
-            );
+            $instance = $this->getPolicyFor($arguments[0]);
 
             if (method_exists($instance, 'before')) {
                 // We will prepend the user and ability onto the arguments so that the before

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -111,6 +111,15 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
     }
 
+    public function test_policy_classes_can_be_defined_to_handle_checks_for_given_class_name()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $this->assertTrue($gate->check('create', AccessGateTestDummy::class));
+    }
+
     public function test_policies_may_have_before_methods_to_override_checks()
     {
         $gate = $this->getBasicGate();
@@ -166,6 +175,11 @@ class AccessGateTestDummy
 
 class AccessGateTestPolicy
 {
+    public function create($user)
+    {
+        return true;
+    }
+
     public function update($user, AccessGateTestDummy $dummy)
     {
         return $user instanceof StdClass;


### PR DESCRIPTION
This change allows developers to pass a class name as the first argument, in situations where an object (i.e. the model) is not instantiated yet (for example, in a create action). This:

`$this->authorize('create', Post::class)`

will be the same as this:

`$this->authorize('create', new Post)`

Then you can simply define the rule like this:

```
    public function create($user)
    {
        return true;
    }
```
