### PR TITLE
[5.1] PHPDoc should @return bool instead of void

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -172,7 +172,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      * Dynamically check if an attribute is set.
      *
      * @param  string  $key
-     * @return void
+     * @return bool
      */
     public function __isset($key)
     {


### PR DESCRIPTION
`isset()` returns a boolean, so this method `__isset()` on the `Fluent` class should have `bool` in the PHPDoc's `@return` tag.
