### PR TITLE
[5.1] Safeguard User password is encrypted before sending to database

### DIFF
--- a/src/Illuminate/Auth/Authenticatable.php
+++ b/src/Illuminate/Auth/Authenticatable.php
@@ -25,6 +25,19 @@ trait Authenticatable
     }
 
     /**
+     * Encrypt the password if not hashed already.
+     *
+     * @param  string  $value
+     * @return void
+     */
+    public function setPasswordAttribute($value)
+    {
+        $value = app('hash')->needsRehash($value) ? bcrypt($value) : $value;
+
+        $this->attributes['password'] = $value;
+    }
+
+    /**
      * Get the token value for the "remember me" session.
      *
      * @return string


### PR DESCRIPTION
In several places Laravel assumes that a password is either encrypted or unencrypted (e.g. `ResetPasswords`, `Guard`, ...). This works great if one uses _only_ the built-in user management tools Laravel provides (such as authentication, password reset, user creation).

In case a developer wants to code tailored versions of a user registration or update routine, the developer currently has to hash the received password explicitly using `bcrypt()` before sending it to the User model. Otherwise plain passwords are being stored in the database and some functions will start to fail.

This tiny PR overcomes this behavior by introducing a mutator for the password attribute. It sort of abuses `Hash::needsRehash` to determine if the passed value is a plain string and then hashes the value if it is not a hash.

This way it is assured that any password value that is being passed to the User model gets inserted into the database as a hash.
So both
`User::create(['password' => 'myValue'])`
`User::create(['password' => bcrypt('myValue')])`
will yield the same hash being inserted into the database.
