### PR TITLE
[5.1] No need to call func_get_args()

### DIFF
--- a/src/Illuminate/Auth/GeneratorServiceProvider.php
+++ b/src/Illuminate/Auth/GeneratorServiceProvider.php
@@ -34,9 +34,9 @@ class GeneratorServiceProvider extends ServiceProvider
             $this->{"register{$command}Command"}();
         }
 
-        $this->commands(
-            'command.auth.resets.clear'
-        );
+        $this->commands([
+            'command.auth.resets.clear',
+        ]);
     }
 
     /**

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -52,7 +52,10 @@ class CacheServiceProvider extends ServiceProvider
             return new CacheTableCommand($app['files'], $app['composer']);
         });
 
-        $this->commands('command.cache.clear', 'command.cache.table');
+        $this->commands([
+            'command.cache.clear',
+            'command.cache.table',
+        ]);
     }
 
     /**

--- a/src/Illuminate/Console/ScheduleServiceProvider.php
+++ b/src/Illuminate/Console/ScheduleServiceProvider.php
@@ -20,7 +20,9 @@ class ScheduleServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->commands('Illuminate\Console\Scheduling\ScheduleRunCommand');
+        $this->commands([
+            'Illuminate\Console\Scheduling\ScheduleRunCommand',
+        ]);
     }
 
     /**

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -90,12 +90,15 @@ class MigrationServiceProvider extends ServiceProvider
         // Once the commands are registered in the application IoC container we will
         // register them with the Artisan start event so that these are available
         // when the Artisan application actually starts up and is getting used.
-        $this->commands(
-            'command.migrate', 'command.migrate.make',
-            'command.migrate.install', 'command.migrate.rollback',
-            'command.migrate.reset', 'command.migrate.refresh',
-            'command.migrate.status'
-        );
+        $this->commands([
+            'command.migrate',
+            'command.migrate.make',
+            'command.migrate.install',
+            'command.migrate.rollback',
+            'command.migrate.reset',
+            'command.migrate.refresh',
+            'command.migrate.status',
+        ]);
     }
 
     /**

--- a/src/Illuminate/Database/SeedServiceProvider.php
+++ b/src/Illuminate/Database/SeedServiceProvider.php
@@ -30,7 +30,10 @@ class SeedServiceProvider extends ServiceProvider
             return new Seeder;
         });
 
-        $this->commands('command.seed', 'command.seeder.make');
+        $this->commands([
+            'command.seed',
+            'command.seeder.make',
+        ]);
     }
 
     /**

--- a/src/Illuminate/Queue/ConsoleServiceProvider.php
+++ b/src/Illuminate/Queue/ConsoleServiceProvider.php
@@ -50,10 +50,14 @@ class ConsoleServiceProvider extends ServiceProvider
             return new FailedTableCommand($app['files'], $app['composer']);
         });
 
-        $this->commands(
-            'command.queue.table', 'command.queue.failed', 'command.queue.retry',
-            'command.queue.forget', 'command.queue.flush', 'command.queue.failed-table'
-        );
+        $this->commands([
+            'command.queue.table',
+            'command.queue.failed',
+            'command.queue.retry',
+            'command.queue.forget',
+            'command.queue.flush',
+            'command.queue.failed-table',
+        ]);
     }
 
     /**

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -97,7 +97,9 @@ class QueueServiceProvider extends ServiceProvider
             return new WorkCommand($app['queue.worker']);
         });
 
-        $this->commands('command.queue.work');
+        $this->commands([
+            'command.queue.work',
+        ]);
     }
 
     /**
@@ -125,7 +127,9 @@ class QueueServiceProvider extends ServiceProvider
             return new ListenCommand($app['queue.listener']);
         });
 
-        $this->commands('command.queue.listen');
+        $this->commands([
+            'command.queue.listen',
+        ]);
     }
 
     /**
@@ -139,7 +143,9 @@ class QueueServiceProvider extends ServiceProvider
             return new RestartCommand;
         });
 
-        $this->commands('command.queue.restart');
+        $this->commands([
+            'command.queue.restart',
+        ]);
     }
 
     /**
@@ -153,7 +159,9 @@ class QueueServiceProvider extends ServiceProvider
             return new SubscribeCommand;
         });
 
-        $this->commands('command.queue.subscribe');
+        $this->commands([
+            'command.queue.subscribe',
+        ]);
     }
 
     /**

--- a/src/Illuminate/Routing/GeneratorServiceProvider.php
+++ b/src/Illuminate/Routing/GeneratorServiceProvider.php
@@ -26,7 +26,10 @@ class GeneratorServiceProvider extends ServiceProvider
 
         $this->registerMiddlewareGenerator();
 
-        $this->commands('command.controller.make', 'command.middleware.make');
+        $this->commands([
+            'command.controller.make',
+            'command.middleware.make',
+        ]);
     }
 
     /**

--- a/src/Illuminate/Session/CommandsServiceProvider.php
+++ b/src/Illuminate/Session/CommandsServiceProvider.php
@@ -25,7 +25,9 @@ class CommandsServiceProvider extends ServiceProvider
             return new SessionTableCommand($app['files'], $app['composer']);
         });
 
-        $this->commands('command.session.database');
+        $this->commands([
+            'command.session.database',
+        ]);
     }
 
     /**


### PR DESCRIPTION
No need to call `func_get_args` in `\Illuminate\Support\ServiceProvider::commands`
