### PR TITLE
[5.1] Add array dig function

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -77,7 +77,7 @@ class Arr
         $results = [];
 
         foreach ($array as $key => $value) {
-            array_set($results, $key, $value);
+            static::set($results, $key, $value);
         }
 
         return $results;

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -67,6 +67,23 @@ class Arr
     }
 
     /**
+     * Create a deep nested array using "dot" notation.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function dig($array)
+    {
+        $results = [];
+
+        foreach($array as $key => $value) {
+            array_set($results, $key, $value);
+        }
+
+        return $results;
+    }
+
+    /**
      * Divide an array into two arrays. One with keys and the other with values.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -76,7 +76,7 @@ class Arr
     {
         $results = [];
 
-        foreach($array as $key => $value) {
+        foreach ($array as $key => $value) {
             array_set($results, $key, $value);
         }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -71,6 +71,19 @@ if (! function_exists('array_collapse')) {
     }
 }
 
+if (! function_exists('array_dig')) {
+    /**
+     * Create a deep nested array using "dot" notation.
+     *
+     * @param  array   $array
+     * @return array
+     */
+    function array_dig($array)
+    {
+        return Arr::dig($array);
+    }
+}
+
 if (! function_exists('array_divide')) {
     /**
      * Divide an array into two arrays. One with keys and the other with values.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -75,7 +75,7 @@ if (! function_exists('array_dig')) {
     /**
      * Create a deep nested array using "dot" notation.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @return array
      */
     function array_dig($array)

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -10,6 +10,12 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
     }
 
+    public function testDig()
+    {
+        $array = Arr::dig(['foo.bar' => 'baz']);
+        $this->assertEquals(['foo' => ['bar' => 'baz']], $array);
+    }
+
     public function testDivide()
     {
         list($keys, $values) = Arr::divide(['name' => 'Desk']);


### PR DESCRIPTION
Add Arr::dig($array) as well as the array_dig($array) helper.

Array dig convert a "dot" notion into a deep nested array.  Works similar to Arr::set() but retains the "dot" notion array value.
