### PR TITLE
[5.2] Make Seeder and its run() method abstract

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -5,7 +5,7 @@ namespace Illuminate\Database;
 use Illuminate\Console\Command;
 use Illuminate\Container\Container;
 
-class Seeder
+abstract class Seeder
 {
     /**
      * The container instance.
@@ -26,10 +26,7 @@ class Seeder
      *
      * @return void
      */
-    public function run()
-    {
-        //
-    }
+    abstract public function run();
 
     /**
      * Seed the given connection from the given path.

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -3,6 +3,14 @@
 use Mockery as m;
 use Illuminate\Database\Seeder;
 
+class TestSeeder extends Seeder
+{
+    public function run()
+    {
+        //
+    }
+}
+
 class DatabaseSeederTest extends PHPUnit_Framework_TestCase
 {
     public function tearDown()
@@ -12,7 +20,7 @@ class DatabaseSeederTest extends PHPUnit_Framework_TestCase
 
     public function testCallResolveTheClassAndCallsRun()
     {
-        $seeder = new Seeder;
+        $seeder = new TestSeeder;
         $seeder->setContainer($container = m::mock('Illuminate\Container\Container'));
         $output = m::mock('Symfony\Component\Console\Output\OutputInterface');
         $output->shouldReceive('writeln')->once()->andReturn('foo');
@@ -29,14 +37,14 @@ class DatabaseSeederTest extends PHPUnit_Framework_TestCase
 
     public function testSetContainer()
     {
-        $seeder = new Seeder;
+        $seeder = new TestSeeder;
         $container = m::mock('Illuminate\Container\Container');
         $this->assertEquals($seeder->setContainer($container), $seeder);
     }
 
     public function testSetCommand()
     {
-        $seeder = new Seeder;
+        $seeder = new TestSeeder;
         $command = m::mock('Illuminate\Console\Command');
         $this->assertEquals($seeder->setCommand($command), $seeder);
     }


### PR DESCRIPTION
Re-submitting this PR to master as requested in #10591:

When I was writing a seeder in my Laravel project, I mistyped the `run()` method name, causing it to be silently skipped.

This change makes `run()` an abstract method, forcing the user to implement it.
