### PR TITLE
[5.1] Have emails that are text only send with Content-Type: text/plain

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -332,11 +332,15 @@ class Mailer implements MailerContract, MailQueueContract
         }
 
         if (isset($plain)) {
-            $message->addPart($this->getView($plain, $data), 'text/plain');
+            $method = isset($view) ? 'addPart' : 'setBody';
+
+            $message->$method($this->getView($plain, $data), 'text/plain');
         }
 
         if (isset($raw)) {
-            $message->addPart($raw, 'text/plain');
+            $method = (isset($view) || isset($plain)) ? 'addPart' : 'setBody';
+
+            $message->$method($raw, 'text/plain');
         }
     }
 


### PR DESCRIPTION
Using addPart() sends the email with "Content-Type: multipart/alternative" and not "Content-Type: text/plain".

This way if you send both html and text, you get multipart/alternative, but if you send raw or text only, then it sends as text/plain.

Example usage : 

``` php
\Mail::raw("simple\nplain\ntext\nemail", function($message) {
    $message->to('test@email.com');
    $message->from('from@email.com');
    $message->subject('Plain Text Test');
});

\Mail::plain('emails.plaintexttemplate', function($message) {
    $message->to('test@email.com');
    $message->from('from@email.com');
    $message->subject('Plain Text Test');
});
```
