### PR TITLE
[5.1] Let use dd() without installing VarDumper

### DIFF
--- a/src/Illuminate/Support/Debug/Dumper.php
+++ b/src/Illuminate/Support/Debug/Dumper.php
@@ -15,8 +15,12 @@ class Dumper
      */
     public function dump($value)
     {
-        $dumper = 'cli' === PHP_SAPI ? new CliDumper : new HtmlDumper;
+        if (class_exists(CliDumper::class)) {
+            $dumper = 'cli' === PHP_SAPI ? new CliDumper : new HtmlDumper;
 
-        $dumper->dump((new VarCloner)->cloneVar($value));
+            $dumper->dump((new VarCloner)->cloneVar($value));
+        } else {
+            var_dump($value);
+        }
     }
 }

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -36,7 +36,7 @@
     "suggest": {
         "jeremeamia/superclosure": "Required to be able to serialize closures (~2.0).",
         "paragonie/random_compat": "Provides a compatible interface like PHP7's random_bytes() in PHP 5 projects (~1.1).",
-        "symfony/var-dumper": "Required to use the dd function (2.7.*)."
+        "symfony/var-dumper": "Improves the dd function (2.7.*)."
     },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
VarDumper shouldn't be mandatory to use `dd()`.
