### PR TITLE
[5.1] Fix for Unions in Models

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1246,7 +1246,7 @@ class Builder
 
         $this->unions[] = compact('query', 'all');
 
-        $this->addBinding($query->bindings, 'union');
+        $this->addBinding(isset($query->bindings) ? $query->bindings : $query->getBindings(), 'union');
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1246,7 +1246,7 @@ class Builder
 
         $this->unions[] = compact('query', 'all');
 
-        $this->addBinding(isset($query->bindings) ? $query->bindings : $query->getBindings(), 'union');
+        $this->addBinding($query->getBindings(), 'union');
 
         return $this;
     }


### PR DESCRIPTION
When you add a clause to an eloquent model and use union or unionAll, this error is generated:

```
ErrorException in Builder.php line 1244:
Undefined property: Illuminate\Database\Eloquent\Builder::$bindings
```

This modification fixes this Exception
