### PR TITLE
[5.1] Add Illuminate\Foundation\Testing\HttpException

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -263,7 +263,7 @@ trait CrawlerTrait
         } catch (PHPUnitException $e) {
             $message = $message ?: "A request to [{$uri}] failed. Received status code [{$status}].";
 
-            throw new PHPUnitException($message, null, $this->response->exception);
+            throw new HttpException($message, null, $this->response->exception);
         }
     }
 

--- a/src/Illuminate/Foundation/Testing/HttpException.php
+++ b/src/Illuminate/Foundation/Testing/HttpException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use PHPUnit_Framework_ExpectationFailedException;
+
+class HttpException extends PHPUnit_Framework_ExpectationFailedException
+{
+    //
+}


### PR DESCRIPTION
This would help testing failing routes, at the moment we have to use the following structure:

``` php
/**
 * You shall not pass!
 *
 * @expectedException PHPUnit_Framework_ExpectationFailedException
 * @expectedExceptionMessage Received status code [403]
 */
public function testUnauthorizedRoute()
{
    $this->visit('/test');
}
```

With this changes, we can make it more readable"-ish" with.

``` php
/**
 * You shall not pass!
 *
 * @expectedException Illuminate\Foundation\Testing\HttpException
 * @expectedExceptionMessage Received status code [403]
 */
public function testUnauthorizedRoute()
{
    $this->visit('/test');
}
```

Related Issues: #10202
