### PR TITLE
[5.1] Remove not used variable: $path

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -76,7 +76,7 @@ abstract class GeneratorCommand extends Command
     {
         $name = $this->parseName($rawName);
 
-        return $this->files->exists($path = $this->getPath($name));
+        return $this->files->exists($this->getPath($name));
     }
 
     /**


### PR DESCRIPTION
In method alreadyExists, the $path variable is informative ?

or better use

``` php
    protected function alreadyExists($rawName)
    {
        $name = $this->parseName($rawName);
        $path = $this->getPath($name);

        return $this->files->exists($path);
    }
```
