### PR TITLE
[5.1] Use provided ID for FindOrNew

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -680,7 +680,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $model;
         }
 
-        return new static;
+        $model = new static;
+        
+        $model->_id = $id
+        
+        return $model
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -680,11 +680,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $model;
         }
 
-        $model = new static;
+        $model->setKeyName($id);
         
-        $model->_id = $id
-        
-        return $model
+        return $model;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -680,7 +680,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $model;
         }
 
-        $model->setKeyName($id);
+        $model->{$model->getKeyName()} = $id
         
         return $model;
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -681,7 +681,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
 
         $model->{$model->getKeyName()} = $id;
-        
+
         return $model;
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -680,7 +680,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $model;
         }
 
-        $model->{$model->getKeyName()} = $id
+        $model->{$model->getKeyName()} = $id;
         
         return $model;
     }


### PR DESCRIPTION
With FindOrNew, in the case of a model not being found, the primary key provided should be the one used in the construction of a new model
