### PR TITLE
[5.2] Use available `symfony/polyfill-php56` for handling `hash_equals()` method on < PHP 5.6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "symfony/routing": "2.8.*|3.0.*",
         "symfony/translation": "2.8.*|3.0.*",
         "symfony/var-dumper": "2.8.*|3.0.*",
+        "symfony/polyfill-php56": "^1.0",
         "vlucas/phpdotenv": "~2.0"
     },
     "replace": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -18,7 +18,8 @@
         "ext-mbstring": "*",
         "illuminate/contracts": "5.2.*",
         "doctrine/inflector": "~1.0",
-        "danielstjules/stringy": "~2.1"
+        "danielstjules/stringy": "~2.1",
+        "symfony/polyfill-php56": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -494,44 +494,6 @@ if (! function_exists('head')) {
     }
 }
 
-if (! function_exists('hash_equals')) {
-    /**
-     * Compares two strings using a constant-time algorithm.
-     *
-     * Note: This method will leak length information.
-     *
-     * Note: Adapted from Symfony\Component\Security\Core\Util\StringUtils.
-     *
-     * @param  string  $knownString
-     * @param  string  $userInput
-     * @return bool
-     */
-    function hash_equals($knownString, $userInput)
-    {
-        if (! is_string($knownString)) {
-            $knownString = (string) $knownString;
-        }
-
-        if (! is_string($userInput)) {
-            $userInput = (string) $userInput;
-        }
-
-        $knownLength = mb_strlen($knownString, '8bit');
-
-        if (mb_strlen($userInput, '8bit') !== $knownLength) {
-            return false;
-        }
-
-        $result = 0;
-
-        for ($i = 0; $i < $knownLength; ++$i) {
-            $result |= (ord($knownString[$i]) ^ ord($userInput[$i]));
-        }
-
-        return 0 === $result;
-    }
-}
-
 if (! function_exists('last')) {
     /**
      * Get the last element from an array.


### PR DESCRIPTION
This would avoid having to babysit the said method if new security flaw is found, one less thing to maintain.

Signed-off-by: crynobone crynobone@gmail.com
