### PR TITLE
[5.2] Rename "lists" to "pluck" in the query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -224,9 +224,9 @@ class Builder
      * @param  string  $key
      * @return \Illuminate\Support\Collection
      */
-    public function lists($column, $key = null)
+    public function pluck($column, $key = null)
     {
-        $results = $this->query->lists($column, $key);
+        $results = $this->query->pluck($column, $key);
 
         // If the model has a mutator for the requested column, we will spin through
         // the results and mutate the values so that the mutated version of these
@@ -240,6 +240,18 @@ class Builder
         }
 
         return collect($results);
+    }
+
+    /**
+     * Alias for the "pluck" method.
+     *
+     * @param  string  $column
+     * @param  string  $key
+     * @return \Illuminate\Support\Collection
+     */
+    public function lists($column, $key = null)
+    {
+        return $this->pluck($column, $key);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -536,7 +536,7 @@ class BelongsToMany extends Relation
 
         $fullKey = $related->getQualifiedKeyName();
 
-        return $this->getQuery()->select($fullKey)->lists($related->getKeyName());
+        return $this->getQuery()->select($fullKey)->pluck($related->getKeyName());
     }
 
     /**
@@ -766,7 +766,7 @@ class BelongsToMany extends Relation
         // First we need to attach any of the associated models that are not currently
         // in this joining table. We'll spin through the given IDs, checking to see
         // if they exist in the array of current ones, and if not we will insert.
-        $current = $this->newPivotQuery()->lists($this->otherKey);
+        $current = $this->newPivotQuery()->pluck($this->otherKey);
 
         $records = $this->formatSyncList($ids);
 

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -50,7 +50,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
         return $this->table()
                 ->orderBy('batch', 'asc')
                 ->orderBy('migration', 'asc')
-                ->lists('migration');
+                ->pluck('migration');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1586,7 +1586,7 @@ class Builder
      */
     public function implode($column, $glue = '')
     {
-        return implode($glue, $this->lists($column));
+        return implode($glue, $this->pluck($column));
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1535,9 +1535,9 @@ class Builder
      * @param  string  $key
      * @return array
      */
-    public function lists($column, $key = null)
+    public function pluck($column, $key = null)
     {
-        $columns = $this->getListSelect($column, $key);
+        $columns = $this->getPluckSelect($column, $key);
 
         $results = new Collection($this->get($columns));
 
@@ -1545,17 +1545,29 @@ class Builder
     }
 
     /**
-     * Get the columns that should be used in a list array.
+     * Alias for the "pluck" method.
      *
      * @param  string  $column
      * @param  string  $key
      * @return array
      */
-    protected function getListSelect($column, $key)
+    public function lists($column, $key = null)
+    {
+        return $this->pluck($column, $key);
+    }
+
+    /**
+     * Get the columns that should be used in a pluck select.
+     *
+     * @param  string  $column
+     * @param  string  $key
+     * @return array
+     */
+    protected function getPluckSelect($column, $key)
     {
         $select = is_null($key) ? [$column] : [$column, $key];
 
-        // If the selected column contains a "dot", we will remove it so that the list
+        // If the selected columns contain "dots", we will remove it so that the pluck
         // operation can run normally. Specifying the table is not needed, since we
         // really want the names of the columns as it is in this resulting array.
         return array_map(function ($column) {

--- a/tests/Database/DatabaseEloquentBelongsToManyTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyTest.php
@@ -399,7 +399,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
-        $query->shouldReceive('lists')->once()->with('role_id')->andReturn([1, 2, 3]);
+        $query->shouldReceive('pluck')->once()->with('role_id')->andReturn([1, 2, 3]);
         $relation->expects($this->once())->method('attach')->with($this->equalTo('x'), $this->equalTo([]), $this->equalTo(false));
         $relation->expects($this->once())->method('detach')->with($this->equalTo([1]));
         $relation->getRelated()->shouldReceive('touches')->andReturn(false);
@@ -424,7 +424,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
-        $query->shouldReceive('lists')->once()->with('role_id')->andReturn([1, 2, 3]);
+        $query->shouldReceive('pluck')->once()->with('role_id')->andReturn([1, 2, 3]);
         $relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(['foo' => 'bar']), $this->equalTo(false));
         $relation->expects($this->once())->method('updateExistingPivot')->with($this->equalTo(3), $this->equalTo(['baz' => 'qux']), $this->equalTo(false))->will($this->returnValue(true));
         $relation->expects($this->once())->method('detach')->with($this->equalTo([1]));
@@ -441,7 +441,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
-        $query->shouldReceive('lists')->once()->with('role_id')->andReturn([1, 2, 3]);
+        $query->shouldReceive('pluck')->once()->with('role_id')->andReturn([1, 2, 3]);
         $relation->expects($this->once())->method('attach')->with($this->equalTo(4), $this->equalTo(['foo' => 'bar']), $this->equalTo(false));
         $relation->expects($this->once())->method('updateExistingPivot')->with($this->equalTo(3), $this->equalTo(['baz' => 'qux']), $this->equalTo(false))->will($this->returnValue(false));
         $relation->expects($this->once())->method('detach')->with($this->equalTo([1]));
@@ -457,7 +457,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $relation->getRelated()->shouldReceive('freshTimestamp')->andReturn(100);
         $relation->getRelated()->shouldReceive('getQualifiedKeyName')->andReturn('table.id');
         $relation->getQuery()->shouldReceive('select')->once()->with('table.id')->andReturn($relation->getQuery());
-        $relation->getQuery()->shouldReceive('lists')->once()->with('id')->andReturn([1, 2, 3]);
+        $relation->getQuery()->shouldReceive('pluck')->once()->with('id')->andReturn([1, 2, 3]);
         $relation->getRelated()->shouldReceive('newQuery')->once()->andReturn($query = m::mock('StdClass'));
         $query->shouldReceive('whereIn')->once()->with('id', [1, 2, 3])->andReturn($query);
         $query->shouldReceive('update')->once()->with(['updated_at' => 100]);
@@ -484,7 +484,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $query->shouldReceive('where')->once()->with('user_id', 1)->andReturn($query);
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock('StdClass'));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
-        $query->shouldReceive('lists')->once()->with('role_id')->andReturn([1, 2, 3]);
+        $query->shouldReceive('pluck')->once()->with('role_id')->andReturn([1, 2, 3]);
 
         $collection = m::mock('Illuminate\Database\Eloquent\Collection');
         $collection->shouldReceive('modelKeys')->once()->andReturn([1, 2, 3]);
@@ -515,7 +515,7 @@ class DatabaseEloquentBelongsToManyTest extends PHPUnit_Framework_TestCase
         $query->shouldReceive('where')->once()->with('foo', '=', 'bar')->andReturn($query);
 
         // This is so $relation->sync() works
-        $query->shouldReceive('lists')->once()->with('role_id')->andReturn([1, 2, 3]);
+        $query->shouldReceive('pluck')->once()->with('role_id')->andReturn([1, 2, 3]);
         $relation->expects($this->once())->method('formatSyncList')->with([1, 2, 3])->will($this->returnValue([1 => [], 2 => [], 3 => []]));
 
         $relation = $relation->wherePivot('foo', '=', 'bar'); // these params are to be stored

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -192,19 +192,19 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         });
     }
 
-    public function testListsReturnsTheMutatedAttributesOfAModel()
+    public function testPluckReturnsTheMutatedAttributesOfAModel()
     {
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(['bar', 'baz']);
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasGetMutator')->with('name')->andReturn(true);
-        $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'bar'])->andReturn(new EloquentBuilderTestListsStub(['name' => 'bar']));
-        $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'baz'])->andReturn(new EloquentBuilderTestListsStub(['name' => 'baz']));
+        $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'bar'])->andReturn(new EloquentBuilderTestPluckStub(['name' => 'bar']));
+        $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'baz'])->andReturn(new EloquentBuilderTestPluckStub(['name' => 'baz']));
 
         $this->assertEquals(['foo_bar', 'foo_baz'], $builder->pluck('name')->all());
     }
 
-    public function testListsWithoutModelGetterJustReturnTheAttributesFoundInDatabase()
+    public function testPluckWithoutModelGetterJustReturnTheAttributesFoundInDatabase()
     {
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(['bar', 'baz']);
@@ -543,7 +543,7 @@ class EloquentBuilderTestNestedStub extends Illuminate\Database\Eloquent\Model
     use Illuminate\Database\Eloquent\SoftDeletes;
 }
 
-class EloquentBuilderTestListsStub
+class EloquentBuilderTestPluckStub
 {
     protected $attributes;
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -195,23 +195,23 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
     public function testListsReturnsTheMutatedAttributesOfAModel()
     {
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('lists')->with('name', '')->andReturn(['bar', 'baz']);
+        $builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(['bar', 'baz']);
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasGetMutator')->with('name')->andReturn(true);
         $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'bar'])->andReturn(new EloquentBuilderTestListsStub(['name' => 'bar']));
         $builder->getModel()->shouldReceive('newFromBuilder')->with(['name' => 'baz'])->andReturn(new EloquentBuilderTestListsStub(['name' => 'baz']));
 
-        $this->assertEquals(['foo_bar', 'foo_baz'], $builder->lists('name')->all());
+        $this->assertEquals(['foo_bar', 'foo_baz'], $builder->pluck('name')->all());
     }
 
     public function testListsWithoutModelGetterJustReturnTheAttributesFoundInDatabase()
     {
         $builder = $this->getBuilder();
-        $builder->getQuery()->shouldReceive('lists')->with('name', '')->andReturn(['bar', 'baz']);
+        $builder->getQuery()->shouldReceive('pluck')->with('name', '')->andReturn(['bar', 'baz']);
         $builder->setModel($this->getMockModel());
         $builder->getModel()->shouldReceive('hasGetMutator')->with('name')->andReturn(false);
 
-        $this->assertEquals(['bar', 'baz'], $builder->lists('name')->all());
+        $this->assertEquals(['bar', 'baz'], $builder->pluck('name')->all());
     }
 
     public function testMacrosAreCalledOnBuilder()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -167,13 +167,13 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(3, $query->getCountForPagination());
     }
 
-    public function testListsRetrieval()
+    public function testPluck()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
 
-        $simple = EloquentTestUser::oldest('id')->lists('users.email')->all();
-        $keyed = EloquentTestUser::oldest('id')->lists('users.email', 'users.id')->all();
+        $simple = EloquentTestUser::oldest('id')->pluck('users.email')->all();
+        $keyed = EloquentTestUser::oldest('id')->pluck('users.email', 'users.id')->all();
 
         $this->assertEquals(['taylorotwell@gmail.com', 'abigailotwell@gmail.com'], $simple);
         $this->assertEquals([1 => 'taylorotwell@gmail.com', 2 => 'abigailotwell@gmail.com'], $keyed);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -513,7 +513,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $model->id);
         $this->assertTrue($model->exists);
         $this->assertEquals(2, count($model->relationMany));
-        $this->assertEquals([2, 3], $model->relationMany->lists('id')->all());
+        $this->assertEquals([2, 3], $model->relationMany->pluck('id')->all());
     }
 
     public function testNewQueryReturnsEloquentQueryBuilder()

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -19,7 +19,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
         $query->shouldReceive('orderBy')->once()->with('batch', 'asc')->andReturn($query);
         $query->shouldReceive('orderBy')->once()->with('migration', 'asc')->andReturn($query);
-        $query->shouldReceive('lists')->once()->with('migration')->andReturn('bar');
+        $query->shouldReceive('pluck')->once()->with('migration')->andReturn('bar');
 
         $this->assertEquals('bar', $repo->getRan());
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -757,7 +757,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar'], ['foo' => 'baz']])->andReturnUsing(function ($query, $results) {
             return $results;
         });
-        $results = $builder->from('users')->where('id', '=', 1)->lists('foo');
+        $results = $builder->from('users')->where('id', '=', 1)->pluck('foo');
         $this->assertEquals(['bar', 'baz'], $results);
 
         $builder = $this->getBuilder();
@@ -765,7 +765,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['id' => 1, 'foo' => 'bar'], ['id' => 10, 'foo' => 'baz']])->andReturnUsing(function ($query, $results) {
             return $results;
         });
-        $results = $builder->from('users')->where('id', '=', 1)->lists('foo', 'id');
+        $results = $builder->from('users')->where('id', '=', 1)->pluck('foo', 'id');
         $this->assertEquals([1 => 'bar', 10 => 'baz'], $results);
     }
 


### PR DESCRIPTION
...to be consistent with `Collection@pluck`, `Arr::pluck` and `array_pluck`.

Keeping `lists` as an alias.
