### PR TITLE
[5.1] ConfirmableTrait: Allow booleans for callback

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -10,14 +10,16 @@ trait ConfirmableTrait
      * Confirm before proceeding with the action.
      *
      * @param  string    $warning
-     * @param  \Closure|null  $callback
+     * @param  \Closure|bool|null  $callback
      * @return bool
      */
-    public function confirmToProceed($warning = 'Application In Production!', Closure $callback = null)
+    public function confirmToProceed($warning = 'Application In Production!', $callback = null)
     {
-        $shouldConfirm = $callback ?: $this->getDefaultConfirmCallback();
+        $callback = is_null($callback) ? $this->getDefaultConfirmCallback() : $callback;
 
-        if (call_user_func($shouldConfirm)) {
+        $shouldConfirm = $callback instanceof Closure ? call_user_func($callback) : $callback;
+
+        if ($shouldConfirm) {
             if ($this->option('force')) {
                 return true;
             }


### PR DESCRIPTION
Permits a cleaner simple usage for ConfirmableTrait's `confirmToProceed()`, allowing boolean values as an alternative to nesting flags in functions. Closure and null values continue to work as they currently do, while other values which previously would error on the type hint are now passed directly along for the if-check.
