### PR TITLE
[5.1] Filesystem tests using virtual file system

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",
         "iron-io/iron_mq": "~2.0",
+        "mikey179/vfsStream": "~1.6",
         "mockery/mockery": "~0.9.2",
         "pda/pheanstalk": "~3.0",
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
This is a proposal to use a virtual file system (everything happens in memory using a stream wrapper) for the Filesystem tests.

A few more tests was also added, like: `testIsFile()`, `testIsDirectory()`, `testLastModified()`.

A side note : This PR doesn't fix anything. It just try to improve the current implementation.

Depends of: https://github.com/mikey179/vfsStream
