### PR TITLE
[5.2] Deprecate View\Expression

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
+use Illuminate\Support\HtmlString;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate;
 
@@ -205,7 +206,7 @@ if (! function_exists('csrf_field')) {
      */
     function csrf_field()
     {
-        return new Illuminate\View\Expression('<input type="hidden" name="_token" value="'.csrf_token().'">');
+        return new HtmlString('<input type="hidden" name="_token" value="'.csrf_token().'">');
     }
 }
 
@@ -442,7 +443,7 @@ if (! function_exists('method_field')) {
      */
     function method_field($method)
     {
-        return new Illuminate\View\Expression('<input type="hidden" name="_method" value="'.$method.'">');
+        return new HtmlString('<input type="hidden" name="_method" value="'.$method.'">');
     }
 }
 

--- a/src/Illuminate/View/Expression.php
+++ b/src/Illuminate/View/Expression.php
@@ -2,45 +2,11 @@
 
 namespace Illuminate\View;
 
-use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HtmlString;
 
-class Expression implements Htmlable
+/**
+ * @deprecated since version 5.2.
+ */
+class Expression extends HtmlString
 {
-    /**
-     * The HTML string.
-     *
-     * @var string
-     */
-    protected $html;
-
-    /**
-     * Create a new HTML string instance.
-     *
-     * @param  string  $html
-     * @return void
-     */
-    public function __construct($html)
-    {
-        $this->html = $html;
-    }
-
-    /**
-     * Get the the HTML string.
-     *
-     * @return string
-     */
-    public function toHtml()
-    {
-        return $this->html;
-    }
-
-    /**
-     * Get the the HTML string.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->toHtml();
-    }
 }


### PR DESCRIPTION
It completely duplicates `HtmlString` which is available in `Support` package.
