### PR TITLE
[5.1] Add support for joins with nested conditions

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -169,6 +169,20 @@ class Grammar extends BaseGrammar
      */
     protected function compileJoinConstraint(array $clause)
     {
+        if ($clause['nested']) {
+            $clauses = [];
+
+            foreach ($clause['join']->clauses as $nestedClause) {
+                $clauses[] = $this->compileJoinConstraint($nestedClause);
+            }
+
+            $clauses[0] = $this->removeLeadingBoolean($clauses[0]);
+
+            $clauses = implode(' ', $clauses);
+
+            return "{$clause['boolean']} ({$clauses})";
+        }
+
         $first = $this->wrap($clause['first']);
 
         if ($clause['where']) {

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -60,7 +60,7 @@ class JoinClause
      *
      * on `contacts`.`user_id` = `users`.`id`  and `contacts`.`info_id` = `info`.`id`
      *
-     * @param  string  $first
+     * @param  string|\Closure  $first
      * @param  string|null  $operator
      * @param  string|null  $second
      * @param  string  $boolean
@@ -97,7 +97,7 @@ class JoinClause
     /**
      * Add an "or on" clause to the join.
      *
-     * @param  string  $first
+     * @param  string|\Closure  $first
      * @param  string|null  $operator
      * @param  string|null  $second
      * @return \Illuminate\Database\Query\JoinClause
@@ -110,7 +110,7 @@ class JoinClause
     /**
      * Add an "on where" clause to the join.
      *
-     * @param  string  $first
+     * @param  string|\Closure  $first
      * @param  string|null  $operator
      * @param  string|null  $second
      * @param  string  $boolean
@@ -124,7 +124,7 @@ class JoinClause
     /**
      * Add an "or on where" clause to the join.
      *
-     * @param  string  $first
+     * @param  string|\Closure  $first
      * @param  string|null  $operator
      * @param  string|null  $second
      * @return \Illuminate\Database\Query\JoinClause
@@ -237,11 +237,11 @@ class JoinClause
      */
     public function nest(Closure $callback, $boolean = 'and')
     {
-        $join = new self($this->type, $this->table);
+        $join = new static($this->type, $this->table);
 
         $callback($join);
 
-        if ($clausesCount = count($join->clauses)) {
+        if (count($join->clauses)) {
             $nested = true;
 
             $this->clauses[] = compact('nested', 'join', 'boolean');

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Database\Query;
 
+use Closure;
+use InvalidArgumentException;
+
 class JoinClause
 {
     /**
@@ -58,14 +61,24 @@ class JoinClause
      * on `contacts`.`user_id` = `users`.`id`  and `contacts`.`info_id` = `info`.`id`
      *
      * @param  string  $first
-     * @param  string  $operator
-     * @param  string  $second
+     * @param  string|null  $operator
+     * @param  string|null  $second
      * @param  string  $boolean
      * @param  bool  $where
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
-    public function on($first, $operator, $second, $boolean = 'and', $where = false)
+    public function on($first, $operator = null, $second = null, $boolean = 'and', $where = false)
     {
+        if ($first instanceof Closure) {
+            return $this->nest($first, $boolean);
+        }
+
+        if (func_num_args() < 3) {
+            throw new InvalidArgumentException('Not enough arguments for the on clause.');
+        }
+
         if ($where) {
             $this->bindings[] = $second;
         }
@@ -74,7 +87,9 @@ class JoinClause
             $second = count($second);
         }
 
-        $this->clauses[] = compact('first', 'operator', 'second', 'boolean', 'where');
+        $nested = false;
+
+        $this->clauses[] = compact('first', 'operator', 'second', 'boolean', 'where', 'nested');
 
         return $this;
     }
@@ -83,11 +98,11 @@ class JoinClause
      * Add an "or on" clause to the join.
      *
      * @param  string  $first
-     * @param  string  $operator
-     * @param  string  $second
+     * @param  string|null  $operator
+     * @param  string|null  $second
      * @return \Illuminate\Database\Query\JoinClause
      */
-    public function orOn($first, $operator, $second)
+    public function orOn($first, $operator = null, $second = null)
     {
         return $this->on($first, $operator, $second, 'or');
     }
@@ -96,12 +111,12 @@ class JoinClause
      * Add an "on where" clause to the join.
      *
      * @param  string  $first
-     * @param  string  $operator
-     * @param  string  $second
+     * @param  string|null  $operator
+     * @param  string|null  $second
      * @param  string  $boolean
      * @return \Illuminate\Database\Query\JoinClause
      */
-    public function where($first, $operator, $second, $boolean = 'and')
+    public function where($first, $operator = null, $second = null, $boolean = 'and')
     {
         return $this->on($first, $operator, $second, $boolean, true);
     }
@@ -110,11 +125,11 @@ class JoinClause
      * Add an "or on where" clause to the join.
      *
      * @param  string  $first
-     * @param  string  $operator
-     * @param  string  $second
+     * @param  string|null  $operator
+     * @param  string|null  $second
      * @return \Illuminate\Database\Query\JoinClause
      */
-    public function orWhere($first, $operator, $second)
+    public function orWhere($first, $operator = null, $second = null)
     {
         return $this->on($first, $operator, $second, 'or', true);
     }
@@ -211,5 +226,28 @@ class JoinClause
     public function orWhereNotIn($column, array $values)
     {
         return $this->on($column, 'not in', $values, 'or', true);
+    }
+
+    /**
+     * Add a nested where statement to the query.
+     *
+     * @param  \Closure  $callback
+     * @param  string   $boolean
+     * @return \Illuminate\Database\Query\JoinClause
+     */
+    public function nest(Closure $callback, $boolean = 'and')
+    {
+        $join = new self($this->type, $this->table);
+
+        $callback($join);
+
+        if ($clausesCount = count($join->clauses)) {
+            $nested = true;
+
+            $this->clauses[] = compact('nested', 'join', 'boolean');
+            $this->bindings = array_merge($this->bindings, $join->bindings);
+        }
+
+        return $this;
     }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -716,7 +716,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->leftJoin('contacts', function ($j) {
-            $j->on('users.id', '=', 'contacts.id')->where(function($j) {
+            $j->on('users.id', '=', 'contacts.id')->where(function ($j) {
                 $j->where('contacts.country', '=', 'US')->orWhere('contacts.is_partner', '=', 1);
             });
         });
@@ -725,10 +725,10 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->leftJoin('contacts', function ($j) {
-            $j->on('users.id', '=', 'contacts.id')->where('contacts.is_active', '=', 1)->orOn(function($j) {
-                $j->orWhere(function($j) {
+            $j->on('users.id', '=', 'contacts.id')->where('contacts.is_active', '=', 1)->orOn(function ($j) {
+                $j->orWhere(function ($j) {
                     $j->where('contacts.country', '=', 'UK')->orOn('contacts.type', '=', 'users.type');
-                })->where(function($j) {
+                })->where(function ($j) {
                     $j->where('contacts.country', '=', 'US')->orWhereNull('contacts.is_partner');
                 });
             });


### PR DESCRIPTION
This PR enables nested conditions within join clauses. This is important for left joins, when we don't have the option to simply add where conditions after the join clause, since it filters out the results that don't match. Also, currently there is no workaround for this functionality other than writing the entire SQL by hand.

With this PR something like this is now possible:

``` php
DB::table('users')->leftJoin('contacts', function ($j) {
    $j->on('users.id', '=', 'contacts.id')
        ->where('contacts.is_active', '=', 1)
        ->on(function($j) {
            $j->orWhere(function($j) {
                $j->where('contacts.country', '=', 'UK')->orOn('contacts.type', '=', 'users.type');
            })->where(function($j) {
                $j->where('contacts.country', '=', 'US')->orWhereNull('contacts.is_partner');
            });
        });
    });
```

The following methods now accept closure as the first argument: `on`, `orOn`, `where`, `orWhere` and a new one `nest` (if you want to be explicit).
