### PR TITLE
[5.2] Simplify global scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -773,9 +773,7 @@ class Builder
         // the has query, and then copy the bindings from the "has" query to the main.
         $relationQuery = $relation->getBaseQuery();
 
-        $hasQuery = $hasQuery->getModel()->removeGlobalScopes($hasQuery);
-
-        $hasQuery->mergeWheres(
+        $hasQuery->removeGlobalScopes()->mergeWheres(
             $relationQuery->wheres, $relationQuery->getBindings()
         );
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -339,11 +339,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      *
      * @param  \Illuminate\Database\Eloquent\ScopeInterface|\Closure|string  $scope
      * @param  \Closure|null  $implementation
-     * @return void
+     * @return mixed
+     * 
+     * @throws \InvalidArgumentException
      */
     public static function addGlobalScope($scope, Closure $implementation = null)
     {
-        if (is_string($scope) && $implementation) {
+        if (is_string($scope) && $implementation !== null) {
             return static::$globalScopes[get_called_class()][$scope] = $implementation;
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1903,17 +1903,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Remove all of the global scopes from an Eloquent builder.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @return \Illuminate\Database\Eloquent\Builder
-     */
-    public function removeGlobalScopes($builder)
-    {
-        return $builder->removeGlobalScopes();
-    }
-
-    /**
      * Create a new Eloquent query builder for the model.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Eloquent/ScopeInterface.php
+++ b/src/Illuminate/Database/Eloquent/ScopeInterface.php
@@ -12,14 +12,4 @@ interface ScopeInterface
      * @return void
      */
     public function apply(Builder $builder, Model $model);
-
-    /**
-     * Remove the scope from the given Eloquent query builder.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     *
-     * @return void
-     */
-    public function remove(Builder $builder, Model $model);
 }

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -26,24 +26,6 @@ class SoftDeletingScope implements ScopeInterface
     }
 
     /**
-     * Remove the scope from the given Eloquent query builder.
-     *
-     * @param  \Illuminate\Database\Eloquent\Builder  $builder
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return void
-     */
-    public function remove(Builder $builder, Model $model)
-    {
-        $column = $model->getQualifiedDeletedAtColumn();
-
-        $query = $builder->getQuery();
-
-        $query->wheres = collect($query->wheres)->reject(function ($where) use ($column) {
-            return $this->isSoftDeleteConstraint($where, $column);
-        })->values()->all();
-    }
-
-    /**
      * Extend the query builder with the needed functions.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $builder
@@ -116,9 +98,7 @@ class SoftDeletingScope implements ScopeInterface
     protected function addWithTrashed(Builder $builder)
     {
         $builder->macro('withTrashed', function (Builder $builder) {
-            $this->remove($builder, $builder->getModel());
-
-            return $builder;
+            return $builder->removeGlobalScope($this);
         });
     }
 
@@ -133,23 +113,9 @@ class SoftDeletingScope implements ScopeInterface
         $builder->macro('onlyTrashed', function (Builder $builder) {
             $model = $builder->getModel();
 
-            $this->remove($builder, $model);
-
-            $builder->getQuery()->whereNotNull($model->getQualifiedDeletedAtColumn());
+            $builder->removeGlobalScope($this)->getQuery()->whereNotNull($model->getQualifiedDeletedAtColumn());
 
             return $builder;
         });
-    }
-
-    /**
-     * Determine if the given where clause is a soft delete constraint.
-     *
-     * @param  array   $where
-     * @param  string  $column
-     * @return bool
-     */
-    protected function isSoftDeleteConstraint(array $where, $column)
-    {
-        return $where['type'] == 'Null' && $where['column'] == $column;
     }
 }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -399,7 +399,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $model = new EloquentBuilderTestNestedStub;
         $this->mockConnectionForModel($model, 'SQLite');
         $query = $model->newQuery()->where('foo', '=', 'bar')->where(function ($query) { $query->where('baz', '>', 9000); });
-        $this->assertEquals('select * from "table" where "table"."deleted_at" is null and "foo" = ? and ("baz" > ?)', $query->toSql());
+        $this->assertEquals('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
         $this->assertEquals(['bar', 9000], $query->getBindings());
     }
 

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use Mockery as m;
+
+class DatabaseEloquentGlobalScopesTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testGlobalScopeIsApplied()
+    {
+        $model = new EloquentGlobalScopesTestModel();
+        $query = $model->newQuery();
+        $this->assertEquals('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
+    public function testGlobalScopeCanBeRemoved()
+    {
+        $model = new EloquentGlobalScopesTestModel();
+        $query = $model->newQuery()->removeGlobalScope(ActiveScope::class);
+        $this->assertEquals('select * from "table"', $query->toSql());
+        $this->assertEquals([], $query->getBindings());
+    }
+
+    public function testClosureGlobalScopeIsApplied()
+    {
+        $model = new EloquentClosureGlobalScopesTestModel();
+        $query = $model->newQuery();
+        $this->assertEquals('select * from "table" where "active" = ? order by "name" asc', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+    }
+
+    public function testClosureGlobalScopeCanBeRemoved()
+    {
+        $model = new EloquentClosureGlobalScopesTestModel();
+        $query = $model->newQuery()->removeGlobalScope('active_scope');
+        $this->assertEquals('select * from "table" order by "name" asc', $query->toSql());
+        $this->assertEquals([], $query->getBindings());
+    }
+
+    public function testGlobalScopeCanBeRemovedAfterTheQueryIsExecuted()
+    {
+        $model = new EloquentClosureGlobalScopesTestModel();
+        $query = $model->newQuery();
+        $this->assertEquals('select * from "table" where "active" = ? order by "name" asc', $query->toSql());
+        $this->assertEquals([1], $query->getBindings());
+
+        $query->removeGlobalScope('active_scope');
+        $this->assertEquals('select * from "table" order by "name" asc', $query->toSql());
+        $this->assertEquals([], $query->getBindings());
+    }
+
+    public function testAllGlobalScopesCanBeRemoved()
+    {
+        $model = new EloquentClosureGlobalScopesTestModel();
+        $query = $model->newQuery()->removeGlobalScopes();
+        $this->assertEquals('select * from "table"', $query->toSql());
+        $this->assertEquals([], $query->getBindings());
+
+        $model = new EloquentClosureGlobalScopesTestModel();
+        $query = $model->newQuery();
+        $model->removeGlobalScopes($query);
+        $this->assertEquals('select * from "table"', $query->toSql());
+        $this->assertEquals([], $query->getBindings());
+    }
+}
+
+class EloquentClosureGlobalScopesTestModel extends Illuminate\Database\Eloquent\Model
+{
+    protected $table = 'table';
+
+    public static function boot()
+    {
+        static::addGlobalScope('active_scope', function ($query) {
+            $query->where('active', 1);
+        });
+
+        static::addGlobalScope(function ($query) {
+            $query->orderBy('name');
+        });
+
+        parent::boot();
+    }
+}
+
+class EloquentGlobalScopesTestModel extends Illuminate\Database\Eloquent\Model
+{
+    protected $table = 'table';
+
+    public static function boot()
+    {
+        static::addGlobalScope(new ActiveScope);
+
+        parent::boot();
+    }
+}
+
+class ActiveScope implements \Illuminate\Database\Eloquent\ScopeInterface
+{
+    public function apply(\Illuminate\Database\Eloquent\Builder $builder, \Illuminate\Database\Eloquent\Model $model)
+    {
+        return $builder->where('active', 1);
+    }
+}

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -60,9 +60,7 @@ class DatabaseEloquentGlobalScopesTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('select * from "table"', $query->toSql());
         $this->assertEquals([], $query->getBindings());
 
-        $model = new EloquentClosureGlobalScopesTestModel();
-        $query = $model->newQuery();
-        $model->removeGlobalScopes($query);
+        $query = EloquentClosureGlobalScopesTestModel::removeGlobalScopes();
         $this->assertEquals('select * from "table"', $query->toSql());
         $this->assertEquals([], $query->getBindings());
     }

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -21,20 +21,6 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase
         $scope->apply($builder, $model);
     }
 
-    public function testScopeCanRemoveDeletedAtConstraints()
-    {
-        $scope = new Illuminate\Database\Eloquent\SoftDeletingScope;
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $model = m::mock('Illuminate\Database\Eloquent\Model');
-        $builder->shouldReceive('getModel')->andReturn($model);
-        $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
-        $builder->shouldReceive('getQuery')->andReturn($query = m::mock('StdClass'));
-        $query->wheres = [['type' => 'Null', 'column' => 'foo'], ['type' => 'Null', 'column' => 'table.deleted_at']];
-        $scope->remove($builder, $model);
-
-        $this->assertEquals($query->wheres, [['type' => 'Null', 'column' => 'foo']]);
-    }
-
     public function testForceDeleteExtension()
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -74,7 +60,7 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase
         $callback = $builder->getMacro('withTrashed');
         $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
         $givenBuilder->shouldReceive('getModel')->andReturn($model = m::mock('Illuminate\Database\Eloquent\Model'));
-        $scope->shouldReceive('remove')->once()->with($givenBuilder, $model);
+        $givenBuilder->shouldReceive('removeGlobalScope')->with($scope)->andReturn($givenBuilder);
         $result = $callback($givenBuilder);
 
         $this->assertEquals($givenBuilder, $result);
@@ -90,9 +76,9 @@ class DatabaseSoftDeletingScopeTest extends PHPUnit_Framework_TestCase
         $scope->extend($builder);
         $callback = $builder->getMacro('onlyTrashed');
         $givenBuilder = m::mock('Illuminate\Database\Eloquent\Builder');
-        $scope->shouldReceive('remove')->once()->with($givenBuilder, $model);
         $givenBuilder->shouldReceive('getQuery')->andReturn($query = m::mock('StdClass'));
         $givenBuilder->shouldReceive('getModel')->andReturn($model);
+        $givenBuilder->shouldReceive('removeGlobalScope')->with($scope)->andReturn($givenBuilder);
         $model->shouldReceive('getQualifiedDeletedAtColumn')->andReturn('table.deleted_at');
         $query->shouldReceive('whereNotNull')->once()->with('table.deleted_at');
         $result = $callback($givenBuilder);


### PR DESCRIPTION
This PR proposes a simplified way of dealing with global scopes in Eloquent. Right now, even for the simplest global scopes (like `is_active = 1`) we need to create a new class that implements `ScopeInterface` and we need to implement `apply` and `remove` methods (and especially `remove` can be tricky).

This PR makes the following changes:
- scopes are applied just-in-time in the Eloquent Builder rather than in the Model, so that they can be removed very easily before they are even added to the query. Therefore the `remove` method in the `ScopeInterface` is not needed any more. It was also removed from the contract.
- The `applyGlobalScope` method on the Model now also accepts closures to enable an easy way of adding simple global scopes. `ScopeInterface` implementations are of course still accepted to maximize BC.
-  `applyGlobalScope` now also accepts an optional identifier as the first argument which can serve as a key to remove the scope by.

Some examples:

``` php
class User extends Model
{
    public static function boot()
    {
        static::addGlobalScope(function($builder) {
            $builder->where('is_active', 1);
        });
        parent::boot();
    }
}

User::all(); // SELECT * FROM users WHERE is_active=1
User::withoutGlobalScopes()->get(); // SELECT * FROM users
```

``` php
class User extends Model
{
    public static function boot()
    {
        static::addGlobalScope('active', function($builder) {
            $builder->where('is_active', 1);
        });

        static::addGlobalScope('order', function($builder) {
            $builder->orderBy('name');
        });

       parent::boot();
    }
}

User::all(); // SELECT * FROM users WHERE is_active=1 ORDER BY name ASC
User::withoutGlobalScope('active')->get(); // SELECT * FROM users ORDER BY name ASC
```

Again, I tried to avoid BC breaks as much as possible, so the old way of using `ScopeInterface` still works. Only the `remove` method can now be deleted.

Any comments? :) Do you all think it's worth to continue working on this?

Edit: updated to reflect the latest changes
Edit2: updated with removeGlobalScopes() example
Edit3: updated with the latest syntax
