### PR TITLE
[5.1] Fix for recent SQS-breaking queue change

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -145,11 +145,13 @@ class SqsQueue extends Queue implements QueueContract
      */
     public function getQueue($queue)
     {
+        $queue = $queue ?: $this->default;
+
         if (filter_var($queue, FILTER_VALIDATE_URL) !== false) {
             return $queue;
         }
 
-        return rtrim($this->prefix, '/').'/'.($queue ?: $this->default);
+        return rtrim($this->prefix, '/').'/'.($queue);
     }
 
     /**

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -22,7 +22,8 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase
         $this->baseUrl = 'https://sqs.someregion.amazonaws.com';
 
         // This is how the modified getQueue builds the queueUrl
-        $this->queueUrl = $this->baseUrl.'/'.$this->account.'/'.$this->queueName;
+        $this->prefix = $this->baseUrl.'/'.$this->account.'/';
+        $this->queueUrl = $this->prefix.$this->queueName;
 
         $this->mockedJob = 'foo';
         $this->mockedData = ['data'];
@@ -98,10 +99,18 @@ class QueueSqsQueueTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($this->mockedMessageId, $id);
     }
 
-    public function testGetQueueProperlyResolvesName()
+    public function testGetQueueProperlyResolvesUrlWithPrefix()
     {
-        $queue = new Illuminate\Queue\SqsQueue($this->sqs, $this->queueName, $this->baseUrl.'/'.$this->account.'/');
-        $this->assertEquals($this->queueUrl, $queue->getQueue($this->queueName));
+        $queue = new Illuminate\Queue\SqsQueue($this->sqs, $this->queueName, $this->prefix);
+        $this->assertEquals($this->queueUrl, $queue->getQueue(null));
+        $queueUrl = $this->baseUrl.'/'.$this->account.'/test';
+        $this->assertEquals($queueUrl, $queue->getQueue('test'));
+    }
+
+    public function testGetQueueProperlyResolvesUrlWithoutPrefix()
+    {
+        $queue = new Illuminate\Queue\SqsQueue($this->sqs, $this->queueUrl);
+        $this->assertEquals($this->queueUrl, $queue->getQueue(null));
         $queueUrl = $this->baseUrl.'/'.$this->account.'/test';
         $this->assertEquals($queueUrl, $queue->getQueue($queueUrl));
     }


### PR DESCRIPTION
[This recent PR](https://github.com/laravel/framework/pull/11129) from @pulkitjalan broke the way SQS queues work. The tests that were added also didn't cover how the `getQueue` method really worked.

If you had an SQS queue url in the `queue` config field, the `getQueue` method would build it with a leading forward slash. This PR fixes the method to properly resolve the queue url in all possible scenarios and adds tests to make sure it doesn't get messed up again.
