### PR TITLE
[5.1] Change the exception the gate throws

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Auth\Access;
 
 use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Auth\Access\UnauthorizedException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
 trait AuthorizesRequests
 {
@@ -91,6 +90,6 @@ trait AuthorizesRequests
      */
     protected function createGateUnauthorizedException($ability, $arguments, $message = 'This action is unauthorized.', $previousException = null)
     {
-        return new HttpException(403, $message, $previousException);
+        return new UnauthorizedException($message, 403, $previousException);
     }
 }

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -25,7 +25,7 @@ class FoundationAuthorizesRequestsTraitTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Symfony\Component\HttpKernel\Exception\HttpException
+     * @expectedException Illuminate\Auth\Access\UnauthorizedException
      */
     public function test_exception_is_thrown_if_gate_check_fails()
     {


### PR DESCRIPTION
I've updated this file in order to throw the correct Exception which is UnauthorizedException on createGateUnauthorizedException method. Also this is useful in order to render a different response here: app/Exceptions/Handler.php
