### PR TITLE
[5.1] Add Collection::except and Collection::only methods

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -162,6 +162,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Get all items except for those with the specified keys.
+     *
+     * @param  mixed  $keys
+     * @return static
+     */
+    public function except($keys)
+    {
+        return new static(Arr::except($this->items, $keys));
+    }
+
+    /**
      * Fetch a nested element of the collection.
      *
      * @param  string  $key
@@ -494,6 +505,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
             return is_null($result) || $value < $result ? $value : $result;
         });
+    }
+
+    /**
+     * Get the items with the specified keys.
+     *
+     * @param  mixed  $keys
+     * @return static
+     */
+    public function only($keys)
+    {
+        return new static(Arr::only($this->items, $keys));
     }
 
     /**


### PR DESCRIPTION
For completeness with `Arr` and `Eloquent\Collection` (#3387, [commit](https://github.com/laravel/framework/commit/a084f61690d10a58645a28ebf835809bd6aae99f)) which have these methods. (edit: and `Request` class also)

If you agree with this PR, I shall add documentation as well.
