### PR TITLE
[5.1] Quote PHP_BINARY's that have spaces

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -42,7 +42,7 @@ class Schedule
             $artisan = 'artisan';
         }
 
-        return $this->exec(PHP_BINARY.' "'.$artisan.'" '.$command, $parameters);
+        return $this->exec('"'.PHP_BINARY.'" "'.$artisan.'" '.$command, $parameters);
     }
 
     /**


### PR DESCRIPTION
When trying to use scheduler with a PHP_BINARY path that has a space in it, the command cannot run. Quoting the path resolves the problem. This fixes Issue #10187.
