### PR TITLE
[5.2] Add depth and collection support to Arr::flatten

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -149,15 +149,26 @@ class Arr
      * Flatten a multi-dimensional array into a single level.
      *
      * @param  array  $array
+     * @param  int  $depth
      * @return array
      */
-    public static function flatten($array)
+    public static function flatten($array, $depth = INF)
     {
-        $return = [];
+        return array_reduce($array, function ($result, $item) use ($depth) {
+            $item = $item instanceof Collection ? $item->all() : $item;
 
-        array_walk_recursive($array, function ($x) use (&$return) { $return[] = $x; });
+            if (is_array($item)) {
+                if ($depth === 1) {
+                    return array_merge($result, $item);
+                }
 
-        return $return;
+                return array_merge($result, static::flatten($item, $depth - 1));
+            }
+
+            $result[] = $item;
+
+            return $result;
+        }, []);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -204,17 +204,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function flatten($depth = INF)
     {
-        return $this->reduce(function ($return, $item) use ($depth) {
-            if ($item instanceof self || is_array($item)) {
-                if ($depth === 1) {
-                    return $return->merge($item);
-                }
-
-                return $return->merge((new static($item))->flatten($depth - 1));
-            }
-
-            return $return->push($item);
-        }, new static);
+        return new static(Arr::flatten($this->items, $depth));
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -163,11 +163,12 @@ if (! function_exists('array_flatten')) {
      * Flatten a multi-dimensional array into a single level.
      *
      * @param  array  $array
+     * @param  int  $depth
      * @return array
      */
-    function array_flatten($array)
+    function array_flatten($array, $depth = INF)
     {
-        return Arr::flatten($array);
+        return Arr::flatten($array, $depth);
     }
 }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 
 class SupportArrTest extends PHPUnit_Framework_TestCase
 {
@@ -50,9 +51,51 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
 
     public function testFlatten()
     {
-        $array = ['name' => 'Joe', 'languages' => ['PHP', 'Ruby']];
-        $array = Arr::flatten($array);
-        $this->assertEquals(['Joe', 'PHP', 'Ruby'], $array);
+        // Flat arrays are unaffected
+        $array = ['#foo', '#bar', '#baz'];
+        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten(['#foo', '#bar', '#baz']));
+
+        // Nested arrays are flattened with existing flat items
+        $array = [['#foo', '#bar'], '#baz'];
+        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+
+        // Sets of nested arrays are flattened
+        $array = [['#foo', '#bar'], ['#baz']];
+        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+
+        // Deeply nested arrays are flattened
+        $array = [['#foo', ['#bar']], ['#baz']];
+        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+
+        // Nested collections are flattened alongside arrays
+        $array = [new Collection(['#foo', '#bar']), ['#baz']];
+        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+
+        // Nested collections containing plain arrays are flattened
+        $array = [new Collection(['#foo', ['#bar']]), ['#baz']];
+        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+
+        // Nested arrays containing collections are flattened
+        $array = [['#foo', new Collection(['#bar'])], ['#baz']];
+        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+
+        // Nested arrays containing collections containing arrays are flattened
+        $array = [['#foo', new Collection(['#bar', ['#zap']])], ['#baz']];
+        $this->assertEquals(['#foo', '#bar', '#zap', '#baz'], Arr::flatten($array));
+    }
+
+    public function testFlattenWithDepth()
+    {
+        // No depth flattens recursively
+        $array = [['#foo', ['#bar', ['#baz']]], '#zap'];
+        $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], Arr::flatten($array));
+
+        // Specifying a depth only flattens to that depth
+        $array = [['#foo', ['#bar', ['#baz']]], '#zap'];
+        $this->assertEquals(['#foo', ['#bar', ['#baz']], '#zap'], Arr::flatten($array, 1));
+
+        $array = [['#foo', ['#bar', ['#baz']]], '#zap'];
+        $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], Arr::flatten($array, 2));
     }
 
     public function testGet()


### PR DESCRIPTION
Moves [this](https://github.com/laravel/framework/pull/10364) change to the `Arr::flatten` method.

This has two advantages:
1. Obviously, it can now be used on a simple array.
2. It's more efficient, since we don't have to [constantly create more collection instances](https://github.com/laravel/framework/blob/ee6786dd35fb8b0fc58d4e027daee7e479f8fccd/src/Illuminate/Support/Collection.php#L213).
