### PR TITLE
[5.1] Fix queue:retry command quotes

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -60,9 +60,9 @@ class RetryCommand extends Command
 
             $this->laravel['queue.failer']->forget($failed->id);
 
-            $this->info('The failed job [{$id}] has been pushed back onto the queue!');
+            $this->info("The failed job [{$id}] has been pushed back onto the queue!");
         } else {
-            $this->error('No failed job matches the given ID [{$id}].');
+            $this->error("No failed job matches the given ID [{$id}].");
         }
     }
 


### PR DESCRIPTION
Same as https://github.com/laravel/framework/commit/5a3071b3e0a402c36cfdbee3b7d7d05f9785adcf, but target to 5.1.
