### PR TITLE
[5.1] Support temporary tables in schema builder

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -31,6 +31,13 @@ class Blueprint
     protected $commands = [];
 
     /**
+     * Whether to make the table temporary.
+     *
+     * @var bool
+     */
+    public $temporary = false;
+
+    /**
      * The storage engine that should be used for the table.
      *
      * @var string
@@ -178,6 +185,16 @@ class Blueprint
     public function create()
     {
         return $this->addCommand('create');
+    }
+
+    /**
+     * Indicate that the table needs to be temporary.
+     *
+     * @return void
+     */
+    public function temporary()
+    {
+        $this->temporary = true;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -54,7 +54,11 @@ class MySqlGrammar extends Grammar
     {
         $columns = implode(', ', $this->getColumns($blueprint));
 
-        $sql = 'create table '.$this->wrapTable($blueprint)." ($columns)";
+        $sql = 'create';
+        if ($blueprint->temporary === true) {
+            $sql .= ' temporary';
+        }
+        $sql .= ' table '.$this->wrapTable($blueprint)." ($columns)";
 
         // Once we have the primary SQL, we can add the encoding option to the SQL for
         // the table.  Then, we can check if a storage engine has been supplied for

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -53,7 +53,13 @@ class PostgresGrammar extends Grammar
     {
         $columns = implode(', ', $this->getColumns($blueprint));
 
-        return 'create table '.$this->wrapTable($blueprint)." ($columns)";
+        $sql = 'create';
+        if ($blueprint->temporary === true) {
+            $sql .= ' temporary';
+        }
+        $sql .= ' table '.$this->wrapTable($blueprint)." ($columns)";
+
+        return $sql;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -54,7 +54,11 @@ class SQLiteGrammar extends Grammar
     {
         $columns = implode(', ', $this->getColumns($blueprint));
 
-        $sql = 'create table '.$this->wrapTable($blueprint)." ($columns";
+        $sql = 'create';
+        if ($blueprint->temporary === true) {
+            $sql .= ' temporary';
+        }
+        $sql .= ' table '.$this->wrapTable($blueprint)." ($columns";
 
         // SQLite forces primary keys to be added when the table is initially created
         // so we will need to check for a primary key commands and add the columns


### PR DESCRIPTION
I frequently run into the need for temporary tables, and it would quite nice to use Laravel's schema builder for it. Here's my implementation of it. I've added a `$temporary` boolean property on `Blueprint` along with a method to set it to `true`, then I've made each grammar file check it when creating a table.

Example usage:

``` php
Schema::create('new_table', function($table) {
    $table->string('first_col', 40);
    $table->temporary(); // or $table->temporary = true;
});
```

Note: I have not updated the SQL Server grammar file, because I don't have a good way to test it at the moment.
