### PR TITLE
[5.2] Support flattening nested collections and specifying a flattening depth

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -201,9 +201,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @return static
      */
-    public function flatten()
+    public function flatten($depth = INF)
     {
-        return new static(Arr::flatten($this->items));
+        return $this->reduce(function ($return, $item) use ($depth) {
+            if ($item instanceof self || is_array($item)) {
+                if ($depth === 1) {
+                    return $return->merge(new static($item));
+                }
+
+                return $return->merge((new static($item))->flatten($depth - 1));
+            }
+
+            return $return->push($item);
+        }, new static);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -190,8 +190,59 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
     public function testFlatten()
     {
+        // Flat arrays are unaffected
+        $c = new Collection(['#foo', '#bar', '#baz']);
+        $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
+
+        // Nested arrays are flattened with existing flat items
+        $c = new Collection([['#foo', '#bar'], '#baz']);
+        $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
+
+        // Sets of nested arrays are flattened
         $c = new Collection([['#foo', '#bar'], ['#baz']]);
         $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
+
+        // Deeply nested arrays are flattened
+        $c = new Collection([['#foo', ['#bar']], ['#baz']]);
+        $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
+
+        // Nested collections are flattened alongside arrays
+        $c = new Collection([new Collection(['#foo', '#bar']), ['#baz']]);
+        $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
+
+        // Nested collections containing plain arrays are flattened
+        $c = new Collection([new Collection(['#foo', ['#bar']]), ['#baz']]);
+        $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
+
+        // Nested arrays containing collections are flattened
+        $c = new Collection([['#foo', new Collection(['#bar'])], ['#baz']]);
+        $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
+
+        // Nested arrays containing collections containing arrays are flattened
+        $c = new Collection([['#foo', new Collection(['#bar', ['#zap']])], ['#baz']]);
+        $this->assertEquals(['#foo', '#bar', '#zap', '#baz'], $c->flatten()->all());
+
+        // Can specify depth to flatten to
+        $c = new Collection([['#foo', ['#bar']], '#baz']);
+        $this->assertEquals(['#foo', ['#bar'], '#baz'], $c->flatten(1)->all());
+
+        // Can specify depth to flatten to
+        $c = new Collection([['#foo', ['#bar']], '#baz']);
+        $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten(2)->all());
+    }
+
+    public function testFlattenWithDepth()
+    {
+        // No depth flattens recursively
+        $c = new Collection([['#foo', ['#bar', ['#baz']]], '#zap']);
+        $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten()->all());
+
+        // Specifying a depth only flattens to that depth
+        $c = new Collection([['#foo', ['#bar', ['#baz']]], '#zap']);
+        $this->assertEquals(['#foo', ['#bar', ['#baz']], '#zap'], $c->flatten(1)->all());
+
+        $c = new Collection([['#foo', ['#bar', ['#baz']]], '#zap']);
+        $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], $c->flatten(2)->all());
     }
 
     public function testMergeNull()


### PR DESCRIPTION
This supports flattening nested collections, and specifying an optional depth to flatten to.

For the TL;DR, see [the tests](https://github.com/adamwathan/framework/blob/aw-better-flatten/tests/Support/SupportCollectionTest.php#L191-L246).
#### Nested Collections

Previously, if you tried to flatten a collection of collections, nothing would happen. Typical example would be something like this:

```
$posts->map(function ($post) {
    return $post->comments;
})->flatten();
```

You would expect a flattened collection of all comments, but what you actually get is the same thing that came out of `map`, because flatten doesn't flatten the nested collections, and `$post->comments` returns a collection.

You might try to work around this like so:

```
$posts->map(function ($post) {
    return $post->comments->toArray();
})->flatten();
```

...but `toArray()` would actually recursively turn the comments into arrays, which is expected in some cases but probably not in this case.

Instead the real work around is:

```
$posts->map(function ($post) {
    return $post->comments->all();
})->flatten();
```

...which is very different than `$post->comments()->all()` in that this returns the underlying array items.

Still, if you had some structure setup where _those_ items might contain a nested collection, it still wouldn't properly flatten.

This PR solves that, but **does introduce a breaking change**, as previously nested collections were not flattened.
#### Optional depth specification

Prior to this PR, flattening was always completely recursive. I find for my use cases, I most often just want to flatten one level down, and I might want to maintain any nested array structures underneath.

This PR adds support for that with an optional `$depth` parameter.

Given a collection like this:

``` php
[1, [2, [3, [4]]]]
```

... `flatten()` will produce:

``` php
[1, 2, 3, 4]
```

...`flatten(1)` will produce:

``` php
[1, 2, [3, [4]]]
```

...`flatten(2)` will produce:

``` php
[1, 2, 3, [4]]
```

...etc.
