### PR TITLE
[5.1] Set .php extension for compiled view files

### DIFF
--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -41,7 +41,7 @@ abstract class Compiler
      */
     public function getCompiledPath($path)
     {
-        return $this->cachePath.'/'.md5($path);
+        return $this->cachePath.'/'.md5($path).'.php';
     }
 
     /**


### PR DESCRIPTION
Having the proper extensions (it's PHP code in there), makes developer's live easier
- Code highlighting in the IDE
- Debugging functionality 
  (at least in PHPStorm)
