### PR TITLE
[5.1] Fixes morphTo relationships being named with snake case attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -104,6 +104,10 @@ class MorphTo extends BelongsTo
      */
     public function match(array $models, Collection $results, $relation)
     {
+        foreach (array_keys($this->dictionary) as $type) {
+            $this->matchToMorphParents($type, $this->getResultsByType($type), $relation);
+        }
+
         return $models;
     }
 
@@ -137,34 +141,18 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Get the results of the relationship.
-     *
-     * Called via eager load method of Eloquent query builder.
-     *
-     * @return mixed
-     */
-    public function getEager()
-    {
-        foreach (array_keys($this->dictionary) as $type) {
-            $this->matchToMorphParents($type, $this->getResultsByType($type));
-        }
-
-        return $this->models;
-    }
-
-    /**
      * Match the results for a given type to their parents.
      *
-     * @param  string  $type
-     * @param  \Illuminate\Database\Eloquent\Collection  $results
-     * @return void
+     * @param  string $type
+     * @param  \Illuminate\Database\Eloquent\Collection $results
+     * @param string $relation
      */
-    protected function matchToMorphParents($type, Collection $results)
+    protected function matchToMorphParents($type, Collection $results, $relation)
     {
         foreach ($results as $result) {
             if (isset($this->dictionary[$type][$result->getKey()])) {
                 foreach ($this->dictionary[$type][$result->getKey()] as $model) {
-                    $model->setRelation($this->relation, $result);
+                    $model->setRelation($relation, $result);
                 }
             }
         }

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -77,7 +77,7 @@ class DatabaseEloquentMorphToTest extends PHPUnit_Framework_TestCase
         $two->shouldReceive('setRelation')->once()->with('relation', $resultOne);
         $three->shouldReceive('setRelation')->once()->with('relation', $resultTwo);
 
-        $relation->getEager();
+        $relation->match([$one, $two, $three], Collection::make([$resultOne, $resultTwo]), 'relation');
     }
 
     public function testModelsWithSoftDeleteAreProperlyPulled()


### PR DESCRIPTION
This reverts commit 5393d40ca936d06d55c2dce4c2540ab47e7c2b4a, with the intention of resolving the memory issue identified in https://github.com/laravel/framework/issues/11138
