### PR TITLE
[5.2] Set .php extension for compiled view files

### DIFF
--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -41,7 +41,7 @@ abstract class Compiler
      */
     public function getCompiledPath($path)
     {
-        return $this->cachePath.'/'.md5($path);
+        return $this->cachePath.'/'.md5($path).'.php';
     }
 
     /**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -13,7 +13,7 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
     public function testIsExpiredReturnsTrueIfCompiledFileDoesntExist()
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
-        $files->shouldReceive('exists')->once()->with(__DIR__.'/'.md5('foo'))->andReturn(false);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/'.md5('foo').'.php')->andReturn(false);
         $this->assertTrue($compiler->isExpired('foo'));
     }
 
@@ -27,23 +27,23 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
     public function testIsExpiredReturnsTrueWhenModificationTimesWarrant()
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
-        $files->shouldReceive('exists')->once()->with(__DIR__.'/'.md5('foo'))->andReturn(true);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/'.md5('foo').'.php')->andReturn(true);
         $files->shouldReceive('lastModified')->once()->with('foo')->andReturn(100);
-        $files->shouldReceive('lastModified')->once()->with(__DIR__.'/'.md5('foo'))->andReturn(0);
+        $files->shouldReceive('lastModified')->once()->with(__DIR__.'/'.md5('foo').'.php')->andReturn(0);
         $this->assertTrue($compiler->isExpired('foo'));
     }
 
     public function testCompilePathIsProperlyCreated()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
-        $this->assertEquals(__DIR__.'/'.md5('foo'), $compiler->getCompiledPath('foo'));
+        $this->assertEquals(__DIR__.'/'.md5('foo').'.php', $compiler->getCompiledPath('foo'));
     }
 
     public function testCompileCompilesFileAndReturnsContents()
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.md5('foo'), 'Hello World');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.md5('foo').'.php', 'Hello World');
         $compiler->compile('foo');
     }
 
@@ -51,7 +51,7 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.md5('foo'), 'Hello World');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.md5('foo').'.php', 'Hello World');
         $compiler->compile('foo');
         $this->assertEquals('foo', $compiler->getPath());
     }
@@ -67,7 +67,7 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/'.md5('foo'), 'Hello World');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/'.md5('foo').'.php', 'Hello World');
         // set path before compilation
         $compiler->setPath('foo');
         // trigger compilation with null $path


### PR DESCRIPTION
Having the proper extensions (it's PHP code in there), makes developer's live easier
- Code highlighting in the IDE
- Debugging functionality (at least in PHPStorm)
