### PR TITLE
[5.1] Escape MySQL index names

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -163,7 +163,7 @@ class MySqlGrammar extends Grammar
 
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} add {$type} {$command->index}($columns)";
+        return "alter table {$table} add {$type} `{$command->index}`($columns)";
     }
 
     /**
@@ -229,7 +229,7 @@ class MySqlGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} drop index {$command->index}";
+        return "alter table {$table} drop index `{$command->index}`";
     }
 
     /**
@@ -243,7 +243,7 @@ class MySqlGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} drop index {$command->index}";
+        return "alter table {$table} drop index `{$command->index}`";
     }
 
     /**
@@ -257,7 +257,7 @@ class MySqlGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} drop foreign key {$command->index}";
+        return "alter table {$table} drop foreign key `{$command->index}`";
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -149,7 +149,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` drop index foo', $statements[0]);
+        $this->assertEquals('alter table `users` drop index `foo`', $statements[0]);
     }
 
     public function testDropIndex()
@@ -159,7 +159,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` drop index foo', $statements[0]);
+        $this->assertEquals('alter table `users` drop index `foo`', $statements[0]);
     }
 
     public function testDropForeign()
@@ -169,7 +169,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` drop foreign key foo', $statements[0]);
+        $this->assertEquals('alter table `users` drop foreign key `foo`', $statements[0]);
     }
 
     public function testDropTimestamps()
@@ -209,7 +209,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add primary key bar(`foo`)', $statements[0]);
+        $this->assertEquals('alter table `users` add primary key `bar`(`foo`)', $statements[0]);
     }
 
     public function testAddingUniqueKey()
@@ -219,7 +219,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add unique bar(`foo`)', $statements[0]);
+        $this->assertEquals('alter table `users` add unique `bar`(`foo`)', $statements[0]);
     }
 
     public function testAddingIndex()
@@ -229,7 +229,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add index baz(`foo`, `bar`)', $statements[0]);
+        $this->assertEquals('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
     }
 
     public function testAddingForeignKey()


### PR DESCRIPTION
Escaping MySQL index names with backticks to prevent MySQL from confusing actual index names with internal keywords.

This fixes #10883.
