### PR TITLE
Add type hint to Manager constructor

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Closure;
 use InvalidArgumentException;
+use Illuminate\Foundation\Application;
 
 abstract class Manager
 {
@@ -34,7 +35,7 @@ abstract class Manager
      * @param  \Illuminate\Foundation\Application  $app
      * @return void
      */
-    public function __construct($app)
+    public function __construct(Application $app)
     {
         $this->app = $app;
     }


### PR DESCRIPTION
When injecting Socialite into a constructor/method, I got this error:

![image](https://cloud.githubusercontent.com/assets/3512335/10017615/5c189fe6-6130-11e5-9365-9993b40d1ae3.png)

This fixes the error.
