### PR TITLE
[5.1] Fixed up DocBlock param alignment

### DIFF
--- a/src/Illuminate/Foundation/Testing/ApplicationTrait.php
+++ b/src/Illuminate/Foundation/Testing/ApplicationTrait.php
@@ -303,8 +303,8 @@ trait ApplicationTrait
     /**
      * Call artisan command and return code.
      *
-     * @param string  $command
-     * @param array   $parameters
+     * @param  string  $command
+     * @param  array  $parameters
      * @return int
      */
     public function artisan($command, $parameters = [])


### PR DESCRIPTION
Added spaces to ensure param and return line up.  Removed space between array and $parameters line to keep with the 2 spaces between type and var name tradition.
