### PR TITLE
[5.1] Fixes issue #10403: empty() over Request returns inconsistent results because __isset() is not defined;

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -896,4 +896,27 @@ class Request extends SymfonyRequest implements ArrayAccess
             return $this->route($key);
         }
     }
+
+    /**
+     * Check if an input element was set in request.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        $all = $this->all();
+
+        if (array_key_exists($key, $all)) {
+            return true;
+        }
+
+        $route = call_user_func($this->getRouteResolver());
+
+        if (is_null($route)) {
+            return false;
+        }
+
+        return array_key_exists($key, $route->parameters());
+    }
 }

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -540,7 +540,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests to issue https://github.com/laravel/framework/issues/10403
+     * Tests to https://github.com/laravel/framework/issues/10403 issue.
      * @dataProvider magicMethodsProvider
      */
     public function testMagicMethods($uri, $route, $parameters, $property, $propertyValue, $propertyIsset, $propertyEmpty)
@@ -548,7 +548,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $request = Request::create($uri, 'GET', $parameters);
 
         // Allow to simulates when a route is inaccessible or undefined.
-        if (!is_null($route)) {
+        if (! is_null($route)) {
             $request->setRouteResolver(function () use ($request, $route) {
                 $route = new Route('GET', $route, []);
                 $route->bind($request);
@@ -566,17 +566,17 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
     {
         return [
             // Simulates QueryStrings.
-            [ '/', null, [ 'foo' => 'bar', 'empty' => '' ], 'foo', 'bar', true, false ],
-            [ '/', null, [ 'foo' => 'bar', 'empty' => '' ], 'empty', '', true, true ],
-            [ '/', null, [ 'foo' => 'bar', 'empty' => '' ], 'undefined', null, false, true ],
+            ['/', null, ['foo' => 'bar', 'empty' => ''], 'foo', 'bar', true, false],
+            ['/', null, ['foo' => 'bar', 'empty' => ''], 'empty', '', true, true],
+            ['/', null, ['foo' => 'bar', 'empty' => ''], 'undefined', null, false, true],
 
             // Simulates Routes.
-            [ '/example/bar', '/example/{foo}/{undefined?}', [], 'foo', 'bar', true, false ],
-            [ '/example/bar', '/example/{foo}/{undefined?}', [], 'undefined', null, false, true ],
+            ['/example/bar', '/example/{foo}/{undefined?}', [], 'foo', 'bar', true, false],
+            ['/example/bar', '/example/{foo}/{undefined?}', [], 'undefined', null, false, true],
 
             // Simulates no QueryStrings or Routes.
-            [ '/', '/', [], 'undefined', null, false, true ],
-            [ '/', null, [], 'undefined', null, false, true ],
+            ['/', '/', [], 'undefined', null, false, true],
+            ['/', null, [], 'undefined', null, false, true],
         ];
     }
 


### PR DESCRIPTION
This was started originally by @kneipp, continuing from PR #10431 about issue #10403.

It'll add the `__isset()` method to `Http\Request`, making possible check if property is `empty()` or `isset()` correctly.

CC @taylorotwell and @GrahamCampbell 
