### PR TITLE
[5.1] Remove the $this->path call from the constructor

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -47,7 +47,6 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         $this->perPage = $perPage;
         $this->lastPage = (int) ceil($total / $perPage);
         $this->currentPage = $this->setCurrentPage($currentPage, $this->lastPage);
-        $this->path = $this->path != '/' ? rtrim($this->path, '/').'/' : $this->path;
         $this->items = $items instanceof Collection ? $items : Collection::make($items);
     }
 

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -47,6 +47,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         $this->perPage = $perPage;
         $this->lastPage = (int) ceil($total / $perPage);
         $this->currentPage = $this->setCurrentPage($currentPage, $this->lastPage);
+        $this->path = empty($this->path) ? '/' : $this->path;
         $this->items = $items instanceof Collection ? $items : Collection::make($items);
     }
 

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -37,7 +37,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
 
         $this->perPage = $perPage;
         $this->currentPage = $this->setCurrentPage($currentPage);
-        $this->path = $this->path != '/' ? rtrim($this->path, '/').'/' : $this->path;
+        $this->path = empty($this->path) ? '/' : $this->path;
         $this->items = $items instanceof Collection ? $items : Collection::make($items);
 
         $this->checkForMorePages();

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -175,9 +175,6 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase
         ], $p->toArray());
     }
 
-    /**
-     * This test is useful when integrating with illuminate/database
-     */
     public function testPaginatorDontMainipulateUrlIssue10909()
     {
         Paginator::currentPageResolver(function ($pageName) {

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -35,7 +35,7 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase
 
     public function testPaginatorCanGenerateUrls()
     {
-        $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, ['path' => 'http://website.com', 'pageName' => 'foo']);
+        $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, ['path' => 'http://website.com/', 'pageName' => 'foo']);
 
         $this->assertEquals('http://website.com/?foo=2', $p->url($p->currentPage()));
         $this->assertEquals('http://website.com/?foo=1', $p->url($p->currentPage() - 1));
@@ -173,5 +173,22 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase
             'per_page' => 2, 'current_page' => 2, 'next_page_url' => '/?page=3',
             'prev_page_url' => '/?page=1', 'from' => 3, 'to' => 4, 'data' => ['item3', 'item4'],
         ], $p->toArray());
+    }
+
+    /**
+     * This test is useful when integrating with illuminate/database
+     */
+    public function testPaginatorDontMainipulateUrlIssue10909()
+    {
+        Paginator::currentPageResolver(function ($pageName) {
+            return 2;
+        });
+        Paginator::currentPathResolver(function () {
+            return '/posts';
+        });
+
+        $p = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, 2, Paginator::resolveCurrentPage(), ['path' => Paginator::resolveCurrentPath()]);
+        $this->assertEquals('/posts?page=2', $p->url($p->currentPage()));
+        $this->assertEquals('/posts?page=1', $p->url($p->currentPage() - 1));
     }
 }


### PR DESCRIPTION
Fixed #10909 .

``` php
$this->path = $this->path != '/' ? rtrim($this->path, '/').'/' : $this->path;
```

is resetting the real path appending a `/` always.
