### PR TITLE
[5.1] Support Class Preloader 3.x as well as 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.5.9",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "classpreloader/classpreloader": "~2.0",
+        "classpreloader/classpreloader": "~2.0|~3.0",
         "danielstjules/stringy": "~1.8",
         "doctrine/inflector": "~1.0",
         "jeremeamia/superclosure": "~2.0",

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -103,7 +103,7 @@ class OptimizeCommand extends Command
     /**
      * Get the class preloader used by the command.
      *
-     * @return \ClassPreloader\Parser\NodeTraverser
+     * @return \ClassPreloader\ClassPreloader
      */
     protected function getClassPreloader()
     {

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -112,9 +112,11 @@ class OptimizeCommand extends Command
         $traverser->addVisitor(new FileVisitor(true));
 
         if (class_exists(StrictTypesVisitor::class)) {
+            // Class Preloader 3.x
             $traverser->addVisitor(new StrictTypesVisitor);
             $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
         } else {
+            // Class Preloader 2.x
             $parser = new Parser(new Lexer);
         }
 

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -108,7 +108,7 @@ class OptimizeCommand extends Command
     {
         // Class Preloader 3.x provides us with a factory class
         if (class_exists(Factory::class)) {
-            return (new Factory)->create(['skip' => true])
+            return (new Factory)->create(['skip' => true]);
         }
 
         $traverser = new NodeTraverser();


### PR DESCRIPTION
This means we can now support people who want to use either php parser 1.x or 2.x with laravel instead of forcing them to use php parser 1.x.
