### PR TITLE
[5.1] Resets mySQL database id to 1 following each test

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -10,9 +10,13 @@ trait DatabaseMigrations
     public function runDatabaseMigrations()
     {
         $this->artisan('migrate');
+    }
 
-        $this->beforeApplicationDestroyed(function () {
-            $this->artisan('migrate:rollback');
-        });
+    /**
+     * @after
+     */
+    public function runDatabaseMigrateRefresh()
+    {
+        $this->artisan('migrate:refresh');
     }
 }


### PR DESCRIPTION
When running tests without this commit, each test will return a different auto-incremented ID.  On the first test the primary ID will be 1, and the second test will return a primary ID of 2.

When testing a repository method which grabs a record by the primary key, the primary key will not be consistent which causes the test to fail.
