### PR TITLE
[5.1] Add empty comments to empty classes

### DIFF
--- a/src/Illuminate/Container/BindingResolutionException.php
+++ b/src/Illuminate/Container/BindingResolutionException.php
@@ -9,4 +9,5 @@ use Exception;
  */
 class BindingResolutionException extends Exception
 {
+    //
 }

--- a/src/Illuminate/Contracts/Bus/SelfHandling.php
+++ b/src/Illuminate/Contracts/Bus/SelfHandling.php
@@ -4,4 +4,5 @@ namespace Illuminate\Contracts\Bus;
 
 interface SelfHandling
 {
+    //
 }

--- a/src/Illuminate/Contracts/Container/BindingResolutionException.php
+++ b/src/Illuminate/Contracts/Container/BindingResolutionException.php
@@ -6,4 +6,5 @@ use Illuminate\Container\BindingResolutionException as BaseException;
 
 class BindingResolutionException extends BaseException
 {
+    //
 }

--- a/src/Illuminate/Contracts/Encryption/DecryptException.php
+++ b/src/Illuminate/Contracts/Encryption/DecryptException.php
@@ -6,4 +6,5 @@ use RuntimeException;
 
 class DecryptException extends RuntimeException
 {
+    //
 }

--- a/src/Illuminate/Contracts/Encryption/EncryptException.php
+++ b/src/Illuminate/Contracts/Encryption/EncryptException.php
@@ -6,4 +6,5 @@ use RuntimeException;
 
 class EncryptException extends RuntimeException
 {
+    //
 }

--- a/src/Illuminate/Contracts/Filesystem/Cloud.php
+++ b/src/Illuminate/Contracts/Filesystem/Cloud.php
@@ -4,4 +4,5 @@ namespace Illuminate\Contracts\Filesystem;
 
 interface Cloud extends Filesystem
 {
+    //
 }

--- a/src/Illuminate/Contracts/Filesystem/FileNotFoundException.php
+++ b/src/Illuminate/Contracts/Filesystem/FileNotFoundException.php
@@ -6,4 +6,5 @@ use Exception;
 
 class FileNotFoundException extends Exception
 {
+    //
 }

--- a/src/Illuminate/Contracts/Queue/ShouldBeQueued.php
+++ b/src/Illuminate/Contracts/Queue/ShouldBeQueued.php
@@ -7,4 +7,5 @@ namespace Illuminate\Contracts\Queue;
  */
 interface ShouldBeQueued extends ShouldQueue
 {
+    //
 }

--- a/src/Illuminate/Contracts/Queue/ShouldQueue.php
+++ b/src/Illuminate/Contracts/Queue/ShouldQueue.php
@@ -4,4 +4,5 @@ namespace Illuminate\Contracts\Queue;
 
 interface ShouldQueue
 {
+    //
 }

--- a/src/Illuminate/Contracts/Validation/UnauthorizedException.php
+++ b/src/Illuminate/Contracts/Validation/UnauthorizedException.php
@@ -6,4 +6,5 @@ use RuntimeException;
 
 class UnauthorizedException extends RuntimeException
 {
+    //
 }

--- a/src/Illuminate/Database/Eloquent/MassAssignmentException.php
+++ b/src/Illuminate/Database/Eloquent/MassAssignmentException.php
@@ -6,4 +6,5 @@ use RuntimeException;
 
 class MassAssignmentException extends RuntimeException
 {
+    //
 }

--- a/src/Illuminate/Http/Exception/PostTooLargeException.php
+++ b/src/Illuminate/Http/Exception/PostTooLargeException.php
@@ -6,4 +6,5 @@ use Exception;
 
 class PostTooLargeException extends Exception
 {
+    //
 }

--- a/src/Illuminate/Session/TokenMismatchException.php
+++ b/src/Illuminate/Session/TokenMismatchException.php
@@ -6,4 +6,5 @@ use Exception;
 
 class TokenMismatchException extends Exception
 {
+    //
 }


### PR DESCRIPTION
As this already the case in `\Illuminate\Contracts\Broadcasting\ShouldBroadcastNow` and in stubs
