### PR TITLE
[5.2] Implement new MySql grammar with 5.7 support

### DIFF
--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -2,11 +2,13 @@
 
 namespace Illuminate\Database;
 
+use PDO;
 use Illuminate\Database\Schema\MySqlBuilder;
 use Illuminate\Database\Query\Processors\MySqlProcessor;
 use Doctrine\DBAL\Driver\PDOMySql\Driver as DoctrineDriver;
 use Illuminate\Database\Query\Grammars\MySqlGrammar as QueryGrammar;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar as SchemaGrammar;
+use Illuminate\Database\Schema\Grammars\MySqlLegacyGrammar as LegacySchemaGrammar;
 
 class MySqlConnection extends Connection
 {
@@ -41,6 +43,16 @@ class MySqlConnection extends Connection
      */
     protected function getDefaultSchemaGrammar()
     {
+        $version = strtolower($this->pdo->getAttribute(PDO::ATTR_SERVER_VERSION));
+
+        if (
+            version_compare($version, '5.7.0', 'lt') ||
+            strpos($version, 'maria') !== false ||
+            strpos($version, 'drizzle') !== false
+        ) {
+            return $this->withTablePrefix(new LegacySchemaGrammar());
+        }
+
         return $this->withTablePrefix(new SchemaGrammar);
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -451,7 +451,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeJson(Fluent $column)
     {
-        return 'text';
+        return 'json';
     }
 
     /**
@@ -462,7 +462,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeJsonb(Fluent $column)
     {
-        return 'text';
+        return 'json';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlLegacyGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlLegacyGrammar.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Database\Schema\Grammars;
+
+use Illuminate\Support\Fluent;
+
+class MySqlLegacyGrammar extends MySqlGrammar
+{
+    /**
+     * Create the column definition for a json type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeJson(Fluent $column)
+    {
+        return 'text';
+    }
+
+    /**
+     * Create the column definition for a jsonb type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeJsonb(Fluent $column)
+    {
+        return 'text';
+    }
+}


### PR DESCRIPTION
Related to #10867 
Checks MySQL version and resolves proper grammar: with JSON support for 5.7+ and with `text` fallback for older.

As of MySQL forks:
1. MariaDB is using other versioning system (10.0+) and currently does not support JSON - using legacy.
2. Drizzle - the same (7.2+)
3. Percona and WebScaleSQL - almost same versioning as MySQL
