### PR TITLE
[5.1] Support for code-side model defaults

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -152,6 +152,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $casts = [];
 
     /**
+     * The default attribute values for unsaved models.
+     *
+     * @var array
+     */
+    protected $defaults;
+
+    /**
      * The relationships that should be touched on save.
      *
      * @var array
@@ -275,7 +282,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $this->syncOriginal();
 
-        $this->fill($attributes);
+        $this->fill($this->mergeDefaults($attributes));
     }
 
     /**
@@ -398,6 +405,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 static::registerModelEvent($event, $className.'@'.$event, $priority);
             }
         }
+    }
+
+    protected function mergeDefaults($attributes)
+    {
+        if ($this->defaults === null) {
+            return $attributes;
+        }
+
+        return array_merge($this->defaults, $attributes);
     }
 
     /**
@@ -1638,7 +1654,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // Newly created models might be missing optional fields that have defaults set
         // by the database. To ensure that those attributes return the correct value
         // and not null, we refresh the model with the updates from this database.
-        $this->refresh();
+        if ($this->defaults === null) {
+            $this->refresh();
+        }
 
         $this->fireModelEvent('created', false);
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -407,7 +407,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
     }
 
-    protected function mergeDefaults($attributes)
+    /**
+     * Merge an array of attributes with the model's default attributes.
+     *
+     * @param  array  $attributes
+     * @return array
+     */
+    protected function mergeDefaults(array $attributes)
     {
         if ($this->defaults === null) {
             return $attributes;

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -614,7 +614,7 @@ class EloquentTestComment extends Eloquent
     protected $table = 'comments';
     protected $guarded = [];
     protected $defaults = [
-        'visibility' => 'public'
+        'visibility' => 'public',
     ];
 
     public $refreshed = false;


### PR DESCRIPTION
**This PR is open for discussion primarily, not looking for immediate merge.**

Continuing the conversation from here: https://github.com/laravel/framework/pull/10392#issuecomment-143513354

This PR allows setting default values on models without having to save them and retrieve them back from the database to have database defaults applied.

```
class Comment extends Model
{
    protected $defaults = [
        'visibility' => 'public',
    ];
}

$comment = new Comment;
$comment->visibility; // 'public'
```

Previously, newly instantiated or created models would _not_ have database defaults applied, which although not surprising when you think about it, can be confusing if you aren't aware of it.

This makes model defaults a first class citizen in your codebase instead of being enforced only by constraints in the database.

**Re: recently merged refresh-on-save behavior**

This PR stops models from refreshing on save _if `$defaults` is not null_. Assume that if the user has set the `$defaults` array, that they want to be in control of a model's defaults through code instead of through the database and don't make the extra query. This also makes it easy to disable the refresh behavior with just `protected $defaults = [];` at the top of your model.

Open to thoughts ripping out the refresh behavior in favor of @crynobone's approach here: 

https://github.com/laravel/framework/pull/10397

Personally I think that _might_ be better as a model property, because you enable it by default and make it easier to turn off, whereas a trait can't really be mixed out.
