### PR TITLE
Added localisation check before defaulting to php default month names.

### DIFF
--- a/src/Illuminate/Html/FormBuilder.php
+++ b/src/Illuminate/Html/FormBuilder.php
@@ -486,9 +486,16 @@ class FormBuilder {
 	{
 		$months = array();
 
-		foreach (range(1, 12) as $month)
+		if (\Lang::has('months'))
 		{
-			$months[$month] = strftime($format, mktime(0, 0, 0, $month, 1));
+			$months = \Lang::get('months');
+		}
+		else
+		{
+			foreach (range(1, 12) as $month)
+			{
+				$months[$month] = ucfirst(strftime($format, mktime(0, 0, 0, $month, 1)));
+			}
 		}
 
 		return $this->select($name, $months, $selected, $options);


### PR DESCRIPTION
A suggestion according to my issue https://github.com/laravel/framework/issues/10813

The translator (Lang) should be injected, but I realized that this small change now would make the FormBuilder dependant on the Translator module, which is probably a bad idea, since it is only used for this single thing.

I wrapped the standard strftime() method call in a ucfirst() to solve a capitalization issue with most languages as well (see issue).
