### PR TITLE
[5.1] Fix Foundation Composer test on various platforms

### DIFF
--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use Symfony\Component\Process\ProcessUtils;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 class FoundationComposerTest extends PHPUnit_Framework_TestCase
 {
@@ -15,7 +17,8 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
         $process = m::mock('stdClass');
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
-        $process->shouldReceive('setCommandLine')->once()->with('\''.PHP_BINARY.'\''.(defined('HHVM_VERSION') ? ' --php' : '').' composer.phar dump-autoload');
+        $binary = ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false));
+        $process->shouldReceive('setCommandLine')->once()->with($binary.(defined('HHVM_VERSION') ? ' --php' : '').' composer.phar dump-autoload');
         $process->shouldReceive('run')->once();
 
         $composer->dumpAutoloads();


### PR DESCRIPTION
Little regression from #10294.

Encountered this issue because `escapeshellarg()` and `ProcessUtils::escapeArgument()` escape with double quotes on Windows, and the test fail.

Just as in [`Foundation\Composer::findComposer()`](https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Composer.php), I'm using the Symfony components for robuster, more portable, escaping and PHP binary detection.

See at Symfony: [`ProcessUtils::escapeArgument()`](https://github.com/symfony/process/blob/master/ProcessUtils.php) - [`PhpExecutableFinder::find()`](https://github.com/symfony/process/blob/master/PhpExecutableFinder.php)
