### PR TITLE
[5.2] Model casting to any object

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2813,11 +2813,24 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function castAttribute($key, $value)
     {
+        $castType = $this->getCastType($key);
+        $isResolvable = class_exists($this->casts[$key]) || in_array($key, app()->getBindings());
+
+        // Some objects aren't stored as json so we'll skip those
+        // here so they'll get handled accordingly later
+        if (! in_array($castType, ['date', 'datetime']) && $isResolvable) {
+            if ($value !== null) {
+                $value = $this->fromJson($value);
+            }
+
+            return app($this->casts[$key], [$value]);
+        }
+
         if (is_null($value)) {
             return $value;
         }
 
-        switch ($this->getCastType($key)) {
+        switch ($castType) {
             case 'int':
             case 'integer':
                 return (int) $value;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3,6 +3,7 @@
 use Mockery as m;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Fluent;
 
 class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 {
@@ -1175,6 +1176,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model->ninth = '1969-07-20';
         $model->tenth = '1969-07-20 22:56:00';
         $model->eleventh = '1969-07-20 22:56:00';
+        $model->twelfth = ['foo' => 'bar'];
 
         $this->assertInternalType('int', $model->first);
         $this->assertInternalType('float', $model->second);
@@ -1184,6 +1186,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertInternalType('object', $model->sixth);
         $this->assertInternalType('array', $model->seventh);
         $this->assertInternalType('array', $model->eighth);
+        $this->assertInternalType('array', $model->twelfth);
         $this->assertTrue($model->fourth);
         $this->assertFalse($model->fifth);
         $this->assertEquals($obj, $model->sixth);
@@ -1195,6 +1198,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('1969-07-20', $model->ninth->toDateString());
         $this->assertEquals('1969-07-20 22:56:00', $model->tenth->toDateTimeString());
         $this->assertEquals(-14173440, $model->eleventh);
+        $this->assertInstanceOf(Fluent::class);
 
         $arr = $model->toArray();
         $this->assertInternalType('int', $arr['first']);
@@ -1204,7 +1208,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertInternalType('boolean', $arr['fifth']);
         $this->assertInternalType('object', $arr['sixth']);
         $this->assertInternalType('array', $arr['seventh']);
-        $this->assertInternalType('array', $arr['eighth']);
+        $this->assertInternalType('array', $arr['twelfth']);
         $this->assertTrue($arr['fourth']);
         $this->assertFalse($arr['fifth']);
         $this->assertEquals($obj, $arr['sixth']);
@@ -1215,6 +1219,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('1969-07-20', $arr['ninth']->toDateString());
         $this->assertEquals('1969-07-20 22:56:00', $arr['tenth']->toDateTimeString());
         $this->assertEquals(-14173440, $arr['eleventh']);
+        $this->assertEquals(['foo' => 'bar'], $arr['twelfth']);
     }
 
     public function testModelAttributeCastingPreservesNull()
@@ -1523,6 +1528,7 @@ class EloquentModelCastingStub extends Model
         'ninth' => 'date',
         'tenth' => 'datetime',
         'eleventh' => 'timestamp',
+        'twelfth' => Fluent::class,
     ];
 
     public function eighthAttributeValue()


### PR DESCRIPTION
The intended functionality of this PR is to provide the ability to cast to any object.  A great example of where this would be useful is user settings when they are stored as json in a `users.settings` column.  Having the json converted to an object allows one to easily define the default values for settings and a streamlined method of accessing these settings.

Here's an example:

``` php
class User extends Model {
    protected $casts = [
        'settings' => Settings::class
    ];
}
```

``` php
class Settings extends Fluent
{
    public function __construct($attributes = [])
    {
        if (!is_null($attributes)) {
            parent::__construct($attributes);
        }
    }

    public function timeszone()
    {
        return $this->get('timezone', 'America/Kentucky/Louisville');
    }
}
```

Currently I'm experiencing an issue with a unit test am I'm unsure how to mock `app()`.  Thus a test is failing:

```
PHP Fatal error:  Call to a member function getBindings() on null in /Users/bkuhl/Personal/framework/src/Illuminate/Database/Eloquent/Model.php on line 2825
```

I'd like to add another assertion or two once I can get passed this issue.
