### PR TITLE
[5.1] Fix undefined variable

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1668,7 +1668,7 @@ class Builder
      */
     public function average($column)
     {
-        return $this->avg($key);
+        return $this->avg($column);
     }
 
     /**


### PR DESCRIPTION
Fixed the undefined variable in the query builder "average" method.
