### PR TITLE
[5.1] Make CrawlerTrait::getInputOrTextareaValue actually filter by input and textarea

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -1027,7 +1027,7 @@ trait CrawlerTrait
     /**
      * Filter elements according to the given name or ID attribute.
      *
-     * @param  string        $name
+     * @param  string  $name
      * @param  array|string  $elements
      * @return \Symfony\Component\DomCrawler\Crawler
      */

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -496,7 +496,7 @@ trait CrawlerTrait
      */
     protected function getInputOrTextAreaValue($selector)
     {
-        $field = $this->filterByNameOrId($selector);
+        $field = $this->filterByNameOrId($selector, ['input', 'textarea']);
 
         if ($field->count() == 0) {
             throw new Exception("There are no elements with the name or ID [$selector].");
@@ -1027,15 +1027,25 @@ trait CrawlerTrait
     /**
      * Filter elements according to the given name or ID attribute.
      *
-     * @param  string  $name
-     * @param  string  $element
+     * @param  string        $name
+     * @param  array|string  $elements
      * @return \Symfony\Component\DomCrawler\Crawler
      */
-    protected function filterByNameOrId($name, $element = '*')
+    protected function filterByNameOrId($name, $elements = '*')
     {
         $name = str_replace('#', '', $name);
 
-        return $this->crawler->filter("{$element}#{$name}, {$element}[name='{$name}']");
+        if (is_array($elements)) {
+            array_walk($elements, function (&$element) use ($name) {
+                $element = "{$element}#{$name}, {$element}[name='{$name}']";
+            });
+
+            $filter = implode(', ', $elements);
+        } else {
+            $filter = "{$elements}#{$name}, {$elements}[name='{$name}']";
+        }
+
+        return $this->crawler->filter($filter);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -1035,17 +1035,13 @@ trait CrawlerTrait
     {
         $name = str_replace('#', '', $name);
 
-        if (is_array($elements)) {
-            array_walk($elements, function (&$element) use ($name) {
-                $element = "{$element}#{$name}, {$element}[name='{$name}']";
-            });
+        $elements = is_array($elements) ? $elements : [$elements];
 
-            $filter = implode(', ', $elements);
-        } else {
-            $filter = "{$elements}#{$name}, {$elements}[name='{$name}']";
-        }
+        array_walk($elements, function (&$element) use ($name) {
+            $element = "{$element}#{$name}, {$element}[name='{$name}']";
+        });
 
-        return $this->crawler->filter($filter);
+        return $this->crawler->filter(implode(', ', $elements));
     }
 
     /**

--- a/tests/Foundation/FoundationCrawlerTraitTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitTest.php
@@ -34,7 +34,7 @@ class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
     public function testSeeInFieldInput()
     {
         $this->crawler->shouldReceive('filter')
-            ->withArgs(["*#framework, *[name='framework']"])
+            ->withArgs(["input#framework, input[name='framework'], textarea#framework, textarea[name='framework']"])
             ->once()
             ->andReturn($this->mockInput('Laravel'));
 
@@ -44,7 +44,7 @@ class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
     public function testDontSeeInFieldInput()
     {
         $this->crawler->shouldReceive('filter')
-            ->withArgs(["*#framework, *[name='framework']"])
+            ->withArgs(["input#framework, input[name='framework'], textarea#framework, textarea[name='framework']"])
             ->once()
             ->andReturn($this->mockInput('Laravel'));
 
@@ -64,7 +64,7 @@ class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
     public function testSeeInFieldTextarea()
     {
         $this->crawler->shouldReceive('filter')
-            ->withArgs(["*#description, *[name='description']"])
+            ->withArgs(["input#description, input[name='description'], textarea#description, textarea[name='description']"])
             ->once()
             ->andReturn($this->mockTextarea('Laravel is awesome'));
 
@@ -74,7 +74,7 @@ class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
     public function testDontSeeInFieldTextarea()
     {
         $this->crawler->shouldReceive('filter')
-            ->withArgs(["*#description, *[name='description']"])
+            ->withArgs(["input#description, input[name='description'], textarea#description, textarea[name='description']"])
             ->once()
             ->andReturn($this->mockTextarea('Laravel is awesome'));
 
@@ -92,7 +92,7 @@ class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
         $select->shouldReceive('nodeName')->once()->andReturn('select');
 
         $this->crawler->shouldReceive('filter')
-            ->withArgs(["*#select, *[name='select']"])
+            ->withArgs(["input#select, input[name='select'], textarea#select, textarea[name='select']"])
             ->once()
             ->andReturn($select);
 


### PR DESCRIPTION
...as expected.

This fixes the scenario where you have a `meta` tag with a name of `description` on a page where you also have a `description` form field, resulting in a false-negative (i.e. the test fails when it should pass) when using `CrawlerTrait::seeInField`.
