### PR TITLE
[5.2] Add missing import

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Illuminate\Contracts\View\View;
 use PHPUnit_Framework_Assert as PHPUnit;
 
 trait MakesHttpRequests


### PR DESCRIPTION
Fixes failing `$this->assertViewHas()` and `$this->assertViewHasAll()`.

Signed-off-by: crynobone crynobone@gmail.com
