### PR TITLE
[5.1] Simplify generated regex when both patterns match in see() and seeInElement()

### DIFF
--- a/src/Illuminate/Foundation/Testing/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/InteractsWithPages.php
@@ -181,7 +181,10 @@ trait InteractsWithPages
 
         $escapedPattern = preg_quote(e($text), '/');
 
-        $this->$method("/({$rawPattern}|{$escapedPattern})/i", $this->response->getContent());
+        $pattern = $rawPattern == $escapedPattern
+                ? $rawPattern : "({$rawPattern}|{$escapedPattern})";
+
+        $this->$method("/$pattern/i", $this->response->getContent());
 
         return $this;
     }
@@ -215,7 +218,10 @@ trait InteractsWithPages
 
         $content = $this->crawler->filter($element)->html();
 
-        $this->$method("/({$rawPattern}|{$escapedPattern})/i", $content);
+        $pattern = $rawPattern == $escapedPattern
+                ? $rawPattern : "({$rawPattern}|{$escapedPattern})";
+
+        $this->$method("/$pattern/i", $content);
 
         return $this;
     }


### PR DESCRIPTION
Rebased patch to 5.1 as previously sent in https://github.com/laravel/framework/pull/10684
