### PR TITLE
[5.1] Revert "[5.1] Deprecated some routing stuff"

### DIFF
--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -6,9 +6,6 @@ use ReflectionClass;
 use ReflectionMethod;
 use Illuminate\Support\Str;
 
-/**
- * @deprecated since version 5.1.
- */
 class ControllerInspector
 {
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -224,8 +224,6 @@ class Router implements RegistrarContract
      *
      * @param  array  $controllers
      * @return void
-     *
-     * @deprecated since version 5.1.
      */
     public function controllers(array $controllers)
     {
@@ -241,8 +239,6 @@ class Router implements RegistrarContract
      * @param  string  $controller
      * @param  array   $names
      * @return void
-     *
-     * @deprecated since version 5.1.
      */
     public function controller($uri, $controller, $names = [])
     {
@@ -278,8 +274,6 @@ class Router implements RegistrarContract
      * @param  string  $method
      * @param  array   $names
      * @return void
-     *
-     * @deprecated since version 5.1.
      */
     protected function registerInspected($route, $controller, $method, &$names)
     {
@@ -299,8 +293,6 @@ class Router implements RegistrarContract
      * @param  string  $controller
      * @param  string  $uri
      * @return void
-     *
-     * @deprecated since version 5.1.
      */
     protected function addFallthroughRoute($controller, $uri)
     {


### PR DESCRIPTION
Reverts laravel/framework#10781. I think it's much better to just add this in 5.2 like with any other new deprecations we added there.
