### PR TITLE
[5.1] Add multiple key support to the forget() method for Collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -232,16 +232,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Remove an item from the collection by key.
      *
-     * @param  string|array  $key
+     * @param  string|array  $keys
      * @return $this
      */
-    public function forget($key)
+    public function forget($keys)
     {
-        if (is_array($key)) {
-            foreach ($key as $arrayValue) {
-                $this->offsetUnset($arrayValue);
-            }
-        } else {
+        foreach ((array) $keys as $key) {
             $this->offsetUnset($key);
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -232,7 +232,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Remove an item from the collection by key.
      *
-     * @param  mixed  $key
+     * @param  string|array  $key
      * @return $this
      */
     public function forget($key)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -237,7 +237,13 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function forget($key)
     {
-        $this->offsetUnset($key);
+        if (is_array($key)) {
+            foreach ($key as $arrayValue) {
+                $this->offsetUnset($arrayValue);
+            }
+        } else {
+            $this->offsetUnset($key);
+        }
 
         return $this;
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -142,6 +142,32 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('jason', $c[0]);
     }
 
+    public function testForgetSingleKey()
+    {
+        $c = new Collection(['foo', 'bar']);
+        $c->forget(0);
+        $this->assertFalse(isset($c['foo']));
+
+        $c = new Collection(['foo' => 'bar', 'baz' => 'qux']);
+        $c->forget('foo');
+        $this->assertFalse(isset($c['foo']));
+    }
+
+    public function testForgetArrayOfKeys()
+    {
+        $c = new Collection(['foo', 'bar', 'baz']);
+        $c->forget([0, 2]);
+        $this->assertFalse(isset($c[0]));
+        $this->assertFalse(isset($c[2]));
+        $this->assertTrue(isset($c[1]));
+
+        $c = new Collection(['name' => 'taylor', 'foo' => 'bar', 'baz' => 'qux']);
+        $c->forget(['foo', 'baz']);
+        $this->assertFalse(isset($c['foo']));
+        $this->assertFalse(isset($c['baz']));
+        $this->assertTrue(isset($c['name']));
+    }
+
     public function testCountable()
     {
         $c = new Collection(['foo', 'bar']);


### PR DESCRIPTION
As discussed with @taylorotwell in Larachat/#internals, currently in `Collections` you can only `forget()` a single key: `$collection->forget('key');` this PR adds the ability to also specify an array of keys to forget, `$collection->forget(['foo', 'baz']);` without breaking if just a single string/key is provided.

Multiple Forget: 

``` php
$collection = new Collection(['name' => 'taylor', 'foo' => 'bar', 'baz' => 'qux']);
$collection->forget(['foo', 'baz']);
```

Results In:

```
>>> $collection->all();
=> [
       "name" => "taylor"
   ]
```

Single Forget (default 5.1):

``` php
$collection = new Collection(['name' => 'taylor', 'foo' => 'bar', 'baz' => 'qux']);
$collection->forget('foo');
```

Results In:

```
>>> $collection->all();
=> [
       "name" => "taylor",
       "baz"  => "qux"
   ]
```
