### PR TITLE
[5.1] Improve exists queries

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1592,13 +1592,14 @@ class Builder
      */
     public function exists()
     {
-        $limit = $this->limit;
+        $sql = $this->grammar->compileExists($this);
+        $results = $this->connection->select($sql, $this->getBindings(), ! $this->useWritePdo);
 
-        $result = $this->limit(1)->count() > 0;
+        if (isset($results[0])) {
+            $results = (array) $results[0];
 
-        $this->limit($limit);
-
-        return $result;
+            return (bool) $results['exists'];
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -622,7 +622,7 @@ class Grammar extends BaseGrammar
     {
         $select = $this->compileSelect($query);
 
-        return "select exists($select) as `exists`";
+        return "select exists($select) as {$this->wrap('exists')}";
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -612,6 +612,20 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile an exists statement into SQL.
+     *
+     * @param \Illuminate\Database\Query\Builder $query
+     *
+     * @return string
+     */
+    public function compileExists(Builder $query)
+    {
+        $select = $this->compileSelect($query);
+
+        return "select exists($select) as `exists`";
+    }
+
+    /**
      * Compile an insert statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -783,8 +783,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $results);
 
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('select')->once()->with('select count(*) as aggregate from "users" limit 1', [], true)->andReturn([['aggregate' => 1]]);
-        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) { return $results; });
+        $builder->getConnection()->shouldReceive('select')->once()->with('select exists(select * from "users") as `exists`', [], true)->andReturn([['exists' => 1]]);
         $results = $builder->from('users')->exists();
         $this->assertTrue($results);
 


### PR DESCRIPTION
As [suggested](https://larachat.slack.com/archives/internals/p1443124679002492) by @JosephSilber, this updates the `exists()` query builder method to do an actual `exists` query, which should be much faster for big tables.

**Edit:** I have tested this on MySQL, Postgres, and SQLite. I don't have a SQLServer lying around to test on, but the docs show that it should work fine.
