### PR TITLE
[5.1] Correctly snake-case string with whitespace delimiter

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -389,9 +389,9 @@ class Str
         }
 
         if (! ctype_lower($value)) {
-            $value = strtolower(preg_replace('/(.)(?=[A-Z])/', '$1'.$delimiter, $value));
-
             $value = preg_replace('/\s+/', '', $value);
+
+            $value = strtolower(preg_replace('/(.)(?=[A-Z])/', '$1'.$delimiter, $value));
         }
 
         return static::$snakeCache[$key] = $value;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -138,6 +138,7 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));
         $this->assertEquals('laravel_php_framework', Str::snake('LaravelPhpFramework'));
+        $this->assertEquals('laravel php framework', Str::snake('LaravelPhpFramework', ' '));
         $this->assertEquals('laravel_php_framework', Str::snake('Laravel Php Framework'));
         $this->assertEquals('laravel_php_framework', Str::snake('Laravel    Php      Framework   '));
     }


### PR DESCRIPTION
In relation to #10509 this fixes an issue where a whitespace cannot be used as a delimiter with `Str::snake()`.
