### PR TITLE
[5.2] Cleanup name command

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -79,8 +79,6 @@ class AppNameCommand extends Command
 
         $this->setDatabaseFactoryNamespaces();
 
-        $this->setPhpSpecNamespace();
-
         $this->info('Application namespace set!');
 
         $this->composer->dumpAutoloads();
@@ -200,7 +198,7 @@ class AppNameCommand extends Command
     protected function setAuthConfigNamespace()
     {
         $this->replaceIn(
-            $this->getAuthConfigPath(), $this->currentRoot.'\\User', $this->argument('name').'\\User'
+            $this->getConfigPath('auth'), $this->currentRoot.'\\User', $this->argument('name').'\\User'
         );
     }
 
@@ -212,20 +210,8 @@ class AppNameCommand extends Command
     protected function setServicesConfigNamespace()
     {
         $this->replaceIn(
-            $this->getServicesConfigPath(), $this->currentRoot.'\\User', $this->argument('name').'\\User'
+            $this->getConfigPath('services'), $this->currentRoot.'\\User', $this->argument('name').'\\User'
         );
-    }
-
-    /**
-     * Set the PHPSpec configuration namespace.
-     *
-     * @return void
-     */
-    protected function setPhpSpecNamespace()
-    {
-        if ($this->files->exists($path = $this->getPhpSpecConfigPath())) {
-            $this->replaceIn($path, $this->currentRoot, $this->argument('name'));
-        }
     }
 
     /**
@@ -292,36 +278,6 @@ class AppNameCommand extends Command
     protected function getConfigPath($name)
     {
         return $this->laravel['path.config'].'/'.$name.'.php';
-    }
-
-    /**
-     * Get the path to the authentication configuration file.
-     *
-     * @return string
-     */
-    protected function getAuthConfigPath()
-    {
-        return $this->getConfigPath('auth');
-    }
-
-    /**
-     * Get the path to the services configuration file.
-     *
-     * @return string
-     */
-    protected function getServicesConfigPath()
-    {
-        return $this->getConfigPath('services');
-    }
-
-    /**
-     * Get the path to the PHPSpec configuration file.
-     *
-     * @return string
-     */
-    protected function getPhpSpecConfigPath()
-    {
-        return $this->laravel->basePath().'/phpspec.yml';
     }
 
     /**


### PR DESCRIPTION
1. We already call `getConfigPath('app')` in here, so why do we need dedicated methods for auth and services? I've removed them.
2. The 5.2 default app doesn't ship with phpspec because phpspec doesn't work with symfony 3, so I've removed that.
