### PR TITLE
[5.1] Use ::class notation

### DIFF
--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -5,6 +5,7 @@ namespace Illuminate\Auth;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -52,7 +53,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerUserResolver()
     {
-        $this->app->bind('Illuminate\Contracts\Auth\Authenticatable', function ($app) {
+        $this->app->bind(AuthenticatableContract::class, function ($app) {
             return $app['auth']->user();
         });
     }

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -5,6 +5,7 @@ namespace Illuminate\Broadcasting;
 use Pusher;
 use Closure;
 use Illuminate\Support\Arr;
+use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
 use Illuminate\Broadcasting\Broadcasters\LogBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\RedisBroadcaster;
@@ -147,7 +148,7 @@ class BroadcastManager implements FactoryContract
     protected function createLogDriver(array $config)
     {
         return new LogBroadcaster(
-            $this->app->make('Psr\Log\LoggerInterface')
+            $this->app->make(LoggerInterface::class)
         );
     }
 

--- a/src/Illuminate/Broadcasting/BroadcastServiceProvider.php
+++ b/src/Illuminate/Broadcasting/BroadcastServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Broadcasting;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactory;
+use Illuminate\Contracts\Broadcasting\Broadcaster as BroadcasterContract;
 
 class BroadcastServiceProvider extends ServiceProvider
 {
@@ -20,16 +22,16 @@ class BroadcastServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('Illuminate\Broadcasting\BroadcastManager', function ($app) {
+        $this->app->singleton(BroadcastManager::class, function ($app) {
             return new BroadcastManager($app);
         });
 
-        $this->app->singleton('Illuminate\Contracts\Broadcasting\Broadcaster', function ($app) {
-            return $app->make('Illuminate\Broadcasting\BroadcastManager')->connection();
+        $this->app->singleton(BroadcasterContract::class, function ($app) {
+            return $app->make(BroadcastManager::class)->connection();
         });
 
         $this->app->alias(
-            'Illuminate\Broadcasting\BroadcastManager', 'Illuminate\Contracts\Broadcasting\Factory'
+            BroadcastManager::class, BroadcastingFactory::class
         );
     }
 
@@ -41,9 +43,9 @@ class BroadcastServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'Illuminate\Broadcasting\BroadcastManager',
-            'Illuminate\Contracts\Broadcasting\Factory',
-            'Illuminate\Contracts\Broadcasting\Broadcaster',
+            BroadcastManager::class,
+            BroadcastingFactory::class,
+            BroadcasterContract::class,
         ];
     }
 }

--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -3,6 +3,9 @@
 namespace Illuminate\Bus;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Bus\QueueingDispatcher;
+use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
 
 class BusServiceProvider extends ServiceProvider
 {
@@ -20,18 +23,18 @@ class BusServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('Illuminate\Bus\Dispatcher', function ($app) {
+        $this->app->singleton(Dispatcher::class, function ($app) {
             return new Dispatcher($app, function () use ($app) {
-                return $app['Illuminate\Contracts\Queue\Queue'];
+                return $app[QueueContract::class];
             });
         });
 
         $this->app->alias(
-            'Illuminate\Bus\Dispatcher', 'Illuminate\Contracts\Bus\Dispatcher'
+            Dispatcher::class, BusDispatcherContract::class
         );
 
         $this->app->alias(
-            'Illuminate\Bus\Dispatcher', 'Illuminate\Contracts\Bus\QueueingDispatcher'
+            Dispatcher::class, QueueingDispatcher::class
         );
     }
 
@@ -43,9 +46,9 @@ class BusServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'Illuminate\Bus\Dispatcher',
-            'Illuminate\Contracts\Bus\Dispatcher',
-            'Illuminate\Contracts\Bus\QueueingDispatcher',
+            Dispatcher::class,
+            BusDispatcherContract::class,
+            QueueingDispatcher::class,
         ];
     }
 }

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -218,7 +218,7 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
         }
 
         return (new ReflectionClass($this->getHandlerClass($command)))->implementsInterface(
-            'Illuminate\Contracts\Queue\ShouldQueue'
+            ShouldQueue::class
         );
     }
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Illuminate\Contracts\Cache\Store;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Cache\Factory as FactoryContract;
 
 class CacheManager implements FactoryContract
@@ -232,9 +233,9 @@ class CacheManager implements FactoryContract
     {
         $repository = new Repository($store);
 
-        if ($this->app->bound('Illuminate\Contracts\Events\Dispatcher')) {
+        if ($this->app->bound(Dispatcher::class)) {
             $repository->setEventDispatcher(
-                $this->app['Illuminate\Contracts\Events\Dispatcher']
+                $this->app[Dispatcher::class]
             );
         }
 

--- a/src/Illuminate/Console/ScheduleServiceProvider.php
+++ b/src/Illuminate/Console/ScheduleServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Console\Scheduling\ScheduleRunCommand;
 
 class ScheduleServiceProvider extends ServiceProvider
 {
@@ -20,7 +21,7 @@ class ScheduleServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->commands('Illuminate\Console\Scheduling\ScheduleRunCommand');
+        $this->commands(ScheduleRunCommand::class);
     }
 
     /**
@@ -31,7 +32,7 @@ class ScheduleServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'Illuminate\Console\Scheduling\ScheduleRunCommand',
+            ScheduleRunCommand::class,
         ];
     }
 }

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -6,6 +6,7 @@ use Faker\Factory as FakerFactory;
 use Faker\Generator as FakerGenerator;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Queue\EntityResolver;
 use Illuminate\Database\Eloquent\QueueEntityResolver;
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Database\Eloquent\Factory as EloquentFactory;
@@ -77,7 +78,7 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     protected function registerQueueableEntityResolver()
     {
-        $this->app->singleton('Illuminate\Contracts\Queue\EntityResolver', function () {
+        $this->app->singleton(EntityResolver::class, function () {
             return new QueueEntityResolver;
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class HasManyThrough extends Relation
@@ -123,7 +124,7 @@ class HasManyThrough extends Relation
      */
     public function parentSoftDeletes()
     {
-        return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses_recursive(get_class($this->parent)));
+        return in_array(SoftDeletes::class, class_uses_recursive(get_class($this->parent)));
     }
 
     /**

--- a/src/Illuminate/Events/CallQueuedHandler.php
+++ b/src/Illuminate/Events/CallQueuedHandler.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Events;
 
 use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Container\Container;
 
 class CallQueuedHandler
@@ -56,7 +57,7 @@ class CallQueuedHandler
      */
     protected function setJobInstanceIfNecessary(Job $job, $instance)
     {
-        if (in_array('Illuminate\Queue\InteractsWithQueue', class_uses_recursive(get_class($instance)))) {
+        if (in_array(InteractsWithQueue::class, class_uses_recursive(get_class($instance)))) {
             $instance->setJob($job);
         }
 

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -6,6 +6,8 @@ use Exception;
 use ReflectionClass;
 use Illuminate\Support\Str;
 use Illuminate\Container\Container;
+use Illuminate\Broadcasting\BroadcastEvent;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
@@ -257,7 +259,7 @@ class Dispatcher implements DispatcherContract
 
             $queue = method_exists($event, 'onQueue') ? $event->onQueue() : null;
 
-            $this->resolveQueue()->connection($connection)->pushOn($queue, 'Illuminate\Broadcasting\BroadcastEvent', [
+            $this->resolveQueue()->connection($connection)->pushOn($queue, BroadcastEvent::class, [
                 'event' => serialize(clone $event),
             ]);
         }
@@ -390,7 +392,7 @@ class Dispatcher implements DispatcherContract
     {
         try {
             return (new ReflectionClass($class))->implementsInterface(
-                'Illuminate\Contracts\Queue\ShouldQueue'
+                ShouldQueue::class
             );
         } catch (Exception $e) {
             return false;

--- a/src/Illuminate/Events/EventServiceProvider.php
+++ b/src/Illuminate/Events/EventServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Events;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Queue\Factory as QueueFactory;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -15,7 +16,7 @@ class EventServiceProvider extends ServiceProvider
     {
         $this->app->singleton('events', function ($app) {
             return (new Dispatcher($app))->setQueueResolver(function () use ($app) {
-                return $app->make('Illuminate\Contracts\Queue\Factory');
+                return $app->make(QueueFactory::class);
             });
         });
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -13,8 +13,11 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Events\EventServiceProvider;
 use Illuminate\Routing\RoutingServiceProvider;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Illuminate\Foundation\Bootstrap\DetectEnvironment;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 
@@ -172,7 +175,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 
         $this->instance('app', $this);
 
-        $this->instance('Illuminate\Container\Container', $this);
+        $this->instance(Container::class, $this);
     }
 
     /**
@@ -215,7 +218,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function afterLoadingEnvironment(Closure $callback)
     {
         return $this->afterBootstrapping(
-            'Illuminate\Foundation\Bootstrap\DetectEnvironment', $callback
+            DetectEnvironment::class, $callback
         );
     }
 
@@ -779,7 +782,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function handle(SymfonyRequest $request, $type = self::MASTER_REQUEST, $catch = true)
     {
-        return $this['Illuminate\Contracts\Http\Kernel']->handle(Request::createFromBase($request));
+        return $this[HttpKernelContract::class]->handle(Request::createFromBase($request));
     }
 
     /**
@@ -1026,38 +1029,38 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function registerCoreContainerAliases()
     {
         $aliases = [
-            'app'                  => ['Illuminate\Foundation\Application', 'Illuminate\Contracts\Container\Container', 'Illuminate\Contracts\Foundation\Application'],
-            'auth'                 => 'Illuminate\Auth\AuthManager',
-            'auth.driver'          => ['Illuminate\Auth\Guard', 'Illuminate\Contracts\Auth\Guard'],
-            'auth.password.tokens' => 'Illuminate\Auth\Passwords\TokenRepositoryInterface',
-            'blade.compiler'       => 'Illuminate\View\Compilers\BladeCompiler',
-            'cache'                => ['Illuminate\Cache\CacheManager', 'Illuminate\Contracts\Cache\Factory'],
-            'cache.store'          => ['Illuminate\Cache\Repository', 'Illuminate\Contracts\Cache\Repository'],
-            'config'               => ['Illuminate\Config\Repository', 'Illuminate\Contracts\Config\Repository'],
-            'cookie'               => ['Illuminate\Cookie\CookieJar', 'Illuminate\Contracts\Cookie\Factory', 'Illuminate\Contracts\Cookie\QueueingFactory'],
-            'encrypter'            => ['Illuminate\Encryption\Encrypter', 'Illuminate\Contracts\Encryption\Encrypter'],
-            'db'                   => 'Illuminate\Database\DatabaseManager',
-            'events'               => ['Illuminate\Events\Dispatcher', 'Illuminate\Contracts\Events\Dispatcher'],
-            'files'                => 'Illuminate\Filesystem\Filesystem',
-            'filesystem'           => ['Illuminate\Filesystem\FilesystemManager', 'Illuminate\Contracts\Filesystem\Factory'],
-            'filesystem.disk'      => 'Illuminate\Contracts\Filesystem\Filesystem',
-            'filesystem.cloud'     => 'Illuminate\Contracts\Filesystem\Cloud',
-            'hash'                 => 'Illuminate\Contracts\Hashing\Hasher',
-            'translator'           => ['Illuminate\Translation\Translator', 'Symfony\Component\Translation\TranslatorInterface'],
-            'log'                  => ['Illuminate\Log\Writer', 'Illuminate\Contracts\Logging\Log', 'Psr\Log\LoggerInterface'],
-            'mailer'               => ['Illuminate\Mail\Mailer', 'Illuminate\Contracts\Mail\Mailer', 'Illuminate\Contracts\Mail\MailQueue'],
-            'auth.password'        => ['Illuminate\Auth\Passwords\PasswordBroker', 'Illuminate\Contracts\Auth\PasswordBroker'],
-            'queue'                => ['Illuminate\Queue\QueueManager', 'Illuminate\Contracts\Queue\Factory', 'Illuminate\Contracts\Queue\Monitor'],
-            'queue.connection'     => 'Illuminate\Contracts\Queue\Queue',
-            'redirect'             => 'Illuminate\Routing\Redirector',
-            'redis'                => ['Illuminate\Redis\Database', 'Illuminate\Contracts\Redis\Database'],
-            'request'              => 'Illuminate\Http\Request',
-            'router'               => ['Illuminate\Routing\Router', 'Illuminate\Contracts\Routing\Registrar'],
-            'session'              => 'Illuminate\Session\SessionManager',
-            'session.store'        => ['Illuminate\Session\Store', 'Symfony\Component\HttpFoundation\Session\SessionInterface'],
-            'url'                  => ['Illuminate\Routing\UrlGenerator', 'Illuminate\Contracts\Routing\UrlGenerator'],
-            'validator'            => ['Illuminate\Validation\Factory', 'Illuminate\Contracts\Validation\Factory'],
-            'view'                 => ['Illuminate\View\Factory', 'Illuminate\Contracts\View\Factory'],
+            'app'                  => [\Illuminate\Foundation\Application::class, \Illuminate\Contracts\Container\Container::class, \Illuminate\Contracts\Foundation\Application::class],
+            'auth'                 => \Illuminate\Auth\AuthManager::class,
+            'auth.driver'          => [\Illuminate\Auth\Guard::class, \Illuminate\Contracts\Auth\Guard::class],
+            'auth.password.tokens' => \Illuminate\Auth\Passwords\TokenRepositoryInterface::class,
+            'blade.compiler'       => \Illuminate\View\Compilers\BladeCompiler::class,
+            'cache'                => [\Illuminate\Cache\CacheManager::class, \Illuminate\Contracts\Cache\Factory::class],
+            'cache.store'          => [\Illuminate\Cache\Repository::class, \Illuminate\Contracts\Cache\Repository::class],
+            'config'               => [\Illuminate\Config\Repository::class, \Illuminate\Contracts\Config\Repository::class],
+            'cookie'               => [\Illuminate\Cookie\CookieJar::class, \Illuminate\Contracts\Cookie\Factory::class, \Illuminate\Contracts\Cookie\QueueingFactory::class],
+            'encrypter'            => [\Illuminate\Encryption\Encrypter::class, \Illuminate\Contracts\Encryption\Encrypter::class],
+            'db'                   => \Illuminate\Database\DatabaseManager::class,
+            'events'               => [\Illuminate\Events\Dispatcher::class, \Illuminate\Contracts\Events\Dispatcher::class],
+            'files'                => \Illuminate\Filesystem\Filesystem::class,
+            'filesystem'           => [\Illuminate\Filesystem\FilesystemManager::class, \Illuminate\Contracts\Filesystem\Factory::class],
+            'filesystem.disk'      => \Illuminate\Contracts\Filesystem\Filesystem::class,
+            'filesystem.cloud'     => \Illuminate\Contracts\Filesystem\Cloud::class,
+            'hash'                 => \Illuminate\Contracts\Hashing\Hasher::class,
+            'translator'           => [\Illuminate\Translation\Translator::class, \Symfony\Component\Translation\TranslatorInterface::class],
+            'log'                  => [\Illuminate\Log\Writer::class, \Illuminate\Contracts\Logging\Log::class, \Psr\Log\LoggerInterface::class],
+            'mailer'               => [\Illuminate\Mail\Mailer::class, \Illuminate\Contracts\Mail\Mailer::class, \Illuminate\Contracts\Mail\MailQueue::class],
+            'auth.password'        => [\Illuminate\Auth\Passwords\PasswordBroker::class, \Illuminate\Contracts\Auth\PasswordBroker::class],
+            'queue'                => [\Illuminate\Queue\QueueManager::class, \Illuminate\Contracts\Queue\Factory::class, \Illuminate\Contracts\Queue\Monitor::class],
+            'queue.connection'     => \Illuminate\Contracts\Queue\Queue::class,
+            'redirect'             => \Illuminate\Routing\Redirector::class,
+            'redis'                => [\Illuminate\Redis\Database::class, \Illuminate\Contracts\Redis\Database::class],
+            'request'              => \Illuminate\Http\Request::class,
+            'router'               => [\Illuminate\Routing\Router::class, \Illuminate\Contracts\Routing\Registrar::class],
+            'session'              => \Illuminate\Session\SessionManager::class,
+            'session.store'        => [\Illuminate\Session\Store::class, \Symfony\Component\HttpFoundation\Session\SessionInterface::class],
+            'url'                  => [\Illuminate\Routing\UrlGenerator::class, \Illuminate\Contracts\Routing\UrlGenerator::class],
+            'validator'            => [\Illuminate\Validation\Factory::class, \Illuminate\Contracts\Validation\Factory::class],
+            'view'                 => [\Illuminate\View\Factory::class, \Illuminate\Contracts\View\Factory::class],
         ];
 
         foreach ($aliases as $key => $aliases) {
@@ -1087,8 +1090,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected function getKernel()
     {
         $kernelContract = $this->runningInConsole()
-                    ? 'Illuminate\Contracts\Console\Kernel'
-                    : 'Illuminate\Contracts\Http\Kernel';
+                    ? ConsoleKernelContract::class
+                    : HttpKernelContract::class;
 
         return $this->make($kernelContract);
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -175,7 +175,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 
         $this->instance('app', $this);
 
-        $this->instance(Container::class, $this);
+        $this->instance(parent::class, $this);
     }
 
     /**

--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Bootstrap;
 
 use Illuminate\Log\Writer;
+use Psr\Log\LoggerInterface;
 use Monolog\Logger as Monolog;
 use Illuminate\Contracts\Foundation\Application;
 
@@ -32,7 +33,7 @@ class ConfigureLogging
         // Next, we will bind a Closure that resolves the PSR logger implementation
         // as this will grant us the ability to be interoperable with many other
         // libraries which are able to utilize the PSR standardized interface.
-        $app->bind('Psr\Log\LoggerInterface', function ($app) {
+        $app->bind(LoggerInterface::class, function ($app) {
             return $app['log']->getMonolog();
         });
     }

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -4,11 +4,11 @@ namespace Illuminate\Foundation\Bootstrap;
 
 use Exception;
 use ErrorException;
-use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Debug\Exception\FatalErrorException;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 
 class HandleExceptions
 {
@@ -152,6 +152,6 @@ class HandleExceptions
      */
     protected function getExceptionHandler()
     {
-        return $this->app->make(ExceptionHandler::class);
+        return $this->app->make(ExceptionHandlerContract::class);
     }
 }

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Bootstrap;
 
 use Exception;
 use ErrorException;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Debug\Exception\FatalErrorException;
@@ -151,6 +152,6 @@ class HandleExceptions
      */
     protected function getExceptionHandler()
     {
-        return $this->app->make('Illuminate\Contracts\Debug\ExceptionHandler');
+        return $this->app->make(ExceptionHandler::class);
     }
 }

--- a/src/Illuminate/Foundation/Bus/DispatchesJobs.php
+++ b/src/Illuminate/Foundation/Bus/DispatchesJobs.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Bus;
 
 use ArrayAccess;
+use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
 
 trait DispatchesJobs
 {
@@ -14,7 +15,7 @@ trait DispatchesJobs
      */
     protected function dispatch($job)
     {
-        return app('Illuminate\Contracts\Bus\Dispatcher')->dispatch($job);
+        return app(BusDispatcherContract::class)->dispatch($job);
     }
 
     /**
@@ -26,7 +27,7 @@ trait DispatchesJobs
      */
     protected function dispatchFromArray($job, array $array)
     {
-        return app('Illuminate\Contracts\Bus\Dispatcher')->dispatchFromArray($job, $array);
+        return app(BusDispatcherContract::class)->dispatchFromArray($job, $array);
     }
 
     /**
@@ -39,6 +40,6 @@ trait DispatchesJobs
      */
     protected function dispatchFrom($job, ArrayAccess $source, $extras = [])
     {
-        return app('Illuminate\Contracts\Bus\Dispatcher')->dispatchFrom($job, $source, $extras);
+        return app(BusDispatcherContract::class)->dispatchFrom($job, $source, $extras);
     }
 }

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 
 class ConfigCacheCommand extends Command
 {
@@ -68,7 +69,7 @@ class ConfigCacheCommand extends Command
     {
         $app = require $this->laravel->basePath().'/bootstrap/app.php';
 
-        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        $app->make(ConsoleKernelContract::class)->bootstrap();
 
         return $app['config']->all();
     }

--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 
 class EventGenerateCommand extends Command
 {
@@ -29,7 +30,7 @@ class EventGenerateCommand extends Command
     public function fire()
     {
         $provider = $this->laravel->getProvider(
-            'Illuminate\Foundation\Support\Providers\EventServiceProvider'
+            EventServiceProvider::class
         );
 
         foreach ($provider->listens() as $event => $listeners) {

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -7,7 +7,6 @@ use Throwable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Application as Artisan;
-use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\BootProviders;
 use Illuminate\Foundation\Bootstrap\RegisterFacades;
@@ -20,6 +19,7 @@ use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Bootstrap\SetRequestForConsole;
 use Illuminate\Contracts\Console\Kernel as KernelContract;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 
 class Kernel implements KernelContract
 {
@@ -257,7 +257,7 @@ class Kernel implements KernelContract
      */
     protected function reportException(Exception $e)
     {
-        $this->app[ExceptionHandler::class]->report($e);
+        $this->app[ExceptionHandlerContract::class]->report($e);
     }
 
     /**
@@ -269,6 +269,6 @@ class Kernel implements KernelContract
      */
     protected function renderException($output, Exception $e)
     {
-        $this->app[ExceptionHandler::class]->renderForConsole($output, $e);
+        $this->app[ExceptionHandlerContract::class]->renderForConsole($output, $e);
     }
 }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -7,7 +7,17 @@ use Throwable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Application as Artisan;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Bootstrap\BootProviders;
+use Illuminate\Foundation\Bootstrap\RegisterFacades;
+use Illuminate\Foundation\Bootstrap\ConfigureLogging;
+use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Illuminate\Contracts\Queue\Queue as QueueContract;
+use Illuminate\Foundation\Bootstrap\DetectEnvironment;
+use Illuminate\Foundation\Bootstrap\LoadConfiguration;
+use Illuminate\Foundation\Bootstrap\RegisterProviders;
+use Illuminate\Foundation\Bootstrap\SetRequestForConsole;
 use Illuminate\Contracts\Console\Kernel as KernelContract;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 
@@ -47,14 +57,14 @@ class Kernel implements KernelContract
      * @var array
      */
     protected $bootstrappers = [
-        'Illuminate\Foundation\Bootstrap\DetectEnvironment',
-        'Illuminate\Foundation\Bootstrap\LoadConfiguration',
-        'Illuminate\Foundation\Bootstrap\ConfigureLogging',
-        'Illuminate\Foundation\Bootstrap\HandleExceptions',
-        'Illuminate\Foundation\Bootstrap\RegisterFacades',
-        'Illuminate\Foundation\Bootstrap\SetRequestForConsole',
-        'Illuminate\Foundation\Bootstrap\RegisterProviders',
-        'Illuminate\Foundation\Bootstrap\BootProviders',
+        DetectEnvironment::class,
+        LoadConfiguration::class,
+        ConfigureLogging::class,
+        HandleExceptions::class,
+        RegisterFacades::class,
+        SetRequestForConsole::class,
+        RegisterProviders::class,
+        BootProviders::class,
     ];
 
     /**
@@ -86,7 +96,7 @@ class Kernel implements KernelContract
     protected function defineConsoleSchedule()
     {
         $this->app->instance(
-            'Illuminate\Console\Scheduling\Schedule', $schedule = new Schedule
+            Schedule::class, $schedule = new Schedule
         );
 
         $this->schedule($schedule);
@@ -168,8 +178,8 @@ class Kernel implements KernelContract
      */
     public function queue($command, array $parameters = [])
     {
-        $this->app['Illuminate\Contracts\Queue\Queue']->push(
-            'Illuminate\Foundation\Console\QueuedJob', func_get_args()
+        $this->app[QueueContract::class]->push(
+            QueuedJob::class, func_get_args()
         );
     }
 
@@ -247,7 +257,7 @@ class Kernel implements KernelContract
      */
     protected function reportException(Exception $e)
     {
-        $this->app['Illuminate\Contracts\Debug\ExceptionHandler']->report($e);
+        $this->app[ExceptionHandler::class]->report($e);
     }
 
     /**
@@ -259,6 +269,6 @@ class Kernel implements KernelContract
      */
     protected function renderException($output, Exception $e)
     {
-        $this->app['Illuminate\Contracts\Debug\ExceptionHandler']->renderForConsole($output, $e);
+        $this->app[ExceptionHandler::class]->renderForConsole($output, $e);
     }
 }

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 
 class RouteCacheCommand extends Command
 {
@@ -77,7 +78,7 @@ class RouteCacheCommand extends Command
     {
         $app = require $this->laravel->basePath().'/bootstrap/app.php';
 
-        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        $app->make(ConsoleKernelContract::class)->bootstrap();
 
         return $app['router']->getRoutes();
     }

--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -5,6 +5,9 @@ namespace Illuminate\Foundation\Console;
 use Psy\Shell;
 use Psy\Configuration;
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Foundation\Application;
+use Illuminate\Database\Eloquent\Model;
 use Symfony\Component\Console\Input\InputArgument;
 
 class TinkerCommand extends Command
@@ -80,9 +83,9 @@ class TinkerCommand extends Command
     protected function getCasters()
     {
         return [
-            'Illuminate\Foundation\Application' => 'Illuminate\Foundation\Console\IlluminateCaster::castApplication',
-            'Illuminate\Support\Collection' => 'Illuminate\Foundation\Console\IlluminateCaster::castCollection',
-            'Illuminate\Database\Eloquent\Model' => 'Illuminate\Foundation\Console\IlluminateCaster::castModel',
+            Application::class => 'Illuminate\Foundation\Console\IlluminateCaster::castApplication',
+            Collection::class => 'Illuminate\Foundation\Console\IlluminateCaster::castCollection',
+            Model::class => 'Illuminate\Foundation\Console\IlluminateCaster::castModel',
         ];
     }
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -8,6 +8,14 @@ use Illuminate\Routing\Router;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Foundation\Bootstrap\BootProviders;
+use Illuminate\Foundation\Bootstrap\RegisterFacades;
+use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Illuminate\Foundation\Bootstrap\ConfigureLogging;
+use Illuminate\Foundation\Bootstrap\RegisterProviders;
+use Illuminate\Foundation\Bootstrap\DetectEnvironment;
+use Illuminate\Foundation\Bootstrap\LoadConfiguration;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 
@@ -33,13 +41,13 @@ class Kernel implements KernelContract
      * @var array
      */
     protected $bootstrappers = [
-        'Illuminate\Foundation\Bootstrap\DetectEnvironment',
-        'Illuminate\Foundation\Bootstrap\LoadConfiguration',
-        'Illuminate\Foundation\Bootstrap\ConfigureLogging',
-        'Illuminate\Foundation\Bootstrap\HandleExceptions',
-        'Illuminate\Foundation\Bootstrap\RegisterFacades',
-        'Illuminate\Foundation\Bootstrap\RegisterProviders',
-        'Illuminate\Foundation\Bootstrap\BootProviders',
+        DetectEnvironment::class,
+        LoadConfiguration::class,
+        ConfigureLogging::class,
+        HandleExceptions::class,
+        RegisterFacades::class,
+        RegisterProviders::class,
+        BootProviders::class,
     ];
 
     /**
@@ -266,7 +274,7 @@ class Kernel implements KernelContract
      */
     protected function reportException(Exception $e)
     {
-        $this->app['Illuminate\Contracts\Debug\ExceptionHandler']->report($e);
+        $this->app[ExceptionHandler::class]->report($e);
     }
 
     /**
@@ -278,7 +286,7 @@ class Kernel implements KernelContract
      */
     protected function renderException($request, Exception $e)
     {
-        return $this->app['Illuminate\Contracts\Debug\ExceptionHandler']->render($request, $e);
+        return $this->app[ExceptionHandler::class]->render($request, $e);
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -8,7 +8,6 @@ use Illuminate\Routing\Router;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Foundation\Bootstrap\BootProviders;
 use Illuminate\Foundation\Bootstrap\RegisterFacades;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
@@ -18,6 +17,7 @@ use Illuminate\Foundation\Bootstrap\DetectEnvironment;
 use Illuminate\Foundation\Bootstrap\LoadConfiguration;
 use Illuminate\Contracts\Http\Kernel as KernelContract;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
+use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 
 class Kernel implements KernelContract
 {
@@ -274,7 +274,7 @@ class Kernel implements KernelContract
      */
     protected function reportException(Exception $e)
     {
-        $this->app[ExceptionHandler::class]->report($e);
+        $this->app[ExceptionHandlerContract::class]->report($e);
     }
 
     /**
@@ -286,7 +286,7 @@ class Kernel implements KernelContract
      */
     protected function renderException($request, Exception $e)
     {
-        return $this->app[ExceptionHandler::class]->render($request, $e);
+        return $this->app[ExceptionHandlerContract::class]->render($request, $e);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
@@ -2,7 +2,13 @@
 
 namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Database\SeedServiceProvider;
+use Illuminate\Queue\ConsoleServiceProvider;
+use Illuminate\Auth\GeneratorServiceProvider;
+use Illuminate\Console\ScheduleServiceProvider;
+use Illuminate\Session\CommandsServiceProvider;
 use Illuminate\Support\AggregateServiceProvider;
+use Illuminate\Database\MigrationServiceProvider;
 
 class ConsoleSupportServiceProvider extends AggregateServiceProvider
 {
@@ -19,13 +25,13 @@ class ConsoleSupportServiceProvider extends AggregateServiceProvider
      * @var array
      */
     protected $providers = [
-        'Illuminate\Auth\GeneratorServiceProvider',
-        'Illuminate\Console\ScheduleServiceProvider',
-        'Illuminate\Database\MigrationServiceProvider',
-        'Illuminate\Database\SeedServiceProvider',
-        'Illuminate\Foundation\Providers\ComposerServiceProvider',
-        'Illuminate\Queue\ConsoleServiceProvider',
-        'Illuminate\Routing\GeneratorServiceProvider',
-        'Illuminate\Session\CommandsServiceProvider',
+        GeneratorServiceProvider::class,
+        ScheduleServiceProvider::class,
+        MigrationServiceProvider::class,
+        SeedServiceProvider::class,
+        ComposerServiceProvider::class,
+        ConsoleServiceProvider::class,
+        GeneratorServiceProvider::class,
+        CommandsServiceProvider::class,
     ];
 }

--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Routing\Redirector;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Http\FormRequest;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,7 +31,7 @@ class FormRequestServiceProvider extends ServiceProvider
                 $this->initializeRequest($request, $app['request']);
 
                 $request->setContainer($app)
-                        ->setRedirector($app['Illuminate\Routing\Redirector']);
+                        ->setRedirector($app[Redirector::class]);
             });
         });
     }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -12,6 +12,6 @@ class FoundationServiceProvider extends AggregateServiceProvider
      * @var array
      */
     protected $providers = [
-        'Illuminate\Foundation\Providers\FormRequestServiceProvider',
+        FormRequestServiceProvider::class,
     ];
 }

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Support\Providers;
 
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Routing\UrlGenerator;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -46,7 +47,7 @@ class RouteServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->app['Illuminate\Contracts\Routing\UrlGenerator']
+        $this->app[UrlGenerator::class]
                         ->setRootControllerNamespace($this->namespace);
     }
 
@@ -80,7 +81,7 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function loadRoutesFrom($path)
     {
-        $router = $this->app['Illuminate\Routing\Router'];
+        $router = $this->app[Router::class];
 
         if (is_null($this->namespace)) {
             return require $path;

--- a/src/Illuminate/Foundation/Testing/ApplicationTrait.php
+++ b/src/Illuminate/Foundation/Testing/ApplicationTrait.php
@@ -5,6 +5,9 @@ namespace Illuminate\Foundation\Testing;
 use Mockery;
 use Exception;
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
+use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcherContract;
 
 trait ApplicationTrait
 {
@@ -60,7 +63,7 @@ trait ApplicationTrait
     {
         $events = is_array($events) ? $events : func_get_args();
 
-        $mock = Mockery::spy('Illuminate\Contracts\Events\Dispatcher');
+        $mock = Mockery::spy(EventDispatcherContract::class);
 
         $mock->shouldReceive('fire')->andReturnUsing(function ($called) use (&$events) {
             foreach ($events as $key => $event) {
@@ -92,7 +95,7 @@ trait ApplicationTrait
      */
     protected function withoutEvents()
     {
-        $mock = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
+        $mock = Mockery::mock(EventDispatcherContract::class);
 
         $mock->shouldReceive('fire');
 
@@ -121,7 +124,7 @@ trait ApplicationTrait
         }
 
         $this->app->instance(
-            'Illuminate\Contracts\Bus\Dispatcher', $mock
+            BusDispatcherContract::class, $mock
         );
 
         return $this;
@@ -296,6 +299,6 @@ trait ApplicationTrait
      */
     public function artisan($command, $parameters = [])
     {
-        return $this->code = $this->app['Illuminate\Contracts\Console\Kernel']->call($command, $parameters);
+        return $this->code = $this->app[ConsoleKernelContract::class]->call($command, $parameters);
     }
 }

--- a/src/Illuminate/Foundation/Testing/AssertionsTrait.php
+++ b/src/Illuminate/Foundation/Testing/AssertionsTrait.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing;
 
 use Illuminate\View\View;
 use PHPUnit_Framework_Assert as PHPUnit;
+use Illuminate\Http\RedirectResponse;
 
 trait AssertionsTrait
 {
@@ -97,7 +98,7 @@ trait AssertionsTrait
      */
     public function assertRedirectedTo($uri, $with = [])
     {
-        PHPUnit::assertInstanceOf('Illuminate\Http\RedirectResponse', $this->response);
+        PHPUnit::assertInstanceOf(RedirectResponse::class, $this->response);
 
         PHPUnit::assertEquals($this->app['url']->to($uri), $this->response->headers->get('Location'));
 

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Foundation\Testing;
 
-use Exception;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 
 trait CrawlerTrait
 {
@@ -382,7 +382,7 @@ trait CrawlerTrait
      */
     public function call($method, $uri, $parameters = [], $cookies = [], $files = [], $server = [], $content = null)
     {
-        $kernel = $this->app->make('Illuminate\Contracts\Http\Kernel');
+        $kernel = $this->app->make(HttpKernelContract::class);
 
         $this->currentUri = $this->prepareUrlForRequest($uri);
 

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -4,8 +4,10 @@ namespace Illuminate\Foundation\Validation;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\UrlGenerator;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exception\HttpResponseException;
+use Illuminate\Contracts\Validation\Factory as ValidationFactoryContract;
 
 trait ValidatesRequests
 {
@@ -107,7 +109,7 @@ trait ValidatesRequests
      */
     protected function getRedirectUrl()
     {
-        return app('Illuminate\Routing\UrlGenerator')->previous();
+        return app(UrlGenerator::class)->previous();
     }
 
     /**
@@ -117,7 +119,7 @@ trait ValidatesRequests
      */
     protected function getValidationFactory()
     {
-        return app('Illuminate\Contracts\Validation\Factory');
+        return app(ValidationFactoryContract::class);
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -2,7 +2,13 @@
 
 use Illuminate\Support\Str;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Routing\ResponseFactory;
+use Illuminate\Database\Eloquent\Factory as EloquentFactory;
+use Illuminate\Contracts\View\Factory as ViewFactoryContract;
+use Illuminate\Contracts\Cookie\Factory as CookieFactoryContract;
+use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
 
 if (! function_exists('abort')) {
     /**
@@ -90,7 +96,7 @@ if (! function_exists('auth')) {
      */
     function auth()
     {
-        return app('Illuminate\Contracts\Auth\Guard');
+        return app(Guard::class);
     }
 }
 
@@ -187,7 +193,7 @@ if (! function_exists('cookie')) {
      */
     function cookie($name = null, $value = null, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true)
     {
-        $cookie = app('Illuminate\Contracts\Cookie\Factory');
+        $cookie = app(CookieFactoryContract::class);
 
         if (is_null($name)) {
             return $cookie;
@@ -347,7 +353,7 @@ if (! function_exists('factory')) {
      */
     function factory()
     {
-        $factory = app('Illuminate\Database\Eloquent\Factory');
+        $factory = app(EloquentFactory::class);
 
         $arguments = func_get_args();
 
@@ -568,7 +574,7 @@ if (! function_exists('response')) {
      */
     function response($content = '', $status = 200, array $headers = [])
     {
-        $factory = app('Illuminate\Contracts\Routing\ResponseFactory');
+        $factory = app(ResponseFactory::class);
 
         if (func_num_args() === 0) {
             return $factory;
@@ -706,7 +712,7 @@ if (! function_exists('url')) {
      */
     function url($path = null, $parameters = [], $secure = null)
     {
-        return app('Illuminate\Contracts\Routing\UrlGenerator')->to($path, $parameters, $secure);
+        return app(UrlGeneratorContract::class)->to($path, $parameters, $secure);
     }
 }
 
@@ -721,7 +727,7 @@ if (! function_exists('view')) {
      */
     function view($view = null, $data = [], $mergeData = [])
     {
-        $factory = app('Illuminate\Contracts\View\Factory');
+        $factory = app(ViewFactoryContract::class);
 
         if (func_num_args() === 0) {
             return $factory;

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Mail;
 
 use Swift_Mailer;
+use Psr\Log\LoggerInterface;
 use Illuminate\Support\ServiceProvider;
 
 class MailServiceProvider extends ServiceProvider
@@ -70,8 +71,8 @@ class MailServiceProvider extends ServiceProvider
     {
         $mailer->setContainer($app);
 
-        if ($app->bound('Psr\Log\LoggerInterface')) {
-            $mailer->setLogger($app->make('Psr\Log\LoggerInterface'));
+        if ($app->bound(LoggerInterface::class)) {
+            $mailer->setLogger($app->make(LoggerInterface::class));
         }
 
         if ($app->bound('queue')) {

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Mail;
 
 use Aws\Ses\SesClient;
 use Illuminate\Support\Arr;
+use Psr\Log\LoggerInterface;
 use Illuminate\Support\Manager;
 use GuzzleHttp\Client as HttpClient;
 use Swift_SmtpTransport as SmtpTransport;
@@ -123,7 +124,7 @@ class TransportManager extends Manager
      */
     protected function createLogDriver()
     {
-        return new LogTransport($this->app->make('Psr\Log\LoggerInterface'));
+        return new LogTransport($this->app->make(LoggerInterface::class));
     }
 
     /**

--- a/src/Illuminate/Pipeline/PipelineServiceProvider.php
+++ b/src/Illuminate/Pipeline/PipelineServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Pipeline;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Pipeline\Hub as HubContract;
 
 class PipelineServiceProvider extends ServiceProvider
 {
@@ -21,7 +22,7 @@ class PipelineServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(
-            'Illuminate\Contracts\Pipeline\Hub', 'Illuminate\Pipeline\Hub'
+            HubContract::class, Hub::class
         );
     }
 
@@ -33,7 +34,7 @@ class PipelineServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'Illuminate\Contracts\Pipeline\Hub',
+            HubContract::class,
         ];
     }
 }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -56,7 +56,7 @@ class CallQueuedHandler
      */
     protected function setJobInstanceIfNecessary(Job $job, $instance)
     {
-        if (in_array('Illuminate\Queue\InteractsWithQueue', class_uses_recursive(get_class($instance)))) {
+        if (in_array(InteractsWithQueue::class, class_uses_recursive(get_class($instance)))) {
             $instance->setJob($job);
         }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Queue\Worker;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Job;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -94,7 +95,7 @@ class WorkCommand extends Command
             $this->worker->setCache($this->laravel['cache']->driver());
 
             $this->worker->setDaemonExceptionHandler(
-                $this->laravel['Illuminate\Contracts\Debug\ExceptionHandler']
+                $this->laravel[ExceptionHandler::class]
             );
 
             return $this->worker->daemon(

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -5,9 +5,9 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Queue\Worker;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Job;
-use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
+use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;
 
 class WorkCommand extends Command
 {
@@ -95,7 +95,7 @@ class WorkCommand extends Command
             $this->worker->setCache($this->laravel['cache']->driver());
 
             $this->worker->setDaemonExceptionHandler(
-                $this->laravel[ExceptionHandler::class]
+                $this->laravel[ExceptionHandlerContract::class]
             );
 
             return $this->worker->daemon(

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue\Jobs;
 
 use DateTime;
 use Illuminate\Support\Str;
+use Illuminate\Contracts\Queue\EntityResolver;
 
 abstract class Job
 {
@@ -214,7 +215,7 @@ abstract class Job
      */
     protected function getEntityResolver()
     {
-        return $this->container->make('Illuminate\Contracts\Queue\EntityResolver');
+        return $this->container->make(EntityResolver::class);
     }
 
     /**

--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -62,7 +62,7 @@ class ControllerInspector
      */
     public function isRoutable(ReflectionMethod $method)
     {
-        if ($method->class == 'Illuminate\Routing\Controller') {
+        if ($method->class == Controller::class) {
             return false;
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -324,8 +324,8 @@ class Router implements RegistrarContract
      */
     public function resource($name, $controller, array $options = [])
     {
-        if ($this->container && $this->container->bound('Illuminate\Routing\ResourceRegistrar')) {
-            $registrar = $this->container->make('Illuminate\Routing\ResourceRegistrar');
+        if ($this->container && $this->container->bound(ResourceRegistrar::class)) {
+            $registrar = $this->container->make(ResourceRegistrar::class);
         } else {
             $registrar = new ResourceRegistrar($this);
         }
@@ -745,7 +745,7 @@ class Router implements RegistrarContract
     {
         $this->current = $route = $this->routes->match($request);
 
-        $this->container->instance('Illuminate\Routing\Route', $route);
+        $this->container->instance(Route::class, $route);
 
         return $this->substituteBindings($route);
     }

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -3,8 +3,12 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Support\ServiceProvider;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response as PsrResponse;
+use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Illuminate\Contracts\View\Factory as ViewFactoryContract;
+use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 
 class RoutingServiceProvider extends ServiceProvider
 {
@@ -116,7 +120,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerPsrRequest()
     {
-        $this->app->bind('Psr\Http\Message\ServerRequestInterface', function ($app) {
+        $this->app->bind(ServerRequestInterface::class, function ($app) {
             return (new DiactorosFactory)->createRequest($app->make('request'));
         });
     }
@@ -128,7 +132,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerPsrResponse()
     {
-        $this->app->bind('Psr\Http\Message\ResponseInterface', function ($app) {
+        $this->app->bind(ResponseInterface::class, function ($app) {
             return new PsrResponse();
         });
     }
@@ -140,8 +144,8 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerResponseFactory()
     {
-        $this->app->singleton('Illuminate\Contracts\Routing\ResponseFactory', function ($app) {
-            return new ResponseFactory($app['Illuminate\Contracts\View\Factory'], $app['redirect']);
+        $this->app->singleton(ResponseFactoryContract::class, function ($app) {
+            return new ResponseFactory($app[ViewFactoryContract::class], $app['redirect']);
         });
     }
 }

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Session;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Session\Middleware\StartSession;
 
 class SessionServiceProvider extends ServiceProvider
 {
@@ -17,7 +18,7 @@ class SessionServiceProvider extends ServiceProvider
 
         $this->registerSessionDriver();
 
-        $this->app->singleton('Illuminate\Session\Middleware\StartSession');
+        $this->app->singleton(StartSession::class);
     }
 
     /**

--- a/src/Illuminate/Support/ClassLoader.php
+++ b/src/Illuminate/Support/ClassLoader.php
@@ -62,7 +62,7 @@ class ClassLoader
     public static function register()
     {
         if (! static::$registered) {
-            static::$registered = spl_autoload_register(['\Illuminate\Support\ClassLoader', 'load']);
+            static::$registered = spl_autoload_register([self::class, 'load']);
         }
     }
 

--- a/src/Illuminate/Support/Facades/Artisan.php
+++ b/src/Illuminate/Support/Facades/Artisan.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Contracts\Console\Kernel as ConsoelKernelContract;
+
 /**
  * @see \Illuminate\Contracts\Console\Kernel
  */
@@ -14,6 +16,6 @@ class Artisan extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Contracts\Console\Kernel';
+        return ConsoelKernelContract::class;
     }
 }

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
+
 /**
  * @see \Illuminate\Contracts\Bus\Dispatcher
  */
@@ -14,6 +16,6 @@ class Bus extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Contracts\Bus\Dispatcher';
+        return BusDispatcherContract::class;
     }
 }

--- a/src/Illuminate/Support/Facades/Gate.php
+++ b/src/Illuminate/Support/Facades/Gate.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Contracts\Auth\Access\Gate as Contract;
+
 /**
  * @see \Illuminate\Contracts\Auth\Access\Gate
  */
@@ -14,6 +16,6 @@ class Gate extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Contracts\Auth\Access\Gate';
+        return Contract::class;
     }
 }

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Contracts\Routing\ResponseFactory;
+
 /**
  * @see \Illuminate\Contracts\Routing\ResponseFactory
  */
@@ -14,6 +16,6 @@ class Response extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Contracts\Routing\ResponseFactory';
+        return ResponseFactory::class;
     }
 }


### PR DESCRIPTION
Since the introduction of `Gate`, classes are resolved using the `::class` notation.
This PR aims to put some consistency for class resolution. 

_Note_ :
FQN are left unchanged on purpose in `\Illuminate\Foundation\Application::registerCoreContainerAliases()`.
