### PR TITLE
[5.1] Add an alias for the Collection avg method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -67,6 +67,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Alias for the avg method.
+     *
+     * @param  string|null  $key
+     * @return mixed
+     */
+    public function average($key = null)
+    {
+        return $this->avg($key);
+    }
+
+    /**
      * Collapse the collection of items into a single array.
      *
      * @return static


### PR DESCRIPTION
After #10386 being closed, this is an alternative, not renaming the `avg` method but merely providing an alias for it, following the naming of methods like `random()` over `rand()`, etc.
