### PR TITLE
[5.1] Arr/Collection combine

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -46,6 +46,21 @@ class Arr
     }
 
     /**
+     * Checks if an item can be cast to string.
+     *
+     * @param  mixed  $item
+     * @return bool
+     */
+    protected static function canBeString($item)
+    {
+        if ((is_object($item) && method_exists($item, '__toString'))) {
+            return true;
+        }
+
+        return is_scalar($item);
+    }
+
+    /**
      * Collapse an array of arrays into a single array.
      *
      * @param  array|\ArrayAccess  $array
@@ -73,7 +88,7 @@ class Arr
      * @param  bool  $includeKeyDeprivedValues
      * @return array
      */
-    public function combine($keys, $values, $includeKeyDeprivedValues = true)
+    public static function combine($keys, $values, $includeKeyDeprivedValues = true)
     {
         $combined = [];
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -67,6 +67,38 @@ class Arr
     }
 
     /**
+     * Creates an array by using one array for keys and another for its values.
+     *
+     * @param  array|\ArrayAccess  $items
+     * @param  bool  $includeKeyDeprivedValues
+     * @return array
+     */
+    public function combine($keys, $values, $includeKeyDeprivedValues = true)
+    {
+        $combined = [];
+
+        if ($keys instanceof Collection) {
+            $keys = $keys->all();
+        }
+
+        if ($values instanceof Collection) {
+            $values = $values->all();
+        }
+
+        for ($i = 0; $i < count($values); $i++) {
+            if (isset($keys[$i]) && $this->canBeString($keys[$i]) && (string) $keys[$i] !== '') {
+                static::put($combined, (string) $keys[$i], $values[$i]);
+            } elseif ($includeKeyDeprivedValues) {
+                array_push($combined, $values[$i]);
+            } else {
+                break;
+            }
+        }
+
+        return $combined;
+    }
+
+    /**
      * Divide an array into two arrays. One with keys and the other with values.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -101,8 +101,8 @@ class Arr
         }
 
         for ($i = 0; $i < count($values); $i++) {
-            if (isset($keys[$i]) && $this->canBeString($keys[$i]) && (string) $keys[$i] !== '') {
-                static::put($combined, (string) $keys[$i], $values[$i]);
+            if (isset($keys[$i]) && static::canBeString($keys[$i]) && (string) $keys[$i] !== '') {
+                static::set($combined, (string) $keys[$i], $values[$i]);
             } elseif ($includeKeyDeprivedValues) {
                 array_push($combined, $values[$i]);
             } else {

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -86,6 +86,30 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         return new static(Arr::collapse($this->items));
     }
+    
+    /**
+     * Combine the collection with the given items
+     * using the collection as keys.
+     *
+     * @param  mixed  $items
+     * @param  boolean
+     * @return static
+     */
+    public function combine($items, $includeKeyDeprivedValues = true)
+    {
+        $combined = new static;
+        $values = $this->getArrayableItems($items);
+        
+        for ($i = 0; $i < count($values); $i++) {
+            if (isset($this->items[$i]) && $this->canBeString($this->items[$i]) && (string) $this->items[$i] !== '') {
+                $combined->put((string) $this->items[$i], $values[$i]);
+            } elseif ($includeKeyDeprivedValues) {
+                $combined->push($values[$i]);
+            }
+        }
+        
+        return $combined;
+    }
 
     /**
      * Determine if an item exists in the collection.
@@ -1085,5 +1109,20 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         return (array) $items;
+    }
+
+    /**
+     * Checks if an item can be cast to string.
+     *
+     * @param  mixed $item
+     * @return boolean
+     */
+    protected function canBeString($item)
+    {
+        if ((is_object($item) && method_exists($item, '__toString'))) {
+            return true;
+        }
+        
+        return is_scalar($item);
     }
 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1098,19 +1098,4 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         return (array) $items;
     }
-
-    /**
-     * Checks if an item can be cast to string.
-     *
-     * @param  mixed  $item
-     * @return bool
-     */
-    protected function canBeString($item)
-    {
-        if ((is_object($item) && method_exists($item, '__toString'))) {
-            return true;
-        }
-
-        return is_scalar($item);
-    }
 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -96,20 +96,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function combine($items, $includeKeyDeprivedValues = true)
     {
-        $combined = new static;
-        $values = $this->getArrayableItems($items);
-
-        for ($i = 0; $i < count($values); $i++) {
-            if (isset($this->items[$i]) && $this->canBeString($this->items[$i]) && (string) $this->items[$i] !== '') {
-                $combined->put((string) $this->items[$i], $values[$i]);
-            } elseif ($includeKeyDeprivedValues) {
-                $combined->push($values[$i]);
-            } else {
-                break;
-            }
-        }
-
-        return $combined;
+        return new static(Arr::combine($this->items, $items, $includeKeyDeprivedValues));
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -92,14 +92,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * using the collection as keys.
      *
      * @param  mixed  $items
-     * @param  boolean
+     * @param  bool
      * @return static
      */
     public function combine($items, $includeKeyDeprivedValues = true)
     {
         $combined = new static;
         $values = $this->getArrayableItems($items);
-        
+
         for ($i = 0; $i < count($values); $i++) {
             if (isset($this->items[$i]) && $this->canBeString($this->items[$i]) && (string) $this->items[$i] !== '') {
                 $combined->put((string) $this->items[$i], $values[$i]);
@@ -109,7 +109,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 break;
             }
         }
-        
+
         return $combined;
     }
 
@@ -1117,14 +1117,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Checks if an item can be cast to string.
      *
      * @param  mixed $item
-     * @return boolean
+     * @return bool
      */
     protected function canBeString($item)
     {
         if ((is_object($item) && method_exists($item, '__toString'))) {
             return true;
         }
-        
+
         return is_scalar($item);
     }
 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -105,6 +105,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 $combined->put((string) $this->items[$i], $values[$i]);
             } elseif ($includeKeyDeprivedValues) {
                 $combined->push($values[$i]);
+            } else {
+                break;
             }
         }
         

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -88,11 +88,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Combine the collection with the given items
-     * using the collection as keys.
+     * Combine the collection with the given items using the collection as keys.
      *
      * @param  mixed  $items
-     * @param  bool
+     * @param  bool  $includeKeyDeprivedValues
      * @return static
      */
     public function combine($items, $includeKeyDeprivedValues = true)
@@ -1116,7 +1115,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Checks if an item can be cast to string.
      *
-     * @param  mixed $item
+     * @param  mixed  $item
      * @return bool
      */
     protected function canBeString($item)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -86,7 +86,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         return new static(Arr::collapse($this->items));
     }
-    
+
     /**
      * Combine the collection with the given items
      * using the collection as keys.

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -248,7 +248,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     {
         $c = new Collection([null]);
         $this->assertEquals(['foo'], $c->combine(['foo'])->all());
-        
+
         $c = new Collection([null]);
         $this->assertEquals([], $c->combine(['foo'], false)->all());
     }
@@ -257,7 +257,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     {
         $c = new Collection(['foo']);
         $this->assertEquals(['foo' => 'bar', 'baz'], $c->combine(['bar', 'baz'])->all());
-        
+
         $c = new Collection(['foo']);
         $this->assertEquals(['foo' => 'bar'], $c->combine(['bar', 'baz'], false)->all());
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -238,6 +238,30 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['name' => 'World', 'id' => 1], $c->merge(new Collection(['name' => 'World', 'id' => 1]))->all());
     }
 
+    public function testCombine()
+    {
+        $c = new Collection(['foo']);
+        $this->assertEquals(['foo' => 'bar'], $c->combine(['bar'])->all());
+    }
+
+    public function testCombineNull()
+    {
+        $c = new Collection([null]);
+        $this->assertEquals(['foo'], $c->combine(['foo'])->all());
+        
+        $c = new Collection([null]);
+        $this->assertEquals([], $c->combine(['foo'], false)->all());
+    }
+
+    public function testCombineMissingKey()
+    {
+        $c = new Collection(['foo']);
+        $this->assertEquals(['foo' => 'bar', 'baz'], $c->combine(['bar', 'baz'])->all());
+        
+        $c = new Collection(['foo']);
+        $this->assertEquals(['foo' => 'bar'], $c->combine(['bar', 'baz'], false)->all());
+    }
+
     public function testDiffCollection()
     {
         $c = new Collection(['id' => 1, 'first_word' => 'Hello']);


### PR DESCRIPTION
Adds a `combine` method to the Collection class that allows you to use the collection as keys for the passed items. Additionally, it will just push values that don't have a corresponding key onto the collection. This behaviour can be turned off by setting the second parameter to `false`. If you do that, values without a corresponding key will be skipped.
