### PR TITLE
[5.1] Run Artisan::call(); through Application

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -61,7 +61,11 @@ class Application extends SymfonyApplication implements ApplicationContract
 
         $this->setCatchExceptions(false);
 
-        return $this->run(new ArrayInput($parameters->toArray()), $this->lastOutput);
+        $result = $this->run(new ArrayInput($parameters->toArray()), $this->lastOutput);
+
+        $this->setCatchExceptions(true);
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -55,11 +55,13 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public function call($command, array $parameters = [])
     {
-        $parameters['command'] = $command;
+        $parameters = collect($parameters)->prepend($command);
 
         $this->lastOutput = new BufferedOutput;
 
-        return $this->find($command)->run(new ArrayInput($parameters), $this->lastOutput);
+        $this->setCatchExceptions(false);
+
+        return $this->run(new ArrayInput($parameters->toArray()), $this->lastOutput);
     }
 
     /**


### PR DESCRIPTION
##### To allow for use of symfony events dispatcher on commands.

This small change runs Artisan::call() though the artisan Application instance, and not by just calling the command itself, opening up more functionality which is inline with artisan via cli.

The reason ive requested this, is because im working on a package which sets the Symfony EventDisapatcher when using artisan through the console, giving additional functionality by being able to disable, or modify commands before and after they are run via cli artisan (see here: https://github.com/leemason/tenantable/blob/master/src/Resolver.php#L183).

Basically its a tenants package which when providing the `--tenant` option sets the correct tenant, or optionally disables the command, and runs it for each tenant. This is acheived by setting the symfony eventdispatcher on the `artisan.start` event and using the dispatcher events to listen for the argument and perform tasks accordingly.

In the real world this translates calling `artisan inspire --tenant=*` into the following output:

```
Running command for tenant1
Smile, breathe, and go slowly. - Thich Nhat Hanh
Running command for tenant2
Well begun is half done. - Aristotle
Running command for ....
....
```

This works perfectly fine currently with the artisan file, but doesnt when called via \Artisan::call() because this method doesnt run through the symfony console at all, it just finds the command instance and runs it.

Framework tests report no issues with this change.
