### PR TITLE
[5.1] View : no need to call session()->get twice

### DIFF
--- a/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
+++ b/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
@@ -38,18 +38,13 @@ class ShareErrorsFromSession
         // If the current session has an "errors" variable bound to it, we will share
         // its value with all view instances so the views can easily access errors
         // without having to bind. An empty bag is set when there aren't errors.
-        if ($request->session()->has('errors')) {
-            $this->view->share(
-                'errors', $request->session()->get('errors')
-            );
-        }
+        $this->view->share(
+            'errors', $request->session()->get('errors', new ViewErrorBag)
+        );
 
         // Putting the errors in the view for every view allows the developer to just
         // assume that some errors are always available, which is convenient since
         // they don't have to continually run checks for the presence of errors.
-        else {
-            $this->view->share('errors', new ViewErrorBag);
-        }
 
         return $next($request);
     }


### PR DESCRIPTION
Use `new ViewErrorBag` as the default value
