### PR TITLE
[5.1] Stricter check for View::render() optional callback return value

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -86,7 +86,7 @@ class View implements ArrayAccess, ViewContract
         // another view gets rendered in the future by the application developer.
         $this->factory->flushSectionsIfDoneRendering();
 
-        return $response ?: $contents;
+        return ! is_null($response) ? $response : $contents;
     }
 
     /**

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -32,10 +32,9 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $view->getFactory()->shouldReceive('decrementRender')->once()->ordered();
         $view->getFactory()->shouldReceive('flushSectionsIfDoneRendering')->once();
 
-        $me = $this;
-        $callback = function (View $rendered, $contents) use ($me, $view) {
-            $me->assertEquals($view, $rendered);
-            $me->assertEquals('contents', $contents);
+        $callback = function (View $rendered, $contents) use ($view) {
+            $this->assertEquals($view, $rendered);
+            $this->assertEquals('contents', $contents);
         };
 
         $this->assertEquals('contents', $view->render($callback));

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -40,6 +40,29 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('contents', $view->render($callback));
     }
 
+    public function testRenderHandlingCallbackReturnValues()
+    {
+        $view = $this->getView();
+        $view->getFactory()->shouldReceive('incrementRender');
+        $view->getFactory()->shouldReceive('callComposer');
+        $view->getFactory()->shouldReceive('getShared')->andReturn(['shared' => 'foo']);
+        $view->getEngine()->shouldReceive('get')->andReturn('contents');
+        $view->getFactory()->shouldReceive('decrementRender');
+        $view->getFactory()->shouldReceive('flushSectionsIfDoneRendering');
+
+        $this->assertEquals('new contents', $view->render(function () {
+            return 'new contents';
+        }));
+
+        $this->assertEquals('', $view->render(function () {
+            return '';
+        }));
+
+        $this->assertEquals('contents', $view->render(function () {
+            return; // null
+        }));
+    }
+
     public function testRenderSectionsReturnsEnvironmentSections()
     {
         $view = m::mock('Illuminate\View\View[render]', [


### PR DESCRIPTION
The callback may return an empty string or even `'0'`.

This undoes https://github.com/laravel/framework/commit/24e5c2f33e70b3f6576d1906adcf058bdc34a5da.
