### PR TITLE
[5.2] Fixed deprecation notices

### DIFF
--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -7,7 +7,7 @@ use ReflectionMethod;
 use Illuminate\Support\Str;
 
 /**
- * @deprecated since version 5.2.
+ * @deprecated since version 5.1.
  */
 class ControllerInspector
 {

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -212,7 +212,7 @@ class Router implements RegistrarContract
      * @param  array  $controllers
      * @return void
      *
-     * @deprecated since version 5.2.
+     * @deprecated since version 5.1.
      */
     public function controllers(array $controllers)
     {
@@ -229,7 +229,7 @@ class Router implements RegistrarContract
      * @param  array   $names
      * @return void
      *
-     * @deprecated since version 5.2.
+     * @deprecated since version 5.1.
      */
     public function controller($uri, $controller, $names = [])
     {
@@ -266,7 +266,7 @@ class Router implements RegistrarContract
      * @param  array   $names
      * @return void
      *
-     * @deprecated since version 5.2.
+     * @deprecated since version 5.1.
      */
     protected function registerInspected($route, $controller, $method, &$names)
     {
@@ -287,7 +287,7 @@ class Router implements RegistrarContract
      * @param  string  $uri
      * @return void
      *
-     * @deprecated since version 5.2.
+     * @deprecated since version 5.1.
      */
     protected function addFallthroughRoute($controller, $uri)
     {

--- a/src/Illuminate/View/Expression.php
+++ b/src/Illuminate/View/Expression.php
@@ -5,7 +5,7 @@ namespace Illuminate\View;
 use Illuminate\Support\HtmlString;
 
 /**
- * @deprecated since version 5.2.
+ * @deprecated since version 5.2. Use Illuminate\Support\HtmlString.
  */
 class Expression extends HtmlString
 {


### PR DESCRIPTION
Those rooting things are marked as deprecated in 5.1, so we shouldn't have bumped that. Also added missing reference to Illuminate\Support\HtmlString in another deprecation notice.
