### PR TITLE
[5.2] Combine the PUT and PATCH "update" routes on RESTful resources

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -332,42 +332,11 @@ class ResourceRegistrar
      */
     protected function addResourceUpdate($name, $base, $controller, $options)
     {
-        $this->addPutResourceUpdate($name, $base, $controller, $options);
-
-        return $this->addPatchResourceUpdate($name, $base, $controller);
-    }
-
-    /**
-     * Add the update method for a resourceful route.
-     *
-     * @param  string  $name
-     * @param  string  $base
-     * @param  string  $controller
-     * @param  array   $options
-     * @return \Illuminate\Routing\Route
-     */
-    protected function addPutResourceUpdate($name, $base, $controller, $options)
-    {
         $uri = $this->getResourceUri($name).'/{'.$base.'}';
 
         $action = $this->getResourceAction($name, $controller, 'update', $options);
 
-        return $this->router->put($uri, $action);
-    }
-
-    /**
-     * Add the update method for a resourceful route.
-     *
-     * @param  string  $name
-     * @param  string  $base
-     * @param  string  $controller
-     * @return void
-     */
-    protected function addPatchResourceUpdate($name, $base, $controller)
-    {
-        $uri = $this->getResourceUri($name).'/{'.$base.'}';
-
-        $this->router->patch($uri, $controller.'@update');
+        return $this->router->match(['PUT', 'PATCH'], $uri, $action);
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -574,6 +574,12 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertCount(8, $routes);
 
         $router = $this->getRouter();
+        $router->resource('foo', 'FooController', ['only' => ['update']]);
+        $routes = $router->getRoutes();
+
+        $this->assertCount(1, $routes);
+
+        $router = $this->getRouter();
         $router->resource('foo', 'FooController', ['only' => ['show', 'destroy']]);
         $routes = $router->getRoutes();
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -571,7 +571,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $router = $this->getRouter();
         $router->resource('foo', 'FooController');
         $routes = $router->getRoutes();
-        $this->assertCount(8, $routes);
+        $this->assertCount(7, $routes);
 
         $router = $this->getRouter();
         $router->resource('foo', 'FooController', ['only' => ['update']]);
@@ -589,7 +589,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $router->resource('foo', 'FooController', ['except' => ['show', 'destroy']]);
         $routes = $router->getRoutes();
 
-        $this->assertCount(6, $routes);
+        $this->assertCount(5, $routes);
 
         $router = $this->getRouter();
         $router->resource('foo-bars', 'FooController', ['only' => ['show']]);


### PR DESCRIPTION
Sending to 5.2 per request (laravel/framework#10581).

This fixes the issue where the PATCH route lacked a name and thus Route::currentRouteName() would return null on PATCH "update" requests. (e.g. issue #9831)

It also fixes the inconsistency of generating 8 routes but only having 7 actions.
