### PR TITLE
[5.1] Allow migrations to be "batched" individually

### DIFF
--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -18,7 +18,7 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', false, null);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', false, false);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -33,7 +33,7 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', false, null);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', false, false);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
         $command->expects($this->once())->method('call')->with($this->equalTo('migrate:install'), $this->equalTo(['--database' => null]));
@@ -48,7 +48,7 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', true, null);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', true, false);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -62,11 +62,25 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with('foo');
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', false, null);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', false, false);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--database' => 'foo']);
+    }
+
+    public function testStepMayBeSet()
+    {
+        $command = new MigrateCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor');
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', false, true);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command, ['--step' => true]);
     }
 
     protected function runCommand($command, $input = [])


### PR DESCRIPTION
This adds a `--step` flag to the `artisan migrate` command that runs pending migrations sequentially, instead of in the same batch.  That way, you can roll them back individually instead of in the batch.
