### PR TITLE
[5.1] Add support casts's new type 'blob' and 'timestamp'

### DIFF
--- a/src/Illuminate/Database/BlobValue.php
+++ b/src/Illuminate/Database/BlobValue.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Database;
+
+use JsonSerializable;
+
+class BlobValue implements JsonSerializable
+{
+    private $_value = '';
+
+    public function __construct($value)
+    {
+        $this->_value = strval($value);
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->_value;
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->_value;
+    }
+}


### PR DESCRIPTION
I am not native English speaker.
Please forgive me my lousy English.

Change binding query parmeter to PDOStatement to PDOStatement::bindValue().

Eloquent don't support binary(blob) data, because it don't specify 'data_type'(PDO::PARAM_*) when bind query parameter to PDOStatement.

I create a patch to fix the problem.
This patch is adding new class 'BlobValue' to mark value as 'Blob data'.

When building query and parameter, specify data_type(PDO::PARAM_LOB) or other by each parameters.

And add 'timestamp' casts type also.
