### PR TITLE
[5.2] passesAuthorization() should not call authorize() (?)

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -18,6 +18,13 @@ class FormRequest extends Request implements ValidatesWhenResolved
     use ValidatesWhenResolvedTrait;
 
     /**
+     * Contains return of authorize method
+     *
+     * @var bool
+     */
+    protected $passesAuthorization;
+
+    /**
      * The container instance.
      *
      * @var \Illuminate\Container\Container
@@ -104,8 +111,10 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function passesAuthorization()
     {
-        if (method_exists($this, 'authorize')) {
-            return $this->container->call([$this, 'authorize']);
+        if (!$this->passesAuthorization) {
+            return false;
+        } elseif (method_exists($this, 'authorize')) {
+            $this->authorize();
         }
 
         return false;

--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -10,6 +10,14 @@ use Illuminate\Contracts\Validation\UnauthorizedException;
  */
 trait ValidatesWhenResolvedTrait
 {
+
+    /**
+     * Contains return of authorize method
+     *
+     * @var bool
+     */
+    protected $passesAuthorization;
+
     /**
      * Validate the class instance.
      *
@@ -54,8 +62,10 @@ trait ValidatesWhenResolvedTrait
      */
     protected function passesAuthorization()
     {
-        if (method_exists($this, 'authorize')) {
-            return $this->authorize();
+        if (!$this->passesAuthorization) {
+            return false;
+        } elseif (method_exists($this, 'authorize')) {
+            $this->authorize();
         }
 
         return true;


### PR DESCRIPTION
passesAuthorization() calls upon authorize(), which seems to recursively call back passesAuthorization(). I envision authorize() actually setting a protected member as a bool, that that's what passesAuthorization() is the acting getter for.

basically, should passesAuthorization() actually be calling authorize()?
