### PR TITLE
Allow additional parameters to be converted to JSON with a model.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2427,24 +2427,26 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Convert the model instance to JSON.
+     * Convert the model instance and any additional additions to JSON.
      *
      * @param  int  $options
+     * @param  array  $additions
      * @return string
      */
-    public function toJson($options = 0)
+    public function toJson($options = 0, $additions = [])
     {
-        return json_encode($this->jsonSerialize(), $options);
+        return json_encode($this->jsonSerialize($additions), $options);
     }
 
     /**
      * Convert the object into something JSON serializable.
      *
+     * @param  array  $additions
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize($additions)
     {
-        return $this->toArray();
+        return array_merge($this->toArray(), $additions);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2435,18 +2435,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function toJson($options = 0, $additions = [])
     {
-        return json_encode($this->jsonSerialize($additions), $options);
+        return json_encode(array_merge($this->jsonSerialize(), $additions), $options);
     }
 
     /**
      * Convert the object into something JSON serializable.
      *
-     * @param  array  $additions
      * @return array
      */
-    public function jsonSerialize($additions)
+    public function jsonSerialize()
     {
-        return array_merge($this->toArray(), $additions);
+        return $this->toArray();
     }
 
     /**


### PR DESCRIPTION
This allows for easier additions to the JSON form of a model, for instance:

```
return $model->toJson(0, ["success" => true]);
```

Attributes that conflict are overwritten by `array_merge`, as would be expected.

```
>>> array_merge(["a" => "b"], ["a" => "c"])
=> [
     "a" => "c",
   ]
```
