### PR TITLE
[5.1] Fix ViewErrorBag unexpected values problem

### DIFF
--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -90,7 +90,7 @@ class ViewErrorBag implements Countable
      */
     public function __get($key)
     {
-        return Arr::get($this->bags, $key) ?: new MessageBag;
+        return $this->getBag($key);
     }
 
     /**
@@ -102,6 +102,6 @@ class ViewErrorBag implements Countable
      */
     public function __set($key, $value)
     {
-        Arr::set($this->bags, $key, $value);
+        $this->put($key, $value);
     }
 }


### PR DESCRIPTION
It was allowed to put unexpected values to the bag through `__set`

~~Passing new object to `Arr::get` is not always good.~~
