### PR TITLE
[5.1] Update SqlServerGrammer to support microseconds

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -249,7 +249,7 @@ class SqlServerGrammar extends Grammar
      */
     public function getDateFormat()
     {
-        return 'Y-m-d H:i:s.000';
+        return 'Y-m-d H:i:s.u';
     }
 
     /**


### PR DESCRIPTION
Taylor Requested a Pull Request to fix #1756
In short, this improves functionality but does not solve all problems.

Long Version:
This causes microsecond characters from SQL Server to be brought in.  This works for datetime fields which have 3 digits.  The old code assumed microseconds would be 0.  This code preserves them and doesn't break if they aren't 0.
This code, however, still does not work for datetime2 fields which have 7 digits of microseconds (or whatever a 7 digit second part is called) because PHP only supports 6 digits of precision.  I'm not sure how to have it ignore the last character without introducing extra symbols into the output date format.  For input `Y-m-d H:i:s.u+` works to ignore the last digit, but that introduces an unneeded `+` in output since the same format is used for input and output conversion.  Laravel creates datetime fields from eloquent so that reduces this issue, but datetime2 is the proper sql server field to use so people may run into it later.)

(Probably also referenced by: https://github.com/briannesbitt/Carbon/issues/331)
