### PR TITLE
[5.2] Restored guzzle 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
         "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (~3.0).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.4).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
-        "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers (~6.0).",
+        "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers (~5.3|~6.0).",
         "iron-io/iron_mq": "Required to use the iron queue driver (~2.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",
         "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0).",

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "suggest": {
-        "guzzlehttp/guzzle": "Required to use the thenPing method on schedules (~6.0).",
+        "guzzlehttp/guzzle": "Required to use the thenPing method on schedules (~5.3|~6.0).",
         "mtdowling/cron-expression": "Required to use scheduling component (~1.0).",
         "symfony/process": "Required to use scheduling component (2.8.*|3.0.*)."
     },

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -48,7 +48,13 @@ class MandrillTransport extends Transport
             'async' => false,
         ];
 
-        return $this->client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', ['form_params' => $data]);
+        if (version_compare(ClientInterface::VERSION, '6') === 1) {
+            $options = ['form_params' => $data];
+        } else {
+            $options = ['body' => $data];
+        }
+
+        return $this->client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', $options);
     }
 
     /**

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -33,7 +33,7 @@
     },
     "suggest": {
         "aws/aws-sdk-php": "Required to use the SES mail driver (~3.0).",
-        "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers (~6.0)."
+        "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers (~5.3|~6.0)."
     },
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
IMO, the adoption of Guzzle 6 hasn't be large enough for us to drop Guzzle 5 support just yet. I proposal we instead remove it in 5.3. In this PR I've basically just copied over the two mail transport classes from 5.1 and replaced the ones currently in 5.2.
