### PR TITLE
[5.1] Support for required_if inside of each

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -275,6 +275,8 @@ class Validator implements ValidatorContract
                 if (! is_string($ruleKey)) {
                     $this->mergeRules("$attribute.$dataKey", $ruleValue);
                 } else {
+                    $ruleValue = is_string($ruleValue) ? str_replace('..', ".$dataKey.", $ruleValue) : $ruleValue;
+
                     $this->mergeRules("$attribute.$dataKey.$ruleKey", $ruleValue);
                 }
             }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1478,6 +1478,24 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateEachWithRequiredIf()
+    {
+        $trans = $this->getRealTranslator();
+        $data = ['foobar' => [
+            ['key' => 'foo'],
+            ['key' => 'bar'],
+        ]];
+
+        $v = new Validator($trans, $data, ['foo' => 'Array']);
+        $v->each('foobar', ['key' => 'required', 'value' => 'required_if:foobar..key,bar']);
+        $this->assertFalse($v->passes());
+
+        $data['foobar'][1]['value'] = 5;
+
+        $v->setData($data);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateEachWithNonArrayWithArrayRule()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
For rules that reference other fields, such as `required_if`, you can now use `..` to indicate that you are referencing a field within that `each` group. Example:

``` php
$rules = [
    'type'       => 'required',
    'other_type' => 'required_if:items..type,other',
];
$validator->each('items', $rules);
```

This converts `..` to `.$index.`, e.g.:

```
'items.0.other_type' => 'required_if:items.0.type,other',
'items.1.other_type' => 'required_if:items.1.type,other',
       ^                                   ^
```

This was previously impossible to do. Includes a test.
