### PR TITLE
[5.2] Reset query builder columns after setting default

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1361,11 +1361,17 @@ class Builder
      */
     public function get($columns = ['*'])
     {
-        if (is_null($this->columns)) {
+        $original = $this->columns;
+
+        if (is_null($original)) {
             $this->columns = $columns;
         }
 
-        return $this->processor->processSelect($this, $this->runSelect());
+        $results = $this->processor->processSelect($this, $this->runSelect());
+
+        $this->columns = $original;
+
+        return $results;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -35,11 +35,17 @@ class Grammar extends BaseGrammar
      */
     public function compileSelect(Builder $query)
     {
+        $original = $query->columns;
+
         if (is_null($query->columns)) {
             $query->columns = ['*'];
         }
 
-        return trim($this->concatenate($this->compileComponents($query)));
+        $sql = trim($this->concatenate($this->compileComponents($query)));
+
+        $query->columns = $original;
+
+        return $sql;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -25,6 +25,8 @@ class SqlServerGrammar extends Grammar
      */
     public function compileSelect(Builder $query)
     {
+        $original = $query->columns;
+
         if (is_null($query->columns)) {
             $query->columns = ['*'];
         }
@@ -38,7 +40,11 @@ class SqlServerGrammar extends Grammar
             return $this->compileAnsiOffset($query, $components);
         }
 
-        return $this->concatenate($components);
+        $sql = $this->concatenate($components);
+
+        $query->columns = $original;
+
+        return $sql;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -18,6 +18,27 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('select * from "users"', $builder->toSql());
     }
 
+    public function testBasicSelectWithGetColumns()
+    {
+        $builder = $this->getBuilder();
+        $builder->getProcessor()->shouldReceive('processSelect');
+        $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
+            $this->assertEquals('select * from "users"', $sql);
+        });
+        $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
+            $this->assertEquals('select "foo", "bar" from "users"', $sql);
+        });
+
+        $builder->from('users')->get();
+        $this->assertNull($builder->columns);
+
+        $builder->from('users')->get(['foo', 'bar']);
+        $this->assertNull($builder->columns);
+
+        $this->assertEquals('select * from "users"', $builder->toSql());
+        $this->assertNull($builder->columns);
+    }
+
     public function testBasicSelectUseWritePdo()
     {
         $builder = $this->getMySqlBuilderWithProcessor();


### PR DESCRIPTION
There's currently a bug where reusing the same query instance sometimes keeps the old `$columns`.

Here's an example:

``` php
$query = DB::table('users');

$all = $query->get();
$ids = $query->get(['id']);
```

If you currently run this piece of code, `$all` and `$ids` will actually be the same, since they both execute with `select *`.

This PR fixes this by resetting the `$columns` property after performing the query.
