### PR TITLE
[5.1] Fixed changes event class with ShouldBroadcast interface and SerializedModels trait

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -258,7 +258,7 @@ class Dispatcher implements DispatcherContract
             $queue = method_exists($event, 'onQueue') ? $event->onQueue() : null;
 
             $this->resolveQueue()->connection($connection)->pushOn($queue, 'Illuminate\Broadcasting\BroadcastEvent', [
-                'event' => serialize($event),
+                'event' => serialize(clone $event),
             ]);
         }
     }


### PR DESCRIPTION
When event implementing _ShouldBroadcast_ interface and uses _SerializedModels_ trait, in the event listeners, the event coming with _ModelIdentifier_ model properties.
