### PR TITLE
[5.1] Assign Variable In Blade Templates

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -685,6 +685,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Compile the var statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileVar($expression)
+    {
+        return preg_replace('/\(\'(.*?)\'\,\s*(.*)\)/', '<?php $$1 = $2; ?>', $expression);
+    }
+
+    /**
      * Compile the extends statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -193,6 +193,18 @@ test
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testVarIsCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@var(\'foo\', \'bar\')';
+        $expected = '<?php $foo = \'bar\'; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+
+        $string = '@var(\'foo\', 1)';
+        $expected = '<?php $foo = 1; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     public function testCommentsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
Reading this issue (https://github.com/laravel/framework/issues/4778), Taylor Otwell and Beau Simensen seems to be both OK to add variable assignment in blade templates. Many issues has been opened for this need so I think it's acceptable.

```
@var('my_variable', 'value')
```

I can change it to `set` too if you want.
