### PR TITLE
[5.1] handle eloquent objects in mail queue

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -193,6 +193,7 @@ class Mailer implements MailerContract, MailQueueContract
     public function queue($view, array $data, $callback, $queue = null)
     {
         $callback = $this->buildQueueCallable($callback);
+        $data = array_map('serialize', $data);
 
         return $this->queue->push('mailer@handleQueuedMessage', compact('view', 'data', 'callback'), $queue);
     }
@@ -283,7 +284,7 @@ class Mailer implements MailerContract, MailQueueContract
      */
     public function handleQueuedMessage($job, $data)
     {
-        $this->send($data['view'], $data['data'], $this->getQueuedCallable($data));
+        $this->send($data['view'], array_map('unserialize', $data['data']), $this->getQueuedCallable($data));
 
         $job->delete();
     }


### PR DESCRIPTION
Mail::send and Mail::queue currently work differently when it comes to passing data to the view especially eloquent models.
