### PR TITLE
[5.2] Add multiGet and multiPut to cache implementations

### DIFF
--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -50,7 +50,7 @@ class ApcStore extends TaggableStore implements Store
 
     /**
      * Retrieve multiple items from the cache by key,
-     * items not found in the cache will have a null value for the key
+     * items not found in the cache will have a null value for the key.
      *
      * @param string[] $keys
      * @return array
@@ -59,7 +59,7 @@ class ApcStore extends TaggableStore implements Store
     {
         $returnValues = [];
 
-        foreach($keys as $singleKey) {
+        foreach ($keys as $singleKey) {
             $returnValues[$singleKey] = $this->get($singleKey);
         }
 
@@ -80,7 +80,7 @@ class ApcStore extends TaggableStore implements Store
     }
 
     /**
-     * Store multiple items in the cache for a set number of minutes
+     * Store multiple items in the cache for a set number of minutes.
      *
      * @param array $values array of key => value pairs
      * @param int   $minutes
@@ -88,8 +88,8 @@ class ApcStore extends TaggableStore implements Store
      */
     public function putMulti(array $values, $minutes)
     {
-        foreach($values as $key => $singleValue) {
-            $this->put($key,$singleValue,$minutes);
+        foreach ($values as $key => $singleValue) {
+            $this->put($key, $singleValue, $minutes);
         }
     }
 

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -49,6 +49,24 @@ class ApcStore extends TaggableStore implements Store
     }
 
     /**
+     * Retrieve multiple items from the cache by key,
+     * items not found in the cache will have a null value for the key
+     *
+     * @param string[] $keys
+     * @return array
+     */
+    public function getMulti(array $keys)
+    {
+        $returnValues = [];
+
+        foreach($keys as $singleKey) {
+            $returnValues[$singleKey] = $this->get($singleKey);
+        }
+
+        return $returnValues;
+    }
+
+    /**
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
@@ -59,6 +77,20 @@ class ApcStore extends TaggableStore implements Store
     public function put($key, $value, $minutes)
     {
         $this->apc->put($this->prefix.$key, $value, $minutes * 60);
+    }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes
+     *
+     * @param array $values array of key => value pairs
+     * @param int   $minutes
+     * @return void
+     */
+    public function putMulti(array $values, $minutes)
+    {
+        foreach($values as $key => $singleValue) {
+            $this->put($key,$singleValue,$minutes);
+        }
     }
 
     /**

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -28,7 +28,7 @@ class ArrayStore extends TaggableStore implements Store
 
     /**
      * Retrieve multiple items from the cache by key,
-     * items not found in the cache will have a null value for the key
+     * items not found in the cache will have a null value for the key.
      *
      * @param string[] $keys
      * @return array
@@ -37,7 +37,7 @@ class ArrayStore extends TaggableStore implements Store
     {
         $returnValues = [];
 
-        foreach($keys as $singleKey) {
+        foreach ($keys as $singleKey) {
             $returnValues[$singleKey] = $this->get($singleKey);
         }
 
@@ -58,7 +58,7 @@ class ArrayStore extends TaggableStore implements Store
     }
 
     /**
-     * Store multiple items in the cache for a set number of minutes
+     * Store multiple items in the cache for a set number of minutes.
      *
      * @param array $values array of key => value pairs
      * @param int   $minutes
@@ -66,7 +66,7 @@ class ArrayStore extends TaggableStore implements Store
      */
     public function putMulti(array $values, $minutes)
     {
-        $this->storage +=$values;
+        $this->storage += $values;
     }
 
     /**

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -27,6 +27,24 @@ class ArrayStore extends TaggableStore implements Store
     }
 
     /**
+     * Retrieve multiple items from the cache by key,
+     * items not found in the cache will have a null value for the key
+     *
+     * @param string[] $keys
+     * @return array
+     */
+    public function getMulti(array $keys)
+    {
+        $returnValues = [];
+
+        foreach($keys as $singleKey) {
+            $returnValues[$singleKey] = $this->get($singleKey);
+        }
+
+        return $returnValues;
+    }
+
+    /**
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
@@ -37,6 +55,18 @@ class ArrayStore extends TaggableStore implements Store
     public function put($key, $value, $minutes)
     {
         $this->storage[$key] = $value;
+    }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes
+     *
+     * @param array $values array of key => value pairs
+     * @param int   $minutes
+     * @return void
+     */
+    public function putMulti(array $values, $minutes)
+    {
+        $this->storage +=$values;
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -86,6 +86,24 @@ class DatabaseStore implements Store
     }
 
     /**
+     * Retrieve multiple items from the cache by key,
+     * items not found in the cache will have a null value for the key
+     *
+     * @param string[] $keys
+     * @return array
+     */
+    public function getMulti(array $keys)
+    {
+        $returnValues = [];
+
+        foreach($keys as $singleKey) {
+            $returnValues[$singleKey] = $this->get($singleKey);
+        }
+
+        return $returnValues;
+    }
+
+    /**
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
@@ -108,6 +126,20 @@ class DatabaseStore implements Store
             $this->table()->insert(compact('key', 'value', 'expiration'));
         } catch (Exception $e) {
             $this->table()->where('key', '=', $key)->update(compact('value', 'expiration'));
+        }
+    }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes
+     *
+     * @param array $values array of key => value pairs
+     * @param int   $minutes
+     * @return void
+     */
+    public function putMulti(array $values, $minutes)
+    {
+        foreach($values as $key => $singleValue) {
+            $this->put($key,$singleValue,$minutes);
         }
     }
 

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -87,7 +87,7 @@ class DatabaseStore implements Store
 
     /**
      * Retrieve multiple items from the cache by key,
-     * items not found in the cache will have a null value for the key
+     * items not found in the cache will have a null value for the key.
      *
      * @param string[] $keys
      * @return array
@@ -96,7 +96,7 @@ class DatabaseStore implements Store
     {
         $returnValues = [];
 
-        foreach($keys as $singleKey) {
+        foreach ($keys as $singleKey) {
             $returnValues[$singleKey] = $this->get($singleKey);
         }
 
@@ -130,7 +130,7 @@ class DatabaseStore implements Store
     }
 
     /**
-     * Store multiple items in the cache for a set number of minutes
+     * Store multiple items in the cache for a set number of minutes.
      *
      * @param array $values array of key => value pairs
      * @param int   $minutes
@@ -138,8 +138,8 @@ class DatabaseStore implements Store
      */
     public function putMulti(array $values, $minutes)
     {
-        foreach($values as $key => $singleValue) {
-            $this->put($key,$singleValue,$minutes);
+        foreach ($values as $key => $singleValue) {
+            $this->put($key, $singleValue, $minutes);
         }
     }
 

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -48,6 +48,24 @@ class FileStore implements Store
     }
 
     /**
+     * Retrieve multiple items from the cache by key,
+     * items not found in the cache will have a null value for the key
+     *
+     * @param string[] $keys
+     * @return array
+     */
+    public function getMulti(array $keys)
+    {
+        $returnValues = [];
+
+        foreach($keys as $singleKey) {
+            $returnValues[$singleKey] = $this->get($singleKey);
+        }
+
+        return $returnValues;
+    }
+
+    /**
      * Retrieve an item and expiry time from the cache by key.
      *
      * @param  string  $key
@@ -100,6 +118,20 @@ class FileStore implements Store
         $this->createCacheDirectory($path = $this->path($key));
 
         $this->files->put($path, $value);
+    }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes
+     *
+     * @param array $values array of key => value pairs
+     * @param int   $minutes
+     * @return void
+     */
+    public function putMulti(array $values, $minutes)
+    {
+        foreach($values as $key => $singleValue) {
+            $this->put($key,$singleValue,$minutes);
+        }
     }
 
     /**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -49,7 +49,7 @@ class FileStore implements Store
 
     /**
      * Retrieve multiple items from the cache by key,
-     * items not found in the cache will have a null value for the key
+     * items not found in the cache will have a null value for the key.
      *
      * @param string[] $keys
      * @return array
@@ -58,7 +58,7 @@ class FileStore implements Store
     {
         $returnValues = [];
 
-        foreach($keys as $singleKey) {
+        foreach ($keys as $singleKey) {
             $returnValues[$singleKey] = $this->get($singleKey);
         }
 
@@ -121,7 +121,7 @@ class FileStore implements Store
     }
 
     /**
-     * Store multiple items in the cache for a set number of minutes
+     * Store multiple items in the cache for a set number of minutes.
      *
      * @param array $values array of key => value pairs
      * @param int   $minutes
@@ -129,8 +129,8 @@ class FileStore implements Store
      */
     public function putMulti(array $values, $minutes)
     {
-        foreach($values as $key => $singleValue) {
-            $this->put($key,$singleValue,$minutes);
+        foreach ($values as $key => $singleValue) {
+            $this->put($key, $singleValue, $minutes);
         }
     }
 

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -59,7 +59,7 @@ class MemcachedStore extends TaggableStore implements Store
     {
         $prefixedKeys = [];
 
-        foreach($keys as $keyToPrefix) {
+        foreach ($keys as $keyToPrefix) {
             $prefixedKeys[] = $this->prefix.$keyToPrefix;
         }
 

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -49,6 +49,29 @@ class MemcachedStore extends TaggableStore implements Store
     }
 
     /**
+     * Retrieve multiple items from the cache by key,
+     * items not found in the cache will have a null value for the key
+     *
+     * @param string[] $keys
+     * @return array
+     */
+    public function getMulti(array $keys)
+    {
+        $prefixedKeys = [];
+
+        foreach($keys as $keyToPrefix) {
+            $prefixedKeys[] = $this->prefix . $keyToPrefix;
+        }
+
+        $cas = null;
+        $cacheValues = $this->memcached->getMulti($prefixedKeys,$cas,\Memcached::GET_PRESERVE_ORDER);
+
+        $returnValues = array_combine($keys,$cacheValues);
+
+        return $returnValues;
+    }
+
+    /**
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
@@ -59,6 +82,24 @@ class MemcachedStore extends TaggableStore implements Store
     public function put($key, $value, $minutes)
     {
         $this->memcached->set($this->prefix.$key, $value, $minutes * 60);
+    }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes
+     *
+     * @param array $values array of key => value pairs
+     * @param int   $minutes
+     * @return void
+     */
+    public function putMulti(array $values, $minutes)
+    {
+        $formattedKeyValues = [];
+
+        foreach($values as $keyToPrefix => $singleValue) {
+            $formattedKeyValues[$this->prefix . $keyToPrefix] = $singleValue;
+        }
+
+        $this->memcached->setMulti($formattedKeyValues, $minutes * 60);
     }
 
     /**

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -50,7 +50,7 @@ class MemcachedStore extends TaggableStore implements Store
 
     /**
      * Retrieve multiple items from the cache by key,
-     * items not found in the cache will have a null value for the key
+     * items not found in the cache will have a null value for the key.
      *
      * @param string[] $keys
      * @return array
@@ -85,7 +85,7 @@ class MemcachedStore extends TaggableStore implements Store
     }
 
     /**
-     * Store multiple items in the cache for a set number of minutes
+     * Store multiple items in the cache for a set number of minutes.
      *
      * @param array $values array of key => value pairs
      * @param int   $minutes
@@ -95,7 +95,7 @@ class MemcachedStore extends TaggableStore implements Store
     {
         $formattedKeyValues = [];
 
-        foreach($values as $keyToPrefix => $singleValue) {
+        foreach ($values as $keyToPrefix => $singleValue) {
             $formattedKeyValues[$this->prefix . $keyToPrefix] = $singleValue;
         }
 

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -64,7 +64,7 @@ class MemcachedStore extends TaggableStore implements Store
         }
 
         $cas = null;
-        $cacheValues = $this->memcached->getMulti($prefixedKeys,$cas,\Memcached::GET_PRESERVE_ORDER);
+        $cacheValues = $this->memcached->getMulti($prefixedKeys, $cas, \Memcached::GET_PRESERVE_ORDER);
 
         $returnValues = array_combine($keys,$cacheValues);
 
@@ -96,7 +96,7 @@ class MemcachedStore extends TaggableStore implements Store
         $formattedKeyValues = [];
 
         foreach ($values as $keyToPrefix => $singleValue) {
-            $formattedKeyValues[$this->prefix . $keyToPrefix] = $singleValue;
+            $formattedKeyValues[$this->prefix.$keyToPrefix] = $singleValue;
         }
 
         $this->memcached->setMulti($formattedKeyValues, $minutes * 60);

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -60,13 +60,13 @@ class MemcachedStore extends TaggableStore implements Store
         $prefixedKeys = [];
 
         foreach($keys as $keyToPrefix) {
-            $prefixedKeys[] = $this->prefix . $keyToPrefix;
+            $prefixedKeys[] = $this->prefix.$keyToPrefix;
         }
 
         $cas = null;
         $cacheValues = $this->memcached->getMulti($prefixedKeys, $cas, \Memcached::GET_PRESERVE_ORDER);
 
-        $returnValues = array_combine($keys,$cacheValues);
+        $returnValues = array_combine($keys, $cacheValues);
 
         return $returnValues;
     }

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -25,6 +25,18 @@ class NullStore extends TaggableStore implements Store
     }
 
     /**
+     * Retrieve multiple items from the cache by key,
+     * items not found in the cache will have a null value for the key
+     *
+     * @param string[] $keys
+     * @return array
+     */
+    public function getMulti(array $keys)
+    {
+        //
+    }
+
+    /**
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
@@ -33,6 +45,18 @@ class NullStore extends TaggableStore implements Store
      * @return void
      */
     public function put($key, $value, $minutes)
+    {
+        //
+    }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes
+     *
+     * @param array $values array of key => value pairs
+     * @param int   $minutes
+     * @return void
+     */
+    public function putMulti(array $values, $minutes)
     {
         //
     }

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -26,7 +26,7 @@ class NullStore extends TaggableStore implements Store
 
     /**
      * Retrieve multiple items from the cache by key,
-     * items not found in the cache will have a null value for the key
+     * items not found in the cache will have a null value for the key.
      *
      * @param string[] $keys
      * @return array
@@ -50,7 +50,7 @@ class NullStore extends TaggableStore implements Store
     }
 
     /**
-     * Store multiple items in the cache for a set number of minutes
+     * Store multiple items in the cache for a set number of minutes.
      *
      * @param array $values array of key => value pairs
      * @param int   $minutes

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -68,7 +68,7 @@ class RedisStore extends TaggableStore implements Store
         $returnValues = [];
         $prefixedKeys = [];
 
-        foreach($keys as $keyToPrefix) {
+        foreach ($keys as $keyToPrefix) {
             $prefixedKeys[] = $this->prefix . $keyToPrefix;
         }
 
@@ -81,7 +81,6 @@ class RedisStore extends TaggableStore implements Store
 
         return $returnValues;
     }
-
 
     /**
      * Store an item in the cache for a given number of minutes.
@@ -117,7 +116,6 @@ class RedisStore extends TaggableStore implements Store
 
         $this->connection()->exec();
     }
-
 
     /**
      * Increment the value of an item in the cache.

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -57,6 +57,33 @@ class RedisStore extends TaggableStore implements Store
     }
 
     /**
+     * Retrieve multiple items from the cache by key,
+     * items not found in the cache will have a null value for the key
+     *
+     * @param string[] $keys
+     * @return array
+     */
+    public function getMulti(array $keys)
+    {
+        $returnValues = [];
+        $prefixedKeys = [];
+
+        foreach($keys as $keyToPrefix) {
+            $prefixedKeys[] = $this->prefix . $keyToPrefix;
+        }
+
+        $cacheValues = $this->connection()->mget($prefixedKeys);
+
+        foreach ($cacheValues as $i => $value) {
+            $key = $keys[$i];
+            $returnValues[$key] = is_numeric($value) ? $value : unserialize($value);
+        }
+
+        return $returnValues;
+    }
+
+
+    /**
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
@@ -72,6 +99,25 @@ class RedisStore extends TaggableStore implements Store
 
         $this->connection()->setex($this->prefix.$key, $minutes * 60, $value);
     }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes
+     *
+     * @param array $values array of key => value pairs
+     * @param int   $minutes
+     * @return void
+     */
+    public function putMulti(array $values, $minutes)
+    {
+        $this->connection()->multi();
+
+        foreach($values as $key => $singleValue) {
+            $this->put($key,$singleValue,$minutes);
+        }
+
+        $this->connection()->exec();
+    }
+
 
     /**
      * Increment the value of an item in the cache.

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -58,7 +58,7 @@ class RedisStore extends TaggableStore implements Store
 
     /**
      * Retrieve multiple items from the cache by key,
-     * items not found in the cache will have a null value for the key
+     * items not found in the cache will have a null value for the key.
      *
      * @param string[] $keys
      * @return array
@@ -101,7 +101,7 @@ class RedisStore extends TaggableStore implements Store
     }
 
     /**
-     * Store multiple items in the cache for a set number of minutes
+     * Store multiple items in the cache for a set number of minutes.
      *
      * @param array $values array of key => value pairs
      * @param int   $minutes
@@ -111,8 +111,8 @@ class RedisStore extends TaggableStore implements Store
     {
         $this->connection()->multi();
 
-        foreach($values as $key => $singleValue) {
-            $this->put($key,$singleValue,$minutes);
+        foreach ($values as $key => $singleValue) {
+            $this->put($key, $singleValue, $minutes);
         }
 
         $this->connection()->exec();

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -69,7 +69,7 @@ class RedisStore extends TaggableStore implements Store
         $prefixedKeys = [];
 
         foreach ($keys as $keyToPrefix) {
-            $prefixedKeys[] = $this->prefix . $keyToPrefix;
+            $prefixedKeys[] = $this->prefix.$keyToPrefix;
         }
 
         $cacheValues = $this->connection()->mget($prefixedKeys);

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -62,6 +62,24 @@ class TaggedCache implements Store
     }
 
     /**
+     * Retrieve multiple items from the cache by key,
+     * items not found in the cache will have a null value for the key.
+     *
+     * @param string[] $keys
+     * @return array
+     */
+    public function getMulti(array $keys)
+    {
+        $returnValues = [];
+
+        foreach ($keys as $singleKey) {
+            $returnValues[$singleKey] = $this->get($singleKey);
+        }
+
+        return $returnValues;
+    }
+
+    /**
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
@@ -75,6 +93,20 @@ class TaggedCache implements Store
 
         if (! is_null($minutes)) {
             $this->store->put($this->taggedItemKey($key), $value, $minutes);
+        }
+    }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes.
+     *
+     * @param array $values array of key => value pairs
+     * @param int   $minutes
+     * @return void
+     */
+    public function putMulti(array $values, $minutes)
+    {
+        foreach ($values as $key => $singleValue) {
+            $this->put($key, $singleValue, $minutes);
         }
     }
 

--- a/src/Illuminate/Cache/WinCacheStore.php
+++ b/src/Illuminate/Cache/WinCacheStore.php
@@ -40,6 +40,24 @@ class WinCacheStore extends TaggableStore implements Store
     }
 
     /**
+     * Retrieve multiple items from the cache by key,
+     * items not found in the cache will have a null value for the key
+     *
+     * @param string[] $keys
+     * @return array
+     */
+    public function getMulti(array $keys)
+    {
+        $returnValues = [];
+
+        foreach($keys as $singleKey) {
+            $returnValues[$singleKey] = $this->get($singleKey);
+        }
+
+        return $returnValues;
+    }
+
+    /**
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
@@ -50,6 +68,20 @@ class WinCacheStore extends TaggableStore implements Store
     public function put($key, $value, $minutes)
     {
         wincache_ucache_set($this->prefix.$key, $value, $minutes * 60);
+    }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes
+     *
+     * @param array $values array of key => value pairs
+     * @param int   $minutes
+     * @return void
+     */
+    public function putMulti(array $values, $minutes)
+    {
+        foreach($values as $key => $singleValue) {
+            $this->put($key,$singleValue,$minutes);
+        }
     }
 
     /**

--- a/src/Illuminate/Cache/WinCacheStore.php
+++ b/src/Illuminate/Cache/WinCacheStore.php
@@ -41,7 +41,7 @@ class WinCacheStore extends TaggableStore implements Store
 
     /**
      * Retrieve multiple items from the cache by key,
-     * items not found in the cache will have a null value for the key
+     * items not found in the cache will have a null value for the key.
      *
      * @param string[] $keys
      * @return array
@@ -50,7 +50,7 @@ class WinCacheStore extends TaggableStore implements Store
     {
         $returnValues = [];
 
-        foreach($keys as $singleKey) {
+        foreach ($keys as $singleKey) {
             $returnValues[$singleKey] = $this->get($singleKey);
         }
 
@@ -71,7 +71,7 @@ class WinCacheStore extends TaggableStore implements Store
     }
 
     /**
-     * Store multiple items in the cache for a set number of minutes
+     * Store multiple items in the cache for a set number of minutes.
      *
      * @param array $values array of key => value pairs
      * @param int   $minutes
@@ -79,8 +79,8 @@ class WinCacheStore extends TaggableStore implements Store
      */
     public function putMulti(array $values, $minutes)
     {
-        foreach($values as $key => $singleValue) {
-            $this->put($key,$singleValue,$minutes);
+        foreach ($values as $key => $singleValue) {
+            $this->put($key, $singleValue, $minutes);
         }
     }
 

--- a/src/Illuminate/Cache/XCacheStore.php
+++ b/src/Illuminate/Cache/XCacheStore.php
@@ -41,7 +41,7 @@ class XCacheStore extends TaggableStore implements Store
 
     /**
      * Retrieve multiple items from the cache by key,
-     * items not found in the cache will have a null value for the key
+     * items not found in the cache will have a null value for the key.
      *
      * @param string[] $keys
      * @return array
@@ -50,7 +50,7 @@ class XCacheStore extends TaggableStore implements Store
     {
         $returnValues = [];
 
-        foreach($keys as $singleKey) {
+        foreach ($keys as $singleKey) {
             $returnValues[$singleKey] = $this->get($singleKey);
         }
 
@@ -71,7 +71,7 @@ class XCacheStore extends TaggableStore implements Store
     }
 
     /**
-     * Store multiple items in the cache for a set number of minutes
+     * Store multiple items in the cache for a set number of minutes.
      *
      * @param array $values array of key => value pairs
      * @param int   $minutes
@@ -79,8 +79,8 @@ class XCacheStore extends TaggableStore implements Store
      */
     public function putMulti(array $values, $minutes)
     {
-        foreach($values as $key => $singleValue) {
-            $this->put($key,$singleValue,$minutes);
+        foreach ($values as $key => $singleValue) {
+            $this->put($key, $singleValue, $minutes);
         }
     }
 

--- a/src/Illuminate/Cache/XCacheStore.php
+++ b/src/Illuminate/Cache/XCacheStore.php
@@ -40,6 +40,24 @@ class XCacheStore extends TaggableStore implements Store
     }
 
     /**
+     * Retrieve multiple items from the cache by key,
+     * items not found in the cache will have a null value for the key
+     *
+     * @param string[] $keys
+     * @return array
+     */
+    public function getMulti(array $keys)
+    {
+        $returnValues = [];
+
+        foreach($keys as $singleKey) {
+            $returnValues[$singleKey] = $this->get($singleKey);
+        }
+
+        return $returnValues;
+    }
+
+    /**
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
@@ -50,6 +68,20 @@ class XCacheStore extends TaggableStore implements Store
     public function put($key, $value, $minutes)
     {
         xcache_set($this->prefix.$key, $value, $minutes * 60);
+    }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes
+     *
+     * @param array $values array of key => value pairs
+     * @param int   $minutes
+     * @return void
+     */
+    public function putMulti(array $values, $minutes)
+    {
+        foreach($values as $key => $singleValue) {
+            $this->put($key,$singleValue,$minutes);
+        }
     }
 
     /**

--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -14,7 +14,7 @@ interface Store
 
     /**
      * Retrieve multiple items from the cache by key,
-     * items not found in the cache will have a null value for the key
+     * items not found in the cache will have a null value for the key.
      *
      * @param string[] $keys
      * @return array
@@ -32,7 +32,7 @@ interface Store
     public function put($key, $value, $minutes);
 
     /**
-     * Store multiple items in the cache for a set number of minutes
+     * Store multiple items in the cache for a set number of minutes.
      *
      * @param array $values array of key => value pairs
      * @param int   $minutes

--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -13,6 +13,15 @@ interface Store
     public function get($key);
 
     /**
+     * Retrieve multiple items from the cache by key,
+     * items not found in the cache will have a null value for the key
+     *
+     * @param string[] $keys
+     * @return array
+     */
+    public function getMulti(array $keys);
+
+    /**
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
@@ -21,6 +30,15 @@ interface Store
      * @return void
      */
     public function put($key, $value, $minutes);
+
+    /**
+     * Store multiple items in the cache for a set number of minutes
+     *
+     * @param array $values array of key => value pairs
+     * @param int   $minutes
+     * @return void
+     */
+    public function putMulti(array $values, $minutes);
 
     /**
      * Increment the value of an item in the cache.

--- a/src/Illuminate/Foundation/Testing/AssertionsTrait.php
+++ b/src/Illuminate/Foundation/Testing/AssertionsTrait.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\View\View;
+use PHPUnit_Framework_Assert as PHPUnit;
+
+trait AssertionsTrait
+{
+    /**
+     * Assert that the client response has an OK status code.
+     *
+     * @return void
+     */
+    public function assertResponseOk()
+    {
+        $actual = $this->response->getStatusCode();
+
+        return PHPUnit::assertTrue($this->response->isOk(), "Expected status code 200, got {$actual}.");
+    }
+
+    /**
+     * Assert that the client response has a given code.
+     *
+     * @param  int  $code
+     * @return void
+     */
+    public function assertResponseStatus($code)
+    {
+        $actual = $this->response->getStatusCode();
+
+        return PHPUnit::assertEquals($code, $this->response->getStatusCode(), "Expected status code {$code}, got {$actual}.");
+    }
+
+    /**
+     * Assert that the response view has a given piece of bound data.
+     *
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function assertViewHas($key, $value = null)
+    {
+        if (is_array($key)) {
+            return $this->assertViewHasAll($key);
+        }
+
+        if (! isset($this->response->original) || ! $this->response->original instanceof View) {
+            return PHPUnit::assertTrue(false, 'The response was not a view.');
+        }
+
+        if (is_null($value)) {
+            PHPUnit::assertArrayHasKey($key, $this->response->original->getData());
+        } else {
+            PHPUnit::assertEquals($value, $this->response->original->$key);
+        }
+    }
+
+    /**
+     * Assert that the view has a given list of bound data.
+     *
+     * @param  array  $bindings
+     * @return void
+     */
+    public function assertViewHasAll(array $bindings)
+    {
+        foreach ($bindings as $key => $value) {
+            if (is_int($key)) {
+                $this->assertViewHas($value);
+            } else {
+                $this->assertViewHas($key, $value);
+            }
+        }
+    }
+
+    /**
+     * Assert that the response view is missing a piece of bound data.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function assertViewMissing($key)
+    {
+        if (! isset($this->response->original) || ! $this->response->original instanceof View) {
+            return PHPUnit::assertTrue(false, 'The response was not a view.');
+        }
+
+        PHPUnit::assertArrayNotHasKey($key, $this->response->original->getData());
+    }
+
+    /**
+     * Assert whether the client was redirected to a given URI.
+     *
+     * @param  string  $uri
+     * @param  array   $with
+     * @return void
+     */
+    public function assertRedirectedTo($uri, $with = [])
+    {
+        PHPUnit::assertInstanceOf('Illuminate\Http\RedirectResponse', $this->response);
+
+        PHPUnit::assertEquals($this->app['url']->to($uri), $this->response->headers->get('Location'));
+
+        $this->assertSessionHasAll($with);
+    }
+
+    /**
+     * Assert whether the client was redirected to a given route.
+     *
+     * @param  string  $name
+     * @param  array   $parameters
+     * @param  array   $with
+     * @return void
+     */
+    public function assertRedirectedToRoute($name, $parameters = [], $with = [])
+    {
+        $this->assertRedirectedTo($this->app['url']->route($name, $parameters), $with);
+    }
+
+    /**
+     * Assert whether the client was redirected to a given action.
+     *
+     * @param  string  $name
+     * @param  array   $parameters
+     * @param  array   $with
+     * @return void
+     */
+    public function assertRedirectedToAction($name, $parameters = [], $with = [])
+    {
+        $this->assertRedirectedTo($this->app['url']->action($name, $parameters), $with);
+    }
+
+    /**
+     * Assert that the session has a given value.
+     *
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function assertSessionHas($key, $value = null)
+    {
+        if (is_array($key)) {
+            return $this->assertSessionHasAll($key);
+        }
+
+        if (is_null($value)) {
+            PHPUnit::assertTrue($this->app['session.store']->has($key), "Session missing key: $key");
+        } else {
+            PHPUnit::assertEquals($value, $this->app['session.store']->get($key));
+        }
+    }
+
+    /**
+     * Assert that the session has a given list of values.
+     *
+     * @param  array  $bindings
+     * @return void
+     */
+    public function assertSessionHasAll(array $bindings)
+    {
+        foreach ($bindings as $key => $value) {
+            if (is_int($key)) {
+                $this->assertSessionHas($value);
+            } else {
+                $this->assertSessionHas($key, $value);
+            }
+        }
+    }
+
+    /**
+     * Assert that the session has errors bound.
+     *
+     * @param  string|array  $bindings
+     * @param  mixed  $format
+     * @return void
+     */
+    public function assertSessionHasErrors($bindings = [], $format = null)
+    {
+        $this->assertSessionHas('errors');
+
+        $bindings = (array) $bindings;
+
+        $errors = $this->app['session.store']->get('errors');
+
+        foreach ($bindings as $key => $value) {
+            if (is_int($key)) {
+                PHPUnit::assertTrue($errors->has($value), "Session missing error: $value");
+            } else {
+                PHPUnit::assertContains($value, $errors->get($key, $format));
+            }
+        }
+    }
+
+    /**
+     * Assert that the session has old input.
+     *
+     * @return void
+     */
+    public function assertHasOldInput()
+    {
+        $this->assertSessionHas('_old_input');
+    }
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -106,7 +106,7 @@ class Router implements RegistrarContract
         $this->routes = new RouteCollection;
         $this->container = $container ?: new Container;
 
-        $this->bind('_missing', function ($v) { 
+        $this->bind('_missing', function ($v) {
             return explode('/', $v);
         });
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -105,6 +105,8 @@ class Router implements RegistrarContract
         $this->events = $events;
         $this->routes = new RouteCollection;
         $this->container = $container ?: new Container;
+        
+        $this->bind('_missing', function($v) { return explode('/', $v); });
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -105,8 +105,10 @@ class Router implements RegistrarContract
         $this->events = $events;
         $this->routes = new RouteCollection;
         $this->container = $container ?: new Container;
-        
-        $this->bind('_missing', function($v) { return explode('/', $v); });
+
+        $this->bind('_missing', function ($v) { 
+            return explode('/', $v);
+        });
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1065,6 +1065,18 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([], $model->toArray());
     }
 
+    public function testGetMutatedAttributes()
+    {
+        $model = new EloquentModelGetMutatorsStub;
+
+        $this->assertEquals(['first_name', 'middle_name', 'last_name'], $model->getMutatedAttributes());
+
+        EloquentModelGetMutatorsStub::resetMutatorCache();
+
+        EloquentModelGetMutatorsStub::$snakeAttributes = false;
+        $this->assertEquals(['firstName', 'middleName', 'lastName'], $model->getMutatedAttributes());
+    }
+
     public function testReplicateCreatesANewModelInstanceWithSameAttributeValues()
     {
         $model = new EloquentModelStub;
@@ -1458,6 +1470,26 @@ class EloquentModelAppendsStub extends Model
     public function getStudlyCasedAttribute()
     {
         return 'StudlyCased';
+    }
+}
+
+class EloquentModelGetMutatorsStub extends Model
+{
+    public static function resetMutatorCache()
+    {
+        static::$mutatorCache = [];
+    }
+
+    public function getFirstNameAttribute()
+    {
+    }
+
+    public function getMiddleNameAttribute()
+    {
+    }
+
+    public function getLastNameAttribute()
+    {
     }
 }
 


### PR DESCRIPTION
Primarily to allow using multi with redis and memcached to prevent unnecessary roundtrips when getting multiple entries.
