### PR TITLE
[5.0] Disable MySQL strict mode

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -46,12 +46,19 @@ class MySqlConnector extends Connector implements ConnectorInterface {
 			)->execute();
 		}
 
-		// If the "strict" option has been configured for the connection we'll enable
-		// strict mode on all of these tables. This enforces some extra rules when
+		// If the "strict" option has been configured for the connection we will setup
+		// strict mode for this session. Strict mode enforces some extra rules when
 		// using the MySQL database system and is a quicker way to enforce them.
-		if (isset($config['strict']) && $config['strict'])
+		if (isset($config['strict']))
 		{
-			$connection->prepare("set session sql_mode='STRICT_ALL_TABLES'")->execute();
+			if ($config['strict'])
+			{
+				$connection->prepare("set session sql_mode='STRICT_ALL_TABLES'")->execute();
+			}
+			else
+			{
+				$connection->prepare("set session sql_mode=''")->execute();
+			}
 		}
 
 		return $connection;


### PR DESCRIPTION
I'm basically moving https://github.com/laravel/framework/pull/9712 from `5.1` to `5.0`, now with latest homestead version which comes with MySQL 5.7, all migrations are broken because of this new restriction.
