### PR TITLE
[5.1] Route Group helper (like get, post... helpers)

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -375,6 +375,20 @@ if (! function_exists('get')) {
     }
 }
 
+if (! function_exists('group')) {
+    /**
+     * Register a new route group with the router.
+     *
+     * @param  array  $attributes
+     * @param  \Closure $callback
+     * @return void
+     */
+    function group($attributes, $callback)
+    {
+        app('router')->group($attributes, $callback);
+    }
+}
+
 if (! function_exists('info')) {
     /**
      * Write some information to the log.


### PR DESCRIPTION
As there are helpers for routing GET, POST, PUT and DELETE. I think having the `group` helper will make more semantic the route definition.
Likewise, I think that if there is fair a short way to a `Route::get()` with `get()`, then there must be a short way to `Route::group()` with `group()`.

``` php

group(['middleware' => 'auth'], function () {
    get('/', function ()    {
        // Uses Auth Middleware
    });

    get('user/profile', function () {
        // Uses Auth Middleware
    });
});

```
