### PR TITLE
[5.1] Added small fixes to allow run tests smoothly on Windows

### DIFF
--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -27,9 +27,9 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('path/to/command', $events[0]->command);
         $this->assertEquals('path/to/command -f --foo="bar"', $events[1]->command);
         $this->assertEquals('path/to/command -f', $events[2]->command);
-        $this->assertEquals('path/to/command --foo='.$escape.'bar'.$escape, $events[3]->command);
-        $this->assertEquals('path/to/command -f --foo='.$escape.'bar'.$escape, $events[4]->command);
-        $this->assertEquals('path/to/command --title='.$escape.'A '.$escapeReal.'real'.$escapeReal.' test'.$escape, $events[5]->command);
+        $this->assertEquals("path/to/command --foo={$escape}bar{$escape}", $events[3]->command);
+        $this->assertEquals("path/to/command -f --foo={$escape}bar{$escape}", $events[4]->command);
+        $this->assertEquals("path/to/command --title={$escape}A {$escapeReal}real{$escapeReal} test{$escape}", $events[5]->command);
     }
 
     public function testCommandCreatesNewArtisanCommand()

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -12,6 +12,9 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
 
     public function testExecCreatesNewCommand()
     {
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+        $escapeReal = '\\' === DIRECTORY_SEPARATOR ? '\\"' : '"';
+
         $schedule = new Schedule;
         $schedule->exec('path/to/command');
         $schedule->exec('path/to/command -f --foo="bar"');
@@ -24,20 +27,22 @@ class ConsoleEventSchedulerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('path/to/command', $events[0]->command);
         $this->assertEquals('path/to/command -f --foo="bar"', $events[1]->command);
         $this->assertEquals('path/to/command -f', $events[2]->command);
-        $this->assertEquals('path/to/command --foo=\'bar\'', $events[3]->command);
-        $this->assertEquals('path/to/command -f --foo=\'bar\'', $events[4]->command);
-        $this->assertEquals('path/to/command --title=\'A "real" test\'', $events[5]->command);
+        $this->assertEquals('path/to/command --foo='.$escape.'bar'.$escape, $events[3]->command);
+        $this->assertEquals('path/to/command -f --foo='.$escape.'bar'.$escape, $events[4]->command);
+        $this->assertEquals('path/to/command --title='.$escape.'A '.$escapeReal.'real'.$escapeReal.' test'.$escape, $events[5]->command);
     }
 
     public function testCommandCreatesNewArtisanCommand()
     {
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+
         $schedule = new Schedule;
         $schedule->command('queue:listen');
         $schedule->command('queue:listen --tries=3');
         $schedule->command('queue:listen', ['--tries' => 3]);
 
         $events = $schedule->events();
-        $binary = '\''.PHP_BINARY.'\''.(defined('HHVM_VERSION') ? ' --php' : '');
+        $binary = $escape.PHP_BINARY.$escape.(defined('HHVM_VERSION') ? ' --php' : '');
         $this->assertEquals($binary.' artisan queue:listen', $events[0]->command);
         $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[1]->command);
         $this->assertEquals($binary.' artisan queue:listen --tries=3', $events[2]->command);

--- a/tests/Foundation/FoundationComposerTest.php
+++ b/tests/Foundation/FoundationComposerTest.php
@@ -11,11 +11,13 @@ class FoundationComposerTest extends PHPUnit_Framework_TestCase
 
     public function testDumpAutoloadRunsTheCorrectCommand()
     {
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
+
         $composer = $this->getMock('Illuminate\Foundation\Composer', ['getProcess'], [$files = m::mock('Illuminate\Filesystem\Filesystem'), __DIR__]);
         $files->shouldReceive('exists')->once()->with(__DIR__.'/composer.phar')->andReturn(true);
         $process = m::mock('stdClass');
         $composer->expects($this->once())->method('getProcess')->will($this->returnValue($process));
-        $process->shouldReceive('setCommandLine')->once()->with('\''.PHP_BINARY.'\''.(defined('HHVM_VERSION') ? ' --php' : '').' composer.phar dump-autoload');
+        $process->shouldReceive('setCommandLine')->once()->with($escape.PHP_BINARY.$escape.(defined('HHVM_VERSION') ? ' --php' : '').' composer.phar dump-autoload');
         $process->shouldReceive('run')->once();
 
         $composer->dumpAutoloads();

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -34,10 +34,11 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase
     {
         $listener = new Illuminate\Queue\Listener(__DIR__);
         $process = $listener->makeProcess('connection', 'queue', 1, 2, 3);
+        $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';
 
         $this->assertInstanceOf('Symfony\Component\Process\Process', $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals('\''.PHP_BINARY.'\''.(defined('HHVM_VERSION') ? ' --php' : '').' artisan queue:work \'connection\' --queue=\'queue\' --delay=1 --memory=2 --sleep=3 --tries=0', $process->getCommandLine());
+        $this->assertEquals($escape.PHP_BINARY.$escape.(defined('HHVM_VERSION') ? ' --php' : '').' artisan queue:work '.$escape.'connection'.$escape.' --queue='.$escape.'queue'.$escape.' --delay=1 --memory=2 --sleep=3 --tries=0', $process->getCommandLine());
     }
 }

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -39,6 +39,6 @@ class QueueListenerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Process\Process', $process);
         $this->assertEquals(__DIR__, $process->getWorkingDirectory());
         $this->assertEquals(3, $process->getTimeout());
-        $this->assertEquals($escape.PHP_BINARY.$escape.(defined('HHVM_VERSION') ? ' --php' : '').' artisan queue:work '.$escape.'connection'.$escape.' --queue='.$escape.'queue'.$escape.' --delay=1 --memory=2 --sleep=3 --tries=0', $process->getCommandLine());
+        $this->assertEquals($escape.PHP_BINARY.$escape.(defined('HHVM_VERSION') ? ' --php' : '')." artisan queue:work {$escape}connection{$escape} --queue={$escape}queue{$escape} --delay=1 --memory=2 --sleep=3 --tries=0", $process->getCommandLine());
     }
 }


### PR DESCRIPTION
Currently, tests on Windows will fail when need to escape commands. Tests expect Unix single quotes, but Windows expect double quotes. It's a limitation of PHP because [`escapeshellargs()`](http://php.net/manual/en/function.escapeshellarg.php) is more powerful on Unix, so the `ProcessUtils` from `symfony/process` do a workaround to solve it, but Laravel tests always expect Unix style, even on Windows.

This PR will fix that by make tests works differently on Windows and Unix, by expect the correct quote style for each case.

Example:
- **Unix:** `'/path/to/file' --version`
- **Windows:** `"/path/to/file" --version`
- **Test (before):** `'/path/to/file' --version` (matches with Unix, but not with Windows)
- **Test (now, on Unix):** `'/path/to/file' --version` (matched on Unix)
- **Test (now, on Windows):** `"/path/to/file" --version` (matched on Windows)

@GrahamCampbell 

**From:** https://github.com/laravel/framework/pull/10438
