### PR TITLE
[5.1] Small fix to getConfigurationNesting()

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -66,9 +66,10 @@ class LoadConfiguration
     protected function getConfigurationFiles(Application $app)
     {
         $files = [];
+        $path = realpath($app->configPath());
 
-        foreach (Finder::create()->files()->name('*.php')->in($app->configPath()) as $file) {
-            $nesting = $this->getConfigurationNesting($file);
+        foreach (Finder::create()->files()->name('*.php')->in($path) as $file) {
+            $nesting = $this->getConfigurationNesting($file, $path);
 
             $files[$nesting.basename($file->getRealPath(), '.php')] = $file->getRealPath();
         }
@@ -80,13 +81,14 @@ class LoadConfiguration
      * Get the configuration file nesting path.
      *
      * @param  \Symfony\Component\Finder\SplFileInfo  $file
+     * @param  string  $path
      * @return string
      */
-    protected function getConfigurationNesting(SplFileInfo $file)
+    protected function getConfigurationNesting(SplFileInfo $file, $path)
     {
         $directory = dirname($file->getRealPath());
 
-        if ($tree = trim(str_replace(config_path(), '', $directory), DIRECTORY_SEPARATOR)) {
+        if ($tree = trim(str_replace($path, '', $directory), DIRECTORY_SEPARATOR)) {
             $tree = str_replace(DIRECTORY_SEPARATOR, '.', $tree).'.';
         }
 


### PR DESCRIPTION
Hey there,

I've spent the evening tracking down a bug that relates to custom paths.

I know L5 doesn't support custom paths in the same way that L4 did, so the workaround is to extend the Application object and override the `$app->*path()` methods.

This seems to be pretty resilient to trailing slashes for all paths, except for `configPath()`.

I eventually traced the problem to `LoadConfiguration::getConfigurationNesting()` which has code that makes a comparison between each config file path and `config_path()` but ends up returning an invalid `nested.config.key` string if the config path has a trailing slash - which subsequently breaks `loadConfigurationFiles()` - and kills the bootstrap.

Ordinarily, the trailing slash would not be a problem, but having this extra resilience there is helpful from an extenders point of view.

It also makes the bootstrap slightly quicker, as it saves on 11 calls to `config_path()` !

Would be great if this was included.

Ta.
