### PR TITLE
[5.1] Added verbose method on command class

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -332,6 +332,20 @@ class Command extends SymfonyCommand
     }
 
     /**
+     * Write a string as verbose output depending on verbosity level.
+     *
+     * @param  string  $string
+     * @param  int  $verbosity
+     * @return void
+     */
+    public function verbose($string, $verbosity = OutputInterface::VERBOSITY_VERBOSE)
+    {
+        if ($this->getOutput()->getVerbosity() >= $verbosity) {
+            $this->comment($string);
+        }
+    }
+
+    /**
      * Write a string as standard output.
      *
      * @param  string  $string


### PR DESCRIPTION
Allows you to call 

```
$this->verbose('some message');
```

inside commands.
