### PR TITLE
[5.1] Fix pagination for group by and having statements

### DIFF
--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Expression as Raw;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Pagination\AbstractPaginator as Paginator;
@@ -41,7 +42,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
     {
         $this->schema()->create('users', function ($table) {
             $table->increments('id');
-            $table->string('email')->unique();
+            $table->string('email');
             $table->timestamps();
         });
 
@@ -162,6 +163,20 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $query = EloquentTestUser::groupBy('email')->getQuery();
 
         $this->assertEquals(3, $query->getCountForPagination());
+    }
+
+    public function testCountForPaginationWithHaving()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
+        EloquentTestUser::create(['id' => 4, 'email' => 'foo@gmail.com']);
+        EloquentTestUser::create(['id' => 5, 'email' => 'bar@gmail.com']);
+        EloquentTestUser::create(['id' => 6, 'email' => 'bar@gmail.com']);
+
+        $query = EloquentTestUser::selectRaw('count("id") as total')->groupBy('email')->having('total', '>', new Raw('1'))->getQuery();
+
+        $this->assertEquals(2, $query->getCountForPagination());
     }
 
     public function testListsRetrieval()


### PR DESCRIPTION
There are two problems that this PR is trying to address:

1.) length-aware pagination with "group by" statements is currently slow since counting of the results is done in PHP instead of in the query
2.) and it's currently not possible to paginate queries containing having statements

In these two cases, we can use a sub query to get the total number of rows:

```
select count(*) as aggregate from (<original query>) AS aggregate_table
```

By doing this, we can now paginate any query and it's all done in SQL so it should be a lot faster. If no "groups" or "havings" are defined, then we still use the normal pagination without a subquery. And since we don't need the "hack" for group by statements any more, I was able to clean up some related code as well and defer to the built-in count function in both cases.

This was tested in SQLite and MySQL. Any feedback about other supported grammars is welcome.
