### PR TITLE
[5.1] allow $casts to transform date and datetime fields

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2748,6 +2748,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Determine whether a value is Date / DateTime castable for inbound manipulation.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isDateCastable($key)
+    {
+        return $this->hasCast($key) && in_array($this->getCastType($key), ['date', 'datetime'], true);
+    }
+
+    /**
      * Determine whether a value is JSON castable for inbound manipulation.
      *
      * @param  string  $key
@@ -2755,13 +2766,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function isJsonCastable($key)
     {
-        if ($this->hasCast($key)) {
-            return in_array(
-                $this->getCastType($key), ['array', 'json', 'object', 'collection'], true
-            );
-        }
-
-        return false;
+        return $this->hasCast($key) && in_array($this->getCastType($key), ['array', 'json', 'object', 'collection'], true);
     }
 
     /**
@@ -2837,7 +2842,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // If an attribute is listed as a "date", we'll convert it from a DateTime
         // instance into a form proper for storage on the database tables using
         // the connection grammar's date format. We will auto set the values.
-        elseif (in_array($key, $this->getDates()) && $value) {
+        elseif ((in_array($key, $this->getDates()) || $this->isDateCastable($key)) && $value) {
             $value = $this->fromDateTime($value);
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2808,6 +2808,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 return json_decode($value, true);
             case 'collection':
                 return new BaseCollection(json_decode($value, true));
+            case 'date':
+            case 'datetime':
+                return $this->asDateTime($value);
             default:
                 return $value;
         }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1158,6 +1158,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $obj->foo = 'bar';
         $model->seventh = $obj;
         $model->eighth = ['foo' => 'bar'];
+        $model->ninth = '1969-07-20';
+        $model->tenth = '1969-07-20 22:56:00';
 
         $this->assertInternalType('int', $model->first);
         $this->assertInternalType('float', $model->second);
@@ -1173,6 +1175,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'bar'], $model->seventh);
         $this->assertEquals(['foo' => 'bar'], $model->eighth);
         $this->assertEquals('{"foo":"bar"}', $model->eighthAttributeValue());
+        $this->assertInstanceOf('Carbon\Carbon', $model->ninth);
+        $this->assertInstanceOf('Carbon\Carbon', $model->tenth);
+        $this->assertEquals('1969-07-20', $model->ninth->toDateString());
+        $this->assertEquals('1969-07-20 22:56:00', $model->tenth->toDateTimeString());
 
         $arr = $model->toArray();
         $this->assertInternalType('int', $arr['first']);
@@ -1188,6 +1194,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($obj, $arr['sixth']);
         $this->assertEquals(['foo' => 'bar'], $arr['seventh']);
         $this->assertEquals(['foo' => 'bar'], $arr['eighth']);
+        $this->assertInstanceOf('Carbon\Carbon', $arr['ninth']);
+        $this->assertInstanceOf('Carbon\Carbon', $arr['tenth']);
+        $this->assertEquals('1969-07-20', $arr['ninth']->toDateString());
+        $this->assertEquals('1969-07-20 22:56:00', $arr['tenth']->toDateTimeString());
     }
 
     public function testModelAttributeCastingPreservesNull()
@@ -1201,6 +1211,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model->sixth = null;
         $model->seventh = null;
         $model->eighth = null;
+        $model->ninth = null;
+        $model->tenth = null;
 
         $attributes = $model->getAttributes();
 
@@ -1212,6 +1224,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertNull($attributes['sixth']);
         $this->assertNull($attributes['seventh']);
         $this->assertNull($attributes['eighth']);
+        $this->assertNull($attributes['ninth']);
+        $this->assertNull($attributes['tenth']);
 
         $this->assertNull($model->first);
         $this->assertNull($model->second);
@@ -1221,6 +1235,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertNull($model->sixth);
         $this->assertNull($model->seventh);
         $this->assertNull($model->eighth);
+        $this->assertNull($model->ninth);
+        $this->assertNull($model->tenth);
 
         $array = $model->toArray();
 
@@ -1232,6 +1248,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertNull($array['sixth']);
         $this->assertNull($array['seventh']);
         $this->assertNull($array['eighth']);
+        $this->assertNull($array['ninth']);
+        $this->assertNull($array['tenth']);
     }
 
     protected function addMockConnection($model)
@@ -1467,6 +1485,8 @@ class EloquentModelCastingStub extends Model
         'sixth' => 'object',
         'seventh' => 'array',
         'eighth' => 'json',
+        'ninth' => 'date',
+        'tenth' => 'datetime',
     ];
 
     public function eighthAttributeValue()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1148,6 +1148,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     public function testModelAttributesAreCastedWhenPresentInCastsArray()
     {
         $model = new EloquentModelCastingStub;
+        $model->setDateFormat('Y-m-d H:i:s');
         $model->first = '3';
         $model->second = '4.0';
         $model->third = 2.5;


### PR DESCRIPTION
This transforms fields marked as date & datetime to carbon objects. Its nice to consolidate this logic in one in certain cases instead of spreading it around to multiple variables.
