### PR TITLE
[5.1] Make DatabaseEloquentMorphTest not dependent on another test

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -903,10 +903,11 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
     public function testModelsAssumeTheirName()
     {
+        require_once __DIR__.'/stubs/EloquentModelNamespacedStub.php';
+
         $model = new EloquentModelWithoutTableStub;
         $this->assertEquals('eloquent_model_without_table_stubs', $model->getTable());
 
-        require_once __DIR__.'/stubs/EloquentModelNamespacedStub.php';
         $namespacedModel = new Foo\Bar\EloquentModelNamespacedStub;
         $this->assertEquals('eloquent_model_namespaced_stubs', $namespacedModel->getTable());
     }

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -212,6 +212,8 @@ class DatabaseEloquentMorphTest extends PHPUnit_Framework_TestCase
 
     protected function getNamespacedRelation($alias)
     {
+        require_once __DIR__.'/stubs/EloquentModelNamespacedStub.php';
+
         Relation::morphMap([
             $alias => 'Foo\Bar\EloquentModelNamespacedStub',
         ]);


### PR DESCRIPTION
Fixes #10860.

Kudos @jairovsky for pointing out the cause.
