### PR TITLE
Added namespace to Foundation helpers to prevent name conflicts with …

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Illuminate\Foundation\Bootstrap;
+use Illuminate\Foundation as help;
 
 use Dotenv;
 use InvalidArgumentException;
@@ -23,7 +24,7 @@ class DetectEnvironment
         }
 
         $app->detectEnvironment(function () {
-            return env('APP_ENV', 'production');
+            return help\env('APP_ENV', 'production');
         });
     }
 }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Illuminate\Foundation;
+
 use Illuminate\Support\Str;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate;


### PR DESCRIPTION
Taylor,

I found that in vendor/laravel/framework/src/Illuminate/Foundation/helpers.php there is no namespace defined which is causing lots of naming collisions. I am putting this into a namespace to prevent this and hopefully doing all the work. I'll update the other repos as well.

These are the global functions defined in helpers.php:
abort
action
app
app_path
asset
auth
back
base_path
bcrypt
config
config_path
cookie
csrf_field
csrf_token
database_path
delete
elixir
env
event
factory
get
info
logger
method_field
old
patch
policy
post
public_path
put
redirect
request
resource
response
route
secure_asset
secure_url
session
storage_path
trans
trans_choice
url
view
