### PR TITLE
[5.1] Remove unnecessary use statement and use FQCNs for DocBlocks

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/controller.plain.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.plain.stub
@@ -3,8 +3,6 @@
 namespace DummyNamespace;
 
 use Illuminate\Http\Request;
-
-use DummyRootNamespaceHttp\Requests;
 use DummyRootNamespaceHttp\Controllers\Controller;
 
 class DummyClass extends Controller

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -3,8 +3,6 @@
 namespace DummyNamespace;
 
 use Illuminate\Http\Request;
-
-use DummyRootNamespaceHttp\Requests;
 use DummyRootNamespaceHttp\Controllers\Controller;
 
 class DummyClass extends Controller
@@ -12,7 +10,7 @@ class DummyClass extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function index()
     {
@@ -22,7 +20,7 @@ class DummyClass extends Controller
     /**
      * Show the form for creating a new resource.
      *
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function create()
     {
@@ -32,8 +30,8 @@ class DummyClass extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  Request  $request
-     * @return Response
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
      */
     public function store(Request $request)
     {
@@ -44,7 +42,7 @@ class DummyClass extends Controller
      * Display the specified resource.
      *
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function show($id)
     {
@@ -55,7 +53,7 @@ class DummyClass extends Controller
      * Show the form for editing the specified resource.
      *
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function edit($id)
     {
@@ -65,9 +63,9 @@ class DummyClass extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  Request  $request
+     * @param  \Illuminate\Http\Request  $request
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function update(Request $request, $id)
     {
@@ -78,7 +76,7 @@ class DummyClass extends Controller
      * Remove the specified resource from storage.
      *
      * @param  int  $id
-     * @return Response
+     * @return \Illuminate\Http\Response
      */
     public function destroy($id)
     {


### PR DESCRIPTION
The title pretty much says it all. This modifies the controller stubs to remove the `use App\Http\Requests`, which is both unused and non-existent, and uses FQCNs in DocBlock. Also removed a couple lines for PSR-2.
