### PR TITLE
[5.1] Add missing PHP extenstion dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "ext-fileinfo": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "classpreloader/classpreloader": "~2.0|~3.0",


### PR DESCRIPTION
`ext-fileinfo` is a requirement of `league/flysystem`

---

Discussed in #10924
