### PR TITLE
[5.1] Use good assertion

### DIFF
--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -55,6 +55,6 @@ class CacheArrayStoreTest extends PHPUnit_Framework_TestCase
     public function testCacheKey()
     {
         $store = new ArrayStore;
-        $this->assertEquals('', $store->getPrefix());
+        $this->assertEmpty($store->getPrefix());
     }
 }

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -67,6 +67,6 @@ class CacheMemcachedStoreTest extends PHPUnit_Framework_TestCase
         $store->setPrefix('foo');
         $this->assertEquals('foo:', $store->getPrefix());
         $store->setPrefix(null);
-        $this->assertSame('', $store->getPrefix());
+        $this->assertEmpty($store->getPrefix());
     }
 }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -88,7 +88,7 @@ class CacheRedisStoreTest extends PHPUnit_Framework_TestCase
         $redis->setPrefix('foo');
         $this->assertEquals('foo:', $redis->getPrefix());
         $redis->setPrefix(null);
-        $this->assertSame('', $redis->getPrefix());
+        $this->assertEmpty($redis->getPrefix());
     }
 
     protected function getRedis()

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -85,9 +85,9 @@ class CacheRepositoryTest extends PHPUnit_Framework_TestCase
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('add', 'get', 'put')->never();
         $result = $repo->add('foo', 'bar', Carbon::now()->subMinutes(10));
-        $this->assertSame(false, $result);
+        $this->assertFalse($result);
         $result = $repo->add('foo', 'bar', Carbon::now()->addSeconds(5));
-        $this->assertSame(false, $result);
+        $this->assertFalse($result);
     }
 
     public function testRegisterMacroWithNonStaticCall()

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -267,7 +267,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation->shouldReceive('get')->once()->andReturn(new Illuminate\Database\Eloquent\Collection([new StdClass]));
         $relation->shouldReceive('take')->with(1)->once()->andReturn($relation);
 
-        $this->assertTrue($relation->first() instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->first());
     }
 
     public function testFindMethod()
@@ -279,7 +279,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $related = $relation->getRelated();
         $related->shouldReceive('getQualifiedKeyName')->once()->andReturn('roles.id');
 
-        $this->assertTrue($relation->find('foo') instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->find('foo'));
     }
 
     public function testFindManyMethod()
@@ -294,7 +294,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $result = $relation->findMany(['foo', 'bar']);
 
         $this->assertEquals(2, count($result));
-        $this->assertTrue($result->first() instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $result->first());
     }
 
     public function testCreateMethodCreatesNewModelAndInsertsAttachmentRecord()
@@ -314,7 +314,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue($model = m::mock('StdClass')));
         $relation->getRelated()->shouldReceive('newInstance')->never();
 
-        $this->assertTrue($relation->findOrNew('foo') instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->findOrNew('foo'));
     }
 
     public function testFindOrNewMethodReturnsNewModel()
@@ -323,7 +323,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation->expects($this->once())->method('find')->with('foo')->will($this->returnValue(null));
         $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'));
 
-        $this->assertTrue($relation->findOrNew('foo') instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->findOrNew('foo'));
     }
 
     public function testFirstOrNewMethodFindsFirstModel()
@@ -333,7 +333,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
         $relation->getRelated()->shouldReceive('newInstance')->never();
 
-        $this->assertTrue($relation->firstOrNew(['foo']) instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrNew(['foo']));
     }
 
     public function testFirstOrNewMethodReturnsNewModel()
@@ -343,7 +343,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
         $relation->getRelated()->shouldReceive('newInstance')->once()->andReturn($model = m::mock('StdClass'));
 
-        $this->assertTrue($relation->firstOrNew(['foo']) instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrNew(['foo']));
     }
 
     public function testFirstOrCreateMethodFindsFirstModel()
@@ -353,7 +353,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation->getQuery()->shouldReceive('first')->once()->andReturn($model = m::mock('StdClass'));
         $relation->expects($this->never())->method('create')->with(['foo'])->will($this->returnValue(null));
 
-        $this->assertTrue($relation->firstOrCreate(['foo']) instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreate(['foo']));
     }
 
     public function testFirstOrCreateMethodReturnsNewModel()
@@ -363,7 +363,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
         $relation->expects($this->once())->method('create')->with(['foo'])->will($this->returnValue($model = m::mock('StdClass')));
 
-        $this->assertTrue($relation->firstOrCreate(['foo']) instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreate(['foo']));
     }
 
     public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
@@ -375,7 +375,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('save')->once();
         $relation->expects($this->never())->method('create')->with(['foo'])->will($this->returnValue(null));
 
-        $this->assertTrue($relation->updateOrCreate(['foo']) instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->updateOrCreate(['foo']));
     }
 
     public function testUpdateOrCreateMethodReturnsNewModel()
@@ -385,7 +385,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation->getQuery()->shouldReceive('first')->once()->andReturn(null);
         $relation->expects($this->once())->method('create')->with(['foo'])->will($this->returnValue($model = m::mock('StdClass')));
 
-        $this->assertTrue($relation->updateOrCreate(['bar'], ['foo']) instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->updateOrCreate(['bar'], ['foo']));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -28,7 +28,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn($model = m::mock('StdClass'));
         $model->shouldReceive('setAttribute')->never();
 
-        $this->assertTrue($relation->findOrNew('foo') instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->findOrNew('foo'));
     }
 
     public function testFindOrNewMethodReturnsNewModelWithForeignKeySet()
@@ -38,7 +38,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock('StdClass'));
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
-        $this->assertTrue($relation->findOrNew('foo') instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->findOrNew('foo'));
     }
 
     public function testFirstOrNewMethodFindsFirstModel()
@@ -48,7 +48,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $relation->getQuery()->shouldReceive('first')->once()->with()->andReturn($model = m::mock('StdClass'));
         $model->shouldReceive('setAttribute')->never();
 
-        $this->assertTrue($relation->firstOrNew(['foo']) instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrNew(['foo']));
     }
 
     public function testFirstOrNewMethodReturnsNewModelWithForeignKeySet()
@@ -59,7 +59,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $relation->getRelated()->shouldReceive('newInstance')->once()->with(['foo'])->andReturn($model = m::mock('StdClass'));
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
-        $this->assertTrue($relation->firstOrNew(['foo']) instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrNew(['foo']));
     }
 
     public function testFirstOrCreateMethodFindsFirstModel()
@@ -71,7 +71,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
 
-        $this->assertTrue($relation->firstOrCreate(['foo']) instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreate(['foo']));
     }
 
     public function testFirstOrCreateMethodCreatesNewModelWithForeignKeySet()
@@ -83,7 +83,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('save')->once()->andReturn(true);
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
-        $this->assertTrue($relation->firstOrCreate(['foo']) instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->firstOrCreate(['foo']));
     }
 
     public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
@@ -95,7 +95,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('fill')->once()->with(['bar']);
         $model->shouldReceive('save')->once();
 
-        $this->assertTrue($relation->updateOrCreate(['foo'], ['bar']) instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->updateOrCreate(['foo'], ['bar']));
     }
 
     public function testUpdateOrCreateMethodCreatesNewModelWithForeignKeySet()
@@ -108,7 +108,7 @@ class DatabaseEloquentHasManyTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('fill')->once()->with(['bar']);
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
-        $this->assertTrue($relation->updateOrCreate(['foo'], ['bar']) instanceof StdClass);
+        $this->assertInstanceOf(StdClass::class, $relation->updateOrCreate(['foo'], ['bar']));
     }
 
     public function testUpdateMethodUpdatesModelsWithTimestamps()

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -76,7 +76,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
 
-        $this->assertTrue($relation->findOrNew('foo') instanceof Model);
+        $this->assertInstanceOf(Model::class, $relation->findOrNew('foo'));
     }
 
     public function testFindOrNewMethodReturnsNewModelWithMorphKeysSet()
@@ -88,7 +88,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
 
-        $this->assertTrue($relation->findOrNew('foo') instanceof Model);
+        $this->assertInstanceOf(Model::class, $relation->findOrNew('foo'));
     }
 
     public function testFirstOrNewMethodFindsFirstModel()
@@ -100,7 +100,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
 
-        $this->assertTrue($relation->firstOrNew(['foo']) instanceof Model);
+        $this->assertInstanceOf(Model::class, $relation->firstOrNew(['foo']));
     }
 
     public function testFirstOrNewMethodReturnsNewModelWithMorphKeysSet()
@@ -113,7 +113,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();
 
-        $this->assertTrue($relation->firstOrNew(['foo']) instanceof Model);
+        $this->assertInstanceOf(Model::class, $relation->firstOrNew(['foo']));
     }
 
     public function testFirstOrCreateMethodFindsFirstModel()
@@ -125,7 +125,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('setAttribute')->never();
         $model->shouldReceive('save')->never();
 
-        $this->assertTrue($relation->firstOrCreate(['foo']) instanceof Model);
+        $this->assertInstanceOf(Model::class, $relation->firstOrCreate(['foo']));
     }
 
     public function testFirstOrCreateMethodCreatesNewMorphModel()
@@ -138,7 +138,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->once()->andReturn(true);
 
-        $this->assertTrue($relation->firstOrCreate(['foo']) instanceof Model);
+        $this->assertInstanceOf(Model::class, $relation->firstOrCreate(['foo']));
     }
 
     public function testUpdateOrCreateMethodFindsFirstModelAndUpdates()
@@ -151,7 +151,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('fill')->once()->with(['bar']);
         $model->shouldReceive('save')->once();
 
-        $this->assertTrue($relation->updateOrCreate(['foo'], ['bar']) instanceof Model);
+        $this->assertInstanceOf(Model::class, $relation->updateOrCreate(['foo'], ['bar']));
     }
 
     public function testUpdateOrCreateMethodCreatesNewMorphModel()
@@ -165,7 +165,7 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('save')->once()->andReturn(true);
         $model->shouldReceive('fill')->once()->with(['bar']);
 
-        $this->assertTrue($relation->updateOrCreate(['foo'], ['bar']) instanceof Model);
+        $this->assertInstanceOf(Model::class, $relation->updateOrCreate(['foo'], ['bar']));
     }
 
     public function testCreateFunctionOnNamespacedMorph()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -72,11 +72,11 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
 
         $router = $this->getRouter();
         $router->get('foo/bar', function () { return 'hello'; });
-        $this->assertEquals('', $router->dispatch(Request::create('foo/bar', 'HEAD'))->getContent());
+        $this->assertEmpty($router->dispatch(Request::create('foo/bar', 'HEAD'))->getContent());
 
         $router = $this->getRouter();
         $router->any('foo/bar', function () { return 'hello'; });
-        $this->assertEquals('', $router->dispatch(Request::create('foo/bar', 'HEAD'))->getContent());
+        $this->assertEmpty($router->dispatch(Request::create('foo/bar', 'HEAD'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/bar', function () { return 'first'; });
@@ -142,7 +142,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
 
         $response = $router->dispatch(Request::create('foo', 'HEAD'));
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('', $response->getContent());
+        $this->assertEmpty($response->getContent());
 
         $router = $this->getRouter();
         $router->match(['GET'], 'foo', function () { return 'bar'; });

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -164,13 +164,13 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('ЛЁ', Str::substr('БГДЖИЛЁ', -2));
         $this->assertEquals('И', Str::substr('БГДЖИЛЁ', -3, 1));
         $this->assertEquals('ДЖИЛ', Str::substr('БГДЖИЛЁ', 2, -1));
-        $this->assertEquals(false, Str::substr('БГДЖИЛЁ', 4, -4));
+        $this->assertEmpty(Str::substr('БГДЖИЛЁ', 4, -4));
         $this->assertEquals('ИЛ', Str::substr('БГДЖИЛЁ', -3, -1));
         $this->assertEquals('ГДЖИЛЁ', Str::substr('БГДЖИЛЁ', 1));
         $this->assertEquals('ГДЖ', Str::substr('БГДЖИЛЁ', 1, 3));
         $this->assertEquals('БГДЖ', Str::substr('БГДЖИЛЁ', 0, 4));
         $this->assertEquals('Ё', Str::substr('БГДЖИЛЁ', -1, 1));
-        $this->assertEquals(false, Str::substr('Б', 2));
+        $this->assertEmpty(Str::substr('Б', 2));
     }
 
     public function testUcfirst()

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -312,7 +312,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
     public function testEmptyStringIsReturnedForNonSections()
     {
         $factory = $this->getFactory();
-        $this->assertEquals('', $factory->yieldContent('foo'));
+        $this->assertEmpty($factory->yieldContent('foo'));
     }
 
     public function testSectionFlushing()


### PR DESCRIPTION
- assertInstanceOf should be used instead of assertTrue : https://github.com/laravel/framework/commit/69e224390576f57234e0aa28b8bf8c295a7db338
- some assertions shall be changed. For instance : `assertSame(true, ...` => `assertTrue(...` : https://github.com/laravel/framework/commit/ebbae988f5697b0a456f27c0c865515b4c0ab51a
