### PR TITLE
[5.1] Normalized calls to mockery's mock method

### DIFF
--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -17,7 +17,7 @@ class ClearCommandTest extends PHPUnit_Framework_TestCase
             $cacheManager = m::mock('Illuminate\Cache\CacheManager')
         );
 
-        $cacheRepository = m::mock('\Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
 
         $app = new Application();
         $command->setLaravel($app);
@@ -34,7 +34,7 @@ class ClearCommandTest extends PHPUnit_Framework_TestCase
             $cacheManager = m::mock('Illuminate\Cache\CacheManager')
         );
 
-        $cacheRepository = m::mock('\Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
 
         $app = new Application();
         $command->setLaravel($app);
@@ -51,7 +51,7 @@ class ClearCommandTest extends PHPUnit_Framework_TestCase
             $cacheManager = m::mock('Illuminate\Cache\CacheManager')
         );
 
-        $cacheRepository = m::mock('\Illuminate\Contracts\Cache\Repository');
+        $cacheRepository = m::mock('Illuminate\Contracts\Cache\Repository');
 
         $app = new Application();
         $command->setLaravel($app);

--- a/tests/Foundation/FoundationCrawlerTraitTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitTest.php
@@ -205,7 +205,7 @@ class FoundationCrawlerTraitTest extends PHPUnit_Framework_TestCase
 
     public function testExtractsRequestParametersFromForm()
     {
-        $form = m::mock('\Symfony\Component\DomCrawler\Form');
+        $form = m::mock('Symfony\Component\DomCrawler\Form');
 
         $form->shouldReceive('getValues')->once()->andReturn([]);
         $this->assertEquals([], $this->extractParametersFromForm($form));

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -27,7 +27,7 @@ class SupportCapsuleManagerTraitTest extends PHPUnit_Framework_TestCase
     {
         $this->container = null;
         $app = new Container;
-        $app['config'] = m::mock('\Illuminate\Config\Repository');
+        $app['config'] = m::mock('Illuminate\Config\Repository');
 
         $this->assertNull($this->setupContainer($app));
         $this->assertEquals($app, $this->getContainer());


### PR DESCRIPTION
We always omit the leading slash since it's actually incorrect to include it. The leading slash is not part of the fully qualified class name, it should only be used when forcefully resolving such classes from within another namespace.
