### PR TITLE
[5.1] Add test for grouped resource routes issue and add fix

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -320,9 +320,10 @@ class Router implements RegistrarContract
      * @param  string  $name
      * @param  string  $controller
      * @param  array   $options
+     * @param  bool    $nested
      * @return void
      */
-    public function resource($name, $controller, array $options = [])
+    public function resource($name, $controller, array $options = [], $nested = false)
     {
         if ($this->container && $this->container->bound('Illuminate\Routing\ResourceRegistrar')) {
             $registrar = $this->container->make('Illuminate\Routing\ResourceRegistrar');
@@ -330,7 +331,7 @@ class Router implements RegistrarContract
             $registrar = new ResourceRegistrar($this);
         }
 
-        $registrar->register($name, $controller, $options);
+        $registrar->register($name, $controller, $options, $nested);
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -834,6 +834,41 @@ return 'foo!'; });
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar'));
     }
 
+    public function testGroupedResourceRouteNaming()
+    {
+        $router = $this->getRouter();
+        $router->group([
+            'prefix' => 'group',
+            'as' => 'group::',
+        ], function () use ($router) {
+            $router->resource('foo', 'FooController');
+        });
+
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.index'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.show'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.create'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.store'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.edit'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.update'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.destroy'));
+
+        $router = $this->getRouter();
+        $router->group([
+            'prefix' => 'group',
+            'as' => 'group::',
+        ], function () use ($router) {
+            $router->resource('foo.bar', 'FooController');
+        });
+
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.bar.index'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.bar.show'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.bar.create'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.bar.store'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.bar.edit'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.bar.update'));
+        $this->assertTrue($router->getRoutes()->hasNamedRoute('group::foo.bar.destroy'));
+    }
+
     public function testRouterFiresRoutedEvent()
     {
         $events = new Illuminate\Events\Dispatcher();


### PR DESCRIPTION
This PR is mainly a bug report - resource routing inside of a group does not form proper route names.

The `ResourceRegistrar` class has the capability of adding grouped resource routes using either group/route or group.route syntax. It uses the standard group stack functionality from the Router in order to accomplish this.

The problem is where the ResourceRegistrar creates its own grouped resource name: it uses the `$this->router->getLastGroupPrefix()` method to get the compiled resource group name. Unfortunately, this method will return the fully compiled group name, not just the group name of the current resource. This means that by the time this route is added the main `Router` class will also add the `Route::group` supplied prefix on top of the resource routes group name.

Example code:

``` php
$router->group([
     'prefix' => 'group',
     'as' => 'group::'
], function() use ($router) {
     $router->resource('foo', 'FooController');
});
```

Will produce a route name like `group::group.foo.index` for the index resource route.

I have a potential solution, however currently it is very ugly and could use some cleanup. I hope to have  a revised version completed tomorrow.
