### PR TITLE
[5.1] Using Path variable instead of getPath Method

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -96,7 +96,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
             $this->setPath($path);
         }
 
-        $contents = $this->compileString($this->files->get($this->getPath()));
+        $contents = $this->compileString($this->files->get($path));
 
         if (! is_null($this->cachePath)) {
             $this->files->put($this->getCompiledPath($this->getPath()), $contents);


### PR DESCRIPTION
No difference but better performance;if $path was an empty string or
null;getPath returns null and if it was not,getPath returns the Path , the
same result as using $path.
