### PR TITLE
[5.1] added queue.finished event for tracking queue throughput

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -64,6 +64,17 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
+     * Register an event listener for the finishing job event.
+     *
+     * @param  mixed  $callback
+     * @return void
+     */
+    public function finishing($callback)
+    {
+        $this->app['events']->listen('illuminate.queue.finished', $callback);
+    }
+
+    /**
      * Register an event listener for the daemon queue stopping.
      *
      * @param  mixed  $callback

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -25,6 +25,7 @@ class SyncQueue extends Queue implements QueueContract
 
         try {
             $queueJob->fire();
+            $this->raiseFinishedJobEvent($queueJob);
         } catch (Exception $e) {
             $this->handleFailedJob($queueJob);
 
@@ -112,6 +113,21 @@ class SyncQueue extends Queue implements QueueContract
 
         if ($this->container->bound('events')) {
             $this->container['events']->fire('illuminate.queue.failed', ['sync', $job, $data]);
+        }
+    }
+
+    /**
+     * Raise the finished queue job event.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     */
+    protected function raiseFinishedJobEvent(Job $job)
+    {
+        $data = json_decode($job->getRawBody(), true);
+
+        if ($this->container->bound('events')) {
+            $this->container['events']->fire('illuminate.queue.finished', ['sync', $job, $data]);
         }
     }
 }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -207,6 +207,8 @@ class Worker
             // the delete method on the job. Otherwise we will just keep moving.
             $job->fire();
 
+            $this->raiseFinishedJobEvent($connection, $job);
+
             return ['job' => $job, 'failed' => false];
         } catch (Exception $e) {
             // If we catch an exception, we will attempt to release the job back onto
@@ -261,6 +263,22 @@ class Worker
             $data = json_decode($job->getRawBody(), true);
 
             $this->events->fire('illuminate.queue.failed', [$connection, $job, $data]);
+        }
+    }
+
+    /**
+     * Raise the finished queue job event.
+     *
+     * @param  string  $connection
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     */
+    protected function raiseFinishedJobEvent($connection, Job $job)
+    {
+        if ($this->events) {
+            $data = json_decode($job->getRawBody(), true);
+
+            $this->events->fire('illuminate.queue.finished', [$connection, $job, $data]);
         }
     }
 


### PR DESCRIPTION
Allows you to throw a call to StatsD in there via a closure or any number of things for specific use cases.
