### PR TITLE
[5.1] Simplify code of View::renderSections()

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -121,10 +121,8 @@ class View implements ArrayAccess, ViewContract
      */
     public function renderSections()
     {
-        $env = $this->factory;
-
-        return $this->render(function ($view) use ($env) {
-            return $env->getSections();
+        return $this->render(function () {
+            return $this->factory->getSections();
         });
     }
 


### PR DESCRIPTION
I have gone through #2844 and #2710.

Code simplification, exact same behaviour. Makes it easier to understand we are intercepting sections data during `render()` execution, before they are flushed.
