### PR TITLE
[5.1] elixir helper: optionally supply build folder for versioned assets

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -261,20 +261,21 @@ if (! function_exists('elixir')) {
      * Get the path to a versioned Elixir file.
      *
      * @param  string  $file
+     * @param  string  $buildFolder
      * @return string
      *
      * @throws \InvalidArgumentException
      */
-    function elixir($file)
+    function elixir($file, $buildFolder = 'build')
     {
         static $manifest = null;
 
         if (is_null($manifest)) {
-            $manifest = json_decode(file_get_contents(public_path('build/rev-manifest.json')), true);
+            $manifest = json_decode(file_get_contents(public_path("{$buildFolder}/rev-manifest.json")), true);
         }
 
         if (isset($manifest[$file])) {
-            return '/build/'.$manifest[$file];
+            return "/{$buildFolder}/{$manifest[$file]}";
         }
 
         throw new InvalidArgumentException("File {$file} not defined in asset manifest.");


### PR DESCRIPTION
Elixir allows configuring the build folder used for versioning via `elixir.config.versioning.buildFolder` [1](default is). In the PHP `elixir()` helper method, the build folder is currently hard-coded.

This commit enables the user to specify it via a second, optional parameter.

[1] https://github.com/laravel/elixir/blob/master/Config.js#L402 
