### PR TITLE
[5.1] Add database connection to DI container

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -50,6 +50,10 @@ class DatabaseServiceProvider extends ServiceProvider
         $this->app->singleton('db', function ($app) {
             return new DatabaseManager($app, $app['db.factory']);
         });
+
+        $this->app->bind('db.connection', function ($app) {
+            return $app['db']->connection();
+        });
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1037,6 +1037,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'cookie'               => ['Illuminate\Cookie\CookieJar', 'Illuminate\Contracts\Cookie\Factory', 'Illuminate\Contracts\Cookie\QueueingFactory'],
             'encrypter'            => ['Illuminate\Encryption\Encrypter', 'Illuminate\Contracts\Encryption\Encrypter'],
             'db'                   => 'Illuminate\Database\DatabaseManager',
+            'db.connection'        => ['Illuminate\Database\Connection', 'Illuminate\Database\ConnectionInterface'],
             'events'               => ['Illuminate\Events\Dispatcher', 'Illuminate\Contracts\Events\Dispatcher'],
             'files'                => 'Illuminate\Filesystem\Filesystem',
             'filesystem'           => ['Illuminate\Filesystem\FilesystemManager', 'Illuminate\Contracts\Filesystem\Factory'],


### PR DESCRIPTION
Allows argument injection of database default connection with proper typehints and IDE support.

``` php
use Illuminate\Database\Connection;
//...
public function index(Connection $db)
{
    $records = $db->table('foo')->get();
}
//...
```
