### PR TITLE
Normalize @param tags on docblocks for array-like arguments

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -540,7 +540,7 @@ class Event
     /**
      * Set the days of the week the command should run on.
      *
-     * @param  array|dynamic  $days
+     * @param  array|mixed  $days
      * @return $this
      */
     public function days($days)
@@ -579,7 +579,7 @@ class Event
     /**
      * Limit the environments the command should run in.
      *
-     * @param  array|dynamic  $environments
+     * @param  array|mixed  $environments
      * @return $this
      */
     public function environments($environments)
@@ -657,7 +657,7 @@ class Event
     /**
      * E-mail the results of the scheduled operation.
      *
-     * @param  array|dynamic  $addresses
+     * @param  array|mixed  $addresses
      * @return $this
      *
      * @throws \LogicException

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -656,7 +656,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Get all of the models from the database.
      *
-     * @param  array  $columns
+     * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Collection|static[]
      */
     public static function all($columns = ['*'])
@@ -1357,7 +1357,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Add an observable event name.
      *
-     * @param  mixed  $observables
+     * @param  array|mixed  $observables
      * @return void
      */
     public function addObservableEvents($observables)
@@ -1370,7 +1370,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Remove an observable event name.
      *
-     * @param  mixed  $observables
+     * @param  array|mixed  $observables
      * @return void
      */
     public function removeObservableEvents($observables)

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1142,7 +1142,7 @@ class BelongsToMany extends Relation
     /**
      * Set the columns on the pivot table to retrieve.
      *
-     * @param  mixed  $columns
+     * @param  array|mixed  $columns
      * @return $this
      */
     public function withPivot($columns)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -224,7 +224,7 @@ class Builder
     /**
      * Set the columns to be selected.
      *
-     * @param  array  $columns
+     * @param  array|mixed  $columns
      * @return $this
      */
     public function select($columns = ['*'])
@@ -283,7 +283,7 @@ class Builder
     /**
      * Add a new select column to the query.
      *
-     * @param  mixed  $column
+     * @param  array|mixed  $column
      * @return $this
      */
     public function addSelect($column)

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -203,12 +203,12 @@ class Blueprint
     /**
      * Indicate that the given columns should be dropped.
      *
-     * @param  string|array  $columns
+     * @param  array|mixed  $columns
      * @return \Illuminate\Support\Fluent
      */
     public function dropColumn($columns)
     {
-        $columns = is_array($columns) ? $columns : (array) func_get_args();
+        $columns = is_array($columns) ? $columns : func_get_args();
 
         return $this->addCommand('dropColumn', compact('columns'));
     }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -112,7 +112,7 @@ class Filesystem
     /**
      * Delete the file at a given path.
      *
-     * @param  string|array  $paths
+     * @param  array|mixed  $paths
      * @return bool
      */
     public function delete($paths)

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -140,7 +140,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     /**
      * Delete the file at a given path.
      *
-     * @param  string|array  $paths
+     * @param  array|mixed  $paths
      * @return bool
      */
     public function delete($paths)

--- a/src/Illuminate/Foundation/Testing/ApplicationTrait.php
+++ b/src/Illuminate/Foundation/Testing/ApplicationTrait.php
@@ -53,7 +53,7 @@ trait ApplicationTrait
      *
      * These events will be mocked, so that handlers will not actually be executed.
      *
-     * @param  array|dynamic  $events
+     * @param  array|mixed  $events
      * @return $this
      */
     public function expectsEvents($events)
@@ -106,7 +106,7 @@ trait ApplicationTrait
      *
      * These jobs will be mocked, so that handlers will not actually be executed.
      *
-     * @param  array|dynamic  $jobs
+     * @param  array|mixed  $jobs
      * @return $this
      */
     protected function expectsJobs($jobs)

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -214,7 +214,7 @@ class Request extends SymfonyRequest implements ArrayAccess
     /**
      * Determine if the request contains a given input item key.
      *
-     * @param  string|array  $key
+     * @param  array|mixed  $key
      * @return bool
      */
     public function exists($key)
@@ -235,7 +235,7 @@ class Request extends SymfonyRequest implements ArrayAccess
     /**
      * Determine if the request contains a non-empty value for an input item.
      *
-     * @param  string|array  $key
+     * @param  array|mixed  $key
      * @return bool
      */
     public function has($key)
@@ -314,7 +314,7 @@ class Request extends SymfonyRequest implements ArrayAccess
     /**
      * Get all of the input except for a specified array of items.
      *
-     * @param  array  $keys
+     * @param  array|mixed  $keys
      * @return array
      */
     public function except($keys)
@@ -460,7 +460,7 @@ class Request extends SymfonyRequest implements ArrayAccess
     /**
      * Flash only some of the input to the session.
      *
-     * @param  mixed  string
+     * @param  array|mixed  $keys
      * @return void
      */
     public function flashOnly($keys)
@@ -473,7 +473,7 @@ class Request extends SymfonyRequest implements ArrayAccess
     /**
      * Flash only some of the input to the session.
      *
-     * @param  mixed  string
+     * @param  array|mixed  $keys
      * @return void
      */
     public function flashExcept($keys)

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -63,7 +63,7 @@ class Pipeline implements PipelineContract
     /**
      * Set the array of pipes.
      *
-     * @param  dynamic|array  $pipes
+     * @param  array|mixed  $pipes
      * @return $this
      */
     public function through($pipes)

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -161,7 +161,7 @@ abstract class ServiceProvider
     /**
      * Register the package's custom Artisan commands.
      *
-     * @param  array  $commands
+     * @param  array|mixed  $commands
      * @return void
      */
     public function commands($commands)


### PR DESCRIPTION
Several methods accept an `array` argument OR a variable-length number
of arguments which are used as an array with `func_get_args()`. The
@param tag on the docblocks of these methods not the same everywhere.
It should be set as `array|mixed`, which is more correct.
