### PR TITLE
[5.1] Additional tests for Model::getMutatedAttributes (and cacheMutatedAttributes), and a fix to make them pass.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3360,7 +3360,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // Here we will extract all of the mutated attributes so that we can quickly
         // spin through them after we export models to their array form, which we
         // need to be fast. This'll let us know the attributes that can mutate.
-        if (preg_match_all('/get([^;]+?)Attribute(;|$)/', implode(';', get_class_methods($class)), $matches)) {
+        if (preg_match_all('/(?<=^|;)get([^;]+?)Attribute(;|$)/', implode(';', get_class_methods($class)), $matches)) {
             foreach ($matches[1] as $match) {
                 if (static::$snakeAttributes) {
                     $match = Str::snake($match);

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -20,7 +20,7 @@ class SqsConnector implements ConnectorInterface
             'version' => 'latest',
             'http' => [
                 'timeout' => 60,
-                'connect_timeout' => 60
+                'connect_timeout' => 60,
             ],
         ], $config);
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1484,6 +1484,22 @@ class EloquentModelGetMutatorsStub extends Model
     public function getLastNameAttribute()
     {
     }
+
+    public function doNotgetFirstInvalidAttribute()
+    {
+    }
+
+    public function doNotGetSecondInvalidAttribute()
+    {
+    }
+
+    public function doNotgetThirdInvalidAttributeEither()
+    {
+    }
+
+    public function doNotGetFourthInvalidAttributeEither()
+    {
+    }
 }
 
 class EloquentModelCastingStub extends Model


### PR DESCRIPTION
- Added 4 variations of function names to the test that should not automatically be picked up as attributes, since they do not conform to the `getFooAttribute` pattern.
- Changed the regex in cacheMutatedAttributes to make these additional tests pass (i.e. to make Laravel not pick up these functions as attributes).
