### PR TITLE
[5.1] Added class path to exception

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -124,7 +124,7 @@ class FactoryBuilder
     {
         return Model::unguarded(function () use ($attributes) {
             if (! isset($this->definitions[$this->class][$this->name])) {
-                throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}].");
+                throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}] [{$this->class}].");
             }
 
             $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker, $attributes);


### PR DESCRIPTION
As per #10460 this will provide more information to the users when testing as currently it just says default all the time which is of no use to anyone, providing the class path will help to know where in your code you are calling that.
