### PR TITLE
[5.1] Add some fluent methods to routes (again)

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -28,6 +28,12 @@ class RouteServiceProvider extends ServiceProvider
             $this->loadCachedRoutes();
         } else {
             $this->loadRoutes();
+
+            // We still want name look-ups to be fast, even if names were specified fluently
+            // on the route itself. This will update the name look-up table just in case.
+            $this->app->booted(function () use ($router) {
+                $router->getRoutes()->refreshNameLookup();
+            });
         }
     }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -256,13 +256,25 @@ class Route
     }
 
     /**
-     * Get the middlewares attached to the route.
+     * Set or get the middlewares attached to the route.
+     *
+     * @param array|string|null $middleware
      *
      * @return array
      */
-    public function middleware()
+    public function middleware($middleware = null)
     {
-        return (array) Arr::get($this->action, 'middleware', []);
+        if (is_null($middleware)) {
+            return (array) Arr::get($this->action, 'middleware', []);
+        }
+
+        if (is_string($middleware)) {
+            $middleware = [$middleware];
+        }
+
+        $this->action['middleware'] = array_merge($this->action['middleware'], $middleware);
+
+        return $this;
     }
 
     /**
@@ -903,6 +915,20 @@ class Route
     public function getName()
     {
         return isset($this->action['as']) ? $this->action['as'] : null;
+    }
+
+    /**
+     * Add or change the route name.
+     *
+     * @param $name
+     *
+     * @return $this
+     */
+    public function name($name)
+    {
+        $this->action['as'] = $name;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -99,6 +99,22 @@ class RouteCollection implements Countable, IteratorAggregate
     }
 
     /**
+     * Refresh the name look-up table, in case any names have been defined fluently.
+     *
+     * @return void
+     */
+    public function refreshNameLookup()
+    {
+        $this->nameList = [];
+
+        foreach ($this->allRoutes as $route) {
+            if ($route->getName()) {
+                $this->nameList[$route->getName()] = $route;
+            }
+        }
+    }
+
+    /**
      * Add a route to the controller action dictionary.
      *
      * @param  array  $action


### PR DESCRIPTION
_Resubmit of #10200 against 5.1_

I'm back!

This is another attempt at #5859, now with new and improved name lookups.

This enables us instead of doing this:

``` php
$router->get('/', ['uses' => 'Controller@method', 'as' => 'route.name', 'middleware' => ['SomeMiddleware']]);
```

to do this:

``` php
$router->get('/', 'Controller@method')->name('route.name')->middleware('SomeMiddleware');
```

Which the folks in #5859 all seemed to agree is much nicer.

This time I've added a one time refresh of the name look-up table in `RouteCollection`, to ensure that it's up-to-date and still blazingly fast, even if some routes had names defined fluently. This refresh, in my testing, adds ~0.7ms, or ~0.0007 of a second, for 1,000 routes.
