### PR TITLE
[5.1] Let app:name also update composer.lock hash.

### DIFF
--- a/src/Illuminate/Foundation/Composer.php
+++ b/src/Illuminate/Foundation/Composer.php
@@ -37,6 +37,20 @@ class Composer
     }
 
     /**
+     * Update the Composer lock file.
+     *
+     * @return void
+     */
+    public function updateLockFileHash()
+    {
+        $process = $this->getProcess();
+
+        $process->setCommandLine(trim($this->findComposer().' update --lock --no-autoloader --no-scripts'));
+
+        $process->run();
+    }
+
+    /**
      * Regenerate the Composer autoloader files.
      *
      * @param  string  $extra

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -83,6 +83,8 @@ class AppNameCommand extends Command
 
         $this->info('Application namespace set!');
 
+        $this->composer->updateLockFileHash();
+
         $this->composer->dumpAutoloads();
 
         $this->call('clear-compiled');


### PR DESCRIPTION
Because at the moment, using `app:name` update the `composer.json` without changing the `composer.lock` file hash.
This will produce the following error on `composer install`:
`> Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. Run update to update them.``

This PR fixes that.
