### PR TITLE
[5.1] using less memory in getExtension

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -305,9 +305,7 @@ class Factory implements FactoryContract
      */
     protected function getExtension($path)
     {
-        $extensions = array_keys($this->extensions);
-
-        return Arr::first($extensions, function ($key, $value) use ($path) {
+        return Arr::first(array_keys($this->extensions), function ($key, $value) use ($path) {
             return Str::endsWith($path, $value);
         });
     }


### PR DESCRIPTION
By remove one useless variable,we will use less memory.
