### PR TITLE
[5.1] alter isJson function to allow other json content types

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -595,7 +595,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      */
     public function isJson()
     {
-        return Str::contains($this->header('CONTENT_TYPE'), '/json');
+        return Str::contains($this->header('CONTENT_TYPE'), 'json');
     }
 
     /**


### PR DESCRIPTION
Currently the Request isJson function will only match requests for ***/json content types, but this wont work with things like the JSON API spec: http://jsonapi.org/format/#content-negotiation-clients

And im sure there are many other content types cropping up with json as part of the string, but not explicitly ***/json.

simple alteration that looks for "json" within the content type.
