### PR TITLE
[5.1] Updated docblock to indicate that $key can be an array

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -32,8 +32,8 @@ class RedirectResponse extends BaseRedirectResponse
     /**
      * Flash a piece of data to the session.
      *
-     * @param  string  $key
-     * @param  mixed   $value
+     * @param  string|array  $key
+     * @param  mixed  $value
      * @return \Illuminate\Http\RedirectResponse
      */
     public function with($key, $value = null)


### PR DESCRIPTION
The method handles $key as array, and this lines up with Illuminate\View\View::with()
