### PR TITLE
[5.1] Changes type casting to Swift's toString() method, enabling Exceptions

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -67,12 +67,12 @@ class MailgunTransport extends Transport
         if (version_compare(ClientInterface::VERSION, '6') === 1) {
             $options['multipart'] = [
                 ['name' => 'to', 'contents' => $to],
-                ['name' => 'message', 'contents' => (string) $message, 'filename' => 'message.mime'],
+                ['name' => 'message', 'contents' => $message->toString(), 'filename' => 'message.mime'],
             ];
         } else {
             $options['body'] = [
                 'to' => $to,
-                'message' => new PostFile('message', (string) $message),
+                'message' => new PostFile('message', $message->toString()),
             ];
         }
 

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -44,7 +44,7 @@ class MandrillTransport extends Transport
         $data = [
             'key' => $this->key,
             'to' => $this->getToAddresses($message),
-            'raw_message' => (string) $message,
+            'raw_message' => $message->toString(),
             'async' => false,
         ];
 

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -35,7 +35,7 @@ class SesTransport extends Transport
         return $this->ses->sendRawEmail([
             'Source' => key($message->getSender() ?: $message->getFrom()),
             'RawMessage' => [
-                'Data' => (string) $message,
+                'Data' => $message->toString(),
             ],
         ]);
     }


### PR DESCRIPTION
Changes type casting used in raw_message to use Swift's built-in toString() method, allowing Exceptions to be properly thrown. This works around PHP's inability for __toString() to throw an exception - see https://bugs.php.net/bug.php?id=53648

I did this as I had an issue with some of my code, and I was only getting unhelpful errors such as:
`exception 'Symfony\Component\Debug\Exception\FatalErrorException' with message 'Method Swift_Message::__toString() must not throw an exception' in /var/www/application/releases/release-last/vendor/laravel/framework/src/Illuminate/Mail/Transport/MandrillTransport.php:0 Stack trace: #0 [internal function]: Illuminate\Exception\Handler->handleShutdown() #1 {main} [] []`

With this change, I'm now receiving useful exceptions detailing the actual problem.

This is updated & tested with 5.1, after discussions in PR #11030 
