### PR TITLE
[5.2] Fix Collection JSON serializing logic

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -922,7 +922,15 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function jsonSerialize()
     {
-        return $this->toArray();
+        return array_map(function ($value) {
+            if ($value instanceof JsonSerializable) {
+                return $value->jsonSerialize();
+            } elseif ($value instanceof Arrayable) {
+                return $value->toArray();
+            } else {
+                return $value;
+            }
+        }, $this->items);
     }
 
     /**
@@ -933,7 +941,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function toJson($options = 0)
     {
-        return json_encode($this->toArray(), $options);
+        return json_encode($this->jsonSerialize(), $options);
     }
 
     /**


### PR DESCRIPTION
#10579

Sometimes models or other objects have different logic in `toArray` and `jsonSerialize` methods (e. g. `jsonSerialize` could force relation loading), though Collection ignores `jsonSerialize` of children at all.

This PR gives `jsonSerialize` priority over `toArray` when Collection is converted to JSON.
