### PR TITLE
[5.1] Added default User model stub

### DIFF
--- a/src/Illuminate/Foundation/Auth/User.php
+++ b/src/Illuminate/Foundation/Auth/User.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Foundation\Auth;
+
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Auth\Passwords\CanResetPassword;
+use Illuminate\Foundation\Auth\Access\Authorizable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
+use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
+use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+
+class User extends Model implements
+    AuthenticatableContract,
+    AuthorizableContract,
+    CanResetPasswordContract
+{
+    use Authenticatable, Authorizable, CanResetPassword;
+}


### PR DESCRIPTION
This PR adds a general user model stub for Laravel 5.1. This is due to issues encountered while using Spark with Laravel 5.1 as mentioned in [#133](https://github.com/laravel/spark/issues/133) & [#135](https://github.com/laravel/spark/issues/135) for [Spark](https://github.com/laravel/spark).  
