### PR TITLE
[5.1] Fix tests on Windows

### DIFF
--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -21,12 +21,13 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
         $schedule->exec('path/to/command', ['--title' => 'A "real" test']);
 
         $events = $schedule->events();
+        $q = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
         $this->assertEquals('path/to/command', $events[0]->command);
         $this->assertEquals('path/to/command -f --foo="bar"', $events[1]->command);
         $this->assertEquals('path/to/command -f', $events[2]->command);
-        $this->assertEquals('path/to/command --foo=\'bar\'', $events[3]->command);
-        $this->assertEquals('path/to/command -f --foo=\'bar\'', $events[4]->command);
-        $this->assertEquals('path/to/command --title=\'A "real" test\'', $events[5]->command);
+        $this->assertEquals('path/to/command --foo='.$q.'bar'.$q, $events[3]->command);
+        $this->assertEquals('path/to/command -f --foo='.$q.'bar'.$q, $events[4]->command);
+        $this->assertEquals('path/to/command --title='.$q.($q == '"' ? 'A \\"real\\" test' : 'A "real" test').$q, $events[5]->command);
     }
 
     public function testCommandCreatesNewArtisanCommand()
@@ -37,7 +38,8 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
         $schedule->command('queue:listen', ['--tries' => 3]);
 
         $events = $schedule->events();
-        $binary = '\''.PHP_BINARY.'\''.(defined('HHVM_VERSION') ? ' --php' : '');
+        $q = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
+        $binary = $q.PHP_BINARY.$q.(defined('HHVM_VERSION') ? ' --php' : '');
         $this->assertEquals($binary.' artisan queue:listen', $events[0]->command);
         $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[1]->command);
         $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[2]->command);

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -15,7 +15,8 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
         $process = m::mock('stdClass');
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
-        $process->shouldReceive('setCommandLine')->once()->with('\''.PHP_BINARY.'\''.(defined('HHVM_VERSION') ? ' --php' : '').' composer.phar dump-autoload');
+        $q = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
+        $process->shouldReceive('setCommandLine')->once()->with($q.PHP_BINARY.$q.(defined('HHVM_VERSION') ? ' --php' : '').' composer.phar dump-autoload');
         $process->shouldReceive('run')->once();
 
         $composer->dumpAutoloads();

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -38,6 +38,7 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Process\Process', $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals('\''.PHP_BINARY.'\''.(defined('HHVM_VERSION') ? ' --php' : '').' artisan queue:work \'connection\' --queue=\'queue\' --delay=1 --memory=2 --sleep=3 --tries=0', $process->getCommandLine());
+        $q = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'";
+        $this->assertEquals($q.PHP_BINARY.$q.(defined('HHVM_VERSION') ? ' --php' : '')." artisan queue:work {$q}connection{$q} --queue={$q}queue{$q} --delay=1 --memory=2 --sleep=3 --tries=0", $process->getCommandLine());
     }
 }


### PR DESCRIPTION
Single/double quotes discrepancies, side effect of #10294.
Follow-up to #10422. All tests fixed, with strict assertions.

I was going to use [`escapeshellarg`](http://php.net/manual/en/function.escapeshellarg.php), but `escapeshellarg('A "real" test')` gave me trouble:

> On Windows, escapeshellarg() instead removes percent signs, **replaces double quotes with spaces** and adds double quotes around the string.

Hence the `$q = (DIRECTORY_SEPARATOR == '\\') ? '"' : "'"` method. I used it in all places for consistency, and strictness (values hardcoded the most possible, trust no function).
