### PR TITLE
[5.1] Simplify removeLeadingBoolean

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -756,6 +756,6 @@ class Grammar extends BaseGrammar
      */
     protected function removeLeadingBoolean($value)
     {
-        return preg_replace('/and |AND |or |OR /', '', $value, 1);
+        return preg_replace('/(and|or) /i', '', $value, 1);
     }
 }


### PR DESCRIPTION
We can simply use the case insensitive option, and the following cases can also be handled : Or, oR, and so on
