### PR TITLE
fix wrap table of grammar

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -38,6 +38,7 @@ abstract class Grammar
         if ($this->tablePrefix && strpos(strtolower($table), ' as ') === false) {
             $table = $table.' as '.$table;
         }
+
         return $this->wrap($this->tablePrefix.$table, true);
     }
 

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -36,7 +36,7 @@ abstract class Grammar
             return $this->getValue($table);
         }
         if ($this->tablePrefix && strpos(strtolower($table), ' as ') === false) {
-            $table = $table . ' as ' . $table;
+            $table = $table.' as '.$table;
         }
         return $this->wrap($this->tablePrefix.$table, true);
     }
@@ -75,7 +75,7 @@ abstract class Grammar
         // normal, so if there is more than one segment, we will wrap the first
         // segments as if it was a table and the rest as just regular values.
         foreach ($segments as $key => $segment) {
-                $wrapped[] = $this->wrapTable($segment);
+            $wrapped[] = $this->wrapTable($segment);
         }
 
         return implode('.', $wrapped);

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -76,7 +76,7 @@ abstract class Grammar
         // normal, so if there is more than one segment, we will wrap the first
         // segments as if it was a table and the rest as just regular values.
         foreach ($segments as $key => $segment) {
-            $wrapped[] = $this->wrapTable($segment);
+            $wrapped[] = $this->wrapValue($segment);
         }
 
         return implode('.', $wrapped);

--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -35,7 +35,9 @@ abstract class Grammar
         if ($this->isExpression($table)) {
             return $this->getValue($table);
         }
-
+        if ($this->tablePrefix && strpos(strtolower($table), ' as ') === false) {
+            $table = $table . ' as ' . $table;
+        }
         return $this->wrap($this->tablePrefix.$table, true);
     }
 
@@ -73,11 +75,7 @@ abstract class Grammar
         // normal, so if there is more than one segment, we will wrap the first
         // segments as if it was a table and the rest as just regular values.
         foreach ($segments as $key => $segment) {
-            if ($key == 0 && count($segments) > 1) {
                 $wrapped[] = $this->wrapTable($segment);
-            } else {
-                $wrapped[] = $this->wrapValue($segment);
-            }
         }
 
         return implode('.', $wrapped);


### PR DESCRIPTION
fix when we have a db prefix "pre_"  and  call select  with some DB:raw like  $query->select([DB::raw('sum(table.field)'])
It will not add table prefix in expression and this patch fix it:
it will add a default table alias as "table" without prefix when not define table alias and remove wrap field with dot .
