### PR TITLE
[5.1] Keep the list of compiled paths

### DIFF
--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -57,8 +57,6 @@ class CompilerEngine extends PhpEngine
         // which have been rendered for right exception messages to be generated.
         $results = $this->evaluatePath($compiled, $data);
 
-        array_pop($this->lastCompiled);
-
         return $results;
     }
 


### PR DESCRIPTION
if we want to have a list of compiled paths in our CompilerEngine we must
not use the array_pop because by doing that we always have the list as an
empty array. 
