### PR TITLE
Combine the PUT and PATCH "update" routes on RESTful resources

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -332,42 +332,11 @@ class ResourceRegistrar
      */
     protected function addResourceUpdate($name, $base, $controller, $options)
     {
-        $this->addPutResourceUpdate($name, $base, $controller, $options);
-
-        return $this->addPatchResourceUpdate($name, $base, $controller);
-    }
-
-    /**
-     * Add the update method for a resourceful route.
-     *
-     * @param  string  $name
-     * @param  string  $base
-     * @param  string  $controller
-     * @param  array   $options
-     * @return \Illuminate\Routing\Route
-     */
-    protected function addPutResourceUpdate($name, $base, $controller, $options)
-    {
         $uri = $this->getResourceUri($name).'/{'.$base.'}';
 
         $action = $this->getResourceAction($name, $controller, 'update', $options);
 
-        return $this->router->put($uri, $action);
-    }
-
-    /**
-     * Add the update method for a resourceful route.
-     *
-     * @param  string  $name
-     * @param  string  $base
-     * @param  string  $controller
-     * @return void
-     */
-    protected function addPatchResourceUpdate($name, $base, $controller)
-    {
-        $uri = $this->getResourceUri($name).'/{'.$base.'}';
-
-        $this->router->patch($uri, $controller.'@update');
+        return $this->router->match(['PUT', 'PATCH'], $uri, $action);
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -763,7 +763,7 @@ return 'foo!'; });
         $router = $this->getRouter();
         $router->resource('foo', 'FooController');
         $routes = $router->getRoutes();
-        $this->assertCount(8, $routes);
+        $this->assertCount(7, $routes);
 
         $router = $this->getRouter();
         $router->resource('foo', 'FooController', ['only' => ['update']]);
@@ -781,7 +781,7 @@ return 'foo!'; });
         $router->resource('foo', 'FooController', ['except' => ['show', 'destroy']]);
         $routes = $router->getRoutes();
 
-        $this->assertCount(6, $routes);
+        $this->assertCount(5, $routes);
 
         $router = $this->getRouter();
         $router->resource('foo-bars', 'FooController', ['only' => ['show']]);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -766,6 +766,12 @@ return 'foo!'; });
         $this->assertCount(8, $routes);
 
         $router = $this->getRouter();
+        $router->resource('foo', 'FooController', ['only' => ['update']]);
+        $routes = $router->getRoutes();
+
+        $this->assertCount(1, $routes);
+
+        $router = $this->getRouter();
         $router->resource('foo', 'FooController', ['only' => ['show', 'destroy']]);
         $routes = $router->getRoutes();
 


### PR DESCRIPTION
This fixes the issue where the PATCH route lacked a name and thus
Route::currentRouteName() would return null on PATCH "update" requests.
(e.g. issue #9831)

It also fixes the inconsistency of generating 8 routes but only having 7
actions.
