### PR TITLE
[5.1] Fix for visible BCC recipients when using Mailgun refs #10650

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -61,8 +61,10 @@ class MailgunTransport extends Transport
         $options = ['auth' => ['api', $this->key]];
 
         if (version_compare(ClientInterface::VERSION, '6') === 1) {
+            $to = $this->getTo($message);
+            $message->setBcc([]);
             $options['multipart'] = [
-                ['name' => 'to', 'contents' => $this->getTo($message)],
+                ['name' => 'to', 'contents' => $to],
                 ['name' => 'message', 'contents' => (string) $message, 'filename' => 'message.mime'],
             ];
         } else {

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -59,17 +59,17 @@ class MailgunTransport extends Transport
         $this->beforeSendPerformed($message);
 
         $options = ['auth' => ['api', $this->key]];
+        $to = $this->getTo($message);
+        $message->setBcc([]);
 
         if (version_compare(ClientInterface::VERSION, '6') === 1) {
-            $to = $this->getTo($message);
-            $message->setBcc([]);
             $options['multipart'] = [
                 ['name' => 'to', 'contents' => $to],
                 ['name' => 'message', 'contents' => (string) $message, 'filename' => 'message.mime'],
             ];
         } else {
             $options['body'] = [
-                'to' => $this->getTo($message),
+                'to' => $to,
                 'message' => new PostFile('message', (string) $message),
             ];
         }


### PR DESCRIPTION
# Test
- `composer require guzzlehttp/guzzle`  
- Edit `config/mail.php` transport to `mailgun`
- Edit `config/services.php` mailgun domain/secret (api key) - or set in .env?
- Edit `.env`  `MAIL_DRIVER` to 'mailgun'

Add the code below to `app/Http/routes.php` before `return view('welcome');`

```
Mail::send('welcome', [], function($message) {
    $message->to('hey@ashleyhindle.com');
    $message->bcc(array('ashley@goremote.io')); // Contains an array of emails
    $message->subject('BCC Laravel Mailgun Test');
});
```
- `cd public; php -S localhost:9999`
- `open -a 'Google Chrome' 'http://localhost:9999/'`

Before the change my GoRemote email could see the BCC address, afterwards it can't.

This calls `setBcc` with an empty array on the Mime message as suggested here https://github.com/mailgun/mailgun-php/issues/81#issuecomment-99575121
