### PR TITLE
[5.1]  Added $collection->any()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -393,6 +393,27 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Determine if there are any items that pass a given truth test.
+     *
+     * @param  callable|null  $callback
+     * @return bool
+     */
+    public function any(callable $callback = null)
+    {
+        if (is_null($callback)) {
+            return ! $this->isEmpty();
+        }
+
+        foreach ($this->items as $key => $item) {
+            if ($callback($item, $key) === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Determine if the given value is callable, but not a string.
      *
      * @param  mixed  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -57,6 +57,23 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($c->isEmpty());
     }
 
+    public function testAny()
+    {
+        $c = new Collection();
+        $this->assertFalse($c->any());
+
+        $c = new Collection(['foo', 'bar']);
+        $this->assertTrue($c->any());
+
+        $this->assertTrue($c->any(function ($item, $key) {
+            return $item === 'foo' && $key === 0;
+        }));
+
+        $this->assertFalse($c->any(function ($item, $key) {
+            return $item === 'foo' && $key === 1;
+        }));
+    }
+
     public function testCollectionIsConstructed()
     {
         $collection = new Collection('foo');


### PR DESCRIPTION
From my experience checking that a collection is NOT empty is actually much more common than checking if it is.

A dedicated method may clean your code a little bit (at least in my opinion)

``` php
@if(!$collection->isEmpty()
      // show content
@endif
```

vs

``` php
@if($collection->isNotEmpty()
      // show content
@endif
```

**UPD:**
Changed to `->any()`
