### PR TITLE
[5.1] New methods for retrieving available database drivers

### DIFF
--- a/src/Illuminate/Database/Connectors/ConnectionFactory.php
+++ b/src/Illuminate/Database/Connectors/ConnectionFactory.php
@@ -46,6 +46,36 @@ class ConnectionFactory
     }
 
     /**
+     * Gets an array of all drivers that we know of.
+     *
+     * @return array
+     */
+    public function getAllDrivers()
+    {
+        return array_keys($this->getDriverClassPrefixes());
+    }
+
+    /**
+     * Gets an array of available drivers.
+     *
+     * @return array
+     */
+    public function getAvailableDrivers()
+    {
+        $drivers = $this->getAllDrivers();
+        $availableDrivers = [];
+
+        foreach ($drivers as $driver) {
+            $connector = $this->createConnector(['driver' => $driver]);
+            if ($connector->isDriverAvailable()) {
+                $availableDrivers[] = $driver;
+            }
+        }
+
+        return $availableDrivers;
+    }
+
+    /**
      * Create a single database connection instance.
      *
      * @param  array  $config

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -103,4 +103,32 @@ class Connector
 
         throw $e;
     }
+
+    /**
+     * Get PDO driver this connection can use.
+     *
+     * @return string|null
+     */
+    protected function getPDODriver()
+    {
+        return;
+    }
+
+    /**
+     * Checks whether this Connector is available or not.
+     *
+     * @return bool
+     */
+    public function isDriverAvailable()
+    {
+        $drivers = \PDO::getAvailableDrivers();
+        $driver = $this->getPDODriver();
+
+        if ($driver === null) {
+            // We do not know if this driver is available or not.
+            return true;
+        }
+
+        return in_array($driver, $drivers);
+    }
 }

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -92,7 +92,9 @@ class MySqlConnector extends Connector implements ConnectorInterface
      */
     protected function getSocketDsn(array $config)
     {
-        return "mysql:unix_socket={$config['unix_socket']};dbname={$config['database']}";
+        $pdoDriver = $this->getPDODriver();
+
+        return "{$pdoDriver}:unix_socket={$config['unix_socket']};dbname={$config['database']}";
     }
 
     /**
@@ -105,8 +107,20 @@ class MySqlConnector extends Connector implements ConnectorInterface
     {
         extract($config);
 
+        $pdoDriver = $this->getPDODriver();
+
         return isset($port)
-                        ? "mysql:host={$host};port={$port};dbname={$database}"
-                        : "mysql:host={$host};dbname={$database}";
+                        ? "{$pdoDriver}:host={$host};port={$port};dbname={$database}"
+                        : "{$pdoDriver}:host={$host};dbname={$database}";
+    }
+
+    /**
+     * Get PDO Driver that can be used for this connection.
+     *
+     * @return string
+     */
+    protected function getPDODriver()
+    {
+        return 'mysql';
     }
 }

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -84,7 +84,8 @@ class PostgresConnector extends Connector implements ConnectorInterface
 
         $host = isset($host) ? "host={$host};" : '';
 
-        $dsn = "pgsql:{$host}dbname={$database}";
+        $pdoDriver = $this->getPDODriver();
+        $dsn = "{$pdoDriver}:{$host}dbname={$database}";
 
         // If a port was specified, we will add it to this Postgres DSN connections
         // format. Once we have done that we are ready to return this connection
@@ -113,5 +114,15 @@ class PostgresConnector extends Connector implements ConnectorInterface
         } else {
             return '"'.$schema.'"';
         }
+    }
+
+    /**
+     * Get PDO Driver that can be used for this connection.
+     *
+     * @return string
+     */
+    protected function getPDODriver()
+    {
+        return 'pgsql';
     }
 }

--- a/src/Illuminate/Database/Connectors/SQLiteConnector.php
+++ b/src/Illuminate/Database/Connectors/SQLiteConnector.php
@@ -17,12 +17,13 @@ class SQLiteConnector extends Connector implements ConnectorInterface
     public function connect(array $config)
     {
         $options = $this->getOptions($config);
+        $pdoDriver = $this->getPDODriver();
 
         // SQLite supports "in-memory" databases that only last as long as the owning
         // connection does. These are useful for tests or for short lifetime store
         // querying. In-memory databases may only have a single open connection.
         if ($config['database'] == ':memory:') {
-            return $this->createConnection('sqlite::memory:', $config, $options);
+            return $this->createConnection("{$pdoDriver}::memory:", $config, $options);
         }
 
         $path = realpath($config['database']);
@@ -34,6 +35,16 @@ class SQLiteConnector extends Connector implements ConnectorInterface
             throw new InvalidArgumentException("Database (${config['database']}) does not exist.");
         }
 
-        return $this->createConnection("sqlite:{$path}", $config, $options);
+        return $this->createConnection("{$pdoDriver}:{$path}", $config, $options);
+    }
+
+    /**
+     * Get PDO Drivers that can be used for this connection.
+     *
+     * @return string
+     */
+    protected function getPDODriver()
+    {
+        return 'sqlite';
     }
 }

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -43,7 +43,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
         // First we will create the basic DSN setup as well as the port if it is in
         // in the configuration options. This will give us the basic DSN we will
         // need to establish the PDO connections and return them back for use.
-        if (in_array('dblib', $this->getAvailableDrivers())) {
+        if ($this->getPDODriver() === 'dblib') {
             return $this->getDblibDsn($config);
         } else {
             return $this->getSqlSrvDsn($config);
@@ -67,7 +67,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
             $arguments, Arr::only($config, ['appname', 'charset'])
         );
 
-        return $this->buildConnectString('dblib', $arguments);
+        return $this->buildConnectString($this->getPDODriver(), $arguments);
     }
 
     /**
@@ -90,7 +90,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
             $arguments['APP'] = $config['appname'];
         }
 
-        return $this->buildConnectString('sqlsrv', $arguments);
+        return $this->buildConnectString($this->getPDODriver(), $arguments);
     }
 
     /**
@@ -133,5 +133,19 @@ class SqlServerConnector extends Connector implements ConnectorInterface
     protected function getAvailableDrivers()
     {
         return PDO::getAvailableDrivers();
+    }
+
+    /**
+     * Get PDO Driver that can be used for this connection.
+     *
+     * @return string
+     */
+    protected function getPDODriver()
+    {
+        if (in_array('dblib', $this->getAvailableDrivers())) {
+            return 'dblib';
+        }
+
+        return 'sqlsrv';
     }
 }

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -285,6 +285,26 @@ class DatabaseManager implements ConnectionResolverInterface
     }
 
     /**
+     * Gets an array of all drivers that we know of.
+     *
+     * @return array
+     */
+    public function getAllDrivers()
+    {
+        return $this->factory->getAllDrivers();
+    }
+
+    /**
+     * Gets an array of available drivers.
+     *
+     * @return array
+     */
+    public function getAvailableDrivers()
+    {
+        return $this->factory->getAvailableDrivers();
+    }
+
+    /**
      * Dynamically pass methods to the default connection.
      *
      * @param  string  $method

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -112,4 +112,21 @@ class DatabaseConnectionFactoryTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('connector', $factory->createConnector(['driver' => 'foo']));
     }
+
+    public function testGetAllDrivers()
+    {
+        $factory = new Illuminate\Database\Connectors\ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
+        $container->shouldReceive('bound')->andReturn(false);
+        $allDrivers = $factory->getAllDrivers();
+        $this->assertEquals(['mysql', 'pgsql', 'sqlite', 'sqlsrv'], $allDrivers);
+    }
+
+    public function testGetAvailableDrivers()
+    {
+        $factory = new Illuminate\Database\Connectors\ConnectionFactory($container = m::mock('Illuminate\Container\Container'));
+        $container->shouldReceive('bound')->andReturn(false);
+        $drivers = $factory->getAvailableDrivers();
+        $allDrivers = $factory->getAllDrivers();
+        $this->assertNotSame([], array_intersect_key($drivers, $allDrivers));
+    }
 }


### PR DESCRIPTION
This cleans up the ConnectionFactory class a bit (repeated list of possible database drivers).

More importantly, it adds public methods to ConnectionFactory and ConnectionManager for getAllDrivers() and getAvailableDrivers().

A use case for getAvailableDrivers() is so that an app that configures databases at runtime (or needs to list what drivers are available in some manner) can be aware of what drivers are actually available without having to resort to touching the underlying (PDO) class.

isDriverAvailable and getPDODriver methods are added to the Connector base class. Any subclass that doesn't implement getPDODriver is assumed to be available.
