### PR TITLE
[5.1] Fix getting an inaccessible properties from the request when isset() or empty() is called

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -896,4 +896,21 @@ class Request extends SymfonyRequest implements ArrayAccess
             return $this->route($key);
         }
     }
+
+    /**
+     * Get an input element from the request when isset() or empty() is called on inaccessible properties.
+     *
+     * @param $key
+     * @return object|string
+     */
+    public function __isset($key)
+    {
+        $all = $this->all();
+
+        if (array_key_exists($key, $all)) {
+            return $all[$key];
+        } else {
+            return $this->route($key);
+        }
+    }
 }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -905,12 +905,6 @@ class Request extends SymfonyRequest implements ArrayAccess
      */
     public function __isset($key)
     {
-        $all = $this->all();
-
-        if (array_key_exists($key, $all)) {
-            return $all[$key];
-        } else {
-            return $this->route($key);
-        }
+        return isset($key);
     }
 }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -910,6 +910,7 @@ class Request extends SymfonyRequest implements ArrayAccess
         if (array_key_exists($key, $all)) {
             return true;
         }
+
         return false;
     }
 }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -898,13 +898,18 @@ class Request extends SymfonyRequest implements ArrayAccess
     }
 
     /**
-     * Get an input element from the request when isset() or empty() is called on inaccessible properties.
+     * Determine if an an input element (inaccessible property) triggered by calling isset() or empty() exists or is empty.
      *
      * @param $key
      * @return bool
      */
     public function __isset($key)
     {
-        return isset($key);
+        $all = $this->all();
+
+        if (array_key_exists($key, $all)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -901,7 +901,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      * Get an input element from the request when isset() or empty() is called on inaccessible properties.
      *
      * @param $key
-     * @return object|string
+     * @return bool
      */
     public function __isset($key)
     {

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -560,8 +560,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $request->shouldReceive('flash')->once()->with('except', ['key1', 'key2']);
         $request->flashExcept(['key1', 'key2']);
     }
-
-
+    
     public function testMagicMethodsWithRouterResolver()
     {
         $base = SymfonyRequest::create('/', 'GET', ['foo' => 'bar', 'empty' => '']);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -560,7 +560,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $request->shouldReceive('flash')->once()->with('except', ['key1', 'key2']);
         $request->flashExcept(['key1', 'key2']);
     }
-    
+
     public function testMagicMethodsWithRouterResolver()
     {
         $base = SymfonyRequest::create('/', 'GET', ['foo' => 'bar', 'empty' => '']);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -560,4 +560,20 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $request->shouldReceive('flash')->once()->with('except', ['key1', 'key2']);
         $request->flashExcept(['key1', 'key2']);
     }
+
+
+    public function testMagicMethodsWithRouterResolver()
+    {
+        $base = SymfonyRequest::create('/', 'GET', [ 'foo' => 'bar', 'empty' => '' ]);
+        $request = Request::createFromBase($base);
+        $this->assertEquals($request->foo, 'bar');
+        $this->assertEquals(isset($request->foo), true);
+        $this->assertEquals(empty($request->foo), false);
+        $this->assertEquals($request->empty, '');
+        $this->assertEquals(isset($request->empty), true);
+        $this->assertEquals(empty($request->empty), true);
+        $this->assertEquals($request->otherFoo, null);
+        $this->assertEquals(isset($request->otherFoo), false);
+        $this->assertEquals(empty($request->otherFoo), true);
+    }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -564,7 +564,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
     public function testMagicMethodsWithRouterResolver()
     {
-        $base = SymfonyRequest::create('/', 'GET', [ 'foo' => 'bar', 'empty' => '' ]);
+        $base = SymfonyRequest::create('/', 'GET', ['foo' => 'bar', 'empty' => '']);
         $request = Request::createFromBase($base);
         $this->assertEquals($request->foo, 'bar');
         $this->assertEquals(isset($request->foo), true);


### PR DESCRIPTION
Get an input element from the request when isset() or empty() is called on inaccessible properties.

More details:
https://github.com/laravel/framework/issues/10403#issuecomment-144459256
https://gist.github.com/kneipp/aee5802d08505d605676
http://php.net/manual/en/language.oop5.overloading.php#object.isset
