### PR TITLE
[5.1] Restore Cache test with DateTime, preventing possible race condition

### DIFF
--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -52,11 +52,14 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase
         /*
          * Use Carbon object...
          */
-        // $repo = $this->getRepository();
-        // $repo->getStore()->shouldReceive('get')->andReturn(null);
-        // $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 9);
-        // $result = $repo->remember('foo', Carbon\Carbon::now()->addMinutes(10), function() { return 'bar'; });
-        // $this->assertEquals('bar', $result);
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('get')->andReturn(null);
+        $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 10);
+        $repo->getStore()->shouldReceive('put')->once()->with('baz', 'qux', 9);
+        $result = $repo->remember('foo', Carbon\Carbon::now()->addMinutes(10)->addSeconds(2), function () { return 'bar'; });
+        $this->assertEquals('bar', $result);
+        $result = $repo->remember('baz', Carbon\Carbon::now()->addMinutes(10)->subSeconds(2), function () { return 'qux'; });
+        $this->assertEquals('qux', $result);
     }
 
     public function testRememberForeverMethodCallsForeverAndReturnsDefault()


### PR DESCRIPTION
I assume the test was sometimes failing due to a race condition: 

(now + 10 minutes) - (now again, but a liiiittle bit later) = 9.9996544555454 minutes, which ends up rounded at 9 minutes
- Added in d9da4dac225ba4dc1fb0f96127e36e259a59dfed (aka "hooray a bug fixed and a shiny test" commit)
- Modified in 95b9b6af667281479df79960f0f91c73e50be785 (aka "maybe? plz plz plz work" commit)
- Commented out in 981890ab3f2a92c11bdd6c348dc2bacee8b96fd6 (aka "nevermind, it's lunch time" commit)
