### PR TITLE
[5.1] Make an alias for count(*) in order to access it from order by clause

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -145,7 +145,7 @@ abstract class Relation
      */
     public function getRelationCountQuery(Builder $query, Builder $parent)
     {
-        $query->select(new Expression('count(*)'));
+        $query->select(new Expression('count(*) AS `aggregate`'));
 
         $key = $this->wrap($this->getQualifiedParentKeyName());
 


### PR DESCRIPTION
This commit helps you to sort query results based on count of `OneToMany` relation.
Example:
Comment model

``` php
// app\comment.php
public function post(){
  return $this->belongsTo('App\Post');
}
```

This is Post model

``` php
// app\post.php
public function comments(){
  return $this->hasMany('App\Comment');
}

// get top posts based on count of comments using ORM
public function scopeTopPosts($query){
  return $query->whereHas('comments', function($query) {
    $query->latest('aggregate');
  });
}
```
