### PR TITLE
[5.2] Fix scopes on Builder helpers

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -385,7 +385,7 @@ class Builder
     {
         $extra = $this->addUpdatedAtColumn($extra);
 
-        return $this->query->increment($column, $amount, $extra);
+        return $this->toBase()->increment($column, $amount, $extra);
     }
 
     /**
@@ -400,7 +400,7 @@ class Builder
     {
         $extra = $this->addUpdatedAtColumn($extra);
 
-        return $this->query->decrement($column, $amount, $extra);
+        return $this->toBase()->decrement($column, $amount, $extra);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -282,7 +282,7 @@ class Builder
      */
     public function pluck($column, $key = null)
     {
-        $results = $this->query->pluck($column, $key);
+        $results = $this->toBase()->pluck($column, $key);
 
         // If the model has a mutator for the requested column, we will spin through
         // the results and mutate the values so that the mutated version of these
@@ -325,9 +325,11 @@ class Builder
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
-        $total = $this->query->getCountForPagination();
+        $query = $this->toBase();
 
-        $this->query->forPage(
+        $total = $query->getCountForPagination();
+
+        $query->forPage(
             $page = $page ?: Paginator::resolveCurrentPage($pageName),
             $perPage = $perPage ?: $this->model->getPerPage()
         );

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -113,6 +113,9 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
 
         $query = SoftDeletesTestUser::query();
         $this->assertCount(1, $query->simplePaginate(2)->all());
+
+        $this->assertEquals(0, SoftDeletesTestUser::where('email', 'taylorotwell@gmail.com')->increment('id'));
+        $this->assertEquals(0, SoftDeletesTestUser::where('email', 'taylorotwell@gmail.com')->decrement('id'));
     }
 
     public function testWithTrashedReturnsAllRecords()


### PR DESCRIPTION
This resolves BC break where scopes are not applied with builder helpers (pluck, paginate, increment and decrement).
