### PR TITLE
[5.1] Add console application default version

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -35,7 +35,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      * @param  string  $version
      * @return void
      */
-    public function __construct(Container $laravel, Dispatcher $events, $version)
+    public function __construct(Container $laravel, Dispatcher $events, $version = 'UNKNOWN')
     {
         parent::__construct('Laravel Framework', $version);
 


### PR DESCRIPTION
This adds a string of 'UNKNOWN' as the default value to the $version parameter of the Console Application constructor. This value is taken from the default parameter in the parent Symphony Console Application class. Without a default value in the constructor, any attempt to use this class for constructor injection, instead of using the Artisan facade, will fail. For a real world example of this problem, see this Stack Overflow post: http://stackoverflow.com/questions/33875166/injecting-artisan-into-service-class
