### PR TITLE
[5.1] Use laravel's log writer class instead of monolog.

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -28,13 +28,6 @@ class ConfigureLogging
         } else {
             $this->configureHandlers($app, $log);
         }
-
-        // Next, we will bind a Closure that resolves the PSR logger implementation
-        // as this will grant us the ability to be interoperable with many other
-        // libraries which are able to utilize the PSR standardized interface.
-        $app->bind('Psr\Log\LoggerInterface', function ($app) {
-            return $app['log']->getMonolog();
-        });
     }
 
     /**


### PR DESCRIPTION
Our Laravel's cool [Illuminate\Log\Writer](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Log/Writer.php#L20) already implements the `Psr\Log\LoggerInterface` interface. Using the Monolog logger for the `Psr\Log\LoggerInterface` binding bypasses the Logging event system of the laravel. For instance, I just wanted to log all the exceptions to the `console` for the quick view :eyeglasses: :

``` php
    public function boot(DispatcherContract $events)
    {
        parent::boot($events);

        $events->listen('illuminate.log',function($level, $message) {

             $output = new \Symfony\Component\Console\Output\ConsoleOutput(3);

             $output->writeln('Console Log::' . $level . ': ' . $message);
             $output->writeln("++++++++++++++++++++++++++++++++++++++++++++++++++++++");

        });

        //
    }
```

And found out that the events were not firing, because the `Monolog\Logger` was being injected for the `Psr\Log\LoggerInterface`.

I hope it all make sense :)

Usman.
