### PR TITLE
[5.1] Add UrlGenerator::clearForceRootUrl() to remove forcedRoot value.

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -584,12 +584,28 @@ class UrlGenerator implements UrlGeneratorContract
      * Set the forced root URL.
      *
      * @param  string  $root
-     * @return void
+     * @return $this
      */
     public function forceRootUrl($root)
     {
         $this->forcedRoot = rtrim($root, '/');
         $this->cachedRoot = null;
+
+        return $this;
+    }
+
+    /**
+     * Clear the forced root URL.
+     *
+     * @param  string  $root
+     * @return $this
+     */
+    public function clearForceRootUrl($root)
+    {
+        $this->forcedRoot = null;
+        $this->cachedRoot = $this->request->root();
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -597,7 +597,6 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Clear the forced root URL.
      *
-     * @param  string  $root
      * @return $this
      */
     public function clearForceRootUrl($root)


### PR DESCRIPTION
It's useful is situation where I need to use different URL for `asset()` etc, and not anything else.

Signed-off-by: crynobone crynobone@gmail.com
