### PR TITLE
[5.2] Use ::class notation

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -147,7 +147,7 @@ class BroadcastManager implements FactoryContract
     protected function createLogDriver(array $config)
     {
         return new LogBroadcaster(
-            $this->app->make('Psr\Log\LoggerInterface')
+            $this->app->make(\Psr\Log\LoggerInterface::class)
         );
     }
 

--- a/src/Illuminate/Broadcasting/BroadcastServiceProvider.php
+++ b/src/Illuminate/Broadcasting/BroadcastServiceProvider.php
@@ -20,16 +20,16 @@ class BroadcastServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('Illuminate\Broadcasting\BroadcastManager', function ($app) {
+        $this->app->singleton(\Illuminate\Broadcasting\BroadcastManager::class, function ($app) {
             return new BroadcastManager($app);
         });
 
-        $this->app->singleton('Illuminate\Contracts\Broadcasting\Broadcaster', function ($app) {
-            return $app->make('Illuminate\Broadcasting\BroadcastManager')->connection();
+        $this->app->singleton(\Illuminate\Contracts\Broadcasting\Broadcaster::class, function ($app) {
+            return $app->make(\Illuminate\Broadcasting\BroadcastManager::class)->connection();
         });
 
         $this->app->alias(
-            'Illuminate\Broadcasting\BroadcastManager', 'Illuminate\Contracts\Broadcasting\Factory'
+            \Illuminate\Broadcasting\BroadcastManager::class, \Illuminate\Contracts\Broadcasting\Factory::class
         );
     }
 
@@ -41,9 +41,9 @@ class BroadcastServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'Illuminate\Broadcasting\BroadcastManager',
-            'Illuminate\Contracts\Broadcasting\Factory',
-            'Illuminate\Contracts\Broadcasting\Broadcaster',
+            \Illuminate\Broadcasting\BroadcastManager::class,
+            \Illuminate\Contracts\Broadcasting\Factory::class,
+            \Illuminate\Contracts\Broadcasting\Broadcaster::class,
         ];
     }
 }

--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -20,18 +20,18 @@ class BusServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('Illuminate\Bus\Dispatcher', function ($app) {
+        $this->app->singleton(\Illuminate\Bus\Dispatcher::class, function ($app) {
             return new Dispatcher($app, function () use ($app) {
-                return $app['Illuminate\Contracts\Queue\Queue'];
+                return $app[\Illuminate\Contracts\Queue\Queue::class];
             });
         });
 
         $this->app->alias(
-            'Illuminate\Bus\Dispatcher', 'Illuminate\Contracts\Bus\Dispatcher'
+            \Illuminate\Bus\Dispatcher::class, \Illuminate\Contracts\Bus\Dispatcher::class
         );
 
         $this->app->alias(
-            'Illuminate\Bus\Dispatcher', 'Illuminate\Contracts\Bus\QueueingDispatcher'
+            \Illuminate\Bus\Dispatcher::class, \Illuminate\Contracts\Bus\QueueingDispatcher::class
         );
     }
 
@@ -43,9 +43,9 @@ class BusServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'Illuminate\Bus\Dispatcher',
-            'Illuminate\Contracts\Bus\Dispatcher',
-            'Illuminate\Contracts\Bus\QueueingDispatcher',
+            \Illuminate\Bus\Dispatcher::class,
+            \Illuminate\Contracts\Bus\Dispatcher::class,
+            \Illuminate\Contracts\Bus\QueueingDispatcher::class,
         ];
     }
 }

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -218,7 +218,7 @@ class Dispatcher implements DispatcherContract, QueueingDispatcher, HandlerResol
         }
 
         return (new ReflectionClass($this->getHandlerClass($command)))->implementsInterface(
-            'Illuminate\Contracts\Queue\ShouldQueue'
+            \Illuminate\Contracts\Queue\ShouldQueue::class
         );
     }
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -232,9 +232,9 @@ class CacheManager implements FactoryContract
     {
         $repository = new Repository($store);
 
-        if ($this->app->bound('Illuminate\Contracts\Events\Dispatcher')) {
+        if ($this->app->bound(\Illuminate\Contracts\Events\Dispatcher::class)) {
             $repository->setEventDispatcher(
-                $this->app['Illuminate\Contracts\Events\Dispatcher']
+                $this->app[\Illuminate\Contracts\Events\Dispatcher::class]
             );
         }
 

--- a/src/Illuminate/Console/ScheduleServiceProvider.php
+++ b/src/Illuminate/Console/ScheduleServiceProvider.php
@@ -20,7 +20,7 @@ class ScheduleServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->commands('Illuminate\Console\Scheduling\ScheduleRunCommand');
+        $this->commands(\Illuminate\Console\Scheduling\ScheduleRunCommand::class);
     }
 
     /**
@@ -31,7 +31,7 @@ class ScheduleServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'Illuminate\Console\Scheduling\ScheduleRunCommand',
+            \Illuminate\Console\Scheduling\ScheduleRunCommand::class,
         ];
     }
 }

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -77,7 +77,7 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     protected function registerQueueableEntityResolver()
     {
-        $this->app->singleton('Illuminate\Contracts\Queue\EntityResolver', function () {
+        $this->app->singleton(\Illuminate\Contracts\Queue\EntityResolver::class, function () {
             return new QueueEntityResolver;
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -123,7 +123,7 @@ class HasManyThrough extends Relation
      */
     public function parentSoftDeletes()
     {
-        return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses_recursive(get_class($this->parent)));
+        return in_array(\Illuminate\Database\Eloquent\SoftDeletes::class, class_uses_recursive(get_class($this->parent)));
     }
 
     /**

--- a/src/Illuminate/Events/CallQueuedHandler.php
+++ b/src/Illuminate/Events/CallQueuedHandler.php
@@ -56,7 +56,7 @@ class CallQueuedHandler
      */
     protected function setJobInstanceIfNecessary(Job $job, $instance)
     {
-        if (in_array('Illuminate\Queue\InteractsWithQueue', class_uses_recursive(get_class($instance)))) {
+        if (in_array(\Illuminate\Queue\InteractsWithQueue::class, class_uses_recursive(get_class($instance)))) {
             $instance->setJob($job);
         }
 

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -257,7 +257,7 @@ class Dispatcher implements DispatcherContract
 
             $queue = method_exists($event, 'onQueue') ? $event->onQueue() : null;
 
-            $this->resolveQueue()->connection($connection)->pushOn($queue, 'Illuminate\Broadcasting\BroadcastEvent', [
+            $this->resolveQueue()->connection($connection)->pushOn($queue, \Illuminate\Broadcasting\BroadcastEvent::class, [
                 'event' => serialize(clone $event),
             ]);
         }
@@ -390,7 +390,7 @@ class Dispatcher implements DispatcherContract
     {
         try {
             return (new ReflectionClass($class))->implementsInterface(
-                'Illuminate\Contracts\Queue\ShouldQueue'
+                \Illuminate\Contracts\Queue\ShouldQueue::class
             );
         } catch (Exception $e) {
             return false;

--- a/src/Illuminate/Events/EventServiceProvider.php
+++ b/src/Illuminate/Events/EventServiceProvider.php
@@ -15,7 +15,7 @@ class EventServiceProvider extends ServiceProvider
     {
         $this->app->singleton('events', function ($app) {
             return (new Dispatcher($app))->setQueueResolver(function () use ($app) {
-                return $app->make('Illuminate\Contracts\Queue\Factory');
+                return $app->make(\Illuminate\Contracts\Queue\Factory::class);
             });
         });
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -172,7 +172,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
 
         $this->instance('app', $this);
 
-        $this->instance('Illuminate\Container\Container', $this);
+        $this->instance(\Illuminate\Container\Container::class, $this);
     }
 
     /**
@@ -215,7 +215,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function afterLoadingEnvironment(Closure $callback)
     {
         return $this->afterBootstrapping(
-            'Illuminate\Foundation\Bootstrap\DetectEnvironment', $callback
+            \Illuminate\Foundation\Bootstrap\DetectEnvironment::class, $callback
         );
     }
 
@@ -779,7 +779,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function handle(SymfonyRequest $request, $type = self::MASTER_REQUEST, $catch = true)
     {
-        return $this['Illuminate\Contracts\Http\Kernel']->handle(Request::createFromBase($request));
+        return $this[\Illuminate\Contracts\Http\Kernel::class]->handle(Request::createFromBase($request));
     }
 
     /**
@@ -1026,38 +1026,38 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function registerCoreContainerAliases()
     {
         $aliases = [
-            'app'                  => ['Illuminate\Foundation\Application', 'Illuminate\Contracts\Container\Container', 'Illuminate\Contracts\Foundation\Application'],
-            'auth'                 => 'Illuminate\Auth\AuthManager',
-            'auth.driver'          => ['Illuminate\Auth\Guard', 'Illuminate\Contracts\Auth\Guard'],
-            'auth.password.tokens' => 'Illuminate\Auth\Passwords\TokenRepositoryInterface',
-            'blade.compiler'       => 'Illuminate\View\Compilers\BladeCompiler',
-            'cache'                => ['Illuminate\Cache\CacheManager', 'Illuminate\Contracts\Cache\Factory'],
-            'cache.store'          => ['Illuminate\Cache\Repository', 'Illuminate\Contracts\Cache\Repository'],
-            'config'               => ['Illuminate\Config\Repository', 'Illuminate\Contracts\Config\Repository'],
-            'cookie'               => ['Illuminate\Cookie\CookieJar', 'Illuminate\Contracts\Cookie\Factory', 'Illuminate\Contracts\Cookie\QueueingFactory'],
-            'encrypter'            => ['Illuminate\Encryption\Encrypter', 'Illuminate\Contracts\Encryption\Encrypter'],
-            'db'                   => 'Illuminate\Database\DatabaseManager',
-            'events'               => ['Illuminate\Events\Dispatcher', 'Illuminate\Contracts\Events\Dispatcher'],
-            'files'                => 'Illuminate\Filesystem\Filesystem',
-            'filesystem'           => ['Illuminate\Filesystem\FilesystemManager', 'Illuminate\Contracts\Filesystem\Factory'],
-            'filesystem.disk'      => 'Illuminate\Contracts\Filesystem\Filesystem',
-            'filesystem.cloud'     => 'Illuminate\Contracts\Filesystem\Cloud',
-            'hash'                 => 'Illuminate\Contracts\Hashing\Hasher',
-            'translator'           => ['Illuminate\Translation\Translator', 'Symfony\Component\Translation\TranslatorInterface'],
-            'log'                  => ['Illuminate\Log\Writer', 'Illuminate\Contracts\Logging\Log', 'Psr\Log\LoggerInterface'],
-            'mailer'               => ['Illuminate\Mail\Mailer', 'Illuminate\Contracts\Mail\Mailer', 'Illuminate\Contracts\Mail\MailQueue'],
-            'auth.password'        => ['Illuminate\Auth\Passwords\PasswordBroker', 'Illuminate\Contracts\Auth\PasswordBroker'],
-            'queue'                => ['Illuminate\Queue\QueueManager', 'Illuminate\Contracts\Queue\Factory', 'Illuminate\Contracts\Queue\Monitor'],
-            'queue.connection'     => 'Illuminate\Contracts\Queue\Queue',
-            'redirect'             => 'Illuminate\Routing\Redirector',
-            'redis'                => ['Illuminate\Redis\Database', 'Illuminate\Contracts\Redis\Database'],
-            'request'              => ['Illuminate\Http\Request', 'Symfony\Component\HttpFoundation\Request'],
-            'router'               => ['Illuminate\Routing\Router', 'Illuminate\Contracts\Routing\Registrar'],
-            'session'              => 'Illuminate\Session\SessionManager',
-            'session.store'        => ['Illuminate\Session\Store', 'Symfony\Component\HttpFoundation\Session\SessionInterface'],
-            'url'                  => ['Illuminate\Routing\UrlGenerator', 'Illuminate\Contracts\Routing\UrlGenerator'],
-            'validator'            => ['Illuminate\Validation\Factory', 'Illuminate\Contracts\Validation\Factory'],
-            'view'                 => ['Illuminate\View\Factory', 'Illuminate\Contracts\View\Factory'],
+            'app'                  => [\Illuminate\Foundation\Application::class, \Illuminate\Contracts\Container\Container::class, \Illuminate\Contracts\Foundation\Application::class],
+            'auth'                 => \Illuminate\Auth\AuthManager::class,
+            'auth.driver'          => [\Illuminate\Auth\Guard::class, \Illuminate\Contracts\Auth\Guard::class],
+            'auth.password.tokens' => \Illuminate\Auth\Passwords\TokenRepositoryInterface::class,
+            'blade.compiler'       => \Illuminate\View\Compilers\BladeCompiler::class,
+            'cache'                => [\Illuminate\Cache\CacheManager::class, \Illuminate\Contracts\Cache\Factory::class],
+            'cache.store'          => [\Illuminate\Cache\Repository::class, \Illuminate\Contracts\Cache\Repository::class],
+            'config'               => [\Illuminate\Config\Repository::class, \Illuminate\Contracts\Config\Repository::class],
+            'cookie'               => [\Illuminate\Cookie\CookieJar::class, \Illuminate\Contracts\Cookie\Factory::class, \Illuminate\Contracts\Cookie\QueueingFactory::class],
+            'encrypter'            => [\Illuminate\Encryption\Encrypter::class, \Illuminate\Contracts\Encryption\Encrypter::class],
+            'db'                   => \Illuminate\Database\DatabaseManager::class,
+            'events'               => [\Illuminate\Events\Dispatcher::class, \Illuminate\Contracts\Events\Dispatcher::class],
+            'files'                => \Illuminate\Filesystem\Filesystem::class,
+            'filesystem'           => [\Illuminate\Filesystem\FilesystemManager::class, \Illuminate\Contracts\Filesystem\Factory::class],
+            'filesystem.disk'      => \Illuminate\Contracts\Filesystem\Filesystem::class,
+            'filesystem.cloud'     => \Illuminate\Contracts\Filesystem\Cloud::class,
+            'hash'                 => \Illuminate\Contracts\Hashing\Hasher::class,
+            'translator'           => [\Illuminate\Translation\Translator::class, 'Symfony\Component\Translation\TranslatorInterface'],
+            'log'                  => [\Illuminate\Log\Writer::class, \Illuminate\Contracts\Logging\Log::class, \Psr\Log\LoggerInterface::class],
+            'mailer'               => [\Illuminate\Mail\Mailer::class, \Illuminate\Contracts\Mail\Mailer::class, \Illuminate\Contracts\Mail\MailQueue::class],
+            'auth.password'        => [\Illuminate\Auth\Passwords\PasswordBroker::class, \Illuminate\Contracts\Auth\PasswordBroker::class],
+            'queue'                => [\Illuminate\Queue\QueueManager::class, \Illuminate\Contracts\Queue\Factory::class, \Illuminate\Contracts\Queue\Monitor::class],
+            'queue.connection'     => \Illuminate\Contracts\Queue\Queue::class,
+            'redirect'             => \Illuminate\Routing\Redirector::class,
+            'redis'                => [\Illuminate\Redis\Database::class, \Illuminate\Contracts\Redis\Database::class],
+            'request'              => [\Illuminate\Http\Request::class, 'Symfony\Component\HttpFoundation\Request'],
+            'router'               => [\Illuminate\Routing\Router::class, \Illuminate\Contracts\Routing\Registrar::class],
+            'session'              => \Illuminate\Session\SessionManager::class,
+            'session.store'        => [\Illuminate\Session\Store::class, 'Symfony\Component\HttpFoundation\Session\SessionInterface'],
+            'url'                  => [\Illuminate\Routing\UrlGenerator::class, \Illuminate\Contracts\Routing\UrlGenerator::class],
+            'validator'            => [\Illuminate\Validation\Factory::class, \Illuminate\Contracts\Validation\Factory::class],
+            'view'                 => [\Illuminate\View\Factory::class, \Illuminate\Contracts\View\Factory::class],
         ];
 
         foreach ($aliases as $key => $aliases) {
@@ -1087,8 +1087,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected function getKernel()
     {
         $kernelContract = $this->runningInConsole()
-                    ? 'Illuminate\Contracts\Console\Kernel'
-                    : 'Illuminate\Contracts\Http\Kernel';
+                    ? \Illuminate\Contracts\Console\Kernel::class
+                    : \Illuminate\Contracts\Http\Kernel::class;
 
         return $this->make($kernelContract);
     }

--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -32,7 +32,7 @@ class ConfigureLogging
         // Next, we will bind a Closure that resolves the PSR logger implementation
         // as this will grant us the ability to be interoperable with many other
         // libraries which are able to utilize the PSR standardized interface.
-        $app->bind('Psr\Log\LoggerInterface', function ($app) {
+        $app->bind(\Psr\Log\LoggerInterface::class, function ($app) {
             return $app['log']->getMonolog();
         });
     }

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -151,6 +151,6 @@ class HandleExceptions
      */
     protected function getExceptionHandler()
     {
-        return $this->app->make('Illuminate\Contracts\Debug\ExceptionHandler');
+        return $this->app->make(\Illuminate\Contracts\Debug\ExceptionHandler::class);
     }
 }

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -68,7 +68,7 @@ class ConfigCacheCommand extends Command
     {
         $app = require $this->laravel->basePath().'/bootstrap/app.php';
 
-        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();
 
         return $app['config']->all();
     }

--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -29,7 +29,7 @@ class EventGenerateCommand extends Command
     public function fire()
     {
         $provider = $this->laravel->getProvider(
-            'Illuminate\Foundation\Support\Providers\EventServiceProvider'
+            \Illuminate\Foundation\Support\Providers\EventServiceProvider::class
         );
 
         foreach ($provider->listens() as $event => $listeners) {

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -47,14 +47,14 @@ class Kernel implements KernelContract
      * @var array
      */
     protected $bootstrappers = [
-        'Illuminate\Foundation\Bootstrap\DetectEnvironment',
-        'Illuminate\Foundation\Bootstrap\LoadConfiguration',
-        'Illuminate\Foundation\Bootstrap\ConfigureLogging',
-        'Illuminate\Foundation\Bootstrap\HandleExceptions',
-        'Illuminate\Foundation\Bootstrap\RegisterFacades',
-        'Illuminate\Foundation\Bootstrap\SetRequestForConsole',
-        'Illuminate\Foundation\Bootstrap\RegisterProviders',
-        'Illuminate\Foundation\Bootstrap\BootProviders',
+        \Illuminate\Foundation\Bootstrap\DetectEnvironment::class,
+        \Illuminate\Foundation\Bootstrap\LoadConfiguration::class,
+        \Illuminate\Foundation\Bootstrap\ConfigureLogging::class,
+        \Illuminate\Foundation\Bootstrap\HandleExceptions::class,
+        \Illuminate\Foundation\Bootstrap\RegisterFacades::class,
+        \Illuminate\Foundation\Bootstrap\SetRequestForConsole::class,
+        \Illuminate\Foundation\Bootstrap\RegisterProviders::class,
+        \Illuminate\Foundation\Bootstrap\BootProviders::class,
     ];
 
     /**
@@ -86,7 +86,7 @@ class Kernel implements KernelContract
     protected function defineConsoleSchedule()
     {
         $this->app->instance(
-            'Illuminate\Console\Scheduling\Schedule', $schedule = new Schedule
+            \Illuminate\Console\Scheduling\Schedule::class, $schedule = new Schedule
         );
 
         $this->schedule($schedule);
@@ -168,8 +168,8 @@ class Kernel implements KernelContract
      */
     public function queue($command, array $parameters = [])
     {
-        $this->app['Illuminate\Contracts\Queue\Queue']->push(
-            'Illuminate\Foundation\Console\QueuedJob', func_get_args()
+        $this->app[\Illuminate\Contracts\Queue\Queue::class]->push(
+            \Illuminate\Foundation\Console\QueuedJob::class, func_get_args()
         );
     }
 
@@ -247,7 +247,7 @@ class Kernel implements KernelContract
      */
     protected function reportException(Exception $e)
     {
-        $this->app['Illuminate\Contracts\Debug\ExceptionHandler']->report($e);
+        $this->app[\Illuminate\Contracts\Debug\ExceptionHandler::class]->report($e);
     }
 
     /**
@@ -259,6 +259,6 @@ class Kernel implements KernelContract
      */
     protected function renderException($output, Exception $e)
     {
-        $this->app['Illuminate\Contracts\Debug\ExceptionHandler']->renderForConsole($output, $e);
+        $this->app[\Illuminate\Contracts\Debug\ExceptionHandler::class]->renderForConsole($output, $e);
     }
 }

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -77,7 +77,7 @@ class RouteCacheCommand extends Command
     {
         $app = require $this->laravel->basePath().'/bootstrap/app.php';
 
-        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();
 
         return $app['router']->getRoutes();
     }

--- a/src/Illuminate/Foundation/Console/TinkerCommand.php
+++ b/src/Illuminate/Foundation/Console/TinkerCommand.php
@@ -80,9 +80,9 @@ class TinkerCommand extends Command
     protected function getCasters()
     {
         return [
-            'Illuminate\Foundation\Application' => 'Illuminate\Foundation\Console\IlluminateCaster::castApplication',
-            'Illuminate\Support\Collection' => 'Illuminate\Foundation\Console\IlluminateCaster::castCollection',
-            'Illuminate\Database\Eloquent\Model' => 'Illuminate\Foundation\Console\IlluminateCaster::castModel',
+            \Illuminate\Foundation\Application::class => 'Illuminate\Foundation\Console\IlluminateCaster::castApplication',
+            \Illuminate\Support\Collection::class => 'Illuminate\Foundation\Console\IlluminateCaster::castCollection',
+            \Illuminate\Database\Eloquent\Model::class => 'Illuminate\Foundation\Console\IlluminateCaster::castModel',
         ];
     }
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -33,13 +33,13 @@ class Kernel implements KernelContract
      * @var array
      */
     protected $bootstrappers = [
-        'Illuminate\Foundation\Bootstrap\DetectEnvironment',
-        'Illuminate\Foundation\Bootstrap\LoadConfiguration',
-        'Illuminate\Foundation\Bootstrap\ConfigureLogging',
-        'Illuminate\Foundation\Bootstrap\HandleExceptions',
-        'Illuminate\Foundation\Bootstrap\RegisterFacades',
-        'Illuminate\Foundation\Bootstrap\RegisterProviders',
-        'Illuminate\Foundation\Bootstrap\BootProviders',
+        \Illuminate\Foundation\Bootstrap\DetectEnvironment::class,
+        \Illuminate\Foundation\Bootstrap\LoadConfiguration::class,
+        \Illuminate\Foundation\Bootstrap\ConfigureLogging::class,
+        \Illuminate\Foundation\Bootstrap\HandleExceptions::class,
+        \Illuminate\Foundation\Bootstrap\RegisterFacades::class,
+        \Illuminate\Foundation\Bootstrap\RegisterProviders::class,
+        \Illuminate\Foundation\Bootstrap\BootProviders::class,
     ];
 
     /**
@@ -266,7 +266,7 @@ class Kernel implements KernelContract
      */
     protected function reportException(Exception $e)
     {
-        $this->app['Illuminate\Contracts\Debug\ExceptionHandler']->report($e);
+        $this->app[\Illuminate\Contracts\Debug\ExceptionHandler::class]->report($e);
     }
 
     /**
@@ -278,7 +278,7 @@ class Kernel implements KernelContract
      */
     protected function renderException($request, Exception $e)
     {
-        return $this->app['Illuminate\Contracts\Debug\ExceptionHandler']->render($request, $e);
+        return $this->app[\Illuminate\Contracts\Debug\ExceptionHandler::class]->render($request, $e);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ConsoleSupportServiceProvider.php
@@ -19,10 +19,10 @@ class ConsoleSupportServiceProvider extends AggregateServiceProvider
      * @var array
      */
     protected $providers = [
-        'Illuminate\Console\ScheduleServiceProvider',
-        'Illuminate\Database\MigrationServiceProvider',
-        'Illuminate\Database\SeedServiceProvider',
-        'Illuminate\Foundation\Providers\ComposerServiceProvider',
-        'Illuminate\Queue\ConsoleServiceProvider',
+        \Illuminate\Console\ScheduleServiceProvider::class,
+        \Illuminate\Database\MigrationServiceProvider::class,
+        \Illuminate\Database\SeedServiceProvider::class,
+        \Illuminate\Foundation\Providers\ComposerServiceProvider::class,
+        \Illuminate\Queue\ConsoleServiceProvider::class,
     ];
 }

--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -31,7 +31,7 @@ class FormRequestServiceProvider extends ServiceProvider
                 $this->initializeRequest($request, $app['request']);
 
                 $request->setContainer($app)
-                        ->setRedirector($app['Illuminate\Routing\Redirector']);
+                        ->setRedirector($app[\Illuminate\Routing\Redirector::class]);
             });
         });
     }

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -12,6 +12,6 @@ class FoundationServiceProvider extends AggregateServiceProvider
      * @var array
      */
     protected $providers = [
-        'Illuminate\Foundation\Providers\FormRequestServiceProvider',
+        \Illuminate\Foundation\Providers\FormRequestServiceProvider::class,
     ];
 }

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -46,7 +46,7 @@ class RouteServiceProvider extends ServiceProvider
             return;
         }
 
-        $this->app['Illuminate\Contracts\Routing\UrlGenerator']
+        $this->app[\Illuminate\Contracts\Routing\UrlGenerator::class]
                         ->setRootControllerNamespace($this->namespace);
     }
 
@@ -80,7 +80,7 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function loadRoutesFrom($path)
     {
-        $router = $this->app['Illuminate\Routing\Router'];
+        $router = $this->app[\Illuminate\Routing\Router::class];
 
         if (is_null($this->namespace)) {
             return require $path;

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -394,7 +394,7 @@ trait MakesHttpRequests
      */
     public function call($method, $uri, $parameters = [], $cookies = [], $files = [], $server = [], $content = null)
     {
-        $kernel = $this->app->make('Illuminate\Contracts\Http\Kernel');
+        $kernel = $this->app->make(\Illuminate\Contracts\Http\Kernel::class);
 
         $this->currentUri = $this->prepareUrlForRequest($uri);
 
@@ -602,7 +602,7 @@ trait MakesHttpRequests
      */
     public function assertRedirectedTo($uri, $with = [])
     {
-        PHPUnit::assertInstanceOf('Illuminate\Http\RedirectResponse', $this->response);
+        PHPUnit::assertInstanceOf(\Illuminate\Http\RedirectResponse::class, $this->response);
 
         PHPUnit::assertEquals($this->app['url']->to($uri), $this->response->headers->get('Location'));
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -19,7 +19,7 @@ trait MocksApplicationServices
     {
         $events = is_array($events) ? $events : func_get_args();
 
-        $mock = Mockery::spy('Illuminate\Contracts\Events\Dispatcher');
+        $mock = Mockery::spy(\Illuminate\Contracts\Events\Dispatcher::class);
 
         $mock->shouldReceive('fire')->andReturnUsing(function ($called) use (&$events) {
             foreach ($events as $key => $event) {
@@ -51,7 +51,7 @@ trait MocksApplicationServices
      */
     protected function withoutEvents()
     {
-        $mock = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
+        $mock = Mockery::mock(\Illuminate\Contracts\Events\Dispatcher::class);
 
         $mock->shouldReceive('fire');
 
@@ -80,7 +80,7 @@ trait MocksApplicationServices
         }
 
         $this->app->instance(
-            'Illuminate\Contracts\Bus\Dispatcher', $mock
+            \Illuminate\Contracts\Bus\Dispatcher::class, $mock
         );
 
         return $this;

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -123,7 +123,7 @@ class TransportManager extends Manager
      */
     protected function createLogDriver()
     {
-        return new LogTransport($this->app->make('Psr\Log\LoggerInterface'));
+        return new LogTransport($this->app->make(\Psr\Log\LoggerInterface::class));
     }
 
     /**

--- a/src/Illuminate/Pipeline/PipelineServiceProvider.php
+++ b/src/Illuminate/Pipeline/PipelineServiceProvider.php
@@ -21,7 +21,7 @@ class PipelineServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(
-            'Illuminate\Contracts\Pipeline\Hub', 'Illuminate\Pipeline\Hub'
+            \Illuminate\Contracts\Pipeline\Hub::class, \Illuminate\Pipeline\Hub::class
         );
     }
 
@@ -33,7 +33,7 @@ class PipelineServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'Illuminate\Contracts\Pipeline\Hub',
+            \Illuminate\Contracts\Pipeline\Hub::class,
         ];
     }
 }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -56,7 +56,7 @@ class CallQueuedHandler
      */
     protected function setJobInstanceIfNecessary(Job $job, $instance)
     {
-        if (in_array('Illuminate\Queue\InteractsWithQueue', class_uses_recursive(get_class($instance)))) {
+        if (in_array(\Illuminate\Queue\InteractsWithQueue::class, class_uses_recursive(get_class($instance)))) {
             $instance->setJob($job);
         }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -94,7 +94,7 @@ class WorkCommand extends Command
             $this->worker->setCache($this->laravel['cache']->driver());
 
             $this->worker->setDaemonExceptionHandler(
-                $this->laravel['Illuminate\Contracts\Debug\ExceptionHandler']
+                $this->laravel[\Illuminate\Contracts\Debug\ExceptionHandler::class]
             );
 
             return $this->worker->daemon(

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -220,7 +220,7 @@ abstract class Job
      */
     protected function getEntityResolver()
     {
-        return $this->container->make('Illuminate\Contracts\Queue\EntityResolver');
+        return $this->container->make(\Illuminate\Contracts\Queue\EntityResolver::class);
     }
 
     /**

--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -62,7 +62,7 @@ class ControllerInspector
      */
     public function isRoutable(ReflectionMethod $method)
     {
-        if ($method->class == 'Illuminate\Routing\Controller') {
+        if ($method->class == \Illuminate\Routing\Controller::class) {
             return false;
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -311,8 +311,8 @@ class Router implements RegistrarContract
      */
     public function resource($name, $controller, array $options = [])
     {
-        if ($this->container && $this->container->bound('Illuminate\Routing\ResourceRegistrar')) {
-            $registrar = $this->container->make('Illuminate\Routing\ResourceRegistrar');
+        if ($this->container && $this->container->bound(\Illuminate\Routing\ResourceRegistrar::class)) {
+            $registrar = $this->container->make(\Illuminate\Routing\ResourceRegistrar::class);
         } else {
             $registrar = new ResourceRegistrar($this);
         }
@@ -726,7 +726,7 @@ class Router implements RegistrarContract
     {
         $this->current = $route = $this->routes->match($request);
 
-        $this->container->instance('Illuminate\Routing\Route', $route);
+        $this->container->instance(\Illuminate\Routing\Route::class, $route);
 
         return $this->substituteBindings($route);
     }

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -116,7 +116,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerPsrRequest()
     {
-        $this->app->bind('Psr\Http\Message\ServerRequestInterface', function ($app) {
+        $this->app->bind(\Psr\Http\Message\ServerRequestInterface::class, function ($app) {
             return (new DiactorosFactory)->createRequest($app->make('request'));
         });
     }
@@ -128,7 +128,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerPsrResponse()
     {
-        $this->app->bind('Psr\Http\Message\ResponseInterface', function ($app) {
+        $this->app->bind(\Psr\Http\Message\ResponseInterface::class, function ($app) {
             return new PsrResponse();
         });
     }
@@ -140,8 +140,8 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerResponseFactory()
     {
-        $this->app->singleton('Illuminate\Contracts\Routing\ResponseFactory', function ($app) {
-            return new ResponseFactory($app['Illuminate\Contracts\View\Factory'], $app['redirect']);
+        $this->app->singleton(\Illuminate\Contracts\Routing\ResponseFactory::class, function ($app) {
+            return new ResponseFactory($app[\Illuminate\Contracts\View\Factory::class], $app['redirect']);
         });
     }
 }

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -17,7 +17,7 @@ class SessionServiceProvider extends ServiceProvider
 
         $this->registerSessionDriver();
 
-        $this->app->singleton('Illuminate\Session\Middleware\StartSession');
+        $this->app->singleton(\Illuminate\Session\Middleware\StartSession::class);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Artisan.php
+++ b/src/Illuminate/Support/Facades/Artisan.php
@@ -14,6 +14,6 @@ class Artisan extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Contracts\Console\Kernel';
+        return \Illuminate\Contracts\Console\Kernel::class;
     }
 }

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -14,6 +14,6 @@ class Bus extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Contracts\Bus\Dispatcher';
+        return \Illuminate\Contracts\Bus\Dispatcher::class;
     }
 }

--- a/src/Illuminate/Support/Facades/Gate.php
+++ b/src/Illuminate/Support/Facades/Gate.php
@@ -14,6 +14,6 @@ class Gate extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Contracts\Auth\Access\Gate';
+        return \Illuminate\Contracts\Auth\Access\Gate::class;
     }
 }

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -14,6 +14,6 @@ class Response extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'Illuminate\Contracts\Routing\ResponseFactory';
+        return \Illuminate\Contracts\Routing\ResponseFactory::class;
     }
 }


### PR DESCRIPTION
Use ::class notation

```
In PHPStorm
'(Illuminate|Psr)\\(.[^@\[:']*)' -->  \\\\$1\\\\$2::class
```

Special case:
- `\Illuminate\Foundation\Application::registerBaseBindings` : here the class name is part of the exception message

---

The namespace imports (and eventually import aliasing) will be part of another PR to ease-up reviewing.

---

Related to #10841 and others
