### PR TITLE
[5.1] Fix EventTest on Windows

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -131,7 +131,7 @@ class Event
      */
     protected function getDefaultOutput()
     {
-        return (strpos(strtoupper(PHP_OS), 'WIN') === 0) ? 'NUL' : '/dev/null';
+        return (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
     }
 
     /**

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -8,7 +8,8 @@ class EventTest extends PHPUnit_Framework_TestCase
     {
         $event = new Event('php -i');
 
-        $this->assertSame('php -i > /dev/null 2>&1 &', $event->buildCommand());
+        $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
+        $this->assertSame("php -i > {$defaultOutput} 2>&1 &", $event->buildCommand());
     }
 
     public function testBuildCommandAppendOutput()


### PR DESCRIPTION
Also simplified the detection in `Event::getDefaultOutput`.
