### PR TITLE
[5.2] Return UrlGenerator if `url()` parameter is empty

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -733,6 +733,10 @@ if (! function_exists('url')) {
      */
     function url($path = null, $parameters = [], $secure = null)
     {
+        if (is_null($path)) {
+            return app('url');
+        }
+
         return app('url')->to($path, $parameters, $secure);
     }
 }


### PR DESCRIPTION
With this, we can use these useful methods

``` php
url()->current();
url()->full();
url()->previous();
```
