### PR TITLE
[5.2] pagination presenters return Htmlable object

### DIFF
--- a/src/Illuminate/Contracts/Pagination/Presenter.php
+++ b/src/Illuminate/Contracts/Pagination/Presenter.php
@@ -7,7 +7,7 @@ interface Presenter
     /**
      * Render the given paginator.
      *
-     * @return \Illuminate\View\Expression|string
+     * @return \Illuminate\Contracts\Support\Htmlable|string
      */
     public function render();
 

--- a/src/Illuminate/Contracts/Pagination/Presenter.php
+++ b/src/Illuminate/Contracts/Pagination/Presenter.php
@@ -7,7 +7,7 @@ interface Presenter
     /**
      * Render the given paginator.
      *
-     * @return \Illuminate\View\Expression
+     * @return \Illuminate\View\Expression|string
      */
     public function render();
 

--- a/src/Illuminate/Contracts/Pagination/Presenter.php
+++ b/src/Illuminate/Contracts/Pagination/Presenter.php
@@ -7,7 +7,7 @@ interface Presenter
     /**
      * Render the given paginator.
      *
-     * @return string
+     * @return \Illuminate\View\Expression
      */
     public function render();
 

--- a/src/Illuminate/Pagination/BootstrapThreePresenter.php
+++ b/src/Illuminate/Pagination/BootstrapThreePresenter.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Pagination;
 
-use Illuminate\View\Expression;
+use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\Pagination\Paginator as PaginatorContract;
 use Illuminate\Contracts\Pagination\Presenter as PresenterContract;
 
@@ -55,7 +55,7 @@ class BootstrapThreePresenter implements PresenterContract
     public function render()
     {
         if ($this->hasPages()) {
-            return new Expression(sprintf(
+            return new HtmlString(sprintf(
                 '<ul class="pagination">%s %s %s</ul>',
                 $this->getPreviousButton(),
                 $this->getLinks(),

--- a/src/Illuminate/Pagination/BootstrapThreePresenter.php
+++ b/src/Illuminate/Pagination/BootstrapThreePresenter.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Pagination;
 
+use Illuminate\View\Expression;
 use Illuminate\Contracts\Pagination\Paginator as PaginatorContract;
 use Illuminate\Contracts\Pagination\Presenter as PresenterContract;
 
@@ -49,17 +50,17 @@ class BootstrapThreePresenter implements PresenterContract
     /**
      * Convert the URL window into Bootstrap HTML.
      *
-     * @return string
+     * @return \Illuminate\View\Expression
      */
     public function render()
     {
         if ($this->hasPages()) {
-            return sprintf(
+            return new Expression(sprintf(
                 '<ul class="pagination">%s %s %s</ul>',
                 $this->getPreviousButton(),
                 $this->getLinks(),
                 $this->getNextButton()
-            );
+            ));
         }
 
         return '';

--- a/src/Illuminate/Pagination/SimpleBootstrapThreePresenter.php
+++ b/src/Illuminate/Pagination/SimpleBootstrapThreePresenter.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Pagination;
 
-use Illuminate\View\Expression;
+use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\Pagination\Paginator as PaginatorContract;
 
 class SimpleBootstrapThreePresenter extends BootstrapThreePresenter
@@ -36,7 +36,7 @@ class SimpleBootstrapThreePresenter extends BootstrapThreePresenter
     public function render()
     {
         if ($this->hasPages()) {
-            return new Expression(sprintf(
+            return new HtmlString(sprintf(
                 '<ul class="pager">%s %s</ul>',
                 $this->getPreviousButton(),
                 $this->getNextButton()

--- a/src/Illuminate/Pagination/SimpleBootstrapThreePresenter.php
+++ b/src/Illuminate/Pagination/SimpleBootstrapThreePresenter.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Pagination;
 
+use Illuminate\View\Expression;
 use Illuminate\Contracts\Pagination\Paginator as PaginatorContract;
 
 class SimpleBootstrapThreePresenter extends BootstrapThreePresenter
@@ -30,16 +31,16 @@ class SimpleBootstrapThreePresenter extends BootstrapThreePresenter
     /**
      * Convert the URL window into Bootstrap HTML.
      *
-     * @return string
+     * @return \Illuminate\View\Expression
      */
     public function render()
     {
         if ($this->hasPages()) {
-            return sprintf(
+            return new Expression(sprintf(
                 '<ul class="pager">%s %s</ul>',
                 $this->getPreviousButton(),
                 $this->getNextButton()
-            );
+            ));
         }
 
         return '';

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": ">=5.5.9",
         "illuminate/contracts": "5.2.*",
-        "illuminate/support": "5.2.*"
+        "illuminate/support": "5.2.*",
+        "illuminate/view": "5.2.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -16,8 +16,7 @@
     "require": {
         "php": ">=5.5.9",
         "illuminate/contracts": "5.2.*",
-        "illuminate/support": "5.2.*",
-        "illuminate/view": "5.2.*"
+        "illuminate/support": "5.2.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Make the pagination contracts return an instance of
`Illuminate\View\Expression` so that safe blade tags can be used.

Same as #10878 but for the 5.2 branch
