### PR TITLE
[5.1] Avoid using collect() helper

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console;
 
+use Illuminate\Support\Collection;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Container\Container;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -55,7 +56,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      */
     public function call($command, array $parameters = [])
     {
-        $parameters = collect($parameters)->prepend($command);
+        $parameters = (new Collection($parameters))->prepend($command);
 
         $this->lastOutput = new BufferedOutput;
 

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use Illuminate\Support\Collection;
 use Symfony\Component\Process\ProcessUtils;
 use Illuminate\Contracts\Foundation\Application;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -79,7 +80,7 @@ class Schedule
      */
     protected function compileParameters(array $parameters)
     {
-        return collect($parameters)->map(function ($value, $key) {
+        return (new Collection($parameters))->map(function ($value, $key) {
             return is_numeric($key) ? $value : $key.'='.(is_numeric($value) ? $value : ProcessUtils::escapeArgument($value));
         })->implode(' ');
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent;
 use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -254,7 +255,7 @@ class Builder
             }
         }
 
-        return collect($results);
+        return new Collection($results);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Relations;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as BaseCollection;
 
 class MorphTo extends BelongsTo
 {
@@ -187,7 +188,7 @@ class MorphTo extends BelongsTo
     {
         $foreign = $this->foreignKey;
 
-        return collect($this->dictionary[$type])->map(function ($models) use ($foreign) {
+        return (new BaseCollection($this->dictionary[$type]))->map(function ($models) use ($foreign) {
             return head($models)->{$foreign};
 
         })->values()->unique();

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Illuminate\Support\Collection as BaseCollection;
+
 class SoftDeletingScope implements ScopeInterface
 {
     /**
@@ -38,7 +40,7 @@ class SoftDeletingScope implements ScopeInterface
 
         $query = $builder->getQuery();
 
-        $query->wheres = collect($query->wheres)->reject(function ($where) use ($column) {
+        $query->wheres = (new BaseCollection($query->wheres))->reject(function ($where) use ($column) {
             return $this->isSoftDeleteConstraint($where, $column);
         })->values()->all();
     }

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 use Symfony\Component\Console\Input\InputArgument;
 
 class RetryCommand extends Command
@@ -31,7 +32,7 @@ class RetryCommand extends Command
         $ids = $this->argument('id');
 
         if (count($ids) === 1 && $ids[0] === 'all') {
-            $ids = collect($this->laravel['queue.failer']->all())->pluck('id')->all();
+            $ids = (new Collection($this->laravel['queue.failer']->all()))->pluck('id')->all();
         }
 
         foreach ($ids as $id) {


### PR DESCRIPTION
`\collect()` helper is perfect to use in a Laravel application, but is not very OOP and calling it is an unnecessary step.
As is it has also been done for all `str_*` and `arr_*` helper functions before in other PRs, this one sets direct calls to `\Illuminate\Support\Collection::__construct()`
