### PR TITLE
  [5.1] Fix getting an inaccessible properties from the request when isset() or empty() is called

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -896,4 +896,27 @@ class Request extends SymfonyRequest implements ArrayAccess
             return $this->route($key);
         }
     }
+
+    /**
+     * Check if an input element was set in request.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        $all = $this->all();
+
+        if (array_key_exists($key, $all)) {
+            return true;
+        }
+
+        $route = call_user_func($this->getRouteResolver());
+
+        if (is_null($route)) {
+            return false;
+        }
+
+        return array_key_exists($key, $route->parameters());
+    }
 }


### PR DESCRIPTION
Improve and fix: https://github.com/laravel/framework/pull/10431
