### PR TITLE
Add file path hint at the top of compiled blade views

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -132,7 +132,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function compileString($value)
     {
-        $result = '';
+        $result = $this->getHeader();
 
         $this->footer = [];
 
@@ -171,6 +171,16 @@ class BladeCompiler extends Compiler implements CompilerInterface
         }
 
         return $content;
+    }
+
+    /**
+     * Get header.
+     *
+     * @return string
+     */
+    protected function getHeader()
+    {
+        return "<?php // File: {$this->getPath()} ?>";
     }
 
     /**


### PR DESCRIPTION
Useful when debugging an error in a blade file when you have a load of views and not sure what the original view is.
