### PR TITLE
[5.1] Improved regular expression helper Str::snake

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -391,7 +391,7 @@ class Str
         if (! ctype_lower($value)) {
             $value = preg_replace('/\s+/', '', $value);
 
-            $value = strtolower(preg_replace('/(.)(?=[A-Z])/', '$1'.$delimiter, $value));
+            $value = strtolower(preg_replace('/([^'.preg_quote($delimiter).'])(?=[A-Z])/', '$1'.$delimiter, $value));
         }
 
         return static::$snakeCache[$key] = $value;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -141,6 +141,7 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('laravel php framework', Str::snake('LaravelPhpFramework', ' '));
         $this->assertEquals('laravel_php_framework', Str::snake('Laravel Php Framework'));
         $this->assertEquals('laravel_php_framework', Str::snake('Laravel    Php      Framework   '));
+        $this->assertEquals('laravel_php_framework', Str::snake('LaravelPhp_Framework'));
     }
 
     public function testStudly()


### PR DESCRIPTION
Maintains a unique delimiter case already exists, instead of doubling.
Before:

``` php
$str = Str::snake('LaravelPhp_Framework');

// laravel_php__framework
```

Now:

``` php
$str = Str::snake('LaravelPhp_Framework');

// laravel_php_framework
```
