### PR TITLE
[5.1] Update "artisan serve" to optionally open site in browser

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -45,13 +45,13 @@ class ServeCommand extends Command
 
         $this->info("Laravel development server started on http://{$host}:{$port}/");
 
-        if($this->input->getOption('open')){
+        if($this->input->getOption('open')) {
             $commands = [
                 'dar' => 'open',
                 'win' => 'start ""',
             ];
             $platform = strtolower(substr(PHP_OS, 0, 3));
-            if(isset($commands[$platform])){
+            if(isset($commands[$platform])) {
                 passthru(sprintf('%s "http://%s:%s"', $commands[$platform], $host, $port));
             }
         }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -45,13 +45,13 @@ class ServeCommand extends Command
 
         $this->info("Laravel development server started on http://{$host}:{$port}/");
 
-        if($this->input->getOption('open')) {
+        if ($this->input->getOption('open')) {
             $commands = [
                 'dar' => 'open',
                 'win' => 'start ""',
             ];
             $platform = strtolower(substr(PHP_OS, 0, 3));
-            if(isset($commands[$platform])) {
+            if (isset($commands[$platform])) {
                 passthru(sprintf('%s "http://%s:%s"', $commands[$platform], $host, $port));
             }
         }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -45,12 +45,16 @@ class ServeCommand extends Command
 
         $this->info("Laravel development server started on http://{$host}:{$port}/");
 
-		$platform = strtolower(substr(PHP_OS, 0, 3));
-		$commands = array('dar' => 'open', 'win' => 'start ""');
-		if(isset($commands[$platform]))
-		{
-			passthru(sprintf('%s "http://%s:%s"', $commands[$platform], $host, $port));
-		}
+        if($this->input->getOption('open')){
+            $commands = [
+                'dar' => 'open',
+                'win' => 'start ""',
+            ];
+            $platform = strtolower(substr(PHP_OS, 0, 3));
+            if(isset($commands[$platform])){
+                passthru(sprintf('%s "http://%s:%s"', $commands[$platform], $host, $port));
+            }
+        }
 
         if (defined('HHVM_VERSION')) {
             if (version_compare(HHVM_VERSION, '3.8.0') >= 0) {
@@ -74,6 +78,8 @@ class ServeCommand extends Command
             ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on.', 'localhost'],
 
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on.', 8000],
+
+            ['open', null, InputOption::VALUE_NONE, 'Open the site in the default browser.'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -45,6 +45,13 @@ class ServeCommand extends Command
 
         $this->info("Laravel development server started on http://{$host}:{$port}/");
 
+		$platform = strtolower(substr(PHP_OS, 0, 3));
+		$commands = array('dar' => 'open', 'win' => 'start ""');
+		if(isset($commands[$platform]))
+		{
+			passthru(sprintf('%s "http://%s:%s"', $commands[$platform], $host, $port));
+		}
+
         if (defined('HHVM_VERSION')) {
             if (version_compare(HHVM_VERSION, '3.8.0') >= 0) {
                 passthru("{$binary} -m server -v Server.Type=proxygen -v Server.SourceRoot={$base}/ -v Server.IP={$host} -v Server.Port={$port} -v Server.DefaultDocument=server.php -v Server.ErrorDocument404=server.php");


### PR DESCRIPTION
I usually have small .bat file I copy from project to project which does a PHP -S and opens the browser, but since discovering "php artisan serve" I missed automatically opening the site.

This PR adds that functionality for Windows and Mac. Unfortunately I don't know the command for linux, but that can be easily added to the array.

A bit less faffing when just wanting to run tutorials or test stuff quickly :)
