### PR TITLE
[5.1] Block the queue when popping for jobs

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -133,7 +133,7 @@ class RedisQueue extends Queue implements QueueContract
             $this->migrateAllExpiredJobs($queue);
         }
 
-        $job = $this->getConnection()->lpop($queue);
+        list($selected_queue, $job) = $this->getConnection()->blpop($queue, 0);
 
         if (! is_null($job)) {
             $this->getConnection()->zadd($queue.':reserved', $this->getTime() + $this->expire, $job);


### PR DESCRIPTION
Using the Redis BLPOP command the worker can wait until a job is poped (or pushed) in to the queue
