### PR TITLE
[5.2] CSPRNG Enchancements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",
         "nesbot/carbon": "~1.20",
+        "paragonie/random_compat": "^1.0.4",
         "psy/psysh": "~0.5.1",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/console": "3.0.*",

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -245,7 +245,7 @@ class Str
      */
     public static function randomBytes($length = 16)
     {
-        if (PHP_MAJOR_VERSION >= 7) {
+        if (PHP_MAJOR_VERSION >= 7 || defined('RANDOM_COMPAT_READ_BUFFER')) {
             $bytes = random_bytes($length);
         } elseif (function_exists('openssl_random_pseudo_bytes')) {
             $bytes = openssl_random_pseudo_bytes($length, $strong);
@@ -300,9 +300,9 @@ class Str
             return hash_equals($knownString, $userInput);
         }
 
-        $knownLength = mb_strlen($knownString);
+        $knownLength = mb_strlen($knownString, '8bit');
 
-        if (mb_strlen($userInput) !== $knownLength) {
+        if (mb_strlen($userInput, '8bit') !== $knownLength) {
             return false;
         }
 

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -35,6 +35,7 @@
     },
     "suggest": {
         "jeremeamia/superclosure": "Required to be able to serialize closures (~2.0).",
+        "paragonie/random_compat": "Provides a compatible interface like PHP7's random_bytes() in PHP 5 projects.",
         "symfony/var-dumper": "Required to use the dd function (3.0.*)."
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
- Adds [paragonie/random_compat](https://github.com/paragonie/random_compat) as a polyfill for PHP 7's interface in PHP 5 projects
- Make sure `Str::equals()` treats bytes as binary strings (`mb_strlen($str)` -> `mb_strlen($str, '8bit')`)

These changes should be safe to backport into earlier versions (random_compat was designed to function even on ancient versions of PHP, to encourage adoption even on ancient frameworks).
