### PR TITLE
[5.2] Include onceUsingId on Guard contract

### DIFF
--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -84,6 +84,14 @@ interface Guard
     public function login(Authenticatable $user, $remember = false);
 
     /**
+     * Log the given user ID into the application without sessions or cookies.
+     *
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function onceUsingId($id);
+
+    /**
      * Log the given user ID into the application.
      *
      * @param  mixed  $id


### PR DESCRIPTION
Proposal to include onceUsingId on Guard contract.
Better autocomplete when using IDE.

Submitting to 5.2 as per https://github.com/laravel/framework/pull/11003#issuecomment-157643861
