### PR TITLE
[5.1] Prevent an extra @stop or @endSection from clearing external output buffers

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -555,7 +555,7 @@ class Factory implements FactoryContract
      */
     public function stopSection($overwrite = false)
     {
-        if(empty($this->sectionStack)) {
+        if (empty($this->sectionStack)) {
             return '';
         }
 
@@ -577,7 +577,7 @@ class Factory implements FactoryContract
      */
     public function appendSection()
     {
-        if(empty($this->sectionStack)) {
+        if (empty($this->sectionStack)) {
             return '';
         }
 

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -555,6 +555,10 @@ class Factory implements FactoryContract
      */
     public function stopSection($overwrite = false)
     {
+        if(empty($this->sectionStack)) {
+            return '';
+        }
+
         $last = array_pop($this->sectionStack);
 
         if ($overwrite) {
@@ -573,6 +577,10 @@ class Factory implements FactoryContract
      */
     public function appendSection()
     {
+        if(empty($this->sectionStack)) {
+            return '';
+        }
+
         $last = array_pop($this->sectionStack);
 
         if (isset($this->sections[$last])) {

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -544,6 +544,10 @@ class Factory implements FactoryContract
      */
     public function yieldSection()
     {
+        if (empty($this->sectionStack)) {
+            return '';
+        }
+
         return $this->yieldContent($this->stopSection());
     }
 
@@ -552,11 +556,12 @@ class Factory implements FactoryContract
      *
      * @param  bool  $overwrite
      * @return string
+     * @throws \InvalidArgumentException
      */
     public function stopSection($overwrite = false)
     {
         if (empty($this->sectionStack)) {
-            return '';
+            throw new InvalidArgumentException('Cannot end a section without first starting one.');
         }
 
         $last = array_pop($this->sectionStack);
@@ -574,11 +579,12 @@ class Factory implements FactoryContract
      * Stop injecting content into a section and append it.
      *
      * @return string
+     * @throws \InvalidArgumentException
      */
     public function appendSection()
     {
         if (empty($this->sectionStack)) {
-            return '';
+            throw new InvalidArgumentException('Cannot end a section without first starting one.');
         }
 
         $last = array_pop($this->sectionStack);

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -396,38 +396,24 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $factory->make('view')->render();
     }
 
-    public function testExtraStopSectionCallDoesCloseExternalOutputBuffers()
+    public function testExtraStopSectionCallThrowsException()
     {
-        ob_start();
-
         $factory = $this->getFactory();
         $factory->startSection('foo');
-        echo 'should be cleared';
         $factory->stopSection();
-        echo 'should not ';
+
+        $this->setExpectedException('InvalidArgumentException', 'Cannot end a section without first starting one.');
         $factory->stopSection();
-        echo 'be cleared';
-
-        $contents = ob_get_clean();
-
-        $this->assertEquals('should not be cleared', $contents);
     }
 
-    public function testExtraAppendSectionCallDoesCloseExternalOutputBuffers()
+    public function testExtraAppendSectionCallThrowsException()
     {
-        ob_start();
-
         $factory = $this->getFactory();
         $factory->startSection('foo');
-        echo 'should be cleared';
         $factory->stopSection();
-        echo 'should not ';
+
+        $this->setExpectedException('InvalidArgumentException', 'Cannot end a section without first starting one.');
         $factory->appendSection();
-        echo 'be cleared';
-
-        $contents = ob_get_clean();
-
-        $this->assertEquals('should not be cleared', $contents);
     }
 
     protected function getFactory()

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -396,6 +396,40 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $factory->make('view')->render();
     }
 
+    public function testExtraStopSectionCallDoesCloseExternalOutputBuffers()
+    {
+        ob_start();
+
+        $factory = $this->getFactory();
+        $factory->startSection('foo');
+        echo 'should be cleared';
+        $factory->stopSection();
+        echo 'should not ';
+        $factory->stopSection();
+        echo 'be cleared';
+
+        $contents = ob_get_clean();
+
+        $this->assertEquals('should not be cleared', $contents);
+    }
+
+    public function testExtraAppendSectionCallDoesCloseExternalOutputBuffers()
+    {
+        ob_start();
+
+        $factory = $this->getFactory();
+        $factory->startSection('foo');
+        echo 'should be cleared';
+        $factory->stopSection();
+        echo 'should not ';
+        $factory->appendSection();
+        echo 'be cleared';
+
+        $contents = ob_get_clean();
+
+        $this->assertEquals('should not be cleared', $contents);
+    }
+
     protected function getFactory()
     {
         return new Factory(


### PR DESCRIPTION
Currently, an orphaned call to `Illuminate\View\Factory::stopSection()` or `appendSection()` will clear the output buffer even if there's no section open. Any external tools that use output buffering (PHPUnit, Codeception, etc) will be negatively impacted if the relevant view is rendered. PHPUnit will mark the test as Risky. Functional tests with Codeception will always fail erroneously as it uses the output buffer to capture responses.

Example:

```
@section('foo')
    valid template content
@endSection

@stop
```

I considered throwing an exception when the orphaned stopSection is called, but I believe failing silently (but harmlessly) is more consistent with the factory's behavior.
