### PR TITLE
Changed the lastPage calculation ceiling to flooring

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -45,7 +45,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
 
         $this->total = $total;
         $this->perPage = $perPage;
-        $this->lastPage = (int) ceil($total / $perPage);
+        $this->lastPage = (int) floor($total / $perPage);
         $this->currentPage = $this->setCurrentPage($currentPage, $this->lastPage);
         $this->path = $this->path != '/' ? rtrim($this->path, '/').'/' : $this->path;
         $this->items = $items instanceof Collection ? $items : Collection::make($items);


### PR DESCRIPTION
When calculating the lastPage (or total pages) in the constructor the ceiling method returns 10 pages for 91/10 which should be 9 pages with one result on the 9th page. I changed the ceiling to flooring, which I assume would be the correct behavior.
