### PR TITLE
[5.1] Arr::forget - Early return when no key(s) is/are provided

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -199,7 +199,13 @@ class Arr
     {
         $original = &$array;
 
-        foreach ((array) $keys as $key) {
+        $keys = (array) $keys;
+
+        if (count($keys) === 0) {
+            return;
+        }
+
+        foreach ($keys as $key) {
             $parts = explode('.', $key);
 
             while (count($parts) > 1) {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -234,6 +234,14 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
     public function testForget()
     {
         $array = ['products' => ['desk' => ['price' => 100]]];
+        Arr::forget($array, null);
+        $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
+
+        $array = ['products' => ['desk' => ['price' => 100]]];
+        Arr::forget($array, []);
+        $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
+
+        $array = ['products' => ['desk' => ['price' => 100]]];
         Arr::forget($array, 'products.desk');
         $this->assertEquals(['products' => []], $array);
 


### PR DESCRIPTION
No need to continue in this case.
