### PR TITLE
[5.2] Nest where conditions for global scopes

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -631,16 +631,23 @@ class Builder
      */
     public function whereNested(Closure $callback, $boolean = 'and')
     {
-        // To handle nested queries we'll actually create a brand new query instance
-        // and pass it off to the Closure that we have. The Closure can simply do
-        // do whatever it wants to a query then we will store it for compiling.
-        $query = $this->newQuery();
-
-        $query->from($this->from);
+        $query = $this->getQueryForNestedWhere();
 
         call_user_func($callback, $query);
 
         return $this->addNestedWhereQuery($query, $boolean);
+    }
+
+    /**
+     * Create a new query instance for nested where condition.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function getQueryForNestedWhere()
+    {
+        $query = $this->newQuery();
+
+        return $query->from($this->from);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -399,7 +399,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $model = new EloquentBuilderTestNestedStub;
         $this->mockConnectionForModel($model, 'SQLite');
         $query = $model->newQuery()->where('foo', '=', 'bar')->where(function ($query) { $query->where('baz', '>', 9000); });
-        $this->assertEquals('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
+        $this->assertEquals('select * from "table" where ("foo" = ? and ("baz" > ?)) and ("table"."deleted_at" is null)', $query->toSql());
         $this->assertEquals(['bar', 9000], $query->getBindings());
     }
 

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -64,6 +64,15 @@ class DatabaseEloquentGlobalScopesTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('select * from "table"', $query->toSql());
         $this->assertEquals([], $query->getBindings());
     }
+
+    public function testThatAllScopeWhereConditionsAreNested()
+    {
+        $model = new EloquentClosureGlobalScopesWithOrTestModel();
+
+        $query = $model->newQuery()->where('col1', 'val1')->orWhere('col2', 'val2');
+        $this->assertEquals('select "email", "password" from "table" where ("col1" = ? or "col2" = ?) and ("email" = ? or "email" = ?) and ("active" = ?) order by "name" asc', $query->toSql());
+        $this->assertEquals(['val1', 'val2', 'taylor@gmail.com', 'someone@else.com', 1], $query->getBindings());
+    }
 }
 
 class EloquentClosureGlobalScopesTestModel extends Illuminate\Database\Eloquent\Model
@@ -72,12 +81,28 @@ class EloquentClosureGlobalScopesTestModel extends Illuminate\Database\Eloquent\
 
     public static function boot()
     {
+        static::addGlobalScope(function ($query) {
+            $query->orderBy('name');
+        });
+
         static::addGlobalScope('active_scope', function ($query) {
             $query->where('active', 1);
         });
 
+        parent::boot();
+    }
+}
+
+class EloquentClosureGlobalScopesWithOrTestModel extends EloquentClosureGlobalScopesTestModel
+{
+    public static function boot()
+    {
+        static::addGlobalScope('or_scope', function ($query) {
+            $query->where('email', 'taylor@gmail.com')->orWhere('email', 'someone@else.com');
+        });
+
         static::addGlobalScope(function ($query) {
-            $query->orderBy('name');
+            $query->select('email', 'password');
         });
 
         parent::boot();

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -198,6 +198,16 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         $this->assertEquals(1, count($users));
     }
 
+    public function testOrWhereWithSoftDeleteConstraint()
+    {
+        $this->createUsers();
+        SoftDeletesTestUser::create(['id' => 3, 'email' => 'something@else.com']);
+
+        $users = SoftDeletesTestUser::where('email', 'something@else.com')->orWhere('email', 'abigailotwell@gmail.com');
+        $this->assertEquals(2, count($users->get()));
+        $this->assertEquals(['abigailotwell@gmail.com', 'something@else.com'], $users->orderBy('id')->pluck('email')->all());
+    }
+
     /**
      * Helpers...
      */


### PR DESCRIPTION
Example: Lets say we have a User model which uses the `SoftDeletes` scope and we run the following query:

``` php
User::where('col1', 'val1')->orWhere('col2', 'val2')->get();
```

Previously we got wrong results that could potentially include deleted rows:

``` sql
select * from "users" where "col1" = "val1" or "col2" = "val2" and "deleted_at" is null 
```

But with this PR, where conditions are automatically wrapped in parenthesis, ensuring correct results:

``` sql
 select * from "users" where ("col1" = "val1" or "col2" = "val2") and ("deleted_at" is null)
```

We couldn't fix this before, but now it's much easier since we refactored global scopes.
