### PR TITLE
[5.1] Using getView() where possible on ViewTest

### DIFF
--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -12,19 +12,19 @@ class ViewTest extends PHPUnit_Framework_TestCase
 
     public function testDataCanBeSetOnView()
     {
-        $view = new View(m::mock('Illuminate\View\Factory'), m::mock('Illuminate\View\Engines\EngineInterface'), 'view', 'path', []);
+        $view = $this->getView();
         $view->with('foo', 'bar');
         $view->with(['baz' => 'boom']);
         $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], $view->getData());
 
-        $view = new View(m::mock('Illuminate\View\Factory'), m::mock('Illuminate\View\Engines\EngineInterface'), 'view', 'path', []);
+        $view = $this->getView();
         $view->withFoo('bar')->withBaz('boom');
         $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], $view->getData());
     }
 
     public function testRenderProperlyRendersView()
     {
-        $view = $this->getView();
+        $view = $this->getView(['foo' => 'bar']);
         $view->getFactory()->shouldReceive('incrementRender')->once()->ordered();
         $view->getFactory()->shouldReceive('callComposer')->once()->ordered()->with($view);
         $view->getFactory()->shouldReceive('getShared')->once()->andReturn(['shared' => 'foo']);
@@ -80,7 +80,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
 
     public function testSectionsAreNotFlushedWhenNotDoneRendering()
     {
-        $view = $this->getView();
+        $view = $this->getView(['foo' => 'bar']);
         $view->getFactory()->shouldReceive('incrementRender')->twice();
         $view->getFactory()->shouldReceive('callComposer')->twice()->with($view);
         $view->getFactory()->shouldReceive('getShared')->twice()->andReturn(['shared' => 'foo']);
@@ -106,13 +106,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $arrayable = m::mock('Illuminate\Contracts\Support\Arrayable');
         $arrayable->shouldReceive('toArray')->once()->andReturn(['foo' => 'bar', 'baz' => ['qux', 'corge']]);
 
-        $view = new View(
-            m::mock('Illuminate\View\Factory'),
-            m::mock('Illuminate\View\Engines\EngineInterface'),
-            'view',
-            'path',
-            $arrayable
-        );
+        $view = $this->getView($arrayable);
 
         $this->assertEquals('bar', $view->foo);
         $this->assertEquals(['qux', 'corge'], $view->baz);
@@ -120,7 +114,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
 
     public function testViewGettersSetters()
     {
-        $view = $this->getView();
+        $view = $this->getView(['foo' => 'bar']);
         $this->assertEquals($view->getName(), 'view');
         $this->assertEquals($view->getPath(), 'path');
         $data = $view->getData();
@@ -131,7 +125,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
 
     public function testViewArrayAccess()
     {
-        $view = $this->getView();
+        $view = $this->getView(['foo' => 'bar']);
         $this->assertInstanceOf('ArrayAccess', $view);
         $this->assertTrue($view->offsetExists('foo'));
         $this->assertEquals($view->offsetGet('foo'), 'bar');
@@ -143,7 +137,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
 
     public function testViewMagicMethods()
     {
-        $view = $this->getView();
+        $view = $this->getView(['foo' => 'bar']);
         $this->assertTrue(isset($view->foo));
         $this->assertEquals($view->foo, 'bar');
         $view->foo = 'baz';
@@ -208,14 +202,14 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($foo[0], 'baz');
     }
 
-    protected function getView()
+    protected function getView($data = [])
     {
         return new View(
             m::mock('Illuminate\View\Factory'),
             m::mock('Illuminate\View\Engines\EngineInterface'),
             'view',
             'path',
-            ['foo' => 'bar']
+            $data
         );
     }
 }


### PR DESCRIPTION
It'll just replace the inline `new View` that yet is instantiated on `getView()`.
