### PR TITLE
[5.2] Update paginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -4,8 +4,9 @@ namespace Illuminate\Pagination;
 
 use Closure;
 use ArrayIterator;
+use Illuminate\Contracts\Support\Htmlable;
 
-abstract class AbstractPaginator
+abstract class AbstractPaginator implements Htmlable
 {
     /**
      * All of the items being paginated.
@@ -482,6 +483,16 @@ abstract class AbstractPaginator
      */
     public function __toString()
     {
-        return $this->render();
+        return (string) $this->render();
+    }
+
+    /**
+     * Render the contents of the paginator to HTML.
+     *
+     * @return string
+     */
+    public function toHtml()
+    {
+        return (string) $this->__toString();
     }
 }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -493,6 +493,6 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function toHtml()
     {
-        return (string) $this->__toString();
+        return (string) $this->render();
     }
 }

--- a/src/Illuminate/Pagination/BootstrapThreePresenter.php
+++ b/src/Illuminate/Pagination/BootstrapThreePresenter.php
@@ -50,7 +50,7 @@ class BootstrapThreePresenter implements PresenterContract
     /**
      * Convert the URL window into Bootstrap HTML.
      *
-     * @return \Illuminate\View\Expression
+     * @return \Illuminate\Support\HtmlString
      */
     public function render()
     {

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -4,6 +4,7 @@ namespace Illuminate\Pagination;
 
 use Countable;
 use ArrayAccess;
+use JsonSerializable;
 use IteratorAggregate;
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Jsonable;
@@ -11,7 +12,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Pagination\Presenter;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator as LengthAwarePaginatorContract;
 
-class LengthAwarePaginator extends AbstractPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, LengthAwarePaginatorContract
+class LengthAwarePaginator extends AbstractPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, JsonSerializable, Jsonable, LengthAwarePaginatorContract
 {
     /**
      * The total number of items before slicing.
@@ -152,6 +153,16 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     }
 
     /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
      * Convert the object to its JSON representation.
      *
      * @param  int  $options
@@ -159,6 +170,6 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     public function toJson($options = 0)
     {
-        return json_encode($this->toArray(), $options);
+        return json_encode($this->jsonSerialize(), $options);
     }
 }

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -4,6 +4,7 @@ namespace Illuminate\Pagination;
 
 use Countable;
 use ArrayAccess;
+use JsonSerializable;
 use IteratorAggregate;
 use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Jsonable;
@@ -11,7 +12,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Pagination\Presenter;
 use Illuminate\Contracts\Pagination\Paginator as PaginatorContract;
 
-class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, PaginatorContract
+class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, JsonSerializable, Jsonable, PaginatorContract
 {
     /**
      * Determine if there are more items in the data source.
@@ -123,6 +124,16 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     }
 
     /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
      * Convert the object to its JSON representation.
      *
      * @param  int  $options
@@ -130,6 +141,6 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      */
     public function toJson($options = 0)
     {
-        return json_encode($this->toArray(), $options);
+        return json_encode($this->jsonSerialize(), $options);
     }
 }

--- a/src/Illuminate/Pagination/SimpleBootstrapThreePresenter.php
+++ b/src/Illuminate/Pagination/SimpleBootstrapThreePresenter.php
@@ -31,7 +31,7 @@ class SimpleBootstrapThreePresenter extends BootstrapThreePresenter
     /**
      * Convert the URL window into Bootstrap HTML.
      *
-     * @return \Illuminate\View\Expression
+     * @return \Illuminate\Support\HtmlString
      */
     public function render()
     {


### PR DESCRIPTION
Several minor refactorings of paginators.
1. CS fix
2. Implement `Htmlable` in `AbstractPaginator` so people can use `{{ $paginator }}` without calling `->render()` as it was possible before.
3. Make sure `__toString()` and `toHtml()` casts render result to string to avoid errors.
4. Implement `JsonSerizlizable` and use `jsonSerialize()` method in `toJson()` conversion.
