### PR TITLE
[5.1] Some cleanup in tests

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1364,17 +1364,6 @@ class EloquentModelSaveStub extends Model
     }
 }
 
-class EloquentModelFindStub extends Model
-{
-    public function newQuery()
-    {
-        $mock = m::mock('Illuminate\Database\Eloquent\Builder');
-        $mock->shouldReceive('find')->once()->with(1, ['*'])->andReturn('foo');
-
-        return $mock;
-    }
-}
-
 class EloquentModelFindWithWritePdoStub extends Model
 {
     public function newQuery()
@@ -1411,17 +1400,6 @@ class EloquentModelHydrateRawStub extends Model
     {
         $mock = m::mock('Illuminate\Database\Connection');
         $mock->shouldReceive('select')->once()->with('SELECT ?', ['foo'])->andReturn([]);
-
-        return $mock;
-    }
-}
-
-class EloquentModelFindManyStub extends Model
-{
-    public function newQuery()
-    {
-        $mock = m::mock('Illuminate\Database\Eloquent\Builder');
-        $mock->shouldReceive('find')->once()->with([1, 2], ['*'])->andReturn('foo');
 
         return $mock;
     }

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -233,10 +233,3 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
 class EloquentMorphResetModelStub extends Illuminate\Database\Eloquent\Model
 {
 }
-
-class EloquentMorphQueryStub extends Illuminate\Database\Query\Builder
-{
-    public function __construct()
-    {
-    }
-}

--- a/tests/Support/stubs/providers/SuperProvider.php
+++ b/tests/Support/stubs/providers/SuperProvider.php
@@ -1,8 +1,0 @@
-<?php
-
-class SuperProvider extends Illuminate\Support\ServiceProvider
-{
-    public function register()
-    {
-    }
-}

--- a/tests/Support/stubs/providers/SuperSuperProvider.php
+++ b/tests/Support/stubs/providers/SuperSuperProvider.php
@@ -1,8 +1,0 @@
-<?php
-
-class SuperSuperProvider extends Illuminate\Support\ServiceProvider
-{
-    public function register()
-    {
-    }
-}


### PR DESCRIPTION
- `EloquentModelFindStub` and `EloquentModelFindManyStub` not used since #8822.
- `EloquentMorphQueryStub` has apparently never been used.
- `SuperProvider.php` and `SuperSuperProvider.php` not used since https://github.com/laravel/framework/commit/6bae9b5b2c60767d91ed18f198859998af4d81f4.
