### PR TITLE
[5.1] Bootstrap SQLite differently to reveal some test problems

### DIFF
--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -19,7 +19,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $db->addConnection([
             'driver'    => 'sqlite',
             'database'  => ':memory:',
-            ]);
+        ]);
         $db->bootEloquent();
         $db->setAsGlobal();
 


### PR DESCRIPTION
3 tests fail now, one due a UNIQUE constraint violation, one due to a NULL constraint violation, and another just because the dummy connection it's trying to use doesn't exist.

Easy fixes, but still can't understand why the original bootstrapping was causing SQLite to silently fail on unique and null constraints.

Not really here to be merged, just for review and to figure out a good solution.
