### PR TITLE
[5.2] Nest where conditions for scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -935,9 +935,7 @@ class Builder
     {
         if ($scope instanceof Closure) {
             $scope($builder);
-        }
-
-        if ($scope instanceof ScopeInterface) {
+        } elseif ($scope instanceof ScopeInterface) {
             $scope->apply($builder, $this->getModel());
         }
     }
@@ -959,20 +957,20 @@ class Builder
     /**
      * Nest where conditions of the builder and each global scope.
      *
-     * @param  \Illuminate\Database\Query\Builder  $builder
+     * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $offsets
      * @return void
      */
-    protected function nestWheresForScope(QueryBuilder $builder, array $offsets)
+    protected function nestWheresForScope(QueryBuilder $query, array $offsets)
     {
-        $wheres = $builder->wheres;
+        $wheres = $query->wheres;
 
-        $builder->wheres = [];
+        $query->wheres = [];
 
         $lastOffset = array_shift($offsets);
 
         foreach ($offsets as $offset) {
-            $builder->wheres[] = $this->sliceWhereConditions($wheres, $lastOffset, $offset - $lastOffset);
+            $query->wheres[] = $this->sliceWhereConditions($wheres, $lastOffset, $offset - $lastOffset);
 
             $lastOffset = $offset;
         }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -631,16 +631,23 @@ class Builder
      */
     public function whereNested(Closure $callback, $boolean = 'and')
     {
-        // To handle nested queries we'll actually create a brand new query instance
-        // and pass it off to the Closure that we have. The Closure can simply do
-        // do whatever it wants to a query then we will store it for compiling.
-        $query = $this->newQuery();
-
-        $query->from($this->from);
+        $query = $this->getQueryForNestedWhere();
 
         call_user_func($callback, $query);
 
         return $this->addNestedWhereQuery($query, $boolean);
+    }
+
+    /**
+     * Create a new query instance for nested where condition.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function getQueryForNestedWhere()
+    {
+        $query = $this->newQuery();
+
+        return $query->from($this->from);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -65,7 +65,7 @@ class DatabaseEloquentGlobalScopesTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([], $query->getBindings());
     }
 
-    public function testThatAllScopeWhereConditionsAreNested()
+    public function testGlobalScopesWithOrWhereConditionsAreNested()
     {
         $model = new EloquentClosureGlobalScopesWithOrTestModel();
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -198,6 +198,16 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         $this->assertEquals(1, count($users));
     }
 
+    public function testOrWhereWithSoftDeleteConstraint()
+    {
+        $this->createUsers();
+        SoftDeletesTestUser::create(['id' => 3, 'email' => 'something@else.com']);
+
+        $users = SoftDeletesTestUser::where('email', 'something@else.com')->orWhere('email', 'abigailotwell@gmail.com');
+        $this->assertEquals(2, count($users->get()));
+        $this->assertEquals(['abigailotwell@gmail.com', 'something@else.com'], $users->orderBy('id')->pluck('email')->all());
+    }
+
     /**
      * Helpers...
      */


### PR DESCRIPTION
Replaces https://github.com/laravel/framework/pull/11154

Original PR:
Example: Lets say we have a User model which uses the `SoftDeletes` scope and we run the following query:

``` php
User::where('col1', 'val1')->orWhere('col2', 'val2')->get();
```

Previously we got wrong results that could potentially include deleted rows:

``` sql
select * from "users" where "col1" = "val1" or "col2" = "val2" and "deleted_at" is null 
```

But with this PR, where conditions are automatically wrapped in parenthesis, ensuring correct results:

``` sql
 select * from "users" where ("col1" = "val1" or "col2" = "val2") and ("deleted_at" is null)
```

We couldn't fix this before, but now it's much easier since we refactored global scopes.

---

New additions:
With this updated proposal, regular scopes are also nested, but only if the query contains any OR booleans. That way we don't add any unnecessary parenthesis.
