### PR TITLE
[5.1] Only store intended redirect URL if the originating request is GET or HEAD

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -70,7 +70,8 @@ class Redirector
     }
 
     /**
-     * Create a new redirect response, while putting the current URL in the session.
+     * Create a new redirect response and stores the current URL in the session if the
+     * current request is "safe" or the previous URL otherwise
      *
      * @param  string  $path
      * @param  int     $status
@@ -80,7 +81,12 @@ class Redirector
      */
     public function guest($path, $status = 302, $headers = [], $secure = null)
     {
-        $this->session->put('url.intended', $this->generator->full());
+        if ($this->generator->getRequest()->isMethodSafe()) {
+            $intendedUrl = $this->generator->full();
+        } else {
+            $intendedUrl = $this->session->previousUrl();
+        }
+        $this->session->put('url.intended', $intendedUrl);
 
         return $this->to($path, $status, $headers, $secure);
     }

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -71,7 +71,7 @@ class Redirector
 
     /**
      * Create a new redirect response and stores the current URL in the session if the
-     * current request is "safe" or the previous URL otherwise
+     * current request is "safe" or the previous URL otherwise.
      *
      * @param  string  $path
      * @param  int     $status


### PR DESCRIPTION
This will resolve #11072, wherein a POST request to an authenticated page is the target URL of the post-authentication redirect. Now, it should redirect to the URL that first created the POST request (a resource's edit page, for example).
