### PR TITLE
adds response status to successful password reset redirect

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -92,7 +92,7 @@ trait ResetsPasswords
 
         switch ($response) {
             case Password::PASSWORD_RESET:
-                return redirect($this->redirectPath());
+                return redirect($this->redirectPath())->with('status', trans($response));
 
             default:
                 return redirect()->back()


### PR DESCRIPTION
ResetsPasswords::postEmail already provides this functionality, this mimics it in postReset so that a success response can be displayed on redirect.
