### PR TITLE
[5.1] Add Model::saveOrFail() to execute save operation within database transaction.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Eloquent;
 
 use DateTime;
 use Exception;
+use Throwable;
 use ArrayAccess;
 use Carbon\Carbon;
 use LogicException;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1522,6 +1522,38 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Save the model to the database using transaction.
+     *
+     * @param  array  $options
+     * @return bool
+     *
+     * @throws \Throwable
+     */
+    public function saveOrFail(array $options = [])
+    {
+        $db = $this->getConnection();
+        $result = false;
+
+        $db->beginTransaction();
+
+        try {
+            $result = $this->save($options);
+
+            $db->commit();
+        } catch (Exception $e) {
+            $db->rollBack();
+
+            throw $e;
+        } catch (Throwable $e) {
+            $db->rollBack();
+
+            throw $e;
+        }
+
+        return $result;
+    }
+
+    /**
      * Finish processing on a successful save operation.
      *
      * @param  array  $options

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -431,6 +431,34 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertNull($photo->imageable);
     }
 
+    public function testSaveOrFail()
+    {
+        $date = '1970-01-01';
+        $post = new EloquentTestPost([
+            'user_id' => 1, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date,
+        ]);
+
+        $this->assertTrue($post->saveOrFail());
+        $this->assertEquals(1, EloquentTestPost::count());
+    }
+
+    /**
+     * @expectedException Exception
+     */
+    public function testSaveOrFailWithDuplicatedEntry()
+    {
+        $date = '1970-01-01';
+        EloquentTestPost::create([
+            'id' => 1, 'user_id' => 1, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date,
+        ]);
+
+        $post = new EloquentTestPost([
+            'id' => 1, 'user_id' => 1, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date,
+        ]);
+
+        $post->saveOrFail();
+    }
+
     public function testMultiInsertsWithDifferentValues()
     {
         $date = '1970-01-01';
@@ -470,6 +498,41 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
             }
             $user = EloquentTestUser::first();
             $this->assertEquals('taylor@laravel.com', $user->email);
+        });
+    }
+
+    public function testNestedTransactionsUsingSaveOrFailWillSucceed()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylor@laravel.com']);
+        $this->connection()->transaction(function () use ($user) {
+            try {
+                $user->email = 'otwell@laravel.com';
+                $user->saveOrFail();
+            } catch (Exception $e) {
+                // ignore the exception
+            }
+
+            $user = EloquentTestUser::first();
+            $this->assertEquals('otwell@laravel.com', $user->email);
+            $this->assertEquals(1, $user->id);
+        });
+    }
+
+    public function testNestedTransactionsUsingSaveOrFailWillFails()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylor@laravel.com']);
+        $this->connection()->transaction(function () use ($user) {
+            try {
+                $user->id = 'invalid';
+                $user->email = 'otwell@laravel.com';
+                $user->saveOrFail();
+            } catch (Exception $e) {
+                // ignore the exception
+            }
+
+            $user = EloquentTestUser::first();
+            $this->assertEquals('taylor@laravel.com', $user->email);
+            $this->assertEquals(1, $user->id);
         });
     }
 


### PR DESCRIPTION
This would simplify the following operation:

``` php
try {
    DB::transaction(function () use ($device) {
        $device->save();
    });
} catch (Exception $e) {
    return false;
}
```

to

``` php
try {
    $device->saveOrFail();
} catch (Exception $e) {
    return false;
}
```

Signed-off-by: crynobone crynobone@gmail.com
