### PR TITLE
[5.1] Added queue prefix for sqs driver

### DIFF
--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -28,6 +28,6 @@ class SqsConnector implements ConnectorInterface
             $config['credentials'] = Arr::only($config, ['key', 'secret']);
         }
 
-        return new SqsQueue(new SqsClient($config), $config['queue']);
+        return new SqsQueue(new SqsClient($config), $config['queue'], Arr::get($config, 'prefix', ''));
     }
 }

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -23,6 +23,13 @@ class SqsQueue extends Queue implements QueueContract
     protected $default;
 
     /**
+     * The sqs prefix url.
+     *
+     * @var string
+     */
+    protected $prefix;
+
+    /**
      * The job creator callback.
      *
      * @var callable|null
@@ -36,10 +43,11 @@ class SqsQueue extends Queue implements QueueContract
      * @param  string  $default
      * @return void
      */
-    public function __construct(SqsClient $sqs, $default)
+    public function __construct(SqsClient $sqs, $default, $prefix)
     {
         $this->sqs = $sqs;
         $this->default = $default;
+        $this->prefix = $prefix;
     }
 
     /**
@@ -136,7 +144,12 @@ class SqsQueue extends Queue implements QueueContract
      */
     public function getQueue($queue)
     {
-        return $queue ?: $this->default;
+        // if queue is already a url, return it.
+        if (filter_var($queue, FILTER_VALIDATE_URL) !== false) {
+            return $queue;
+        }
+
+        return $this->prefix.($queue ?: $this->default);
     }
 
     /**

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -97,4 +97,12 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase
         $id = $queue->push($this->mockedJob, $this->mockedData, $this->queueName);
         $this->assertEquals($this->mockedMessageId, $id);
     }
+
+    public function testGetQueueProperlyResolvesName()
+    {
+        $queue = new Illuminate\Queue\SqsQueue($this->sqs, $this->queueName, $this->baseUrl.'/'.$this->account.'/');
+        $this->assertEquals($this->queueUrl, $queue->getQueue($this->queueName));
+        $queueUrl = $this->baseUrl.'/'.$this->account.'/test';
+        $this->assertEquals($queueUrl, $queue->getQueue($queueUrl));
+    }
 }


### PR DESCRIPTION
Adding an optional `prefix` to the sqs queue driver to allow for the `queue` to be set to just the name and not a url.

Its a bit strange that `beanstalkd`, `iron` and `redis` work fine with just the queue name but `sqs` requires the full queue url.

```
'sqs' => [
    'driver' => 'sqs',
    'key'    => env('AWS_ACCESS_KEY_ID'),
    'secret' => env('AWS_SECRET_ACCESS_KEY'),
    'prefix' => 'https://sqs.someregion.amazonaws.com/1234567891011/'
    'queue'  => 'emails',
    'region' => 'us-east-1',
],
```

The prefix is optional and defaults to an empty string if its not set. The `getQueue` function also works if the full sqs queue url is provided (the prefix is ignored).
