### PR TITLE
[5.1] Directly use Arr::pluck

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue\Console;
 
+use Illuminate\Support\Arr;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -31,7 +32,7 @@ class RetryCommand extends Command
         $ids = $this->argument('id');
 
         if (count($ids) === 1 && $ids[0] === 'all') {
-            $ids = collect($this->laravel['queue.failer']->all())->pluck('id')->all();
+            $ids = Arr::pluck($this->laravel['queue.failer']->all(), 'id');
         }
 
         foreach ($ids as $id) {


### PR DESCRIPTION
Just a quick proposal following [these notes](https://github.com/laravel/framework/pull/11027/files#diff-6d8a6da22b27175e7282237f70b17d68). Your pick.

I think it's more straightforward, and it removes the confusion between Collection->all() and FailedJobProvider->all().
