### PR TITLE
Added timestamps to workCommand output.

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -120,9 +120,9 @@ class WorkCommand extends Command
     protected function writeOutput(Job $job, $failed)
     {
         if ($failed) {
-            $this->output->writeln('<error>[' . Carbon::now()->format('Y-m-d H:i:s') . '] Failed:</error> '.$job->getName());
+            $this->output->writeln('<error>['.Carbon::now()->format('Y-m-d H:i:s').'] Failed:</error> '.$job->getName());
         } else {
-            $this->output->writeln('<info>[' . Carbon::now()->format('Y-m-d H:i:s') . '] Processed:</info> '.$job->getName());
+            $this->output->writeln('<info>['.Carbon::now()->format('Y-m-d H:i:s').'] Processed:</info> '.$job->getName());
         }
     }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Console;
 
+use Carbon\Carbon;
 use Illuminate\Queue\Worker;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Job;
@@ -119,9 +120,9 @@ class WorkCommand extends Command
     protected function writeOutput(Job $job, $failed)
     {
         if ($failed) {
-            $this->output->writeln('<error>Failed:</error> '.$job->getName());
+            $this->output->writeln('<error>[' . Carbon::now()->format('Y-m-d H:i:s') . '] Failed:</error> '.$job->getName());
         } else {
-            $this->output->writeln('<info>Processed:</info> '.$job->getName());
+            $this->output->writeln('<info>[' . Carbon::now()->format('Y-m-d H:i:s') . '] Processed:</info> '.$job->getName());
         }
     }
 


### PR DESCRIPTION
So you can track progress on the Command line.

`Failed: Illuminate\Queue\CallQueuedHandler@call`
`Processed: Illuminate\Queue\CallQueuedHandler@call`
`Processed: Illuminate\Queue\CallQueuedHandler@call`
`Processed: Illuminate\Queue\CallQueuedHandler@call`
`Processed: Illuminate\Queue\CallQueuedHandler@call`
`Processed: Illuminate\Queue\CallQueuedHandler@call`

turns into

`[2015-10-20 11:06:55] Failed: Illuminate\Queue\CallQueuedHandler@call`
`[2015-10-20 11:06:55] Processed: Illuminate\Queue\CallQueuedHandler@call`
`[2015-10-20 11:06:56] Processed: Illuminate\Queue\CallQueuedHandler@call`
`[2015-10-20 11:06:56] Processed: Illuminate\Queue\CallQueuedHandler@call`
`[2015-10-20 11:06:56] Processed: Illuminate\Queue\CallQueuedHandler@call`
`[2015-10-20 11:06:57] Processed: Illuminate\Queue\CallQueuedHandler@call`

so you can see new lines appearing in the terminal :-)
