### PR TITLE
[5.1] CookieJar should honor 'secure' setting for Session cookies

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -23,6 +23,13 @@ class CookieJar implements JarContract
     protected $domain = null;
 
     /**
+     * The default secure setting (defaults to false).
+     *
+     * @var bool
+     */
+    protected $secure = false;
+
+    /**
      * All of the cookies queued for sending.
      *
      * @var array
@@ -43,7 +50,7 @@ class CookieJar implements JarContract
      */
     public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true)
     {
-        list($path, $domain) = $this->getPathAndDomain($path, $domain);
+        list($path, $domain, $secure) = $this->getPathAndDomain($path, $domain, $secure);
 
         $time = ($minutes == 0) ? 0 : time() + ($minutes * 60);
 
@@ -134,11 +141,12 @@ class CookieJar implements JarContract
      *
      * @param  string  $path
      * @param  string  $domain
+     * @param  bool    $secure
      * @return array
      */
-    protected function getPathAndDomain($path, $domain)
+    protected function getPathAndDomain($path, $domain, $secure = false)
     {
-        return [$path ?: $this->path, $domain ?: $this->domain];
+        return [$path ?: $this->path, $domain ?: $this->domain, $secure ?: $this->secure];
     }
 
     /**
@@ -146,11 +154,12 @@ class CookieJar implements JarContract
      *
      * @param  string  $path
      * @param  string  $domain
+     * @param  bool    $secure
      * @return $this
      */
-    public function setDefaultPathAndDomain($path, $domain)
+    public function setDefaultPathAndDomain($path, $domain, $secure = false)
     {
-        list($this->path, $this->domain) = [$path, $domain];
+        list($this->path, $this->domain, $this->secure) = [$path, $domain, $secure];
 
         return $this;
     }

--- a/src/Illuminate/Cookie/CookieServiceProvider.php
+++ b/src/Illuminate/Cookie/CookieServiceProvider.php
@@ -16,7 +16,7 @@ class CookieServiceProvider extends ServiceProvider
         $this->app->singleton('cookie', function ($app) {
             $config = $app['config']['session'];
 
-            return (new CookieJar)->setDefaultPathAndDomain($config['path'], $config['domain']);
+            return (new CookieJar)->setDefaultPathAndDomain($config['path'], $config['domain'], $config['secure']);
         });
     }
 }


### PR DESCRIPTION
When using the cookie session driver (i.e., set `'driver' => 'cookie'` in `config/session.php`), two cookies are created: (1) the "named" session cookie (defaults to `laravel_session`) and (2) the session id cookie (named a 40-character hexadecimal string like `055f7f3e004c69f30b1add93160054334b5d6aca`). When `'secure' => true` in `config/session.php`, the first cookie is marked for "encrypted connections only", but the second cookie is marked for "any type of connection". Here is an example (using the CookieManager+ Add-on for Firefox).

![before](https://cloud.githubusercontent.com/assets/135982/11573054/d9858d8c-99c9-11e5-9d32-982306435367.png)

This is a problem since the session data is stored in the second cookie, which can be sent over http (rather than https), and thus could be read by eavesdroppers.

The pull request fixes this issue by modifying CookieJar.php and CookieServiceProvider.php to use the configured `secure` setting when saving the session id cookie. This results in BOTH cookies being marked for "encrypted connections only". Here is an example after the patch is applied with `'secure' => true`.

![after](https://cloud.githubusercontent.com/assets/135982/11573141/53fa7bfe-99ca-11e5-9024-062bcf2097fa.png)
