### PR TITLE
[5.2] Deprecate lists

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -248,6 +248,8 @@ class Builder
      * @param  string  $column
      * @param  string  $key
      * @return \Illuminate\Support\Collection
+     *
+     * @deprecated since version 5.2. Use the "pluck" method directly.
      */
     public function lists($column, $key = null)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1550,6 +1550,8 @@ class Builder
      * @param  string  $column
      * @param  string  $key
      * @return array
+     *
+     * @deprecated since version 5.2. Use the "pluck" method directly.
      */
     public function lists($column, $key = null)
     {

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -421,6 +421,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  string  $value
      * @param  string  $key
      * @return static
+     *
+     * @deprecated since version 5.2. Use the "pluck" method directly.
      */
     public function lists($value, $key = null)
     {


### PR DESCRIPTION
This does _not_ mean that we have to remove this in 5.3.

We can go more than a single cycle with these methods deprecated.
