### PR TITLE
[5.2] Allow table-qualified columns in pluck operations

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1537,7 +1537,7 @@ class Builder
      * Get an array with the values of a given column.
      *
      * @param  string  $column
-     * @param  string  $key
+     * @param  string|null  $key
      * @return array
      */
     public function pluck($column, $key = null)
@@ -1551,7 +1551,7 @@ class Builder
      * Alias for the "pluck" method.
      *
      * @param  string  $column
-     * @param  string  $key
+     * @param  string|null  $key
      * @return array
      *
      * @deprecated since version 5.2. Use the "pluck" method directly.
@@ -1565,7 +1565,7 @@ class Builder
      * Strip off the table name or alias from a column identifier.
      *
      * @param  string  $column
-     * @return string
+     * @return string|null
      */
     protected function stripTable($column)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1562,14 +1562,14 @@ class Builder
     }
 
     /**
-     * Strip off the table name from a column identifier.
+     * Strip off the table name or alias from a column identifier.
      *
      * @param  string  $column
      * @return string
      */
     protected function stripTable($column)
     {
-        return is_null($column) ? $column : last(explode('.', $column));
+        return is_null($column) ? $column : last(preg_split('~\.| ~', $column));
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1544,6 +1544,9 @@ class Builder
     {
         $results = $this->get(func_get_args());
 
+        // If the columns are qualified with a table or have an alias, we cannot use
+        // those directly in the "pluck" operation, since the results from the DB
+        // are only keyed by the column itself. We will strip everything else.
         return Arr::pluck($results, $this->stripTable($column), $this->stripTable($key));
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -41,6 +41,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
     {
         $this->schema()->create('users', function ($table) {
             $table->increments('id');
+            $table->string('name')->nullable();
             $table->string('email')->unique();
             $table->string('role')->default('standard');
             $table->timestamps();
@@ -181,16 +182,17 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testPluckWithJoin()
     {
-        $user1 = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
-        $user2 = EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        $user1 = EloquentTestUser::create(['id' => 1, 'name' => 'Taylor', 'email' => 'taylorotwell@gmail.com']);
+        $user2 = EloquentTestUser::create(['id' => 2, 'name' => 'Abigail', 'email' => 'abigailotwell@gmail.com']);
 
         $user2->posts()->create(['id' => 1, 'name' => 'First post']);
         $user1->posts()->create(['id' => 2, 'name' => 'Second post']);
 
         $query = EloquentTestUser::join('posts', 'users.id', '=', 'posts.user_id');
 
-        $this->assertEquals([1 => 'First post', 2 => 'Second post'], $query->pluck('name', 'posts.id')->all());
-        $this->assertEquals([2 => 'First post', 1 => 'Second post'], $query->pluck('name', 'users.id')->all());
+        $this->assertEquals([1 => 'First post', 2 => 'Second post'], $query->pluck('posts.name', 'posts.id')->all());
+        $this->assertEquals([2 => 'First post', 1 => 'Second post'], $query->pluck('posts.name', 'users.id')->all());
+        $this->assertEquals(['Abigail' => 'First post', 'Taylor' => 'Second post'], $query->pluck('posts.name', 'users.name as user_name')->all());
     }
 
     public function testFindOrFail()

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -179,6 +179,20 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([1 => 'taylorotwell@gmail.com', 2 => 'abigailotwell@gmail.com'], $keyed);
     }
 
+    public function testPluckWithJoin()
+    {
+        $user1 = EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        $user2 = EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+
+        $user2->posts()->create(['id' => 1, 'name' => 'First post']);
+        $user1->posts()->create(['id' => 2, 'name' => 'Second post']);
+
+        $query = EloquentTestUser::join('posts', 'users.id', '=', 'posts.user_id');
+
+        $this->assertEquals([1 => 'First post', 2 => 'Second post'], $query->pluck('name', 'posts.id')->all());
+        $this->assertEquals([2 => 'First post', 1 => 'Second post'], $query->pluck('name', 'users.id')->all());
+    }
+
     public function testFindOrFail()
     {
         EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
Would allow you to do this:

``` php
User::join('posts', 'users.id', '=', 'posts.user_id')->pluck('users.name', 'posts.id');
```
