### PR TITLE
[5.1] Reflash Session::now() data properly

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -55,13 +55,6 @@ class Store implements SessionInterface
     protected $bagData = [];
 
     /**
-     * The keys that should only be available for the current request.
-     *
-     * @var array
-     */
-    protected $nowKeys = [];
-
-    /**
      * The session handler implementation.
      *
      * @var \SessionHandlerInterface
@@ -266,8 +259,6 @@ class Store implements SessionInterface
 
         $this->ageFlashData();
 
-        $this->removeFlashNowData();
-
         $this->handler->write($this->getId(), $this->prepareForStorage(serialize($this->attributes)));
 
         $this->started = false;
@@ -308,18 +299,6 @@ class Store implements SessionInterface
         $this->put('flash.old', $this->get('flash.new', []));
 
         $this->put('flash.new', []);
-    }
-
-    /**
-     * Remove data that was flashed for only the current request.
-     *
-     * @return void
-     */
-    public function removeFlashNowData()
-    {
-        $this->forget($this->nowKeys);
-
-        $this->nowKeys = [];
     }
 
     /**
@@ -450,7 +429,7 @@ class Store implements SessionInterface
     {
         $this->put($key, $value);
 
-        $this->nowKeys[] = $key;
+        $this->push('flash.old', $key);
     }
 
     /**

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -171,7 +171,7 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $session->get('foo'));
         $this->assertEquals(0, $session->get('bar'));
 
-        $session->removeFlashNowData();
+        $session->ageFlashData();
 
         $this->assertFalse($session->has('foo'));
         $this->assertNull($session->get('foo'));
@@ -197,6 +197,15 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase
         $session = $this->getSession();
         $session->flash('foo', 'bar');
         $session->set('flash.old', ['foo']);
+        $session->reflash();
+        $this->assertNotFalse(array_search('foo', $session->get('flash.new')));
+        $this->assertFalse(array_search('foo', $session->get('flash.old')));
+    }
+
+    public function testReflashWithNow()
+    {
+        $session = $this->getSession();
+        $session->now('foo', 'bar');
         $session->reflash();
         $this->assertNotFalse(array_search('foo', $session->get('flash.new')));
         $this->assertFalse(array_search('foo', $session->get('flash.old')));


### PR DESCRIPTION
`Session::now()` has been recently introduced in #11117 
It "flashes a key / value pair to the session for immediate use".

`keep()` and `reflash()` must handle this data properly therefore.

A sane way to achieve that is to simply use `flash.old` array.

ping @sknoslo, @taylorotwell 
