### PR TITLE
[5.1] Allow Route::group 'middleware' attribute to be passed as string

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -274,7 +274,7 @@ class Route
         }
 
         $this->action['middleware'] = array_merge(
-            Arr::get($this->action, 'middleware', []), $middleware
+            (array) Arr::get($this->action, 'middleware', []), $middleware
         );
 
         return $this;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -682,6 +682,20 @@ return 'foo!'; });
         $this->assertEquals('foo/bar/baz', $route->getPath());
     }
 
+    public function testRouteMiddlewareMergeWithMiddlewareAttributesAsStrings()
+    {
+        $router = $this->getRouter();
+        $router->group(['prefix'=> 'foo', 'middleware' => 'boo:foo'], function () use ($router) {
+            $router->get('bar', function () {return 'hello';})->middleware('baz:gaz');
+        });
+        $routes = $router->getRoutes()->getRoutes();
+        $route = $routes[0];
+        $this->assertEquals(
+            ['boo:foo', 'baz:gaz'],
+            $route->middleware()
+        );
+    }
+
     public function testRoutePrefixing()
     {
         /*

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -685,7 +685,7 @@ return 'foo!'; });
     public function testRouteMiddlewareMergeWithMiddlewareAttributesAsStrings()
     {
         $router = $this->getRouter();
-        $router->group(['prefix'=> 'foo', 'middleware' => 'boo:foo'], function () use ($router) {
+        $router->group(['prefix' => 'foo', 'middleware' => 'boo:foo'], function () use ($router) {
             $router->get('bar', function () {return 'hello';})->middleware('baz:gaz');
         });
         $routes = $router->getRoutes()->getRoutes();


### PR DESCRIPTION
Bugfix for #11116
