### PR TITLE
[5.1] Throw JsonException if json_encode fails inside Model::toJson method

### DIFF
--- a/src/Illuminate/Database/Eloquent/JsonException.php
+++ b/src/Illuminate/Database/Eloquent/JsonException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use RuntimeException;
+
+class JsonException extends RuntimeException
+{
+    //
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2431,10 +2431,23 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      *
      * @param  int  $options
      * @return string
+     *
+     * @throws \Illuminate\Database\Eloquent\JsonException
      */
     public function toJson($options = 0)
     {
-        return json_encode($this->jsonSerialize(), $options);
+        $json = json_encode($this->jsonSerialize(), $options);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            return $json;
+        } else {
+            $jsonLastErrorMsg = json_last_error_msg();
+
+            throw new JsonException(
+                "Error encoding model to JSON. Reason: {$jsonLastErrorMsg}",
+                json_last_error()
+            );
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1266,6 +1266,17 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertNull($array['tenth']);
     }
 
+    /**
+     * @expectedException Illuminate\Database\Eloquent\JsonException
+     * @expectedExceptionMessageRegExp /^Error encoding model to JSON\. Reason\:\s.*$/
+     */
+    public function testToJsonThrowExceptionWhenDataIsMalformed()
+    {
+        $model = new EloquentModelStub;
+        $model->unencoded_binary_column = "\xBB\x00\x00\xBB";
+        $model->toJson();
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));


### PR DESCRIPTION
Addresses one of the problems described in  #11100.

When `json_encode` fails, it returns `false` or `"null"` (depending on the PHP version), and this failure may propagate to other parts of the code without giving any detailed error message, leaving the programmer with no clues why the code is failing.

Since no one expects a `false` returning from `Model::toJson()`, I think this can be integrated right into 5.1 without breaking anyone else's code.
