### PR TITLE
build path should not be hardcoded

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -711,20 +711,21 @@ if (! function_exists('elixir')) {
      * Get the path to a versioned Elixir file.
      *
      * @param  string  $file
+     * @param  string  $path (optional) From public.path
      * @return string
      *
      * @throws \InvalidArgumentException
      */
-    function elixir($file)
+    function elixir($file, $path = 'build')
     {
         static $manifest = null;
 
         if (is_null($manifest)) {
-            $manifest = json_decode(file_get_contents(public_path('build/rev-manifest.json')), true);
+            $manifest = json_decode(file_get_contents(public_path(ltrim($path, "/").'/rev-manifest.json')), true);
         }
 
         if (isset($manifest[$file])) {
-            return '/build/'.$manifest[$file];
+            return '/'.ltrim($path, "/").'/'.$manifest[$file];
         }
 
         throw new InvalidArgumentException("File {$file} not defined in asset manifest.");


### PR DESCRIPTION
One could customize the elixir "version" build path as `elixir/version.js` has a `buildPath` parameter to be used in the `gulpfile.js`
see https://github.com/laravel/elixir/blob/master/tasks/version.js#L24

That's really great, but I suggest to avoid hardcoding `build` path in elixir PHP helper to be able to customize it there too if needed.
