### PR TITLE
[5.1] Fixing date validation for relative dates

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1360,7 +1360,7 @@ class Validator implements ValidatorContract
 
         $date = date_parse($value);
 
-        return checkdate($date['month'], $date['day'], $date['year']);
+        return $date['error_count'] == 0;
     }
 
     /**


### PR DESCRIPTION
Changing the date validation for relative dates to check for
error_count instead of looking for a month/day/year set which are not
returned by date_parse for relative dates.
