### PR TITLE
[5.1] Use write pdo when locking for update

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1272,6 +1272,10 @@ class Builder
     {
         $this->lock = $value;
 
+        if ($this->lock) {
+            $this->useWritePdo();
+        }
+
         return $this;
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1166,6 +1166,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
+    public function testSelectWithLockUsesWritePdo()
+    {
+        $builder = $this->getMySqlBuilderWithProcessor();
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->with(m::any(), m::any(), false);
+        $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock()->get();
+    }
+
     public function testBindingOrder()
     {
         $expectedSql = 'select * from "users" inner join "othertable" on "bar" = ? where "registered" = ? group by "city" having "population" > ? order by match ("foo") against(?)';


### PR DESCRIPTION
Whenever you query locking for update on a read-only database you'll get:
`cannot execute SELECT FOR UPDATE in a read-only transaction`.

This PR makes sure the writePdo is used when `lockForUpdate` is used
