### PR TITLE
[5.1] Fix whereDate bug when using sqlite

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -74,6 +74,18 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Compile a "where date" clause.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereDate(Builder $query, $where)
+    {
+        return $this->dateBasedWhere('%Y-%m-%d', $query, $where);
+    }
+
+    /**
      * Compile a "where day" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query


### PR DESCRIPTION
When using Sqlite and `whereDate` in the query builder, it compiles to `strftime('date', "date_column")` which yields `"date"` as value, while it is supposed to be the date part of the datetime column. With this change, it will format to `Y-m-d` properly.
