### PR TITLE
[5.1] Fix CrawlerTrait::assertPageLoaded() error case

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -289,7 +289,7 @@ trait CrawlerTrait
         } catch (PHPUnitException $e) {
             $message = $message ?: "A request to [{$uri}] failed. Received status code [{$status}].";
 
-            throw new HttpException($message, null, $this->response->exception);
+            throw new HttpException($message, null, data_get($this->response, 'exception'));
         }
     }
 


### PR DESCRIPTION
Currently, if the response http status is not 200 an HttpException is thrown with the previous exception constructor parameter set to `$this->response->exception`.

This leads to the following message when a not successful response that is not an instance of `Illuminate\Http\Response` is returned:

```
1) TestClass::testMethod
ErrorException: Undefined property: ---HttpResponseClassName---::$exception`
```
