### PR TITLE
[5.1] Allow "message" key as mail parameter

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -163,7 +163,7 @@ class Mailer implements MailerContract, MailQueueContract
         // be used when sending an e-mail. We will extract both of them out here.
         list($view, $plain, $raw) = $this->parseView($view);
 
-        $data['message'] = $message = $this->createMessage();
+        $data['__message'] = $message = $this->createMessage();
 
         // Once we have retrieved the view content for the e-mail we will set the body
         // of this message using the HTML type, which will provide a simple wrapper

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -17,7 +17,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         $message = m::mock('Swift_Mime_Message');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock('StdClass');
-        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', '__message' => $message])->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
         $message->shouldReceive('setFrom')->never();
@@ -35,8 +35,8 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         $message = m::mock('Swift_Mime_Message');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock('StdClass');
-        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
-        $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message])->andReturn($view);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', '__message' => $message])->andReturn($view);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', '__message' => $message])->andReturn($view);
         $view->shouldReceive('render')->twice()->andReturn('rendered.view');
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
         $message->shouldReceive('addPart')->once()->with('rendered.view', 'text/plain');
@@ -55,8 +55,8 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         $message = m::mock('Swift_Mime_Message');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock('StdClass');
-        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
-        $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message])->andReturn($view);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', '__message' => $message])->andReturn($view);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', '__message' => $message])->andReturn($view);
         $view->shouldReceive('render')->twice()->andReturn('rendered.view');
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
         $message->shouldReceive('addPart')->once()->with('rendered.view', 'text/plain');
@@ -125,7 +125,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
         $message = m::mock('Swift_Mime_Message');
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock('StdClass');
-        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', '__message' => $message])->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
         $message->shouldReceive('setFrom')->never();
@@ -154,7 +154,7 @@ class MailMailerTest extends PHPUnit_Framework_TestCase
             return $mockMailer;
         });
         $mockMailer->shouldReceive('mail')->once()->with($message);
-        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', '__message' => $message])->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
         $message->shouldReceive('setFrom')->never();


### PR DESCRIPTION
Fix https://github.com/laravel/framework/issues/11236
