### PR TITLE
[5.2] Changed The Way Hash Equals Works

### DIFF
--- a/src/Illuminate/Encryption/BaseEncrypter.php
+++ b/src/Illuminate/Encryption/BaseEncrypter.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Encryption;
 
-use Illuminate\Support\Str;
 use Illuminate\Contracts\Encryption\DecryptException;
 
 abstract class BaseEncrypter
@@ -77,6 +76,6 @@ abstract class BaseEncrypter
 
         $calcMac = hash_hmac('sha256', $this->hash($payload['iv'], $payload['value']), $bytes, true);
 
-        return Str::equals(hash_hmac('sha256', $payload['mac'], $bytes, true), $calcMac);
+        return hash_equals(hash_hmac('sha256', $payload['mac'], $bytes, true), $calcMac);
     }
 }

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
-use Illuminate\Support\Str;
 use Illuminate\Foundation\Application;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Contracts\Encryption\Encrypter;
@@ -108,7 +107,7 @@ class VerifyCsrfToken
             $token = $this->encrypter->decrypt($header);
         }
 
-        return Str::equals($request->session()->token(), $token);
+        return hash_equals($request->session()->token(), $token);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -287,34 +287,12 @@ class Str
      * @param  string  $knownString
      * @param  string  $userInput
      * @return bool
+     *
+     * @deprecated since version 5.2. Use hash_equals instead.
      */
     public static function equals($knownString, $userInput)
     {
-        if (! is_string($knownString)) {
-            $knownString = (string) $knownString;
-        }
-
-        if (! is_string($userInput)) {
-            $userInput = (string) $userInput;
-        }
-
-        if (function_exists('hash_equals')) {
-            return hash_equals($knownString, $userInput);
-        }
-
-        $knownLength = mb_strlen($knownString, '8bit');
-
-        if (mb_strlen($userInput, '8bit') !== $knownLength) {
-            return false;
-        }
-
-        $result = 0;
-
-        for ($i = 0; $i < $knownLength; ++$i) {
-            $result |= (ord($knownString[$i]) ^ ord($userInput[$i]));
-        }
-
-        return 0 === $result;
+        return hash_equals($knownString, $userInput);
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -467,6 +467,44 @@ if (! function_exists('head')) {
     }
 }
 
+if (! function_exists('hash_equals')) {
+    /**
+     * Compares two strings using a constant-time algorithm.
+     *
+     * Note: This method will leak length information.
+     *
+     * Note: Adapted from Symfony\Component\Security\Core\Util\StringUtils.
+     *
+     * @param  string  $knownString
+     * @param  string  $userInput
+     * @return bool
+     */
+    function hash_equals($array)
+    {
+        if (! is_string($knownString)) {
+            $knownString = (string) $knownString;
+        }
+
+        if (! is_string($userInput)) {
+            $userInput = (string) $userInput;
+        }
+
+        $knownLength = mb_strlen($knownString, '8bit');
+
+        if (mb_strlen($userInput, '8bit') !== $knownLength) {
+            return false;
+        }
+
+        $result = 0;
+
+        for ($i = 0; $i < $knownLength; ++$i) {
+            $result |= (ord($knownString[$i]) ^ ord($userInput[$i]));
+        }
+
+        return 0 === $result;
+    }
+}
+
 if (! function_exists('last')) {
     /**
      * Get the last element from an array.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -479,7 +479,7 @@ if (! function_exists('hash_equals')) {
      * @param  string  $userInput
      * @return bool
      */
-    function hash_equals($array)
+    function hash_equals($knownString, $userInput)
     {
         if (! is_string($knownString)) {
             $knownString = (string) $knownString;


### PR DESCRIPTION
Similarly to random_bytes, I think it would be better to encourage the use of php's built in function.

Note that `hash_equals` is new in php 5.6, so we need to conditionally register our own version of it until we decided to drop php 5.5 support, whenever that may be.
