### PR TITLE
Update Collection.php to use the $key => $value convention

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -117,8 +117,8 @@ class Collection extends BaseCollection
     {
         $dictionary = $this->getDictionary();
 
-        foreach ($items as $item) {
-            $dictionary[$item->getKey()] = $item;
+        foreach ($items as $key => $item) {
+            $dictionary[$key] = $item;
         }
 
         return new static(array_values($dictionary));
@@ -136,8 +136,8 @@ class Collection extends BaseCollection
 
         $dictionary = $this->getDictionary($items);
 
-        foreach ($this->items as $item) {
-            if (! isset($dictionary[$item->getKey()])) {
+        foreach ($this->items as $key => $item) {
+            if (! isset($dictionary[$key])) {
                 $diff->add($item);
             }
         }
@@ -157,8 +157,8 @@ class Collection extends BaseCollection
 
         $dictionary = $this->getDictionary($items);
 
-        foreach ($this->items as $item) {
-            if (isset($dictionary[$item->getKey()])) {
+        foreach ($this->items as $key => $item) {
+            if (isset($dictionary[$key])) {
                 $intersect->add($item);
             }
         }
@@ -234,8 +234,8 @@ class Collection extends BaseCollection
 
         $dictionary = [];
 
-        foreach ($items as $value) {
-            $dictionary[$value->getKey()] = $value;
+        foreach ($items as $key => $value) {
+            $dictionary[$key] = $value;
         }
 
         return $dictionary;


### PR DESCRIPTION
Using the `$key => $value` convention in the foreach statements to avoid calling `$item->getKey()` on values that might not have that method, such as doubles.
