### PR TITLE
[5.1] Replaced the static uri parameter with a dynamic version

### DIFF
--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -122,7 +122,7 @@ class ControllerInspector
 
 
     /**
-     * Gets the parameters from the method and adds it to the uri
+     * Gets the parameters from the method and adds it to the uri.
      *
      * @param  ReflectionMethod  $method
      * @param  string  $uri
@@ -131,15 +131,14 @@ class ControllerInspector
      */
     public function addUriParameters(ReflectionMethod $method, $uri)
     {
-        foreach ($method->getParameters() as $parameter)
-        {
+        foreach ($method->getParameters() as $parameter) {
             //if the parameter has a class we assume it is
             //not part of the the uri
             if ($parameter->getClass()) {
                 continue;
             }
 
-            $uri .= sprintf("/{%s%s}",
+            $uri .= sprintf('/{%s%s}',
                 $parameter->name,
                 ($parameter->isDefaultValueAvailable()) ? '?' : ''
             );

--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -80,7 +80,7 @@ class ControllerInspector
     {
         $verb = $this->getVerb($name = $method->name);
 
-        $uri = $this->addUriWildcards($plain = $this->getPlainUri($name, $prefix));
+        $uri = $this->addUriParameters($method, $plain = $this->getPlainUri($name, $prefix));
 
         return compact('verb', 'plain', 'uri');
     }
@@ -120,14 +120,31 @@ class ControllerInspector
         return $prefix.'/'.implode('-', array_slice(explode('_', Str::snake($name)), 1));
     }
 
+
     /**
-     * Add wildcards to the given URI.
+     * Gets the parameters from the method and adds it to the uri
      *
+     * @param  ReflectionMethod  $method
      * @param  string  $uri
+     *
      * @return string
      */
-    public function addUriWildcards($uri)
+    public function addUriParameters(ReflectionMethod $method, $uri)
     {
-        return $uri.'/{one?}/{two?}/{three?}/{four?}/{five?}';
+        foreach ($method->getParameters() as $parameter)
+        {
+            //if the parameter has a class we assume it is
+            //not part of the the uri
+            if ($parameter->getClass()) {
+                continue;
+            }
+
+            $uri .= sprintf("/{%s%s}",
+                $parameter->name,
+                ($parameter->isDefaultValueAvailable()) ? '?' : ''
+            );
+        }
+
+        return $uri;
     }
 }


### PR DESCRIPTION
instead of having a fix number of route parameter, we use the reflection api to extract the parameter from the method.

Example: 

```
public function getSearch() -> [GET] event/search
public function getSearch($id, $title = '') -> [GET] event/search/{id}/{title?}
public function getSearch($id, Request $request,  $title = '') -> [GET] event/search/{id}/{title?}
```
