### PR TITLE
[5.1] Return false instead of error if policy method does not exist

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -275,6 +275,10 @@ class Gate implements GateContract
                 }
             }
 
+            if (! method_exists($instance, $ability)) {
+                return false;
+            }
+
             return call_user_func_array(
                 [$instance, $ability], array_merge([$user], $arguments)
             );

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -111,6 +111,15 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
     }
 
+    public function test_policy_default_to_false_if_method_does_not_exist()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $this->assertFalse($gate->check('nonexistent_method', new AccessGateTestDummy));
+    }
+
     public function test_policy_classes_can_be_defined_to_handle_checks_for_given_class_name()
     {
         $gate = $this->getBasicGate();


### PR DESCRIPTION
The gate defaults to false when you call an ability that doesn't exist, but throws an error if you attempt to call a policy method that doesn't exist. With this change, I try to make the behavior more consistent.
