### PR TITLE
Changes type casting to Swift's toString() method, enabling Exceptions

### DIFF
--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -59,7 +59,7 @@ class MandrillTransport implements Swift_Transport {
 		$client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', [
 			'body' => [
 				'key' => $this->key,
-				'raw_message' => (string) $message,
+				'raw_message' => $message->toString(),
 				'async' => false,
 			],
 		]);


### PR DESCRIPTION
Changes type casting used in raw_message to use Swift's built-in toString() method, allowing Exceptions to be properly thrown. This works around PHP's inability for __toString() to throw an exception - see https://bugs.php.net/bug.php?id=53648

I did this as I had an issue with some of my code, and I was only getting unhelpful errors such as:
`exception 'Symfony\Component\Debug\Exception\FatalErrorException' with message 'Method Swift_Message::__toString() must not throw an exception' in /var/www/application/releases/release-last/vendor/laravel/framework/src/Illuminate/Mail/Transport/MandrillTransport.php:0 Stack trace: #0 [internal function]: Illuminate\Exception\Handler->handleShutdown() #1 {main} [] []`

With this change, I'm now receiving useful exceptions detailing the actual problem.

This may be useful for later Laravel versions too as I see the same code in current master; I'm just stuck on 4.2 with this project so that's what this has been tested successfully with.
