### PR TITLE
[5.1] Have the $commands property initialized by default

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -49,6 +49,14 @@ class Kernel implements KernelContract
         'Illuminate\Foundation\Bootstrap\RegisterProviders',
         'Illuminate\Foundation\Bootstrap\BootProviders',
     ];
+    
+    /**
+     * The Artisan commands provided by the application.
+     * Initialized as empty here, in case there is no need of separate Console Kernel.
+     *
+     * @var array
+     */
+    protected $commands = [];
 
     /**
      * Create a new console kernel instance.

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -49,7 +49,7 @@ class Kernel implements KernelContract
         'Illuminate\Foundation\Bootstrap\RegisterProviders',
         'Illuminate\Foundation\Bootstrap\BootProviders',
     ];
-    
+
     /**
      * The Artisan commands provided by the application.
      * Initialized as empty here, in case there is no need of separate Console Kernel.


### PR DESCRIPTION
With this change, the developers can bind "Illuminate\Foundation\Console\Kernel" to "Illuminate\Contracts\Console\Kernel".
