### PR TITLE
[5.1] Synchronizing the value env('APP_ENV') when the argument --env is passed to artisan.

### DIFF
--- a/src/Illuminate/Foundation/EnvironmentDetector.php
+++ b/src/Illuminate/Foundation/EnvironmentDetector.php
@@ -48,7 +48,10 @@ class EnvironmentDetector
         // and if it was that automatically overrides as the environment. Otherwise, we
         // will check the environment as a "web" request like a typical HTTP request.
         if (! is_null($value = $this->getEnvironmentArgument($args))) {
-            return head(array_slice(explode('=', $value), 1));
+            $env = head(array_slice(explode('=', $value), 1));
+            putenv("APP_ENV=$env");
+
+            return $env;
         }
 
         return $this->detectWebEnvironment($callback);

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -20,8 +20,8 @@ class FoundationEnvironmentDetectorTest extends PHPUnit_Framework_TestCase
     public function testConsoleEnvironmentDetection()
     {
         $env = new Illuminate\Foundation\EnvironmentDetector;
-
         $result = $env->detect(function () { return 'foobar'; }, ['--env=local']);
         $this->assertEquals('local', $result);
+        $this->assertEquals(env('APP_ENV'), $result);
     }
 }


### PR DESCRIPTION
Synchronizing the value env('APP_ENV') when the argument --env is passed to artisan.
