### PR TITLE
[5.1] Added annotations on tests where fileinfo extension will be required.

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -205,6 +205,9 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
         @unlink(__DIR__.'/foo.txt');
     }
 
+    /**
+     * @requires extension fileinfo
+     */
     public function testMimeTypeOutputsMimeType()
     {
         file_put_contents(__DIR__.'/foo.txt', 'foo');

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1024,6 +1024,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
     }
 
+    /**
+     * @requires extension fileinfo
+     */
     public function testValidateMimetypes()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
Currently, Laravel doesn't requires fileinfo extension to works. So, tests can be skiped when it is used but no installed to avoid _fatal errors_ when run tests.

@GrahamCampbell 

**From:** https://github.com/laravel/framework/pull/10438
