### PR TITLE
[5.2] Add getMultiple and putMultiple to cache implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "iron-io/iron_mq": "~2.0",
         "mockery/mockery": "~0.9.2",
         "pda/pheanstalk": "~3.0",
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.1",
         "predis/predis": "~1.0",
         "symfony/css-selector": "2.8.*|3.0.*",
         "symfony/dom-crawler": "2.8.*|3.0.*"

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Cache\Store;
 
 class ApcStore extends TaggableStore implements Store
 {
+    use DefaultMultipleTrait;
+
     /**
      * The APC wrapper instance.
      *

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Cache\Store;
 
 class ArrayStore extends TaggableStore implements Store
 {
+    use DefaultMultipleTrait;
+
     /**
      * The array of stored values.
      *
@@ -37,6 +39,18 @@ class ArrayStore extends TaggableStore implements Store
     public function put($key, $value, $minutes)
     {
         $this->storage[$key] = $value;
+    }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes.
+     *
+     * @param  array  $values
+     * @param  int  $minutes
+     * @return void
+     */
+    public function putMultiple(array $values, $minutes)
+    {
+        $this->storage += $values;
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -10,6 +10,8 @@ use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 
 class DatabaseStore implements Store
 {
+    use DefaultMultipleTrait;
+
     /**
      * The database connection instance.
      *

--- a/src/Illuminate/Cache/DefaultMultipleTrait.php
+++ b/src/Illuminate/Cache/DefaultMultipleTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Cache;
+
+trait DefaultMultipleTrait
+{
+    /**
+     * Retrieve multiple items from the cache by key.
+     *
+     * Items not found in the cache will have a null value for the key.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function getMultiple(array $keys)
+    {
+        $returnValues = [];
+
+        foreach ($keys as $singleKey) {
+            $returnValues[$singleKey] = $this->get($singleKey);
+        }
+
+        return $returnValues;
+    }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes.
+     *
+     * @param  array  $values
+     * @param  int  $minutes
+     * @return void
+     */
+    public function putMultiple(array $values, $minutes)
+    {
+        foreach ($values as $key => $singleValue) {
+            $this->put($key, $singleValue, $minutes);
+        }
+    }
+}

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -9,6 +9,8 @@ use Illuminate\Contracts\Cache\Store;
 
 class FileStore implements Store
 {
+    use DefaultMultipleTrait;
+
     /**
      * The Illuminate Filesystem instance.
      *

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Cache;
 
+use Memcached;
 use Illuminate\Contracts\Cache\Store;
 
 class MemcachedStore extends TaggableStore implements Store
@@ -49,6 +50,34 @@ class MemcachedStore extends TaggableStore implements Store
     }
 
     /**
+     * Retrieve multiple items from the cache by key.
+     *
+     * Items not found in the cache will have a null value for the key.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function getMultiple(array $keys)
+    {
+        $prefixedKeys = [];
+
+        foreach ($keys as $keyToPrefix) {
+            $prefixedKeys[] = $this->prefix.$keyToPrefix;
+        }
+
+        $cas = null;
+        $cacheValues = $this->memcached->getMulti($prefixedKeys, $cas, Memcached::GET_PRESERVE_ORDER);
+
+        if ($this->memcached->getResultCode() != 0) {
+            return array_fill_keys($keys, null);
+        }
+
+        $returnValues = array_combine($keys, $cacheValues);
+
+        return $returnValues;
+    }
+
+    /**
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
@@ -59,6 +88,24 @@ class MemcachedStore extends TaggableStore implements Store
     public function put($key, $value, $minutes)
     {
         $this->memcached->set($this->prefix.$key, $value, $minutes * 60);
+    }
+
+    /**
+     * Store multiple items in the cache for a set number of minutes.
+     *
+     * @param  array  $values
+     * @param  int  $minutes
+     * @return void
+     */
+    public function putMultiple(array $values, $minutes)
+    {
+        $formattedKeyValues = [];
+
+        foreach ($values as $keyToPrefix => $singleValue) {
+            $formattedKeyValues[$this->prefix.$keyToPrefix] = $singleValue;
+        }
+
+        $this->memcached->setMulti($formattedKeyValues, $minutes * 60);
     }
 
     /**

--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Cache\Store;
 
 class NullStore extends TaggableStore implements Store
 {
+    use DefaultMultipleTrait;
+
     /**
      * The array of stored values.
      *

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -9,6 +9,8 @@ use Illuminate\Contracts\Cache\Store;
 
 class TaggedCache implements Store
 {
+    use DefaultMultipleTrait;
+
     /**
      * The cache store implementation.
      *

--- a/src/Illuminate/Cache/WinCacheStore.php
+++ b/src/Illuminate/Cache/WinCacheStore.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Cache\Store;
 
 class WinCacheStore extends TaggableStore implements Store
 {
+    use DefaultMultipleTrait;
+
     /**
      * A string that should be prepended to keys.
      *

--- a/src/Illuminate/Cache/XCacheStore.php
+++ b/src/Illuminate/Cache/XCacheStore.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Cache\Store;
 
 class XCacheStore extends TaggableStore implements Store
 {
+    use DefaultMultipleTrait;
+
     /**
      * A string that should be prepended to keys.
      *

--- a/src/Illuminate/Contracts/Cache/Store.php
+++ b/src/Illuminate/Contracts/Cache/Store.php
@@ -13,6 +13,16 @@ interface Store
     public function get($key);
 
     /**
+     * Retrieve multiple items from the cache by key.
+     *
+     * Items not found in the cache will have a null value for the key.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function getMultiple(array $keys);
+
+    /**
      * Store an item in the cache for a given number of minutes.
      *
      * @param  string  $key
@@ -21,6 +31,15 @@ interface Store
      * @return void
      */
     public function put($key, $value, $minutes);
+
+    /**
+     * Store multiple items in the cache for a set number of minutes.
+     *
+     * @param  array  $values
+     * @param  int  $minutes
+     * @return void
+     */
+    public function putMultiple(array $values, $minutes);
 
     /**
      * Increment the value of an item in the cache.

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -18,12 +18,46 @@ class CacheApcStoreTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $store->get('foo'));
     }
 
+    public function testGetMultipleReturnsNullWhenNotFoundAndValueWhenFound()
+    {
+        $apc = $this->getMock('Illuminate\Cache\ApcWrapper', ['get']);
+        $apc->expects($this->exactly(3))->method('get')->willReturnMap([
+            ['foo', 'qux'],
+            ['bar', null],
+            ['baz', 'norf'],
+        ]);
+        $store = new Illuminate\Cache\ApcStore($apc);
+        $this->assertEquals([
+            'foo'   => 'qux',
+            'bar'   => null,
+            'baz'   => 'norf',
+        ], $store->getMultiple(['foo', 'bar', 'baz']));
+    }
+
     public function testSetMethodProperlyCallsAPC()
     {
         $apc = $this->getMock('Illuminate\Cache\ApcWrapper', ['put']);
         $apc->expects($this->once())->method('put')->with($this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60));
         $store = new Illuminate\Cache\ApcStore($apc);
         $store->put('foo', 'bar', 1);
+    }
+
+    public function testSetMultipleMethodProperlyCallsAPC()
+    {
+        $apc = $this->getMock('Illuminate\Cache\ApcWrapper', ['put']);
+        $apc->expects($this->exactly(3))->method('put')->withConsecutive([
+            $this->equalTo('foo'), $this->equalTo('bar'), $this->equalTo(60),
+        ], [
+            $this->equalTo('baz'), $this->equalTo('qux'), $this->equalTo(60),
+        ], [
+            $this->equalTo('bar'), $this->equalTo('norf'), $this->equalTo(60),
+        ]);
+        $store = new Illuminate\Cache\ApcStore($apc);
+        $store->putMultiple([
+            'foo'   => 'bar',
+            'baz'   => 'qux',
+            'bar'   => 'norf',
+        ], 1);
     }
 
     public function testIncrementMethodProperlyCallsAPC()

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -11,6 +11,22 @@ class CacheArrayStoreTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $store->get('foo'));
     }
 
+    public function testMultipleItemsCanBeSetAndRetrieved()
+    {
+        $store = new ArrayStore;
+        $store->put('foo', 'bar', 10);
+        $store->putMultiple([
+            'fizz'  => 'buz',
+            'quz'   => 'baz',
+        ], 10);
+        $this->assertEquals([
+            'foo'   => 'bar',
+            'fizz'  => 'buz',
+            'quz'   => 'baz',
+            'norf'  => null,
+        ], $store->getMultiple(['foo', 'fizz', 'quz', 'norf']));
+    }
+
     public function testStoreItemForeverProperlyStoresInArray()
     {
         $mock = $this->getMock('Illuminate\Cache\ArrayStore', ['put']);

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -20,6 +20,29 @@ class CacheMemcachedStoreTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $store->get('foo'));
     }
 
+    public function testMemcacheGetMultiValuesAreReturnedWithCorrectKeys()
+    {
+        if (! class_exists('Memcached')) {
+            $this->markTestSkipped('Memcached module not installed');
+        }
+
+        $memcache = $this->getMock('StdClass', ['getMulti', 'getResultCode']);
+        $memcache->expects($this->once())->method('getMulti')->with(
+            ['foo:foo', 'foo:bar', 'foo:baz']
+        )->will($this->returnValue([
+            'fizz', 'buzz', 'norf',
+        ]));
+        $memcache->expects($this->once())->method('getResultCode')->will($this->returnValue(0));
+        $store = new Illuminate\Cache\MemcachedStore($memcache, 'foo');
+        $this->assertEquals([
+            'foo'   => 'fizz',
+            'bar'   => 'buzz',
+            'baz'   => 'norf',
+        ], $store->getMultiple([
+            'foo', 'bar', 'baz',
+        ]));
+    }
+
     public function testSetMethodProperlyCallsMemcache()
     {
         $memcache = $this->getMock('Memcached', ['set']);

--- a/tests/Cache/CacheNullStoreTest.php
+++ b/tests/Cache/CacheNullStoreTest.php
@@ -10,4 +10,17 @@ class CacheNullStoreTest extends PHPUnit_Framework_TestCase
         $store->put('foo', 'bar', 10);
         $this->assertNull($store->get('foo'));
     }
+
+    public function testGetMultipleReturnsMultipleNulls()
+    {
+        $store = new NullStore;
+
+        $this->assertEquals([
+            'foo'   => null,
+            'bar'   => null,
+        ], $store->getMultiple([
+            'foo',
+            'bar',
+        ]));
+    }
 }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -25,6 +25,25 @@ class CacheRedisStoreTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $redis->get('foo'));
     }
 
+    public function testRedisMultipleValuesAreReturned()
+    {
+        $redis = $this->getRedis();
+        $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
+        $redis->getRedis()->shouldReceive('mget')->once()->with(['prefix:foo', 'prefix:fizz', 'prefix:norf'])
+            ->andReturn([
+                serialize('bar'),
+                serialize('buzz'),
+                serialize('quz'),
+            ]);
+        $this->assertEquals([
+            'foo'   => 'bar',
+            'fizz'  => 'buzz',
+            'norf'  => 'quz',
+        ], $redis->getMultiple([
+            'foo', 'fizz', 'norf',
+        ]));
+    }
+
     public function testRedisValueIsReturnedForNumerics()
     {
         $redis = $this->getRedis();
@@ -39,6 +58,25 @@ class CacheRedisStoreTest extends PHPUnit_Framework_TestCase
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
         $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60 * 60, serialize('foo'));
         $redis->put('foo', 'foo', 60);
+    }
+
+    public function testSetMultipleMethodProperlyCallsRedis()
+    {
+        $redis = $this->getRedis();
+        /** @var m\MockInterface $connection */
+        $connection = $redis->getRedis();
+        $connection->shouldReceive('connection')->with('default')->andReturn($redis->getRedis());
+        $connection->shouldReceive('multi')->once();
+        $redis->getRedis()->shouldReceive('setex')->with('prefix:foo', 60 * 60, serialize('bar'));
+        $redis->getRedis()->shouldReceive('setex')->with('prefix:baz', 60 * 60, serialize('qux'));
+        $redis->getRedis()->shouldReceive('setex')->with('prefix:bar', 60 * 60, serialize('norf'));
+        $connection->shouldReceive('exec')->once();
+
+        $redis->putMultiple([
+            'foo'   => 'bar',
+            'baz'   => 'qux',
+            'bar' => 'norf',
+        ], 60);
     }
 
     public function testSetMethodProperlyCallsRedisForNumerics()


### PR DESCRIPTION
Primarily to save round-trips to redis and memcached when working with multiple objects
