### PR TITLE
[5.1] Prevent middleware from running on empty 'only'

### DIFF
--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -143,7 +143,7 @@ class ControllerDispatcher
      */
     public function methodExcludedByOptions($method, array $options)
     {
-        return (! empty($options['only']) && ! in_array($method, (array) $options['only'])) ||
+        return (isset($options['only']) && ! in_array($method, (array) $options['only'])) ||
             (! empty($options['except']) && in_array($method, (array) $options['except']));
     }
 


### PR DESCRIPTION
When we set middleware with 'only' parameter we should expect the application to **only** load that middleware for the routes which are declared in the array we are passing it. Thus if we pass it an empty or (non instantiated) array it should not load that middleware.    

However as is **this is not the case**. Take Laravel documentation example:  

``` php
<?php

class BaseController extends Controller
{
  /**
  * If controller extending this BaseController needs to load this middleware it will declare this
  * array with names of routes/methods which require it.
  * @array Routes which should load some middleware.
  */
  public $middlewareRoutes;

  public function __construct()
  {
    // We will load this middleware ONLY for routes declared in $middlewareRoutes
    $this->middleware('some_middleware', ['only' => $this->middlewareRoutes]);

    // ^ This however does not behave as you would expect, yes ? Because if we pass it like this or  
    // even if we declare $middlewareRoutes = [] the middleware will stil run when it should not.  

    // If the controller does not declare $middlewareRoutes or if it's an empty array the middleware  
    // should not be loaded.
  }

}

class IndexController extends BaseController
{
  // We do not want middleware to run for this method but it will regardless
  public function index()
  {
    return view('...');
  }
}

```

Now you could wrap the `$this->middleware` with an if but wouldn't that kinda defeat the purpose of `'only'` ? With my change this works as expected.
