### PR TITLE
[5.1] Fix Cache if expiration given as a DateTime in the past, or < 1 minute future

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -334,7 +334,7 @@ class Repository implements CacheContract, ArrayAccess
     protected function getMinutes($duration)
     {
         if ($duration instanceof DateTime) {
-            $fromNow = Carbon::instance($duration)->diffInMinutes();
+            $fromNow = Carbon::now()->diffInMinutes(Carbon::instance($duration), false);
 
             return $fromNow > 0 ? $fromNow : null;
         }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -152,8 +152,14 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function add($key, $value, $minutes)
     {
+        $minutes = $this->getMinutes($minutes);
+
+        if (is_null($minutes)) {
+            return false;
+        }
+
         if (method_exists($this->store, 'add')) {
-            return $this->store->add($key, $value, $this->getMinutes($minutes));
+            return $this->store->add($key, $value, $minutes);
         }
 
         if (is_null($this->get($key))) {

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -239,7 +239,7 @@ class TaggedCache implements Store
     protected function getMinutes($duration)
     {
         if ($duration instanceof DateTime) {
-            $fromNow = Carbon::instance($duration)->diffInMinutes();
+            $fromNow = Carbon::now()->diffInMinutes(Carbon::instance($duration), false);
 
             return $fromNow > 0 ? $fromNow : null;
         }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -68,6 +68,14 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $result);
     }
 
+    public function testPutWithDatetimeInPastOrZeroMinutesDoesntSaveItem()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('put')->never();
+        $repo->put('foo', 'bar', Carbon\Carbon::now()->subMinutes(10));
+        $repo->put('foo', 'bar', Carbon\Carbon::now()->addSeconds(5));
+    }
+
     public function testRegisterMacroWithNonStaticCall()
     {
         $repo = $this->getRepository();

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -76,6 +76,16 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase
         $repo->put('foo', 'bar', Carbon\Carbon::now()->addSeconds(5));
     }
 
+    public function testAddWithDatetimeInPastOrZeroMinutesReturnsImmediately()
+    {
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('add', 'get', 'put')->never();
+        $result = $repo->add('foo', 'bar', Carbon\Carbon::now()->subMinutes(10));
+        $this->assertSame(false, $result);
+        $result = $repo->add('foo', 'bar', Carbon\Carbon::now()->addSeconds(5));
+        $this->assertSame(false, $result);
+    }
+
     public function testRegisterMacroWithNonStaticCall()
     {
         $repo = $this->getRepository();


### PR DESCRIPTION
Background: by default, Carbon gives absolute values for differences (2nd param $abs = true by default).

Before #4294, when providing a DateTime in the past, getMinutes() was returning 0 (so, with some drivers, erroneously infinite storage).
After #4294, providing a DateTime in the past was erroneously returning a positive value…

Also, a DateTime of the same moment, with a difference < 1 minute, so 0 minutes, was resulting in an infinite storage.

All of this has been fixed in #5384, expect for two important things: the difference was reversed… and hasn't been put back to relative, non-absolute value (then overlooked in 83bcd1e5dfb7e2a5cd621ede3715cbe14042d776)

My first commit fixes the calculation. The second one fixes possible issues that could then have emerged more frequently.

<br>To summarize, the resulting behaviour:
with minutes as integer:
- positive number of minutes: just works.
- minutes = 0: Depends on the driver. Don't do it! Use `forever()`.
- negative number of minutes: Unsupported. Bad things may happen.

with DateTime:
- DateTime in future >= 1 minute: just works.
- DateTime in the past, or difference < 1 minute: no storage.
