### PR TITLE
[5.1] Let \Illuminate\Support\Collection be Macroable

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -9,11 +9,14 @@ use CachingIterator;
 use JsonSerializable;
 use IteratorAggregate;
 use InvalidArgumentException;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
 class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable
 {
+    use Macroable;
+
     /**
      * The items contained in the collection.
      *

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -476,6 +476,21 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['dayle', 'shawn'], $data->all());
     }
 
+    public function testMacroable()
+    {
+        // Macro : unique values starting with A
+        Collection::macro('foo', function ($items) {
+            return (new Collection($items))
+                ->filter(function ($item) {
+                    return strpos($item, 'a') === 0;
+                })
+                ->unique()
+                ->values();
+        });
+
+        $this->assertSame(['a', 'aa', 'aaa'], (new Collection)->foo(['a', 'a', 'aa', 'aaa', 'bar'])->toArray());
+    }
+
     public function testMakeMethod()
     {
         $collection = Collection::make('foo');

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -478,17 +478,18 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
     public function testMacroable()
     {
-        // Macro : unique values starting with A
-        Collection::macro('foo', function ($items) {
-            return (new Collection($items))
-                ->filter(function ($item) {
+        // Foo() macro : unique values starting with A
+        Collection::macro('foo', function () {
+            return $this->filter(function ($item) {
                     return strpos($item, 'a') === 0;
                 })
                 ->unique()
                 ->values();
         });
 
-        $this->assertSame(['a', 'aa', 'aaa'], (new Collection)->foo(['a', 'a', 'aa', 'aaa', 'bar'])->toArray());
+        $c = new Collection(['a', 'a', 'aa', 'aaa', 'bar']);
+
+        $this->assertSame(['a', 'aa', 'aaa'], $c->foo()->all());
     }
 
     public function testMakeMethod()


### PR DESCRIPTION
Let `\Illuminate\Support\Collection` be `Macroable`.
Still not sure if `5.2` should be targeted instead of `5.1`
