### PR TITLE
Match against incomplete action paths in Router@currentRouteUses

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1370,7 +1370,7 @@ class Router implements RegistrarContract
      */
     public function currentRouteUses($action)
     {
-        return $this->currentRouteAction() == $action;
+        return str_contains($this->currentRouteAction(), $action);
     }
 
     /**


### PR DESCRIPTION
Before:

``` php
Route::getCurrentAction(); // App\Http\Controllers\Controller@action
Route::currentRouteUses('App\Http\Controllers\Controller@action'); // true
Route::currentRouteUses('Controller@action'); // false
```

After:

``` php
Route::getCurrentAction(); // App\Http\Controllers\Controller@action
Route::currentRouteUses('App\Http\Controllers\Controller@action'); // true
Route::currentRouteUses('Controller@action'); // true
```
