### PR TITLE
[5.2] Cleanup scope nesting

### DIFF
--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -399,7 +399,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $model = new EloquentBuilderTestNestedStub;
         $this->mockConnectionForModel($model, 'SQLite');
         $query = $model->newQuery()->where('foo', '=', 'bar')->where(function ($query) { $query->where('baz', '>', 9000); });
-        $this->assertEquals('select * from "table" where ("foo" = ? and ("baz" > ?)) and ("table"."deleted_at" is null)', $query->toSql());
+        $this->assertEquals('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
         $this->assertEquals(['bar', 9000], $query->getBindings());
     }
 
@@ -408,7 +408,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $model = new EloquentBuilderTestNestedStub;
         $this->mockConnectionForModel($model, 'SQLite');
         $query = $model->newQuery()->empty()->where('foo', '=', 'bar')->empty()->where(function ($query) { $query->empty()->where('baz', '>', 9000); });
-        $this->assertEquals('select * from "table" where ("foo" = ? and ("baz" > ?)) and ("table"."deleted_at" is null)', $query->toSql());
+        $this->assertEquals('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
         $this->assertEquals(['bar', 9000], $query->getBindings());
     }
 

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -70,7 +70,7 @@ class DatabaseEloquentGlobalScopesTest extends PHPUnit_Framework_TestCase
         $model = new EloquentClosureGlobalScopesWithOrTestModel();
 
         $query = $model->newQuery()->where('col1', 'val1')->orWhere('col2', 'val2');
-        $this->assertEquals('select "email", "password" from "table" where ("col1" = ? or "col2" = ?) and ("email" = ? or "email" = ?) and ("active" = ?) order by "name" asc', $query->toSql());
+        $this->assertEquals('select "email", "password" from "table" where ("col1" = ? or "col2" = ?) and ("email" = ? or "email" = ?) and "active" = ? order by "name" asc', $query->toSql());
         $this->assertEquals(['val1', 'val2', 'taylor@gmail.com', 'someone@else.com', 1], $query->getBindings());
     }
 


### PR DESCRIPTION
Changes:
- use `toBase()` instead of `applyScopes()->getQuery()`
- simplify `nestWheresForScope()` so that you don't need to pass through the first (0) and last (total count) offset - only pass the position where you want to split where clauses.
- change parameter order for `shouldNestWheresForScope()` to match `nestWheresForScope()`
- check each slice of wheres if it needs to be nested to avoid unnecessary parenthesis (this ensures we never nest if not needed).
