### PR TITLE
[5.2] Proposal: string wrapper

### DIFF
--- a/src/Illuminate/Support/StringBuffer.php
+++ b/src/Illuminate/Support/StringBuffer.php
@@ -1,0 +1,521 @@
+<?php
+
+namespace Illuminate\Support;
+
+use ArrayAccess;
+use InvalidArgumentException;
+
+class StringBuffer implements ArrayAccess
+{
+    /**
+     * The string wrapped with the StringBuffer.
+     *
+     * @var string
+     */
+    protected $string;
+
+    /**
+     * Default encoding for multi-byte strings.
+     *
+     * @var string
+     */
+    protected $encoding = 'UTF-8';
+
+    /**
+     * Create a new StringBuffer.
+     *
+     * @param  mixed  $string
+     */
+    public function __construct($string)
+    {
+        if (is_array($string)) {
+            throw new InvalidArgumentException('Cannot create a string from an array');
+        }
+
+        if (is_object($string) && ! method_exists($string, '__toString')) {
+            throw new InvalidArgumentException('Cannot create string from an object that does not implement __toString');
+        }
+
+        $this->string = (string) $string;
+    }
+
+    /**
+     * Capitalize the first letter of the string.
+     *
+     * @return $this|static
+     */
+    public function ucfirst()
+    {
+        return new static(Str::ucfirst($this->string));
+    }
+
+    /**
+     * Lowercase the first letter of the string.
+     *
+     * @return $this|static
+     */
+    public function lcfirst()
+    {
+        if (! $this->length()) {
+            return $this;
+        }
+
+        return new static(mb_strtolower($this[0], $this->encoding).$this->substring(1));
+    }
+
+    /**
+     * Determine if the string starts with a given substring.
+     *
+     * @param  string|array  $needles
+     * @return bool
+     */
+    public function startsWith($needles)
+    {
+        return Str::startsWith($this->string, $needles);
+    }
+
+    /**
+     * Determine if the string ends with a given substring.
+     *
+     * @param  string|array  $needles
+     * @return bool
+     */
+    public function endsWith($needles)
+    {
+        return Str::endsWith($this->string, $needles);
+    }
+
+    /**
+     * Determine if the string contains a given substring.
+     *
+     * @param  string|array  $needles
+     * @return bool
+     */
+    public function contains($needles)
+    {
+        return Str::contains($this->string, $needles);
+    }
+
+    /**
+     * Determine if the string equals the given input.
+     *
+     * @param  string  $input
+     * @return bool
+     */
+    public function equals($input)
+    {
+        return Str::equals($this->string, $input);
+    }
+
+    /**
+     * Determine if the string matches a given pattern.
+     *
+     * @param  string  $pattern
+     * @return bool
+     */
+    public function matches($pattern)
+    {
+        return Str::is($pattern, $this->string);
+    }
+
+    /**
+     * Split the string with a given delimiter.
+     *
+     * @param  string|array  $delimiters
+     * @return \Illuminate\Support\Collection
+     */
+    public function explode($delimiters)
+    {
+        $delimiters = array_map(function ($delimiter) {
+            return preg_quote($delimiter, '/');
+        }, (array) $delimiters);
+
+        $strings = preg_split('/('.implode('|', $delimiters).')/', $this->string);
+
+        return collect($strings);
+    }
+
+    /**
+     * Find the first occurrence of a given needle in the string.
+     *
+     * @param  string $needle
+     * @param  int  $offset
+     * @return int
+     */
+    public function indexOf($needle, $offset = 0)
+    {
+        return mb_strpos($this->string, $needle, $offset, $this->encoding);
+    }
+
+    /**
+     * Find the last occurrence of a given needle in the string.
+     *
+     * @param  string $needle
+     * @param  int  $offset
+     * @return int
+     */
+    public function lastIndexOf($needle, $offset = 0)
+    {
+        return mb_strrpos($this->string, $needle, $offset, $this->encoding);
+    }
+
+    /**
+     * Replace all occurrences of the search string with the replacement string.
+     *
+     * @param  string|array  $search
+     * @param  string|array  $replace
+     * @param  int  $count
+     * @param  int  $index
+     * @return static
+     */
+    public function replace($search, $replace, &$count = 0, $index = 0)
+    {
+        $string = new static($this->string);
+
+        if (is_array($search)) {
+            foreach ($search as $char) {
+                $string = $string->replace($char, $replace, $count, $index++);
+            }
+
+            return $string;
+        }
+
+        if (is_array($replace)) {
+            $replace = isset($replace[$index]) ? $replace[$index] : $replace[count($replace) - 1];
+        }
+
+        while (($pos = $string->indexOf($search)) !== false) {
+            $count++;
+
+            $string = $string->substring(0, $pos)->append($replace)
+                ->append($string->substring($pos + mb_strlen($search, $this->encoding)));
+        }
+
+        return $string;
+    }
+
+    /**
+     * Returns the portion of string specified by the start and length parameters.
+     *
+     * @param  int  $start
+     * @param  int|null  $length
+     * @return static
+     */
+    public function substring($start, $length = null)
+    {
+        return new static(Str::substr($this->string, $start, $length));
+    }
+
+    /**
+     * Transliterate a UTF-8 value to ASCII.
+     *
+     * @return static
+     */
+    public function toAscii()
+    {
+        return new static(Str::ascii($this->string));
+    }
+
+    /**
+     * Convert a value to camel case.
+     *
+     * @return static
+     */
+    public function toCamel()
+    {
+        return new static(Str::camel($this->string));
+    }
+
+    /**
+     * Convert the given string to lower-case.
+     *
+     * @return static
+     */
+    public function toLower()
+    {
+        return new static(Str::lower($this->string));
+    }
+
+    /**
+     * Convert a string to snake case.
+     *
+     * @return static
+     */
+    public function toSnake()
+    {
+        return new static(Str::snake($this->string));
+    }
+
+    /**
+     * Convert a value to studly caps case.
+     *
+     * @return static
+     */
+    public function toStudly()
+    {
+        return new static(Str::studly($this->string));
+    }
+
+    /**
+     * Convert the given string to title case.
+     *
+     * @return static
+     */
+    public function toTitle()
+    {
+        return new static(Str::title($this->string));
+    }
+
+    /**
+     * Convert the given string to upper-case.
+     *
+     * @return static
+     */
+    public function toUpper()
+    {
+        return new static(Str::upper($this->string));
+    }
+
+    /**
+     * Get the plural form of an English word.
+     *
+     * @return static
+     */
+    public function toPlural()
+    {
+        return new static(Str::plural($this->string));
+    }
+
+    /**
+     * Get the singular form of an English word.
+     *
+     * @return static
+     */
+    public function toSingular()
+    {
+        return new static(Str::singular($this->string));
+    }
+
+    /**
+     * Generate a URL friendly "slug" from a given string.
+     *
+     * @return static
+     */
+    public function toSlug()
+    {
+        return new static(Str::slug($this->string));
+    }
+
+    /**
+     * Return the length of the given string.
+     *
+     * @return int
+     */
+    public function length()
+    {
+        return Str::length($this->string);
+    }
+
+    /**
+     * Return a Collection of individual words in the string.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function words()
+    {
+        $words = preg_split('/[\s,.;?!:-]+/', $this->string);
+
+        return (new Collection($words))->filter()->values();
+    }
+
+    /**
+     * Return a collection of individual lines in the string.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function lines()
+    {
+        $lines = preg_split('/\r\n|\n|\r/', $this->string);
+
+        return (new Collection($lines));
+    }
+
+    /**
+     * Prepend a given input to the string.
+     *
+     * @param  string  $string
+     * @return static
+     */
+    public function prepend($string)
+    {
+        return new static($string.$this->string);
+    }
+
+    /**
+     * Append a given input to the string.
+     *
+     * @param  string  $string
+     * @return static
+     */
+    public function append($string)
+    {
+        return new static($this->string.$string);
+    }
+
+    /**
+     * Trim given characters from both ends of the string.
+     *
+     * @param  string  $chars
+     * @return static
+     */
+    public function trim($chars = null)
+    {
+        if (is_null($chars)) {
+            return new static(trim($this->string));
+        }
+
+        $charList = preg_quote($chars, '/');
+
+        return new static(preg_replace("/(^[$charList]+)|([$charList]+$)/us", '', $this->string));
+    }
+
+    /**
+     * Trim given characters from the left end of the string.
+     *
+     * @param  string  $chars
+     * @return static
+     */
+    public function ltrim($chars = null)
+    {
+        if (is_null($chars)) {
+            return new static(ltrim($this->string));
+        }
+
+        $charList = preg_quote($chars, '/');
+
+        return new static(preg_replace("/(^[$charList]+)/us", '', $this->string));
+    }
+
+    /**
+     * Trim given characters from the left end of the string.
+     *
+     * @param  string  $chars
+     * @return static
+     */
+    public function rtrim($chars = null)
+    {
+        if (is_null($chars)) {
+            return new static(rtrim($this->string));
+        }
+
+        $charList = preg_quote($chars, '/');
+
+        return new static(preg_replace("/([$charList]+$)/us", '', $this->string));
+    }
+
+    /**
+     * Limit the number of characters in the string.
+     *
+     * @param  int  $limit
+     * @param  string  $end
+     * @return static
+     */
+    public function limit($limit = 100, $end = '...')
+    {
+        return new static(Str::limit($this->string, $limit, $end));
+    }
+
+    /**
+     * Limit the number of words in the string.
+     *
+     * @param  int  $words
+     * @param  string  $end
+     * @return static
+     */
+    public function limitWords($words = 100, $end = '...')
+    {
+        return new static(Str::words($this->string, $words, $end));
+    }
+
+    /**
+     * Return the word at the given index.
+     *
+     * @param  int  $index
+     * @return static
+     */
+    public function wordAt($index)
+    {
+        $words = $this->words();
+
+        return isset($words[$index]) ? new static($words[$index]) : new static('');
+    }
+
+    /**
+     * Determine if a character exists at the given offset.
+     *
+     * @param  mixed  $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return is_numeric($offset) && ($offset < mb_strlen($this->string, $this->encoding));
+    }
+
+    /**
+     * Return the character at the given offset.
+     *
+     * @param  mixed  $offset
+     * @return string
+     */
+    public function offsetGet($offset)
+    {
+        return mb_substr($this->string, $offset, 1, $this->encoding);
+    }
+
+    /**
+     * Replace a character at the given offset with the given value.
+     *
+     * @param  mixed  $offset
+     * @param  mixed  $value
+     */
+    public function offsetSet($offset, $value)
+    {
+        $start = mb_substr($this->string, 0, $offset, $this->encoding);
+        $end = mb_substr($this->string, $offset + 1, null, $this->encoding);
+
+        $this->string = $start.$value.$end;
+    }
+
+    /**
+     * Remove the character at the given offset.
+     *
+     * @param  mixed  $offset
+     */
+    public function offsetUnset($offset)
+    {
+        $start = mb_substr($this->string, 0, $offset, $this->encoding);
+        $end = mb_substr($this->string, $offset + 1, null, $this->encoding);
+
+        $this->string = $start.$end;
+    }
+
+    /**
+     * Return the unwrapped string.
+     *
+     * @return string
+     */
+    public function get()
+    {
+        return $this->string;
+    }
+
+    /**
+     * Cast to string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->get();
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
+use Illuminate\Support\StringBuffer;
 use Illuminate\Support\Debug\Dumper;
 use Illuminate\Contracts\Support\Htmlable;
 
@@ -360,6 +361,19 @@ if (! function_exists('class_uses_recursive')) {
         }
 
         return array_unique($results);
+    }
+}
+
+if (! function_exists('str')) {
+    /**
+     * Create a string buffer from the given value.
+     *
+     * @param  mixed $value
+     * @return \Illuminate\Support\StringBuffer
+     */
+    function str($value)
+    {
+        return new StringBuffer($value);
     }
 }
 

--- a/tests/Support/SupportStringBufferTest.php
+++ b/tests/Support/SupportStringBufferTest.php
@@ -1,0 +1,198 @@
+<?php
+
+use Illuminate\Support\StringBuffer;
+
+class SupportStringBufferTest extends PHPUnit_Framework_TestCase
+{
+    public function testCanBeInstantiated()
+    {
+        $string = new StringBuffer('string');
+        $this->assertEquals('string', $string->get());
+
+        $string = new StringBuffer(new TestToStringObject);
+        $this->assertEquals('string', $string->get());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCannotBeInstantiatedFromArray()
+    {
+        new StringBuffer([1,2,3]);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCannotBeInstantiatedFromObject()
+    {
+        new StringBuffer(new TestObjectWithoutToString);
+    }
+
+    public function testCanBeCastedToString()
+    {
+        $string = new StringBuffer('string');
+        $this->assertEquals('string', $string->get());
+        $this->assertEquals('string', (string) $string);
+    }
+
+    public function testLowerCaseFirst()
+    {
+        $string = new StringBuffer('Hello World!');
+        $this->assertEquals('hello World!', $string->lcfirst()->get());
+
+        $string = new StringBuffer('Τάχιστη');
+        $this->assertEquals('τάχιστη', $string->lcfirst()->get());
+    }
+
+    public function testExplodeByDelimiters()
+    {
+        $string = new StringBuffer('Hello/World!');
+        $this->assertEquals(['Hello', 'World!'], $string->explode('/')->all());
+
+        $string = new StringBuffer('Laravel Php--Framework');
+        $this->assertEquals(['Laravel', 'Php', 'Framework'], $string->explode([' ', '--'])->all());
+
+        $string = new StringBuffer('Τάχιστη');
+        $this->assertEquals(['Τά', 'ιστη'], $string->explode('χ')->all());
+    }
+
+    public function testIndexOf()
+    {
+        $string = new StringBuffer('Hello World!!!');
+        $this->assertEquals(11, $string->indexOf('!'));
+
+        $string = new StringBuffer('Pešci, sčistite cestišče!');
+        $this->assertEquals(21, $string->indexOf('šč'));
+    }
+
+    public function testLastIndexOf()
+    {
+        $string = new StringBuffer('Hello World!!!!');
+        $this->assertEquals(14, $string->lastIndexOf('!'));
+
+        $string = new StringBuffer('Pešci, sčistite cestišče!');
+        $this->assertEquals(22, $string->lastIndexOf('č'));
+    }
+
+    public function testReplaceWithSubstring()
+    {
+        $string = new StringBuffer('Hello World!');
+        $this->assertEquals('Hello Laravel!', $string->replace('World', 'Laravel')->get());
+
+        $string = new StringBuffer('Pešci, sčistite cestišče!');
+        $this->assertEquals('Pesci, scistite cestisce!', $string->replace(['č','š'], ['c','s'], $count1)->get());
+        $this->assertEquals(4, $count1);
+
+        $string = new StringBuffer('Hello, World.');
+        $this->assertEquals('Hello! World!', $string->replace([',','.'], ['!'], $count2)->get());
+        $this->assertEquals('Hello! World!', $string->replace([',','.'], '!', $count3)->get());
+        $this->assertEquals(2, $count2);
+        $this->assertEquals(2, $count3);
+    }
+
+    public function testSplitByWords()
+    {
+        $string = new StringBuffer('one, two ,   three');
+        $this->assertEquals(['one', 'two', 'three'], $string->words()->all());
+
+        $string = new StringBuffer("\nHello? \n Laravel: The Php Framework... ");
+        $this->assertEquals(['Hello', 'Laravel', 'The', 'Php', 'Framework'], $string->words()->all());
+    }
+
+    public function testSplitByLines()
+    {
+        $string = new StringBuffer("one\ntwo\r\nthree\rfour\n\nfive");
+        $this->assertEquals(['one', 'two', 'three', 'four', '', 'five'], $string->lines()->all());
+    }
+
+    public function testAppendAndPrepend()
+    {
+        $string = new StringBuffer('Hello');
+        $this->assertEquals('Hello world!', $string->append(' ')->append('world')->append('!')->get());
+
+        $string = new StringBuffer('world');
+        $this->assertEquals('Hello world!', $string->prepend(' ')->prepend('Hello')->append('!')->get());
+    }
+
+    public function testTrimming()
+    {
+        $string = new StringBuffer(' Hello world! ');
+        $this->assertEquals('Hello world!', $string->trim()->get());
+
+        $string = new StringBuffer(' Hello world! ');
+        $this->assertEquals('Hello world! ', $string->ltrim()->get());
+
+        $string = new StringBuffer(' Hello world! ');
+        $this->assertEquals(' Hello world!', $string->rtrim()->get());
+
+        $string = new StringBuffer('"Hello world!"');
+        $this->assertEquals('Hello world', $string->trim('"!')->get());
+
+        $string = new StringBuffer('Ψ Hello world! Ψ');
+        $this->assertEquals('Hello world', $string->trim('Ψ! ')->get());
+
+        $string = new StringBuffer('Ψ Hello world! Ψ');
+        $this->assertEquals('Hello world! Ψ', $string->ltrim('Ψ! ')->get());
+
+        $string = new StringBuffer('Ψ Hello world! Ψ');
+        $this->assertEquals('Ψ Hello world', $string->rtrim('Ψ! ')->get());
+    }
+
+    public function testWordAtIndex()
+    {
+        $string = new StringBuffer('Hello, world!');
+        $this->assertEquals('world', $string->wordAt(1)->get());
+    }
+
+    public function testOffsets()
+    {
+        $string = new StringBuffer('Τάχιστη');
+        $this->assertEquals('ά', $string[1]);
+        $this->assertTrue(isset($string[6]));
+        $this->assertFalse(isset($string[7]));
+
+        $string[1] = 'a';
+        $this->assertEquals('Τaχιστη', $string->get());
+
+        $string = new StringBuffer('Τάχιστη');
+        unset($string[1]);
+        $this->assertEquals('Τχιστη', $string->get());
+    }
+
+    public function testMethodsDeferredToStrHelper()
+    {
+        $this->assertEquals('Hello world', (new StringBuffer('hello world'))->ucfirst()->get());
+        $this->assertTrue((new StringBuffer('hello world'))->startsWith('hello'));
+        $this->assertTrue((new StringBuffer('hello world'))->endsWith('world'));
+        $this->assertTrue((new StringBuffer('hello world'))->contains('world'));
+        $this->assertTrue((new StringBuffer('hello world'))->equals('hello world'));
+        $this->assertTrue((new StringBuffer('hello/world'))->matches('*/*'));
+        $this->assertEquals('Hell', (new StringBuffer('Hello world'))->substring(0, 4)->get());
+        $this->assertEquals('CcZzSs', (new StringBuffer('ČčŽžŠš'))->toAscii()->get());
+        $this->assertEquals('helloWorld', (new StringBuffer('hello world'))->toCamel()->get());
+        $this->assertEquals('hello world', (new StringBuffer('HELLO WORLD'))->toLower()->get());
+        $this->assertEquals('hello_world', (new StringBuffer('helloWorld'))->toSnake()->get());
+        $this->assertEquals('HelloWorld', (new StringBuffer('hello world'))->toStudly()->get());
+        $this->assertEquals('Hello World', (new StringBuffer('hello world'))->toTitle()->get());
+        $this->assertEquals('HELLO WORLD', (new StringBuffer('hello world'))->toUpper()->get());
+        $this->assertEquals('worlds', (new StringBuffer('world'))->toPlural()->get());
+        $this->assertEquals('world', (new StringBuffer('worlds'))->toSingular()->get());
+        $this->assertEquals('hello-world', (new StringBuffer('hello world'))->toSlug()->get());
+        $this->assertEquals(11, (new StringBuffer('hello world'))->length());
+        $this->assertEquals('hello...', (new StringBuffer('hello world'))->limit(5)->get());
+        $this->assertEquals('hello...', (new StringBuffer('hello world'))->limitWords(1)->get());
+    }
+}
+
+class TestToStringObject
+{
+    public function __toString()
+    {
+        return 'string';
+    }
+}
+
+class TestObjectWithoutToString
+{
+}


### PR DESCRIPTION
This PR proposes a string wrapper (similar to how collections wrap arrays). Basically, I had to deal with a lot of string manipulation in a project recently, so I wrote this class to make my code more readable and avoid all of that UTF-8 and needle-haystack problems. Would you consider adding something like that into core? If not, I'll just make a package for anyone who'd like to use it.

I also added a `str` helper, since we already have a `collect` helper for collections. Below are some real world scenarios that this PR helps to solve:

``` php
// lets say that a user provides tags in the following format: "tag1, tag2, tag3"

str($tags)->words()->each(function ($tag) {
    // do something with a tag here
});
```

``` php
// we can avoid nesting str functions and needle-haystack problems

str('  some text  ')->trim()->substring(0, 4); // returns "some"
```

``` php
// lets say we have a slug "my-blog-title-4" and we need to find the index "4"

$lastIndex = str($lastSlug)->explode('-')->last();
```

``` php
// lets say we have some custom "colon separated" multi line file that we need to import

str($content)->lines()->each(function ($row) {
    $data = str($row)->explode(':');
    // do something with data here
});
```

etc.
