### PR TITLE
[5.1] Second call to the function loadDeferredProviders() was removed

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -149,11 +149,6 @@ class Kernel implements KernelContract
     {
         $this->bootstrap();
 
-        // If we are calling a arbitary command from within the application, we will load
-        // all of the available deferred providers which will make all of the commands
-        // available to an application. Otherwise the command will not be available.
-        $this->app->loadDeferredProviders();
-
         return $this->getArtisan()->call($command, $parameters);
     }
 
@@ -196,7 +191,7 @@ class Kernel implements KernelContract
     }
 
     /**
-     * Bootstrap the application for HTTP requests.
+     * Bootstrap the application for artisan commands.
      *
      * @return void
      */
@@ -206,6 +201,9 @@ class Kernel implements KernelContract
             $this->app->bootstrapWith($this->bootstrappers());
         }
 
+        // If we are calling a arbitary command from within the application, we will load
+        // all of the available deferred providers which will make all of the commands
+        // available to an application. Otherwise the command will not be available.
         $this->app->loadDeferredProviders();
     }
 


### PR DESCRIPTION
The second call to `loadDeferredProviders()` does nothing since all the deferred providers were
already loaded inside the `bootstrap()` function.
Also, bootstrap function doc block was changed.
