### PR TITLE
[5.1] Validation rule: required_unless

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -147,7 +147,7 @@ class Validator implements ValidatorContract
      * @var array
      */
     protected $implicitRules = [
-        'Required', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll', 'RequiredIf', 'Accepted',
+        'Required', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll', 'RequiredIf', 'RequiredUnless', 'Accepted',
     ];
 
     /**
@@ -681,6 +681,29 @@ class Validator implements ValidatorContract
         $values = array_slice($parameters, 1);
 
         if (in_array($data, $values)) {
+            return $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that an attribute exists when another attribute does not have a given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  mixed   $parameters
+     * @return bool
+     */
+    protected function validateRequiredUnless($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'required_unless');
+
+        $data = Arr::get($this->data, $parameters[0]);
+
+        $values = array_slice($parameters, 1);
+
+        if (! in_array($data, $values)) {
             return $this->validateRequired($attribute, $value);
         }
 
@@ -1945,6 +1968,22 @@ class Validator implements ValidatorContract
         $parameters[0] = $this->getAttribute($parameters[0]);
 
         return str_replace([':other', ':value'], $parameters, $message);
+    }
+
+    /**
+     * Replace all place-holders for the required_unless rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return string
+     */
+    protected function replaceRequiredUnless($message, $attribute, $rule, $parameters)
+    {
+        $other = $this->getAttribute(array_shift($parameters));
+
+        return str_replace([':other', ':values'], [$other, implode(', ', $parameters)], $message);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -691,8 +691,8 @@ class Validator implements ValidatorContract
      * Validate that an attribute exists when another attribute does not have a given value.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
+     * @param  mixed  $value
+     * @param  mixed  $parameters
      * @return bool
      */
     protected function validateRequiredUnless($attribute, $value, $parameters)

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -445,6 +445,36 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('The last field is required when first is dayle.', $v->messages()->first('last'));
     }
 
+    public function testRequiredUnless()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['first' => 'sven'], ['last' => 'required_unless:first,taylor']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'required_unless:first,taylor']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['first' => 'sven', 'last' => 'wittevrongel'], ['last' => 'required_unless:first,taylor']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'required_unless:first,taylor,sven']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['first' => 'sven'], ['last' => 'required_unless:first,taylor,sven']);
+        $this->assertTrue($v->passes());
+
+        // error message when passed multiple values (required_unless:foo,bar,baz)
+        $trans = $this->getRealTranslator();
+        $trans->addResource('array', ['validation.required_unless' => 'The :attribute field is required unless :other is in :values.'], 'en', 'messages');
+        $v = new Validator($trans, ['first' => 'dayle', 'last' => ''], ['last' => 'RequiredUnless:first,taylor,sven']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals('The last field is required unless first is in taylor, sven.', $v->messages()->first('last'));
+    }
+
     public function testValidateConfirmed()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
Since that Laravel already comes with the `required_if` validation rule out of the box, I thought it would make sense to add a `required_unless` rule too. It would do the exact opposite, and require a field unless another field is set to value.

Additional changes in laravel/laravel needed if this is accepted.
