### PR TITLE
[5.1] Added sequence validation rule

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -779,6 +779,18 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Validate that an attribute is a sequential array.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    protected function validateSequence($attribute, $value)
+    {
+        return is_array($value) && (array_keys($value) === range(0, count($value) - 1));
+    }
+
+    /**
      * Validate that an attribute is a boolean.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -533,6 +533,17 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateSequence()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => ['bar', 'baz']], ['foo' => 'sequence']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => ['bar' => 'baz']], ['foo' => 'sequence']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateString()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
To be sure that an input is a sequential array `['foo', 'bar']` not an associative one `['foo' => 'bar']` or `[0 => 'foo', 2 => 'bar']`; one can use the new `sequence` validation rule.
## The motivation

Knowing the $input1, and $input2 are sequences of the same size makes it safe to do 

``` php
for($i = 0; $i <= $n; $i++)
    doSomething($input1[$i], $input2[$i]);
```

or

``` php
foreach($input1 as $key => $value)
    doSomething($value, $input2[$key]);
```
