### PR TITLE
[5.2] Ensure LengthAwarePaginator works in the same way as Paginator

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -47,7 +47,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         $this->perPage = $perPage;
         $this->lastPage = (int) ceil($total / $perPage);
         $this->currentPage = $this->setCurrentPage($currentPage, $this->lastPage);
-        $this->path = $this->path != '/' ? rtrim($this->path, '/').'/' : $this->path;
+        $this->path = $this->path != '/' ? rtrim($this->path, '/') : $this->path;
         $this->items = $items instanceof Collection ? $items : Collection::make($items);
     }
 

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -37,9 +37,18 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase
     {
         $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, ['path' => 'http://website.com', 'pageName' => 'foo']);
 
-        $this->assertEquals('http://website.com/?foo=2', $p->url($p->currentPage()));
-        $this->assertEquals('http://website.com/?foo=1', $p->url($p->currentPage() - 1));
-        $this->assertEquals('http://website.com/?foo=1', $p->url($p->currentPage() - 2));
+        $this->assertEquals('http://website.com?foo=2', $p->url($p->currentPage()));
+        $this->assertEquals('http://website.com?foo=1', $p->url($p->currentPage() - 1));
+        $this->assertEquals('http://website.com?foo=1', $p->url($p->currentPage() - 2));
+    }
+
+    public function testLengthAwarePaginatorCanGenerateUrlsWithoutTrailingSlashes()
+    {
+        $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, ['path' => 'http://website.com/test/', 'pageName' => 'foo']);
+
+        $this->assertEquals('http://website.com/test?foo=2', $p->url($p->currentPage()));
+        $this->assertEquals('http://website.com/test?foo=1', $p->url($p->currentPage() - 1));
+        $this->assertEquals('http://website.com/test?foo=1', $p->url($p->currentPage() - 2));
     }
 
     public function testPresenterCanDetermineIfThereAreAnyPagesToShow()


### PR DESCRIPTION
Does the same as #10217 but for the LengthAwarePaginator, to ensure consistent behaviour
