### PR TITLE
[5.1] Failing test for union with join

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -337,9 +337,13 @@ class Builder
         // is trying to build a join with a complex "on" clause containing more than
         // one condition, so we'll add the join and call a Closure with the query.
         if ($one instanceof Closure) {
-            $this->joins[] = new JoinClause($type, $table);
+            $join = new JoinClause($type, $table);
 
-            call_user_func($one, end($this->joins));
+            call_user_func($one, $join);
+
+            $this->joins[] = $join;
+
+            $this->addBinding($join->bindings, 'join');
         }
 
         // If the column is simply a string, we can assume the join simply has a basic
@@ -351,6 +355,8 @@ class Builder
             $this->joins[] = $join->on(
                 $one, $operator, $two, 'and', $where
             );
+
+            $this->addBinding($join->bindings, 'join');
         }
 
         return $this;

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -131,8 +131,6 @@ class Grammar extends BaseGrammar
     {
         $sql = [];
 
-        $query->setBindings([], 'join');
-
         foreach ($joins as $join) {
             $table = $this->wrapTable($join->table);
 
@@ -143,10 +141,6 @@ class Grammar extends BaseGrammar
 
             foreach ($join->clauses as $clause) {
                 $clauses[] = $this->compileJoinConstraint($clause);
-            }
-
-            foreach ($join->bindings as $binding) {
-                $query->addBinding($binding, 'join');
             }
 
             // Once we have constructed the clauses, we'll need to take the boolean connector

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -367,6 +367,18 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('select * from "users" union select * from "dogs" limit 10 offset 5', $builder->toSql());
     }
 
+    public function testUnionWithJoin()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users');
+        $builder->union($this->getBuilder()->select('*')->from('dogs')->join('breeds', function($join) {
+            $join->on('dogs.breed_id', '=', 'breeds.id')
+                ->where('breeds.is_native', '=', 1);
+        }));
+        $this->assertEquals('select * from "users" union select * from "dogs" inner join "breeds" on "dogs"."breed_id" = "breeds"."id" and "breeds"."is_native" = ?', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+    }
+
     public function testMySqlUnionOrderBys()
     {
         $builder = $this->getMySqlBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -371,7 +371,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users');
-        $builder->union($this->getBuilder()->select('*')->from('dogs')->join('breeds', function($join) {
+        $builder->union($this->getBuilder()->select('*')->from('dogs')->join('breeds', function ($join) {
             $join->on('dogs.breed_id', '=', 'breeds.id')
                 ->where('breeds.is_native', '=', 1);
         }));


### PR DESCRIPTION
There is a bug when creating a union, if the second query contains a join with nested condition. The bindings don't get merged. Original issue: https://github.com/laravel/framework/issues/10451

I wrote a failing unit test and I'd really appreciate if anyone more familiar with QueryBuilder could take a look.
