### PR TITLE
[5.1] Prevent $config conflicts within config files

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -50,10 +50,10 @@ class LoadConfiguration
      * @param  \Illuminate\Contracts\Config\Repository  $config
      * @return void
      */
-    protected function loadConfigurationFiles(Application $app, RepositoryContract $config)
+    protected function loadConfigurationFiles(Application $app, RepositoryContract $configRepo)
     {
         foreach ($this->getConfigurationFiles($app) as $key => $path) {
-            $config->set($key, require $path);
+            $configRepo->set($key, require $path);
         }
     }
 

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -47,7 +47,7 @@ class LoadConfiguration
      * Load the configuration items from all of the files.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @param  \Illuminate\Contracts\Config\Repository  $config
+     * @param  \Illuminate\Contracts\Config\Repository  $configRepo
      * @return void
      */
     protected function loadConfigurationFiles(Application $app, RepositoryContract $configRepo)


### PR DESCRIPTION
Sometimes, config files require a special logic, such as specific configuration within different environments. This can lead to changing a config from from:

``` php
return [
    // ...
];
```

to something like:

```
$config = [];

if (some_conditional) {
    $config['foo'] = [
        // ...
    ];

    if (some_other_conditional) {
        $config['foo']['bar'] = 'baz';
    }
}

return $config + [
    // ... remaining config
]
```

This is great, but using the most likely variable name, `$config`, will actually cause an exception to be thrown. This exception can be very unexpected, and takes a bit to track down the issue. 

```
Fatal error: Call to a member function set() on array in [path]/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php on line 56
```

Changing the variable symbol within the LoadConfig::loadConfigurationFiles() will prevent this.
