### PR TITLE
[5.1] Fix issue where "/" route cannot be excluded from default CSRF token verification

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -62,7 +62,6 @@ class VerifyCsrfToken
     protected function shouldPassThrough($request)
     {
         foreach ($this->except as $except) {
-
             if ($except !== '/') {
                 $except = trim($except, '/');
             }

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -62,7 +62,12 @@ class VerifyCsrfToken
     protected function shouldPassThrough($request)
     {
         foreach ($this->except as $except) {
-            if ($request->is(trim($except, '/'))) {
+
+            if ($except !== '/') {
+                $except = trim($except, '/');
+            }
+
+            if ($request->is($except)) {
                 return true;
             }
         }


### PR DESCRIPTION
This pull request fixes an issue I recently encountered, where adding the "/" route to the array to be excluded from CSRF token verification in the default `VerifyCsrfToken` middleware that ships with Laravel, did not exempt the route from undergoing the check.
