### PR TITLE
[5.1] Directly call request methods without using useless aliases

### DIFF
--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -17,7 +17,7 @@ trait ThrottlesLogins
     protected function hasTooManyLoginAttempts(Request $request)
     {
         return app(RateLimiter::class)->tooManyAttempts(
-            $request->input($this->loginUsername()).$request->ip(),
+            $request->input($this->loginUsername()).$request->getClientIp(),
             $this->maxLoginAttempts(), $this->lockoutTime() / 60
         );
     }
@@ -31,7 +31,7 @@ trait ThrottlesLogins
     protected function incrementLoginAttempts(Request $request)
     {
         app(RateLimiter::class)->hit(
-            $request->input($this->loginUsername()).$request->ip()
+            $request->input($this->loginUsername()).$request->getClientIp()
         );
     }
 
@@ -44,7 +44,7 @@ trait ThrottlesLogins
     protected function retriesLeft(Request $request)
     {
         $attempts = app(RateLimiter::class)->attempts(
-            $request->input($this->loginUsername()).$request->ip()
+            $request->input($this->loginUsername()).$request->getClientIp()
         );
 
         return $this->maxLoginAttempts() - $attempts + 1;
@@ -59,7 +59,7 @@ trait ThrottlesLogins
     protected function sendLockoutResponse(Request $request)
     {
         $seconds = app(RateLimiter::class)->availableIn(
-            $request->input($this->loginUsername()).$request->ip()
+            $request->input($this->loginUsername()).$request->getClientIp()
         );
 
         return redirect($this->loginPath())
@@ -91,7 +91,7 @@ trait ThrottlesLogins
     protected function clearLoginAttempts(Request $request)
     {
         app(RateLimiter::class)->clear(
-            $request->input($this->loginUsername()).$request->ip()
+            $request->input($this->loginUsername()).$request->getClientIp()
         );
     }
 

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -126,6 +126,6 @@ class VerifyCsrfToken
      */
     protected function isReading($request)
     {
-        return in_array($request->method(), ['HEAD', 'GET', 'OPTIONS']);
+        return in_array($request->getMethod(), ['HEAD', 'GET', 'OPTIONS']);
     }
 }

--- a/src/Illuminate/Routing/Matching/SchemeValidator.php
+++ b/src/Illuminate/Routing/Matching/SchemeValidator.php
@@ -17,9 +17,9 @@ class SchemeValidator implements ValidatorInterface
     public function matches(Route $route, Request $request)
     {
         if ($route->httpOnly()) {
-            return ! $request->secure();
+            return ! $request->isSecure();
         } elseif ($route->secure()) {
-            return $request->secure();
+            return $request->isSecure();
         }
 
         return true;

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -196,7 +196,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     protected function getRouteForMethods($request, array $methods)
     {
-        if ($request->method() == 'OPTIONS') {
+        if ($request->getMethod() == 'OPTIONS') {
             return (new Route('OPTIONS', $request->path(), function () use ($methods) {
                 return new Response('', 200, ['Allow' => implode(',', $methods)]);
 

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -128,7 +128,7 @@ class StartSession
      */
     protected function storeCurrentUrl(Request $request, $session)
     {
-        if ($request->method() === 'GET' && $request->route() && ! $request->ajax()) {
+        if ($request->getMethod() === 'GET' && $request->route() && ! $request->ajax()) {
             $session->setPreviousUrl($request->fullUrl());
         }
     }


### PR DESCRIPTION
The following functions do nothing but calling another function:
- `\Illuminate\Http\Request::ip()`
- `\Illuminate\Http\Request::method()` (`getMethod` used in `\Illuminate\Routing`)
- `\Illuminate\Http\Request::secure()` (`isSecure` used in `\Illuminate\Routing`)

In my opinion these 3 functions could even be marked as deprecated for 5.2
