### PR TITLE
[5.3] Blade annotations

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -781,6 +781,19 @@ if (! function_exists('trait_uses_recursive')) {
     }
 }
 
+if (! function_exists('type_of')) {
+    /**
+     * Returns the type of the given variable.
+     *
+     * @param  mixed  $object
+     * @return string
+     */
+    function type_of($object)
+    {
+        return is_object($object) ? get_class($object) : gettype($object);
+    }
+}
+
 if (! function_exists('value')) {
     /**
      * Return the default value of the given value.

--- a/src/Illuminate/View/Exception/ViewParamException.php
+++ b/src/Illuminate/View/Exception/ViewParamException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\View\Exception;
+
+use InvalidArgumentException;
+
+class ViewParamException extends InvalidArgumentException
+{
+    /**
+     * Creates a new exception.
+     *
+     * @param  string  $file
+     * @param  string  $variableName
+     * @param  string  $expectedType
+     * @param  string  $actualType
+     * @return static
+     */
+    public static function forVariable($file, $variableName, $expectedType, $actualType)
+    {
+        return new static("Invalid parameter \${$variableName} supplied to view {$file}: expecting type of {$expectedType} while {$actualType} given");
+    }
+}


### PR DESCRIPTION
Adds a similar syntax to PHPDoc annotations to the blade templating engine. These are similar blade directives except that the parenthesis are omitted and a single annotation _must_ encompass an entire line. The original inspiration for this was adding `@param` annotation below, it feels as though it would mesh really well with the current blade syntax. They are designed to also benefit ide-integration.
# **`@param`**

Provides a mechanism to implement strongly-typed views a la ASP .NET MVC. These are implemented to be syntactically identical to the typical `@param`'s in docblocks. The goal of this is to provide better debugging via explicit type information for view parameters.  Currently classes and primitive types are supported. Perhaps collections could be in the future scope?

``` blade
{{-- $var must exist --}}
@param $var

{{-- $var must exist and be instance of SomeClass --}}
@param SomeClass $var

{{-- $var must exist and be an int --}}
@param int $var

{{-- $var must exist and be instance of SomeClass or null --}}
@param SomeClass|null $var
```

If any of the `@param` conditions fail, an exception of type `Illuminate\View\Exception\ViewParamException` will be thrown.
# **`@use`**

Equivalent to PHP's `use` keyword, used for importing/aliasing namespaced class names.

``` blade
@use Some\Namespaced\Class
@use Some\Namespaced\Class as ClassAlias
```
# **`@inject`**

Behaves exactly like the current `@inject` directive, it is mainly a syntactical change. Instead of relying on strings to describe variables and class names, it has its own syntax matching the `@param` annotation.

``` blade
{{-- equivalent to @inject('var', 'Some\ClassName') --}}
@inject Some\ClassName $var
```

This does not affect the current `@inject` syntax, as such code relying on the current syntax should remain unaffected.
# Notes

Due to sharing syntax with current blade directives, there could be BC issues, but currently, to mitigate this, annotations forbid parenthesis and will fallback to standard directives if there is no implemented compiler for it. If this does not suffice perhaps an additional token could be added to the syntax to remove collisions.
# Usage

Here is usage example of some annotations.

``` blade
@param string $title
@param bool $showSidebar
<html>
    <head>
        <title>App Name - {{ $title }}</title>
    </head>
    <body>
        @if($showSidebar)
            @section('sidebar')
                 This is the master sidebar.
            @show
        @endif

        <div class="container">
            @yield('content')
        </div>
    </body>
</html>
```

I am interested to get people's feedback on this idea.
