### PR TITLE
[5.1] Deprecate query builder getFresh()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1370,7 +1370,11 @@ class Builder
      */
     public function get($columns = ['*'])
     {
-        return $this->getFresh($columns);
+        if (is_null($this->columns)) {
+            $this->columns = $columns;
+        }
+
+        return $this->processor->processSelect($this, $this->runSelect());
     }
 
     /**
@@ -1378,14 +1382,12 @@ class Builder
      *
      * @param  array  $columns
      * @return array|static[]
+     *
+     * @deprecated since version 5.1. Use get instead.
      */
     public function getFresh($columns = ['*'])
     {
-        if (is_null($this->columns)) {
-            $this->columns = $columns;
-        }
-
-        return $this->processor->processSelect($this, $this->runSelect());
+        return $this->get($columns);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1111,21 +1111,6 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->noValidMethodHere();
     }
 
-    public function setupCacheTestQuery($cache, $driver)
-    {
-        $connection = m::mock('Illuminate\Database\ConnectionInterface');
-        $connection->shouldReceive('getName')->andReturn('connection_name');
-        $connection->shouldReceive('getCacheManager')->once()->andReturn($cache);
-        $cache->shouldReceive('driver')->once()->andReturn($driver);
-        $grammar = new Illuminate\Database\Query\Grammars\Grammar;
-        $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
-
-        $builder = $this->getMock('Illuminate\Database\Query\Builder', ['getFresh'], [$connection, $grammar, $processor]);
-        $builder->expects($this->once())->method('getFresh')->with($this->equalTo(['*']))->will($this->returnValue(['results']));
-
-        return $builder->select('*')->from('users')->where('email', 'foo@bar.com');
-    }
-
     public function testMySqlLock()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
This `getFresh` method had been added along database caching, introduced in https://github.com/laravel/framework/commit/8caec12d14608b480fea5309352812ef03e79dc1, which then has been removed in https://github.com/laravel/framework/commit/ea6b9589514b0139508b35166b63e9fbc045c285. So today it serves no purpose, it just does the same as `get`.

I've made `getFresh` an alias to `get`, marked it as deprecated, and also removed a leftover method in tests.

Then, you may want to remove it in Laravel 5.2.
