### PR TITLE
[5.1] Allow local driver to have links argument set

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -128,8 +128,12 @@ class FilesystemManager implements FactoryContract
     {
         $permissions = isset($config['permissions']) ? $config['permissions'] : [];
 
+        $links = (array_get($config, 'links') === 'skip')
+            ? LocalAdapter::SKIP_LINKS
+            : LocalAdapter::DISALLOW_LINKS;
+
         return $this->adapt($this->createFlysystem(new LocalAdapter(
-            $config['root'], LOCK_EX, LocalAdapter::DISALLOW_LINKS, $permissions
+            $config['root'], LOCK_EX, $links, $permissions
         ), $config));
     }
 


### PR DESCRIPTION
Flysystem throws an exception when links are encountered.

There's an argument to change the behavior, see: http://flysystem.thephpleague.com/adapter/local/#links-added-in-108

Currently that argument is hardcoded. This PR allows you to add `'links' => 'skip'` to local driver configs in `filesystems.php`.
