### PR TITLE
make CrawlerTrait::getInputOrTextareaValue actually filter by input and textarea

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -496,7 +496,7 @@ trait CrawlerTrait
      */
     protected function getInputOrTextAreaValue($selector)
     {
-        $field = $this->filterByNameOrId($selector);
+        $field = $this->filterByNameOrId($selector)->filter('input, textarea');
 
         if ($field->count() == 0) {
             throw new Exception("There are no elements with the name or ID [$selector].");


### PR DESCRIPTION
Which would be as expected...

I have a field named `description` and was getting the description `meta` element instead.
