### PR TITLE
[5.1] Fixes case where noConstraints callback throws exception leaving relationship without constraints

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -167,9 +167,11 @@ abstract class Relation
         // When resetting the relation where clause, we want to shift the first element
         // off of the bindings, leaving only the constraints that the developers put
         // as "extra" on the relationships, and not original relation constraints.
-        $results = call_user_func($callback);
-
-        static::$constraints = $previous;
+        try {
+            $results = call_user_func($callback);
+        } finally {
+            static::$constraints = $previous;
+        }
 
         return $results;
     }


### PR DESCRIPTION
The bug causes problems for example when an attempted eager nested relationship is defined incorrectly resulting in a `BadMethodCallException`. If the exception is caught and the relationship is attempted again it results in incorrect results (constraints removed).

This is especially problematic in test suites, as the exception might have been asserted earlier and a subsequent unrelated test fails due to the constraints being removed.
