### PR TITLE
Less collisions in sessions ids

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -201,7 +201,7 @@ class Store implements SessionInterface
      */
     protected function generateSessionId()
     {
-        return sha1(uniqid('', true).Str::random(25).microtime(true));
+        return sha1(uniqid('', true).Str::random(mt_rand(25, 99)).microtime(true).app()->request->ip());
     }
 
     /**


### PR DESCRIPTION
It helps prevent the error: Integrity constraint violation: Duplicate entry for key 'sessions_id_unique'
