### PR TITLE
[5.2] Use Str::studly to resolve driver method

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -76,7 +76,7 @@ abstract class Manager
      */
     protected function createDriver($driver)
     {
-        $method = 'create'.ucfirst($driver).'Driver';
+        $method = 'create'.Str::studly($driver).'Driver';
 
         // We'll check to see if a creator method exists for the given driver. If not we
         // will check for a custom driver creator, which allows developers to create


### PR DESCRIPTION
Camel-cased method names are used everywhere as a good practice, but using camel-cased names in strings IMO looks ugly and confusing. And if someone uses snake-casing, it looks even uglier in method names.

``` php
$manager->driver('myDriver'); // createMyDriver()
$manager->driver('my_driver'); // createMy_driver()
$manager->driver('my-driver'); // pretty, but method createMy-driver() cannot exist.
```

This gives consistency to such calls as in #10534
And also provides a way to make good-looking configs.

``` php
return [
    // ...
    // 'previous' => 'awesomeDriver', // camel case among lower cased everything
    'default' => 'awesome-driver',
    'fallback' => 'awesome_driver', // if someone prefers snake case in config
    // ...
    'awesome-driver' => [
        'uri' => '...',
        // ...
    ],
];
$manager->driver('awesome-driver');
```

This is not a great change since referenced usages are quite rare. And old behaviour remains for common usages.

``` php
$manager->driver('mydriver'); // Old behaviour remains
$manager->driver('myDriver'); // Old behaviour remains
```

This was once rejected (#8490 - there also was my mistake in code), however I will try to convince you again, as it is, actually, an important thing for consistency.
