### PR TITLE
[5.1] Import Illuminate\Http\Response to controller stub

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -3,6 +3,7 @@
 namespace DummyNamespace;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 
 use DummyRootNamespaceHttp\Requests;
 use DummyRootNamespaceHttp\Controllers\Controller;


### PR DESCRIPTION
Every time you create resource controller via artisan, it creates set of methods with dummy phpdocs:

``` php
    /**
     * Show the form for creating a new resource.
     *
     * @return Response
     */
    public function create()
    {

    }
```

Where returning `Response` is not imported and every IDE begins to worry about it. How about to add it?
