### PR TITLE
[5.1] Pass optional filter to CrawlerTrait see and dontSee methods

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -294,34 +294,45 @@ trait CrawlerTrait
     }
 
     /**
-     * Assert that a given string is seen on the page.
+     * Assert that a given string is seen on the page, or inside an element.
      *
      * @param  string  $text
+     * @param  bool|string|null  $element
      * @param  bool  $negate
      * @return $this
      */
-    protected function see($text, $negate = false)
+    protected function see($text, $element = null, $negate = false)
     {
+        if (is_bool($element)) {
+            $negate = $element;
+            $element = null;
+        }
+
         $method = $negate ? 'assertNotRegExp' : 'assertRegExp';
 
         $rawPattern = preg_quote($text, '/');
 
         $escapedPattern = preg_quote(e($text), '/');
 
-        $this->$method("/({$rawPattern}|{$escapedPattern})/i", $this->response->getContent());
+        $content = is_null($element)
+            ? $this->crawler->html()
+            : $this->crawler->filter($element)->html();
+
+        $this->$method("/({$rawPattern}|{$escapedPattern})/i", $content);
 
         return $this;
     }
 
     /**
-     * Assert that a given string is not seen on the page.
+     * Assert that a given string is not seen on the page, or inside an element.
      *
      * @param  string  $text
+     * @param  string|null  $element
      * @return $this
      */
-    protected function dontSee($text)
+    protected function dontSee($text, $element = null)
     {
-        return $this->see($text, true);
+        return $this->see($text, $element, true);
     }
 
     /**

--- a/tests/Foundation/FoundationCrawlerTraitIntegrationTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitIntegrationTest.php
@@ -7,6 +7,44 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 {
     use CrawlerTrait;
 
+    public function testSee()
+    {
+        $this->crawler = new Crawler(
+            '<p>Laravel 5.1</p>'
+        );
+
+        $this->see('Laravel 5.1');
+    }
+
+    public function testDontSee()
+    {
+        $this->crawler = new Crawler(
+            '<p>Laravel 5.1</p>'
+        );
+
+        $this->see('Symfony', true);
+        $this->dontSee('Symfony');
+    }
+
+    public function testSeeElement()
+    {
+        $this->crawler = new Crawler(
+            '<div>Laravel was created by <strong>Taylor Otwell</strong></div>'
+        );
+
+        $this->see('Taylor', 'strong');
+    }
+
+    public function testDontSeeElement()
+    {
+        $this->crawler = new Crawler(
+            '<div>Laravel was created by <strong>Taylor Otwell</strong></div>'
+        );
+
+        $this->see('Laravel', 'strong', true);
+        $this->dontSee('Laravel', 'strong');
+    }
+
     public function testSeeLink()
     {
         $this->crawler = new Crawler(
@@ -24,7 +62,7 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
         );
 
         $this->dontSeeLink('Symfony');
-        $this->dontSeeLink('Symfony', 'https://symfonyc.com');
+        $this->dontSeeLink('Symfony', 'https://symfony.com');
     }
 
     protected function getInputHtml()


### PR DESCRIPTION
Pass another argument to be able to filter where you expect to see a text.

Consider you are logged in an admin panel, and you want to test a list of users. Your username will be probably in the right up corner of the page, so if you write this:

`$this->see('sileence')`

This might return a false positive since you can't filter where is that text. But with this:

`$this->see('sileence', 'table')`

You can check that the text "sileence" is inside the table element.

This PR keeps the backward compatibility, since it swaps the parameters, so these examples are valid:

```
$this->see('sileence', true)
$this->see('sileence', 'table')
$this->see('sileence', 'table', true)
```

I also added some integration tests.
