### PR TITLE
[5.1] Fix Request::only() docblock

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -293,7 +293,7 @@ class Request extends SymfonyRequest implements ArrayAccess
     /**
      * Get a subset of the items from the input data.
      *
-     * @param  array  $keys
+     * @param  array|mixed  $keys
      * @return array
      */
     public function only($keys)


### PR DESCRIPTION
The `$keys` @param tag in the docblock of the `Request::only()` method does not strictly accept an array.

Any number of parameters can be passed, since the `$keys` array can be assigned with the `func_get_args()` function. Therefore `array|mixed` is more correct.
