### PR TITLE
[5.1] Use studly case conversion for dashed calls to policies

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Auth\Access;
 
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
@@ -273,6 +274,10 @@ class Gate implements GateContract
                 if (! is_null($result)) {
                     return $result;
                 }
+            }
+
+            if (strpos($ability, '-') !== false) {
+                $ability = Str::camel($ability);
             }
 
             if (! is_callable([$instance, $ability])) {

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -111,6 +111,15 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($gate->check('update', new AccessGateTestDummy));
     }
 
+    public function test_policy_converts_dash_to_camel()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $this->assertTrue($gate->check('update-dash', new AccessGateTestDummy));
+    }
+
     public function test_policy_default_to_false_if_method_does_not_exist()
     {
         $gate = $this->getBasicGate();
@@ -190,6 +199,11 @@ class AccessGateTestPolicy
     }
 
     public function update($user, AccessGateTestDummy $dummy)
+    {
+        return $user instanceof StdClass;
+    }
+
+    public function updateDash($user, AccessGateTestDummy $dummy)
     {
         return $user instanceof StdClass;
     }


### PR DESCRIPTION
As far as classes cannot contain dashed methods, but [docs](http://laravel.com/docs/5.1/authorization) use dashed definitions for gate rules e.g. `Gate::allows('delete-comment')` it would be nice to have auto-conversion of such calls to studly case methods on policies: `'delete-comment'` calls `Policy@deleteComment`.

This will allow to keep consistency of rules naming and method naming without need to use underscored names.
