### PR TITLE
[5.2] Allow negative condition in presence verifier

### DIFF
--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Validation;
 
+use Illuminate\Support\Str;
 use Illuminate\Database\ConnectionResolverInterface;
 
 class DatabasePresenceVerifier implements PresenceVerifierInterface
@@ -91,6 +92,8 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface
             $query->whereNull($key);
         } elseif ($extraValue === 'NOT_NULL') {
             $query->whereNotNull($key);
+        } elseif (Str::startsWith($extraValue, '!')) {
+            $query->where($key, '!=', mb_substr($extraValue, 1));
         } else {
             $query->where($key, $extraValue);
         }

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -16,11 +16,12 @@ class ValidationDatabasePresenceVerifierTest extends PHPUnit_Framework_TestCase
         $db->shouldReceive('connection')->once()->with('connection')->andReturn($conn = m::mock('StdClass'));
         $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock('StdClass'));
         $builder->shouldReceive('where')->with('column', '=', 'value')->andReturn($builder);
-        $extra = ['foo' => 'NULL', 'bar' => 'NOT_NULL', 'baz' => 'taylor', 'faz' => true];
+        $extra = ['foo' => 'NULL', 'bar' => 'NOT_NULL', 'baz' => 'taylor', 'faz' => true, 'not' => '!admin'];
         $builder->shouldReceive('whereNull')->with('foo');
         $builder->shouldReceive('whereNotNull')->with('bar');
         $builder->shouldReceive('where')->with('baz', 'taylor');
         $builder->shouldReceive('where')->with('faz', true);
+        $builder->shouldReceive('where')->with('not', '!=', 'admin');
         $builder->shouldReceive('count')->once()->andReturn(100);
 
         $this->assertEquals(100, $verifier->getCount('table', 'column', 'value', null, null, $extra));


### PR DESCRIPTION
Allows using `!` to negate conditions in validation presence verifier.

``` php
$rules = [
    'author_id' => 'exists:users,id,role,!admin',
];
```
