### PR TITLE
[5.2] Drop support for class preloader 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.5.9",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "classpreloader/classpreloader": "~2.0|~3.0",
+        "classpreloader/classpreloader": "~3.0",
         "danielstjules/stringy": "~2.1",
         "doctrine/inflector": "~1.0",
         "jeremeamia/superclosure": "~2.0",


### PR DESCRIPTION
- Laravel 5.1.0-5.1.23 supported class preloader 2.x only.
- Laravel 5.1.24-5.1.xx supports class preloader 2.x and 3.x.
- After this PR, Laravel 5.2+ will support class preloader 3.x only.
