### PR TITLE
[5.1] Fixed using versioning with BrowserSync/LiveReload

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -267,6 +267,10 @@ if (! function_exists('elixir')) {
      */
     function elixir($file)
     {
+        if (App::environment('local')) {
+            return $file;
+        }
+
         static $manifest = null;
 
         if (is_null($manifest)) {


### PR DESCRIPTION
Versioning is great for production, but when working in your local environment it tends to get in the way of plugins like LiveReload and BrowserSync.

I don't think turning off versioning in local environments should any anyone and it will definitely be a welcome change for anyone using these tools.
