### PR TITLE
[5.1] Added reservation id to IronMQ delete method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",
-        "iron-io/iron_mq": "~2.0 || ~4.0",
+        "iron-io/iron_mq": "~2.0|~4.0",
         "mockery/mockery": "~0.9.1",
         "pda/pheanstalk": "~3.0",
         "phpunit/phpunit": "~4.0",
@@ -103,7 +103,7 @@
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.4).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
         "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers (~5.3|~6.0).",
-        "iron-io/iron_mq": "Required to use the iron queue driver (~2.0).",
+        "iron-io/iron_mq": "Required to use the iron queue driver (~2.0|~4.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",
         "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (~3.0).",

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",
-        "iron-io/iron_mq": "~2.0",
+        "iron-io/iron_mq": "~2.0 || ~4.0",
         "mockery/mockery": "~0.9.1",
         "pda/pheanstalk": "~3.0",
         "phpunit/phpunit": "~4.0",

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -145,11 +145,17 @@ class IronQueue extends Queue implements QueueContract
      *
      * @param  string  $queue
      * @param  string  $id
+     * @param  string  $reservation_id Required for version 3
      * @return void
      */
-    public function deleteMessage($queue, $id)
+    public function deleteMessage($queue, $id, $reservation_id = null)
     {
-        $this->iron->deleteMessage($queue, $id);
+        if ($reservation_id) {
+            $this->iron->deleteMessage($queue, $id, $reservation_id);
+        } else {
+            // Version 1 of API does not use reservation_id
+            $this->iron->deleteMessage($queue, $id);
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -145,13 +145,13 @@ class IronQueue extends Queue implements QueueContract
      *
      * @param  string  $queue
      * @param  string  $id
-     * @param  string  $reservation_id Required for version 3
+     * @param  string|null  $reservation
      * @return void
      */
-    public function deleteMessage($queue, $id, $reservation_id = null)
+    public function deleteMessage($queue, $id, $reservation = null)
     {
-        if ($reservation_id) {
-            $this->iron->deleteMessage($queue, $id, $reservation_id);
+        if ($reservation) {
+            $this->iron->deleteMessage($queue, $id, $reservation);
         } else {
             // Version 1 of API does not use reservation_id
             $this->iron->deleteMessage($queue, $id);

--- a/src/Illuminate/Queue/Jobs/IronJob.php
+++ b/src/Illuminate/Queue/Jobs/IronJob.php
@@ -83,7 +83,9 @@ class IronJob extends Job implements JobContract
             return;
         }
 
-        $this->iron->deleteMessage($this->getQueue(), $this->job->id);
+        $reservation_id = property_exists($this->job, 'reservation_id') ? $this->job->reservation_id : null;
+
+        $this->iron->deleteMessage($this->getQueue(), $this->job->id, $reservation_id);
     }
 
     /**

--- a/src/Illuminate/Queue/Jobs/IronJob.php
+++ b/src/Illuminate/Queue/Jobs/IronJob.php
@@ -84,7 +84,7 @@ class IronJob extends Job implements JobContract
         }
 
         if (property_exists($this->job, 'reservation_id')) {
-            $this->iron->deleteMessage($this->getQueue(), $this->job->id, $reservation_id);
+            $this->iron->deleteMessage($this->getQueue(), $this->job->id, $this->job->reservation_id);
         } else {
             $this->iron->deleteMessage($this->getQueue(), $this->job->id);
         }

--- a/src/Illuminate/Queue/Jobs/IronJob.php
+++ b/src/Illuminate/Queue/Jobs/IronJob.php
@@ -83,9 +83,11 @@ class IronJob extends Job implements JobContract
             return;
         }
 
-        $reservation_id = property_exists($this->job, 'reservation_id') ? $this->job->reservation_id : null;
-
-        $this->iron->deleteMessage($this->getQueue(), $this->job->id, $reservation_id);
+        if (property_exists($this->job, 'reservation_id')) {
+            $this->iron->deleteMessage($this->getQueue(), $this->job->id, $reservation_id);
+        } else {
+            $this->iron->deleteMessage($this->getQueue(), $this->job->id);
+        }
     }
 
     /**

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -39,7 +39,7 @@
     "suggest": {
         "aws/aws-sdk-php": "Required to use the SQS queue driver (~3.0).",
         "illuminate/redis": "Required to use the redis queue driver (5.1.*).",
-        "iron-io/iron_mq": "Required to use the iron queue driver (~2.0).",
+        "iron-io/iron_mq": "Required to use the iron queue driver (~2.0|~4.0).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (~3.0)."
     },
     "minimum-stability": "dev"

--- a/tests/Queue/QueueIronJobTest.php
+++ b/tests/Queue/QueueIronJobTest.php
@@ -21,7 +21,7 @@ class QueueIronJobTest extends PHPUnit_Framework_TestCase
     public function testDeleteRemovesTheJobFromIron()
     {
         $job = $this->getJob();
-        $job->getIron()->shouldReceive('deleteMessage')->once()->with('default', 1);
+        $job->getIron()->shouldReceive('deleteMessage')->once()->with('default', 1, null);
 
         $job->delete();
     }

--- a/tests/Queue/QueueIronJobTest.php
+++ b/tests/Queue/QueueIronJobTest.php
@@ -21,7 +21,7 @@ class QueueIronJobTest extends PHPUnit_Framework_TestCase
     public function testDeleteRemovesTheJobFromIron()
     {
         $job = $this->getJob();
-        $job->getIron()->shouldReceive('deleteMessage')->once()->with('default', 1, null);
+        $job->getIron()->shouldReceive('deleteMessage')->once()->with('default', 1);
 
         $job->delete();
     }


### PR DESCRIPTION
This is required in order to support the v3 API.
IronIO is rapidly moving to the v3 API as it has increased performance.
References Issue #10828 

Due to the incompatibility this likely requires forcing an upgrade of the composer package the is required. Also, there are different endpoints that are defaulted for the new API
Old Endpoint: `mq-aws-us-east-1.iron.io`
New Endpoint: `mq-aws-us-east-1-1.iron.io`
