### PR TITLE
[5.2] Bump minimum super closure version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "classpreloader/classpreloader": "~3.0",
         "danielstjules/stringy": "~2.1",
         "doctrine/inflector": "~1.0",
-        "jeremeamia/superclosure": "~2.0",
+        "jeremeamia/superclosure": "~2.2",
         "league/flysystem": "~1.0",
         "monolog/monolog": "~1.11",
         "mtdowling/cron-expression": "~1.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -35,7 +35,7 @@
     },
     "suggest": {
         "illuminate/filesystem": "Required to use the composer class (5.2.*).",
-        "jeremeamia/superclosure": "Required to be able to serialize closures (~2.0).",
+        "jeremeamia/superclosure": "Required to be able to serialize closures (~2.2).",
         "paragonie/random_compat": "Provides a compatible interface like PHP7's random_bytes() in PHP 5 projects (~1.1).",
         "symfony/polyfill-php56": "Required to use the hash_equals function on PHP 5.5 (~1.0).",
         "symfony/process": "Required to use the composer class (2.8.*|3.0.*).",


### PR DESCRIPTION
This version is the first to properly support PHP 7. Bumping the version should also speed up composer by giving it fewer versions to examine.
