### PR TITLE
[5.1] Fix query builder pagination count

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1465,8 +1465,8 @@ class Builder
         // so we don't break "count()" compatibility and "where" dependencies
         $this->aggregate = [
             'function' => 'count',
-            'columns' => $this->clearSelectAliases($columns),
-            'helpers' => $this->onlySelectAliases($columns),
+            'columns' => $this->clearSelectForCount($columns),
+            'helpers' => $this->rawSelectForCount($columns),
         ];
 
         $results = $this->get();
@@ -1508,12 +1508,16 @@ class Builder
      * @param  array  $columns
      * @return array
      */
-    protected function clearSelectAliases(array $columns)
+    protected function clearSelectForCount(array $columns)
     {
-        return array_map(function ($column) {
-            return is_string($column) && ($aliasPosition = strpos(strtolower($column), ' as ')) !== false
+        return array_filter(array_map(function ($column) {
+            if (! is_string($column)) {
+                return;
+            }
+
+            return ($aliasPosition = strpos(strtolower($column), ' as ')) !== false
                     ? substr($column, 0, $aliasPosition) : $column;
-        }, $columns);
+        }, $columns));
     }
 
     /**
@@ -1522,10 +1526,10 @@ class Builder
      * @param  array  $columns
      * @return array
      */
-    protected function onlySelectAliases(array $columns)
+    protected function rawSelectForCount(array $columns)
     {
         return array_filter($columns, function ($column) {
-            return strpos(strtolower($column), ' as ') !== false;
+            return ! is_string($column) || strpos(strtolower($column), ' as ') !== false;
         });
     }
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -84,7 +84,14 @@ class Grammar extends BaseGrammar
             $column = 'distinct '.$column;
         }
 
-        return 'select '.$aggregate['function'].'('.$column.') as aggregate';
+        $select = 'select '.$aggregate['function'].'('.$column.') as aggregate';
+
+        // Append fields for "where" conditions that depend on them
+        if (isset($aggregate['helpers']) && ! empty($aggregate['helpers'])) {
+            $select .= ', '.$this->columnize($aggregate['helpers']);
+        }
+
+        return $select;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -575,6 +575,21 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $count);
     }
 
+    public function testGetCountForPaginationWithColumnAliasesAndExpressions()
+    {
+        $builder = $this->getBuilder();
+        $columns = ['body as post_body', 'teaser', new \Illuminate\Database\Query\Expression('"test" as "foo"')];
+        $builder->from('posts')->select($columns);
+
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->with('select count("body", "teaser") as aggregate, "body" as "post_body", "test" as "foo" from "posts"', [], true)
+            ->andReturn([['aggregate' => 1]]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) { return $results; });
+
+        $count = $builder->getCountForPagination($columns);
+        $this->assertEquals(1, $count);
+    }
+
     public function testWhereShortcut()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -566,7 +566,9 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $columns = ['body as post_body', 'teaser', 'posts.created as published'];
         $builder->from('posts')->select($columns);
 
-        $builder->getConnection()->shouldReceive('select')->once()->with('select count("body", "teaser", "posts"."created") as aggregate from "posts"', [], true)->andReturn([['aggregate' => 1]]);
+        $builder->getConnection()->shouldReceive('select')->once()
+            ->with('select count("body", "teaser", "posts"."created") as aggregate, "body" as "post_body", "posts"."created" as "published" from "posts"', [], true)
+            ->andReturn([['aggregate' => 1]]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturnUsing(function ($builder, $results) { return $results; });
 
         $count = $builder->getCountForPagination($columns);


### PR DESCRIPTION
Fix for #10855

After this change aliased columns are appended to `select` so we keep their names for using in `where` statements.

```
DB::table('posts')->select(['posts.body as b'])->where('b', '!=', 'foo')->paginate();
>>
select count("posts"."body") as aggreagte, "posts"."body" as "b" where "b" != 'foo'
```

I've tested this in MySQL and PostgreSQL locally - looks like working. But I think unit tests should be improved anyway.

**update**

It looks quite difficult with using expressions as far as they may contain sub queries with own aliases.

``` php
DB::table('foo')
    ->select([
        DB::raw('(select count(*) from bar where foo_id=foo.id) as bar_count'), 
        'foo.*'
    ])
    ->paginate();
```

So this makes cleaning very buggy when trimming `as` in expressions. So the only posible thing I see here is to remove expressions from `count()` and append them to `select`

I left two commits so you can see two steps: first resolving aliases problem with simple selects and second with expressions.
