### PR TITLE
[5.2] Eloquent proper JSON casting based on connection charset

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2873,7 +2873,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
 
         if ($this->isJsonCastable($key) && ! is_null($value)) {
-            $value = json_encode($value);
+            $options = (strtolower($this->getConnection()->getConfig('charset')) == 'utf8') ? JSON_UNESCAPED_UNICODE : 0;
+            $value = json_encode($value, $options);
         }
 
         $this->attributes[$key] = $value;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1149,6 +1149,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     {
         $model = new EloquentModelCastingStub;
         $model->setDateFormat('Y-m-d H:i:s');
+        $this->addMockConnection($model);
+        $model->getConnection()->shouldReceive('getConfig')->with('charset')->andReturn('utf8');
         $model->first = '3';
         $model->second = '4.0';
         $model->third = 2.5;
@@ -1251,6 +1253,18 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertNull($array['eighth']);
         $this->assertNull($array['ninth']);
         $this->assertNull($array['tenth']);
+    }
+
+    public function testJsonCastingEncoding()
+    {
+        $model = new EloquentModelCastingStub;
+        $this->addMockConnection($model);
+        $model->getConnection()->shouldReceive('getConfig')->once()->with('charset')->andReturn('utf8');
+        $model->getConnection()->shouldReceive('getConfig')->once()->with('charset')->andReturn('latin1');
+        $model->sixth = ['юникод'];
+        $this->assertEquals($model->getAttributes()['sixth'], '["юникод"]');
+        $model->sixth = ['юникод'];
+        $this->assertEquals($model->getAttributes()['sixth'], '["\u044e\u043d\u0438\u043a\u043e\u0434"]');
     }
 
     protected function addMockConnection($model)


### PR DESCRIPTION
I hope you changed your mind since #8873. This implementation is based on connection charset. 

This problem is quite critical, especially for MySQL which stores JSON as text - where character limit is present.

Also current algorithm makes JSON responses with unicode completely unreadable during debug.
