### PR TITLE
[5.2] Remove the array_fetch helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -112,22 +112,6 @@ if (! function_exists('array_except')) {
     }
 }
 
-if (! function_exists('array_fetch')) {
-    /**
-     * Fetch a flattened array of a nested array element.
-     *
-     * @param  array   $array
-     * @param  string  $key
-     * @return array
-     *
-     * @deprecated since version 5.1. Use array_pluck instead.
-     */
-    function array_fetch($array, $key)
-    {
-        return Arr::fetch($array, $key);
-    }
-}
-
 if (! function_exists('array_first')) {
     /**
      * Return the first element in an array passing a given truth test.


### PR DESCRIPTION
The underlying `Arr::fetch` method doesn't even exist anymore.
