### PR TITLE
[5.2] Only store intended redirect URL if the originating request is GET or HEAD

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -72,6 +72,8 @@ class Redirector
     /**
      * Create a new redirect response, while putting the current URL in the session.
      *
+     * Note that we're only going to store the current URL if the request was "safe".
+     *
      * @param  string  $path
      * @param  int     $status
      * @param  array   $headers
@@ -80,7 +82,12 @@ class Redirector
      */
     public function guest($path, $status = 302, $headers = [], $secure = null)
     {
-        $this->session->put('url.intended', $this->generator->full());
+        if ($this->generator->getRequest()->isMethodSafe()) {
+            $intendedUrl = $this->generator->full();
+        } else {
+            $intendedUrl = $this->session->previousUrl();
+        }
+        $this->session->put('url.intended', $intendedUrl);
 
         return $this->to($path, $status, $headers, $secure);
     }


### PR DESCRIPTION
This will resolve #11072, wherein a POST request to an authenticated page is the target URL of the post-authentication redirect. Now, it should redirect to the URL that first created the POST request (a resource's edit page, for example). This is a resubmission of pr #11113 to the 5.2 branch since this is a breaking change.
