### PR TITLE
migrate:status to accept --path and --database options

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -78,7 +78,7 @@ class StatusCommand extends BaseCommand
     /**
      * Get all of the migration files.
      *
-     * @param string  $path
+     * @param  string  $path
      * @return array
      */
     protected function getAllMigrationFiles($path)

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Database\Migrations\Migrator;
+use Symfony\Component\Console\Input\InputOption;
 
 class StatusCommand extends BaseCommand
 {
@@ -51,11 +52,19 @@ class StatusCommand extends BaseCommand
             return $this->error('No migrations found.');
         }
 
+        $this->migrator->setConnection($this->input->getOption('database'));
+
+        if (! is_null($path = $this->input->getOption('path'))) {
+            $path = $this->laravel->basePath().'/'.$path;
+        } else {
+            $path = $this->getMigrationPath();
+        }
+
         $ran = $this->migrator->getRepository()->getRan();
 
         $migrations = [];
 
-        foreach ($this->getAllMigrationFiles() as $migration) {
+        foreach ($this->getAllMigrationFiles($path) as $migration) {
             $migrations[] = in_array($migration, $ran) ? ['<info>Y</info>', $migration] : ['<fg=red>N</fg=red>', $migration];
         }
 
@@ -69,10 +78,25 @@ class StatusCommand extends BaseCommand
     /**
      * Get all of the migration files.
      *
+     * @param string  $path
      * @return array
      */
-    protected function getAllMigrationFiles()
+    protected function getAllMigrationFiles($path)
     {
-        return $this->migrator->getMigrationFiles($this->getMigrationPath());
+        return $this->migrator->getMigrationFiles($path);
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
+
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to use.'],
+        ];
     }
 }


### PR DESCRIPTION
`migrate:status` does not work if your migrations are in a different folder and database.  Simply adding `--path` and `--database` options like the other `migrate` commands enables this to work.
