### PR TITLE
[5.1] Add Queue console commands for releasing of multiple failed jobs

### DIFF
--- a/src/Illuminate/Queue/Console/RetryAllCommand.php
+++ b/src/Illuminate/Queue/Console/RetryAllCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+
+class RetryAllCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'queue:retry-all';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Release all failed-jobs onto the queue.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
+        $failed = $this->laravel['queue.failer']->all();
+
+        if (! empty($failed)) {
+            collect($failed)->each(function($value) {
+                $this->call('queue:retry', ['id' => $value->id]);
+            });
+        } else {
+            $this->error('No failed jobs.');
+        }
+    }
+}

--- a/src/Illuminate/Queue/Console/RetryAllCommand.php
+++ b/src/Illuminate/Queue/Console/RetryAllCommand.php
@@ -37,11 +37,12 @@ class RetryAllCommand extends Command
         $failed = $this->laravel['queue.failer']->all();
 
         if (! empty($failed)) {
-            collect($failed)->each(function($value) {
+            collect($failed)->each(function ($value) {
                 $this->call('queue:retry', ['id' => $value->id]);
             });
         } else {
             $this->error('No failed jobs.');
         }
     }
+
 }

--- a/src/Illuminate/Queue/Console/RetryAllCommand.php
+++ b/src/Illuminate/Queue/Console/RetryAllCommand.php
@@ -44,5 +44,4 @@ class RetryAllCommand extends Command
             $this->error('No failed jobs.');
         }
     }
-
 }

--- a/src/Illuminate/Queue/Console/RetryMultipleCommand.php
+++ b/src/Illuminate/Queue/Console/RetryMultipleCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
+
+class RetryMultipleCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'queue:retry-multiple';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Release multiple failed-jobs onto the queue.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        collect($this->argument('ids'))->each(function($id) {
+            $this->call('queue:retry', ['id' => $id]);
+        });
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [[
+            'ids',
+            InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+            'IDs of the failed-jobs you would like released (separate multiple ids with a space).'],
+        ];
+    }
+}

--- a/src/Illuminate/Queue/Console/RetryMultipleCommand.php
+++ b/src/Illuminate/Queue/Console/RetryMultipleCommand.php
@@ -46,5 +46,4 @@ class RetryMultipleCommand extends Command
             'IDs of the failed-jobs you would like released (separate multiple ids with a space).', ],
         ];
     }
-
 }

--- a/src/Illuminate/Queue/Console/RetryMultipleCommand.php
+++ b/src/Illuminate/Queue/Console/RetryMultipleCommand.php
@@ -28,7 +28,7 @@ class RetryMultipleCommand extends Command
      */
     public function handle()
     {
-        collect($this->argument('ids'))->each(function($id) {
+        collect($this->argument('ids'))->each(function ($id) {
             $this->call('queue:retry', ['id' => $id]);
         });
     }
@@ -43,7 +43,8 @@ class RetryMultipleCommand extends Command
         return [[
             'ids',
             InputArgument::IS_ARRAY | InputArgument::REQUIRED,
-            'IDs of the failed-jobs you would like released (separate multiple ids with a space).'],
+            'IDs of the failed-jobs you would like released (separate multiple ids with a space).', ],
         ];
     }
+
 }

--- a/src/Illuminate/Queue/ConsoleServiceProvider.php
+++ b/src/Illuminate/Queue/ConsoleServiceProvider.php
@@ -77,7 +77,7 @@ class ConsoleServiceProvider extends ServiceProvider
         return [
             'command.queue.table', 'command.queue.failed', 'command.queue.retry',
             'command.queue.retry-all', 'command.queue.forget', 'command.queue.flush',
-            'command.queue.failed-table', 'command.queue.retry-multiple'
+            'command.queue.failed-table', 'command.queue.retry-multiple',
         ];
     }
 }

--- a/src/Illuminate/Queue/ConsoleServiceProvider.php
+++ b/src/Illuminate/Queue/ConsoleServiceProvider.php
@@ -5,10 +5,12 @@ namespace Illuminate\Queue;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Console\TableCommand;
 use Illuminate\Queue\Console\RetryCommand;
+use Illuminate\Queue\Console\RetryAllCommand;
 use Illuminate\Queue\Console\ListFailedCommand;
 use Illuminate\Queue\Console\FlushFailedCommand;
 use Illuminate\Queue\Console\FailedTableCommand;
 use Illuminate\Queue\Console\ForgetFailedCommand;
+use Illuminate\Queue\Console\RetryMultipleCommand;
 
 class ConsoleServiceProvider extends ServiceProvider
 {
@@ -38,6 +40,10 @@ class ConsoleServiceProvider extends ServiceProvider
             return new RetryCommand;
         });
 
+        $this->app->singleton('command.queue.retry-all', function () {
+            return new RetryAllCommand;
+        });
+
         $this->app->singleton('command.queue.forget', function () {
             return new ForgetFailedCommand;
         });
@@ -46,13 +52,18 @@ class ConsoleServiceProvider extends ServiceProvider
             return new FlushFailedCommand;
         });
 
+        $this->app->singleton('command.queue.retry-multiple', function () {
+            return new RetryMultipleCommand;
+        });
+
         $this->app->singleton('command.queue.failed-table', function ($app) {
             return new FailedTableCommand($app['files'], $app['composer']);
         });
 
         $this->commands(
             'command.queue.table', 'command.queue.failed', 'command.queue.retry',
-            'command.queue.forget', 'command.queue.flush', 'command.queue.failed-table'
+            'command.queue.retry-all', 'command.queue.forget', 'command.queue.flush',
+            'command.queue.failed-table', 'command.queue.retry-multiple'
         );
     }
 
@@ -65,7 +76,8 @@ class ConsoleServiceProvider extends ServiceProvider
     {
         return [
             'command.queue.table', 'command.queue.failed', 'command.queue.retry',
-            'command.queue.forget', 'command.queue.flush', 'command.queue.failed-table',
+            'command.queue.retry-all', 'command.queue.forget', 'command.queue.flush',
+            'command.queue.failed-table', 'command.queue.retry-multiple'
         ];
     }
 }


### PR DESCRIPTION
For when [Amazon blows up in your face](https://gistlog.co/JacobBennett/ae3a361820713977c9ca) and you don't want to release each job manually :boom::dizzy_face: 

Also @taylorotwell, if you think it would be easier for users, I could merge the code for retry-multiple into the retry command which would allow users to pass through a single id or multiple ids separated by a space.

Not sure if it is advantageous or not to have a separate command for retry-multiple or not.
