### PR TITLE
[5.1] optimize: write to temporary file first, then rename it

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -82,7 +82,9 @@ class OptimizeCommand extends Command
     {
         $preloader = new ClassPreloader(new PrettyPrinter, new Parser(new Lexer), $this->getTraverser());
 
-        $handle = $preloader->prepareOutput($this->laravel->getCachedCompilePath());
+        $cachedFile = $this->laravel->getCachedCompilePath();
+        $tempFile = $cachedFile.'.temp';
+        $handle = $preloader->prepareOutput($tempFile);
 
         foreach ($this->getClassFiles() as $file) {
             try {
@@ -93,6 +95,7 @@ class OptimizeCommand extends Command
         }
 
         fclose($handle);
+        rename($tempFile, $cachedFile);
     }
 
     /**


### PR DESCRIPTION
The cached file is written to as the classes are compiled, which can
result in a partial file being used for serving the application,
resulting in all kinds of possible errors. The client will receive a 500
usually.

By first writing to a temporary file and then moving it over, we
mitigate this factor.
