### PR TITLE
[5.2] Corrected ironmq version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",
-        "iron-io/iron_mq": "~2.0|~4.0",
+        "iron-io/iron_mq": "~4.0",
         "mockery/mockery": "~0.9.2",
         "pda/pheanstalk": "~3.0",
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
You missed this when you took out the old code. ;)
