### PR TITLE
[5.1] NullQueue fixes, null to "null" string conversion.

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -182,7 +182,11 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["queue.connections.{$name}"];
+        $nullConfig = [
+            'driver' => 'null'
+        ];
+
+        return $this->app['config']["queue.connections.{$name}"] ?: $nullConfig;
     }
 
     /**
@@ -192,7 +196,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['queue.default'];
+        return $this->app['config']['queue.default'] ?: 'null';
     }
 
     /**
@@ -203,7 +207,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['queue.default'] = $name;
+        $this->app['config']['queue.default'] = is_null($name) ? 'null' : $name;
     }
 
     /**

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -183,7 +183,7 @@ class QueueManager implements FactoryContract, MonitorContract
     protected function getConfig($name)
     {
         $nullConfig = [
-            'driver' => 'null'
+            'driver' => 'null',
         ];
 
         return $this->app['config']["queue.connections.{$name}"] ?: $nullConfig;


### PR DESCRIPTION
Fix for #11051 

The `env` helper function takes null and (null) 'strings' and returns null. This is no good when configuring the NullQueue. 

This commit provides this behaviour:
If a connection/driver has been set in `queue.php` but the connector does not exist `InvalidArgumentException` will throw as expected. If no connection has been defined in the queue.php file a NullQueue is assumed regardless of what the `QUEUE_DRIVER` var has been set to.

Only problem I can see is if you misspell a queue driver it will default to null rather than give you a warning.

Up for discussion on this one if this doesn't seem acceptable, it works as a quick fix but a bigger refactor of QueueManager or changing the name of NullQueue to something that doesn't contain a type would be other options. This would most likely be breaking changes though right?
