### PR TITLE
[5.1] Gelf logging handler for Monolog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
         "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (~3.0).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.4).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
-        "graylog2/gelf-php": "Required to use Gelf logging transport (~1.4)",
+        "graylog2/gelf-php": "Required to use Gelf logging transport (~1.4).",
         "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers and the ping methods on schedules (~5.3|~6.0).",
         "iron-io/iron_mq": "Required to use the iron queue driver (~2.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",

--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,8 @@
         "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (~3.0).",
         "predis/predis": "Required to use the redis cache and queue drivers (~1.0).",
-        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~2.0)."
+        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~2.0).",
+        "graylog2/gelf-php": "Required to use Gelf logging transport (~1.4)"
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -101,14 +101,14 @@
         "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (~3.0).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.4).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
+        "graylog2/gelf-php": "Required to use Gelf logging transport (~1.4)",
         "guzzlehttp/guzzle": "Required to use the Mailgun and Mandrill mail drivers and the ping methods on schedules (~5.3|~6.0).",
         "iron-io/iron_mq": "Required to use the iron queue driver (~2.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",
         "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (~3.0).",
         "predis/predis": "Required to use the redis cache and queue drivers (~1.0).",
-        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~2.0).",
-        "graylog2/gelf-php": "Required to use Gelf logging transport (~1.4)"
+        "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (~2.0)."
     },
     "minimum-stability": "dev"
 }

--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -109,4 +109,19 @@ class ConfigureLogging
     {
         $log->useErrorLog();
     }
+
+    /**
+     * Configure the Monolog handlers for the application.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Log\Writer  $log
+     */
+    protected function configureGelfHandler(Application $app, Writer $log)
+    {
+        $log->useGelf(
+            $app->make('config')->get('app.log_gelf_host'),
+            $app->make('config')->get('app.log_gelf_port', 12201),
+            $app->make('config')->get('app.log_gelf_protocol', 'udp')
+        );
+    }
 }

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -3,18 +3,18 @@
 namespace Illuminate\Log;
 
 use Closure;
+use Gelf\Publisher;
 use RuntimeException;
 use InvalidArgumentException;
+use Gelf\Transport\TcpTransport;
+use Gelf\Transport\UdpTransport;
+use Monolog\Handler\GelfHandler;
 use Monolog\Handler\SyslogHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger as MonologLogger;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\RotatingFileHandler;
-use Monolog\Handler\GelfHandler;
-use Gelf\Publisher;
-use Gelf\Transport\TcpTransport;
-use Gelf\Transport\UdpTransport;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
@@ -269,7 +269,7 @@ class Writer implements LogContract, PsrLoggerInterface
      * Register a Gelf handler.
      *
      * @param  string  $host
-     * @param  int     $port
+     * @param  int  $port
      * @param  string  $protocol
      * @param  string  $level
      *
@@ -282,7 +282,7 @@ class Writer implements LogContract, PsrLoggerInterface
         } elseif ($protocol === 'tcp') {
             $transport = new TcpTransport($host, $port);
         } else {
-            throw new \RuntimeException('Gelf transport supports only tcp and udp protocols. Invalid protocol passed.');
+            throw new RuntimeException('Gelf transport supports only tcp and udp protocols. Invalid protocol passed.');
         }
 
         return $this->monolog->pushHandler(

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -272,7 +272,6 @@ class Writer implements LogContract, PsrLoggerInterface
      * @param  int  $port
      * @param  string  $protocol
      * @param  string  $level
-     *
      * @return \Psr\Log\LoggerInterface
      */
     public function useGelf($host, $port = 12201, $protocol = 'udp', $level = 'debug')

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -11,6 +11,10 @@ use Monolog\Logger as MonologLogger;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\RotatingFileHandler;
+use Monolog\Handler\GelfHandler;
+use Gelf\Publisher;
+use Gelf\Transport\TcpTransport;
+use Gelf\Transport\UdpTransport;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
@@ -259,6 +263,31 @@ class Writer implements LogContract, PsrLoggerInterface
         );
 
         $handler->setFormatter($this->getDefaultFormatter());
+    }
+
+    /**
+     * Register a Gelf handler.
+     *
+     * @param  string  $host
+     * @param  int     $port
+     * @param  string  $protocol
+     * @param  string  $level
+     *
+     * @return \Psr\Log\LoggerInterface
+     */
+    public function useGelf($host, $port = 12201, $protocol = 'udp', $level = 'debug')
+    {
+        if ($protocol === 'udp') {
+            $transport = new UdpTransport($host, $port);
+        } elseif ($protocol === 'tcp') {
+            $transport = new TcpTransport($host, $port);
+        } else {
+            throw new \RuntimeException('Gelf transport supports only tcp and udp protocols. Invalid protocol passed.');
+        }
+
+        return $this->monolog->pushHandler(
+            new GelfHandler(new Publisher($transport), $this->parseLevel($level))
+        );
     }
 
     /**

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -34,11 +34,24 @@ class LogWriterTest extends PHPUnit_Framework_TestCase
     public function testGelfLogHandlerCanBeAdded()
     {
         if (! class_exists('Gelf\Publisher')) {
-            $this->markTestSkipped('graylog/gelf-php package is not installed');
+            $this->markTestSkipped('graylog2/gelf-php package is not installed.');
         }
         $writer = new Writer($monolog = m::mock('Monolog\Logger'));
         $monolog->shouldReceive('pushHandler')->once()->with(m::type('Monolog\Handler\GelfHandler'));
         $writer->useGelf('localhost');
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testGelfLogHandlerFailsWithInvalidProtocol()
+    {
+        if (! class_exists('Gelf\Publisher')) {
+            $this->markTestSkipped('graylog2/gelf-php package is not installed.');
+        }
+
+        $writer = new Writer($monolog = m::mock('Monolog\Logger'));
+        $writer->useGelf('localhost', 12201, 'http');
     }
 
     public function testMethodsPassErrorAdditionsToMonolog()

--- a/tests/Log/LogWriterTest.php
+++ b/tests/Log/LogWriterTest.php
@@ -31,6 +31,16 @@ class LogWriterTest extends PHPUnit_Framework_TestCase
         $writer->useErrorLog();
     }
 
+    public function testGelfLogHandlerCanBeAdded()
+    {
+        if (! class_exists('Gelf\Publisher')) {
+            $this->markTestSkipped('graylog/gelf-php package is not installed');
+        }
+        $writer = new Writer($monolog = m::mock('Monolog\Logger'));
+        $monolog->shouldReceive('pushHandler')->once()->with(m::type('Monolog\Handler\GelfHandler'));
+        $writer->useGelf('localhost');
+    }
+
     public function testMethodsPassErrorAdditionsToMonolog()
     {
         $writer = new Writer($monolog = m::mock('Monolog\Logger'));


### PR DESCRIPTION
This PR is adding support of Gelf log format. It allows to send logs to popular Graylog and Logstash logging servers. I suppose it will be one more step for Laravel towards easy multi-host cloud deployments.

To enable log formatter developer should change config/app.php

``` php
    'log' => 'gelf',
    'log_gelf_host' => '10.0.0.1', // required
    'log_gelf_port' => 12201, // optional, 12201 by default
    'log_gelf_protocol' => 'udp', // optional, "udp" (default) and "tcp" supported
```

To make it work, please make sure you have graylog/gelf-php package installed 

```
composer require graylog2/gelf-php
```
