### PR TITLE
[5.2] Fix updateRememberToken call during logout

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -609,11 +609,9 @@ class Guard implements GuardContract
      */
     protected function discardRememberToken(UserContract $user)
     {
-        if (! empty($user->getRememberToken())) {
-            // Calls updateRememberToken on UserProvider contract as stated in Authentication documentation
-            $this->provider->updateRememberToken($user, null);
-            $user->setRememberToken(null);
-        }
+        // Calls updateRememberToken on UserProvider contract as stated in Authentication documentation
+        $this->provider->updateRememberToken($user, null);
+        $user->setRememberToken(null);
     }
 
     /**

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -610,7 +610,7 @@ class Guard implements GuardContract
      */
     protected function discardRememberToken(UserContract $user)
     {
-        // Calls updateRememberToken on UserProvider contract as stated in Authentication documentation
+        // Calls updateRememberToken on UserProvider contract with null $token
         $this->provider->updateRememberToken($user, null);
         $user->setRememberToken(null);
     }

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -548,9 +548,7 @@ class Guard implements GuardContract
         // listening for anytime a user signs out of this application manually.
         $this->clearUserDataFromStorage();
 
-        if (! is_null($this->user)) {
-            $this->refreshRememberToken($user);
-        }
+        $this->discardRememberToken($user);
 
         if (isset($this->events)) {
             $this->events->fire(new Events\Logout($user));
@@ -601,6 +599,20 @@ class Guard implements GuardContract
     {
         if (empty($user->getRememberToken())) {
             $this->refreshRememberToken($user);
+        }
+    }
+
+    /**
+     * Discards remember token for the user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
+     */
+    protected function discardRememberToken(UserContract $user)
+    {
+        if (!empty($user->getRememberToken())) {
+            // Calls updateRememberToken on UserProvider contract as stated in Authentication documentation
+            $this->provider->updateRememberToken($user, null);
+            $user->setRememberToken(null);
         }
     }
 

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -603,7 +603,8 @@ class Guard implements GuardContract
     }
 
     /**
-     * Discards remember token for the user.
+     * Discard "remember me" token for the user.
+     *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -603,13 +603,13 @@ class Guard implements GuardContract
     }
 
     /**
-     * Discards remember token for the user
+     * Discards remember token for the user.
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
     protected function discardRememberToken(UserContract $user)
     {
-        if (!empty($user->getRememberToken())) {
+        if (! empty($user->getRememberToken())) {
             // Calls updateRememberToken on UserProvider contract as stated in Authentication documentation
             $this->provider->updateRememberToken($user, null);
             $user->setRememberToken(null);


### PR DESCRIPTION
During logout call updateRememberToken with $token=null as stated in Authentication documentation:

> The updateRememberToken method updates the $user field remember_token with the new $token. The new token can be either a fresh token, assigned on a successful "remember me" login attempt, or a null when the user is logged out.
