### PR TITLE
[5.1] Include onceUsingId on Guard contract.

### DIFF
--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -77,6 +77,14 @@ interface Guard
     public function login(Authenticatable $user, $remember = false);
 
     /**
+     * Log the given user ID into the application without sessions or cookies.
+     *
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function onceUsingId($id);
+
+    /**
      * Log the given user ID into the application.
      *
      * @param  mixed  $id


### PR DESCRIPTION
Proposal to include onceUsingId on Guard contract.
Better autocomplete when using IDE.
