### PR TITLE
[5.1] Fix ClassLoader::register bug

### DIFF
--- a/src/Illuminate/Support/ClassLoader.php
+++ b/src/Illuminate/Support/ClassLoader.php
@@ -62,7 +62,7 @@ class ClassLoader
     public static function register()
     {
         if (! static::$registered) {
-            static::$registered = spl_autoload_register(['\Illuminate\Support\ClassLoader', 'load']);
+            static::$registered = spl_autoload_register([static::class, 'load']);
         }
     }
 


### PR DESCRIPTION
Fix SPL autoload registration bug for classes extending `ClassLoader`

``` php
class MyLoader extends ClassLoader { ... }
MyLoader::register(); // registered ClassLoader::load before
```
