### PR TITLE
[5.1] Fix when using Lang::hasForLocale('foo'); without setting the second parameter.

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -55,7 +55,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * Determine if a translation exists for a given locale.
      *
      * @param  string  $key
-     * @param  string  $locale
+     * @param  string|null  $locale
      * @return bool
      */
     public function hasForLocale($key, $locale = null)
@@ -67,7 +67,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * Determine if a translation exists.
      *
      * @param  string  $key
-     * @param  string  $locale
+     * @param  string|null  $locale
      * @param  bool  $fallback
      * @return bool
      */
@@ -81,7 +81,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      *
      * @param  string  $key
      * @param  array   $replace
-     * @param  string  $locale
+     * @param  string|null  $locale
      * @param  bool  $fallback
      * @return string
      */
@@ -92,7 +92,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
         // Here we will get the locale that should be used for the language line. If one
         // was not passed, we will use the default locales which was given to us when
         // the translator was instantiated. Then, we can load the lines and return.
-        $locales = $fallback ? $this->parseLocale($locale) : [$locale];
+        $locales = $fallback ? $this->parseLocale($locale) : [$locale ?: $this->locale];
 
         foreach ($locales as $locale) {
             $this->load($namespace, $group, $locale);

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -26,6 +26,16 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase
         $t = $this->getMock('Illuminate\Translation\Translator', ['get'], [$this->getLoader(), 'en']);
         $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->will($this->returnValue('foo'));
         $this->assertFalse($t->hasForLocale('foo', 'bar'));
+
+        $t = $this->getMock('Illuminate\Translation\Translator', ['load', 'getLine'], [$this->getLoader(), 'en']);
+        $t->expects($this->once())->method('load')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'))->will($this->returnValue(null));
+        $t->expects($this->once())->method('getLine')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'), null, $this->equalTo([]))->will($this->returnValue('bar'));
+        $this->assertTrue($t->hasForLocale('foo'));
+
+        $t = $this->getMock('Illuminate\Translation\Translator', ['load', 'getLine'], [$this->getLoader(), 'en']);
+        $t->expects($this->once())->method('load')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'))->will($this->returnValue(null));
+        $t->expects($this->once())->method('getLine')->with($this->equalTo('*'), $this->equalTo('foo'), $this->equalTo('en'), null, $this->equalTo([]))->will($this->returnValue('foo'));
+        $this->assertFalse($t->hasForLocale('foo'));
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItem()


### PR DESCRIPTION
Added additional tests to ensure that locale set to current app locale when the variable is set to NULL.

Signed-off-by: crynobone crynobone@gmail.com
