### PR TITLE
[5.1] Add authorisation methods for multiple abilities

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -150,6 +150,30 @@ class Gate implements GateContract
     }
 
     /**
+     * Determine if any of the given abilites should be granted for the current user.
+     *
+     * @param  array  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function allowsAny($abilities, $arguments = [])
+    {
+        return $this->checkAny($abilities, $arguments);
+    }
+
+    /**
+     * Determine if all of the given abilites should be granted for the current user.
+     *
+     * @param  array  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function allowsAll($abilities, $arguments = [])
+    {
+        return $this->checkAll($abilities, $arguments);
+    }
+
+    /**
      * Determine if the given ability should be denied for the current user.
      *
      * @param  string  $ability
@@ -185,6 +209,42 @@ class Gate implements GateContract
         );
 
         return call_user_func_array($callback, array_merge([$user], $arguments));
+    }
+
+    /**
+     * Determine if any of the given abilities should be granted for the current user.
+     *
+     * @param  array  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function checkAny($abilities, $arguments = [])
+    {
+        foreach ($abilities as $ability) {
+            if ($this->check($ability, $arguments)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if all of the given abilities should be granted for the current user.
+     *
+     * @param  array  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function checkAll($abilities, $arguments = [])
+    {
+        foreach ($abilities as $ability) {
+            if (! $this->check($ability, $arguments)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Foundation/Auth/Access/Authorizable.php
@@ -19,6 +19,30 @@ trait Authorizable
     }
 
     /**
+     * Determine if the entity has any of the given abilities.
+     *
+     * @param  array  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function canAny($abilities, $arguments = [])
+    {
+        return app(Gate::class)->forUser($this)->checkAny($abilities, $arguments);
+    }
+
+    /**
+     * Determine if the entity has all of the given abilities.
+     *
+     * @param  array  $abilities
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function canAll($abilities, $arguments = [])
+    {
+        return app(Gate::class)->forUser($this)->checkAll($abilities, $arguments);
+    }
+
+    /**
      * Determine if the entity does not have a given ability.
      *
      * @param  string  $ability

--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -26,6 +26,38 @@ trait AuthorizesRequests
     }
 
     /**
+     * Authorize any of the given actions against a set of arguments.
+     *
+     * @param  array  $abilities
+     * @param  mixed|array  $arguments
+     * @return void
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function authorizeAny($abilities, $arguments = [])
+    {
+        if (! app(Gate::class)->checkAny($abilities, $arguments)) {
+            throw $this->createGateUnauthorizedException($abilities, $arguments);
+        }
+    }
+
+    /**
+     * Authorize all of the given actions against a set of arguments.
+     *
+     * @param  array  $abilities
+     * @param  mixed|array  $arguments
+     * @return void
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function authorizeAll($abilities, $arguments = [])
+    {
+        if (! app(Gate::class)->checkAll($abilities, $arguments)) {
+            throw $this->createGateUnauthorizedException($abilities, $arguments);
+        }
+    }
+
+    /**
      * Authorize a given action for a user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable|mixed  $user
@@ -43,6 +75,40 @@ trait AuthorizesRequests
 
         if (! $result) {
             throw $this->createGateUnauthorizedException($ability, $arguments);
+        }
+    }
+
+    /**
+     * Authorize any of the given actions for a user.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|mixed  $user
+     * @param  array  $abilities
+     * @param  mixed|array  $arguments
+     * @return void
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function authorizeAnyForUser($user, $abilities, $arguments = [])
+    {
+        if (! app(Gate::class)->forUser($user)->checkAny($abilities, $arguments)) {
+            throw $this->createGateUnauthorizedException($abilities, $arguments);
+        }
+    }
+
+    /**
+     * Authorize all of the given actions for a user.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|mixed  $user
+     * @param  array  $abilities
+     * @param  mixed|array  $arguments
+     * @return void
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function authorizeAllForUser($user, $abilities, $arguments = [])
+    {
+        if (! app(Gate::class)->forUser($user)->checkAll($abilities, $arguments)) {
+            throw $this->createGateUnauthorizedException($abilities, $arguments);
         }
     }
 
@@ -65,7 +131,7 @@ trait AuthorizesRequests
     /**
      * Throw an unauthorized exception based on gate results.
      *
-     * @param  string  $ability
+     * @param  string|array  $ability
      * @param  array  $arguments
      * @return \Symfony\Component\HttpKernel\Exception\HttpException
      */

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -551,6 +551,28 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Compile the can-any statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileCanany($expression)
+    {
+        return "<?php if (Gate::checkAny{$expression}): ?>";
+    }
+
+    /**
+     * Compile the can-all statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileCanall($expression)
+    {
+        return "<?php if (Gate::checkAll{$expression}): ?>";
+    }
+
+    /**
      * Compile the cannot statements into valid PHP.
      *
      * @param  string  $expression
@@ -647,6 +669,28 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @return string
      */
     protected function compileEndcan($expression)
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the end-can-any statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileEndcanany($expression)
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the end-can-all statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileEndcanall($expression)
     {
         return '<?php endif; ?>';
     }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -93,6 +93,17 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($gate->check('foo', [$dummy1, $dummy2]));
     }
 
+    public function test_any_or_all_of_specified_abilities_can_be_checked()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('foo', function ($user) { return true; });
+        $gate->define('bar', function ($user) { return false; });
+
+        $this->assertTrue($gate->checkAny(['foo', 'bar']));
+        $this->assertFalse($gate->checkAll(['foo', 'bar']));
+    }
+
     public function test_classes_can_be_defined_as_callbacks_using_at_notation()
     {
         $gate = $this->getBasicGate();

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -22,6 +22,27 @@ class FoundationAuthorizesRequestsTraitTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($_SERVER['_test.authorizes.trait']);
     }
 
+    public function test_multiple_abilities_gate_check()
+    {
+        unset($_SERVER['_test.authorizes.trait']);
+
+        $gate = $this->getBasicGate();
+
+        $gate->define('foo', function () {
+            $_SERVER['_test.authorizes.trait'] = true;
+
+            return true;
+        });
+
+        $gate->define('bar', function () {
+            return false;
+        });
+
+        (new FoundationTestAuthorizeTraitClass)->authorizeAny(['foo', 'bar']);
+
+        $this->assertTrue($_SERVER['_test.authorizes.trait']);
+    }
+
     /**
      * @expectedException Symfony\Component\HttpKernel\Exception\HttpException
      */
@@ -34,6 +55,24 @@ class FoundationAuthorizesRequestsTraitTest extends PHPUnit_Framework_TestCase
         });
 
         (new FoundationTestAuthorizeTraitClass)->authorize('foo');
+    }
+
+    /**
+     * @expectedException Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function test_exception_is_thrown_if_gate_check_with_multiple_abilities_fails()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('foo', function () {
+            return false;
+        });
+
+        $gate->define('bar', function () {
+            return true;
+        });
+
+        (new FoundationTestAuthorizeTraitClass)->authorizeAll(['foo', 'bar']);
     }
 
     public function test_policies_may_be_called()

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -233,6 +233,30 @@ breeze
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testCanAnyStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@canany ([\'update\', \'delete\'], [$post])
+breeze
+@endcanany';
+        $expected = '<?php if (Gate::checkAny([\'update\', \'delete\'], [$post])): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testCanAllStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@canall ([\'update\', \'delete\'], [$post])
+breeze
+@endcanall';
+        $expected = '<?php if (Gate::checkAll([\'update\', \'delete\'], [$post])): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     public function testCannotStatementsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
Currently, the only way to check multiple Gate/Policy abilities in one go is to perform multiple checks in a single condition. This is especially cumbersome in views where you want to use the new `@can` Blade directive - you have to instead use the Gate facade directly, passing the same argument(s) into multiple `allows()` or `denies()` calls.

This introduces the following:
- New Gate methods: `allowsAny()`, `allowsAll()`, `checkAny()`, `checkAll()`
- New Blade directives: `@canany()`/`@endcanany` and `@canall()`/`@endcanall`
- New Authorizable/AuthorizesRequests trait methods: `authorizeAny()`, `authorizeAll()`, `authorizeAnyForUser()`, `authorizeAllForuser()`, `canAny()`, `canAll()`

Usage is the same as existing methods, only you pass an array of abilities instead of a string. Blade example:

```
@canany (['edit', 'delete'], $message)
<tr>
    <td>
        <input type="checkbox" ...>
    </td>
</tr>
@endcanany
```
