### PR TITLE
[5.1] Use static instead of self

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1090,7 +1090,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     protected function getArrayableItems($items)
     {
-        if ($items instanceof self) {
+        if ($items instanceof static) {
             return $items->all();
         } elseif ($items instanceof Arrayable) {
             return $items->toArray();


### PR DESCRIPTION
Use `static` instead of `self`
