### PR TITLE
[5.1] Implement ODBC-Connector

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Connectors;
 use PDO;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
+use Illuminate\Database\OdbcConnection;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\PostgresConnection;
@@ -190,6 +191,9 @@ class ConnectionFactory
 
             case 'sqlsrv':
                 return new SqlServerConnector;
+
+            case 'odbc':
+                return new OdbcConnector;
         }
 
         throw new InvalidArgumentException("Unsupported driver [{$config['driver']}]");
@@ -225,6 +229,9 @@ class ConnectionFactory
 
             case 'sqlsrv':
                 return new SqlServerConnection($connection, $database, $prefix, $config);
+
+            case 'odbc':
+                return new OdbcConnection($connection, $database, $prefix, $config);
         }
 
         throw new InvalidArgumentException("Unsupported driver [$driver]");

--- a/src/Illuminate/Database/Connectors/OdbcConnector.php
+++ b/src/Illuminate/Database/Connectors/OdbcConnector.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Database\Connectors;
+
+class OdbcConnector extends Connector implements ConnectorInterface
+{
+    /**
+     * Establish a database connection.
+     *
+     * @param  array  $config
+     * @return \PDO
+     */
+    public function connect(array $config)
+    {
+        $options = $this->getOptions($config);
+        $dsn = $this->getDsn($config);
+
+        return $this->createConnection($dsn, $config, $options);
+    }
+
+    /**
+     * Get the DSN string for a DbLib connection.
+     *
+     * @param  array  $config
+     * @return string
+     */
+    protected function getDsn(array $config)
+    {
+        $arguments = $config['dsn'];
+        $arguments['Driver'] = '{'.$arguments['Driver'].'}';
+
+        $options = array_map(function ($key) use ($arguments) {
+            return sprintf('%s=%s', $key, $arguments[$key]);
+        }, array_keys($arguments));
+
+        return 'odbc:'.implode(';', $options);
+    }
+}

--- a/src/Illuminate/Database/OdbcConnection.php
+++ b/src/Illuminate/Database/OdbcConnection.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Database;
+
+use PDO;
+use Exception;
+
+/**
+ * This is a wrapper for ODBC connections, which just proxies a different grammar, schema
+ * and postprocessor.
+ *
+ * Class OdbcConnection
+ */
+class OdbcConnection extends Connection
+{
+    /**
+     * @var \Illuminate\Database\Connection|null
+     */
+    private $internalConnectionType = null;
+
+    public function __construct(PDO $pdo, $database = '', $tablePrefix = '', array $config = [])
+    {
+        if (! isset($config['connectionType'])) {
+            throw new Exception('Missing connection type.');
+        }
+
+        $connectionType = $config['connectionType'];
+        if ($connectionType == self::class) {
+            throw new Exception('Can\'t use '.self::class.' as connection type.');
+        }
+
+        $this->internalConnectionType = new $connectionType($pdo, $database, $tablePrefix, $config);
+
+        if (! ($this->internalConnectionType instanceof Connection)) {
+            throw new Exception('Unsupported connection type.');
+        }
+
+        parent::__construct($pdo, $database, $tablePrefix, $config);
+    }
+
+    /**
+     * Get the default query grammar instance.
+     *
+     * @return \Illuminate\Database\Query\Grammars\Grammar
+     */
+    protected function getDefaultQueryGrammar()
+    {
+        return $this->internalConnectionType->getDefaultQueryGrammar();
+    }
+
+    /**
+     * Get the default schema grammar instance.
+     *
+     * @return \Illuminate\Database\Schema\Grammars\Grammar
+     */
+    protected function getDefaultSchemaGrammar()
+    {
+        return $this->internalConnectionType->getDefaultSchemaGrammar();
+    }
+
+    /**
+     * Get the default post processor instance.
+     *
+     * @return \Illuminate\Database\Query\Processors\Processor
+     */
+    protected function getDefaultPostProcessor()
+    {
+        return $this->internalConnectionType->getDefaultPostProcessor();
+    }
+
+    /**
+     * Get the Doctrine DBAL driver.
+     *
+     * @return \Doctrine\DBAL\Driver\PDOSqlsrv\Driver
+     */
+    protected function getDoctrineDriver()
+    {
+        return new DoctrineDriver;
+    }
+}

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -83,6 +83,7 @@ class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Illuminate\Database\Connectors\PostgresConnector', $factory->createConnector(['driver' => 'pgsql']));
         $this->assertInstanceOf('Illuminate\Database\Connectors\SQLiteConnector', $factory->createConnector(['driver' => 'sqlite']));
         $this->assertInstanceOf('Illuminate\Database\Connectors\SqlServerConnector', $factory->createConnector(['driver' => 'sqlsrv']));
+        $this->assertInstanceOf('Illuminate\Database\Connectors\OdbcConnector', $factory->createConnector(['driver' => 'odbc']));
     }
 
     /**

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -234,6 +234,44 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertSame($connection, $schema->getConnection());
     }
 
+    public function testOdbConnectionWrappingSqlServerConnection()
+    {
+        $pdoMock = new DatabaseConnectionTestMockPDO;
+        $config = ['connectionType' => Illuminate\Database\SqlServerConnection::class];
+
+        $connection = new Illuminate\Database\OdbcConnection($pdoMock, 'foobar', '', $config);
+        $connection->getSchemaBuilder();
+
+        $this->assertInstanceOf('Illuminate\Database\Schema\Grammars\SqlServerGrammar', $connection->getSchemaGrammar());
+        $this->assertInstanceOf('Illuminate\Database\Query\Grammars\SqlServerGrammar', $connection->getQueryGrammar());
+        $this->assertInstanceOf('Illuminate\Database\Query\Processors\SqlServerProcessor', $connection->getPostProcessor());
+    }
+
+    public function testOdbConnectionWrappingMySqlConnection()
+    {
+        $pdoMock = new DatabaseConnectionTestMockPDO;
+        $config = ['connectionType' => Illuminate\Database\MySqlConnection::class];
+
+        $connection = new Illuminate\Database\OdbcConnection($pdoMock, 'foobar', '', $config);
+        $connection->getSchemaBuilder();
+
+        $this->assertInstanceOf('Illuminate\Database\Schema\Grammars\MySqlGrammar', $connection->getSchemaGrammar());
+        $this->assertInstanceOf('Illuminate\Database\Query\Grammars\MySqlGrammar', $connection->getQueryGrammar());
+        $this->assertInstanceOf('Illuminate\Database\Query\Processors\MySqlProcessor', $connection->getPostProcessor());
+    }
+
+    public function testOdbConnectionShouldFailWrappingOdbcConnection()
+    {
+        $pdoMock = new DatabaseConnectionTestMockPDO;
+        $config = ['connectionType' => Illuminate\Database\OdbcConnection::class];
+
+        try {
+            $connection = new Illuminate\Database\OdbcConnection($pdoMock, 'foobar', '', $config);
+        } catch (Exception $e) {
+            $this->assertEquals('Can\'t use Illuminate\Database\OdbcConnection as connection type.', $e->getMessage());
+        }
+    }
+
     protected function getMockConnection($methods = [], $pdo = null)
     {
         $pdo = $pdo ?: new DatabaseConnectionTestMockPDO;

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -157,6 +157,19 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase
         $this->assertSame($result, $connection);
     }
 
+    public function testOdbcConnectCallsCreateConnectionWithProperArguments()
+    {
+        $config = ['dsn' => ['Driver' => 'ODBC Driver 11', 'Server' => 'example.server.com', 'App' => 'UnitTest']];
+        $dsn = 'odbc:Driver={ODBC Driver 11};Server=example.server.com;App=UnitTest';
+        $connector = $this->getMock('Illuminate\Database\Connectors\OdbcConnector', ['createConnection', 'getOptions']);
+        $connection = m::mock('stdClass');
+        $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
+        $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
+        $result = $connector->connect($config);
+
+        $this->assertSame($result, $connection);
+    }
+
     protected function getDsn(array $config)
     {
         extract($config);


### PR DESCRIPTION
Implements an ODBC-Connector which allows the usage of third-party drivers.

To be compatible, the ODBC-Connector accepts a connectionType which repesents an already existing Connection like MySqlConnection or SqlServerConnection.

In our case we wanted to use the native SqlServer Driver from Microsoft for Linux with the SqlServer Query- and SchemaGrammar, which already existed.
