### PR TITLE
[5.1] Rename avg to average for eloquence

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -59,7 +59,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  string|null  $key
      * @return mixed
      */
-    public function avg($key = null)
+    public function average($key = null)
     {
         if ($count = $this->count()) {
             return $this->sum($key) / $count;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -802,16 +802,16 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     public function testGettingAvgItemsFromCollection()
     {
         $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
-        $this->assertEquals(15, $c->avg('foo'));
+        $this->assertEquals(15, $c->average('foo'));
 
         $c = new Collection([['foo' => 10], ['foo' => 20]]);
-        $this->assertEquals(15, $c->avg('foo'));
+        $this->assertEquals(15, $c->average('foo'));
 
         $c = new Collection([1, 2, 3, 4, 5]);
-        $this->assertEquals(3, $c->avg());
+        $this->assertEquals(3, $c->average());
 
         $c = new Collection();
-        $this->assertNull($c->avg());
+        $this->assertNull($c->average());
     }
 }
 


### PR DESCRIPTION
Renames the newly added `Collection::avg` to `average` for fluency.
