### PR TITLE
[5.1] Schema builder: Add defaultCurrentTimestamp() column modifier

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -528,6 +528,10 @@ class MySqlGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
+        if ($column->defaultCurrentTimestamp) {
+            return 'timestamp default CURRENT_TIMESTAMP';
+        }
+
         if (! $column->nullable && $column->default === null) {
             return 'timestamp default 0';
         }
@@ -543,6 +547,10 @@ class MySqlGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
+        if ($column->defaultCurrentTimestamp) {
+            return 'timestamp default CURRENT_TIMESTAMP';
+        }
+
         if (! $column->nullable && $column->default === null) {
             return 'timestamp default 0';
         }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -480,6 +480,10 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
+        if ($column->defaultCurrentTimestamp) {
+            return 'timestamp(0) without time zone default CURRENT_TIMESTAMP(0)';
+        }
+
         return 'timestamp(0) without time zone';
     }
 
@@ -491,6 +495,10 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
+        if ($column->defaultCurrentTimestamp) {
+            return 'timestamp(0) with time zone default CURRENT_TIMESTAMP(0)';
+        }
+
         return 'timestamp(0) with time zone';
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -539,6 +539,10 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
+        if ($column->defaultCurrentTimestamp) {
+            return 'datetime default CURRENT_TIMESTAMP';
+        }
+
         return 'datetime';
     }
 
@@ -550,6 +554,10 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
+        if ($column->defaultCurrentTimestamp) {
+            return 'datetime default CURRENT_TIMESTAMP';
+        }
+
         return 'datetime';
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -482,6 +482,10 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
+        if ($column->defaultCurrentTimestamp) {
+            return 'datetime default CURRENT_TIMESTAMP';
+        }
+
         return 'datetime';
     }
 
@@ -495,6 +499,10 @@ class SqlServerGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
+        if ($column->defaultCurrentTimestamp) {
+            return 'datetimeoffset(0) default CURRENT_TIMESTAMP';
+        }
+
         return 'datetimeoffset(0)';
     }
 

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -2,6 +2,10 @@
 
 use Mockery as m;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Grammars\MySqlGrammar;
+use Illuminate\Database\Schema\Grammars\PostgresGrammar;
+use Illuminate\Database\Schema\Grammars\SQLiteGrammar;
+use Illuminate\Database\Schema\Grammars\SqlServerGrammar;
 
 class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase
 {
@@ -46,5 +50,26 @@ class DatabaseSchemaBlueprintTest extends PHPUnit_Framework_TestCase
         $blueprint->dropIndex(['foo']);
         $commands = $blueprint->getCommands();
         $this->assertEquals('users_foo_index', $commands[0]->index);
+    }
+
+    public function testDefaultCurrentTimestamp()
+    {
+        $base = new Blueprint('users', function ($table) {
+            $table->timestamp('created')->defaultCurrentTimestamp();
+        });
+
+        $connection = m::mock('Illuminate\Database\Connection');
+
+        $blueprint = clone $base;
+        $this->assertEquals(['alter table `users` add `created` timestamp default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new MySqlGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals(['alter table "users" add column "created" timestamp(0) without time zone default CURRENT_TIMESTAMP(0) not null'], $blueprint->toSql($connection, new PostgresGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals(['alter table "users" add column "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SQLiteGrammar));
+
+        $blueprint = clone $base;
+        $this->assertEquals(['alter table "users" add "created" datetime default CURRENT_TIMESTAMP not null'], $blueprint->toSql($connection, new SqlServerGrammar));
     }
 }


### PR DESCRIPTION
This PR probably has some room for improvement ;) Just a first draft to have your opinion on this.

```
Schema::table('users', function ($table) {

    // Let us do this:
    $table->timestamp('created')->defaultCurrentTimestamp();

    // Instead of this:
    $table->timestamp('created')->default(DB::raw('CURRENT_TIMESTAMP'));
});
```

More importantly, the PostgreSQL driver is a special case: it should be passed `CURRENT_TIMESTAMP(0)` instead of `CURRENT_TIMESTAMP`. See [this answer on Stack Overflow](http://stackoverflow.com/questions/18067614/how-can-i-set-the-default-value-of-a-timestamp-column-to-current-timestamp-on-u#20822267).
