### PR TITLE
Add user() helper function to get the currently authenticated user.

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -710,6 +710,18 @@ if (! function_exists('url')) {
     }
 }
 
+if (! function_exists('user')) {
+    /**
+     * Get the currently authenticated user.
+     *
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    function user()
+    {
+        return app('auth')->user();
+    }
+}
+
 if (! function_exists('view')) {
     /**
      * Get the evaluated view contents for the given view.


### PR DESCRIPTION
Okay, so I'm not sure if this one has ever been suggested, or what the feeling on this will be, but to me this feels like a natural addition to the `helpers.php` file.

In Laravel we can do this:

``` php
$user = Auth::user();
```

And this:

``` php
$user = request()->user();
```

Why not just have a helper like this?

``` php
$user = user();
```

I use helper functions (`response()`, `redirect()`, `request()`, `view()`) frequently in my controllers, and being able to access the currently authenticated user in a similar way just feels more consistent.
