### PR TITLE
[5.1] Properly format both DateTime and DateTimeImmutable in queries

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -4,11 +4,11 @@ namespace Illuminate\Database;
 
 use PDO;
 use Closure;
-use DateTime;
 use Exception;
 use Throwable;
 use LogicException;
 use RuntimeException;
+use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Database\Query\Expression;
@@ -435,10 +435,10 @@ class Connection implements ConnectionInterface
         $grammar = $this->getQueryGrammar();
 
         foreach ($bindings as $key => $value) {
-            // We need to transform all instances of the DateTime class into an actual
+            // We need to transform all instances of DateTimeInterface into an actual
             // date string. Each query grammar maintains its own date string format
             // so we'll just ask the grammar for the format to get from the date.
-            if ($value instanceof DateTime) {
+            if ($value instanceof DateTimeInterface) {
                 $bindings[$key] = $value->format($grammar->getDateFormat());
             } elseif ($value === false) {
                 $bindings[$key] = 0;


### PR DESCRIPTION
Laravel automatically formats `DateTime` objects when used in query bindings. Pass in a `DateTimeImmutable` object, however, and you get the error:

```
ErrorException: Object of class DateTimeImmutable could not be converted to string
```

Since Laravel 5.1 requires PHP 5.5, we can now handle both types of objects by checking `DateTimeInterface` instead of just `DateTime`.
