### PR TITLE
Mongodb support for Queue

### DIFF
--- a/src/Illuminate/Queue/Connectors/MongodbConnector.php
+++ b/src/Illuminate/Queue/Connectors/MongodbConnector.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Queue\Connectors;
+
+use Illuminate\Support\Arr;
+use Illuminate\Queue\MongodbQueue;
+use Illuminate\Database\ConnectionResolverInterface;
+
+class MongodbConnector implements ConnectorInterface
+{
+    /**
+     * Database connections.
+     *
+     * @var \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected $connections;
+
+    /**
+     * Create a new connector instance.
+     *
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $connections
+     * @return void
+     */
+    public function __construct(ConnectionResolverInterface $connections)
+    {
+        $this->connections = $connections;
+    }
+
+    /**
+     * Establish a queue connection.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Contracts\Queue\Queue
+     */
+    public function connect(array $config)
+    {
+        return new MongodbQueue(
+            $this->connections->connection(Arr::get($config, 'connection')),
+            $config['table'],
+            $config['queue'],
+            Arr::get($config, 'expire', 60)
+        );
+    }
+}

--- a/src/Illuminate/Queue/Jobs/MongodbJob.php
+++ b/src/Illuminate/Queue/Jobs/MongodbJob.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Illuminate\Queue\Jobs;
+
+use Illuminate\Queue\MongodbQueue;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\Job as JobContract;
+
+class MongodbJob extends Job implements JobContract
+{
+    /**
+     * The database queue instance.
+     *
+     * @var \Illuminate\Queue\DatabaseQueue
+     */
+    protected $database;
+
+    /**
+     * The database job payload.
+     *
+     * @var \StdClass
+     */
+    protected $job;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param  \Illuminate\Container\Container  $container
+     * @param  \Illuminate\Queue\DatabaseQueue  $database
+     * @param  \StdClass  $job
+     * @param  string  $queue
+     * @return void
+     */
+    public function __construct(Container $container, MongodbQueue $database, $job, $queue)
+    {
+        $this->job = $job;
+        $this->queue = $queue;
+        $this->database = $database;
+        $this->container = $container;
+        $this->job->attempts = $this->job->attempts + 1;
+    }
+
+    /**
+     * Fire the job.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $this->resolveAndFire(json_decode($this->job->payload, true));
+    }
+
+    /**
+     * Delete the job from the queue.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        parent::delete();
+
+        $this->database->deleteReserved($this->queue, $this->job->_id);
+    }
+
+    /**
+     * Release the job back into the queue.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    public function release($delay = 0)
+    {
+        parent::release($delay);
+
+        $this->delete();
+
+        $this->database->release($this->queue, $this->job, $delay);
+    }
+
+    /**
+     * Get the number of times the job has been attempted.
+     *
+     * @return int
+     */
+    public function attempts()
+    {
+        return (int) $this->job->attempts;
+    }
+
+    /**
+     * Get the job identifier.
+     *
+     * @return string
+     */
+    public function getJobId()
+    {
+        return $this->job->id;
+    }
+
+    /**
+     * Get the raw body string for the job.
+     *
+     * @return string
+     */
+    public function getRawBody()
+    {
+        return $this->job->payload;
+    }
+
+    /**
+     * Get the IoC container instance.
+     *
+     * @return \Illuminate\Container\Container
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
+     * Get the underlying queue driver instance.
+     *
+     * @return \Illuminate\Queue\DatabaseQueue
+     */
+    public function getDatabaseQueue()
+    {
+        return $this->database;
+    }
+
+    /**
+     * Get the underlying database job.
+     *
+     * @return \StdClass
+     */
+    public function getDatabaseJob()
+    {
+        return $this->job;
+    }
+}

--- a/src/Illuminate/Queue/MongodbQueue.php
+++ b/src/Illuminate/Queue/MongodbQueue.php
@@ -1,0 +1,339 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use DateTime;
+use MongoId;
+use Carbon\Carbon;
+use Illuminate\Database\Connection;
+use Illuminate\Queue\Jobs\MongodbJob;
+use Illuminate\Contracts\Queue\Queue as QueueContract;
+
+class MongodbQueue extends Queue implements QueueContract
+{
+    /**
+     * The database connection instance.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $database;
+
+    /**
+     * The database table that holds the jobs.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * The name of the default queue.
+     *
+     * @var string
+     */
+    protected $default;
+
+    /**
+     * The expiration time of a job.
+     *
+     * @var int|null
+     */
+    protected $expire = 60;
+
+    /**
+     * Create a new database queue instance.
+     *
+     * @param  \Illuminate\Database\Connection  $database
+     * @param  string  $table
+     * @param  string  $default
+     * @param  int  $expire
+     * @return void
+     */
+    public function __construct(Connection $database, $table, $default = 'default', $expire = 60)
+    {
+        $this->table = $table;
+        $this->expire = $expire;
+        $this->default = $default;
+        $this->database = $database;
+    }
+
+    /**
+     * Push a new job onto the queue.
+     *
+     * @param  string  $job
+     * @param  mixed   $data
+     * @param  string  $queue
+     * @return void
+     */
+    public function push($job, $data = '', $queue = null)
+    {
+        return $this->pushToDatabase(0, $queue, $this->createPayload($job, $data));
+    }
+
+    /**
+     * Push a raw payload onto the queue.
+     *
+     * @param  string  $payload
+     * @param  string  $queue
+     * @param  array   $options
+     * @return mixed
+     */
+    public function pushRaw($payload, $queue = null, array $options = [])
+    {
+        return $this->pushToDatabase(0, $queue, $payload);
+    }
+
+    /**
+     * Push a new job onto the queue after a delay.
+     *
+     * @param  \DateTime|int  $delay
+     * @param  string  $job
+     * @param  mixed   $data
+     * @param  string  $queue
+     * @return void
+     */
+    public function later($delay, $job, $data = '', $queue = null)
+    {
+        return $this->pushToDatabase($delay, $queue, $this->createPayload($job, $data));
+    }
+
+    /**
+     * Push an array of jobs onto the queue.
+     *
+     * @param  array   $jobs
+     * @param  mixed   $data
+     * @param  string  $queue
+     * @return mixed
+     */
+    public function bulk($jobs, $data = '', $queue = null)
+    {
+        $queue = $this->getQueue($queue);
+
+        $availableAt = $this->getAvailableAt(0);
+
+        $records = array_map(function ($job) use ($queue, $data, $availableAt) {
+            return $this->buildDatabaseRecord(
+                $queue, $this->createPayload($job, $data), $availableAt
+            );
+        }, (array) $jobs);
+
+        return $this->database->table($this->table)->insert($records);
+    }
+
+    /**
+     * Release a reserved job back onto the queue.
+     *
+     * @param  string  $queue
+     * @param  \StdClass  $job
+     * @param  int  $delay
+     * @return void
+     */
+    public function release($queue, $job, $delay)
+    {
+        return $this->pushToDatabase($delay, $queue, $job->payload, $job->attempts);
+    }
+
+    /**
+     * Push a raw payload to the database with a given delay.
+     *
+     * @param  \DateTime|int  $delay
+     * @param  string|null  $queue
+     * @param  string  $payload
+     * @param  int  $attempts
+     * @return mixed
+     */
+    protected function pushToDatabase($delay, $queue, $payload, $attempts = 0)
+    {
+        $attributes = $this->buildDatabaseRecord(
+            $this->getQueue($queue), $payload, $this->getAvailableAt($delay), $attempts
+        );
+
+        return $this->database->table($this->table)->insertGetId($attributes);
+    }
+
+    /**
+     * Pop the next job off of the queue.
+     *
+     * @param  string  $queue
+     * @return \Illuminate\Contracts\Queue\Job|null
+     */
+    public function pop($queue = null)
+    {
+        $queue = $this->getQueue($queue);
+
+        if (! is_null($this->expire)) {
+            $this->releaseJobsThatHaveBeenReservedTooLong($queue);
+        }
+
+        if ($job = $this->getNextAvailableJob($queue)) {
+
+            $this->markJobAsReserved($job->_id);
+
+            //$this->database->commit();
+
+            return new MongodbJob(
+                $this->container, $this, $job, $queue
+            );
+        }
+
+      //  $this->database->commit();
+    }
+
+    /**
+     * Release the jobs that have been reserved for too long.
+     *
+     * @param  string  $queue
+     * @return void
+     */
+    protected function releaseJobsThatHaveBeenReservedTooLong($queue)
+    {
+        $expired = Carbon::now()->subSeconds($this->expire)->getTimestamp();
+        $reserved = $this->database->collection($this->table)
+                    ->where('queue', $this->getQueue($queue))
+                    ->where('reserved', 1)
+                    ->where('reserved_at', '<=', $expired)->get();
+
+        foreach( $reserved as $job ){
+           $attempts = $job['attempts'] + 1;
+           $this->releaseJob($job['_id'],$attempts);
+        }
+    }
+
+    /**
+     * Get the next available job for the queue.
+     *
+     * @param  string|null  $queue
+     * @return \StdClass|null
+     */
+    protected function getNextAvailableJob($queue)
+    {
+      //  $this->database->beginTransaction();
+
+        $job = $this->database->table($this->table)
+                    ->lockForUpdate()
+                    ->where('queue', $this->getQueue($queue))
+                    ->where('reserved', 0)
+                    ->where('available_at', '<=', $this->getTime())
+                    ->orderBy('_id', 'asc')
+                    ->first();
+
+        return $job ? (object) $job : null;
+    }
+
+    /**
+     * Mark the given job ID as reserved.
+     *
+     * @param  string  $id
+     * @return void
+     */
+    protected function markJobAsReserved($id)
+    {
+        $this->database->table($this->table)->where('_id', $id)->update([
+            'reserved' => 1, 'reserved_at' => $this->getTime(),
+        ]);
+    }
+
+    /**
+     * Release the given job ID from reservation.
+     *
+     * @param  string  $id
+     * @return void
+     */
+    protected function releaseJob($id,$attempts)
+    {
+        $this->database->table($this->table)->where('_id', $id)->update([
+          'reserved' => 0,
+          'reserved_at' => null,
+          'attempts' => $attempts,
+        ]);
+    }
+
+
+    /**
+     * Delete a reserved job from the queue.
+     *
+     * @param  string  $queue
+     * @param  string  $id
+     * @return void
+     */
+    public function deleteReserved($queue, $id)
+    {
+        $this->database->table($this->table)->where('_id', $id)->delete();
+    }
+
+    /**
+     * Get the "available at" UNIX timestamp.
+     *
+     * @param  \DateTime|int  $delay
+     * @return int
+     */
+    protected function getAvailableAt($delay)
+    {
+        $availableAt = $delay instanceof DateTime ? $delay : Carbon::now()->addSeconds($delay);
+
+        return $availableAt->getTimestamp();
+    }
+
+    /**
+     * Create an array to insert for the given job.
+     *
+     * @param  string|null  $queue
+     * @param  string  $payload
+     * @param  int  $availableAt
+     * @param  int  $attempts
+     * @return array
+     */
+    protected function buildDatabaseRecord($queue, $payload, $availableAt, $attempts = 0)
+    {
+        return [
+            'queue' => $queue,
+            'payload' => $payload,
+            'attempts' => $attempts,
+            'reserved' => 0,
+            'reserved_at' => null,
+            'available_at' => $availableAt,
+            'created_at' => $this->getTime(),
+        ];
+    }
+
+    /**
+     * Get the queue or return the default.
+     *
+     * @param  string|null  $queue
+     * @return string
+     */
+    protected function getQueue($queue)
+    {
+        return $queue ?: $this->default;
+    }
+
+    /**
+     * Get the underlying database instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    public function getDatabase()
+    {
+        return $this->database;
+    }
+
+    /**
+     * Get the expiration time in seconds.
+     *
+     * @return int|null
+     */
+    public function getExpire()
+    {
+        return $this->expire;
+    }
+
+    /**
+     * Set the expiration time in seconds.
+     *
+     * @param  int|null  $seconds
+     * @return void
+     */
+    public function setExpire($seconds)
+    {
+        $this->expire = $seconds;
+    }
+}

--- a/src/Illuminate/Queue/MongodbQueue.php
+++ b/src/Illuminate/Queue/MongodbQueue.php
@@ -165,7 +165,6 @@ class MongodbQueue extends Queue implements QueueContract
         }
 
         if ($job = $this->getNextAvailableJob($queue)) {
-
             $this->markJobAsReserved($job->_id);
 
             return new MongodbJob(
@@ -204,8 +203,6 @@ class MongodbQueue extends Queue implements QueueContract
      */
     protected function getNextAvailableJob($queue)
     {
-      //  $this->database->beginTransaction();
-
         $job = $this->database->table($this->table)
                     ->lockForUpdate()
                     ->where('queue', $this->getQueue($queue))

--- a/src/Illuminate/Queue/MongodbQueue.php
+++ b/src/Illuminate/Queue/MongodbQueue.php
@@ -7,7 +7,6 @@ use Carbon\Carbon;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\Jobs\MongodbJob;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
-use MongoId;
 
 class MongodbQueue extends Queue implements QueueContract
 {

--- a/src/Illuminate/Queue/MongodbQueue.php
+++ b/src/Illuminate/Queue/MongodbQueue.php
@@ -3,11 +3,11 @@
 namespace Illuminate\Queue;
 
 use DateTime;
-use MongoId;
 use Carbon\Carbon;
 use Illuminate\Database\Connection;
 use Illuminate\Queue\Jobs\MongodbJob;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
+use MongoId;
 
 class MongodbQueue extends Queue implements QueueContract
 {
@@ -168,14 +168,12 @@ class MongodbQueue extends Queue implements QueueContract
 
             $this->markJobAsReserved($job->_id);
 
-            //$this->database->commit();
-
             return new MongodbJob(
                 $this->container, $this, $job, $queue
             );
         }
 
-      //  $this->database->commit();
+        $this->database->commit();
     }
 
     /**
@@ -192,9 +190,9 @@ class MongodbQueue extends Queue implements QueueContract
                     ->where('reserved', 1)
                     ->where('reserved_at', '<=', $expired)->get();
 
-        foreach( $reserved as $job ){
-           $attempts = $job['attempts'] + 1;
-           $this->releaseJob($job['_id'],$attempts);
+        foreach ($reserved as $job) {
+            $attempts = $job['attempts'] + 1;
+            $this->releaseJob($job['_id'], $attempts);
         }
     }
 
@@ -238,7 +236,7 @@ class MongodbQueue extends Queue implements QueueContract
      * @param  string  $id
      * @return void
      */
-    protected function releaseJob($id,$attempts)
+    protected function releaseJob($id, $attempts)
     {
         $this->database->table($this->table)->where('_id', $id)->update([
           'reserved' => 0,
@@ -246,7 +244,6 @@ class MongodbQueue extends Queue implements QueueContract
           'attempts' => $attempts,
         ]);
     }
-
 
     /**
      * Delete a reserved job from the queue.

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -14,6 +14,7 @@ use Illuminate\Queue\Connectors\SyncConnector;
 use Illuminate\Queue\Connectors\IronConnector;
 use Illuminate\Queue\Connectors\RedisConnector;
 use Illuminate\Queue\Connectors\DatabaseConnector;
+use Illuminate\Queue\Connectors\MongodbConnector;
 use Illuminate\Queue\Connectors\BeanstalkdConnector;
 use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
 
@@ -163,7 +164,7 @@ class QueueServiceProvider extends ServiceProvider
      */
     public function registerConnectors($manager)
     {
-        foreach (['Null', 'Sync', 'Database', 'Beanstalkd', 'Redis', 'Sqs', 'Iron'] as $connector) {
+        foreach (['Null', 'Sync', 'Database', 'Mongodb', 'Beanstalkd', 'Redis', 'Sqs', 'Iron'] as $connector) {
             $this->{"register{$connector}Connector"}($manager);
         }
     }
@@ -217,6 +218,19 @@ class QueueServiceProvider extends ServiceProvider
     {
         $manager->addConnector('database', function () {
             return new DatabaseConnector($this->app['db']);
+        });
+    }
+
+    /**
+     * Register the mongodb queue connector.
+     *
+     * @param  \Illuminate\Queue\QueueManager  $manager
+     * @return void
+     */
+    protected function registerMongodbConnector($manager)
+    {
+        $manager->addConnector('mongodb', function () {
+            return new MongodbConnector($this->app['db']);
         });
     }
 

--- a/tests/Queue/QueueMongodbQueueTest.php
+++ b/tests/Queue/QueueMongodbQueueTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Mockery as m;
+
+class QueueMongodbQueueTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testPushProperlyPushesJobOntoDatabase()
+    {
+        $queue = $this->getMock('Illuminate\Queue\MongodbQueue', ['getTime'], [$database = m::mock('Illuminate\Database\Connection'), 'table', 'default']);
+        $queue->expects($this->any())->method('getTime')->will($this->returnValue('time'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
+        $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
+            $this->assertEquals('default', $array['queue']);
+            $this->assertEquals(json_encode(['job' => 'foo', 'data' => ['data']]), $array['payload']);
+            $this->assertEquals(0, $array['attempts']);
+            $this->assertEquals(0, $array['reserved']);
+            $this->assertNull($array['reserved_at']);
+            $this->assertInternalType('int', $array['available_at']);
+        });
+
+        $queue->push('foo', ['data']);
+    }
+
+    public function testDelayedPushProperlyPushesJobOntoDatabase()
+    {
+        $queue = $this->getMock(
+            'Illuminate\Queue\MongodbQueue',
+            ['getTime'],
+            [$database = m::mock('Illuminate\Database\Connection'), 'table', 'default']
+        );
+        $queue->expects($this->any())->method('getTime')->will($this->returnValue('time'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
+        $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
+            $this->assertEquals('default', $array['queue']);
+            $this->assertEquals(json_encode(['job' => 'foo', 'data' => ['data']]), $array['payload']);
+            $this->assertEquals(0, $array['attempts']);
+            $this->assertEquals(0, $array['reserved']);
+            $this->assertNull($array['reserved_at']);
+            $this->assertInternalType('int', $array['available_at']);
+        });
+
+        $queue->later(10, 'foo', ['data']);
+    }
+
+    public function testBulkBatchPushesOntoDatabase()
+    {
+        $database = m::mock('Illuminate\Database\Connection');
+        $queue = $this->getMock('Illuminate\Queue\MongodbQueue', ['getTime', 'getAvailableAt'], [$database, 'table', 'default']);
+        $queue->expects($this->any())->method('getTime')->will($this->returnValue('created'));
+        $queue->expects($this->any())->method('getAvailableAt')->will($this->returnValue('available'));
+        $database->shouldReceive('table')->with('table')->andReturn($query = m::mock('StdClass'));
+        $query->shouldReceive('insert')->once()->andReturnUsing(function ($records) {
+            $this->assertEquals([[
+                'queue' => 'queue',
+                'payload' => json_encode(['job' => 'foo', 'data' => ['data']]),
+                'attempts' => 0,
+                'reserved' => 0,
+                'reserved_at' => null,
+                'available_at' => 'available',
+                'created_at' => 'created',
+            ], [
+                'queue' => 'queue',
+                'payload' => json_encode(['job' => 'bar', 'data' => ['data']]),
+                'attempts' => 0,
+                'reserved' => 0,
+                'reserved_at' => null,
+                'available_at' => 'available',
+                'created_at' => 'created',
+            ]], $records);
+        });
+
+        $queue->bulk(['foo', 'bar'], ['data'], 'queue');
+    }
+}


### PR DESCRIPTION
The Queue functionality doesn't work MongoDb because of the ObjectId's and because it tries to use an expression in an update which Mongo does not support.  This creates a separate set of classes to handle  Mongo.
