### PR TITLE
[5.1] should we gather route middlewares or not

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -690,14 +690,17 @@ class Router implements RegistrarContract
      */
     protected function runRouteWithinStack(Route $route, Request $request)
     {
-        $middleware = $this->gatherRouteMiddlewares($route);
-
+        // First we try to know if middleware is disabled or not, if it is disabled it
+        // means we should skip middleware so we just pass an empty array
+        // otherwise we try to gather route middlewares.
         $shouldSkipMiddleware = $this->container->bound('middleware.disable') &&
                                 $this->container->make('middleware.disable') === true;
 
+        $middleware = $shouldSkipMiddleware ? [] : $this->gatherRouteMiddlewares($route);
+
         return (new Pipeline($this->container))
                         ->send($request)
-                        ->through($shouldSkipMiddleware ? [] : $middleware)
+                        ->through($middleware)
                         ->then(function ($request) use ($route) {
                             return $this->prepareResponse(
                                 $request,


### PR DESCRIPTION
Before this change we first gather the route middlewares and then check
wether we should pass them or not , but now we check if we want to use
them or not , if yes then we gather them otherwise we do not gather them and just pass an empty array.
