### PR TITLE
[5.1] Middleware fluent method not working

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -271,9 +271,13 @@ class Route
             $middleware = [$middleware];
         }
 
-        $this->action['middleware'] = array_merge(
-            array_get($this->action['middleware'], []), $middleware
-        );
+        if (isset($this->action['middleware'])) {
+            $this->action['middleware'] = array_merge(
+                array_get($this->action['middleware'], []), $middleware
+            );
+        } else {
+            $this->action['middleware'] = $middleware;
+        }
 
         return $this;
     }


### PR DESCRIPTION
Fixes an issue where an `Undefined index: middleware` error is thrown when using the `middleware` fluent route method.
