### PR TITLE
[5.1] Make formatErrors() adhere to contracts

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -156,7 +156,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function formatErrors(Validator $validator)
     {
-        return $validator->errors()->getMessages();
+        return $validator->getMessageBag()->toArray();
     }
 
     /**


### PR DESCRIPTION
This change makes the implementation of `FormRequest::formatErrors()` method adhere to the `Validator` and `MessageBag` contracts. Note that the behavior is exactly the same, because `getMessageBag()` is just an alias for `errors()` and the same holds for `toArray()` and `getMessages()`. However, `errors()` and `getMessages()` are not in the contracts, while the method typehints the `Validator` interface. So without this change, if you would want to swap the implementation of `Validator` or `MessageBag` to a custom one, `FormRequest` breaks.

This change also improves IDE navigation.
