### PR TITLE
[5.1] Add flashNow function to Session

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -95,6 +95,8 @@ class Store implements SessionInterface
             $this->regenerateToken();
         }
 
+        $this->removeFlashNowData();
+
         return $this->started = true;
     }
 
@@ -304,6 +306,20 @@ class Store implements SessionInterface
     }
 
     /**
+     * Remove data that was flashed on last request
+     * 
+     * @return void
+     */
+    public function removeFlashNowData()
+    {
+        foreach ($this->get('flash.now', []) as $old) {
+            $this->forget($old);
+        }
+
+        $this->remove('flash.now');
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function has($name)
@@ -417,6 +433,21 @@ class Store implements SessionInterface
         $this->push('flash.new', $key);
 
         $this->removeFromOldFlashData([$key]);
+    }
+
+    /**
+     * Flash a key / value pair to the session
+     * for immediate use
+     * 
+     * @param  string $key
+     * @param  mixed $value
+     * @return void
+     */
+    public function flashNow($key, $value)
+    {
+        $this->put($key, $value);
+
+        $this->push('flash.now', $key);
     }
 
     /**

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -95,8 +95,6 @@ class Store implements SessionInterface
             $this->regenerateToken();
         }
 
-        $this->removeFlashNowData();
-
         return $this->started = true;
     }
 
@@ -261,6 +259,8 @@ class Store implements SessionInterface
 
         $this->ageFlashData();
 
+        $this->removeFlashNowData();
+
         $this->handler->write($this->getId(), $this->prepareForStorage(serialize($this->attributes)));
 
         $this->started = false;
@@ -306,7 +306,7 @@ class Store implements SessionInterface
     }
 
     /**
-     * Remove data that was flashed on last request
+     * Remove data that was flashed for only the current request.
      *
      * @return void
      */
@@ -316,7 +316,7 @@ class Store implements SessionInterface
             $this->forget($old);
         }
 
-        $this->remove('flash.now');
+        $this->put('flash.now', []);
     }
 
     /**
@@ -437,7 +437,7 @@ class Store implements SessionInterface
 
     /**
      * Flash a key / value pair to the session
-     * for immediate use
+     * for immediate use.
      *
      * @param  string $key
      * @param  mixed $value

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -307,7 +307,7 @@ class Store implements SessionInterface
 
     /**
      * Remove data that was flashed on last request
-     * 
+     *
      * @return void
      */
     public function removeFlashNowData()
@@ -438,7 +438,7 @@ class Store implements SessionInterface
     /**
      * Flash a key / value pair to the session
      * for immediate use
-     * 
+     *
      * @param  string $key
      * @param  mixed $value
      * @return void

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -17,6 +17,7 @@ class EncryptedSessionStoreTest extends PHPUnit_Framework_TestCase
         $session->start();
         $session->put('foo', 'bar');
         $session->flash('baz', 'boom');
+        $session->flashNow('qux', 'norf');
         $serialized = serialize([
             '_token' => $session->token(),
             'foo' => 'bar',
@@ -24,6 +25,7 @@ class EncryptedSessionStoreTest extends PHPUnit_Framework_TestCase
             'flash' => [
                 'new' => [],
                 'old' => ['baz'],
+                'now' => [],
             ],
             '_sf2_meta' => $session->getBagData('_sf2_meta'),
         ]);

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -160,6 +160,22 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase
         $this->assertNull($session->get('foo'));
     }
 
+    public function testDataFlashingNow()
+    {
+        $session = $this->getSession();
+        $session->flashNow('foo', 'bar');
+        $session->flashNow('bar', 0);
+
+        $this->assertTrue($session->has('foo'));
+        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertEquals(0, $session->get('bar'));
+
+        $session->removeFlashNowData();
+
+        $this->assertFalse($session->has('foo'));
+        $this->assertNull($session->get('foo'));
+    }
+
     public function testDataMergeNewFlashes()
     {
         $session = $this->getSession();

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -101,6 +101,7 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase
         $session->start();
         $session->put('foo', 'bar');
         $session->flash('baz', 'boom');
+        $session->flashNow('qux', 'norf');
         $session->getHandler()->shouldReceive('write')->once()->with(
             $this->getSessionId(),
             serialize([
@@ -110,6 +111,7 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase
                 'flash' => [
                     'new' => [],
                     'old' => ['baz'],
+                    'now' => [],
                 ],
                 '_sf2_meta' => $session->getBagData('_sf2_meta'),
             ])


### PR DESCRIPTION
Useful for writing flash data without redirecting.

For example, in a controller you could write:

``` php
...

$request->session()->flashNow('foo', 'bar');
return view('foo');
```

And this way it won't persist in the next request. Rails does something similar with [flash.now](http://api.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html#method-i-now).
