### PR TITLE
[5.2] Add ability to mass-asign automatically from request when injected

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -10,6 +10,7 @@ use LogicException;
 use JsonSerializable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Http\Request;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
@@ -269,11 +270,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  array  $attributes
      * @return void
      */
-    public function __construct(array $attributes = [])
+    public function __construct(array $attributes = [], Request $request = null)
     {
         $this->bootIfNotBooted();
 
         $this->syncOriginal();
+
+        $attributes = $this->merge($attributes, $request);
 
         $this->fill($attributes);
     }
@@ -398,6 +401,28 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 static::registerModelEvent($event, $className.'@'.$event, $priority);
             }
         }
+    }
+
+    /**
+     * Merge the given attributes with those from the request.
+     *
+     * @param array                         $attributes
+     * @param \Illuminate\Http\Request|null $request
+     * @return array
+     */
+    protected function merge(array $attributes = [], Request $request = null)
+    {
+        if (is_null($request)) {
+            return $attributes;
+        }
+
+        $fromRequest = $request->input(class_basename($this));
+
+        if (! is_array($fromRequest)) {
+            return $attributes;
+        }
+
+        return array_merge($attributes, $fromRequest);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -267,7 +267,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Create a new Eloquent model instance.
      *
-     * @param  array  $attributes
+     * @param  array                        $attributes
+     * @param \Illuminate\Http\Request|null $request
      * @return void
      */
     public function __construct(array $attributes = [], Request $request = null)


### PR DESCRIPTION
Eloquent's mass-assign feature makes it possible to save a model from a form with writing very little code, like so:

``` php
public function store(CreateUserRequest $request)
{
    $user = new User($request->all());
    $user->save();
}
```

Because the `$fillable` property on the model would make sure only the correct attributes are filled. While the `CreateUserRequest` makes sure the form is valid before you even hit the controller. Super cool stuff, because it eliminates a lot of boilerplate. Now if you'd have a relationship in the form-data, then you do something like this:

``` php
public function store(CreateUserRequest $request)
{
    $person = new Person($request->only('name', 'infix', 'surname'));
    $person->save();
    $user = new User($request->only('email', 'password'));
    $user->associate($person);
    $user->save();
}
```

Here a bit more repeated code is popping up. I wanted to make that a bit cleaner. So my pull-request makes it possible to turn that code into this:

``` php
public function store(CreateUserRequest $request, Person $person, User $user)
{
    $person->save();
    $user->associate($person);
    $user->save();
}
```

Provided you set your form up like this, which I think isn't bad practice anyway:

``` html
<form>
    <input name="Person[name]" type="text">
    <input name="Person[infix]" type="text">
    <input name="Person[surname]" type="text">

    <input name="User[email]" type="email">
    <input name="User[password]" type="password">
    <input name="User[password_confirmation]" type="password">
</form>
```
