### PR TITLE
[5.2] Allow null to be passed to pluck explicitely

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1542,7 +1542,7 @@ class Builder
      */
     public function pluck($column, $key = null)
     {
-        $results = $this->get(func_get_args());
+        $results = $this->get(is_null($key) ? [$column] : [$column, $key]);
 
         // If the columns are qualified with a table or have an alias, we cannot use
         // those directly in the "pluck" operations since the results from the DB


### PR DESCRIPTION
This is actually a bug fix, since [Eloquent's builder](https://github.com/laravel/framework/blob/d43da74/src/Illuminate/Database/Eloquent/Builder.php#L229) passes in `null` explicitly.

This should be caught by [the unit tests](https://github.com/laravel/framework/blob/5.2/tests/Database/DatabaseEloquentIntegrationTest.php#L176), but it's not. I fear it might have something to do with #11042.
