### PR TITLE
[5.2] Refresh new models after saving them to the database

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1621,6 +1621,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $this->wasRecentlyCreated = true;
 
+        // When inserting newly created models, they might have default values for some
+        // attributes. So it's important that we refresh the model after it has been
+        // saved so that any missing fields with database defaults are populated.
         $this->refresh();
 
         $this->fireModelEvent('created', false);
@@ -1628,6 +1631,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         return true;
     }
 
+    /**
+     * Refresh the current model with the current attributes from the database.
+     * @return void
+     */
     protected function refresh()
     {
         $fresh = $this->fresh();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1621,9 +1621,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $this->wasRecentlyCreated = true;
 
-        // When inserting newly created models, they might have default values for some
-        // attributes. So it's important that we refresh the model after it has been
-        // saved so that any missing fields with database defaults are populated.
+        // Newly created models might be missing optional fields that have defaults set
+        // by the database. To ensure that those attributes return the correct value
+        // and not null, we refresh the model with the updates from the database.
         $this->refresh();
 
         $this->fireModelEvent('created', false);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1621,9 +1621,18 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $this->wasRecentlyCreated = true;
 
+        $this->refresh();
+
         $this->fireModelEvent('created', false);
 
         return true;
+    }
+
+    protected function refresh()
+    {
+        $fresh = $this->fresh();
+        $this->setRawAttributes($fresh->getAttributes());
+        $this->setRelations($fresh->getRelations());
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -61,9 +61,9 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
 
         $this->schema()->create('photos', function ($table) {
             $table->increments('id');
-            $table->unsignedInteger("imageable_id")->nullable();
-            $table->string("imageable_type")->nullable();
-            $table->index(["imageable_id", "imageable_type"]);
+            $table->unsignedInteger('imageable_id')->nullable();
+            $table->string('imageable_type')->nullable();
+            $table->index(['imageable_id', 'imageable_type']);
             $table->string('name');
             $table->timestamps();
         });

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -61,7 +61,9 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
 
         $this->schema()->create('photos', function ($table) {
             $table->increments('id');
-            $table->morphs('imageable');
+            $table->unsignedInteger("imageable_id")->nullable();
+            $table->string("imageable_type")->nullable();
+            $table->index(["imageable_id", "imageable_type"]);
             $table->string('name');
             $table->timestamps();
         });
@@ -418,6 +420,13 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($map1, Relation::morphMap());
         Relation::morphMap($map2, false);
         $this->assertEquals($map2, Relation::morphMap());
+    }
+
+    public function testEmptyMorphToRelationship()
+    {
+        $photo = EloquentTestPhoto::create(['name' => 'Avatar 1']);
+
+        $this->assertNull($photo->imageable);
     }
 
     public function testMultiInsertsWithDifferentValues()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -42,6 +42,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->schema()->create('users', function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
+            $table->string('role')->default('standard');
             $table->timestamps();
         });
 
@@ -419,13 +420,6 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($map2, Relation::morphMap());
     }
 
-    public function testEmptyMorphToRelationship()
-    {
-        $photo = EloquentTestPhoto::create(['name' => 'Avatar 1']);
-
-        $this->assertNull($photo->imageable);
-    }
-
     public function testMultiInsertsWithDifferentValues()
     {
         $date = '1970-01-01';
@@ -464,6 +458,12 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
             $user = EloquentTestUser::first();
             $this->assertEquals('taylor@laravel.com', $user->email);
         });
+    }
+
+    public function testNewlyCreatedModelsInheritDatabaseDefaults()
+    {
+        $model = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        $this->assertEquals('standard', $model->role);
     }
 
     public function testToArrayIncludesDefaultFormattedTimestamps()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -336,7 +336,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
     public function testInsertProcess()
     {
-        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
+        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -354,7 +354,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $model->id);
         $this->assertTrue($model->exists);
 
-        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
+        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('insert')->once()->with(['name' => 'taylor']);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -402,7 +402,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
     public function testPushNoRelations()
     {
-        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
+        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -418,7 +418,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
     public function testPushEmptyOneRelation()
     {
-        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
+        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -436,7 +436,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
     public function testPushOneRelation()
     {
-        $related1 = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
+        $related1 = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'related1'], 'id')->andReturn(2);
         $related1->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -444,7 +444,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $related1->name = 'related1';
         $related1->exists = false;
 
-        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
+        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -465,7 +465,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
     public function testPushEmptyManyRelation()
     {
-        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
+        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -483,7 +483,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
     public function testPushManyRelation()
     {
-        $related1 = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
+        $related1 = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'related1'], 'id')->andReturn(2);
         $related1->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -491,7 +491,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $related1->name = 'related1';
         $related1->exists = false;
 
-        $related2 = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
+        $related2 = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'related2'], 'id')->andReturn(3);
         $related2->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -499,7 +499,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $related2->name = 'related2';
         $related2->exists = false;
 
-        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
+        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
         $query->shouldReceive('insertGetId')->once()->with(['name' => 'taylor'], 'id')->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));


### PR DESCRIPTION
Currently when a new model is created or saved, it does not honor database default values for optional fields that were not set before saving the model.

For example, if you had a table like this:

``` php
Schema::create('users', function ($table) {
    $table->increments('id');
    $table->string('email')->unique();
    $table->boolean('is_admin')->default(false);
    $table->timestamps();
});
```

...and created a new user like this:

``` php
$user = User::create(['email' => 'jennifer@example.com']);
```

...then `$user->is_admin` would be `null`, not `false`.

This change adds a `refresh` method to the `Model` class and calls it at the end of saving a newly created model to ensure that the model's attributes in memory reflect the values that are in the database.

It's unfortunate that it needs to execute a second query when creating the model, but I'm not sure what a better solution would be. Open to feedback.
