### PR TITLE
[5.1] Fixes morphTo relationships being named with snake case attributes in…

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -104,6 +104,10 @@ class MorphTo extends BelongsTo
      */
     public function match(array $models, Collection $results, $relation)
     {
+        foreach (array_keys($this->dictionary) as $type) {
+            $this->matchToMorphParents($type, $this->getResultsByType($type), $relation);
+        }
+
         return $models;
     }
 
@@ -137,34 +141,18 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Get the results of the relationship.
-     *
-     * Called via eager load method of Eloquent query builder.
-     *
-     * @return mixed
-     */
-    public function getEager()
-    {
-        foreach (array_keys($this->dictionary) as $type) {
-            $this->matchToMorphParents($type, $this->getResultsByType($type));
-        }
-
-        return $this->models;
-    }
-
-    /**
      * Match the results for a given type to their parents.
      *
-     * @param  string  $type
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
-     * @return void
+     * @param  string $type
+     * @param  \Illuminate\Database\Eloquent\Collection $results
+     * @param string $relation
      */
-    protected function matchToMorphParents($type, Collection $results)
+    protected function matchToMorphParents($type, Collection $results, $relation)
     {
         foreach ($results as $result) {
             if (isset($this->dictionary[$type][$result->getKey()])) {
                 foreach ($this->dictionary[$type][$result->getKey()] as $model) {
-                    $model->setRelation($this->relation, $result);
+                    $model->setRelation($relation, $result);
                 }
             }
         }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -77,7 +77,7 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
         $two->shouldReceive('setRelation')->once()->with('relation', $resultOne);
         $three->shouldReceive('setRelation')->once()->with('relation', $resultTwo);
 
-        $relation->getEager();
+        $relation->match([$one, $two, $three], Collection::make([$resultOne, $resultTwo]), 'relation');
     }
 
     public function testModelsWithSoftDeleteAreProperlyPulled()


### PR DESCRIPTION
This fixes the case where `morphTo` relationship is eagerly loaded and the parent model has the related model keyed by a snake cased attribute (`MorphTo->relationship`) rather then the camel cased relationship name that is passed to the `match` function.

This also bring the `morphTo` relationship in line with the other relationships that load the relationship into the model in the `match` function, rather than an extended `getEager` method.

See https://github.com/laravel/framework/issues/10501 for related issue.
