### PR TITLE
[5.1] Introduce Cache Helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -151,11 +151,11 @@ if (! function_exists('cache')) {
     {
         $manager = app('cache');
 
-        if (func_num_args() == 0)
+        if (func_num_args() == 0) {
             return $manager;
+        }
 
-        if (func_num_args() == 1)
-        {
+        if (func_num_args() == 1) {
             throw new \Exception('Call signature does not match function definition.');
         }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -145,6 +145,8 @@ if (! function_exists('cache')) {
      * @param  \DateTime|int|null  $minutes
      * @param  \Closure|null  $callback
      * @return mixed
+     *
+     * @throws \InvalidArgumentException
      */
     function cache($key = null, $minutes = null, Closure $callback = null)
     {
@@ -155,7 +157,7 @@ if (! function_exists('cache')) {
         }
 
         if (func_num_args() == 1) {
-            throw new \Exception('Call signature does not match function definition.');
+            throw new InvalidArgumentException('Call signature does not match function definition.');
         }
 
         $args = func_get_args();

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -137,14 +137,13 @@ if (! function_exists('bcrypt')) {
 
 if (! function_exists('cache')) {
     /**
-     * Get the cache manager.
+     * Get an item from the cache, or store the default value.
      *
-     * If any parameters are given, we will assume you want to specify
-     * something to be cached.
+     * If no parameters are given, we will assume you want the cache manager.
      *
-     * @param  string  $key
-     * @param  \DateTime|int  $minutes
-     * @param  \Closure  $callback
+     * @param  string|null  $key
+     * @param  \DateTime|int|null  $minutes
+     * @param  \Closure|null  $callback
      * @return mixed
      */
     function cache($key = null, $minutes = null, Closure $callback = null)

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -135,6 +135,36 @@ if (! function_exists('bcrypt')) {
     }
 }
 
+if (! function_exists('cache')) {
+    /**
+     * Get the cache manager.
+     *
+     * If any parameters are given, we will assume you want to specify
+     * something to be cached.
+     *
+     * @param  string  $key
+     * @param  \DateTime|int  $minutes
+     * @param  \Closure  $callback
+     * @return mixed
+     */
+    function cache($key = null, $minutes = null, Closure $callback = null)
+    {
+        $manager = app('cache');
+
+        if (func_num_args() == 0)
+            return $manager;
+
+        if (func_num_args() == 1)
+        {
+            throw new \Exception('Call signature does not match function definition.');
+        }
+
+        $args = func_get_args();
+
+        return $manager->remember($args[0], $args[1], $args[2]);
+    }
+}
+
 if (! function_exists('config')) {
     /**
      * Get / set the specified configuration value.


### PR DESCRIPTION
This PR introduces the cache helper.

```
cache(); // returns \Illuminate\Cache\CacheManager

cache('key', 5, function ()
{
    return 'foo';
}); // returns 'foo' and caches as `\Cache::remember` would do
```
