### PR TITLE
Adds the ability to select which language faker will generate the data

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -60,7 +60,7 @@ class DatabaseServiceProvider extends ServiceProvider
     protected function registerEloquentFactory()
     {
         $this->app->singleton(FakerGenerator::class, function () {
-        	return FakerFactory::create(config('database.faker_locale', 'en_US'));
+        	 return FakerFactory::create(config('database.faker_locale', 'en_US'));
         });
 
         $this->app->singleton(EloquentFactory::class, function ($app) {

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -60,7 +60,7 @@ class DatabaseServiceProvider extends ServiceProvider
     protected function registerEloquentFactory()
     {
         $this->app->singleton(FakerGenerator::class, function () {
-        	 return FakerFactory::create(config('database.faker_locale', 'en_US'));
+        	return FakerFactory::create(config('database.faker_locale', 'en_US'));
         });
 
         $this->app->singleton(EloquentFactory::class, function ($app) {

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -60,7 +60,7 @@ class DatabaseServiceProvider extends ServiceProvider
     protected function registerEloquentFactory()
     {
         $this->app->singleton(FakerGenerator::class, function () {
-            return FakerFactory::create();
+        	return FakerFactory::create(config('database.faker_locale', 'en_US'));
         });
 
         $this->app->singleton(EloquentFactory::class, function ($app) {

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -14,8 +14,6 @@ class DatabaseServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap the application events.
-     *
-     * @return void
      */
     public function boot()
     {
@@ -26,8 +24,6 @@ class DatabaseServiceProvider extends ServiceProvider
 
     /**
      * Register the service provider.
-     *
-     * @return void
      */
     public function register()
     {
@@ -54,13 +50,11 @@ class DatabaseServiceProvider extends ServiceProvider
 
     /**
      * Register the Eloquent factory instance in the container.
-     *
-     * @return void
      */
     protected function registerEloquentFactory()
     {
-        $this->app->singleton(FakerGenerator::class, function () {
-        	return FakerFactory::create(config('database.faker_locale', 'en_US'));
+        $this->app->singleton(FakerGenerator::class, function ($app) {
+            return FakerFactory::create($app['config']->get('database.faker_locale', 'en_US'));
         });
 
         $this->app->singleton(EloquentFactory::class, function ($app) {
@@ -72,13 +66,11 @@ class DatabaseServiceProvider extends ServiceProvider
 
     /**
      * Register the queueable entity resolver implementation.
-     *
-     * @return void
      */
     protected function registerQueueableEntityResolver()
     {
         $this->app->singleton('Illuminate\Contracts\Queue\EntityResolver', function () {
-            return new QueueEntityResolver;
+            return new QueueEntityResolver();
         });
     }
 }


### PR DESCRIPTION
It would be nice to be able to select which language Faker will generate the factory data from.

I thought of using the app.locale var but what if the language is not available in faker... might be cleaner to differentiate the two.

So instead I thought you could add a dedicated config option in the database file for instance. That way you can swap it easily.

Sorry if this is not very clean, just trying to contribute in my own little way with a solution to something that's bothering me.

Thank you.

config/database.php

```
    /*
    |--------------------------------------------------------------------------
    | Faker locale
    |--------------------------------------------------------------------------
    |
    | Language in which faker will generate dummy data
    |
    */

    'faker_locale' => 'fr_FR', 
```
