### PR TITLE
[5.2] ResourseRegistrar resource wildcards formatting

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -228,7 +228,7 @@ class ResourceRegistrar
      */
     public function getResourceWildcard($value)
     {
-        return str_replace('-', '_', $value);
+        return camel_case($value);
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
+use Illuminate\Routing\ResourceRegistrar;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
 use Symfony\Component\HttpFoundation\Response;
@@ -796,22 +797,29 @@ return 'foo!'; });
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foo-bars/{foo_bars}', $routes[0]->getUri());
+        $this->assertEquals('foo-bars/{fooBars}', $routes[0]->getUri());
 
         $router = $this->getRouter();
         $router->resource('foo-bars.foo-bazs', 'FooController', ['only' => ['show']]);
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foo-bars/{foo_bars}/foo-bazs/{foo_bazs}', $routes[0]->getUri());
+        $this->assertEquals('foo-bars/{fooBars}/foo-bazs/{fooBazs}', $routes[0]->getUri());
 
         $router = $this->getRouter();
         $router->resource('foo-bars', 'FooController', ['only' => ['show'], 'as' => 'prefix']);
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foo-bars/{foo_bars}', $routes[0]->getUri());
+        $this->assertEquals('foo-bars/{fooBars}', $routes[0]->getUri());
         $this->assertEquals('prefix.foo-bars.show', $routes[0]->getName());
+    }
+
+    public function testResourceWildcardCase()
+    {
+        $registrar = new ResourceRegistrar($this->getRouter());
+
+        $this->assertEquals('fooBarAndFooBaz', $registrar->getResourceWildCard('foo-bar_and fooBaz'));
     }
 
     public function testResourceRouteNaming()


### PR DESCRIPTION
If we try to register resource like 

``` php

$router->resource('task-choice', 'TaskChoiceController');

// or

$router->resource('task_choice', 'TaskChoiceController');
```

After that our resource routes will look like:

| POST | task-choice | task-choice.store | App\Http\Controllers\TaskChoiceController@store |
| --- | --- | --- | --- |
| GET/HEAD | task-choice | task-choice.index | App\Http\Controllers\TaskChoiceController@index |
| GET/HEAD | task-choice/create | task-choice.create | App\Http\Controllers\TaskChoiceController@create |
| PUT | task-choice/**{task_choice}** | task-choice.update | App\Http\Controllers\TaskChoiceController@update |
| GET/HEAD | task-choice/**{task_choice}** | task-choice.show | App\Http\Controllers\TaskChoiceController@show |
| PATCH | task-choice/**{task_choice}** |  | App\Http\Controllers\TaskChoiceController@update |
| DELETE | task-choice/**{task_choice}** | task-choice.destroy | App\Http\Controllers\TaskChoiceController@destroy |
| GET/HEAD | task-choice/**{task_choice}**/edit | task-choice.edit | App\Http\Controllers\TaskChoiceController@edit |

Now we can bind model to the router to use all advantages from Method Injection.

``` php

$router->model('task_choise', App\TaskChoice::class);
```

And in our resource controller methods will like:

``` php

public function edit(App\TaskChoice $task_choice)
{
   //code here
}
```

The problem is, we can't bind model in camel case like `taskChoice`.
And in our controllers we must write only in under score, but it does not match laravel code style.

Solution makes it possible to use camel case naming in such situations.

Tests were changed, where were snake case resource wildcards verification and added a new one.
