### PR TITLE
[5.1] Fix the HasManyThrough::join 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -109,7 +109,7 @@ class HasManyThrough extends Relation
 
         $foreignKey = $this->related->getTable().'.'.$this->secondKey;
 
-        $query->join($this->parent->getTable(), $this->getQualifiedParentKeyName(), '=', $foreignKey);
+        $query->join($this->parent->getTable(), $this->parent->getTable().'.'.$this->localKey, '=', $foreignKey);
 
         if ($this->parentSoftDeletes()) {
             $query->whereNull($this->parent->getQualifiedDeletedAtColumn());


### PR DESCRIPTION
HasManyThrough::join  method so that it uses the local key - it was assuming the local key in the table was the parents default key, which may not be the case. E.g.

Table 1: products
id
product_name

Table 2: product_items
id
product_id
item_id

Table 3: items
id
item_name

With the supplied setup, you would think you could do (in Product model class)

public function items()
{
  return $this->hasManyThrough('App\Item','App\ProductItem','product_item','id','item_id');
}

However, since local key is ignored, the above would have resulted in an sql error.
