### PR TITLE
[5.1] Make refreshing model on create an optional trait.

### DIFF
--- a/src/Illuminate/Database/Eloquent/RefreshOnCreate.php
+++ b/src/Illuminate/Database/Eloquent/RefreshOnCreate.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+trait RefreshOnCreate
+{
+    /**
+     * Boot the refresh on create trait for a model.
+     *
+     * @return void
+     */
+    public static function bootRefreshOnCreate()
+    {
+        static::created(function ($model) {
+            static::refresh($model);
+        });
+    }
+
+    /**
+     * Refresh the current model with the current attributes from the database.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    protected static function refresh(Model $model)
+    {
+        $fresh = $model->fresh();
+
+        $model->setRawAttributes($fresh->getAttributes());
+
+        $model->setRelations($fresh->getRelations());
+    }
+}

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\RefreshOnCreate;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Pagination\AbstractPaginator as Paginator;
@@ -42,6 +43,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->schema()->create('users', function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
+            $table->string('role')->default('standard');
             $table->timestamps();
         });
 
@@ -468,6 +470,16 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         });
     }
 
+    public function testNewlyCreatedModelsInheritDatabaseDefaults()
+    {
+        Eloquent::clearBootedModels();
+
+        $model = EloquentTestUserWithRefreshOnCreate::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+
+        $this->assertEquals('standard', $model->getAttribute('role'));
+        $this->assertEquals('standard', $model->role);
+    }
+
     public function testToArrayIncludesDefaultFormattedTimestamps()
     {
         $model = new EloquentTestUser;
@@ -551,6 +563,11 @@ class EloquentTestUser extends Eloquent
     {
         return $this->morphMany('EloquentTestPhoto', 'imageable');
     }
+}
+
+class EloquentTestUserWithRefreshOnCreate extends EloquentTestUser
+{
+    use RefreshOnCreate;
 }
 
 class EloquentTestPost extends Eloquent


### PR DESCRIPTION
This make refreshing model after creating an option, just like "soft deletes".

Related to #10392

Signed-off-by: crynobone crynobone@gmail.com
