### PR TITLE
[5.2] Fixed stringy version constraint

### DIFF
--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -18,7 +18,7 @@
         "ext-mbstring": "*",
         "illuminate/contracts": "5.2.*",
         "doctrine/inflector": "~1.0",
-        "danielstjules/stringy": "~1.8"
+        "danielstjules/stringy": "~2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Just updating this to match the one in the main composer.json. Looks like it was forgotten about.
