### PR TITLE
[5.1] Fix tests results on Windows

### DIFF
--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -12,6 +12,9 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
 
     public function testExecCreatesNewCommand()
     {
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+        $escapeReal = '\\' === DIRECTORY_SEPARATOR ? '\\"' : '"';
+
         $schedule = new Schedule;
         $schedule->exec('path/to/command');
         $schedule->exec('path/to/command -f --foo="bar"');
@@ -24,20 +27,22 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('path/to/command', $events[0]->command);
         $this->assertEquals('path/to/command -f --foo="bar"', $events[1]->command);
         $this->assertEquals('path/to/command -f', $events[2]->command);
-        $this->assertEquals('path/to/command --foo=\'bar\'', $events[3]->command);
-        $this->assertEquals('path/to/command -f --foo=\'bar\'', $events[4]->command);
-        $this->assertEquals('path/to/command --title=\'A "real" test\'', $events[5]->command);
+        $this->assertEquals('path/to/command --foo='.$escape.'bar'.$escape, $events[3]->command);
+        $this->assertEquals('path/to/command -f --foo='.$escape.'bar'.$escape, $events[4]->command);
+        $this->assertEquals('path/to/command --title='.$escape.'A '.$escapeReal.'real'.$escapeReal.' test'.$escape, $events[5]->command);
     }
 
     public function testCommandCreatesNewArtisanCommand()
     {
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+
         $schedule = new Schedule;
         $schedule->command('queue:listen');
         $schedule->command('queue:listen --tries=3');
         $schedule->command('queue:listen', ['--tries' => 3]);
 
         $events = $schedule->events();
-        $binary = '\''.PHP_BINARY.'\''.(defined('HHVM_VERSION') ? ' --php' : '');
+        $binary = $escape.PHP_BINARY.$escape.(defined('HHVM_VERSION') ? ' --php' : '');
         $this->assertEquals($binary.' artisan queue:listen', $events[0]->command);
         $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[1]->command);
         $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[2]->command);

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -205,6 +205,9 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
         @unlink(__DIR__.'/foo.txt');
     }
 
+    /**
+     * @requires extension fileinfo
+     */
     public function testMimeTypeOutputsMimeType()
     {
         file_put_contents(__DIR__.'/foo.txt', 'foo');

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -11,11 +11,13 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase
 
     public function testDumpAutoloadRunsTheCorrectCommand()
     {
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+
         $composer = $this->getMock('Illuminate\Foundation\Composer', ['getProcess'], [$files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__]);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
         $process = m::mock('stdClass');
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
-        $process->shouldReceive('setCommandLine')->once()->with('\''.PHP_BINARY.'\''.(defined('HHVM_VERSION') ? ' --php' : '').' composer.phar dump-autoload');
+        $process->shouldReceive('setCommandLine')->once()->with($escape.PHP_BINARY.$escape.(defined('HHVM_VERSION') ? ' --php' : '').' composer.phar dump-autoload');
         $process->shouldReceive('run')->once();
 
         $composer->dumpAutoloads();

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -34,10 +34,11 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase
     {
         $listener = new Illuminate\Queue\Listener(__DIR__);
         $process = $listener->makeProcess('connection', 'queue', 1, 2, 3);
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
 
         $this->assertInstanceOf('Symfony\Component\Process\Process', $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals('\''.PHP_BINARY.'\''.(defined('HHVM_VERSION') ? ' --php' : '').' artisan queue:work \'connection\' --queue=\'queue\' --delay=1 --memory=2 --sleep=3 --tries=0', $process->getCommandLine());
+        $this->assertEquals($escape.PHP_BINARY.$escape.(defined('HHVM_VERSION') ? ' --php' : '').' artisan queue:work '.$escape.'connection'.$escape.' --queue='.$escape.'queue'.$escape.' --delay=1 --memory=2 --sleep=3 --tries=0', $process->getCommandLine());
     }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1024,6 +1024,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
     }
 
+    /**
+     * @requires extension fileinfo
+     */
     public function testValidateMimetypes()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
Laravel fails in some tests on Windows because it uses double quote as escape character on command-line, Unix uses single quote.

Additionally, it too fixes a `fileinfo` extension dependency on tests. On [Laravel docs](http://laravel.com/docs/5.1) it's not shown as a dependency, so it can be skiped on tests if you don't have enabled this extension without problem. 
