### PR TITLE
Fixed URLGenerator stripping required parameters when optional parameters are included

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -346,7 +346,7 @@ class UrlGenerator implements UrlGeneratorContract
             );
         }
 
-        return trim(preg_replace('/\{.*?\?\}/', '', $path), '/');
+        return trim(preg_replace('/\{[^?}]+?\?\}/', '', $path), '/');
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -314,7 +314,7 @@ class RoutingUrlGeneratorTest extends PHPUnit_Framework_TestCase
         $route = new Illuminate\Routing\Route(['GET'], 'foo/{one}/{two?}/{three?}', ['as' => 'foo', function () {}]);
         $routes->add($route);
 
-        $this->assertEquals('http://www.foo.com:8080/foo', $url->route('foo'));
+        $this->assertEquals('http://www.foo.com:8080/foo/%7Bone%7D', $url->route('foo'));
     }
 
     public function testForceRootUrl()


### PR DESCRIPTION
When generating URLs via named routes, placeholders for any parameters are left in the path if no parameters are provided
e.g Generating the URL for `Route::get('/alpha/{requiredParam}/omega', ...);` with no parameters results in `http://localhost:8000/alpha/%7BrequiredParam%7D/omega`

However, if the path contains any optional parameters:
`Route::get('/alpha/{requiredParam}/omega/{optionalParam?}', ...)` it can sometimes strip required parameters if they're not provided (e.g. => `http://localhost:8000/alpha`). This also results in dropping any part of the path that is surrounded by unprovided parameters. This occurs because the regex that strips missing optional parameters might match the start of a missing required parameter.

The following can be dropped into a vanilla routes.php file in order to see the inconsistency

```
Route::get('/alpha/{requiredParam}/omega', ['as' => 'test1']);
var_dump(route('test1', 'hello'));
var_dump(route('test1'));
// string 'http://localhost:8000/alpha/hello/omega' (length=39)
// string 'http://localhost:8000/alpha/%7BrequiredParam%7D/omega' (length=53)

Route::get('/alpha/{requiredParam}/omega/{optionalParam?}', ['as' => 'test2']);

var_dump(route('test2', 'hello'));
var_dump(route('test2'));
// string 'http://localhost:8000/alpha/hello/omega' (length=39)
// string 'http://localhost:8000/alpha' (length=27)
```

Note the last generated route is missing the `{requiredParam}` placeholder and the following segment has been dropped `/omega`.

I have fixed the regex pattern to only match optional parameters, also modified a test as it was expecting an unspecified required parameter to be stripped.
