### PR TITLE
[5.1] Fixed the Mail::send() and Mail::queue() inconsistencies

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -166,7 +166,13 @@ abstract class Job
         }
 
         if (is_array($data)) {
-            array_walk($data, function (&$d) { $d = $this->resolveQueueableEntity($d); });
+            array_walk($data, $callback = function (&$d) use (&$callback) { 
+                if(is_array($d)) {
+                    array_walk($d, $callback);
+                }
+
+                $d = $this->resolveQueueableEntity($d); 
+            });
         }
 
         return $data;

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -166,12 +166,12 @@ abstract class Job
         }
 
         if (is_array($data)) {
-            array_walk($data, $callback = function (&$d) use (&$callback) { 
-                if(is_array($d)) {
+            array_walk($data, $callback = function (&$d) use (&$callback) {
+                if (is_array($d)) {
                     array_walk($d, $callback);
                 }
 
-                $d = $this->resolveQueueableEntity($d); 
+                $d = $this->resolveQueueableEntity($d);
             });
         }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -121,7 +121,13 @@ abstract class Queue
         }
 
         if (is_array($data)) {
-            array_walk($data, function (&$d) { $d = $this->prepareQueueableEntity($d); });
+            array_walk($data, $callback = function (&$d) use (&$callback) {
+                if (is_array($d)) {
+                    array_walk($d, $callback);
+                }
+
+                $d = $this->prepareQueueableEntity($d);
+            });
         }
 
         return $data;


### PR DESCRIPTION
When using the `Mail::queue` method the data field containing the `QueueableEntities` does not serialized properly for instance, when using a call like this ( with a database driver ):

``` php

    $user = App\User::first();

    Mail::queue('email', compact('user'), function($message) {

        $message->from('me@mysite.com','Home Dev');
        $message->to('myusername@gmail.com');
        $message->subject('hello');

    });
```

The data is serialized / formated like (due to the `json_encode`):

```
[
  "view" => "email"
  "data" => array:1 [
    "user" => array:7 [
      "id" => 1
      "username" => "aut"
      "email" => "uOKeefe@Sawayn.com"
      "role_id" => 0
      "department_id" => 0
      "created_at" => "2015-09-16 11:21:40"
      "updated_at" => "2015-09-16 11:21:40"
    ]
  ]
  ......
]

```

This is not intended behaviour because the `User` which is essentially a `QueueableEntity` is not serialized like:

```
  "view" => "email"
  "data" => array:1 [
    "user" => "::entity::|App\User|1"
  ]

```

This also results in an `ErrorException` on the view side stating `Trying to get the property of a non object`. The fix checks the data recursively and converts the `QueueableEntities` to their propr format before sending them to the queue.

Laracast Discussions:

https://laracasts.com/discuss/channels/general-discussion/mailqueue-vs-send-on-delivery-episode

https://laracasts.com/discuss/channels/laravel/mailer-queue-throws-exception-trying-to-get-property-of-non-object

https://laracasts.com/discuss/channels/laravel/l51-database-queue-not-working
