### PR TITLE
[5.1] Some pagination bug

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -272,7 +272,8 @@ class Builder
     {
         $total = $this->query->getCountForPagination();
 
-        $this->query->forPage(
+        $this->query->forPageWithTotal(
+            $total,
             $page = $page ?: Paginator::resolveCurrentPage($pageName),
             $perPage = $perPage ?: $this->model->getPerPage()
         );

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1238,6 +1238,25 @@ class Builder
     }
 
     /**
+     * Set the limit and offset for a given total item and page.
+     *
+     * @param  int  $total
+     * @param  int  $page
+     * @param  int  $perPage
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function forPageWithTotal($total, $page, $perPage = 15)
+    {
+        $offset = ($page - 1) * $perPage;
+
+        if ($offset > $total) {
+            $offset = (ceil($total / $perPage) - 1) * $perPage;
+        }
+
+        return $this->skip($offset)->take($perPage);
+    }
+
+    /**
      * Add a union statement to the query.
      *
      * @param  \Illuminate\Database\Query\Builder|\Closure  $query
@@ -1421,7 +1440,7 @@ class Builder
 
         $total = $this->getCountForPagination($columns);
 
-        $results = $this->forPage($page, $perPage)->get($columns);
+        $results = $this->forPageWithTotal($total, $page, $perPage)->get($columns);
 
         return new LengthAwarePaginator($results, $total, $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -314,7 +314,7 @@ abstract class AbstractPaginator
     public static function resolveCurrentPage($pageName = 'page', $default = 1)
     {
         if (isset(static::$currentPageResolver)) {
-            return call_user_func(static::$currentPageResolver, $pageName);
+            return (int) call_user_func(static::$currentPageResolver, $pageName);
         }
 
         return $default;

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -499,6 +499,21 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('05-12-12', $array['updated_at']);
     }
 
+    public function testPaginatedModelCollectionRetrievalWhenCurrentPageGreaterThanTotalPages()
+    {
+        EloquentTestUser::create(['id' => 1, 'email' => 'taylorotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
+        EloquentTestUser::create(['id' => 3, 'email' => 'trinhquanghuy95@gmail.com']);
+
+        Paginator::currentPageResolver(function () { return 3; });
+        $models = EloquentTestUser::oldest('id')->paginate(2);
+
+        $this->assertEquals(1, $models->count());
+        $this->assertInstanceOf('Illuminate\Pagination\LengthAwarePaginator', $models);
+        $this->assertInstanceOf('EloquentTestUser', $models[0]);
+        $this->assertEquals('trinhquanghuy95@gmail.com', $models[0]->email);
+    }
+
     /**
      * Helpers...
      */

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -186,4 +186,18 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2, ['path' => 'http://website.com/test']);
         $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
     }
+
+    public function testPaginatorWhenCurrentPageStartWithZero()
+    {
+        Paginator::currentPageResolver(function () { return '03'; });
+        $p = new LengthAwarePaginator($array = ['item1', 'item2'], 100, 2);
+        $this->assertEquals(3, $p->currentPage());
+    }
+
+    public function testPaginatorWhenCurrentPageIsGarbagetext()
+    {
+        Paginator::currentPageResolver(function () { return 'garbagetext'; });
+        $p = new LengthAwarePaginator($array = ['item1', 'item2'], 100, 2);
+        $this->assertEquals(1, $p->currentPage());
+    }
 }


### PR DESCRIPTION
Bug 1: If current page start with zero (ex: 012), Eloquent will return rows of page 12, but Paginator will return current page is 1.
Bug 2: If you have total pages is 20, when you go to page greater than 20 (ex: 21, 22, 23 ...),  Paginator will return current page is 20, but Eloquent will return empty array.
If you have 20 rows per page, when you go to page: 500000000000000000, you will get MySQL error
