### PR TITLE
[5.1] Make Request invokable for syntactic sugar

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -911,11 +911,13 @@ class Request extends SymfonyRequest implements ArrayAccess
     /**
      * Get a subset of the items from the input data.
      *
-     * @param  mixed string
+     * @param  array|mixed  $keys
      * @return array
      */
-    public function __invoke()
+    public function __invoke($keys)
     {
-        return $this->only(func_get_args());
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        return $this->only($keys);
     }
 }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -907,4 +907,15 @@ class Request extends SymfonyRequest implements ArrayAccess
             return $this->route($key);
         }
     }
+
+    /**
+     * Get a subset of the items from the input data.
+     *
+     * @param  mixed string
+     * @return array
+     */
+    public function __invoke()
+    {
+        return $this->only(func_get_args());
+    }
 }


### PR DESCRIPTION
With this you can do:

``` php
// ItemsController
public function store(Request $request)
{
    $data = $request('some', 'inputs', 'that', 'were', 'sent');
    // proceed
}
```
