### PR TITLE
[5.1] handle eloquent objects in mail queue

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -193,6 +193,7 @@ class Mailer implements MailerContract, MailQueueContract
     public function queue($view, array $data, $callback, $queue = null)
     {
         $callback = $this->buildQueueCallable($callback);
+        $data = array_map('serialize', $data);
 
         return $this->queue->push('mailer@handleQueuedMessage', compact('view', 'data', 'callback'), $queue);
     }
@@ -240,6 +241,7 @@ class Mailer implements MailerContract, MailQueueContract
     public function later($delay, $view, array $data, $callback, $queue = null)
     {
         $callback = $this->buildQueueCallable($callback);
+        $data = array_map('serialize', $data);
 
         return $this->queue->later($delay, 'mailer@handleQueuedMessage', compact('view', 'data', 'callback'), $queue);
     }
@@ -283,7 +285,7 @@ class Mailer implements MailerContract, MailQueueContract
      */
     public function handleQueuedMessage($job, $data)
     {
-        $this->send($data['view'], $data['data'], $this->getQueuedCallable($data));
+        $this->send($data['view'], array_map('unserialize', $data['data']), $this->getQueuedCallable($data));
 
         $job->delete();
     }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -73,7 +73,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
         $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
-        $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'callback' => 'callable'], null);
+        $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [serialize(1)], 'callback' => 'callable'], null);
 
         $mailer->queue('foo', [1], 'callable');
     }
@@ -83,7 +83,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
         $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
-        $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'callback' => 'callable'], 'queue');
+        $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [serialize(1)], 'callback' => 'callable'], 'queue');
 
         $mailer->queueOn('queue', 'foo', [1], 'callable');
     }
@@ -94,7 +94,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
         $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
         $serialized = (new Serializer)->serialize($closure = function () {});
-        $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'callback' => $serialized], null);
+        $queue->shouldReceive('push')->once()->with('mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [serialize(1)], 'callback' => $serialized], null);
 
         $mailer->queue('foo', [1], $closure);
     }
@@ -104,7 +104,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
         $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
-        $queue->shouldReceive('later')->once()->with(10, 'mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'callback' => 'callable'], null);
+        $queue->shouldReceive('later')->once()->with(10, 'mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [serialize(1)], 'callback' => 'callable'], null);
 
         $mailer->later(10, 'foo', [1], 'callable');
     }
@@ -114,7 +114,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         list($view, $swift) = $this->getMocks();
         $mailer = new Illuminate\Mail\Mailer($view, $swift);
         $mailer->setQueue($queue = m::mock('Illuminate\Contracts\Queue\Queue'));
-        $queue->shouldReceive('later')->once()->with(10, 'mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [1], 'callback' => 'callable'], 'queue');
+        $queue->shouldReceive('later')->once()->with(10, 'mailer@handleQueuedMessage', ['view' => 'foo', 'data' => [serialize(1)], 'callback' => 'callable'], 'queue');
 
         $mailer->laterOn('queue', 10, 'foo', [1], 'callable');
     }


### PR DESCRIPTION
Mail::send and Mail::queue currently work differently when it comes to passing data to the view especially eloquent models.
