### PR TITLE
[5.1] Add split method into collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -820,6 +820,25 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Split the collection into several pieces.
+     *
+     * @param  int  $amount
+     * @return static
+     */
+    public function split($amount)
+    {
+        $pieces = [];
+
+        $size = ceil($this->count() / $amount);
+
+        foreach (range(1, $amount) as $page) {
+            $pieces[] = $this->forPage($page, $size);
+        }
+
+        return new static($pieces);
+    }
+
+    /**
      * Get the sum of the given values.
      *
      * @param  callable|string|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -568,6 +568,27 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['baz'], $cut->all());
     }
 
+    public function testSplit()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $data = $data->split(3);
+        $this->assertInstanceOf('Illuminate\Support\Collection', $data);
+        $this->assertInstanceOf('Illuminate\Support\Collection', $data[0]);
+        $this->assertEquals(3, $data->count());
+        $this->assertEquals([1, 2, 3, 4], $data[0]->toArray());
+        $this->assertEquals([5, 6, 7, 8], $data[1]->toArray());
+        $this->assertEquals([9, 10], $data[2]->toArray());
+
+        $data = new Collection([1, 2]);
+        $data = $data->split(3);
+        $this->assertInstanceOf('Illuminate\Support\Collection', $data);
+        $this->assertInstanceOf('Illuminate\Support\Collection', $data[0]);
+        $this->assertEquals(3, $data->count());
+        $this->assertEquals([1], $data[0]->toArray());
+        $this->assertEquals([2], $data[1]->toArray());
+        $this->assertEquals([], $data[2]->toArray());
+    }
+
     public function testGetPluckValueWithAccessors()
     {
         $model = new TestAccessorEloquentTestStub(['some' => 'foo']);


### PR DESCRIPTION
Use case:
I need to split a collection of arbitary length into 3 columns of relatively equal length.

Notes:
1. Maybe `divide` is a better name?
2. Should we care about preserving the keys? In this implementation they never preserve.
