### PR TITLE
[5.2] Improvements on DI aliases

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1025,43 +1025,48 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function registerCoreContainerAliases()
     {
-        $aliases = [
+        $core = [
             'app'                  => ['Illuminate\Foundation\Application', 'Illuminate\Contracts\Container\Container', 'Illuminate\Contracts\Foundation\Application'],
-            'auth'                 => 'Illuminate\Auth\AuthManager',
+            'auth'                 => ['Illuminate\Auth\AuthManager'],
             'auth.driver'          => ['Illuminate\Auth\Guard', 'Illuminate\Contracts\Auth\Guard'],
-            'auth.password.tokens' => 'Illuminate\Auth\Passwords\TokenRepositoryInterface',
-            'blade.compiler'       => 'Illuminate\View\Compilers\BladeCompiler',
+            'auth.gate'            => ['Illuminate\Auth\Access\Gate', 'Illuminate\Contracts\Auth\Access\Gate'],
+            'auth.password'        => ['Illuminate\Auth\Passwords\PasswordBroker', 'Illuminate\Contracts\Auth\PasswordBroker'],
+            'auth.password.tokens' => ['Illuminate\Auth\Passwords\TokenRepositoryInterface'],
+            'blade.compiler'       => ['Illuminate\View\Compilers\BladeCompiler'],
+            'bus'                  => ['Illuminate\Bus\Dispatcher', 'Illuminate\Contracts\Bus\Dispatcher'],
             'cache'                => ['Illuminate\Cache\CacheManager', 'Illuminate\Contracts\Cache\Factory'],
             'cache.store'          => ['Illuminate\Cache\Repository', 'Illuminate\Contracts\Cache\Repository'],
             'config'               => ['Illuminate\Config\Repository', 'Illuminate\Contracts\Config\Repository'],
+            'console'              => ['Illuminate\Contracts\Console\Kernel'],
             'cookie'               => ['Illuminate\Cookie\CookieJar', 'Illuminate\Contracts\Cookie\Factory', 'Illuminate\Contracts\Cookie\QueueingFactory'],
             'encrypter'            => ['Illuminate\Encryption\Encrypter', 'Illuminate\Contracts\Encryption\Encrypter'],
-            'db'                   => 'Illuminate\Database\DatabaseManager',
+            'db'                   => ['Illuminate\Database\DatabaseManager'],
+            'db.factory'           => ['Illuminate\Database\Eloquent\Factory'],
             'events'               => ['Illuminate\Events\Dispatcher', 'Illuminate\Contracts\Events\Dispatcher'],
-            'files'                => 'Illuminate\Filesystem\Filesystem',
+            'files'                => ['Illuminate\Filesystem\Filesystem'],
             'filesystem'           => ['Illuminate\Filesystem\FilesystemManager', 'Illuminate\Contracts\Filesystem\Factory'],
-            'filesystem.disk'      => 'Illuminate\Contracts\Filesystem\Filesystem',
-            'filesystem.cloud'     => 'Illuminate\Contracts\Filesystem\Cloud',
-            'hash'                 => 'Illuminate\Contracts\Hashing\Hasher',
+            'filesystem.disk'      => ['Illuminate\Contracts\Filesystem\Filesystem'],
+            'filesystem.cloud'     => ['Illuminate\Contracts\Filesystem\Cloud'],
+            'hash'                 => ['Illuminate\Contracts\Hashing\Hasher'],
             'translator'           => ['Illuminate\Translation\Translator', 'Symfony\Component\Translation\TranslatorInterface'],
             'log'                  => ['Illuminate\Log\Writer', 'Illuminate\Contracts\Logging\Log', 'Psr\Log\LoggerInterface'],
             'mailer'               => ['Illuminate\Mail\Mailer', 'Illuminate\Contracts\Mail\Mailer', 'Illuminate\Contracts\Mail\MailQueue'],
-            'auth.password'        => ['Illuminate\Auth\Passwords\PasswordBroker', 'Illuminate\Contracts\Auth\PasswordBroker'],
             'queue'                => ['Illuminate\Queue\QueueManager', 'Illuminate\Contracts\Queue\Factory', 'Illuminate\Contracts\Queue\Monitor'],
-            'queue.connection'     => 'Illuminate\Contracts\Queue\Queue',
-            'redirect'             => 'Illuminate\Routing\Redirector',
+            'queue.connection'     => ['Illuminate\Contracts\Queue\Queue'],
+            'redirect'             => ['Illuminate\Routing\Redirector'],
             'redis'                => ['Illuminate\Redis\Database', 'Illuminate\Contracts\Redis\Database'],
-            'request'              => 'Illuminate\Http\Request',
+            'response'             => ['Illuminate\Routing\ResponseFactory', 'Illuminate\Contracts\Routing\ResponseFactory'],
+            'request'              => ['Illuminate\Http\Request', 'Symfony\Component\HttpFoundation\Request'],
             'router'               => ['Illuminate\Routing\Router', 'Illuminate\Contracts\Routing\Registrar'],
-            'session'              => 'Illuminate\Session\SessionManager',
+            'session'              => ['Illuminate\Session\SessionManager'],
             'session.store'        => ['Illuminate\Session\Store', 'Symfony\Component\HttpFoundation\Session\SessionInterface'],
             'url'                  => ['Illuminate\Routing\UrlGenerator', 'Illuminate\Contracts\Routing\UrlGenerator'],
             'validator'            => ['Illuminate\Validation\Factory', 'Illuminate\Contracts\Validation\Factory'],
             'view'                 => ['Illuminate\View\Factory', 'Illuminate\Contracts\View\Factory'],
         ];
 
-        foreach ($aliases as $key => $aliases) {
-            foreach ((array) $aliases as $alias) {
+        foreach ($core as $key => $aliases) {
+            foreach ($aliases as $alias) {
                 $this->alias($key, $alias);
             }
         }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -90,7 +90,7 @@ if (! function_exists('auth')) {
      */
     function auth()
     {
-        return app('Illuminate\Contracts\Auth\Guard');
+        return app('auth.guard');
     }
 }
 
@@ -187,7 +187,7 @@ if (! function_exists('cookie')) {
      */
     function cookie($name = null, $value = null, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true)
     {
-        $cookie = app('Illuminate\Contracts\Cookie\Factory');
+        $cookie = app('cookie');
 
         if (is_null($name)) {
             return $cookie;
@@ -373,7 +373,7 @@ if (! function_exists('factory')) {
      */
     function factory()
     {
-        $factory = app('Illuminate\Database\Eloquent\Factory');
+        $factory = app('db.factory');
 
         $arguments = func_get_args();
 
@@ -594,7 +594,7 @@ if (! function_exists('response')) {
      */
     function response($content = '', $status = 200, array $headers = [])
     {
-        $factory = app('Illuminate\Contracts\Routing\ResponseFactory');
+        $factory = app('response');
 
         if (func_num_args() === 0) {
             return $factory;
@@ -732,7 +732,7 @@ if (! function_exists('url')) {
      */
     function url($path = null, $parameters = [], $secure = null)
     {
-        return app('Illuminate\Contracts\Routing\UrlGenerator')->to($path, $parameters, $secure);
+        return app('url')->to($path, $parameters, $secure);
     }
 }
 
@@ -747,7 +747,7 @@ if (! function_exists('view')) {
      */
     function view($view = null, $data = [], $mergeData = [])
     {
-        $factory = app('Illuminate\Contracts\View\Factory');
+        $factory = app('view');
 
         if (func_num_args() === 0) {
             return $factory;

--- a/src/Illuminate/Support/Facades/Artisan.php
+++ b/src/Illuminate/Support/Facades/Artisan.php
@@ -14,6 +14,6 @@ class Artisan extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Contracts\Console\Kernel';
+        return 'console';
     }
 }

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -14,6 +14,6 @@ class Bus extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Contracts\Bus\Dispatcher';
+        return 'bus';
     }
 }

--- a/src/Illuminate/Support/Facades/Gate.php
+++ b/src/Illuminate/Support/Facades/Gate.php
@@ -14,6 +14,6 @@ class Gate extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Contracts\Auth\Access\Gate';
+        return 'auth.gate';
     }
 }

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -14,6 +14,6 @@ class Response extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Contracts\Routing\ResponseFactory';
+        return 'response';
     }
 }


### PR DESCRIPTION
1. Added `'auth.gate'`, `'bus'`, `'console'`, `'db.factory'` and `'response'` aliases to application.
2. Added alias for Symfony Request.
3. Minor refactoring of core aliases binding - removed duplicate `$aliases` variable usage and unnescessary `(array)` casting.
4. Made aliases consistent in helpers (shortcuts only).
5. Made aliases in facade consistent (shortcuts only).
