### PR TITLE
[5.1] Validator tests with missing values

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -532,6 +532,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['foo' => null], ['foo' => 'Accepted']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, ['foo' => ''], ['foo' => 'Accepted']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, [], ['foo' => 'Accepted']);
         $this->assertFalse($v->passes());
 
@@ -566,6 +569,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testValidateString()
     {
         $trans = $this->getRealTranslator();
+        $v = new Validator($trans, [], ['foo' => 'string']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => null], ['foo' => 'string']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ''], ['foo' => 'string']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['x' => 'aslsdlks'], ['x' => 'string']);
         $this->assertTrue($v->passes());
 
@@ -607,6 +619,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, [], ['foo' => 'Boolean']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['foo' => null], ['foo' => 'Boolean']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ''], ['foo' => 'Boolean']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => false], ['foo' => 'Boolean']);
         $this->assertTrue($v->passes());
 
@@ -644,6 +662,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, [], ['foo' => 'Bool']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['foo' => null], ['foo' => 'Bool']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ''], ['foo' => 'Bool']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => false], ['foo' => 'Bool']);
         $this->assertTrue($v->passes());
 
@@ -666,6 +690,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testValidateNumeric()
     {
         $trans = $this->getRealTranslator();
+        $v = new Validator($trans, [], ['foo' => 'Numeric']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => null], ['foo' => 'Numeric']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ''], ['foo' => 'Numeric']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Numeric']);
         $this->assertFalse($v->passes());
 
@@ -682,6 +715,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testValidateInteger()
     {
         $trans = $this->getRealTranslator();
+        $v = new Validator($trans, [], ['foo' => 'Integer']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => null], ['foo' => 'Integer']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ''], ['foo' => 'Integer']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Integer']);
         $this->assertFalse($v->passes());
 
@@ -698,6 +740,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testValidateInt()
     {
         $trans = $this->getRealTranslator();
+        $v = new Validator($trans, [], ['foo' => 'Int']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => null], ['foo' => 'Int']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => ''], ['foo' => 'Int']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => 'asdad'], ['foo' => 'Int']);
         $this->assertFalse($v->passes());
 


### PR DESCRIPTION
Why this tests ?

In laravel 5.2 (Branch master)

``` php
    /**
     * The validation rules that imply the field is required.
     *
     * @var array
     */
    protected $implicitRules = [
        'Required', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
        'RequiredIf', 'RequiredUnless', 'Accepted',
        'Array', 'Boolean', 'Integer', 'Numeric', 'String',
    ];
```

You were added new implicit rules

``` php
 'Array', 'Boolean', 'Integer', 'Numeric', 'String',
```

In laravel 5.1, **Accepted**  no pass rule for:

``` php
        $v = new Validator($trans, ['foo' => null], ['foo' => 'Accepted']);
        $this->assertFalse($v->passes());

        $v = new Validator($trans, ['foo' => ''], ['foo' => 'Accepted']);
        $this->assertFalse($v->passes());

        $v = new Validator($trans, [], ['foo' => 'Accepted']);
        $this->assertFalse($v->passes());
```

While **'Boolean', 'Integer', 'Numeric', 'String'**, pass rule for:

``` php
        $v = new Validator($trans, [], ['foo' => 'Numeric']);
        $this->assertTrue($v->passes());

        $v = new Validator($trans, ['foo' => null], ['foo' => 'Numeric']);
        $this->assertTrue($v->passes());

        $v = new Validator($trans, ['foo' => ''], ['foo' => 'Numeric']);
        $this->assertTrue($v->passes());
```

I think they need to correct something in the code so that it behaves like **Accepted**
