### PR TITLE
[5.2] Adding seeJsonStructure helper method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -240,7 +240,7 @@ trait MakesHttpRequests
     {
         return $this->seeJson($data, true);
     }
-    
+
     /**
      * Assert that the json response has a certain structure.
      *

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -240,6 +240,37 @@ trait MakesHttpRequests
     {
         return $this->seeJson($data, true);
     }
+    
+    /**
+     * Assert that the json response has a certain structure.
+     *
+     * @param array|null $structure
+     * @param array|null $responseData
+     * @return $this
+     */
+    public function seeJsonStructure(array $structure = null, $responseData = null)
+    {
+        if (is_null($structure)) {
+            $this->assertJson(
+                $this->response->getContent(), "JSON was not returned from [{$this->currentUri}]."
+            );
+
+            return $this;
+        }
+
+        if (! $responseData) {
+            $responseData = json_decode($this->response->getContent(), true);
+        }
+
+        foreach ($structure as $key => $value) {
+            if (is_array($value)) {
+                $this->assertArrayHasKey($key, $responseData);
+                $this->seeJsonStructure($structure[$key], $responseData[$key]);
+            } else {
+                $this->assertArrayHasKey($value, $responseData);
+            }
+        }
+    }
 
     /**
      * Assert that the response contains the given JSON.

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -244,8 +244,8 @@ trait MakesHttpRequests
     /**
      * Assert that the json response has a certain structure.
      *
-     * @param array|null $structure
-     * @param array|null $responseData
+     * @param  array|null $structure
+     * @param  array|null $responseData
      * @return $this
      */
     public function seeJsonStructure(array $structure = null, $responseData = null)

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -244,8 +244,8 @@ trait MakesHttpRequests
     /**
      * Assert that the json response has a certain structure.
      *
-     * @param  array|null $structure
-     * @param  array|null $responseData
+     * @param  array|null  $structure
+     * @param  array|null  $responseData
      * @return $this
      */
     public function seeJsonStructure(array $structure = null, $responseData = null)


### PR DESCRIPTION
Using this method you can check if a response has a certain structure.
This is also a recursive method, example usage:

``` php
$this->seeJsonStructure([
    'token',
    'user' => [
        'id',
        'name' => [
            'first_name',
            'last_name',
            'full_name'
        ],
        'email',
        'created_at',
        'updated_at'
    ]
]);
```
