### PR TITLE
[5.1] Alias docblock quotes

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -67,7 +67,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Alias for the avg method.
+     * Alias for the "avg" method.
      *
      * @param  string|null  $key
      * @return mixed


### PR DESCRIPTION
To be consistent with the other alias methods' docblocks.
