### PR TITLE
[5.1] Update ProviderRepository::writeManifest

### DIFF
--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -74,7 +74,7 @@ class ProviderRepository
             $this->app->register($this->createProvider($provider));
         }
 
-        $this->app->setDeferredServices($manifest['deferred']);
+        $this->app->addDeferredServices($manifest['deferred']);
     }
 
     /**

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -187,7 +187,7 @@ class ProviderRepository
             $this->manifestPath, json_encode($manifest, JSON_PRETTY_PRINT)
         );
 
-        return $manifest;
+        return array_merge(['when' => []], $manifest);
     }
 
     /**

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -11,7 +11,7 @@ class FoundationProviderRepositoryTest extends PHPUnit_Framework_TestCase
 
     public function testServicesAreRegisteredWhenManifestIsNotRecompiled()
     {
-        $app = m::mock('Illuminate\Foundation\Application')->makePartial();
+        $app = m::mock('Illuminate\Foundation\Application');
 
         $repo = m::mock('Illuminate\Foundation\ProviderRepository[createProvider,loadManifest,shouldRecompile]', [$app, m::mock('Illuminate\Filesystem\Filesystem'), [__DIR__.'/services.json']]);
         $repo->shouldReceive('loadManifest')->once()->andReturn(['eager' => ['foo'], 'deferred' => ['deferred'], 'providers' => ['providers'], 'when' => []]);
@@ -21,7 +21,7 @@ class FoundationProviderRepositoryTest extends PHPUnit_Framework_TestCase
 
         $app->shouldReceive('register')->once()->with($provider);
         $app->shouldReceive('runningInConsole')->andReturn(false);
-        $app->shouldReceive('setDeferredServices')->once()->with(['deferred']);
+        $app->shouldReceive('addDeferredServices')->once()->with(['deferred']);
 
         $repo->load([]);
     }
@@ -51,7 +51,7 @@ class FoundationProviderRepositoryTest extends PHPUnit_Framework_TestCase
 
         $app->shouldReceive('register')->once()->with($barMock);
         $app->shouldReceive('runningInConsole')->andReturn(false);
-        $app->shouldReceive('setDeferredServices')->once()->with(['foo.provides1' => 'foo', 'foo.provides2' => 'foo']);
+        $app->shouldReceive('addDeferredServices')->once()->with(['foo.provides1' => 'foo', 'foo.provides2' => 'foo']);
 
         $manifest = $repo->load(['foo', 'bar']);
     }

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -44,7 +44,7 @@ class FoundationProviderRepositoryTest extends PHPUnit_Framework_TestCase
         // bar mock is added to eagers since it's not reserved
         $repo->shouldReceive('createProvider')->once()->with('bar')->andReturn($barMock = m::mock('Illuminate\Support\ServiceProvider'));
         $barMock->shouldReceive('isDeferred')->once()->andReturn(false);
-        $repo->shouldReceive('writeManifest')->once()->andReturnUsing(function ($manifest) { return $manifest; });
+        $repo->shouldReceive('writeManifest')->once()->andReturn([0 => 'foo', 'when' => []]);
 
         // bar mock should be registered with the application since it's eager
         $repo->shouldReceive('createProvider')->once()->with('bar')->andReturn($barMock);

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -44,7 +44,7 @@ class FoundationProviderRepositoryTest extends PHPUnit_Framework_TestCase
         // bar mock is added to eagers since it's not reserved
         $repo->shouldReceive('createProvider')->once()->with('bar')->andReturn($barMock = m::mock('Illuminate\Support\ServiceProvider'));
         $barMock->shouldReceive('isDeferred')->once()->andReturn(false);
-        $repo->shouldReceive('writeManifest')->once()->andReturn([0 => 'foo', 'when' => []]);
+        $repo->shouldReceive('writeManifest')->once()->andReturnUsing(function ($manifest) { return $manifest; });
 
         // bar mock should be registered with the application since it's eager
         $repo->shouldReceive('createProvider')->once()->with('bar')->andReturn($barMock);
@@ -80,6 +80,6 @@ class FoundationProviderRepositoryTest extends PHPUnit_Framework_TestCase
 
         $result = $repo->writeManifest(['foo']);
 
-        $this->assertEquals(['foo'], $result);
+        $this->assertEquals(['foo', 'when' => []], $result);
     }
 }


### PR DESCRIPTION
Make sure `ProviderRepository::writeManifest` always returns an array that has the `when` key.
