### PR TITLE
[5.2] Add methods defined in Gate implementation to contract

### DIFF
--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -31,6 +31,32 @@ interface Gate
     public function policy($class, $policy);
 
     /**
+     * Register a callback to run before all Gate checks.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function before(callable $callback);
+
+    /**
+     * Determine if the given ability should be granted for the current user.
+     *
+     * @param  string  $ability
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function allows($ability, $arguments = []);
+
+    /**
+     * Determine if the given ability should be denied for the current user.
+     *
+     * @param  string  $ability
+     * @param  array|mixed  $arguments
+     * @return bool
+     */
+    public function denies($ability, $arguments = []);
+
+    /**
      * Determine if the given ability should be granted.
      *
      * @param  string  $ability
@@ -38,4 +64,12 @@ interface Gate
      * @return bool
      */
     public function check($ability, $arguments = []);
+
+    /**
+     * Get a guard instance for the given user.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|mixed  $user
+     * @return static
+     */
+    public function forUser($user);
 }


### PR DESCRIPTION
There are four methods (before, allows, denies and forUser)
mentioned in the documentation which are defined in the concrete
implementation of Gate but not in the contract.

This leads to issues when type hinting on the Gate interface as
methods are not defined in the type hinted type object:

```
public function update(GateContract $gate)
{
    $gate->allows('post-user');
}
```

This either limits the implementation being used to the provided
one or forces the use of the check method when type hinting the
interface which is often less clear than the explicit allows /
denies methods.

There are other methods which are public but not on the contract
but it appears as though they are intended to be internal and as
such should be marked protected. This change does not address
these methods.

This change adds the four documented methods in the public api
to the Gate contract.
