### PR TITLE
[5.2] Fix update with timestamps=false option

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -54,7 +54,7 @@ class Builder
      * @var array
      */
     protected $passthru = [
-        'insert', 'insertGetId', 'getBindings', 'toSql',
+        'insert', 'insertGetId', 'update', 'getBindings', 'toSql',
         'exists', 'count', 'min', 'max', 'avg', 'sum',
     ];
 
@@ -288,17 +288,6 @@ class Builder
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => $pageName,
         ]);
-    }
-
-    /**
-     * Update a record in the database.
-     *
-     * @param  array  $values
-     * @return int
-     */
-    public function update(array $values)
-    {
-        return $this->query->update($this->addUpdatedAtColumn($values));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1131,11 +1131,18 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
     public function testTimestampsAreNotUpdatedWithTimestampsFalseSaveOption()
     {
-        $model = m::mock('EloquentModelStub[newQueryWithoutScopes]');
-        $query = m::mock('Illuminate\Database\Eloquent\Builder');
-        $query->shouldReceive('where')->once()->with('id', '=', 1);
-        $query->shouldReceive('update')->once()->with(['name' => 'taylor']);
-        $model->shouldReceive('newQueryWithoutScopes')->once()->andReturn($query);
+        $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'getDateFormat']);
+
+        $base_query = m::mock('Illuminate\Database\Query\Builder');
+        $base_query->shouldReceive('update')->once()->with(['name' => 'taylor']);
+        $base_query->shouldReceive('where')->once()->with('id', '=', 1);
+        $base_query->shouldReceive('from')->with('stub');
+
+        $query = new Illuminate\Database\Eloquent\Builder($base_query);
+        $query->setModel($model);
+
+        $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
+        $model->expects($this->any())->method('getDateFormat')->will($this->returnValue('Y-m-d H:i:s'));
 
         $model->id = 1;
         $model->syncOriginal();


### PR DESCRIPTION
Currently running `$model->save(['timestamps' => false]);` will still update the updated_at timestamp because the Eloquent query builder will update the timestamp itself. 

Since the timestamps are refreshed by the model itself prior to calling update on the query builder, that code in the Eloquent query builder is unnecessary and causes unexpected behavior (updated_at is still updated despite the timestamps=false option). This patch addresses that problem and updates the unit test to test to make sure the underlying base query builder is not receiving a new `updated_at` timestamp.
