### PR TITLE
[5.1] Modifcation for handling multiple database slave

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -98,6 +98,11 @@ class ConnectionFactory
     {
         $readConfig = $this->getReadWriteConfig($config, 'read');
 
+        if (isset($readConfig['host']) && is_array($readConfig['host'])) {
+            $readConfig['host'] = count($readConfig['host']) > 1 ?
+                $readConfig['host'][array_rand($readConfig['host'])] : $readConfig['host'][0];
+        }
+
         return $this->mergeReadWriteConfig($config, $readConfig);
     }
 


### PR DESCRIPTION
This merge would enhance the capabilities of _ConnectionFactory_ to support multiple read-only database slaves without breaking any current configuration. 

The change would kick in only if the _read_ setting is enabled and _host_ is defined as an array, in which case one of them is selected at random for all read/select queries for particular _connection_.

In the _config/database.php_, the following _connections_ configurations are then possible:

```
'connections' => [

        'default' => [

            'read'=> [
                'host' => ['db-slave-1','db-slave-2'],

                // Backward compatible 
                // host => 'db-slave'
            ],

            'write' => [
                'host' => 'localhost'
            ],
            'driver'    => 'mysql',
            'host'      => "localhost",
            'database'  => "database",
            'username'  => "user",
            'password'  => "*****",
            'charset'   => 'utf8',
            'collation' => 'utf8_unicode_ci',
            'prefix'    => '',
            'strict'    => false,

        ],
    ]
```
