### PR TITLE
[5.2] Added verbosity level checking to output methods

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -58,6 +58,18 @@ class Command extends SymfonyCommand
     protected $description;
 
     /**
+     * The mapping between human readable verbosity levels and Symfony's OutputInterface.
+     *
+     * @var int[]
+     */
+    protected $verbosity = [
+        'v'     => OutputInterface::VERBOSITY_VERBOSE,
+        'vv'    => OutputInterface::VERBOSITY_VERY_VERBOSE,
+        'vvv'   => OutputInterface::VERBOSITY_DEBUG,
+        'quiet' => OutputInterface::VERBOSITY_QUIET,
+    ];
+
+    /**
      * Create a new console command instance.
      *
      * @return void
@@ -320,67 +332,92 @@ class Command extends SymfonyCommand
     }
 
     /**
+     * Convert the input level to the OutputInterface level.
+     *
+     * @param  string|int  $level
+     * @return bool
+     */
+    public function convertVerbosity($level)
+    {
+        if (isset($this->verbosity[$level])) {
+            $level = $this->verbosity[$level];
+        } elseif (! is_int($level)) {
+            $level = OutputInterface::VERBOSITY_NORMAL;
+        }
+
+        return $level;
+    }
+
+    /**
      * Write a string as information output.
      *
      * @param  string  $string
+     * @param  int|string  $verbosityLevel
      * @return void
      */
-    public function info($string)
+    public function info($string, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
     {
-        $this->output->writeln("<info>$string</info>");
+        $this->line($string, 'info', $verbosityLevel);
     }
 
     /**
      * Write a string as standard output.
      *
      * @param  string  $string
+     * @param  string  $style
+     * @param  int|string  $verbosityLevel
      * @return void
      */
-    public function line($string)
+    public function line($string, $style = null, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
     {
-        $this->output->writeln($string);
+        $styledString = $style ? "<$style>$string</$style>" : $string;
+        $this->output->writeln($styledString, $this->convertVerbosity($verbosityLevel));
     }
 
     /**
      * Write a string as comment output.
      *
      * @param  string  $string
+     * @param  int|string  $verbosityLevel
      * @return void
      */
-    public function comment($string)
+    public function comment($string, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
     {
-        $this->output->writeln("<comment>$string</comment>");
+        $this->line($string, 'comment', $verbosityLevel);
     }
 
     /**
      * Write a string as question output.
      *
      * @param  string  $string
+     * @param  int|string  $verbosityLevel
      * @return void
      */
-    public function question($string)
+    public function question($string, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
     {
-        $this->output->writeln("<question>$string</question>");
+        $this->line($string, 'question', $verbosityLevel);
     }
 
     /**
      * Write a string as error output.
      *
      * @param  string  $string
+     * @param  int|string  $verbosityLevel
      * @return void
      */
-    public function error($string)
+    public function error($string, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
     {
-        $this->output->writeln("<error>$string</error>");
+        $this->line($string, 'error', $verbosityLevel);
     }
 
     /**
      * Write a string as warning output.
      *
      * @param  string  $string
+     * @param  int|string  $verbosityLevel
      * @return void
      */
-    public function warn($string)
+    public function warn($string, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
     {
         if (! $this->output->getFormatter()->hasStyle('warning')) {
             $style = new OutputFormatterStyle('yellow');
@@ -388,7 +425,7 @@ class Command extends SymfonyCommand
             $this->output->getFormatter()->setStyle('warning', $style);
         }
 
-        $this->output->writeln("<warning>$string</warning>");
+        $this->line($string, 'warning', $verbosityLevel);
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -60,14 +60,22 @@ class Command extends SymfonyCommand
     /**
      * The mapping between human readable verbosity levels and Symfony's OutputInterface.
      *
-     * @var int[]
+     * @var array
      */
-    protected $verbosity = [
-        'v'     => OutputInterface::VERBOSITY_VERBOSE,
-        'vv'    => OutputInterface::VERBOSITY_VERY_VERBOSE,
-        'vvv'   => OutputInterface::VERBOSITY_DEBUG,
-        'quiet' => OutputInterface::VERBOSITY_QUIET,
+    protected $verbosityMap = [
+        'v'      => OutputInterface::VERBOSITY_VERBOSE,
+        'vv'     => OutputInterface::VERBOSITY_VERY_VERBOSE,
+        'vvv'    => OutputInterface::VERBOSITY_DEBUG,
+        'quiet'  => OutputInterface::VERBOSITY_QUIET,
+        'normal' => OutputInterface::VERBOSITY_NORMAL,
     ];
+
+    /**
+     * The default verbosity of output commands.
+     *
+     * @var int
+     */
+    protected $verbosity = OutputInterface::VERBOSITY_NORMAL;
 
     /**
      * Create a new console command instance.
@@ -332,30 +340,41 @@ class Command extends SymfonyCommand
     }
 
     /**
-     * Convert the input level to the OutputInterface level.
+     * Get the verbosity level in terms of Symfony's OutputInterface level.
      *
      * @param  string|int  $level
-     * @return bool
+     * @return int
      */
-    public function convertVerbosity($level)
+    public function getVerbosity($level = null)
     {
-        if (isset($this->verbosity[$level])) {
-            $level = $this->verbosity[$level];
+        if (isset($this->verbosityMap[$level])) {
+            $level = $this->verbosityMap[$level];
         } elseif (! is_int($level)) {
-            $level = OutputInterface::VERBOSITY_NORMAL;
+            $level = $this->verbosity;
         }
 
         return $level;
     }
 
     /**
+     * Set the verbosity level.
+     *
+     * @param string|int $level
+     * @return void
+     */
+    public function setVerbosity($level)
+    {
+        $this->verbosity = $this->getVerbosity($level);
+    }
+
+    /**
      * Write a string as information output.
      *
      * @param  string  $string
-     * @param  int|string  $verbosityLevel
+     * @param  null|int|string  $verbosityLevel
      * @return void
      */
-    public function info($string, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
+    public function info($string, $verbosityLevel = null)
     {
         $this->line($string, 'info', $verbosityLevel);
     }
@@ -365,23 +384,23 @@ class Command extends SymfonyCommand
      *
      * @param  string  $string
      * @param  string  $style
-     * @param  int|string  $verbosityLevel
+     * @param  null|int|string  $verbosityLevel
      * @return void
      */
-    public function line($string, $style = null, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
+    public function line($string, $style = null, $verbosityLevel = null)
     {
         $styledString = $style ? "<$style>$string</$style>" : $string;
-        $this->output->writeln($styledString, $this->convertVerbosity($verbosityLevel));
+        $this->output->writeln($styledString, $this->getVerbosity($verbosityLevel));
     }
 
     /**
      * Write a string as comment output.
      *
      * @param  string  $string
-     * @param  int|string  $verbosityLevel
+     * @param  null|int|string  $verbosityLevel
      * @return void
      */
-    public function comment($string, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
+    public function comment($string, $verbosityLevel = null)
     {
         $this->line($string, 'comment', $verbosityLevel);
     }
@@ -390,10 +409,10 @@ class Command extends SymfonyCommand
      * Write a string as question output.
      *
      * @param  string  $string
-     * @param  int|string  $verbosityLevel
+     * @param  null|int|string  $verbosityLevel
      * @return void
      */
-    public function question($string, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
+    public function question($string, $verbosityLevel = null)
     {
         $this->line($string, 'question', $verbosityLevel);
     }
@@ -402,10 +421,10 @@ class Command extends SymfonyCommand
      * Write a string as error output.
      *
      * @param  string  $string
-     * @param  int|string  $verbosityLevel
+     * @param  null|int|string  $verbosityLevel
      * @return void
      */
-    public function error($string, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
+    public function error($string, $verbosityLevel = null)
     {
         $this->line($string, 'error', $verbosityLevel);
     }
@@ -414,10 +433,10 @@ class Command extends SymfonyCommand
      * Write a string as warning output.
      *
      * @param  string  $string
-     * @param  int|string  $verbosityLevel
+     * @param  null|int|string  $verbosityLevel
      * @return void
      */
-    public function warn($string, $verbosityLevel = OutputInterface::VERBOSITY_NORMAL)
+    public function warn($string, $verbosityLevel = null)
     {
         if (! $this->output->getFormatter()->hasStyle('warning')) {
             $style = new OutputFormatterStyle('yellow');


### PR DESCRIPTION
Add verbosity level checking to info, line and comment output methods
This is an update to #10984 
