### PR TITLE
[5.2] Allows app:name to replace namespace in tests/ folder

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -95,9 +95,10 @@ class AppNameCommand extends Command
      */
     protected function setAppDirectoryNamespace()
     {
-        $files = Finder::create()
-                            ->in($this->laravel['path'])
-                            ->name('*.php');
+        $files = Finder::create()->in([
+            $this->laravel['path'],
+            $this->laravel->basePath().'/tests',
+        ])->name('*.php');
 
         foreach ($files as $file) {
             $this->replaceNamespace($file->getRealPath());
@@ -134,12 +135,14 @@ class AppNameCommand extends Command
     {
         $search = [
             $this->currentRoot.'\\Http',
+            $this->currentRoot.'\\Tests',
             $this->currentRoot.'\\Console',
             $this->currentRoot.'\\Exceptions',
         ];
 
         $replace = [
             $this->argument('name').'\\Http',
+            $this->argument('name').'\\Tests',
             $this->argument('name').'\\Console',
             $this->argument('name').'\\Exceptions',
         ];


### PR DESCRIPTION
Required by https://github.com/laravel/laravel/pull/3556
