### PR TITLE
[5.1] After callbacks for gate

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -48,6 +48,26 @@ class GateTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($gate->check('foo'));
     }
 
+    public function test_after_callbacks_are_called_with_result()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('foo', function ($user) { return true; });
+        $gate->define('bar', function ($user) { return false; });
+
+        $gate->after(function ($user, $ability, $result) {
+            if ($ability == 'foo') {
+                $this->assertTrue($result, 'After callback on `foo` should receive true as result');
+            } else {
+                $this->assertFalse($result, 'After callback on `bar` or `missing` should receive false as result');
+            }
+        });
+
+        $this->assertTrue($gate->check('foo'));
+        $this->assertFalse($gate->check('bar'));
+        $this->assertFalse($gate->check('missing'));
+    }
+
     public function test_current_user_that_is_on_gate_always_injected_into_closure_callbacks()
     {
         $gate = $this->getBasicGate();


### PR DESCRIPTION
This allows to make additional actions after receiving log result, e. g. event triggering or logging check results.

```
Gate::after(function($user, $ability, $result) {
    // Do some stuff
});
```
