### PR TITLE
[5.1] Extract variable usage to getter

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -233,6 +233,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     public function getErrorBagName()
     {
         $this->dontFlash[] = '_error_bag';
+
         return $this->input('_error_bag', $this->errorBag);
     }
 }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -226,12 +226,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
-     * Get the key to be used for the view error bag
+     * Get the key to be used for the view error bag.
      *
      * @return string
      */
     public function getErrorBagName()
     {
-        return $this->errorBag;
+        $this->dontFlash[] = '_error_bag';
+        return $this->input('_error_bag', $this->errorBag);
     }
 }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -135,7 +135,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
 
         return $this->redirector->to($this->getRedirectUrl())
                                         ->withInput($this->except($this->dontFlash))
-                                        ->withErrors($errors, $this->errorBag);
+                                        ->withErrors($errors, $this->getErrorBagName());
     }
 
     /**
@@ -223,5 +223,15 @@ class FormRequest extends Request implements ValidatesWhenResolved
     public function attributes()
     {
         return [];
+    }
+
+    /**
+     * Get the key to be used for the view error bag
+     *
+     * @return string
+     */
+    public function getErrorBagName()
+    {
+        return $this->errorBag;
     }
 }


### PR DESCRIPTION
This provides an easy way to set dynamic error bag names (without hijacking another method) when you have multiple forms using the same form request on the same page (like create and edit).

Example usage with bag name included in input

``` php
public function getErrorBagName()
{
    $this->dontFlash[] = '_error_bag';
    return $this->input('_error_bag', $this->errorBag);
}
```
