### PR TITLE
Add getKeyName to Authenticatable

### DIFF
--- a/src/Illuminate/Contracts/Auth/Authenticatable.php
+++ b/src/Illuminate/Contracts/Auth/Authenticatable.php
@@ -10,6 +10,13 @@ interface Authenticatable
      * @return mixed
      */
     public function getAuthIdentifier();
+    
+    /**
+     * Get the primary key for the model.
+     *
+     * @return string
+     */
+     public function getKeyName();
 
     /**
      * Get the password for the user.


### PR DESCRIPTION
In EloquentUserProvider `getKeyName()` is called in `retrieveByToken()`. 
It would be very useful if this method would exist on the contract as well, so non-Eloquent implementations can implement the interface as well without having to define a new interface that extends Authenticatable. No breaking changes for Eloquent usage.
