### PR TITLE
[5.1] Remove the useless pass

### DIFF
--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -76,7 +76,7 @@ class ViewServiceProvider extends ServiceProvider
         });
 
         $resolver->register('blade', function () use ($app) {
-            return new CompilerEngine($app['blade.compiler'], $app['files']);
+            return new CompilerEngine($app['blade.compiler']);
         });
     }
 


### PR DESCRIPTION
why are we passing Illuminate\Filesystem\Filesystem when
Illuminate\View\Compilers\CompilerEngine only accepts one argument ?! :
