### PR TITLE
[5.2] Ignore scopes in model firstOr... methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -574,7 +574,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public static function firstOrCreate(array $attributes)
     {
-        if (! is_null($instance = static::where($attributes)->first())) {
+        if (! is_null($instance = (new static)->newQueryWithoutScopes()->where($attributes)->first())) {
             return $instance;
         }
 
@@ -589,7 +589,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public static function firstOrNew(array $attributes)
     {
-        if (! is_null($instance = static::where($attributes)->first())) {
+        if (! is_null($instance = (new static)->newQueryWithoutScopes()->where($attributes)->first())) {
             return $instance;
         }
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -124,6 +124,14 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         $this->assertEquals(1, $users->first()->id);
     }
 
+    public function testFirstOrNewIgnoresSoftDelete()
+    {
+        $this->createUsers();
+
+        $taylor = SoftDeletesTestUser::firstOrNew(['id' => 1]);
+        $this->assertEquals('taylorotwell@gmail.com', $taylor->email);
+    }
+
     /**
      * Helpers...
      */


### PR DESCRIPTION
Currently causes errors when used with unique fields.

``` php
// User has SoftDelete trait
$user = User::create(['email' => 'test@example.com']); // E-mail is unique field
$user->delete();

$new = User::firstOrCreate(['email' => 'test@example.com']); // Duplicate index error.
```

Also was discussed in #10996
