### PR TITLE
[5.1] Don't attempt to fetch relationships on the primary key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2673,6 +2673,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getRelationValue($key)
     {
+        // Relationships aren't defined with the primary key
+        if ($key == $this->primaryKey) {
+            return;
+        }
+
         // If the key already exists in the relationships array, it just means the
         // relationship has already been loaded, so we'll just return it out of
         // here because there is no need to query within the relations twice.

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1333,6 +1333,11 @@ class EloquentModelStub extends Model
     {
         return 'appended';
     }
+
+    public function id()
+    {
+        return $this->id;
+    }
 }
 
 class EloquentModelCamelStub extends EloquentModelStub


### PR DESCRIPTION
I had an issue with an eloquent model where I had an `id()` getter method defined.

When I associated this model with another through a belongsTo relationship, an exception would be thrown as it attempted to get the inverse relationship by the `otherKey` property, namely `id`.
