### PR TITLE
Wrap tests in transaction on all databases, not just the default

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -9,10 +9,20 @@ trait DatabaseTransactions
      */
     public function beginDatabaseTransaction()
     {
-        $this->app->make('db')->beginTransaction();
+        $db = $this->app->make('db');
+        $names = array_keys($this->app['config']['database.connections']);
+
+        foreach ($names as $name) {
+            $db->connection($name)->beginTransaction();
+        }
 
         $this->beforeApplicationDestroyed(function () {
-            $this->app->make('db')->rollBack();
+            $db = $this->app->make('db');
+            $names = array_keys($this->app['config']['database.connections']);
+
+            foreach ($names as $name) {
+                $db->connection($name)->rollBack();
+            }
         });
     }
 }


### PR DESCRIPTION
Was hit by this recently; the current code only puts the default connection into a transaction and leaves the others out.
