### PR TITLE
[5.1] Allow uppercase booleans

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -756,6 +756,6 @@ class Grammar extends BaseGrammar
      */
     protected function removeLeadingBoolean($value)
     {
-        return preg_replace('/and |or /', '', $value, 1);
+        return preg_replace('/and |AND |or |OR /', '', $value, 1);
     }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1248,6 +1248,20 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expectedBindings, $builder->getBindings());
     }
 
+    public function testUppercaseLeadingBooleansAreRemoved()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('name', '=', 'Taylor', 'AND');
+        $this->assertEquals('select * from "users" where "name" = ?', $builder->toSql());
+    }
+
+    public function testLowercaseLeadingBooleansAreRemoved()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('name', '=', 'Taylor', 'and');
+        $this->assertEquals('select * from "users" where "name" = ?', $builder->toSql());
+    }
+
     protected function getBuilder()
     {
         $grammar = new Illuminate\Database\Query\Grammars\Grammar;


### PR DESCRIPTION
This resolves #10173 by extending the `preg_replace` being used to ensure both `and` and `AND` are treated the same way.
