### PR TITLE
[5.1] Always return a morph class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2071,7 +2071,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $class = get_class($this);
 
-        if (! empty($morphMap)) {
+        if (! empty($morphMap) && in_array($class, $morphMap)) {
             return array_search($class, $morphMap, true);
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2,6 +2,7 @@
 
 use Mockery as m;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 {
@@ -816,6 +817,17 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('save_stub.morph_id', $relation->getForeignKey());
         $this->assertEquals('save_stub.morph_type', $relation->getMorphType());
         $this->assertEquals('EloquentModelStub', $relation->getMorphClass());
+    }
+
+    public function testCorrectMorphClassIsReturned()
+    {
+        Relation::morphMap([
+            'alias' => 'AnotherModel',
+        ]);
+        $model = new EloquentModelStub;
+        $this->assertEquals('EloquentModelStub', $model->getMorphClass());
+
+        Relation::morphMap([], false);
     }
 
     public function testHasManyCreatesProperRelation()


### PR DESCRIPTION
This should resolve #10167 by always checking if the class is first mapped, rather than merely checking if the morph map exists before running `array_search`.
