### PR TITLE
Use is_callable() in Gate::resolvePolicyCallback()

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -275,7 +275,7 @@ class Gate implements GateContract
                 }
             }
 
-            if (! method_exists($instance, $ability)) {
+            if (! is_callable([$instance, $ability])) {
                 return false;
             }
 


### PR DESCRIPTION
The `method_exists()` function only checks for hard coded methods on objects. However using the `is_callable()` function will consider methods added to policies using `__call()`.
