### PR TITLE
[5.2] Add flatMap method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -458,6 +458,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Map a collection and flatten the result by a single level.
+     *
+     * @param  callable $callback
+     * @return static
+     */
+    public function flatMap(callable $callback)
+    {
+        return $this->map($callback)->collapse();
+    }
+
+    /**
      * Get the max value of a given key.
      *
      * @param  string|null  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -655,6 +655,16 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
     }
 
+    public function testFlatMap()
+    {
+        $data = new Collection([
+            ['name' => 'taylor', 'hobbies' => ['programming', 'basketball']],
+            ['name' => 'adam', 'hobbies' => ['music', 'powerlifting']],
+        ]);
+        $data = $data->flatMap(function ($person) { return $person['hobbies']; });
+        $this->assertEquals(['programming', 'basketball', 'music', 'powerlifting'], $data->all());
+    }
+
     public function testTransform()
     {
         $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);


### PR DESCRIPTION
Another common array operation from functional languages, makes it quick to map out an array of arrays and collapse them into one.

Reference:
http://ruby-doc.org/core-2.2.3/Enumerable.html#method-i-flat_map
http://elixir-lang.org/docs/v1.0/elixir/Enum.html#flat_map/2
http://alvinalexander.com/scala/collection-scala-flatmap-examples-map-fl
atten

Also in Clojure, Haskell, Java (!), etc.

If you think it's a good addition, let me know and I'll cook up a PR for the Collection documentation.
