### PR TITLE
[5.2] Fix contextual binding for classes w/ leading slash

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -120,6 +120,8 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function when($concrete)
     {
+        $concrete = $this->normalize($concrete);
+
         return new ContextualBindingBuilder($this, $concrete);
     }
 
@@ -131,6 +133,8 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function bound($abstract)
     {
+        $abstract = $this->normalize($abstract);
+
         return isset($this->bindings[$abstract]) || isset($this->instances[$abstract]) || $this->isAlias($abstract);
     }
 
@@ -142,6 +146,8 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function resolved($abstract)
     {
+        $abstract = $this->normalize($abstract);
+
         return isset($this->resolved[$abstract]) || isset($this->instances[$abstract]);
     }
 
@@ -153,7 +159,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function isAlias($name)
     {
-        return isset($this->aliases[$name]);
+        return isset($this->aliases[$this->normalize($name)]);
     }
 
     /**
@@ -166,6 +172,9 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function bind($abstract, $concrete = null, $shared = false)
     {
+        $abstract = $this->normalize($abstract);
+        $concrete = $this->normalize($concrete);
+
         // If the given types are actually an array, we will assume an alias is being
         // defined and will grab this "real" abstract class name and register this
         // alias with the container so that it can be used as a shortcut for it.
@@ -227,7 +236,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function addContextualBinding($concrete, $abstract, $implementation)
     {
-        $this->contextual[$concrete][$abstract] = $implementation;
+        $this->contextual[$this->normalize($concrete)][$this->normalize($abstract)] = $this->normalize($implementation);
     }
 
     /**
@@ -290,6 +299,8 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function extend($abstract, Closure $closure)
     {
+        $abstract = $this->normalize($abstract);
+
         if (isset($this->instances[$abstract])) {
             $this->instances[$abstract] = $closure($this->instances[$abstract], $this);
 
@@ -308,6 +319,8 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function instance($abstract, $instance)
     {
+        $abstract = $this->normalize($abstract);
+
         // First, we will extract the alias from the abstract if it is an array so we
         // are using the correct name when binding the type. If we get an alias it
         // will be registered with the container so we can resolve it out later.
@@ -348,7 +361,7 @@ class Container implements ArrayAccess, ContainerContract
             }
 
             foreach ((array) $abstracts as $abstract) {
-                $this->tags[$tag][] = $abstract;
+                $this->tags[$tag][] = $this->normalize($abstract);
             }
         }
     }
@@ -381,7 +394,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function alias($abstract, $alias)
     {
-        $this->aliases[$alias] = $abstract;
+        $this->aliases[$alias] = $this->normalize($abstract);
     }
 
     /**
@@ -404,7 +417,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function rebinding($abstract, Closure $callback)
     {
-        $this->reboundCallbacks[$abstract][] = $callback;
+        $this->reboundCallbacks[$this->normalize($abstract)][] = $callback;
 
         if ($this->bound($abstract)) {
             return $this->make($abstract);
@@ -421,7 +434,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function refresh($abstract, $target, $method)
     {
-        return $this->rebinding($abstract, function ($app, $instance) use ($target, $method) {
+        return $this->rebinding($this->normalize($abstract), function ($app, $instance) use ($target, $method) {
             $target->{$method}($instance);
         });
     }
@@ -595,7 +608,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function make($abstract, array $parameters = [])
     {
-        $abstract = $this->getAlias($abstract);
+        $abstract = $this->getAlias($this->normalize($abstract));
 
         // If an instance of the type is currently being managed as a singleton we'll
         // just return an existing instance instead of instantiating new instances
@@ -652,11 +665,6 @@ class Container implements ArrayAccess, ContainerContract
         // assume each type is a concrete name and will attempt to resolve it as is
         // since the container should be able to resolve concretes automatically.
         if (! isset($this->bindings[$abstract])) {
-            if ($this->missingLeadingSlash($abstract) &&
-                isset($this->bindings['\\'.$abstract])) {
-                $abstract = '\\'.$abstract;
-            }
-
             return $abstract;
         }
 
@@ -677,14 +685,21 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Determine if the given abstract has a leading slash.
-     *
-     * @param  string  $abstract
-     * @return bool
+     * @param  mixed  $service
+     * @return mixed
      */
-    protected function missingLeadingSlash($abstract)
+    protected function normalize($service)
     {
-        return is_string($abstract) && strpos($abstract, '\\') !== 0;
+        // Whether a class name begins with a backslash or not, it's still the same class,
+        // so they need to be treated as the same class. Reflection doesn't use leading slash,
+        // Reflection doesn't use leading backslash when it reports dependencies, so just
+        // dropping it seems to be the only solution that works consistently for simple and
+        // contextual binding
+        if (is_string($service)) {
+            $service = ltrim($service, '\\');
+        }
+
+        return $service;
     }
 
     /**
@@ -868,7 +883,7 @@ class Container implements ArrayAccess, ContainerContract
         if ($callback === null && $abstract instanceof Closure) {
             $this->resolvingCallback($abstract);
         } else {
-            $this->resolvingCallbacks[$abstract][] = $callback;
+            $this->resolvingCallbacks[$this->normalize($abstract)][] = $callback;
         }
     }
 
@@ -884,7 +899,7 @@ class Container implements ArrayAccess, ContainerContract
         if ($abstract instanceof Closure && $callback === null) {
             $this->afterResolvingCallback($abstract);
         } else {
-            $this->afterResolvingCallbacks[$abstract][] = $callback;
+            $this->afterResolvingCallbacks[$this->normalize($abstract)][] = $callback;
         }
     }
 
@@ -1015,6 +1030,8 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function isShared($abstract)
     {
+        $abstract = $this->normalize($abstract);
+
         if (isset($this->bindings[$abstract]['shared'])) {
             $shared = $this->bindings[$abstract]['shared'];
         } else {
@@ -1076,7 +1093,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function forgetInstance($abstract)
     {
-        unset($this->instances[$abstract]);
+        unset($this->instances[$this->normalize($abstract)]);
     }
 
     /**
@@ -1131,7 +1148,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function offsetExists($key)
     {
-        return isset($this->bindings[$key]);
+        return isset($this->bindings[$this->normalize($key)]);
     }
 
     /**
@@ -1174,6 +1191,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function offsetUnset($key)
     {
+        $key = $this->normalize($key);
         unset($this->bindings[$key], $this->instances[$key], $this->resolved[$key]);
     }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -445,6 +445,31 @@ return $obj; });
         $this->assertInstanceOf('ContainerImplementationStubTwo', $two->impl);
     }
 
+    public function testContextualBindingWorksRegardlessOfLeadingBackslash()
+    {
+        $container = new Container;
+
+        $container->bind('IContainerContractStub', 'ContainerImplementationStub');
+
+        $container->when('\ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerImplementationStubTwo');
+        $container->when('ContainerTestContextInjectTwo')->needs('\IContainerContractStub')->give('ContainerImplementationStubTwo');
+
+        $this->assertInstanceOf(
+            'ContainerImplementationStubTwo',
+            $container->make('ContainerTestContextInjectOne')->impl
+        );
+
+        $this->assertInstanceOf(
+            'ContainerImplementationStubTwo',
+            $container->make('ContainerTestContextInjectTwo')->impl
+        );
+
+        $this->assertInstanceOf(
+            'ContainerImplementationStubTwo',
+            $container->make('\ContainerTestContextInjectTwo')->impl
+        );
+    }
+
     public function testContainerTags()
     {
         $container = new Container;


### PR DESCRIPTION
Even though #10507 sounds like a bug to me, proposed fix changes service definition in a way that is not fully backward-compatible, although I would say that the odds of having an app broken because of this are pretty minor because having 2 different services with names that differ only by a backslash in the beginning is rather creepy. Anyway, I think this kind of fix (if accepted) belogngs to master rather than to 5.1.
