### PR TITLE
[5.1] Adding @method docblocks on the class

### DIFF
--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -6,14 +6,15 @@ use ArrayAccess;
 use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
+
 /**
  * @method $this index() Creates index on the column
  * @method $this primary() Creates primery index on the column
- * @method $this unique()Creates unique index on the column
+ * @method $this unique() Creates unique index on the column
  * @method $this first() Place the column "first" in the table (MySQL Only)
- * @method $this after(string $colName)  Place the column "after" another column (MySQL Only)
+ * @method $this after(string $colName) Place the column "after" another column (MySQL Only)
  * @method $this nullable() Allow NULL values to be inserted into the column
- * @method $this default($value)	Specify a "default" value for the column
+ * @method $this default($value) Specify a "default" value for the column
  * @method $this unsigned()	Set integer columns to UNSIGNED
  */
 class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -6,7 +6,16 @@ use ArrayAccess;
 use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
-
+/**
+ * @method $this index() Creates index on the column
+ * @method $this primary() Creates primery index on the column
+ * @method $this unique()Creates unique index on the column
+ * @method $this first() Place the column "first" in the table (MySQL Only)
+ * @method $this after(string $colName)  Place the column "after" another column (MySQL Only)
+ * @method $this nullable() Allow NULL values to be inserted into the column
+ * @method $this default($value)	Specify a "default" value for the column
+ * @method $this unsigned()	Set integer columns to UNSIGNED
+ */
 class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
 {
     /**


### PR DESCRIPTION
Laravel makes extensive use of __call and __staticCall magic methods.
And it causes the IDE auto-completion to break down.
For compensating that we can use @method docblocks.

http://www.phpdoc.org/docs/latest/references/phpdoc/tags/method.html#examples
# 

In this case, docblocks help IDE when we are chaining methods on migration classes.

```
$table->string('title')->|
```

now provides auto-completion for the methods which are handled by __call()
