### PR TITLE
[5.1] Add seeElement and dontSeeElement methods to CrawlerTrait

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -325,6 +325,41 @@ trait CrawlerTrait
     }
 
     /**
+     * Assert that a given string is seen inside an element.
+     *
+     * @param  bool|string|null  $element
+     * @param  string  $text
+     * @param  bool  $negate
+     * @return $this
+     */
+    protected function seeElement($element, $text, $negate = false)
+    {
+        $method = $negate ? 'assertNotRegExp' : 'assertRegExp';
+
+        $rawPattern = preg_quote($text, '/');
+
+        $escapedPattern = preg_quote(e($text), '/');
+
+        $content = $this->crawler->filter($element)->html();
+
+        $this->$method("/({$rawPattern}|{$escapedPattern})/i", $content);
+
+        return $this;
+    }
+
+    /**
+     * Assert that a given string is not seen inside an element.
+     *
+     * @param  string  $text
+     * @param  string|null  $element
+     * @return $this
+     */
+    protected function dontSeeElement($element, $text)
+    {
+        return $this->seeElement($element, $text, true);
+    }
+
+    /**
      * Assert that a given link is seen on the page.
      *
      * @param  string  $text

--- a/tests/Foundation/FoundationCrawlerTraitIntegrationTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitIntegrationTest.php
@@ -7,6 +7,25 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 {
     use CrawlerTrait;
 
+    public function testSeeElement()
+    {
+        $this->crawler = new Crawler(
+            '<div>Laravel was created by <strong>Taylor Otwell</strong></div>'
+        );
+
+        $this->seeElement('strong', 'Taylor');
+    }
+
+    public function testDontSeeElement()
+    {
+        $this->crawler = new Crawler(
+            '<div>Laravel was created by <strong>Taylor Otwell</strong></div>'
+        );
+
+        $this->seeElement('strong', 'Laravel', true);
+        $this->dontSeeElement('strong', 'Laravel');
+    }
+
     public function testSeeLink()
     {
         $this->crawler = new Crawler(


### PR DESCRIPTION
Methods to check that a given text is presented inside an element.

Consider you are logged in an admin panel, and you want to test a list of users. Your username will be probably in the right up corner of the page, so if you write this:

`$this->see('sileence')`

This might return a false positive since you can't filter where is that text. But with this:

`$this->seeElement('table', 'sileence')`

You can check that the text "sileence" is inside the table element.

There is a method to check that you don't see a text inside an element as well:

```
$this->dontSeeElement('table', 'sileence', true)
```

The method names and parameters are the same as in Codeception, but you can rename them if you want.

I also added some integration tests.
