### PR TITLE
[5.1] Allow different namespace roots within RouteGroups

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -417,7 +417,7 @@ class Router implements RegistrarContract
     protected static function formatUsesPrefix($new, $old)
     {
         if (isset($new['namespace'])) {
-            // If a namespace is provided and prefixed by a '\' character this should
+            // If a namespace is provided and prefixed by a '\' character, this should
             // be interpreted as the start of a new namespace and shouldn't be put
             // upon the stacked namespaces inherited from predescessing groups.
             if (substr(trim($new['namespace']), 0, 1) === '\\') {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -417,6 +417,13 @@ class Router implements RegistrarContract
     protected static function formatUsesPrefix($new, $old)
     {
         if (isset($new['namespace'])) {
+            // If a namespace is provided and prefixed by a '\' character this should
+            // be interpreted as the start of a new namespace and shouldn't be put
+            // upon the stacked namespaces inherited from predescessing groups.
+            if (substr(trim($new['namespace']), 0, 1) === '\\') {
+                return trim($new['namespace'], '\\');
+            }
+
             return isset($old['namespace'])
                     ? trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\')
                     : trim($new['namespace'], '\\');


### PR DESCRIPTION
This will fix the behaviour as described below.

Imagine a package with a service provider that creates a Router macro to include all the required routes for the package.
Like this:

```
$this->app['router']->macro('package', function () {
    $this->group(['prefix' => 'package', 'namespace' => '\Vendor\Package\Http\Controllers'], function ($router) {
        $router->get('demo', 'DemosController@getDemo');
    });
});
```

Then in the `routes.php` file this macro will be called in the way described below:

```
Route::group(['prefix' => 'admin', 'namespace' => 'Admin'], function() {
    Route::get('dashboard', 'HomeController@getDashboard');

    Route::package();
});
```

This should result in the following routes:

```
/admin/dashboard    -> App\Http\Controllers\Admin\HomeController@getDashboard
/admin/package/demo -> Vendor\Package\Http\Controllers\DemosController@getDemo 
```

but in fact this results in:

```
/admin/dashboard    -> App\Http\Controllers\Admin\HomeController@getDashboard
/admin/package/demo -> App\Http\Controllers\Admin\Vendor\Package\Http\Controllers\DemosController@getDemo 
```

As a result of this the controllers outside of the current scope are not found.

Therefor it should be possible to break out of the namespace stack when the namespace is explicitly prefix with a '\' symbol.
