### PR TITLE
Allow saveMany() to accept Collections as first parameter

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -559,11 +559,11 @@ class BelongsToMany extends Relation
     /**
      * Save an array of new models and attach them to the parent model.
      *
-     * @param  array  $models
+     * @param  \Illuminate\Support\Collection|array  $models
      * @param  array  $joinings
      * @return array
      */
-    public function saveMany(array $models, array $joinings = [])
+    public function saveMany($models, array $joinings = [])
     {
         foreach ($models as $key => $model) {
             $this->save($model, (array) Arr::get($joinings, $key), false);


### PR DESCRIPTION
Currently, when using `saveMany()` in a seeding/model factory context, you have to use `create()` and then call `all()` on the returned Collection. This PR makes it to where you can just call `create()`:

``` php
$people->each(function ($person, $key) {
    $person->contacts()->saveMany(factory(Contact::class, 5)->create());
});
```
