### PR TITLE
[5.2] Deprecated randomBytes

### DIFF
--- a/src/Illuminate/Encryption/BaseEncrypter.php
+++ b/src/Illuminate/Encryption/BaseEncrypter.php
@@ -73,7 +73,7 @@ abstract class BaseEncrypter
      */
     protected function validMac(array $payload)
     {
-        $bytes = Str::randomBytes(16);
+        $bytes = random_bytes(16);
 
         $calcMac = hash_hmac('sha256', $this->hash($payload['iv'], $payload['value']), $bytes, true);
 

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -58,7 +58,7 @@ class Encrypter extends BaseEncrypter implements EncrypterContract
      */
     public function encrypt($value)
     {
-        $iv = Str::randomBytes($this->getIvSize());
+        $iv = random_bytes($this->getIvSize());
 
         $value = openssl_encrypt(serialize($value), $this->cipher, $this->key, 0, $iv);
 

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Encryption;
 
 use RuntimeException;
-use Illuminate\Support\Str;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\EncryptException;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -242,6 +242,8 @@ class Str
      * @return string
      *
      * @throws \RuntimeException
+     *
+     * @deprecated since version 5.2. Use random_bytes instead.
      */
     public static function randomBytes($length = 16)
     {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -227,7 +227,7 @@ class Str
         while (($len = strlen($string)) < $length) {
             $size = $length - $len;
 
-            $bytes = static::randomBytes($size);
+            $bytes = random_bytes($size);
 
             $string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
         }


### PR DESCRIPTION
I think it makes sense to internally switch to just calling random_bytes, and deprecate our randomBytes method, for removal in 5.3.
