### PR TITLE
[5.1] Removed period to be consistent with existing descriptions

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -18,7 +18,7 @@ class DummyClass extends Command
      *
      * @var string
      */
-    protected $description = 'Command description.';
+    protected $description = 'Command description';
 
     /**
      * Create a new command instance.


### PR DESCRIPTION
Running `php artisan list` shows Laravel commands and their descriptions, none of which use periods at the end of their description.

To be a major nitpicker, I vote to remove the period at the end of the description to remain consistent with the rest of the Laravel commands.

Example:
![screen shot 2015-11-04 at 11 09 22 am](https://cloud.githubusercontent.com/assets/468779/10928548/8bedacb8-82e4-11e5-9847-7e70ca753208.jpg)
