### PR TITLE
[5.1] Fix incorrect @return value in docblock

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -731,7 +731,7 @@ class BelongsToMany extends Relation
      *
      * @param  array  $records
      * @param  array  $joinings
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return array
      */
     public function createMany(array $records, array $joinings = [])
     {


### PR DESCRIPTION
On the `createMany()` method of the `BelongsToMany` relation, the `$instances` variable being returned is an array and not an `\Illuminate\Database\Eloquent\Model` instance as the @return tag in the docblock states.
