### PR TITLE
[5.2] [Proposal] Restrict filling of Eloquent Collection with models only

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support;
 
+use UnexpectedValueException;
 use Illuminate\Support\Traits\Macroable;
 
 class Arr
@@ -440,5 +441,25 @@ class Arr
         }
 
         return $filtered;
+    }
+
+    /**
+     * Check each element with a callback and throw an exception on fail.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @param  string  $exceptionClass
+     *
+     * @return array
+     */
+    public static function check($array, callable $callback, $exceptionClass = UnexpectedValueException::class)
+    {
+        foreach ($array as $key => $value) {
+            if (! call_user_func($callback, $value)) {
+                throw new $exceptionClass('Invalid array element at offset '.$key);
+            }
+        }
+
+        return $array;
     }
 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -29,7 +29,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function __construct($items = [])
     {
-        $this->items = is_array($items) ? $items : $this->getArrayableItems($items);
+        $this->fill($items);
     }
 
     /**
@@ -41,6 +41,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public static function make($items = [])
     {
         return new static($items);
+    }
+
+    /**
+     * Fill the collection with new items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function fill($items = [])
+    {
+        $this->items = is_array($items) ? $items : $this->getArrayableItems($items);
+
+        return $this;
     }
 
     /**
@@ -823,9 +836,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function transform(callable $callback)
     {
-        $this->items = $this->map($callback)->all();
-
-        return $this;
+        return $this->fill($this->map($callback)->all());
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -287,6 +287,22 @@ if (! function_exists('array_sort_recursive')) {
     }
 }
 
+if (! function_exists('array_check')) {
+    /**
+     * Check each element with a callback and throw an exception on fail.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @param  string  $exceptionClass
+     *
+     * @return array
+     */
+    function array_check($array, callable $callback, $exceptionClass = UnexpectedValueException::class)
+    {
+        return Arr::check($array, $callback, $exceptionClass);
+    }
+}
+
 if (! function_exists('array_where')) {
     /**
      * Filter the array using the given callback.

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -264,10 +264,10 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
     public function testFirstMethod()
     {
         $relation = m::mock('Illuminate\Database\Eloquent\Relations\BelongsToMany[get]', $this->getRelationArguments());
-        $relation->shouldReceive('get')->once()->andReturn(new Illuminate\Database\Eloquent\Collection([new StdClass]));
+        $relation->shouldReceive('get')->once()->andReturn(new Illuminate\Database\Eloquent\Collection([new EloquentBelongsToManyModelStub]));
         $relation->shouldReceive('take')->with(1)->once()->andReturn($relation);
 
-        $this->assertInstanceOf(StdClass::class, $relation->first());
+        $this->assertInstanceOf(EloquentBelongsToManyModelStub::class, $relation->first());
     }
 
     public function testFindMethod()
@@ -285,7 +285,8 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
     public function testFindManyMethod()
     {
         $relation = m::mock('Illuminate\Database\Eloquent\Relations\BelongsToMany[get]', $this->getRelationArguments());
-        $relation->shouldReceive('get')->once()->andReturn(new Illuminate\Database\Eloquent\Collection([new StdClass, new StdClass]));
+        $relation->shouldReceive('get')->once()
+            ->andReturn(new Illuminate\Database\Eloquent\Collection([new EloquentBelongsToManyModelStub, new EloquentBelongsToManyModelStub]));
         $relation->shouldReceive('whereIn')->with('roles.id', ['foo', 'bar'])->once()->andReturn($relation);
 
         $related = $relation->getRelated();
@@ -294,7 +295,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $result = $relation->findMany(['foo', 'bar']);
 
         $this->assertEquals(2, count($result));
-        $this->assertInstanceOf(StdClass::class, $result->first());
+        $this->assertInstanceOf(EloquentBelongsToManyModelStub::class, $result->first());
     }
 
     public function testCreateMethodCreatesNewModelAndInsertsAttachmentRecord()

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -43,9 +43,9 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase
     public function testModelsAreProperlyMatchedToParents()
     {
         $relation = $this->getRelation();
-        $result1 = m::mock('stdClass');
+        $result1 = m::mock('Illuminate\Database\Eloquent\Model');
         $result1->shouldReceive('getAttribute')->with('id')->andReturn(1);
-        $result2 = m::mock('stdClass');
+        $result2 = m::mock('Illuminate\Database\Eloquent\Model');
         $result2->shouldReceive('getAttribute')->with('id')->andReturn(2);
         $model1 = new EloquentBelongsToModelStub;
         $model1->foreign_key = 1;

--- a/tests/Database/DatabaseEloquentHasManyThroughTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughTest.php
@@ -130,10 +130,12 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase
     public function testFirstMethod()
     {
         $relation = m::mock('Illuminate\Database\Eloquent\Relations\HasManyThrough[get]', $this->getRelationArguments());
-        $relation->shouldReceive('get')->once()->andReturn(new Illuminate\Database\Eloquent\Collection(['first', 'second']));
+        $first = new EloquentHasManyThroughModelStub;
+        $second = new EloquentHasManyThroughModelStub;
+        $relation->shouldReceive('get')->once()->andReturn(new Illuminate\Database\Eloquent\Collection([$first, $second]));
         $relation->shouldReceive('take')->with(1)->once()->andReturn($relation);
 
-        $this->assertEquals('first', $relation->first());
+        $this->assertEquals($first, $relation->first());
     }
 
     public function testFindMethod()
@@ -151,7 +153,9 @@ class DatabaseEloquentHasManyThroughTest extends PHPUnit_Framework_TestCase
     public function testFindManyMethod()
     {
         $relation = m::mock('Illuminate\Database\Eloquent\Relations\HasManyThrough[get]', $this->getRelationArguments());
-        $relation->shouldReceive('get')->once()->andReturn(new Illuminate\Database\Eloquent\Collection(['first', 'second']));
+        $first = new EloquentHasManyThroughModelStub;
+        $second = new EloquentHasManyThroughModelStub;
+        $relation->shouldReceive('get')->once()->andReturn(new Illuminate\Database\Eloquent\Collection([$first, $second]));
         $relation->shouldReceive('whereIn')->with('posts.id', ['foo', 'bar'])->once()->andReturn($relation);
 
         $related = $relation->getRelated();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -513,7 +513,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $model->id);
         $this->assertTrue($model->exists);
         $this->assertEquals(2, count($model->relationMany));
-        $this->assertEquals([2, 3], $model->relationMany->lists('id')->all());
+        $this->assertEquals([2, 3], $model->relationMany->toBase()->lists('id')->all());
     }
 
     public function testNewQueryReturnsEloquentQueryBuilder()

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -15,9 +15,9 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
     {
         $relation = $this->getRelation();
         $relation->addEagerConstraints([
-            $one = (object) ['morph_type' => 'morph_type_1', 'foreign_key' => 'foreign_key_1'],
-            $two = (object) ['morph_type' => 'morph_type_1', 'foreign_key' => 'foreign_key_1'],
-            $three = (object) ['morph_type' => 'morph_type_2', 'foreign_key' => 'foreign_key_2'],
+            $one = new EloquentMorphToEmptyModelStub(['morph_type' => 'morph_type_1', 'foreign_key' => 'foreign_key_1']),
+            $two = new EloquentMorphToEmptyModelStub(['morph_type' => 'morph_type_1', 'foreign_key' => 'foreign_key_1']),
+            $three = new EloquentMorphToEmptyModelStub(['morph_type' => 'morph_type_2', 'foreign_key' => 'foreign_key_2']),
         ]);
 
         $dictionary = $relation->getDictionary();
@@ -41,17 +41,18 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
     {
         $relation = $this->getRelation();
 
-        $one = m::mock('StdClass');
-        $one->morph_type = 'morph_type_1';
-        $one->foreign_key = 'foreign_key_1';
+        $one = m::mock('Illuminate\Database\Eloquent\Model');
+        $two = m::mock('Illuminate\Database\Eloquent\Model');
+        $three = m::mock('Illuminate\Database\Eloquent\Model');
 
-        $two = m::mock('StdClass');
-        $two->morph_type = 'morph_type_1';
-        $two->foreign_key = 'foreign_key_1';
+        $one->shouldReceive('getAttribute')->with('morph_type')->andReturn('morph_type_1');
+        $one->shouldReceive('getAttribute')->with('foreign_key')->andReturn('foreign_key_1');
 
-        $three = m::mock('StdClass');
-        $three->morph_type = 'morph_type_2';
-        $three->foreign_key = 'foreign_key_2';
+        $two->shouldReceive('getAttribute')->with('morph_type')->andReturn('morph_type_1');
+        $two->shouldReceive('getAttribute')->with('foreign_key')->andReturn('foreign_key_1');
+
+        $three->shouldReceive('getAttribute')->with('morph_type')->andReturn('morph_type_2');
+        $three->shouldReceive('getAttribute')->with('foreign_key')->andReturn('foreign_key_2');
 
         $relation->addEagerConstraints([$one, $two, $three]);
 
@@ -64,11 +65,11 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
         $secondQuery->shouldReceive('newQuery')->once()->andReturn($secondQuery);
 
         $firstQuery->shouldReceive('whereIn')->once()->with('id', ['foreign_key_1'])->andReturn($firstQuery);
-        $firstQuery->shouldReceive('get')->once()->andReturn(Collection::make([$resultOne = m::mock('StdClass')]));
+        $firstQuery->shouldReceive('get')->once()->andReturn(Collection::make([$resultOne = m::mock('Illuminate\Database\Eloquent\Model')]));
         $resultOne->shouldReceive('getKey')->andReturn('foreign_key_1');
 
         $secondQuery->shouldReceive('whereIn')->once()->with('id', ['foreign_key_2'])->andReturn($secondQuery);
-        $secondQuery->shouldReceive('get')->once()->andReturn(Collection::make([$resultTwo = m::mock('StdClass')]));
+        $secondQuery->shouldReceive('get')->once()->andReturn(Collection::make([$resultTwo = m::mock('Illuminate\Database\Eloquent\Model')]));
         $resultTwo->shouldReceive('getKey')->andReturn('foreign_key_2');
 
         $one->shouldReceive('setRelation')->once()->with('relation', $resultOne);
@@ -152,4 +153,9 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
 class EloquentMorphToModelStub extends Illuminate\Database\Eloquent\Model
 {
     public $foreign_key = 'foreign.value';
+}
+
+class EloquentMorphToEmptyModelStub  extends Illuminate\Database\Eloquent\Model
+{
+    protected $guarded = [];
 }


### PR DESCRIPTION
The main feature of this PR if related to all bugs mentioned in #9163, #10627 and #10596.

As Eloquent Collection has many model-specific features, it must not accept any data different from Models, otherwise it can trigger errors.

Te realize this, I've implemented `Arr::check` helper with throws an exception in case an item in array does not match filter.
In second, there is a new method `fill` in base collection which allows to replace collection items. It is now used in `__construct`, so allows to control injected items in its descendant classes.
And finally all checks and type hints are implemented in Eloquent Collections.

Tests are currently fixed to work with new logic and don't test new features. However I'll do the new ones if you accept this proposal.
