### PR TITLE
Gelf logging handler for Monolog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,8 @@
         "predis/predis": "Required to use the redis cache and queue drivers (~1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~2.0).",
         "symfony/css-selector": "Required to use some of the crawler integration testing tools (3.1.*).",
-        "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (3.1.*)."
+        "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (3.1.*).",
+        "graylog2/gelf-php": "Required to use Gelf logging transport (~1.4)"
     },
     "minimum-stability": "dev"
 }

--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -109,4 +109,19 @@ class ConfigureLogging
     {
         $log->useErrorLog();
     }
+
+    /**
+     * Configure the Monolog handlers for the application
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Log\Writer  $log
+     */
+    protected function configureGelfHandler(Application $app, Writer $log)
+    {
+        $log->useGelf(
+            $app->make('config')->get('app.log_gelf_host'),
+            $app->make('config')->get('app.log_gelf_port', 12201),
+            $app->make('config')->get('app.log_gelf_protocol', 'udp')
+        );
+    }
 }

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -31,6 +31,16 @@ class LogWriterTest extends PHPUnit_Framework_TestCase
         $writer->useErrorLog();
     }
 
+    public function testGelfLogHandlerCanBeAdded()
+    {
+        if (!class_exists('Gelf\Publisher')) {
+            $this->markTestSkipped('graylog/gelf-php package is not installed');
+        }
+        $writer = new Writer($monolog = m::mock('Monolog\Logger'));
+        $monolog->shouldReceive('pushHandler')->once()->with(m::type('Monolog\Handler\GelfHandler'));
+        $writer->useGelf('localhost');
+    }
+
     public function testMethodsPassErrorAdditionsToMonolog()
     {
         $writer = new Writer($monolog = m::mock('Monolog\Logger'));


### PR DESCRIPTION
This PR is adding support of Gelf log format. It allows to send logs to popular Graylog and Logstash logging servers. I suppose it will be one more step for Laravel towards easy multi-host cloud deployments.

To enable log formatter developer should change config/app.php

``` php
    'log' => 'gelf',
    'log_gelf_host' => '10.0.0.1', // required
    'log_gelf_port' => 12201, // optional, 12201 by default
    'log_gelf_protocol' => 'udp', // optional, "udp" (default) and "tcp" supported
```

To make it work, please make sure you have graylog/gelf-php package installed 

```
composer require graylog/gelf-php
```
