### PR TITLE
[5.2] shouldReceiveJson() simplification

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -189,11 +189,7 @@ trait MakesHttpRequests
      */
     protected function receiveJson($data = null)
     {
-        $this->seeJson();
-
-        if (! is_null($data)) {
-            return $this->seeJson($data);
-        }
+        return $this->seeJson($data);
     }
 
     /**


### PR DESCRIPTION
Both conditional routes eventually end up at `seeJson()`; and since `seeJson()`'s first parameter's default is `null`, this conditional doesn't actually do anything; if you pass a null `$data` to `receiveJson()`, you will get a null first parameter in `seeJson()` either way.

The one caveat is that a `null` `$data` would not `return` from this method like one with real content would, but I don't think that was intentional or consequential.

Note that there's no test coverage on this method, so I can't be _entirely_ sure that there are no other consequences here. But I can't see what they may be.

Also note that `shouldReturnJson()` does the exact same thing, but again I assumed that to be an intentional alias.
