### PR TITLE
[5.1] Update hydrate to handle binary stream resources

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -516,8 +516,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             // cache correctly. Doing this allows proper attribute mutation and
             // type casting without any headache or checking which database
             // system we are using before doing business logic.
-            // 
-            // See: https://github.com/laravel/framework/issues/10847
             foreach ($item as $column => &$datum) {
                 if (is_resource($datum)) {
                     $datum = stream_get_contents($datum);


### PR DESCRIPTION
`Eloquent->hydrate` now runs `stream_get_contents` on resource columns before passing them into the model.
This resolves an issue where it is impossible to adequately deal with binary data from PostgreSQL.
https://github.com/laravel/framework/issues/10847
