### PR TITLE
[5.1] Ask developer to install sqlite when driver is not found.

### DIFF
--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -585,7 +585,16 @@ class DatabaseIntegrationTestConnectionResolver implements Illuminate\Database\C
             return $this->connection;
         }
 
-        return $this->connection = new Illuminate\Database\SQLiteConnection(new PDO('sqlite::memory:'));
+        $driver = 'sqlite';
+        try {
+            return $this->connection = new Illuminate\Database\SQLiteConnection(new PDO("$driver::memory:"));
+        } catch (PDOException $e) {
+            if (ends_with($msg = $e->getMessage(), 'could not find driver')) {
+                throw new PDOException("$msg - please install $driver.", $e->getCode());
+            }
+
+            throw $e;
+        }
     }
 
     public function getDefaultConnection()

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -181,7 +181,16 @@ class SoftDeletesDatabaseIntegrationTestConnectionResolver implements Illuminate
             return $this->connection;
         }
 
-        return $this->connection = new Illuminate\Database\SQLiteConnection(new PDO('sqlite::memory:'));
+        $driver = 'sqlite';
+        try {
+            return $this->connection = new Illuminate\Database\SQLiteConnection(new PDO("$driver::memory:"));
+        } catch (PDOException $e) {
+            if (ends_with($msg = $e->getMessage(), 'could not find driver')) {
+                throw new PDOException("$msg - please install $driver.", $e->getCode());
+            }
+
+            throw $e;
+        }
     }
 
     public function getDefaultConnection()


### PR DESCRIPTION
The situation: wanted to contribute, forked `laravel/framework`, ran `composer install`, then ran `phpunit`.

I got the following nondescript error:

```
14) DatabaseEloquentIntegrationTest::testHasOnSelfReferencingHasManyRelationship
PDOException: could not find driver

/var/www/framework/tests/Database/DatabaseEloquentIntegrationTest.php:588
/var/www/framework/tests/Database/DatabaseEloquentIntegrationTest.php:495
/var/www/framework/tests/Database/DatabaseEloquentIntegrationTest.php:505
/var/www/framework/tests/Database/DatabaseEloquentIntegrationTest.php:42
```

Most Google hits said "install PDO extension" (which was installed) but after further digging it turns out sqlite wasn't installed. Ideally, that would be mentioned as a requirement for successful tests.

This displays a more friendly error message when the problem happens (note the "please install sqlite") - but only if it's a driver not found error.

```
57) DatabaseEloquentSoftDeletesIntegrationTest::testRestoreRestoresRecords
PDOException: could not find driver - please install sqlite.

/var/www/framework/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php:189
/var/www/framework/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php:145
/var/www/framework/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php:155
/var/www/framework/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php:42
```

To reproduce this behaviour on a debian machine:

```
# Uninstall sqlite
sudo apt-get remove php5-sqlite
phpunit

# Reinstall sqlite
sudo apt-get install php5-sqlite
phpunit
```
