### PR TITLE
[5.2] Move is_array check to getArrayableItems method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -29,7 +29,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function __construct($items = [])
     {
-        $this->items = is_array($items) ? $items : $this->getArrayableItems($items);
+        $this->items = $this->getArrayableItems($items);
     }
 
     /**
@@ -1042,7 +1042,9 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     protected function getArrayableItems($items)
     {
-        if ($items instanceof self) {
+        if (is_array($items)) {
+            return $items;
+        } elseif ($items instanceof self) {
             return $items->all();
         } elseif ($items instanceof Arrayable) {
             return $items->toArray();


### PR DESCRIPTION
Makes extending `__construct` method a bit more simple.

``` php
class MyCollection extends Collection
{
    public function __construct($items = [])
    {
        $array = $this->getArrayableItems($items);
        // instead of
        // $array = is_array($items) ? $items : $this->getArrayableItems($items);

        // Do some stuff with $items.

        $this->items = $array;
    }
}
```
