### PR TITLE
[5.2] Remove duplicated collection tests and add flatten param doc block

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -199,6 +199,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Get a flattened array of the items in the collection.
      *
+     * @param  int  $depth
      * @return static
      */
     public function flatten($depth = INF)

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -221,14 +221,6 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         // Nested arrays containing collections containing arrays are flattened
         $c = new Collection([['#foo', new Collection(['#bar', ['#zap']])], ['#baz']]);
         $this->assertEquals(['#foo', '#bar', '#zap', '#baz'], $c->flatten()->all());
-
-        // Can specify depth to flatten to
-        $c = new Collection([['#foo', ['#bar']], '#baz']);
-        $this->assertEquals(['#foo', ['#bar'], '#baz'], $c->flatten(1)->all());
-
-        // Can specify depth to flatten to
-        $c = new Collection([['#foo', ['#bar']], '#baz']);
-        $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten(2)->all());
     }
 
     public function testFlattenWithDepth()


### PR DESCRIPTION
The depth tests had been moved to a separate test and weren't cleaned up, whoops.
