### PR TITLE
Consolidate callbacks

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -112,7 +112,7 @@ class PasswordBroker implements PasswordBrokerContract
         return $this->mailer->send($view, compact('token', 'user'), function ($m) use ($user, $token, $callback) {
             $m->to($user->getEmailForPasswordReset());
 
-            if (! is_null($callback)) {
+            if ($callback instanceof Closure) {
                 call_user_func($callback, $m, $user, $token);
             }
         });

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -97,7 +97,7 @@ class BroadcastManager implements FactoryContract
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($config);
         } else {
-            return $this->{'create'.ucfirst($config['driver']).'Driver'}($config);
+            return call_user_func([$this, 'create'.ucfirst($config['driver']).'Driver'], $config);
         }
     }
 

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -162,7 +162,7 @@ class DatabaseStore implements Store
 
             if (is_numeric($current)) {
                 $this->table()->where('key', $prefixed)->update([
-                    'value' => $this->encrypter->encrypt($callback($current)),
+                    'value' => $this->encrypter->encrypt(call_user_func($callback, $current)),
                 ]);
             }
         }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -202,7 +202,9 @@ class Repository implements CacheContract, ArrayAccess
             return $value;
         }
 
-        $this->put($key, $value = $callback(), $minutes);
+        $value = call_user_func($callback);
+
+        $this->put($key, $value, $minutes);
 
         return $value;
     }
@@ -235,7 +237,9 @@ class Repository implements CacheContract, ArrayAccess
             return $value;
         }
 
-        $this->forever($key, $value = $callback());
+        $value = call_user_func($callback);
+
+        $this->forever($key, $value);
 
         return $value;
     }

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -171,7 +171,9 @@ class TaggedCache implements Store
             return $value;
         }
 
-        $this->put($key, $value = $callback(), $minutes);
+        $value = call_user_func($callback);
+
+        $this->put($key, $value, $minutes);
 
         return $value;
     }
@@ -204,7 +206,9 @@ class TaggedCache implements Store
             return $value;
         }
 
-        $this->forever($key, $value = $callback());
+        $value = call_user_func($callback);
+
+        $this->forever($key, $value);
 
         return $value;
     }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -879,7 +879,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function resolving($abstract, Closure $callback = null)
     {
-        if ($callback === null && $abstract instanceof Closure) {
+        if (is_null($callback) && $abstract instanceof Closure) {
             $this->resolvingCallback($abstract);
         } else {
             $this->resolvingCallbacks[$abstract][] = $callback;
@@ -895,7 +895,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function afterResolving($abstract, Closure $callback = null)
     {
-        if ($abstract instanceof Closure && $callback === null) {
+        if ($abstract instanceof Closure && is_null($callback)) {
             $this->afterResolvingCallback($abstract);
         } else {
             $this->afterResolvingCallbacks[$abstract][] = $callback;
@@ -1017,7 +1017,7 @@ class Container implements ArrayAccess, ContainerContract
     protected function fireCallbackArray($object, array $callbacks)
     {
         foreach ($callbacks as $callback) {
-            $callback($object, $this);
+            call_user_func($callback, $object, $this);
         }
     }
 

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -71,18 +71,18 @@ interface Application extends Container
     /**
      * Register a new boot listener.
      *
-     * @param  mixed  $callback
+     * @param  callable  $callback
      * @return void
      */
-    public function booting($callback);
+    public function booting(callable $callback);
 
     /**
      * Register a new "booted" listener.
      *
-     * @param  mixed  $callback
+     * @param  callable  $callback
      * @return void
      */
-    public function booted($callback);
+    public function booted(callable $callback);
 
     /**
      * Get the path to the cached "compiled.php" file.

--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -33,8 +33,8 @@ interface Validator extends MessageProvider
     /**
      * After an after validation callback.
      *
-     * @param  callable|string  $callback
+     * @param  callable  $callback
      * @return $this
      */
-    public function after($callback);
+    public function after(callable $callback);
 }

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -473,7 +473,7 @@ class Connection implements ConnectionInterface
         // and if we catch any exception we can rollback the transaction
         // so that none of the changes are persisted to the database.
         try {
-            $result = $callback($this);
+            $result = call_user_func($callback, $this);
 
             $this->commit();
         }
@@ -579,7 +579,7 @@ class Connection implements ConnectionInterface
         // Basically to make the database connection "pretend", we will just return
         // the default values for all the query methods, then we will return an
         // array of queries that were "executed" within the Closure callback.
-        $callback($this);
+        call_user_func($callback, $this);
 
         $this->pretending = false;
 
@@ -641,7 +641,7 @@ class Connection implements ConnectionInterface
         // run the SQL against the PDO connection. Then we can calculate the time it
         // took to execute and log the query SQL, bindings and time in our memory.
         try {
-            $result = $callback($this, $query, $bindings);
+            $result = call_user_func($callback, $this, $query, $bindings);
         }
 
         // If an exception occurs when attempting to run a query, we'll format the error

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -582,7 +582,7 @@ class Builder
 
         $query = $relation->getRelationCountQuery($relation->getRelated()->newQuery(), $this);
 
-        if ($callback) {
+        if ($callback instanceof Closure) {
             call_user_func($callback, $query);
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2305,12 +2305,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public static function unguarded(callable $callback)
     {
         if (static::$unguarded) {
-            return $callback();
+            return call_user_func($callback);
         }
 
         static::unguard();
 
-        $result = $callback();
+        $result = call_user_func($callback);
 
         static::reguard();
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -264,7 +264,7 @@ class Builder
         if ($query instanceof Closure) {
             $callback = $query;
 
-            $callback($query = $this->newQuery());
+            call_user_func($callback, $query = $this->newQuery());
         }
 
         if ($query instanceof self) {

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -58,8 +58,8 @@ class Blueprint
     {
         $this->table = $table;
 
-        if (! is_null($callback)) {
-            $callback($this);
+        if ($callback instanceof Closure) {
+            call_user_func($callback, $this);
         }
     }
 

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -129,7 +129,7 @@ class Builder
 
         $blueprint->create();
 
-        $callback($blueprint);
+        call_user_func($callback, $blueprint);
 
         $this->build($blueprint);
     }

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -32,7 +32,7 @@ class SqlServerConnection extends Connection
         // and if we catch any exception we can rollback the transaction
         // so that none of the changes are persisted to the database.
         try {
-            $result = $callback($this);
+            $result = call_user_func($callback, $this);
 
             $this->pdo->exec('COMMIT TRAN');
         }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -738,10 +738,10 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Register a new boot listener.
      *
-     * @param  mixed  $callback
+     * @param  callable  $callback
      * @return void
      */
-    public function booting($callback)
+    public function booting(callable $callback)
     {
         $this->bootingCallbacks[] = $callback;
     }
@@ -749,10 +749,10 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Register a new "booted" listener.
      *
-     * @param  mixed  $callback
+     * @param  callable  $callback
      * @return void
      */
-    public function booted($callback)
+    public function booted(callable $callback)
     {
         $this->bootedCallbacks[] = $callback;
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -107,7 +107,7 @@ class SqsQueue extends Queue implements QueueContract
         );
 
         if (count($response['Messages']) > 0) {
-            if ($this->jobCreator) {
+            if (is_callable($this->jobCreator)) {
                 return call_user_func($this->jobCreator, $this->container, $this->sqs, $queue, $response);
             } else {
                 return new SqsJob($this->container, $this->sqs, $queue, $response['Messages'][0]);

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -129,7 +129,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function each(callable $callback)
     {
         foreach ($this->items as $key => $item) {
-            if ($callback($item, $key) === false) {
+            if (call_user_func($callback, $item, $key) === false) {
                 break;
             }
         }
@@ -182,7 +182,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function filter(callable $callback = null)
     {
-        if ($callback) {
+        if (is_callable($callback)) {
             return new static(array_filter($this->items, $callback));
         }
 
@@ -615,7 +615,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         if ($this->useAsCallable($callback)) {
             return $this->filter(function ($item) use ($callback) {
-                return ! $callback($item);
+                return ! call_user_func($callback, $item);
             });
         }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -208,7 +208,7 @@ if (! function_exists('array_last')) {
      * @param  mixed  $default
      * @return mixed
      */
-    function array_last($array, $callback, $default = null)
+    function array_last($array, callable $callback, $default = null)
     {
         return Arr::last($array, $callback, $default);
     }

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -144,11 +144,11 @@ class Factory implements FactoryContract
      */
     protected function resolve(array $data, array $rules, array $messages, array $customAttributes)
     {
-        if (is_null($this->resolver)) {
-            return new Validator($this->translator, $data, $rules, $messages, $customAttributes);
+        if (is_callable($this->resolver)) {
+            return call_user_func($this->resolver, $this->translator, $data, $rules, $messages, $customAttributes);
         }
 
-        return call_user_func($this->resolver, $this->translator, $data, $rules, $messages, $customAttributes);
+        return new Validator($this->translator, $data, $rules, $messages, $customAttributes);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -218,10 +218,10 @@ class Validator implements ValidatorContract
     /**
      * After an after validation callback.
      *
-     * @param  callable|string  $callback
+     * @param  callable  $callback
      * @return $this
      */
-    public function after($callback)
+    public function after(callable $callback)
     {
         $this->after[] = function () use ($callback) {
             return call_user_func_array($callback, [$this]);

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -79,7 +79,7 @@ class View implements ArrayAccess, ViewContract
     {
         $contents = $this->renderContents();
 
-        $response = isset($callback) ? call_user_func($callback, $this, $contents) : null;
+        $response = is_callable($callback) ? call_user_func($callback, $this, $contents) : null;
 
         // Once we have the contents of the view, we will flush the sections if we are
         // done rendering all views so that there is nothing left hanging over when

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -46,7 +46,7 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase
         $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('delete')->once();
 
-        $callback($givenBuilder);
+        call_user_func($callback, $givenBuilder);
     }
 
     public function testRestoreExtension()
@@ -62,7 +62,7 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase
         $model->shouldReceive('getDeletedAtColumn')->once()->andReturn('deleted_at');
         $givenBuilder->shouldReceive('update')->once()->with(['deleted_at' => null]);
 
-        $callback($givenBuilder);
+        call_user_func($callback, $givenBuilder);
     }
 
     public function testWithTrashedExtension()
@@ -75,7 +75,7 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase
         $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
         $givenBuilder->shouldReceive('getModel')->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
         $scope->shouldReceive('remove')->once()->with($givenBuilder, $model);
-        $result = $callback($givenBuilder);
+        $result = call_user_func($callback, $givenBuilder);
 
         $this->assertEquals($givenBuilder, $result);
     }
@@ -95,7 +95,7 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
         $query->shouldReceive('whereNotNull')->once()->with('table.deleted_at');
-        $result = $callback($givenBuilder);
+        $result = call_user_func($callback, $givenBuilder);
 
         $this->assertEquals($givenBuilder, $result);
     }

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -89,7 +89,7 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase
         $transaction = m::mock('StdClass');
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('transaction')->with(m::any(), m::type('Closure'))->andReturnUsing(function ($options, $callback) use ($transaction) {
-            $callback($transaction);
+            call_user_func($callback, $transaction);
         });
         $transaction->shouldReceive('zrangebyscore')->once()->with('from', '-inf', 1)->andReturn(['foo', 'bar']);
         $transaction->shouldReceive('multi')->once();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -139,7 +139,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $callback = $factory->composer('foo', function () { return 'bar'; });
         $callback = $callback[0];
 
-        $this->assertEquals('bar', $callback());
+        $this->assertEquals('bar', call_user_func($callback));
     }
 
     public function testComposersAreProperlyRegisteredWithPriority()
@@ -149,7 +149,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $callback = $factory->composer('foo', function () { return 'bar'; }, 1);
         $callback = $callback[0];
 
-        $this->assertEquals('bar', $callback());
+        $this->assertEquals('bar', call_user_func($callback));
     }
 
     public function testComposersCanBeMassRegistered()
@@ -182,7 +182,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $callback = $factory->composer('foo', 'FooComposer');
         $callback = $callback[0];
 
-        $this->assertEquals('composed', $callback('view'));
+        $this->assertEquals('composed', call_user_func($callback, 'view'));
     }
 
     public function testClassCallbacksWithMethods()
@@ -195,7 +195,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $callback = $factory->composer('foo', 'FooComposer@doComposer');
         $callback = $callback[0];
 
-        $this->assertEquals('composed', $callback('view'));
+        $this->assertEquals('composed', call_user_func($callback, 'view'));
     }
 
     public function testCallComposerCallsProperEvent()


### PR DESCRIPTION
Some callback arguments are not called in the same fashion everywhere
across the framework.
For example `$callback()` was used instead of
`call_user_func($callback)`, some `$callback` arguments were missing
the callable/Closure hint, and some `$callback` variables were not
verified by `is_callable()` or `instanceof Closure` in conditionals.
