### PR TITLE
[5.1] CrawlerTrait::seeIsSelected doesn't need to be so strict

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -461,7 +461,7 @@ trait CrawlerTrait
      */
     public function seeIsSelected($selector, $expected)
     {
-        $this->assertSame(
+        $this->assertEquals(
             $expected, $this->getSelectedValue($selector),
             "The field [{$selector}] does not contain the selected value [{$expected}]."
         );
@@ -478,7 +478,7 @@ trait CrawlerTrait
      */
     public function dontSeeIsSelected($selector, $value)
     {
-        $this->assertNotSame(
+        $this->assertNotEquals(
             $value, $this->getSelectedValue($selector),
             "The field [{$selector}] contains the selected value [{$value}]."
         );


### PR DESCRIPTION
The problem is `CrawlerTrait::getSelectedValue($selector)` returns a `string`, and `assertSame` compares types.

**_Example scenario:**_ I have a select field to choose a relationship with the values being IDs. So, unless I cast my relationship IDs to strings for the tests it will fail. 

Changing the test in `seeIsSelected` to `assertEquals` instead of `assertSame` fixes that.
