### PR TITLE
[5.3] Allow guzzle based mail drivers to use specific guzzle options

### DIFF
--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -97,8 +97,8 @@ class TransportManager extends Manager
      */
     protected function createMailgunDriver()
     {
-        $client = new HttpClient;
         $config = $this->app['config']->get('services.mailgun', []);
+        $client = new HttpClient(Arr::get($config, 'guzzleOptions', []));
 
         return new MailgunTransport($client, $config['secret'], $config['domain']);
     }
@@ -110,8 +110,8 @@ class TransportManager extends Manager
      */
     protected function createMandrillDriver()
     {
-        $client = new HttpClient;
         $config = $this->app['config']->get('services.mandrill', []);
+        $client = new HttpClient(Arr::get($config, 'guzzleOptions', []));
 
         return new MandrillTransport($client, $config['secret']);
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Closure;
 use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Pipeline\Pipeline;


### PR DESCRIPTION
Mandrill and MailGun mail drivers are guzzle based. In some specific cases it would be a good idea to allow custom guzzle options. For example when you need to use a proxy or a custom timeout policy, or even to debug guzzle stack. These options could be defined into services.name_of_service.guzzleOptions configuration path.
