### PR TITLE
Skip subsequent validation rules for a field when the one before it fails

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -312,6 +312,13 @@ class Validator implements ValidatorContract
         foreach ($this->rules as $attribute => $rules) {
             foreach ($rules as $rule) {
                 $this->validate($attribute, $rule);
+
+                // Check if the current field rule failed.
+                if (count($this->messages->all()) !== 0) {
+                    // Rule failed, skip all other possible rules for
+                    // this field and move on to the next field.
+                    continue 2;
+                }
             }
         }
 


### PR DESCRIPTION
Proposal for issue https://github.com/laravel/framework/issues/4789. Prevents fields validation rules from being executed when the input field doesn't meet the rule requirements of the rule before it. E.g. don't run all validation rules of a field when one fails.
