### PR TITLE
[5.1] Introduce CheckHttpCache middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/CheckHttpCache.php
+++ b/src/Illuminate/Foundation/Http/Middleware/CheckHttpCache.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Middleware;
+
+use Closure;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckHttpCache
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        if ($response instanceof Response) {
+            $response->isNotModified($request);
+        }
+
+        return $response;
+    }
+}


### PR DESCRIPTION
Provides native symfony handling of cached responses.

I propose include this in 5.1 and enable by default in 5.2 base project.
