### PR TITLE
[5.1] Re-added parameter binder in constructor

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -118,8 +118,10 @@ class Router implements RegistrarContract
         $this->events = $events;
         $this->routes = new RouteCollection;
         $this->container = $container ?: new Container;
-        
-        $this->bind('_missing', function($v) { return explode('/', $v); });
+
+        $this->bind('_missing', function ($v) { 
+            return explode('/', $v);
+        });
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -119,7 +119,7 @@ class Router implements RegistrarContract
         $this->routes = new RouteCollection;
         $this->container = $container ?: new Container;
 
-        $this->bind('_missing', function ($v) { 
+        $this->bind('_missing', function ($v) {
             return explode('/', $v);
         });
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -118,6 +118,8 @@ class Router implements RegistrarContract
         $this->events = $events;
         $this->routes = new RouteCollection;
         $this->container = $container ?: new Container;
+        
+        $this->bind('_missing', function($v) { return explode('/', $v); });
     }
 
     /**


### PR DESCRIPTION
Fix for #10998

Registering controllers in the router was added back in commit f622f516740371b6217d36448f04d407a7594c3f however this parameter binder was not.

This does affect 5.0. 4.2 works as expected but I see that PR's are not being accepted for 5.0 correct?
