### PR TITLE
[5.1] Always add table name when fetching related models for morph to

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -180,7 +180,7 @@ class MorphTo extends BelongsTo
     {
         $instance = $this->createModelByType($type);
 
-        $key = $instance->getKeyName();
+        $key = $instance->getTable() . '.' . $instance->getKeyName();
 
         $query = $instance->newQuery();
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -180,7 +180,7 @@ class MorphTo extends BelongsTo
     {
         $instance = $this->createModelByType($type);
 
-        $key = $instance->getTable() . '.' . $instance->getKeyName();
+        $key = $instance->getTable().'.'.$instance->getKeyName();
 
         $query = $instance->newQuery();
 

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -57,17 +57,19 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
 
         $relation->shouldReceive('createModelByType')->once()->with('morph_type_1')->andReturn($firstQuery = m::mock('Illuminate\Database\Eloquent\Builder'));
         $relation->shouldReceive('createModelByType')->once()->with('morph_type_2')->andReturn($secondQuery = m::mock('Illuminate\Database\Eloquent\Builder'));
+        $firstQuery->shouldReceive('getTable')->andReturn('foreign_table_1');
         $firstQuery->shouldReceive('getKeyName')->andReturn('id');
+        $secondQuery->shouldReceive('getTable')->andReturn('foreign_table_2');
         $secondQuery->shouldReceive('getKeyName')->andReturn('id');
 
         $firstQuery->shouldReceive('newQuery')->once()->andReturn($firstQuery);
         $secondQuery->shouldReceive('newQuery')->once()->andReturn($secondQuery);
 
-        $firstQuery->shouldReceive('whereIn')->once()->with('id', ['foreign_key_1'])->andReturn($firstQuery);
+        $firstQuery->shouldReceive('whereIn')->once()->with('foreign_table_1.id', ['foreign_key_1'])->andReturn($firstQuery);
         $firstQuery->shouldReceive('get')->once()->andReturn(Collection::make([$resultOne = m::mock('StdClass')]));
         $resultOne->shouldReceive('getKey')->andReturn('foreign_key_1');
 
-        $secondQuery->shouldReceive('whereIn')->once()->with('id', ['foreign_key_2'])->andReturn($secondQuery);
+        $secondQuery->shouldReceive('whereIn')->once()->with('foreign_table_2.id', ['foreign_key_2'])->andReturn($secondQuery);
         $secondQuery->shouldReceive('get')->once()->andReturn(Collection::make([$resultTwo = m::mock('StdClass')]));
         $resultTwo->shouldReceive('getKey')->andReturn('foreign_key_2');
 


### PR DESCRIPTION
When the related model has any join clause in it's global scope, queries will no longer fail.

```
class Tag extends Model{

    public function taggable()
    {
        return $this->morphTo();
    }

}

class Posts extends Model{

    public static boot()
    {
        static::addGlobalScope(new PostsScope);
    }

    public function tags()
    {
        return $this->morphMany();
    }

}

class PostsScope implements ScopeInterface{

    public function apply(Builder $query, Model $model)
    {
        $query->join('images', 'posts.image_id', '=', 'images.id');
        $query->select(['posts.*']);
    }

}


```

the problem happens when you want to do something like

```
$tags = Tag::limit(5)->get();

//say posts 1, 2 and 3 woulds be the posts that match these tags.

$tags->load('taggable') //problem line
```

previous implementation would generate something like:
`select posts.* from posts inner join images on posts.image_id = images.id where id in (1,2,3)`

the `where id in (1,2,3)` part fails due to ambiguous column names.
