### PR TITLE
[5.1] Update Facade.php

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -201,7 +201,9 @@ abstract class Facade
     public static function __callStatic($method, $args)
     {
         $instance = static::getFacadeRoot();
-        if(!$instance) throw new \RuntimeException('Facade Root not found.');
+        if(!$instance){
+            throw new \RuntimeException('Facade Root not found.');
+        } 
         switch (count($args)) {
             case 0:
                 return $instance->$method();

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -202,7 +202,7 @@ abstract class Facade
     {
         $instance = static::getFacadeRoot();
         if(!$instance){
-            throw new \RuntimeException('Facade Root not found.');
+            throw new \RuntimeException('Facade root not found.');
         } 
         switch (count($args)) {
             case 0:

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -201,7 +201,7 @@ abstract class Facade
     public static function __callStatic($method, $args)
     {
         $instance = static::getFacadeRoot();
-
+        if(!$instance) throw new \RuntimeException('Facade Root not found.');
         switch (count($args)) {
             case 0:
                 return $instance->$method();


### PR DESCRIPTION
Preventing Facade to throw error when $instance is not found. (It happens when you try to use a Facade outside laravel).
