### PR TITLE
[4.2] Allow for version 1.0 of predis to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "nesbot/carbon": "~1.0",
         "patchwork/utf8": "~1.1",
         "phpseclib/phpseclib": "0.3.*",
-        "predis/predis": "0.8.*",
+        "predis/predis": "0.8.*|^1.0",
         "stack/builder": "~1.0",
         "swiftmailer/swiftmailer": "~5.1",
         "symfony/browser-kit": "2.5.*",


### PR DESCRIPTION
There are some great improvements in the new Predis client, and still works perfectly with Laravel 4.2.

This would allow both the old version and the new version of Predis to be installed
