### PR TITLE
[5.1] Run migrations inside database transaction

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -108,9 +108,17 @@ class Migrator
         // Once we have the array of migrations, we will spin through them and run the
         // migrations "up" so the changes are made to the databases. We'll then log
         // that the migration was run so we don't repeat it next time we execute.
+        // This is done as a transaction so that if any of the migrations fail
+        // before they are completely finished, you can fix and rerun them.
+        $db = $this->resolveConnection($this->connection);
+        
+        $db->beginTransaction();
+        
         foreach ($migrations as $file) {
             $this->runUp($file, $batch, $pretend);
         }
+        
+        $db->commit();
     }
 
     /**


### PR DESCRIPTION
Just an idea but we've found when using CI that when we've pushed our code that also migrates any database changes, if one of them fails (for whatever reason) we have to figure out where and manually repair the databases.

Something I've been doing recently is running seeders in a migration so that if one fails, you don't end up with a partially seeded database so thought I'd apply this to migrations too.

This might provoke a wider discussion but I think it's quite handy and has saved us some time at least.
