### PR TITLE
[5.1] Fix env helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Str;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Access\Gate;
 
@@ -315,7 +314,9 @@ if (! function_exists('env')) {
                 return;
         }
 
-        if (Str::startsWith($value, '"') && Str::endsWith($value, '"')) {
+        $len = strlen($value);
+
+        if ($len > 1 && $value[0] === '"' && $value[$len - 1] === '"') {
             return substr($value, 1, -1);
         }
 


### PR DESCRIPTION
There is edge case in handling environment variables.  If a value consists only of double quote `env` returns `FALSE`.  In this case `env` should not interpret value in a special way.
