### PR TITLE
[5.1] Optimize RouteCollection::check

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -229,9 +229,11 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     protected function check(array $routes, $request, $includingMethod = true)
     {
-        return Arr::first($routes, function ($key, $value) use ($request, $includingMethod) {
-            return $value->matches($request, $includingMethod);
-        });
+        foreach ($routes as $route) {
+            if ($route->matches($request, $includingMethod)) {
+                return $route;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This implementation is simpler and lighter overall, and it has a major benefit:
<del>Current implementation calls `matches` (and the underlying `compileRoute`, etc.) on all existing routes, whereas this implementation will stop once a match is found.</del> (see below)

As a side note, `compileRoute` is still called twice on the matching route: first in `$route->matches`, then in `$route->bind`.
