### PR TITLE
[5.1] Use UTC on Eloquent Model's test

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -316,6 +316,8 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
     public function testFromDateTime()
     {
+        date_default_timezone_set('UTC');
+
         $model = new EloquentModelStub();
 
         $value = Carbon\Carbon::parse('2015-04-17 22:59:01');


### PR DESCRIPTION
This PR prevent the use of a wrong timezone in Model's test.
In my case the default timezone was Europe/Berlin and did fail the test.

![schermata 2015-12-07 alle 12 37 51](https://cloud.githubusercontent.com/assets/779534/11626174/02f48352-9ce1-11e5-87b0-6ec005cfb37d.png)
