### PR TITLE
Fixing phpdoc across several files

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -354,8 +354,8 @@ class Guard implements GuardContract
      * Attempt to authenticate a user using the given credentials.
      *
      * @param  array  $credentials
-     * @param  bool   $remember
-     * @param  bool   $login
+     * @param  bool  $remember
+     * @param  bool  $login
      * @return bool
      */
     public function attempt(array $credentials = [], $remember = false, $login = true)
@@ -479,7 +479,7 @@ class Guard implements GuardContract
      * Log the given user ID into the application.
      *
      * @param  mixed  $id
-     * @param  bool   $remember
+     * @param  bool  $remember
      * @return \Illuminate\Contracts\Auth\Authenticatable
      */
     public function loginUsingId($id, $remember = false)

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -186,7 +186,7 @@ class BroadcastManager implements FactoryContract
     /**
      * Register a custom driver creator Closure.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $callback
      * @return $this
      */
@@ -201,7 +201,7 @@ class BroadcastManager implements FactoryContract
      * Dynamically call the default driver instance.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -52,8 +52,8 @@ class ApcStore extends TaggableStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param  mixed  $value
+     * @param  int  $minutes
      * @return void
      */
     public function put($key, $value, $minutes)
@@ -65,7 +65,7 @@ class ApcStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value = 1)
@@ -77,7 +77,7 @@ class ApcStore extends TaggableStore implements Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value = 1)
@@ -89,7 +89,7 @@ class ApcStore extends TaggableStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return array|bool
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/ApcWrapper.php
+++ b/src/Illuminate/Cache/ApcWrapper.php
@@ -36,8 +36,8 @@ class ApcWrapper
      * Store an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $seconds
+     * @param  mixed  $value
+     * @param  int  $seconds
      * @return array|bool
      */
     public function put($key, $value, $seconds)
@@ -49,7 +49,7 @@ class ApcWrapper
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value)
@@ -61,7 +61,7 @@ class ApcWrapper
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value)

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -30,8 +30,8 @@ class ArrayStore extends TaggableStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param  mixed  $value
+     * @param  int  $minutes
      * @return void
      */
     public function put($key, $value, $minutes)
@@ -43,7 +43,7 @@ class ArrayStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function increment($key, $value = 1)
@@ -57,7 +57,7 @@ class ArrayStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function decrement($key, $value = 1)
@@ -69,7 +69,7 @@ class ArrayStore extends TaggableStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -287,7 +287,7 @@ class CacheManager implements FactoryContract
     /**
      * Register a custom driver creator Closure.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $callback
      * @return $this
      */
@@ -302,7 +302,7 @@ class CacheManager implements FactoryContract
      * Dynamically call the default driver instance.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -89,8 +89,8 @@ class DatabaseStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param  mixed  $value
+     * @param  int  $minutes
      * @return void
      */
     public function put($key, $value, $minutes)
@@ -115,7 +115,7 @@ class DatabaseStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function increment($key, $value = 1)
@@ -131,7 +131,7 @@ class DatabaseStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function decrement($key, $value = 1)
@@ -182,7 +182,7 @@ class DatabaseStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -89,8 +89,8 @@ class FileStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param  mixed  $value
+     * @param  int  $minutes
      * @return void
      */
     public function put($key, $value, $minutes)
@@ -119,7 +119,7 @@ class FileStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function increment($key, $value = 1)
@@ -137,7 +137,7 @@ class FileStore implements Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function decrement($key, $value = 1)
@@ -149,7 +149,7 @@ class FileStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -24,7 +24,7 @@ class MemcachedStore extends TaggableStore implements Store
      * Create a new Memcached store.
      *
      * @param  \Memcached  $memcached
-     * @param  string      $prefix
+     * @param  string  $prefix
      * @return void
      */
     public function __construct($memcached, $prefix = '')
@@ -52,8 +52,8 @@ class MemcachedStore extends TaggableStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param  mixed  $value
+     * @param  int  $minutes
      * @return void
      */
     public function put($key, $value, $minutes)
@@ -65,8 +65,8 @@ class MemcachedStore extends TaggableStore implements Store
      * Store an item in the cache if the key doesn't exist.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param  mixed  $value
+     * @param  int  $minutes
      * @return bool
      */
     public function add($key, $value, $minutes)
@@ -78,7 +78,7 @@ class MemcachedStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value = 1)
@@ -90,7 +90,7 @@ class MemcachedStore extends TaggableStore implements Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value = 1)
@@ -102,7 +102,7 @@ class MemcachedStore extends TaggableStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -28,8 +28,8 @@ class NullStore extends TaggableStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param  mixed  $value
+     * @param  int  $minutes
      * @return void
      */
     public function put($key, $value, $minutes)
@@ -41,7 +41,7 @@ class NullStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function increment($key, $value = 1)
@@ -53,7 +53,7 @@ class NullStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function decrement($key, $value = 1)
@@ -65,7 +65,7 @@ class NullStore extends TaggableStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -60,8 +60,8 @@ class RedisStore extends TaggableStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param  mixed  $value
+     * @param  int  $minutes
      * @return void
      */
     public function put($key, $value, $minutes)
@@ -77,7 +77,7 @@ class RedisStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function increment($key, $value = 1)
@@ -89,7 +89,7 @@ class RedisStore extends TaggableStore implements Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function decrement($key, $value = 1)
@@ -101,7 +101,7 @@ class RedisStore extends TaggableStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -8,7 +8,7 @@ class RedisTaggedCache extends TaggedCache
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -89,7 +89,7 @@ class Repository implements CacheContract, ArrayAccess
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null)
@@ -111,7 +111,7 @@ class Repository implements CacheContract, ArrayAccess
      * Retrieve an item from the cache and delete it.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function pull($key, $default = null)
@@ -127,7 +127,7 @@ class Repository implements CacheContract, ArrayAccess
      * Store an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  \DateTime|int  $minutes
      * @return void
      */
@@ -146,7 +146,7 @@ class Repository implements CacheContract, ArrayAccess
      * Store an item in the cache if the key does not exist.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  \DateTime|int  $minutes
      * @return bool
      */
@@ -175,7 +175,7 @@ class Repository implements CacheContract, ArrayAccess
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)
@@ -210,7 +210,7 @@ class Repository implements CacheContract, ArrayAccess
     /**
      * Get an item from the cache, or store the default value forever.
      *
-     * @param  string   $key
+     * @param  string  $key
      * @param  \Closure  $callback
      * @return mixed
      */
@@ -222,7 +222,7 @@ class Repository implements CacheContract, ArrayAccess
     /**
      * Get an item from the cache, or store the default value forever.
      *
-     * @param  string   $key
+     * @param  string  $key
      * @param  \Closure  $callback
      * @return mixed
      */
@@ -243,7 +243,7 @@ class Repository implements CacheContract, ArrayAccess
     /**
      * Remove an item from the cache.
      *
-     * @param  string $key
+     * @param  string  $key
      * @return bool
      */
     public function forget($key)
@@ -268,7 +268,7 @@ class Repository implements CacheContract, ArrayAccess
     /**
      * Set the default cache time in minutes.
      *
-     * @param  int   $minutes
+     * @param  int  $minutes
      * @return void
      */
     public function setDefaultCacheTime($minutes)
@@ -312,7 +312,7 @@ class Repository implements CacheContract, ArrayAccess
      * Store an item in the cache for the default time.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function offsetSet($key, $value)
@@ -352,7 +352,7 @@ class Repository implements CacheContract, ArrayAccess
      * Handle dynamic calls into macros or pass missing methods to the store.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -51,7 +51,7 @@ class TaggedCache implements Store
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null)
@@ -65,7 +65,7 @@ class TaggedCache implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  \DateTime|int  $minutes
      * @return void
      */
@@ -82,7 +82,7 @@ class TaggedCache implements Store
      * Store an item in the cache if the key does not exist.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  \DateTime|int  $minutes
      * @return bool
      */
@@ -101,7 +101,7 @@ class TaggedCache implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function increment($key, $value = 1)
@@ -113,7 +113,7 @@ class TaggedCache implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function decrement($key, $value = 1)
@@ -125,7 +125,7 @@ class TaggedCache implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)
@@ -179,7 +179,7 @@ class TaggedCache implements Store
     /**
      * Get an item from the cache, or store the default value forever.
      *
-     * @param  string    $key
+     * @param  string  $key
      * @param  \Closure  $callback
      * @return mixed
      */
@@ -191,7 +191,7 @@ class TaggedCache implements Store
     /**
      * Get an item from the cache, or store the default value forever.
      *
-     * @param  string    $key
+     * @param  string  $key
      * @param  \Closure  $callback
      * @return mixed
      */

--- a/src/Illuminate/Cache/WinCacheStore.php
+++ b/src/Illuminate/Cache/WinCacheStore.php
@@ -43,8 +43,8 @@ class WinCacheStore extends TaggableStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param  mixed  $value
+     * @param  int  $minutes
      * @return void
      */
     public function put($key, $value, $minutes)
@@ -56,7 +56,7 @@ class WinCacheStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value = 1)
@@ -68,7 +68,7 @@ class WinCacheStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value = 1)
@@ -80,7 +80,7 @@ class WinCacheStore extends TaggableStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Cache/XCacheStore.php
+++ b/src/Illuminate/Cache/XCacheStore.php
@@ -43,8 +43,8 @@ class XCacheStore extends TaggableStore implements Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param  mixed  $value
+     * @param  int  $minutes
      * @return void
      */
     public function put($key, $value, $minutes)
@@ -56,7 +56,7 @@ class XCacheStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function increment($key, $value = 1)
@@ -68,7 +68,7 @@ class XCacheStore extends TaggableStore implements Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int
      */
     public function decrement($key, $value = 1)
@@ -80,7 +80,7 @@ class XCacheStore extends TaggableStore implements Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value)

--- a/src/Illuminate/Config/Repository.php
+++ b/src/Illuminate/Config/Repository.php
@@ -41,7 +41,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Get the specified configuration value.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null)
@@ -53,7 +53,7 @@ class Repository implements ArrayAccess, ConfigContract
      * Set a given configuration value.
      *
      * @param  array|string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function set($key, $value = null)

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -154,7 +154,7 @@ class Command extends SymfonyCommand
      * Call another console command.
      *
      * @param  string  $command
-     * @param  array   $arguments
+     * @param  array  $arguments
      * @return int
      */
     public function call($command, array $arguments = [])
@@ -170,7 +170,7 @@ class Command extends SymfonyCommand
      * Call another console command silently.
      *
      * @param  string  $command
-     * @param  array   $arguments
+     * @param  array  $arguments
      * @return int
      */
     public function callSilent($command, array $arguments = [])
@@ -216,7 +216,7 @@ class Command extends SymfonyCommand
      * Confirm a question with the user.
      *
      * @param  string  $question
-     * @param  bool    $default
+     * @param  bool  $default
      * @return bool
      */
     public function confirm($question, $default = false)
@@ -240,7 +240,7 @@ class Command extends SymfonyCommand
      * Prompt the user for input with auto completion.
      *
      * @param  string  $question
-     * @param  array   $choices
+     * @param  array  $choices
      * @param  string  $default
      * @return string
      */
@@ -253,7 +253,7 @@ class Command extends SymfonyCommand
      * Prompt the user for input with auto completion.
      *
      * @param  string  $question
-     * @param  array   $choices
+     * @param  array  $choices
      * @param  string  $default
      * @return string
      */
@@ -270,7 +270,7 @@ class Command extends SymfonyCommand
      * Prompt the user for input but hide the answer from the console.
      *
      * @param  string  $question
-     * @param  bool    $fallback
+     * @param  bool  $fallback
      * @return string
      */
     public function secret($question, $fallback = true)
@@ -286,10 +286,10 @@ class Command extends SymfonyCommand
      * Give the user a single choice from an array of answers.
      *
      * @param  string  $question
-     * @param  array   $choices
+     * @param  array  $choices
      * @param  string  $default
-     * @param  mixed   $attempts
-     * @param  bool    $multiple
+     * @param  mixed  $attempts
+     * @param  bool  $multiple
      * @return bool
      */
     public function choice($question, array $choices, $default = null, $attempts = null, $multiple = null)
@@ -304,7 +304,7 @@ class Command extends SymfonyCommand
     /**
      * Format input to textual table.
      *
-     * @param  array   $headers
+     * @param  array  $headers
      * @param  array|\Illuminate\Contracts\Support\Arrayable  $rows
      * @param  string  $style
      * @return void

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -9,7 +9,7 @@ trait ConfirmableTrait
     /**
      * Confirm before proceeding with the action.
      *
-     * @param  string    $warning
+     * @param  string  $warning
      * @param  \Closure|bool|null  $callback
      * @return bool
      */

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -19,7 +19,7 @@ class Schedule
      * Add a new callback event to the schedule.
      *
      * @param  string  $callback
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return \Illuminate\Console\Scheduling\Event
      */
     public function call($callback, array $parameters = [])

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -282,7 +282,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Bind a shared Closure into the container.
      *
-     * @param  string    $abstract
+     * @param  string  $abstract
      * @param  \Closure  $closure
      * @return void
      *
@@ -296,7 +296,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * "Extend" an abstract type in the container.
      *
-     * @param  string    $abstract
+     * @param  string  $abstract
      * @param  \Closure  $closure
      * @return void
      *
@@ -317,7 +317,7 @@ class Container implements ArrayAccess, ContainerContract
      * Register an existing instance as shared in the container.
      *
      * @param  string  $abstract
-     * @param  mixed   $instance
+     * @param  mixed  $instance
      * @return void
      */
     public function instance($abstract, $instance)
@@ -349,7 +349,7 @@ class Container implements ArrayAccess, ContainerContract
      * Assign a set of tags to a given binding.
      *
      * @param  array|string  $abstracts
-     * @param  array|mixed   ...$tags
+     * @param  array|mixed  ...$tags
      * @return void
      */
     public function tag($abstracts, $tags)
@@ -412,7 +412,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Bind a new callback to an abstract's rebind event.
      *
-     * @param  string    $abstract
+     * @param  string  $abstract
      * @param  \Closure  $callback
      * @return mixed
      */
@@ -429,7 +429,7 @@ class Container implements ArrayAccess, ContainerContract
      * Refresh an instance on the given target and method.
      *
      * @param  string  $abstract
-     * @param  mixed   $target
+     * @param  mixed  $target
      * @param  string  $method
      * @return mixed
      */
@@ -604,7 +604,7 @@ class Container implements ArrayAccess, ContainerContract
      * Resolve the given type from the container.
      *
      * @param  string  $abstract
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function make($abstract, array $parameters = [])
@@ -654,7 +654,7 @@ class Container implements ArrayAccess, ContainerContract
      * Get the concrete type for a given abstract.
      *
      * @param  string  $abstract
-     * @return mixed   $concrete
+     * @return mixed  $concrete
      */
     protected function getConcrete($abstract)
     {
@@ -720,7 +720,7 @@ class Container implements ArrayAccess, ContainerContract
      * Instantiate a concrete instance of the given type.
      *
      * @param  string  $concrete
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
@@ -873,7 +873,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Register a new resolving callback.
      *
-     * @param  string    $abstract
+     * @param  string  $abstract
      * @param  \Closure|null  $callback
      * @return void
      */
@@ -889,8 +889,8 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Register a new after resolving callback for all types.
      *
-     * @param  string   $abstract
-     * @param  \Closure|null $callback
+     * @param  string  $abstract
+     * @param  \Closure|null  $callback
      * @return void
      */
     public function afterResolving($abstract, Closure $callback = null)
@@ -963,7 +963,7 @@ class Container implements ArrayAccess, ContainerContract
      * Fire all of the resolving callbacks.
      *
      * @param  string  $abstract
-     * @param  mixed   $object
+     * @param  mixed  $object
      * @return void
      */
     protected function fireResolvingCallbacks($abstract, $object)
@@ -990,7 +990,7 @@ class Container implements ArrayAccess, ContainerContract
      *
      * @param  string  $abstract
      * @param  object  $object
-     * @param  array   $callbacksPerType
+     * @param  array  $callbacksPerType
      *
      * @return array
      */
@@ -1041,7 +1041,7 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Determine if the given concrete is buildable.
      *
-     * @param  mixed   $concrete
+     * @param  mixed  $concrete
      * @param  string  $abstract
      * @return bool
      */
@@ -1163,7 +1163,7 @@ class Container implements ArrayAccess, ContainerContract
      * Set the value at a given offset.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function offsetSet($key, $value)
@@ -1206,7 +1206,7 @@ class Container implements ArrayAccess, ContainerContract
      * Dynamically set container services.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function __set($key, $value)

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -37,8 +37,8 @@ interface Guard
      * Attempt to authenticate a user using the given credentials.
      *
      * @param  array  $credentials
-     * @param  bool   $remember
-     * @param  bool   $login
+     * @param  bool  $remember
+     * @param  bool  $login
      * @return bool
      */
     public function attempt(array $credentials = [], $remember = false, $login = true);
@@ -80,7 +80,7 @@ interface Guard
      * Log the given user ID into the application.
      *
      * @param  mixed  $id
-     * @param  bool   $remember
+     * @param  bool  $remember
      * @return \Illuminate\Contracts\Auth\Authenticatable
      */
     public function loginUsingId($id, $remember = false);

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -53,7 +53,7 @@ interface PasswordBroker
     /**
      * Reset the password for the given token.
      *
-     * @param  array     $credentials
+     * @param  array  $credentials
      * @param  \Closure  $callback
      * @return mixed
      */

--- a/src/Illuminate/Contracts/Auth/UserProvider.php
+++ b/src/Illuminate/Contracts/Auth/UserProvider.php
@@ -15,7 +15,7 @@ interface UserProvider
     /**
      * Retrieve a user by their unique identifier and "remember me" token.
      *
-     * @param  mixed   $identifier
+     * @param  mixed  $identifier
      * @param  string  $token
      * @return \Illuminate\Contracts\Auth\Authenticatable|null
      */

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -18,7 +18,7 @@ interface Repository
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null);
@@ -27,7 +27,7 @@ interface Repository
      * Retrieve an item from the cache and delete it.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function pull($key, $default = null);
@@ -36,7 +36,7 @@ interface Repository
      * Store an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  \DateTime|int  $minutes
      * @return void
      */
@@ -46,7 +46,7 @@ interface Repository
      * Store an item in the cache if the key does not exist.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  \DateTime|int  $minutes
      * @return bool
      */
@@ -56,7 +56,7 @@ interface Repository
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value);
@@ -74,7 +74,7 @@ interface Repository
     /**
      * Get an item from the cache, or store the default value forever.
      *
-     * @param  string   $key
+     * @param  string  $key
      * @param  \Closure  $callback
      * @return mixed
      */
@@ -83,7 +83,7 @@ interface Repository
     /**
      * Get an item from the cache, or store the default value forever.
      *
-     * @param  string   $key
+     * @param  string  $key
      * @param  \Closure  $callback
      * @return mixed
      */
@@ -92,7 +92,7 @@ interface Repository
     /**
      * Remove an item from the cache.
      *
-     * @param  string $key
+     * @param  string  $key
      * @return bool
      */
     public function forget($key);

--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -16,8 +16,8 @@ interface Store
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
-     * @param  mixed   $value
-     * @param  int     $minutes
+     * @param  mixed  $value
+     * @param  int  $minutes
      * @return void
      */
     public function put($key, $value, $minutes);
@@ -26,7 +26,7 @@ interface Store
      * Increment the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function increment($key, $value = 1);
@@ -35,7 +35,7 @@ interface Store
      * Decrement the value of an item in the cache.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return int|bool
      */
     public function decrement($key, $value = 1);
@@ -44,7 +44,7 @@ interface Store
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function forever($key, $value);

--- a/src/Illuminate/Contracts/Config/Repository.php
+++ b/src/Illuminate/Contracts/Config/Repository.php
@@ -16,7 +16,7 @@ interface Repository
      * Get the specified configuration value.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null);
@@ -32,7 +32,7 @@ interface Repository
      * Set a given configuration value.
      *
      * @param  array|string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function set($key, $value = null);

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -27,7 +27,7 @@ interface Container
      * Assign a set of tags to a given binding.
      *
      * @param  array|string  $abstracts
-     * @param  array|mixed   ...$tags
+     * @param  array|mixed  ...$tags
      * @return void
      */
     public function tag($abstracts, $tags);
@@ -72,7 +72,7 @@ interface Container
     /**
      * "Extend" an abstract type in the container.
      *
-     * @param  string    $abstract
+     * @param  string  $abstract
      * @param  \Closure  $closure
      * @return void
      *
@@ -84,7 +84,7 @@ interface Container
      * Register an existing instance as shared in the container.
      *
      * @param  string  $abstract
-     * @param  mixed   $instance
+     * @param  mixed  $instance
      * @return void
      */
     public function instance($abstract, $instance);
@@ -101,7 +101,7 @@ interface Container
      * Resolve the given type from the container.
      *
      * @param  string  $abstract
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function make($abstract, array $parameters = []);
@@ -119,7 +119,7 @@ interface Container
     /**
      * Determine if the given abstract type has been resolved.
      *
-     * @param  string $abstract
+     * @param  string  $abstract
      * @return bool
      */
     public function resolved($abstract);
@@ -127,7 +127,7 @@ interface Container
     /**
      * Register a new resolving callback.
      *
-     * @param  string    $abstract
+     * @param  string  $abstract
      * @param  \Closure|null  $callback
      * @return void
      */
@@ -136,7 +136,7 @@ interface Container
     /**
      * Register a new after resolving callback.
      *
-     * @param  string    $abstract
+     * @param  string  $abstract
      * @param  \Closure|null  $callback
      * @return void
      */

--- a/src/Illuminate/Contracts/Cookie/Factory.php
+++ b/src/Illuminate/Contracts/Cookie/Factory.php
@@ -9,11 +9,11 @@ interface Factory
      *
      * @param  string  $name
      * @param  string  $value
-     * @param  int     $minutes
+     * @param  int  $minutes
      * @param  string  $path
      * @param  string  $domain
-     * @param  bool    $secure
-     * @param  bool    $httpOnly
+     * @param  bool  $secure
+     * @param  bool  $httpOnly
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
     public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true);
@@ -25,8 +25,8 @@ interface Factory
      * @param  string  $value
      * @param  string  $path
      * @param  string  $domain
-     * @param  bool    $secure
-     * @param  bool    $httpOnly
+     * @param  bool  $secure
+     * @param  bool  $httpOnly
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
     public function forever($name, $value, $path = null, $domain = null, $secure = false, $httpOnly = true);

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -47,7 +47,7 @@ interface Application extends Container
      *
      * @param  \Illuminate\Support\ServiceProvider|string  $provider
      * @param  array  $options
-     * @param  bool   $force
+     * @param  bool  $force
      * @return \Illuminate\Support\ServiceProvider
      */
     public function register($provider, $options = [], $force = false);

--- a/src/Illuminate/Contracts/Hashing/Hasher.php
+++ b/src/Illuminate/Contracts/Hashing/Hasher.php
@@ -8,7 +8,7 @@ interface Hasher
      * Hash the given value.
      *
      * @param  string  $value
-     * @param  array   $options
+     * @param  array  $options
      * @return string
      */
     public function make($value, array $options = []);
@@ -18,7 +18,7 @@ interface Hasher
      *
      * @param  string  $value
      * @param  string  $hashedValue
-     * @param  array   $options
+     * @param  array  $options
      * @return bool
      */
     public function check($value, $hashedValue, array $options = []);
@@ -27,7 +27,7 @@ interface Hasher
      * Check if the given hash has been hashed using the given options.
      *
      * @param  string  $hashedValue
-     * @param  array   $options
+     * @param  array  $options
      * @return bool
      */
     public function needsRehash($hashedValue, array $options = []);

--- a/src/Illuminate/Contracts/Logging/Log.php
+++ b/src/Illuminate/Contracts/Logging/Log.php
@@ -90,7 +90,7 @@ interface Log
      * Register a daily file log handler.
      *
      * @param  string  $path
-     * @param  int     $days
+     * @param  int  $days
      * @param  string  $level
      * @return void
      */

--- a/src/Illuminate/Contracts/Mail/MailQueue.php
+++ b/src/Illuminate/Contracts/Mail/MailQueue.php
@@ -8,7 +8,7 @@ interface MailQueue
      * Queue a new e-mail message for sending.
      *
      * @param  string|array  $view
-     * @param  array   $data
+     * @param  array  $data
      * @param  \Closure|string  $callback
      * @param  string  $queue
      * @return mixed

--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -21,7 +21,7 @@ interface Job
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0);

--- a/src/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Illuminate/Contracts/Queue/Queue.php
@@ -8,7 +8,7 @@ interface Queue
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -19,7 +19,7 @@ interface Queue
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = []);
@@ -29,7 +29,7 @@ interface Queue
      *
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -40,7 +40,7 @@ interface Queue
      *
      * @param  string  $queue
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @return mixed
      */
     public function pushOn($queue, $job, $data = '');
@@ -51,7 +51,7 @@ interface Queue
      * @param  string  $queue
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @return mixed
      */
     public function laterOn($queue, $delay, $job, $data = '');

--- a/src/Illuminate/Contracts/Redis/Database.php
+++ b/src/Illuminate/Contracts/Redis/Database.php
@@ -8,7 +8,7 @@ interface Database
      * Run a command against the Redis database.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function command($method, array $parameters = []);

--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -75,7 +75,7 @@ interface Registrar
      *
      * @param  string  $name
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return void
      */
     public function resource($name, $controller, array $options = []);
@@ -83,7 +83,7 @@ interface Registrar
     /**
      * Create a route group with shared attributes.
      *
-     * @param  array     $attributes
+     * @param  array  $attributes
      * @param  \Closure  $callback
      * @return void
      */

--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -18,7 +18,7 @@ interface UrlGenerator
      * Generate a secure, absolute URL to the given path.
      *
      * @param  string  $path
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     public function secure($path, $parameters = []);
@@ -27,7 +27,7 @@ interface UrlGenerator
      * Generate a URL to an application asset.
      *
      * @param  string  $path
-     * @param  bool    $secure
+     * @param  bool  $secure
      * @return string
      */
     public function asset($path, $secure = null);
@@ -36,7 +36,7 @@ interface UrlGenerator
      * Get the URL to a named route.
      *
      * @param  string  $name
-     * @param  mixed   $parameters
+     * @param  mixed  $parameters
      * @param  bool  $absolute
      * @return string
      *
@@ -48,8 +48,8 @@ interface UrlGenerator
      * Get the URL to a controller action.
      *
      * @param  string  $action
-     * @param  mixed $parameters
-     * @param  bool $absolute
+     * @param  mixed  $parameters
+     * @param  bool  $absolute
      * @return string
      */
     public function action($action, $parameters = [], $absolute = true);

--- a/src/Illuminate/Contracts/Validation/Factory.php
+++ b/src/Illuminate/Contracts/Validation/Factory.php
@@ -28,7 +28,7 @@ interface Factory
     /**
      * Register a custom implicit validator extension.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $extension
      * @param  string  $message
      * @return void
@@ -38,7 +38,7 @@ interface Factory
     /**
      * Register a custom implicit validator message replacer.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $replacer
      * @return void
      */

--- a/src/Illuminate/Contracts/View/View.php
+++ b/src/Illuminate/Contracts/View/View.php
@@ -17,7 +17,7 @@ interface View extends Renderable
      * Add a piece of data to the view.
      *
      * @param  string|array  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return $this
      */
     public function with($key, $value = null);

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -34,11 +34,11 @@ class CookieJar implements JarContract
      *
      * @param  string  $name
      * @param  string  $value
-     * @param  int     $minutes
+     * @param  int  $minutes
      * @param  string  $path
      * @param  string  $domain
-     * @param  bool    $secure
-     * @param  bool    $httpOnly
+     * @param  bool  $secure
+     * @param  bool  $httpOnly
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
     public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true)
@@ -57,8 +57,8 @@ class CookieJar implements JarContract
      * @param  string  $value
      * @param  string  $path
      * @param  string  $domain
-     * @param  bool    $secure
-     * @param  bool    $httpOnly
+     * @param  bool  $secure
+     * @param  bool  $httpOnly
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
     public function forever($name, $value, $path = null, $domain = null, $secure = false, $httpOnly = true)
@@ -94,7 +94,7 @@ class CookieJar implements JarContract
      * Get a queued cookie instance.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
     public function queued($key, $default = null)

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -39,7 +39,7 @@ class EncryptCookies
     /**
      * Disable encryption for the given cookie name(s).
      *
-     * @param string|array $cookieName
+     * @param  string|array  $cookieName
      * @return void
      */
     public function disableFor($cookieName)
@@ -151,7 +151,7 @@ class EncryptCookies
     /**
      * Determine whether encryption has been disabled for the given cookie.
      *
-     * @param  string $name
+     * @param  string  $name
      * @return bool
      */
     public function isDisabled($name)

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -111,7 +111,7 @@ class Manager
     /**
      * Register a connection with the manager.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @param  string  $name
      * @return void
      */
@@ -191,7 +191,7 @@ class Manager
      * Dynamically pass methods to the default connection.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public static function __callStatic($method, $parameters)

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -137,10 +137,10 @@ class Connection implements ConnectionInterface
     /**
      * Create a new database connection instance.
      *
-     * @param  \PDO     $pdo
-     * @param  string   $database
-     * @param  string   $tablePrefix
-     * @param  array    $config
+     * @param  \PDO  $pdo
+     * @param  string  $database
+     * @param  string  $tablePrefix
+     * @param  array  $config
      * @return void
      */
     public function __construct(PDO $pdo, $database = '', $tablePrefix = '', array $config = [])
@@ -276,7 +276,7 @@ class Connection implements ConnectionInterface
      * Run a select statement and return a single result.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return mixed
      */
     public function selectOne($query, $bindings = [])
@@ -290,7 +290,7 @@ class Connection implements ConnectionInterface
      * Run a select statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return array
      */
     public function selectFromWriteConnection($query, $bindings = [])
@@ -339,7 +339,7 @@ class Connection implements ConnectionInterface
      * Run an insert statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return bool
      */
     public function insert($query, $bindings = [])
@@ -351,7 +351,7 @@ class Connection implements ConnectionInterface
      * Run an update statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return int
      */
     public function update($query, $bindings = [])
@@ -363,7 +363,7 @@ class Connection implements ConnectionInterface
      * Run a delete statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return int
      */
     public function delete($query, $bindings = [])
@@ -375,7 +375,7 @@ class Connection implements ConnectionInterface
      * Execute an SQL statement and return the boolean result.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return bool
      */
     public function statement($query, $bindings = [])
@@ -395,7 +395,7 @@ class Connection implements ConnectionInterface
      * Run an SQL statement and get the number of rows affected.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return int
      */
     public function affectingStatement($query, $bindings = [])
@@ -591,8 +591,8 @@ class Connection implements ConnectionInterface
     /**
      * Run a SQL statement and log its execution context.
      *
-     * @param  string    $query
-     * @param  array     $bindings
+     * @param  string  $query
+     * @param  array  $bindings
      * @param  \Closure  $callback
      * @return mixed
      *
@@ -628,8 +628,8 @@ class Connection implements ConnectionInterface
     /**
      * Run a SQL statement.
      *
-     * @param  string    $query
-     * @param  array     $bindings
+     * @param  string  $query
+     * @param  array  $bindings
      * @param  \Closure  $callback
      * @return mixed
      *
@@ -660,8 +660,8 @@ class Connection implements ConnectionInterface
      * Handle a query exception that occurred during query execution.
      *
      * @param  \Illuminate\Database\QueryException  $e
-     * @param  string    $query
-     * @param  array     $bindings
+     * @param  string  $query
+     * @param  array  $bindings
      * @param  \Closure  $callback
      * @return mixed
      *
@@ -720,7 +720,7 @@ class Connection implements ConnectionInterface
      * Log a query in the connection's query log.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @param  float|null  $time
      * @return void
      */
@@ -766,7 +766,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the elapsed time since a given starting point.
      *
-     * @param  int    $start
+     * @param  int  $start
      * @return float
      */
     protected function getElapsedTime($start)

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -26,7 +26,7 @@ interface ConnectionInterface
      * Run a select statement and return a single result.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return mixed
      */
     public function selectOne($query, $bindings = []);
@@ -35,7 +35,7 @@ interface ConnectionInterface
      * Run a select statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return array
      */
     public function select($query, $bindings = []);
@@ -44,7 +44,7 @@ interface ConnectionInterface
      * Run an insert statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return bool
      */
     public function insert($query, $bindings = []);
@@ -53,7 +53,7 @@ interface ConnectionInterface
      * Run an update statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return int
      */
     public function update($query, $bindings = []);
@@ -62,7 +62,7 @@ interface ConnectionInterface
      * Run a delete statement against the database.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return int
      */
     public function delete($query, $bindings = []);
@@ -71,7 +71,7 @@ interface ConnectionInterface
      * Execute an SQL statement and return the boolean result.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return bool
      */
     public function statement($query, $bindings = []);
@@ -80,7 +80,7 @@ interface ConnectionInterface
      * Run an SQL statement and get the number of rows affected.
      *
      * @param  string  $query
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return int
      */
     public function affectingStatement($query, $bindings = []);

--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -34,7 +34,7 @@ class ConnectionFactory
     /**
      * Establish a PDO connection based on the configuration.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @param  string  $name
      * @return \Illuminate\Database\Connection
      */
@@ -123,7 +123,7 @@ class ConnectionFactory
     /**
      * Get a read / write level configuration.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @param  string  $type
      * @return array
      */
@@ -151,7 +151,7 @@ class ConnectionFactory
     /**
      * Parse and prepare the database configuration.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @param  string  $name
      * @return array
      */
@@ -198,11 +198,11 @@ class ConnectionFactory
     /**
      * Create a new connection instance.
      *
-     * @param  string   $driver
-     * @param  \PDO     $connection
-     * @param  string   $database
-     * @param  string   $prefix
-     * @param  array    $config
+     * @param  string  $driver
+     * @param  \PDO  $connection
+     * @param  string  $database
+     * @param  string  $prefix
+     * @param  array  $config
      * @return \Illuminate\Database\Connection
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -41,8 +41,8 @@ class Connector
      * Create a new PDO connection.
      *
      * @param  string  $dsn
-     * @param  array   $config
-     * @param  array   $options
+     * @param  array  $config
+     * @param  array  $options
      * @return \PDO
      */
     public function createConnection($dsn, array $config, array $options)
@@ -90,7 +90,7 @@ class Connector
      * @param  string  $dsn
      * @param  string  $username
      * @param  string  $password
-     * @param  array   $options
+     * @param  array  $options
      * @return \PDO
      *
      * @throws \Exception

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -65,7 +65,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
      *
      * Chooses socket or host/port based on the 'unix_socket' config value.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @return string
      */
     protected function getDsn(array $config)

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -72,7 +72,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
     /**
      * Create a DSN string from a configuration.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @return string
      */
     protected function getDsn(array $config)

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -35,7 +35,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
     /**
      * Create a DSN string from a configuration.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @return string
      */
     protected function getDsn(array $config)

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -86,7 +86,7 @@ class MigrateMakeCommand extends BaseCommand
      *
      * @param  string  $name
      * @param  string  $table
-     * @param  bool    $create
+     * @param  bool  $create
      * @return string
      */
     protected function writeMigration($name, $table, $create)

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -31,7 +31,7 @@ class StatusCommand extends BaseCommand
     /**
      * Create a new migration rollback command instance.
      *
-     * @param  \Illuminate\Database\Migrations\Migrator $migrator
+     * @param  \Illuminate\Database\Migrations\Migrator  $migrator
      * @return \Illuminate\Database\Console\Migrations\StatusCommand
      */
     public function __construct(Migrator $migrator)

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -265,7 +265,7 @@ class DatabaseManager implements ConnectionResolverInterface
     /**
      * Register an extension connection resolver.
      *
-     * @param  string    $name
+     * @param  string  $name
      * @param  callable  $resolver
      * @return void
      */
@@ -288,7 +288,7 @@ class DatabaseManager implements ConnectionResolverInterface
      * Dynamically pass methods to the default connection.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -320,8 +320,8 @@ class Builder
      * Increment a column's value by a given amount.
      *
      * @param  string  $column
-     * @param  int     $amount
-     * @param  array   $extra
+     * @param  int  $amount
+     * @param  array  $extra
      * @return int
      */
     public function increment($column, $amount = 1, array $extra = [])
@@ -335,8 +335,8 @@ class Builder
      * Decrement a column's value by a given amount.
      *
      * @param  string  $column
-     * @param  int     $amount
-     * @param  array   $extra
+     * @param  int  $amount
+     * @param  array  $extra
      * @return int
      */
     public function decrement($column, $amount = 1, array $extra = [])
@@ -436,8 +436,8 @@ class Builder
     /**
      * Eagerly load the relationship on a set of models.
      *
-     * @param  array     $models
-     * @param  string    $name
+     * @param  array  $models
+     * @param  string  $name
      * @param  \Closure  $constraints
      * @return array
      */
@@ -530,7 +530,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  string  $boolean
      * @return $this
      */
@@ -554,7 +554,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhere($column, $operator = null, $value = null)
@@ -567,7 +567,7 @@ class Builder
      *
      * @param  string  $relation
      * @param  string  $operator
-     * @param  int     $count
+     * @param  int  $count
      * @param  string  $boolean
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
@@ -594,7 +594,7 @@ class Builder
      *
      * @param  string  $relations
      * @param  string  $operator
-     * @param  int     $count
+     * @param  int  $count
      * @param  string  $boolean
      * @param  \Closure|null  $callback
      * @return \Illuminate\Database\Eloquent\Builder|static
@@ -633,10 +633,10 @@ class Builder
     /**
      * Add a relationship count condition to the query with where clauses.
      *
-     * @param  string    $relation
+     * @param  string  $relation
      * @param  \Closure  $callback
-     * @param  string    $operator
-     * @param  int       $count
+     * @param  string  $operator
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function whereHas($relation, Closure $callback, $operator = '>=', $count = 1)
@@ -661,7 +661,7 @@ class Builder
      *
      * @param  string  $relation
      * @param  string  $operator
-     * @param  int     $count
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orHas($relation, $operator = '>=', $count = 1)
@@ -672,10 +672,10 @@ class Builder
     /**
      * Add a relationship count condition to the query with where clauses and an "or".
      *
-     * @param  string    $relation
+     * @param  string  $relation
      * @param  \Closure  $callback
-     * @param  string    $operator
-     * @param  int       $count
+     * @param  string  $operator
+     * @param  int  $count
      * @return \Illuminate\Database\Eloquent\Builder|static
      */
     public function orWhereHas($relation, Closure $callback, $operator = '>=', $count = 1)
@@ -794,7 +794,7 @@ class Builder
      * Parse the nested relationships in a relation.
      *
      * @param  string  $name
-     * @param  array   $results
+     * @param  array  $results
      * @return array
      */
     protected function parseNested($name, $results)
@@ -819,7 +819,7 @@ class Builder
      * Call the given model scope on the underlying model.
      *
      * @param  string  $scope
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return \Illuminate\Database\Query\Builder
      */
     protected function callScope($scope, $parameters)
@@ -903,7 +903,7 @@ class Builder
     /**
      * Extend the builder with a given callback.
      *
-     * @param  string    $name
+     * @param  string  $name
      * @param  \Closure  $callback
      * @return void
      */
@@ -927,7 +927,7 @@ class Builder
      * Dynamically handle calls into the query instance.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -16,7 +16,7 @@ class ModelNotFoundException extends RuntimeException
     /**
      * Set the affected Eloquent model.
      *
-     * @param  string   $model
+     * @param  string  $model
      * @return $this
      */
     public function setModel($model)

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -172,7 +172,7 @@ class BelongsTo extends Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -188,7 +188,7 @@ class BelongsTo extends Relation
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -104,7 +104,7 @@ class BelongsToMany extends Relation
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  string  $boolean
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
@@ -120,7 +120,7 @@ class BelongsToMany extends Relation
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
     public function orWherePivot($column, $operator = null, $value = null)
@@ -131,7 +131,7 @@ class BelongsToMany extends Relation
     /**
      * Execute the query and get the first result.
      *
-     * @param  array   $columns
+     * @param  array  $columns
      * @return mixed
      */
     public function first($columns = ['*'])
@@ -441,7 +441,7 @@ class BelongsToMany extends Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -457,7 +457,7 @@ class BelongsToMany extends Relation
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -544,7 +544,7 @@ class BelongsToMany extends Relation
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @param  array  $joining
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
     public function save(Model $model, array $joining = [], $touch = true)
@@ -670,7 +670,7 @@ class BelongsToMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $joining
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
     public function firstOrCreate(array $attributes, array $joining = [], $touch = true)
@@ -688,7 +688,7 @@ class BelongsToMany extends Relation
      * @param  array  $attributes
      * @param  array  $values
      * @param  array  $joining
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
@@ -709,7 +709,7 @@ class BelongsToMany extends Relation
      *
      * @param  array  $attributes
      * @param  array  $joining
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return \Illuminate\Database\Eloquent\Model
      */
     public function create(array $attributes, array $joining = [], $touch = true)
@@ -750,7 +750,7 @@ class BelongsToMany extends Relation
      * Sync the intermediate tables with a list of IDs or collection of models.
      *
      * @param  \Illuminate\Database\Eloquent\Collection|array  $ids
-     * @param  bool   $detaching
+     * @param  bool  $detaching
      * @return array
      */
     public function sync($ids, $detaching = true)
@@ -823,7 +823,7 @@ class BelongsToMany extends Relation
      *
      * @param  array  $records
      * @param  array  $current
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return array
      */
     protected function attachNew(array $records, array $current, $touch = true)
@@ -857,7 +857,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array  $attributes
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return int
      */
     public function updateExistingPivot($id, array $attributes, $touch = true)
@@ -880,7 +880,7 @@ class BelongsToMany extends Relation
      *
      * @param  mixed  $id
      * @param  array  $attributes
-     * @param  bool   $touch
+     * @param  bool  $touch
      * @return void
      */
     public function attach($id, array $attributes = [], $touch = true)
@@ -925,10 +925,10 @@ class BelongsToMany extends Relation
     /**
      * Create a full attachment record payload.
      *
-     * @param  int    $key
+     * @param  int  $key
      * @param  mixed  $value
      * @param  array  $attributes
-     * @param  bool   $timed
+     * @param  bool  $timed
      * @return array
      */
     protected function attacher($key, $value, $attributes, $timed)
@@ -963,7 +963,7 @@ class BelongsToMany extends Relation
     /**
      * Create a new pivot attachment record.
      *
-     * @param  int   $id
+     * @param  int  $id
      * @param  bool  $timed
      * @return array
      */
@@ -987,7 +987,7 @@ class BelongsToMany extends Relation
      * Set the creation and update timestamps on an attach record.
      *
      * @param  array  $record
-     * @param  bool   $exists
+     * @param  bool  $exists
      * @return array
      */
     protected function setTimestampsOnAttach(array $record, $exists = false)
@@ -1118,7 +1118,7 @@ class BelongsToMany extends Relation
      * Create a new pivot model instance.
      *
      * @param  array  $attributes
-     * @param  bool   $exists
+     * @param  bool  $exists
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
     public function newPivot(array $attributes = [], $exists = false)

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -19,7 +19,7 @@ class HasMany extends HasOneOrMany
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -35,7 +35,7 @@ class HasMany extends HasOneOrMany
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -142,7 +142,7 @@ class HasManyThrough extends Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -158,7 +158,7 @@ class HasManyThrough extends Relation
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -218,7 +218,7 @@ class HasManyThrough extends Relation
     /**
      * Execute the query and get the first related model.
      *
-     * @param  array   $columns
+     * @param  array  $columns
      * @return mixed
      */
     public function first($columns = ['*'])

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -19,7 +19,7 @@ class HasOne extends HasOneOrMany
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -35,7 +35,7 @@ class HasOne extends HasOneOrMany
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -112,7 +112,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Match the eagerly loaded results to their single parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -125,7 +125,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Match the eagerly loaded results to their many parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -138,7 +138,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Match the eagerly loaded results to their many parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @param  string  $type
@@ -167,7 +167,7 @@ abstract class HasOneOrMany extends Relation
     /**
      * Get the value of a relationship by one or many type.
      *
-     * @param  array   $dictionary
+     * @param  array  $dictionary
      * @param  string  $key
      * @param  string  $type
      * @return mixed

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -19,7 +19,7 @@ class MorphMany extends MorphOneOrMany
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -35,7 +35,7 @@ class MorphMany extends MorphOneOrMany
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -19,7 +19,7 @@ class MorphOne extends MorphOneOrMany
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -35,7 +35,7 @@ class MorphOne extends MorphOneOrMany
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -97,7 +97,7 @@ class MorphTo extends BelongsTo
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -143,9 +143,9 @@ class MorphTo extends BelongsTo
     /**
      * Match the results for a given type to their parents.
      *
-     * @param  string $type
-     * @param  \Illuminate\Database\Eloquent\Collection $results
-     * @param string $relation
+     * @param  string  $type
+     * @param  \Illuminate\Database\Eloquent\Collection  $results
+     * @param  string  $relation
      */
     protected function matchToMorphParents($type, Collection $results, $relation)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -97,7 +97,7 @@ class MorphToMany extends BelongsToMany
     /**
      * Create a new pivot attachment record.
      *
-     * @param  int   $id
+     * @param  int  $id
      * @param  bool  $timed
      * @return array
      */
@@ -124,7 +124,7 @@ class MorphToMany extends BelongsToMany
      * Create a new pivot model instance.
      *
      * @param  array  $attributes
-     * @param  bool   $exists
+     * @param  bool  $exists
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
     public function newPivot(array $attributes = [], $exists = false)

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -39,9 +39,9 @@ class Pivot extends Model
      * Create a new pivot model instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
-     * @param  array   $attributes
+     * @param  array  $attributes
      * @param  string  $table
-     * @param  bool    $exists
+     * @param  bool  $exists
      * @return void
      */
     public function __construct(Model $parent, $attributes, $table, $exists = false)

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -80,7 +80,7 @@ abstract class Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $relation
      * @return array
      */
@@ -89,7 +89,7 @@ abstract class Relation
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
      * @return array
@@ -179,7 +179,7 @@ abstract class Relation
     /**
      * Get all of the primary keys for an array of models.
      *
-     * @param  array   $models
+     * @param  array  $models
      * @param  string  $key
      * @return array
      */
@@ -323,7 +323,7 @@ abstract class Relation
      * Handle dynamic method calls to the relationship.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -144,7 +144,7 @@ class SoftDeletingScope implements ScopeInterface
     /**
      * Determine if the given where clause is a soft delete constraint.
      *
-     * @param  array   $where
+     * @param  array  $where
      * @param  string  $column
      * @return bool
      */

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -43,7 +43,7 @@ abstract class Grammar
      * Wrap a value in keyword identifiers.
      *
      * @param  string|\Illuminate\Database\Query\Expression  $value
-     * @param  bool    $prefixAlias
+     * @param  bool  $prefixAlias
      * @return string
      */
     public function wrap($value, $prefixAlias = false)
@@ -101,7 +101,7 @@ abstract class Grammar
     /**
      * Convert an array of column names into a delimited string.
      *
-     * @param  array   $columns
+     * @param  array  $columns
      * @return string
      */
     public function columnize(array $columns)
@@ -112,7 +112,7 @@ abstract class Grammar
     /**
      * Create query parameter place-holders for an array.
      *
-     * @param  array   $values
+     * @param  array  $values
      * @return string
      */
     public function parameterize(array $values)
@@ -123,7 +123,7 @@ abstract class Grammar
     /**
      * Get the appropriate query parameter place-holder for a value.
      *
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return string
      */
     public function parameter($value)

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -69,7 +69,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      * Log that a migration was run.
      *
      * @param  string  $file
-     * @param  int     $batch
+     * @param  int  $batch
      * @return void
      */
     public function log($file, $batch)

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -39,7 +39,7 @@ class MigrationCreator
      * @param  string  $name
      * @param  string  $path
      * @param  string  $table
-     * @param  bool    $create
+     * @param  bool  $create
      * @return string
      */
     public function create($name, $path, $table = null, $create = false)
@@ -62,7 +62,7 @@ class MigrationCreator
      * Get the migration stub file.
      *
      * @param  string  $table
-     * @param  bool    $create
+     * @param  bool  $create
      * @return string
      */
     protected function getStub($table, $create)

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -22,7 +22,7 @@ interface MigrationRepositoryInterface
      * Log that a migration was run.
      *
      * @param  string  $file
-     * @param  int     $batch
+     * @param  int  $batch
      * @return void
      */
     public function log($file, $batch);

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -64,7 +64,7 @@ class Migrator
      * Run the outstanding migrations at a given path.
      *
      * @param  string  $path
-     * @param  bool    $pretend
+     * @param  bool  $pretend
      * @return void
      */
     public function run($path, $pretend = false)
@@ -89,7 +89,7 @@ class Migrator
      * Run an array of migrations.
      *
      * @param  array  $migrations
-     * @param  bool   $pretend
+     * @param  bool  $pretend
      * @return void
      */
     public function runMigrationList($migrations, $pretend = false)
@@ -117,8 +117,8 @@ class Migrator
      * Run "up" a migration instance.
      *
      * @param  string  $file
-     * @param  int     $batch
-     * @param  bool    $pretend
+     * @param  int  $batch
+     * @param  bool  $pretend
      * @return void
      */
     protected function runUp($file, $batch, $pretend)
@@ -202,7 +202,7 @@ class Migrator
      * Run "down" a migration instance.
      *
      * @param  object  $migration
-     * @param  bool    $pretend
+     * @param  bool  $pretend
      * @return void
      */
     protected function runDown($migration, $pretend)
@@ -262,7 +262,7 @@ class Migrator
      * Require in all the migration files in a given path.
      *
      * @param  string  $path
-     * @param  array   $files
+     * @param  array  $files
      * @return void
      */
     public function requireFiles($path, array $files)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -238,7 +238,7 @@ class Builder
      * Add a new "raw" select expression to the query.
      *
      * @param  string  $expression
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function selectRaw($expression, array $bindings = [])
@@ -255,7 +255,7 @@ class Builder
     /**
      * Add a subselect expression to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @param  string  $as
      * @return \Illuminate\Database\Query\Builder|static
      */
@@ -328,7 +328,7 @@ class Builder
      * @param  string  $operator
      * @param  string  $two
      * @param  string  $type
-     * @param  bool    $where
+     * @param  bool  $where
      * @return $this
      */
     public function join($table, $one, $operator = null, $two = null, $type = 'inner', $where = false)
@@ -438,7 +438,7 @@ class Builder
      *
      * @param  string|array|\Closure  $column
      * @param  string  $operator
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  string  $boolean
      * @return $this
      *
@@ -513,7 +513,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $operator
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhere($column, $operator = null, $value = null)
@@ -539,7 +539,7 @@ class Builder
      * Add a raw where clause to the query.
      *
      * @param  string  $sql
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @param  string  $boolean
      * @return $this
      */
@@ -558,7 +558,7 @@ class Builder
      * Add a raw or where clause to the query.
      *
      * @param  string  $sql
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereRaw($sql, array $bindings = [])
@@ -570,7 +570,7 @@ class Builder
      * Add a where between statement to the query.
      *
      * @param  string  $column
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
@@ -590,7 +590,7 @@ class Builder
      * Add an or where between statement to the query.
      *
      * @param  string  $column
-     * @param  array   $values
+     * @param  array  $values
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereBetween($column, array $values)
@@ -602,7 +602,7 @@ class Builder
      * Add a where not between statement to the query.
      *
      * @param  string  $column
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
@@ -615,7 +615,7 @@ class Builder
      * Add an or where not between statement to the query.
      *
      * @param  string  $column
-     * @param  array   $values
+     * @param  array  $values
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereNotBetween($column, array $values)
@@ -626,8 +626,8 @@ class Builder
     /**
      * Add a nested where statement to the query.
      *
-     * @param  \Closure $callback
-     * @param  string   $boolean
+     * @param  \Closure  $callback
+     * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function whereNested(Closure $callback, $boolean = 'and')
@@ -647,7 +647,7 @@ class Builder
     /**
      * Add another query builder as a nested where to the query builder.
      *
-     * @param  \Illuminate\Database\Query\Builder|static $query
+     * @param  \Illuminate\Database\Query\Builder|static  $query
      * @param  string  $boolean
      * @return $this
      */
@@ -667,10 +667,10 @@ class Builder
     /**
      * Add a full sub-select to the query.
      *
-     * @param  string   $column
-     * @param  string   $operator
-     * @param  \Closure $callback
-     * @param  string   $boolean
+     * @param  string  $column
+     * @param  string  $operator
+     * @param  \Closure  $callback
+     * @param  string  $boolean
      * @return $this
      */
     protected function whereSub($column, $operator, Closure $callback, $boolean)
@@ -694,9 +694,9 @@ class Builder
     /**
      * Add an exists clause to the query.
      *
-     * @param  \Closure $callback
-     * @param  string   $boolean
-     * @param  bool     $not
+     * @param  \Closure  $callback
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     public function whereExists(Closure $callback, $boolean = 'and', $not = false)
@@ -720,8 +720,8 @@ class Builder
     /**
      * Add an or exists clause to the query.
      *
-     * @param  \Closure $callback
-     * @param  bool     $not
+     * @param  \Closure  $callback
+     * @param  bool  $not
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereExists(Closure $callback, $not = false)
@@ -732,8 +732,8 @@ class Builder
     /**
      * Add a where not exists clause to the query.
      *
-     * @param  \Closure $callback
-     * @param  string   $boolean
+     * @param  \Closure  $callback
+     * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function whereNotExists(Closure $callback, $boolean = 'and')
@@ -756,9 +756,9 @@ class Builder
      * Add a "where in" clause to the query.
      *
      * @param  string  $column
-     * @param  mixed   $values
+     * @param  mixed  $values
      * @param  string  $boolean
-     * @param  bool    $not
+     * @param  bool  $not
      * @return $this
      */
     public function whereIn($column, $values, $boolean = 'and', $not = false)
@@ -787,7 +787,7 @@ class Builder
      * Add an "or where in" clause to the query.
      *
      * @param  string  $column
-     * @param  mixed   $values
+     * @param  mixed  $values
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereIn($column, $values)
@@ -799,7 +799,7 @@ class Builder
      * Add a "where not in" clause to the query.
      *
      * @param  string  $column
-     * @param  mixed   $values
+     * @param  mixed  $values
      * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
@@ -812,7 +812,7 @@ class Builder
      * Add an "or where not in" clause to the query.
      *
      * @param  string  $column
-     * @param  mixed   $values
+     * @param  mixed  $values
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orWhereNotIn($column, $values)
@@ -823,10 +823,10 @@ class Builder
     /**
      * Add a where in with a sub-select to the query.
      *
-     * @param  string   $column
-     * @param  \Closure $callback
-     * @param  string   $boolean
-     * @param  bool     $not
+     * @param  string  $column
+     * @param  \Closure  $callback
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     protected function whereInSub($column, Closure $callback, $boolean, $not)
@@ -850,7 +850,7 @@ class Builder
      *
      * @param  string  $column
      * @param  string  $boolean
-     * @param  bool    $not
+     * @param  bool  $not
      * @return $this
      */
     public function whereNull($column, $boolean = 'and', $not = false)
@@ -900,9 +900,9 @@ class Builder
      * Add a "where date" statement to the query.
      *
      * @param  string  $column
-     * @param  string   $operator
-     * @param  int   $value
-     * @param  string   $boolean
+     * @param  string  $operator
+     * @param  int  $value
+     * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function whereDate($column, $operator, $value, $boolean = 'and')
@@ -914,9 +914,9 @@ class Builder
      * Add a "where day" statement to the query.
      *
      * @param  string  $column
-     * @param  string   $operator
-     * @param  int   $value
-     * @param  string   $boolean
+     * @param  string  $operator
+     * @param  int  $value
+     * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function whereDay($column, $operator, $value, $boolean = 'and')
@@ -928,9 +928,9 @@ class Builder
      * Add a "where month" statement to the query.
      *
      * @param  string  $column
-     * @param  string   $operator
-     * @param  int   $value
-     * @param  string   $boolean
+     * @param  string  $operator
+     * @param  int  $value
+     * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function whereMonth($column, $operator, $value, $boolean = 'and')
@@ -942,9 +942,9 @@ class Builder
      * Add a "where year" statement to the query.
      *
      * @param  string  $column
-     * @param  string   $operator
-     * @param  int   $value
-     * @param  string   $boolean
+     * @param  string  $operator
+     * @param  int  $value
+     * @param  string  $boolean
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function whereYear($column, $operator, $value, $boolean = 'and')
@@ -1017,8 +1017,8 @@ class Builder
      *
      * @param  string  $segment
      * @param  string  $connector
-     * @param  array   $parameters
-     * @param  int     $index
+     * @param  array  $parameters
+     * @param  int  $index
      * @return void
      */
     protected function addDynamic($segment, $connector, $parameters, $index)
@@ -1085,7 +1085,7 @@ class Builder
      * Add a raw having clause to the query.
      *
      * @param  string  $sql
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @param  string  $boolean
      * @return $this
      */
@@ -1104,7 +1104,7 @@ class Builder
      * Add a raw or having clause to the query.
      *
      * @param  string  $sql
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function orHavingRaw($sql, array $bindings = [])
@@ -1318,7 +1318,7 @@ class Builder
     /**
      * Execute a query for a single record by ID.
      *
-     * @param  int    $id
+     * @param  int  $id
      * @param  array  $columns
      * @return mixed|static
      */
@@ -1358,7 +1358,7 @@ class Builder
     /**
      * Execute the query and get the first result.
      *
-     * @param  array   $columns
+     * @param  array  $columns
      * @return mixed|static
      */
     public function first($columns = ['*'])
@@ -1699,7 +1699,7 @@ class Builder
      * Execute an aggregate function on the database.
      *
      * @param  string  $function
-     * @param  array   $columns
+     * @param  array  $columns
      * @return float|int
      */
     public function aggregate($function, $columns = ['*'])
@@ -1786,7 +1786,7 @@ class Builder
     /**
      * Insert a new record and get the value of the primary key.
      *
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $sequence
      * @return int
      */
@@ -1818,8 +1818,8 @@ class Builder
      * Increment a column's value by a given amount.
      *
      * @param  string  $column
-     * @param  int     $amount
-     * @param  array   $extra
+     * @param  int  $amount
+     * @param  array  $extra
      * @return int
      */
     public function increment($column, $amount = 1, array $extra = [])
@@ -1835,8 +1835,8 @@ class Builder
      * Decrement a column's value by a given amount.
      *
      * @param  string  $column
-     * @param  int     $amount
-     * @param  array   $extra
+     * @param  int  $amount
+     * @param  array  $extra
      * @return int
      */
     public function decrement($column, $amount = 1, array $extra = [])
@@ -1951,7 +1951,7 @@ class Builder
     /**
      * Set the bindings on the query builder.
      *
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @param  string  $type
      * @return $this
      *
@@ -1971,7 +1971,7 @@ class Builder
     /**
      * Add a binding to the query.
      *
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @param  string  $type
      * @return $this
      *
@@ -2051,7 +2051,7 @@ class Builder
      * Handle dynamic method calls into the method.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \BadMethodCallException

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -261,8 +261,8 @@ class Grammar extends BaseGrammar
     /**
      * Compile a where condition with a sub-select.
      *
-     * @param  \Illuminate\Database\Query\Builder $query
-     * @param  array   $where
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
      * @return string
      */
     protected function whereSub(Builder $query, $where)
@@ -516,7 +516,7 @@ class Grammar extends BaseGrammar
     /**
      * Compile a single having clause.
      *
-     * @param  array   $having
+     * @param  array  $having
      * @return string
      */
     protected function compileHaving(array $having)
@@ -534,7 +534,7 @@ class Grammar extends BaseGrammar
     /**
      * Compile a basic having clause.
      *
-     * @param  array   $having
+     * @param  array  $having
      * @return string
      */
     protected function compileBasicHaving($having)
@@ -633,7 +633,7 @@ class Grammar extends BaseGrammar
     /**
      * Compile an exists statement into SQL.
      *
-     * @param \Illuminate\Database\Query\Builder $query
+     * @param  \Illuminate\Database\Query\Builder  $query
      * @return string
      */
     public function compileExists(Builder $query)
@@ -681,7 +681,7 @@ class Grammar extends BaseGrammar
      * Compile an insert and get ID statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $sequence
      * @return string
      */
@@ -802,7 +802,7 @@ class Grammar extends BaseGrammar
     /**
      * Concatenate an array of segments, removing empties.
      *
-     * @param  array   $segments
+     * @param  array  $segments
      * @return string
      */
     protected function concatenate($segments)

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -59,7 +59,7 @@ class PostgresGrammar extends Grammar
     /**
      * Compile the columns for the update statement.
      *
-     * @param  array   $values
+     * @param  array  $values
      * @return string
      */
     protected function compileUpdateColumns($values)
@@ -154,7 +154,7 @@ class PostgresGrammar extends Grammar
      * Compile an insert and get ID statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $sequence
      * @return string
      */

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -206,7 +206,7 @@ class SqlServerGrammar extends Grammar
     /**
      * Compile an exists statement into SQL.
      *
-     * @param \Illuminate\Database\Query\Builder $query
+     * @param  \Illuminate\Database\Query\Builder  $query
      * @return string
      */
     public function compileExists(Builder $query)

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -232,7 +232,7 @@ class JoinClause
      * Add a nested where statement to the query.
      *
      * @param  \Closure  $callback
-     * @param  string   $boolean
+     * @param  string  $boolean
      * @return \Illuminate\Database\Query\JoinClause
      */
     public function nest(Closure $callback, $boolean = 'and')

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -11,7 +11,7 @@ class PostgresProcessor extends Processor
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $sql
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $sequence
      * @return int
      */

--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -23,7 +23,7 @@ class Processor
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $sql
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $sequence
      * @return int
      */

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -11,7 +11,7 @@ class SqlServerProcessor extends Processor
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  string  $sql
-     * @param  array   $values
+     * @param  array  $values
      * @param  string  $sequence
      * @return int
      */

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -25,7 +25,7 @@ class QueryException extends PDOException
      *
      * @param  string  $sql
      * @param  array  $bindings
-     * @param  \Exception $previous
+     * @param  \Exception  $previous
      * @return void
      */
     public function __construct($sql, array $bindings, $previous)
@@ -48,7 +48,7 @@ class QueryException extends PDOException
      *
      * @param  string  $sql
      * @param  array  $bindings
-     * @param  \Exception $previous
+     * @param  \Exception  $previous
      * @return string
      */
     protected function formatMessage($sql, $bindings, $previous)

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -74,7 +74,7 @@ class Blueprint
      * Execute the blueprint against the database.
      *
      * @param  \Illuminate\Database\Connection  $connection
-     * @param  \Illuminate\Database\Schema\Grammars\Grammar $grammar
+     * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return void
      */
     public function build(Connection $connection, Grammar $grammar)
@@ -615,8 +615,8 @@ class Blueprint
      * Create a new float column on the table.
      *
      * @param  string  $column
-     * @param  int     $total
-     * @param  int     $places
+     * @param  int  $total
+     * @param  int  $places
      * @return \Illuminate\Support\Fluent
      */
     public function float($column, $total = 8, $places = 2)
@@ -627,9 +627,9 @@ class Blueprint
     /**
      * Create a new double column on the table.
      *
-     * @param  string   $column
-     * @param  int|null    $total
-     * @param  int|null $places
+     * @param  string  $column
+     * @param  int|null  $total
+     * @param  int|null  $places
      * @return \Illuminate\Support\Fluent
      */
     public function double($column, $total = null, $places = null)
@@ -641,8 +641,8 @@ class Blueprint
      * Create a new decimal column on the table.
      *
      * @param  string  $column
-     * @param  int     $total
-     * @param  int     $places
+     * @param  int  $total
+     * @param  int  $places
      * @return \Illuminate\Support\Fluent
      */
     public function decimal($column, $total = 8, $places = 2)
@@ -665,7 +665,7 @@ class Blueprint
      * Create a new enum column on the table.
      *
      * @param  string  $column
-     * @param  array   $allowed
+     * @param  array  $allowed
      * @return \Illuminate\Support\Fluent
      */
     public function enum($column, array $allowed)
@@ -893,9 +893,9 @@ class Blueprint
     /**
      * Add a new index command to the blueprint.
      *
-     * @param  string        $type
+     * @param  string  $type
      * @param  string|array  $columns
-     * @param  string        $index
+     * @param  string  $index
      * @return \Illuminate\Support\Fluent
      */
     protected function indexCommand($type, $columns, $index)
@@ -916,7 +916,7 @@ class Blueprint
      * Create a default index name for the table.
      *
      * @param  string  $type
-     * @param  array   $columns
+     * @param  array  $columns
      * @return string
      */
     protected function createIndexName($type, array $columns)
@@ -931,7 +931,7 @@ class Blueprint
      *
      * @param  string  $type
      * @param  string  $name
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return \Illuminate\Support\Fluent
      */
     protected function addColumn($type, $name, array $parameters = [])
@@ -976,7 +976,7 @@ class Blueprint
      * Create a new Fluent command.
      *
      * @param  string  $name
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return \Illuminate\Support\Fluent
      */
     protected function createCommand($name, array $parameters = [])

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -73,7 +73,7 @@ class Builder
      * Determine if the given table has given columns.
      *
      * @param  string  $table
-     * @param  array   $columns
+     * @param  array  $columns
      * @return bool
      */
     public function hasColumns($table, array $columns)
@@ -107,7 +107,7 @@ class Builder
     /**
      * Modify a table on the schema.
      *
-     * @param  string    $table
+     * @param  string  $table
      * @param  \Closure  $callback
      * @return \Illuminate\Database\Schema\Blueprint
      */
@@ -119,7 +119,7 @@ class Builder
     /**
      * Create a new table on the schema.
      *
-     * @param  string    $table
+     * @param  string  $table
      * @param  \Closure  $callback
      * @return \Illuminate\Database\Schema\Blueprint
      */

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -112,7 +112,7 @@ abstract class Grammar extends BaseGrammar
     /**
      * Compile the blueprint's column definitions.
      *
-     * @param  \Illuminate\Database\Schema\Blueprint $blueprint
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @return array
      */
     protected function getColumns(Blueprint $blueprint)
@@ -195,7 +195,7 @@ abstract class Grammar extends BaseGrammar
      * Add a prefix to an array of values.
      *
      * @param  string  $prefix
-     * @param  array   $values
+     * @param  array  $values
      * @return array
      */
     public function prefixArray($prefix, array $values)
@@ -209,7 +209,7 @@ abstract class Grammar extends BaseGrammar
     /**
      * Wrap a table in keyword identifiers.
      *
-     * @param  mixed   $table
+     * @param  mixed  $table
      * @return string
      */
     public function wrapTable($table)
@@ -236,7 +236,7 @@ abstract class Grammar extends BaseGrammar
     /**
      * Format a value so that it can be used in "default" clauses.
      *
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return string
      */
     protected function getDefaultValue($value)
@@ -275,7 +275,7 @@ abstract class Grammar extends BaseGrammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @param  \Illuminate\Database\Connection $connection
+     * @param  \Illuminate\Database\Connection  $connection
      * @return array
      */
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -261,7 +261,7 @@ class Filesystem
      * Find path names matching a given pattern.
      *
      * @param  string  $pattern
-     * @param  int     $flags
+     * @param  int  $flags
      * @return array
      */
     public function glob($pattern, $flags = 0)
@@ -323,9 +323,9 @@ class Filesystem
      * Create a directory.
      *
      * @param  string  $path
-     * @param  int     $mode
-     * @param  bool    $recursive
-     * @param  bool    $force
+     * @param  int  $mode
+     * @param  bool  $recursive
+     * @param  bool  $force
      * @return bool
      */
     public function makeDirectory($path, $mode = 0755, $recursive = false, $force = false)
@@ -342,7 +342,7 @@ class Filesystem
      *
      * @param  string  $directory
      * @param  string  $destination
-     * @param  int     $options
+     * @param  int  $options
      * @return bool
      */
     public function copyDirectory($directory, $destination, $options = null)
@@ -395,7 +395,7 @@ class Filesystem
      * The directory itself may be optionally preserved.
      *
      * @param  string  $directory
-     * @param  bool    $preserve
+     * @param  bool  $preserve
      * @return bool
      */
     public function deleteDirectory($directory, $preserve = false)

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -270,7 +270,7 @@ class FilesystemManager implements FactoryContract
     /**
      * Register a custom driver creator Closure.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $callback
      * @return $this
      */
@@ -285,7 +285,7 @@ class FilesystemManager implements FactoryContract
      * Dynamically call the default driver instance.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -512,7 +512,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @param  \Illuminate\Support\ServiceProvider|string  $provider
      * @param  array  $options
-     * @param  bool   $force
+     * @param  bool  $force
      * @return \Illuminate\Support\ServiceProvider
      */
     public function register($provider, $options = [], $force = false)
@@ -660,7 +660,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      * (Overriding Container::make)
      *
      * @param  string  $abstract
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function make($abstract, array $parameters = [])
@@ -866,9 +866,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     /**
      * Throw an HttpException with the given data.
      *
-     * @param  int     $code
+     * @param  int  $code
      * @param  string  $message
-     * @param  array   $headers
+     * @param  array  $headers
      * @return void
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -163,7 +163,7 @@ class Kernel implements KernelContract
      * Queue the given console command.
      *
      * @param  string  $command
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return void
      */
     public function queue($command, array $parameters = [])

--- a/src/Illuminate/Foundation/Testing/AssertionsTrait.php
+++ b/src/Illuminate/Foundation/Testing/AssertionsTrait.php
@@ -92,7 +92,7 @@ trait AssertionsTrait
      * Assert whether the client was redirected to a given URI.
      *
      * @param  string  $uri
-     * @param  array   $with
+     * @param  array  $with
      * @return void
      */
     public function assertRedirectedTo($uri, $with = [])
@@ -108,8 +108,8 @@ trait AssertionsTrait
      * Assert whether the client was redirected to a given route.
      *
      * @param  string  $name
-     * @param  array   $parameters
-     * @param  array   $with
+     * @param  array  $parameters
+     * @param  array  $with
      * @return void
      */
     public function assertRedirectedToRoute($name, $parameters = [], $with = [])
@@ -121,8 +121,8 @@ trait AssertionsTrait
      * Assert whether the client was redirected to a given action.
      *
      * @param  string  $name
-     * @param  array   $parameters
-     * @param  array   $with
+     * @param  array  $parameters
+     * @param  array  $with
      * @return void
      */
     public function assertRedirectedToAction($name, $parameters = [], $with = [])

--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -302,8 +302,8 @@ trait CrawlerTrait
     /**
      * Asserts that the response contains the given header and equals the optional value.
      *
-     * @param  string $headerName
-     * @param  mixed $value
+     * @param  string  $headerName
+     * @param  mixed  $value
      * @return $this
      */
     protected function seeHeader($headerName, $value = null)
@@ -325,8 +325,8 @@ trait CrawlerTrait
     /**
      * Asserts that the response contains the given cookie and equals the optional value.
      *
-     * @param  string $cookieName
-     * @param  mixed $value
+     * @param  string  $cookieName
+     * @param  mixed  $value
      * @return $this
      */
     protected function seeCookie($cookieName, $value = null)
@@ -372,10 +372,10 @@ trait CrawlerTrait
      *
      * @param  string  $method
      * @param  string  $uri
-     * @param  array   $parameters
-     * @param  array   $cookies
-     * @param  array   $files
-     * @param  array   $server
+     * @param  array  $parameters
+     * @param  array  $cookies
+     * @param  array  $files
+     * @param  array  $server
      * @param  string  $content
      * @return \Illuminate\Http\Response
      */
@@ -402,10 +402,10 @@ trait CrawlerTrait
      *
      * @param  string  $method
      * @param  string  $uri
-     * @param  array   $parameters
-     * @param  array   $cookies
-     * @param  array   $files
-     * @param  array   $server
+     * @param  array  $parameters
+     * @param  array  $cookies
+     * @param  array  $files
+     * @param  array  $server
      * @param  string  $content
      * @return \Illuminate\Http\Response
      */
@@ -421,11 +421,11 @@ trait CrawlerTrait
      *
      * @param  string  $method
      * @param  string  $action
-     * @param  array   $wildcards
-     * @param  array   $parameters
-     * @param  array   $cookies
-     * @param  array   $files
-     * @param  array   $server
+     * @param  array  $wildcards
+     * @param  array  $parameters
+     * @param  array  $cookies
+     * @param  array  $files
+     * @param  array  $server
      * @param  string  $content
      * @return \Illuminate\Http\Response
      */
@@ -441,11 +441,11 @@ trait CrawlerTrait
      *
      * @param  string  $method
      * @param  string  $name
-     * @param  array   $routeParameters
-     * @param  array   $parameters
-     * @param  array   $cookies
-     * @param  array   $files
-     * @param  array   $server
+     * @param  array  $routeParameters
+     * @param  array  $parameters
+     * @param  array  $cookies
+     * @param  array  $files
+     * @param  array  $server
      * @param  string  $content
      * @return \Illuminate\Http\Response
      */

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -8,9 +8,9 @@ if (! function_exists('abort')) {
     /**
      * Throw an HttpException with the given data.
      *
-     * @param  int     $code
+     * @param  int  $code
      * @param  string  $message
-     * @param  array   $headers
+     * @param  array  $headers
      * @return void
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
@@ -27,8 +27,8 @@ if (! function_exists('action')) {
      * Generate a URL to a controller action.
      *
      * @param  string  $name
-     * @param  array   $parameters
-     * @param  bool    $absolute
+     * @param  array  $parameters
+     * @param  bool  $absolute
      * @return string
      */
     function action($name, $parameters = [], $absolute = true)
@@ -42,7 +42,7 @@ if (! function_exists('app')) {
      * Get the available container instance.
      *
      * @param  string  $make
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed|\Illuminate\Foundation\Application
      */
     function app($make = null, $parameters = [])
@@ -73,7 +73,7 @@ if (! function_exists('asset')) {
      * Generate an asset path for the application.
      *
      * @param  string  $path
-     * @param  bool    $secure
+     * @param  bool  $secure
      * @return string
      */
     function asset($path, $secure = null)
@@ -98,7 +98,7 @@ if (! function_exists('back')) {
     /**
      * Create a new redirect response to the previous location.
      *
-     * @param  int    $status
+     * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
@@ -126,7 +126,7 @@ if (! function_exists('bcrypt')) {
      * Hash the given value.
      *
      * @param  string  $value
-     * @param  array   $options
+     * @param  array  $options
      * @return string
      */
     function bcrypt($value, $options = [])
@@ -178,11 +178,11 @@ if (! function_exists('cookie')) {
      *
      * @param  string  $name
      * @param  string  $value
-     * @param  int     $minutes
+     * @param  int  $minutes
      * @param  string  $path
      * @param  string  $domain
-     * @param  bool    $secure
-     * @param  bool    $httpOnly
+     * @param  bool  $secure
+     * @param  bool  $httpOnly
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
     function cookie($name = null, $value = null, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true)
@@ -286,7 +286,7 @@ if (! function_exists('env')) {
      * Gets the value of an environment variable. Supports boolean, empty and null.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     function env($key, $default = null)
@@ -380,7 +380,7 @@ if (! function_exists('info')) {
      * Write some information to the log.
      *
      * @param  string  $message
-     * @param  array   $context
+     * @param  array  $context
      * @return void
      */
     function info($message, $context = [])
@@ -425,7 +425,7 @@ if (! function_exists('old')) {
      * Retrieve an old input item.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     function old($key = null, $default = null)
@@ -509,9 +509,9 @@ if (! function_exists('redirect')) {
      * Get an instance of the redirector.
      *
      * @param  string|null  $to
-     * @param  int     $status
-     * @param  array   $headers
-     * @param  bool    $secure
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool  $secure
      * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
      */
     function redirect($to = null, $status = 302, $headers = [], $secure = null)
@@ -529,7 +529,7 @@ if (! function_exists('request')) {
      * Get an instance of the current request or an input item from the request.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return \Illuminate\Http\Request|string|array
      */
     function request($key = null, $default = null)
@@ -548,7 +548,7 @@ if (! function_exists('resource')) {
      *
      * @param  string  $name
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     function resource($name, $controller, array $options = [])
@@ -562,8 +562,8 @@ if (! function_exists('response')) {
      * Return a new response from the application.
      *
      * @param  string  $content
-     * @param  int     $status
-     * @param  array   $headers
+     * @param  int  $status
+     * @param  array  $headers
      * @return \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Routing\ResponseFactory
      */
     function response($content = '', $status = 200, array $headers = [])
@@ -583,8 +583,8 @@ if (! function_exists('route')) {
      * Generate a URL to a named route.
      *
      * @param  string  $name
-     * @param  array   $parameters
-     * @param  bool    $absolute
+     * @param  array  $parameters
+     * @param  bool  $absolute
      * @param  \Illuminate\Routing\Route  $route
      * @return string
      */
@@ -612,7 +612,7 @@ if (! function_exists('secure_url')) {
      * Generate a HTTPS url for the application.
      *
      * @param  string  $path
-     * @param  mixed   $parameters
+     * @param  mixed  $parameters
      * @return string
      */
     function secure_url($path, $parameters = [])
@@ -663,7 +663,7 @@ if (! function_exists('trans')) {
      * Translate the given message.
      *
      * @param  string  $id
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @param  string  $domain
      * @param  string  $locale
      * @return string
@@ -683,8 +683,8 @@ if (! function_exists('trans_choice')) {
      * Translates the given message based on a count.
      *
      * @param  string  $id
-     * @param  int     $number
-     * @param  array   $parameters
+     * @param  int  $number
+     * @param  array  $parameters
      * @param  string  $domain
      * @param  string  $locale
      * @return string
@@ -700,8 +700,8 @@ if (! function_exists('url')) {
      * Generate a url for the application.
      *
      * @param  string  $path
-     * @param  mixed   $parameters
-     * @param  bool    $secure
+     * @param  mixed  $parameters
+     * @param  bool  $secure
      * @return string
      */
     function url($path = null, $parameters = [], $secure = null)
@@ -715,8 +715,8 @@ if (! function_exists('view')) {
      * Get the evaluated view contents for the given view.
      *
      * @param  string  $view
-     * @param  array   $data
-     * @param  array   $mergeData
+     * @param  array  $data
+     * @param  array  $mergeData
      * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
      */
     function view($view = null, $data = [], $mergeData = [])

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -18,7 +18,7 @@ class BcryptHasher implements HasherContract
      * Hash the given value.
      *
      * @param  string  $value
-     * @param  array   $options
+     * @param  array  $options
      * @return string
      *
      * @throws \RuntimeException
@@ -41,7 +41,7 @@ class BcryptHasher implements HasherContract
      *
      * @param  string  $value
      * @param  string  $hashedValue
-     * @param  array   $options
+     * @param  array  $options
      * @return bool
      */
     public function check($value, $hashedValue, array $options = [])
@@ -57,7 +57,7 @@ class BcryptHasher implements HasherContract
      * Check if the given hash has been hashed using the given options.
      *
      * @param  string  $hashedValue
-     * @param  array   $options
+     * @param  array  $options
      * @return bool
      */
     public function needsRehash($hashedValue, array $options = [])

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -20,9 +20,9 @@ class JsonResponse extends BaseJsonResponse
      * Constructor.
      *
      * @param  mixed  $data
-     * @param  int    $status
+     * @param  int  $status
      * @param  array  $headers
-     * @param  int    $options
+     * @param  int  $options
      */
     public function __construct($data = null, $status = 200, $headers = [], $options = 0)
     {
@@ -35,7 +35,7 @@ class JsonResponse extends BaseJsonResponse
      * Get the json_decoded data from the response.
      *
      * @param  bool  $assoc
-     * @param  int   $depth
+     * @param  int  $depth
      * @return mixed
      */
     public function getData($assoc = false, $depth = 512)

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -447,7 +447,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      * Flash the input for the current request to the session.
      *
      * @param  string  $filter
-     * @param  array   $keys
+     * @param  array  $keys
      * @return void
      */
     public function flash($filter = null, $keys = [])
@@ -536,7 +536,7 @@ class Request extends SymfonyRequest implements ArrayAccess
      * Get the JSON payload for the request.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function json($key = null, $default = null)
@@ -774,7 +774,7 @@ class Request extends SymfonyRequest implements ArrayAccess
     /**
      * Get the route handling the request.
      *
-     * @param string|null $param
+     * @param  string|null  $param
      *
      * @return \Illuminate\Routing\Route|object|string
      */

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -57,7 +57,7 @@ class Response extends BaseResponse
     /**
      * Morph the given content into JSON.
      *
-     * @param  mixed   $content
+     * @param  mixed  $content
      * @return string
      */
     protected function morphToJson($content)

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -29,7 +29,7 @@ trait ResponseTrait
      *
      * @param  string  $key
      * @param  string  $value
-     * @param  bool    $replace
+     * @param  bool  $replace
      * @return $this
      */
     public function header($key, $value, $replace = true)

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -220,7 +220,7 @@ class Writer implements LogContract, PsrLoggerInterface
      * Register a daily file log handler.
      *
      * @param  string  $path
-     * @param  int     $days
+     * @param  int  $days
      * @param  string  $level
      * @return void
      */
@@ -283,7 +283,7 @@ class Writer implements LogContract, PsrLoggerInterface
      *
      * @param  string  $level
      * @param  string  $message
-     * @param  array   $context
+     * @param  array  $context
      * @return void
      */
     protected function fireLogEvent($level, $message, array $context = [])

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -39,7 +39,7 @@ class LogTransport extends Transport
     /**
      * Get a loggable string out of a Swiftmailer entity.
      *
-     * @param  \Swift_Mime_MimeEntity $entity
+     * @param  \Swift_Mime_MimeEntity  $entity
      * @return string
      */
     protected function getMimeEntityString(Swift_Mime_MimeEntity $entity)

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -62,7 +62,7 @@ class MandrillTransport extends Transport
      *
      * Note that Mandrill still respects CC, BCC headers in raw message itself.
      *
-     * @param  \Swift_Mime_Message $message
+     * @param  \Swift_Mime_Message  $message
      * @return array
      */
     protected function getToAddresses(Swift_Mime_Message $message)

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -143,7 +143,7 @@ class Pipeline implements PipelineContract
     /**
      * Parse full pipe string to get name and parameters.
      *
-     * @param  string $pipe
+     * @param  string  $pipe
      * @return array
      */
     protected function parsePipeString($pipe)

--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -49,7 +49,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -63,7 +63,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -78,7 +78,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      *
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -85,7 +85,7 @@ class Manager
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @param  string  $connection
      * @return mixed
@@ -98,8 +98,8 @@ class Manager
     /**
      * Push a new an array of jobs onto the queue.
      *
-     * @param  array   $jobs
-     * @param  mixed   $data
+     * @param  array  $jobs
+     * @param  mixed  $data
      * @param  string  $queue
      * @param  string  $connection
      * @return mixed
@@ -114,7 +114,7 @@ class Manager
      *
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @param  string  $connection
      * @return mixed
@@ -138,7 +138,7 @@ class Manager
     /**
      * Register a connection with the manager.
      *
-     * @param  array   $config
+     * @param  array  $config
      * @param  string  $name
      * @return void
      */
@@ -173,7 +173,7 @@ class Manager
      * Dynamically pass methods to the default connection.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public static function __callStatic($method, $parameters)

--- a/src/Illuminate/Queue/Console/FailedTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedTableCommand.php
@@ -39,7 +39,7 @@ class FailedTableCommand extends Command
      * Create a new failed queue jobs table command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  \Illuminate\Foundation\Composer    $composer
+     * @param  \Illuminate\Foundation\Composer  $composer
      * @return void
      */
     public function __construct(Filesystem $files, Composer $composer)

--- a/src/Illuminate/Queue/Console/TableCommand.php
+++ b/src/Illuminate/Queue/Console/TableCommand.php
@@ -39,7 +39,7 @@ class TableCommand extends Command
      * Create a new queue job table command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
-     * @param  \Illuminate\Foundation\Composer    $composer
+     * @param  \Illuminate\Foundation\Composer  $composer
      * @return void
      */
     public function __construct(Filesystem $files, Composer $composer)

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -60,7 +60,7 @@ class DatabaseQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -74,7 +74,7 @@ class DatabaseQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -87,7 +87,7 @@ class DatabaseQueue extends Queue implements QueueContract
      *
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return void
      */
@@ -99,8 +99,8 @@ class DatabaseQueue extends Queue implements QueueContract
     /**
      * Push an array of jobs onto the queue.
      *
-     * @param  array   $jobs
-     * @param  mixed   $data
+     * @param  array  $jobs
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -28,7 +28,7 @@ trait InteractsWithQueue
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/IronQueue.php
+++ b/src/Illuminate/Queue/IronQueue.php
@@ -59,7 +59,7 @@ class IronQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -73,7 +73,7 @@ class IronQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -90,7 +90,7 @@ class IronQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  int     $delay
+     * @param  int  $delay
      * @return mixed
      */
     public function recreate($payload, $queue = null, $delay)
@@ -105,7 +105,7 @@ class IronQueue extends Queue implements QueueContract
      *
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -203,7 +203,7 @@ class IronQueue extends Queue implements QueueContract
      * Create a payload string from the given job and data.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return string
      */

--- a/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
+++ b/src/Illuminate/Queue/Jobs/BeanstalkdJob.php
@@ -78,7 +78,7 @@ class BeanstalkdJob extends Job implements JobContract
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/Jobs/IronJob.php
+++ b/src/Illuminate/Queue/Jobs/IronJob.php
@@ -36,7 +36,7 @@ class IronJob extends Job implements JobContract
      * @param  \Illuminate\Container\Container  $container
      * @param  \Illuminate\Queue\IronQueue  $iron
      * @param  object  $job
-     * @param  bool    $pushed
+     * @param  bool  $pushed
      * @return void
      */
     public function __construct(Container $container,
@@ -93,7 +93,7 @@ class IronJob extends Job implements JobContract
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -72,7 +72,7 @@ abstract class Job
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -75,7 +75,7 @@ class RedisJob extends Job implements JobContract
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/Jobs/SqsJob.php
+++ b/src/Illuminate/Queue/Jobs/SqsJob.php
@@ -28,7 +28,7 @@ class SqsJob extends Job implements JobContract
      * @param  \Illuminate\Container\Container  $container
      * @param  \Aws\Sqs\SqsClient  $sqs
      * @param  string  $queue
-     * @param  array   $job
+     * @param  array  $job
      * @return void
      */
     public function __construct(Container $container,
@@ -81,7 +81,7 @@ class SqsJob extends Job implements JobContract
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/Jobs/SyncJob.php
+++ b/src/Illuminate/Queue/Jobs/SyncJob.php
@@ -57,7 +57,7 @@ class SyncJob extends Job implements JobContract
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -94,7 +94,7 @@ class Listener
      * @param  string  $queue
      * @param  string  $delay
      * @param  string  $memory
-     * @param  int     $timeout
+     * @param  int  $timeout
      * @return void
      */
     public function listen($connection, $queue, $delay, $memory, $timeout = 60)
@@ -132,9 +132,9 @@ class Listener
      *
      * @param  string  $connection
      * @param  string  $queue
-     * @param  int     $delay
-     * @param  int     $memory
-     * @param  int     $timeout
+     * @param  int  $delay
+     * @param  int  $memory
+     * @param  int  $timeout
      * @return \Symfony\Component\Process\Process
      */
     public function makeProcess($connection, $queue, $delay, $memory, $timeout)

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -10,7 +10,7 @@ class NullQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -24,7 +24,7 @@ class NullQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -37,7 +37,7 @@ class NullQueue extends Queue implements QueueContract
      *
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -25,7 +25,7 @@ abstract class Queue
      *
      * @param  string  $queue
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @return mixed
      */
     public function pushOn($queue, $job, $data = '')
@@ -39,7 +39,7 @@ abstract class Queue
      * @param  string  $queue
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @return mixed
      */
     public function laterOn($queue, $delay, $job, $data = '')
@@ -62,8 +62,8 @@ abstract class Queue
     /**
      * Push an array of jobs onto the queue.
      *
-     * @param  array   $jobs
-     * @param  mixed   $data
+     * @param  array  $jobs
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -78,7 +78,7 @@ abstract class Queue
      * Create a payload string from the given job and data.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return string
      */
@@ -152,7 +152,7 @@ abstract class Queue
      * Create a payload string for the given Closure job.
      *
      * @param  \Closure  $job
-     * @param  mixed     $data
+     * @param  mixed  $data
      * @return string
      */
     protected function createClosurePayload($job, $data)

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -153,7 +153,7 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Add a queue connection resolver.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $resolver
      * @return void
      */
@@ -165,7 +165,7 @@ class QueueManager implements FactoryContract, MonitorContract
     /**
      * Add a queue connection resolver.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $resolver
      * @return void
      */
@@ -231,7 +231,7 @@ class QueueManager implements FactoryContract, MonitorContract
      * Dynamically pass calls to the default connection.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -57,7 +57,7 @@ class RedisQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -71,7 +71,7 @@ class RedisQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -86,7 +86,7 @@ class RedisQueue extends Queue implements QueueContract
      *
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -242,7 +242,7 @@ class RedisQueue extends Queue implements QueueContract
      * Create a payload string from the given job and data.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return string
      */

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -46,7 +46,7 @@ class SqsQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -60,7 +60,7 @@ class SqsQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -75,7 +75,7 @@ class SqsQueue extends Queue implements QueueContract
      *
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -14,7 +14,7 @@ class SyncQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      * @throws \Throwable
@@ -45,7 +45,7 @@ class SyncQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -58,7 +58,7 @@ class SyncQueue extends Queue implements QueueContract
      *
      * @param  \DateTime|int  $delay
      * @param  string  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -70,10 +70,10 @@ class Worker
      *
      * @param  string  $connectionName
      * @param  string  $queue
-     * @param  int     $delay
-     * @param  int     $memory
-     * @param  int     $sleep
-     * @param  int     $maxTries
+     * @param  int  $delay
+     * @param  int  $memory
+     * @param  int  $sleep
+     * @param  int  $maxTries
      * @return array
      */
     public function daemon($connectionName, $queue = null, $delay = 0, $memory = 128, $sleep = 3, $maxTries = 0)
@@ -139,9 +139,9 @@ class Worker
      *
      * @param  string  $connectionName
      * @param  string  $queue
-     * @param  int     $delay
-     * @param  int     $sleep
-     * @param  int     $maxTries
+     * @param  int  $delay
+     * @param  int  $sleep
+     * @param  int  $maxTries
      * @return array
      */
     public function pop($connectionName, $queue = null, $delay = 0, $sleep = 3, $maxTries = 0)
@@ -285,7 +285,7 @@ class Worker
     /**
      * Determine if the memory limit has been exceeded.
      *
-     * @param  int   $memoryLimit
+     * @param  int  $memoryLimit
      * @return bool
      */
     public function memoryExceeded($memoryLimit)
@@ -308,7 +308,7 @@ class Worker
     /**
      * Sleep the script for a given number of seconds.
      *
-     * @param  int   $seconds
+     * @param  int  $seconds
      * @return void
      */
     public function sleep($seconds)

--- a/src/Illuminate/Redis/Database.php
+++ b/src/Illuminate/Redis/Database.php
@@ -80,7 +80,7 @@ class Database implements DatabaseContract
      * Run a command against the Redis database.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function command($method, array $parameters = [])
@@ -129,7 +129,7 @@ class Database implements DatabaseContract
      * Dynamically make a Redis command.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -42,7 +42,7 @@ abstract class Controller
      * Register middleware on the controller.
      *
      * @param  string  $middleware
-     * @param  array   $options
+     * @param  array  $options
      * @return void
      */
     public function middleware($middleware, array $options = [])
@@ -179,7 +179,7 @@ abstract class Controller
      * Remove the given controller filter from the provided filter array.
      *
      * @param  string  $removing
-     * @param  array   $current
+     * @param  array  $current
      * @return array
      */
     protected function removeFilter($removing, $current)
@@ -248,7 +248,7 @@ abstract class Controller
      * Execute an action on the controller.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function callAction($method, $parameters)
@@ -259,7 +259,7 @@ abstract class Controller
     /**
      * Handle calls to missing methods on the controller.
      *
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
@@ -273,7 +273,7 @@ abstract class Controller
      * Handle calls to missing methods on the controller.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \BadMethodCallException

--- a/src/Illuminate/Routing/ControllerInspector.php
+++ b/src/Illuminate/Routing/ControllerInspector.php
@@ -88,7 +88,7 @@ class ControllerInspector
     /**
      * Get the routable data for an index method.
      *
-     * @param  array   $data
+     * @param  array  $data
      * @param  string  $prefix
      * @return array
      */

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -46,7 +46,7 @@ class Redirector
     /**
      * Create a new redirect response to the previous location.
      *
-     * @param  int    $status
+     * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
@@ -60,7 +60,7 @@ class Redirector
     /**
      * Create a new redirect response to the current URI.
      *
-     * @param  int    $status
+     * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
@@ -73,9 +73,9 @@ class Redirector
      * Create a new redirect response, while putting the current URL in the session.
      *
      * @param  string  $path
-     * @param  int     $status
-     * @param  array   $headers
-     * @param  bool    $secure
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool  $secure
      * @return \Illuminate\Http\RedirectResponse
      */
     public function guest($path, $status = 302, $headers = [], $secure = null)
@@ -89,9 +89,9 @@ class Redirector
      * Create a new redirect response to the previously intended location.
      *
      * @param  string  $default
-     * @param  int     $status
-     * @param  array   $headers
-     * @param  bool    $secure
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool  $secure
      * @return \Illuminate\Http\RedirectResponse
      */
     public function intended($default = '/', $status = 302, $headers = [], $secure = null)
@@ -105,9 +105,9 @@ class Redirector
      * Create a new redirect response to the given path.
      *
      * @param  string  $path
-     * @param  int     $status
-     * @param  array   $headers
-     * @param  bool    $secure
+     * @param  int  $status
+     * @param  array  $headers
+     * @param  bool  $secure
      * @return \Illuminate\Http\RedirectResponse
      */
     public function to($path, $status = 302, $headers = [], $secure = null)
@@ -121,8 +121,8 @@ class Redirector
      * Create a new redirect response to an external URL (no validation).
      *
      * @param  string  $path
-     * @param  int     $status
-     * @param  array   $headers
+     * @param  int  $status
+     * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
     public function away($path, $status = 302, $headers = [])
@@ -134,8 +134,8 @@ class Redirector
      * Create a new redirect response to the given HTTPS path.
      *
      * @param  string  $path
-     * @param  int     $status
-     * @param  array   $headers
+     * @param  int  $status
+     * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
     public function secure($path, $status = 302, $headers = [])
@@ -147,9 +147,9 @@ class Redirector
      * Create a new redirect response to a named route.
      *
      * @param  string  $route
-     * @param  array   $parameters
-     * @param  int     $status
-     * @param  array   $headers
+     * @param  array  $parameters
+     * @param  int  $status
+     * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
     public function route($route, $parameters = [], $status = 302, $headers = [])
@@ -163,9 +163,9 @@ class Redirector
      * Create a new redirect response to a controller action.
      *
      * @param  string  $action
-     * @param  array   $parameters
-     * @param  int     $status
-     * @param  array   $headers
+     * @param  array  $parameters
+     * @param  int  $status
+     * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
     public function action($action, $parameters = [], $status = 302, $headers = [])
@@ -179,8 +179,8 @@ class Redirector
      * Create a new redirect response.
      *
      * @param  string  $path
-     * @param  int     $status
-     * @param  array   $headers
+     * @param  int  $status
+     * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
      */
     protected function createRedirect($path, $status, $headers)

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -36,7 +36,7 @@ class ResourceRegistrar
      *
      * @param  string  $name
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return void
      */
     public function register($name, $controller, array $options = [])
@@ -67,7 +67,7 @@ class ResourceRegistrar
      *
      * @param  string  $name
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return void
      */
     protected function prefixedResource($name, $controller, array $options)
@@ -145,7 +145,7 @@ class ResourceRegistrar
     /**
      * Get the URI for a nested resource segment array.
      *
-     * @param  array   $segments
+     * @param  array  $segments
      * @return string
      */
     protected function getNestedResourceUri(array $segments)
@@ -165,7 +165,7 @@ class ResourceRegistrar
      * @param  string  $resource
      * @param  string  $controller
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return array
      */
     protected function getResourceAction($resource, $controller, $method, $options)
@@ -180,7 +180,7 @@ class ResourceRegistrar
      *
      * @param  string  $resource
      * @param  string  $method
-     * @param  array   $options
+     * @param  array  $options
      * @return string
      */
     protected function getResourceName($resource, $method, $options)
@@ -237,7 +237,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceIndex($name, $base, $controller, $options)
@@ -255,7 +255,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceCreate($name, $base, $controller, $options)
@@ -273,7 +273,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceStore($name, $base, $controller, $options)
@@ -291,7 +291,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceShow($name, $base, $controller, $options)
@@ -309,7 +309,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceEdit($name, $base, $controller, $options)
@@ -327,7 +327,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return void
      */
     protected function addResourceUpdate($name, $base, $controller, $options)
@@ -343,7 +343,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addPutResourceUpdate($name, $base, $controller, $options)
@@ -376,7 +376,7 @@ class ResourceRegistrar
      * @param  string  $name
      * @param  string  $base
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return \Illuminate\Routing\Route
      */
     protected function addResourceDestroy($name, $base, $controller, $options)

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -95,7 +95,7 @@ class Route
     /**
      * Create a new Route instance.
      *
-     * @param  array   $methods
+     * @param  array  $methods
      * @param  string  $uri
      * @param  \Closure|array  $action
      * @return void
@@ -260,7 +260,7 @@ class Route
     /**
      * Get or set the middlewares attached to the route.
      *
-     * @param  array|string|null $middleware
+     * @param  array|string|null  $middleware
      * @return array
      */
     public function middleware($middleware = null)
@@ -392,7 +392,7 @@ class Route
     /**
      * Determine a given parameter exists from the route.
      *
-     * @param  string $name
+     * @param  string  $name
      * @return bool
      */
     public function hasParameter($name)
@@ -404,7 +404,7 @@ class Route
      * Get a given parameter from the route.
      *
      * @param  string  $name
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return string|object
      */
     public function getParameter($name, $default = null)
@@ -416,7 +416,7 @@ class Route
      * Get a given parameter from the route.
      *
      * @param  string  $name
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return string|object
      */
     public function parameter($name, $default = null)
@@ -428,7 +428,7 @@ class Route
      * Set a parameter to the given value.
      *
      * @param  string  $name
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function setParameter($name, $value)

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -237,7 +237,7 @@ class Router implements RegistrarContract
      *
      * @param  string  $uri
      * @param  string  $controller
-     * @param  array   $names
+     * @param  array  $names
      * @return void
      */
     public function controller($uri, $controller, $names = [])
@@ -269,10 +269,10 @@ class Router implements RegistrarContract
     /**
      * Register an inspected controller route.
      *
-     * @param  array   $route
+     * @param  array  $route
      * @param  string  $controller
      * @param  string  $method
-     * @param  array   $names
+     * @param  array  $names
      * @return void
      */
     protected function registerInspected($route, $controller, $method, &$names)
@@ -319,7 +319,7 @@ class Router implements RegistrarContract
      *
      * @param  string  $name
      * @param  string  $controller
-     * @param  array   $options
+     * @param  array  $options
      * @return void
      */
     public function resource($name, $controller, array $options = [])
@@ -336,7 +336,7 @@ class Router implements RegistrarContract
     /**
      * Create a route group with shared attributes.
      *
-     * @param  array     $attributes
+     * @param  array  $attributes
      * @param  \Closure  $callback
      * @return void
      */
@@ -477,7 +477,7 @@ class Router implements RegistrarContract
      *
      * @param  array|string  $methods
      * @param  string  $uri
-     * @param  mixed   $action
+     * @param  mixed  $action
      * @return \Illuminate\Routing\Route
      */
     protected function createRoute($methods, $uri, $action)
@@ -510,7 +510,7 @@ class Router implements RegistrarContract
      *
      * @param  array|string  $methods
      * @param  string  $uri
-     * @param  mixed   $action
+     * @param  mixed  $action
      * @return \Illuminate\Routing\Route
      */
     protected function newRoute($methods, $uri, $action)
@@ -821,7 +821,7 @@ class Router implements RegistrarContract
      * Register a new global filter with the router.
      *
      * @param  string  $filter
-     * @param  string|callable   $callback
+     * @param  string|callable  $callback
      * @return void
      */
     protected function addGlobalFilter($filter, $callback)
@@ -904,9 +904,9 @@ class Router implements RegistrarContract
     /**
      * Register a regular expression based filter with the router.
      *
-     * @param  string     $pattern
-     * @param  string     $name
-     * @param  array|null $methods
+     * @param  string  $pattern
+     * @param  string  $name
+     * @param  array|null  $methods
      * @return void
      *
      * @deprecated since version 5.1.
@@ -976,7 +976,7 @@ class Router implements RegistrarContract
     /**
      * Create a class based binding using the IoC container.
      *
-     * @param  string    $binding
+     * @param  string  $binding
      * @return \Closure
      */
     public function createClassBinding($binding)
@@ -1024,7 +1024,7 @@ class Router implements RegistrarContract
      * Call the given filter with the request and response.
      *
      * @param  string  $filter
-     * @param  \Illuminate\Http\Request   $request
+     * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Http\Response  $response
      * @return mixed
      */
@@ -1108,7 +1108,7 @@ class Router implements RegistrarContract
      * Filter pattern filters that don't apply to the request verb.
      *
      * @param  string  $method
-     * @param  array   $filters
+     * @param  array  $filters
      * @return array
      */
     protected function patternsByMethod($method, $filters)
@@ -1185,7 +1185,7 @@ class Router implements RegistrarContract
      * @param  array  $parameters
      * @param  \Illuminate\Routing\Route  $route
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Http\Response|null $response
+     * @param  \Illuminate\Http\Response|null  $response
      * @return mixed
      *
      * @deprecated since version 5.1.

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -184,7 +184,7 @@ class UrlGenerator implements UrlGeneratorContract
      * Generate a secure, absolute URL to the given path.
      *
      * @param  string  $path
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     public function secure($path, $parameters = [])
@@ -291,7 +291,7 @@ class UrlGenerator implements UrlGeneratorContract
      * Get the URL to a named route.
      *
      * @param  string  $name
-     * @param  mixed   $parameters
+     * @param  mixed  $parameters
      * @param  bool  $absolute
      * @return string
      *
@@ -311,7 +311,7 @@ class UrlGenerator implements UrlGeneratorContract
      *
      * @param  \Illuminate\Routing\Route  $route
      * @param  mixed  $parameters
-     * @param  bool   $absolute
+     * @param  bool  $absolute
      * @return string
      */
     protected function toRoute($route, $parameters, $absolute)
@@ -565,8 +565,8 @@ class UrlGenerator implements UrlGeneratorContract
      * Get the URL to a controller action.
      *
      * @param  string  $action
-     * @param  mixed   $parameters
-     * @param  bool    $absolute
+     * @param  mixed  $parameters
+     * @param  bool  $absolute
      * @return string
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/Session/EncryptedStore.php
+++ b/src/Illuminate/Session/EncryptedStore.php
@@ -18,10 +18,10 @@ class EncryptedStore extends Store
     /**
      * Create a new session instance.
      *
-     * @param  string $name
-     * @param  \SessionHandlerInterface $handler
-     * @param  \Illuminate\Contracts\Encryption\Encrypter $encrypter
-     * @param  string|null $id
+     * @param  string  $name
+     * @param  \SessionHandlerInterface  $handler
+     * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
+     * @param  string|null  $id
      * @return void
      */
     public function __construct($name, SessionHandlerInterface $handler, EncrypterContract $encrypter, $id = null)

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -71,9 +71,9 @@ class Store implements SessionInterface
     /**
      * Create a new session instance.
      *
-     * @param  string $name
-     * @param  \SessionHandlerInterface $handler
-     * @param  string|null $id
+     * @param  string  $name
+     * @param  \SessionHandlerInterface  $handler
+     * @param  string|null  $id
      * @return void
      */
     public function __construct($name, SessionHandlerInterface $handler, $id = null)
@@ -348,7 +348,7 @@ class Store implements SessionInterface
      * Get the requested item from the flashed input array.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function getOldInput($key = null, $default = null)
@@ -373,7 +373,7 @@ class Store implements SessionInterface
      * Put a key / value pair or array of key / value pairs in the session.
      *
      * @param  string|array  $key
-     * @param  mixed       $value
+     * @param  mixed  $value
      * @return void
      */
     public function put($key, $value = null)
@@ -391,7 +391,7 @@ class Store implements SessionInterface
      * Push a value onto a session array.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function push($key, $value)
@@ -407,7 +407,7 @@ class Store implements SessionInterface
      * Flash a key / value pair to the session.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function flash($key, $value)

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -11,9 +11,9 @@ class Arr
     /**
      * Add an element to an array using "dot" notation if it doesn't exist.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return array
      */
     public static function add($array, $key, $value)
@@ -80,7 +80,7 @@ class Arr
     /**
      * Flatten a multi-dimensional associative array with dots.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $prepend
      * @return array
      */
@@ -116,7 +116,7 @@ class Arr
     /**
      * Fetch a flattened array of a nested array element.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
      * @return array
      *
@@ -220,9 +220,9 @@ class Arr
     /**
      * Get an item from an array using "dot" notation.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public static function get($array, $key, $default = null)
@@ -249,7 +249,7 @@ class Arr
     /**
      * Check if an item exists in an array using "dot" notation.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
      * @return bool
      */
@@ -304,7 +304,7 @@ class Arr
     /**
      * Pluck an array of values from an array.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string|array  $value
      * @param  string|array|null  $key
      * @return array
@@ -371,9 +371,9 @@ class Arr
     /**
      * Get a value from the array, and remove it.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public static function pull(&$array, $key, $default = null)
@@ -390,9 +390,9 @@ class Arr
      *
      * If no key is given to the method, the entire array will be replaced.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return array
      */
     public static function set(&$array, $key, $value)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -301,7 +301,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Group an associative array by a field or using a callback.
      *
      * @param  callable|string  $groupBy
-     * @param  bool             $preserveKeys
+     * @param  bool  $preserveKeys
      * @return static
      */
     public function groupBy($groupBy, $preserveKeys = false)
@@ -635,7 +635,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Reduce the collection to a single value.
      *
      * @param  callable  $callback
-     * @param  mixed     $initial
+     * @param  mixed  $initial
      * @return mixed
      */
     public function reduce(callable $callback, $initial = null)
@@ -676,7 +676,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Search the collection for a given value and return the corresponding key if successful.
      *
      * @param  mixed  $value
-     * @param  bool   $strict
+     * @param  bool  $strict
      * @return mixed
      */
     public function search($value, $strict = false)
@@ -721,8 +721,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Slice the underlying collection array.
      *
-     * @param  int   $offset
-     * @param  int   $length
+     * @param  int  $offset
+     * @param  int  $length
      * @param  bool  $preserveKeys
      * @return static
      */
@@ -734,7 +734,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Chunk the underlying collection array.
      *
-     * @param  int   $size
+     * @param  int  $size
      * @param  bool  $preserveKeys
      * @return static
      */
@@ -775,7 +775,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Sort the collection using the given callback.
      *
      * @param  callable|string  $callback
-     * @param  int   $options
+     * @param  int  $options
      * @param  bool  $descending
      * @return static
      */
@@ -939,7 +939,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * e.g. new Collection([1, 2, 3])->zip([4, 5, 6]);
      *      => [[1, 4], [2, 5], [3, 6]]
      *
-     * @param  mixed ...$items
+     * @param  mixed  ...$items
      * @return static
      */
     public function zip($items)

--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -22,7 +22,7 @@ class Cookie extends Facade
      * Retrieve a cookie from the request.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return string
      */
     public static function get($key = null, $default = null)

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -197,7 +197,7 @@ abstract class Facade
      * Handle dynamic, static calls to the object.
      *
      * @param  string  $method
-     * @param  array   $args
+     * @param  array  $args
      * @return mixed
      */
     public static function __callStatic($method, $args)

--- a/src/Illuminate/Support/Facades/Input.php
+++ b/src/Illuminate/Support/Facades/Input.php
@@ -13,7 +13,7 @@ class Input extends Facade
      * This method is used for all request verbs (GET, POST, PUT, and DELETE)
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public static function get($key = null, $default = null)

--- a/src/Illuminate/Support/Fluent.php
+++ b/src/Illuminate/Support/Fluent.php
@@ -19,7 +19,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
     /**
      * Create a new fluent container instance.
      *
-     * @param  array|object    $attributes
+     * @param  array|object  $attributes
      * @return void
      */
     public function __construct($attributes = [])
@@ -33,7 +33,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      * Get an attribute from the container.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function get($key, $default = null)
@@ -112,7 +112,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      * Set the value at the given offset.
      *
      * @param  string  $offset
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function offsetSet($offset, $value)
@@ -135,7 +135,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      * Handle dynamic calls to the container to set attributes.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return $this
      */
     public function __call($method, $parameters)
@@ -160,7 +160,7 @@ class Fluent implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
      * Dynamically set the value of an attribute.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function __set($key, $value)

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -104,7 +104,7 @@ abstract class Manager
     /**
      * Register a custom driver creator Closure.
      *
-     * @param  string    $driver
+     * @param  string  $driver
      * @param  \Closure  $callback
      * @return $this
      */
@@ -129,7 +129,7 @@ abstract class Manager
      * Dynamically call the default driver instance.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -161,7 +161,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     /**
      * Format an array of messages.
      *
-     * @param  array   $messages
+     * @param  array  $messages
      * @param  string  $format
      * @param  string  $messageKey
      * @return array

--- a/src/Illuminate/Support/NamespacedItemResolver.php
+++ b/src/Illuminate/Support/NamespacedItemResolver.php
@@ -94,7 +94,7 @@ class NamespacedItemResolver
      * Set the parsed value of a key.
      *
      * @param  string  $key
-     * @param  array   $parsed
+     * @param  array  $parsed
      * @return void
      */
     public function setParsedKey($key, $parsed)

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -41,7 +41,7 @@ class Pluralizer
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int     $count
+     * @param  int  $count
      * @return string
      */
     public static function plural($value, $count = 2)

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -145,7 +145,7 @@ class Str
      * Limit the number of characters in a string.
      *
      * @param  string  $value
-     * @param  int     $limit
+     * @param  int  $limit
      * @param  string  $end
      * @return string
      */
@@ -173,7 +173,7 @@ class Str
      * Limit the number of words in a string.
      *
      * @param  string  $value
-     * @param  int     $words
+     * @param  int  $words
      * @param  string  $end
      * @return string
      */
@@ -204,7 +204,7 @@ class Str
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int     $count
+     * @param  int  $count
      * @return string
      */
     public static function plural($value, $count = 2)

--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -17,7 +17,7 @@ trait Macroable
     /**
      * Register a custom macro.
      *
-     * @param  string    $name
+     * @param  string  $name
      * @param  callable  $macro
      * @return void
      */
@@ -41,7 +41,7 @@ trait Macroable
      * Dynamically handle calls to the class.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \BadMethodCallException
@@ -63,7 +63,7 @@ trait Macroable
      * Dynamically handle calls to the class.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \BadMethodCallException

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -33,9 +33,9 @@ if (! function_exists('array_add')) {
     /**
      * Add an element to an array using "dot" notation if it doesn't exist.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return array
      */
     function array_add($array, $key, $value)
@@ -88,7 +88,7 @@ if (! function_exists('array_dot')) {
     /**
      * Flatten a multi-dimensional associative array with dots.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $prepend
      * @return array
      */
@@ -116,7 +116,7 @@ if (! function_exists('array_fetch')) {
     /**
      * Fetch a flattened array of a nested array element.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
      * @return array
      *
@@ -174,9 +174,9 @@ if (! function_exists('array_get')) {
     /**
      * Get an item from an array using "dot" notation.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     function array_get($array, $key, $default = null)
@@ -189,7 +189,7 @@ if (! function_exists('array_has')) {
     /**
      * Check if an item exists in an array using "dot" notation.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
      * @return bool
      */
@@ -232,7 +232,7 @@ if (! function_exists('array_pluck')) {
     /**
      * Pluck an array of values from an array.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string|array  $value
      * @param  string|array|null  $key
      * @return array
@@ -262,9 +262,9 @@ if (! function_exists('array_pull')) {
     /**
      * Get a value from the array, and remove it.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     function array_pull(&$array, $key, $default = null)
@@ -279,9 +279,9 @@ if (! function_exists('array_set')) {
      *
      * If no key is given to the method, the entire array will be replaced.
      *
-     * @param  array   $array
+     * @param  array  $array
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return array
      */
     function array_set(&$array, $key, $value)
@@ -395,9 +395,9 @@ if (! function_exists('data_get')) {
     /**
      * Get an item from an array or object using "dot" notation.
      *
-     * @param  mixed   $target
+     * @param  mixed  $target
      * @param  string|array  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     function data_get($target, $key, $default = null)
@@ -516,7 +516,7 @@ if (! function_exists('object_get')) {
      *
      * @param  object  $object
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     function object_get($object, $key, $default = null)
@@ -542,7 +542,7 @@ if (! function_exists('preg_replace_sub')) {
      * Replace a given pattern with each value in the array in sequentially.
      *
      * @param  string  $pattern
-     * @param  array   $replacements
+     * @param  array  $replacements
      * @param  string  $subject
      * @return string
      */
@@ -632,7 +632,7 @@ if (! function_exists('str_limit')) {
      * Limit the number of characters in a string.
      *
      * @param  string  $value
-     * @param  int     $limit
+     * @param  int  $limit
      * @param  string  $end
      * @return string
      */
@@ -647,7 +647,7 @@ if (! function_exists('str_plural')) {
      * Get the plural form of an English word.
      *
      * @param  string  $value
-     * @param  int     $count
+     * @param  int  $count
      * @return string
      */
     function str_plural($value, $count = 2)
@@ -676,7 +676,7 @@ if (! function_exists('str_replace_array')) {
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string  $subject
      * @return string
      */

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -80,7 +80,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * Get the translation for the given key.
      *
      * @param  string  $key
-     * @param  array   $replace
+     * @param  array  $replace
      * @param  string  $locale
      * @param  bool  $fallback
      * @return string
@@ -123,7 +123,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * @param  string  $group
      * @param  string  $locale
      * @param  string  $item
-     * @param  array   $replace
+     * @param  array  $replace
      * @return string|array|null
      */
     protected function getLine($namespace, $group, $locale, $item, array $replace)
@@ -141,7 +141,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * Make the place-holder replacements on a line.
      *
      * @param  string  $line
-     * @param  array   $replace
+     * @param  array  $replace
      * @return string
      */
     protected function makeReplacements($line, array $replace)
@@ -172,8 +172,8 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * Get a translation according to an integer value.
      *
      * @param  string  $key
-     * @param  int     $number
-     * @param  array   $replace
+     * @param  int  $number
+     * @param  array  $replace
      * @param  string  $locale
      * @return string
      */
@@ -190,7 +190,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * Get the translation for a given key.
      *
      * @param  string  $id
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @param  string  $domain
      * @param  string  $locale
      * @return string
@@ -204,8 +204,8 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * Get a translation according to an integer value.
      *
      * @param  string  $id
-     * @param  int     $number
-     * @param  array   $parameters
+     * @param  int  $number
+     * @param  array  $parameters
      * @param  string  $domain
      * @param  string  $locale
      * @return string

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -37,9 +37,9 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface
      * @param  string  $collection
      * @param  string  $column
      * @param  string  $value
-     * @param  int     $excludeId
+     * @param  int  $excludeId
      * @param  string  $idColumn
-     * @param  array   $extra
+     * @param  array  $extra
      * @return int
      */
     public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = [])
@@ -62,8 +62,8 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface
      *
      * @param  string  $collection
      * @param  string  $column
-     * @param  array   $values
-     * @param  array   $extra
+     * @param  array  $values
+     * @param  array  $extra
      * @return int
      */
     public function getMultiCount($collection, $column, array $values, array $extra = [])

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -171,7 +171,7 @@ class Factory implements FactoryContract
     /**
      * Register a custom implicit validator extension.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $extension
      * @param  string  $message
      * @return void
@@ -188,7 +188,7 @@ class Factory implements FactoryContract
     /**
      * Register a custom implicit validator message replacer.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $replacer
      * @return void
      */

--- a/src/Illuminate/Validation/PresenceVerifierInterface.php
+++ b/src/Illuminate/Validation/PresenceVerifierInterface.php
@@ -10,9 +10,9 @@ interface PresenceVerifierInterface
      * @param  string  $collection
      * @param  string  $column
      * @param  string  $value
-     * @param  int     $excludeId
+     * @param  int  $excludeId
      * @param  string  $idColumn
-     * @param  array   $extra
+     * @param  array  $extra
      * @return int
      */
     public function getCount($collection, $column, $value, $excludeId = null, $idColumn = null, array $extra = []);
@@ -22,8 +22,8 @@ interface PresenceVerifierInterface
      *
      * @param  string  $collection
      * @param  string  $column
-     * @param  array   $values
-     * @param  array   $extra
+     * @param  array  $values
+     * @param  array  $extra
      * @return int
      */
     public function getMultiCount($collection, $column, array $values, array $extra = []);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -172,7 +172,7 @@ class Validator implements ValidatorContract
     /**
      * Parse the data and hydrate the files array.
      *
-     * @param  array   $data
+     * @param  array  $data
      * @param  string  $arrayKey
      * @return array
      */
@@ -412,7 +412,7 @@ class Validator implements ValidatorContract
      *
      * @param  string  $rule
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function isValidatable($rule, $attribute, $value)
@@ -427,7 +427,7 @@ class Validator implements ValidatorContract
      *
      * @param  string  $rule
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function presentOrRuleIsImplicit($rule, $attribute, $value)
@@ -483,7 +483,7 @@ class Validator implements ValidatorContract
      *
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return void
      */
     protected function addFailure($attribute, $rule, $parameters)
@@ -498,7 +498,7 @@ class Validator implements ValidatorContract
      *
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return void
      */
     protected function addError($attribute, $rule, $parameters)
@@ -526,7 +526,7 @@ class Validator implements ValidatorContract
      * Validate that a required attribute exists.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateRequired($attribute, $value)
@@ -548,7 +548,7 @@ class Validator implements ValidatorContract
      * Validate the given attribute is filled if it is present.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateFilled($attribute, $value)
@@ -598,8 +598,8 @@ class Validator implements ValidatorContract
      * Validate that an attribute exists when any other attribute exists.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
+     * @param  mixed  $value
+     * @param  mixed  $parameters
      * @return bool
      */
     protected function validateRequiredWith($attribute, $value, $parameters)
@@ -615,8 +615,8 @@ class Validator implements ValidatorContract
      * Validate that an attribute exists when all other attributes exists.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
+     * @param  mixed  $value
+     * @param  mixed  $parameters
      * @return bool
      */
     protected function validateRequiredWithAll($attribute, $value, $parameters)
@@ -632,8 +632,8 @@ class Validator implements ValidatorContract
      * Validate that an attribute exists when another attribute does not.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
+     * @param  mixed  $value
+     * @param  mixed  $parameters
      * @return bool
      */
     protected function validateRequiredWithout($attribute, $value, $parameters)
@@ -649,8 +649,8 @@ class Validator implements ValidatorContract
      * Validate that an attribute exists when all other attributes do not.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
+     * @param  mixed  $value
+     * @param  mixed  $parameters
      * @return bool
      */
     protected function validateRequiredWithoutAll($attribute, $value, $parameters)
@@ -666,8 +666,8 @@ class Validator implements ValidatorContract
      * Validate that an attribute exists when another attribute has a given value.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  mixed   $parameters
+     * @param  mixed  $value
+     * @param  mixed  $parameters
      * @return bool
      */
     protected function validateRequiredIf($attribute, $value, $parameters)
@@ -731,7 +731,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute has a matching confirmation.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateConfirmed($attribute, $value)
@@ -743,8 +743,8 @@ class Validator implements ValidatorContract
      * Validate that two attributes match.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateSame($attribute, $value, $parameters)
@@ -760,8 +760,8 @@ class Validator implements ValidatorContract
      * Validate that an attribute is different from another attribute.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateDifferent($attribute, $value, $parameters)
@@ -779,7 +779,7 @@ class Validator implements ValidatorContract
      * This validation rule implies the attribute is "required".
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateAccepted($attribute, $value)
@@ -793,7 +793,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute is an array.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateArray($attribute, $value)
@@ -805,7 +805,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute is a boolean.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateBoolean($attribute, $value)
@@ -819,7 +819,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute is an integer.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateInteger($attribute, $value)
@@ -831,7 +831,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute is numeric.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateNumeric($attribute, $value)
@@ -843,7 +843,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute is a string.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateString($attribute, $value)
@@ -855,7 +855,7 @@ class Validator implements ValidatorContract
      * Validate the attribute is a valid JSON string.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateJson($attribute, $value)
@@ -869,8 +869,8 @@ class Validator implements ValidatorContract
      * Validate that an attribute has a given number of digits.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateDigits($attribute, $value, $parameters)
@@ -885,8 +885,8 @@ class Validator implements ValidatorContract
      * Validate that an attribute is between a given number of digits.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateDigitsBetween($attribute, $value, $parameters)
@@ -903,8 +903,8 @@ class Validator implements ValidatorContract
      * Validate the size of an attribute.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateSize($attribute, $value, $parameters)
@@ -918,8 +918,8 @@ class Validator implements ValidatorContract
      * Validate the size of an attribute is between a set of values.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateBetween($attribute, $value, $parameters)
@@ -935,8 +935,8 @@ class Validator implements ValidatorContract
      * Validate the size of an attribute is greater than a minimum value.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateMin($attribute, $value, $parameters)
@@ -950,8 +950,8 @@ class Validator implements ValidatorContract
      * Validate the size of an attribute is less than a maximum value.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateMax($attribute, $value, $parameters)
@@ -969,7 +969,7 @@ class Validator implements ValidatorContract
      * Get the size of an attribute.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return mixed
      */
     protected function getSize($attribute, $value)
@@ -995,8 +995,8 @@ class Validator implements ValidatorContract
      * Validate an attribute is contained within a list of values.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateIn($attribute, $value, $parameters)
@@ -1012,8 +1012,8 @@ class Validator implements ValidatorContract
      * Validate an attribute is not contained within a list of values.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateNotIn($attribute, $value, $parameters)
@@ -1027,8 +1027,8 @@ class Validator implements ValidatorContract
      * If a database column is not specified, the attribute will be used.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateUnique($attribute, $value, $parameters)
@@ -1113,8 +1113,8 @@ class Validator implements ValidatorContract
      * Validate the existence of an attribute value in a database table.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateExists($attribute, $value, $parameters)
@@ -1136,11 +1136,11 @@ class Validator implements ValidatorContract
     /**
      * Get the number of records that exist in storage.
      *
-     * @param  mixed   $connection
+     * @param  mixed  $connection
      * @param  string  $table
      * @param  string  $column
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return int
      */
     protected function getExistCount($connection, $table, $column, $value, $parameters)
@@ -1194,7 +1194,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute is a valid IP.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateIp($attribute, $value)
@@ -1206,7 +1206,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute is a valid e-mail address.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateEmail($attribute, $value)
@@ -1218,7 +1218,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute is a valid URL.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateUrl($attribute, $value)
@@ -1230,7 +1230,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute is an active URL.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateActiveUrl($attribute, $value)
@@ -1244,7 +1244,7 @@ class Validator implements ValidatorContract
      * Validate the MIME type of a file is an image MIME type.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateImage($attribute, $value)
@@ -1257,7 +1257,7 @@ class Validator implements ValidatorContract
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateMimes($attribute, $value, $parameters)
@@ -1305,7 +1305,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute contains only alphabetic characters.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateAlpha($attribute, $value)
@@ -1317,7 +1317,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute contains only alpha-numeric characters.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateAlphaNum($attribute, $value)
@@ -1333,7 +1333,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute contains only alpha-numeric characters, dashes, and underscores.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateAlphaDash($attribute, $value)
@@ -1349,8 +1349,8 @@ class Validator implements ValidatorContract
      * Validate that an attribute passes a regular expression check.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateRegex($attribute, $value, $parameters)
@@ -1368,7 +1368,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute is a valid date.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateDate($attribute, $value)
@@ -1390,8 +1390,8 @@ class Validator implements ValidatorContract
      * Validate that an attribute matches a date format.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateDateFormat($attribute, $value, $parameters)
@@ -1407,8 +1407,8 @@ class Validator implements ValidatorContract
      * Validate the date is before a given date.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateBefore($attribute, $value, $parameters)
@@ -1430,8 +1430,8 @@ class Validator implements ValidatorContract
      * Validate the date is before a given date with a given format.
      *
      * @param  string  $format
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateBeforeWithFormat($format, $value, $parameters)
@@ -1445,8 +1445,8 @@ class Validator implements ValidatorContract
      * Validate the date is after a given date.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateAfter($attribute, $value, $parameters)
@@ -1468,8 +1468,8 @@ class Validator implements ValidatorContract
      * Validate the date is after a given date with a given format.
      *
      * @param  string  $format
-     * @param  mixed   $value
-     * @param  array   $parameters
+     * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
     protected function validateAfterWithFormat($format, $value, $parameters)
@@ -1522,7 +1522,7 @@ class Validator implements ValidatorContract
      * Validate that an attribute is a valid timezone.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return bool
      */
     protected function validateTimezone($attribute, $value)
@@ -1606,7 +1606,7 @@ class Validator implements ValidatorContract
      *
      * @param  string  $attribute
      * @param  string  $lowerRule
-     * @param  array   $source
+     * @param  array  $source
      * @return string|null
      */
     protected function getInlineMessage($attribute, $lowerRule, $source = null)
@@ -1674,7 +1674,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function doReplacements($message, $attribute, $rule, $parameters)
@@ -1744,7 +1744,7 @@ class Validator implements ValidatorContract
      * Get the displayable name of the value.
      *
      * @param  string  $attribute
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return string
      */
     public function getDisplayableValue($attribute, $value)
@@ -1768,7 +1768,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceBetween($message, $attribute, $rule, $parameters)
@@ -1782,7 +1782,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceDigits($message, $attribute, $rule, $parameters)
@@ -1796,7 +1796,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceDigitsBetween($message, $attribute, $rule, $parameters)
@@ -1810,7 +1810,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceSize($message, $attribute, $rule, $parameters)
@@ -1824,7 +1824,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceMin($message, $attribute, $rule, $parameters)
@@ -1838,7 +1838,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceMax($message, $attribute, $rule, $parameters)
@@ -1852,7 +1852,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceIn($message, $attribute, $rule, $parameters)
@@ -1870,7 +1870,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceNotIn($message, $attribute, $rule, $parameters)
@@ -1884,7 +1884,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceMimes($message, $attribute, $rule, $parameters)
@@ -1898,7 +1898,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceRequiredWith($message, $attribute, $rule, $parameters)
@@ -1914,7 +1914,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceRequiredWithAll($message, $attribute, $rule, $parameters)
@@ -1928,7 +1928,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceRequiredWithout($message, $attribute, $rule, $parameters)
@@ -1942,7 +1942,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceRequiredWithoutAll($message, $attribute, $rule, $parameters)
@@ -1956,7 +1956,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceRequiredIf($message, $attribute, $rule, $parameters)
@@ -1974,7 +1974,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceRequiredUnless($message, $attribute, $rule, $parameters)
@@ -1990,7 +1990,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceSame($message, $attribute, $rule, $parameters)
@@ -2004,7 +2004,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceDifferent($message, $attribute, $rule, $parameters)
@@ -2018,7 +2018,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceDateFormat($message, $attribute, $rule, $parameters)
@@ -2032,7 +2032,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceBefore($message, $attribute, $rule, $parameters)
@@ -2050,7 +2050,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function replaceAfter($message, $attribute, $rule, $parameters)
@@ -2237,7 +2237,7 @@ class Validator implements ValidatorContract
     /**
      * Register a custom implicit validator extension.
      *
-     * @param  string   $rule
+     * @param  string  $rule
      * @param  \Closure|string  $extension
      * @return void
      */
@@ -2575,7 +2575,7 @@ class Validator implements ValidatorContract
      * Call a custom validator extension.
      *
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return bool|null
      */
     protected function callExtension($rule, $parameters)
@@ -2593,7 +2593,7 @@ class Validator implements ValidatorContract
      * Call a class based validator extension.
      *
      * @param  string  $callback
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return bool
      */
     protected function callClassBasedExtension($callback, $parameters)
@@ -2609,7 +2609,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string|null
      */
     protected function callReplacer($message, $attribute, $rule, $parameters)
@@ -2630,7 +2630,7 @@ class Validator implements ValidatorContract
      * @param  string  $message
      * @param  string  $attribute
      * @param  string  $rule
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return string
      */
     protected function callClassBasedReplacer($callback, $message, $attribute, $rule, $parameters)
@@ -2643,7 +2643,7 @@ class Validator implements ValidatorContract
     /**
      * Require a certain number of parameters to be present.
      *
-     * @param  int    $count
+     * @param  int  $count
      * @param  array  $parameters
      * @param  string  $rule
      * @return void
@@ -2660,7 +2660,7 @@ class Validator implements ValidatorContract
      * Handle dynamic calls to class methods.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      *
      * @throws \BadMethodCallException

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -821,7 +821,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      *
      * @param  string  $openTag
      * @param  string  $closeTag
-     * @param  bool    $escaped
+     * @param  bool  $escaped
      * @return void
      */
     public function setContentTags($openTag, $closeTag, $escaped = false)

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -36,7 +36,7 @@ class CompilerEngine extends PhpEngine
      * Get the evaluated contents of the view.
      *
      * @param  string  $path
-     * @param  array   $data
+     * @param  array  $data
      * @return string
      */
     public function get($path, array $data = [])

--- a/src/Illuminate/View/Engines/EngineInterface.php
+++ b/src/Illuminate/View/Engines/EngineInterface.php
@@ -8,7 +8,7 @@ interface EngineInterface
      * Get the evaluated contents of the view.
      *
      * @param  string  $path
-     * @param  array   $data
+     * @param  array  $data
      * @return string
      */
     public function get($path, array $data = []);

--- a/src/Illuminate/View/Engines/EngineResolver.php
+++ b/src/Illuminate/View/Engines/EngineResolver.php
@@ -26,7 +26,7 @@ class EngineResolver
      *
      * The engine string typically corresponds to a file extension.
      *
-     * @param  string   $engine
+     * @param  string  $engine
      * @param  \Closure  $resolver
      * @return void
      */

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -12,7 +12,7 @@ class PhpEngine implements EngineInterface
      * Get the evaluated contents of the view.
      *
      * @param  string  $path
-     * @param  array   $data
+     * @param  array  $data
      * @return string
      */
     public function get($path, array $data = [])
@@ -24,7 +24,7 @@ class PhpEngine implements EngineInterface
      * Get the evaluated contents of the view at the given path.
      *
      * @param  string  $__path
-     * @param  array   $__data
+     * @param  array  $__data
      * @return string
      */
     protected function evaluatePath($__path, $__data)

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -119,8 +119,8 @@ class Factory implements FactoryContract
      * Get the evaluated view contents for the given view.
      *
      * @param  string  $path
-     * @param  array   $data
-     * @param  array   $mergeData
+     * @param  array  $data
+     * @param  array  $mergeData
      * @return \Illuminate\View\View
      */
     public function file($path, $data = [], $mergeData = [])
@@ -136,8 +136,8 @@ class Factory implements FactoryContract
      * Get the evaluated view contents for the given view.
      *
      * @param  string  $view
-     * @param  array   $data
-     * @param  array   $mergeData
+     * @param  array  $data
+     * @param  array  $mergeData
      * @return \Illuminate\Contracts\View\View
      */
     public function make($view, $data = [], $mergeData = [])
@@ -160,7 +160,7 @@ class Factory implements FactoryContract
     /**
      * Normalize a view name.
      *
-     * @param  string $name
+     * @param  string  $name
      * @return string
      */
     protected function normalizeName($name)
@@ -191,7 +191,7 @@ class Factory implements FactoryContract
      * Get the evaluated view contents for a named view.
      *
      * @param  string  $view
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @return \Illuminate\View\View
      */
     public function of($view, $data = [])
@@ -244,7 +244,7 @@ class Factory implements FactoryContract
      * Get the rendered contents of a partial from a loop.
      *
      * @param  string  $view
-     * @param  array   $data
+     * @param  array  $data
      * @param  string  $iterator
      * @param  string  $empty
      * @return string
@@ -333,7 +333,7 @@ class Factory implements FactoryContract
     /**
      * Register a view creator event.
      *
-     * @param  array|string     $views
+     * @param  array|string  $views
      * @param  \Closure|string  $callback
      * @return array
      */
@@ -409,9 +409,9 @@ class Factory implements FactoryContract
     /**
      * Register a class based view composer.
      *
-     * @param  string    $view
-     * @param  string    $class
-     * @param  string    $prefix
+     * @param  string  $view
+     * @param  string  $class
+     * @param  string  $prefix
      * @param  int|null  $priority
      * @return \Closure
      */
@@ -432,7 +432,7 @@ class Factory implements FactoryContract
     /**
      * Add a listener to the event dispatcher.
      *
-     * @param  string    $name
+     * @param  string  $name
      * @param  \Closure  $callback
      * @param  int|null  $priority
      * @return void
@@ -714,8 +714,8 @@ class Factory implements FactoryContract
     /**
      * Register a valid view extension and its engine.
      *
-     * @param  string    $extension
-     * @param  string    $engine
+     * @param  string  $extension
+     * @param  string  $engine
      * @param  \Closure  $resolver
      * @return void
      */
@@ -819,7 +819,7 @@ class Factory implements FactoryContract
      * Get an item from the shared data.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function shared($key, $default = null)

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -119,7 +119,7 @@ class FileViewFinder implements ViewFinderInterface
      * Find the given view in the list of paths.
      *
      * @param  string  $name
-     * @param  array   $paths
+     * @param  array  $paths
      * @return string
      *
      * @throws \InvalidArgumentException

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -56,7 +56,7 @@ class View implements ArrayAccess, ViewContract
      * @param  \Illuminate\View\Engines\EngineInterface  $engine
      * @param  string  $view
      * @param  string  $path
-     * @param  array   $data
+     * @param  array  $data
      * @return void
      */
     public function __construct(Factory $factory, EngineInterface $engine, $view, $path, $data = [])
@@ -157,7 +157,7 @@ class View implements ArrayAccess, ViewContract
      * Add a piece of data to the view.
      *
      * @param  string|array  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return $this
      */
     public function with($key, $value = null)
@@ -176,7 +176,7 @@ class View implements ArrayAccess, ViewContract
      *
      * @param  string  $key
      * @param  string  $view
-     * @param  array   $data
+     * @param  array  $data
      * @return $this
      */
     public function nest($key, $view, array $data = [])
@@ -298,7 +298,7 @@ class View implements ArrayAccess, ViewContract
      * Set a piece of data on the view.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function offsetSet($key, $value)
@@ -332,7 +332,7 @@ class View implements ArrayAccess, ViewContract
      * Set a piece of data on the view.
      *
      * @param  string  $key
-     * @param  mixed   $value
+     * @param  mixed  $value
      * @return void
      */
     public function __set($key, $value)
@@ -366,7 +366,7 @@ class View implements ArrayAccess, ViewContract
      * Dynamically bind parameters to the view.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return \Illuminate\View\View
      *
      * @throws \BadMethodCallException


### PR DESCRIPTION
Fixing spacing between param in all phpdocs.

Used some regex: 

``` php
   @param\s\S|@param\s{3,}|@param\s{2}\S*\s\S|@param\s{2}\S*\s{3,}
```

Which can be useful.
Explanation:

``` shell
@param\s\S # fetch params that have only one space between @param and the param type.
@param\s{3,} # fetch all that have more than two spaces between @param and the param type.
@param\s{2}\S*\s\S # fetch all that have only one space after the param type.
@param\s{2}\S*\s{3,} # fetch all that have more than two spaces after the param type.
```

It still fetches `* @param mixed\n`, in 6 files:
[src/Illuminate/Contracts/Cookie/QueueingFactory.php#L10](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Contracts/Cookie/QueueingFactory.php#L10)
[src/Illuminate/Contracts/Foundation/Application.php#L26](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Contracts/Foundation/Application.php#L26)
[src/Illuminate/Cookie/CookieJar.php#L108](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Cookie/CookieJar.php#L108)
[src/Illuminate/Foundation/Application.php#L434](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Foundation/Application.php#L434)
[src/Illuminate/Support/Facades/Facade.php#L41](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Support/Facades/Facade.php#L41)
[src/Illuminate/Support/helpers.php#L443](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Support/helpers.php#L443)

Maybe the regex can be bettered ignoring variadic functions and be added into the build process.

Anyway, what called my attention was the lack of return type here: [src/Illuminate/Database/Eloquent/Relations/MorphTo.php#L150](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Database/Eloquent/Relations/MorphTo.php#L150)

Thanks for the awesome framework. John.
