### PR TITLE
[5.1] Guard::clearUserDataFromStorage() checks if "remember me" cookie exists before enqueing it for deletion

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -571,9 +571,20 @@ class Guard implements GuardContract
     {
         $this->session->remove($this->getName());
 
-        $recaller = $this->getRecallerName();
+        $this->forgetRecallerCookieIfExists();
+    }
 
-        $this->getCookieJar()->queue($this->getCookieJar()->forget($recaller));
+    /**
+     * Enqueue recaller cookie for deletion if the cookie exists.
+     *
+     * @return void
+     */
+    protected function forgetRecallerCookieIfExists()
+    {
+        if (! is_null($this->getRecaller())) {
+            $recaller = $this->getRecallerName();
+            $this->getCookieJar()->queue($this->getCookieJar()->forget($recaller));
+        }
     }
 
     /**

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -151,17 +151,36 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
     public function testLogoutRemovesSessionTokenAndRememberMeCookie()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $mock = $this->getMock('Illuminate\Auth\Guard', ['getName', 'getRecallerName'], [$provider, $session, $request]);
+        $mock = $this->getMock('Illuminate\Auth\Guard', ['getName', 'getRecallerName', 'getRecaller'], [$provider, $session, $request]);
         $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
         $user->shouldReceive('setRememberToken')->once();
         $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
         $mock->expects($this->once())->method('getRecallerName')->will($this->returnValue('bar'));
+        $mock->expects($this->once())->method('getRecaller')->will($this->returnValue('non-null-cookie'));
         $provider->shouldReceive('updateRememberToken')->once();
 
         $cookie = m::mock('Symfony\Component\HttpFoundation\Cookie');
         $cookies->shouldReceive('forget')->once()->with('bar')->andReturn($cookie);
         $cookies->shouldReceive('queue')->once()->with($cookie);
+        $mock->getSession()->shouldReceive('remove')->once()->with('foo');
+        $mock->setUser($user);
+        $mock->logout();
+        $this->assertNull($mock->getUser());
+    }
+
+    public function testLogoutDoesNotEnqueueRememberMeCookieForDeletionIfCookieDoesntExist()
+    {
+        list($session, $provider, $request, $cookie) = $this->getMocks();
+        $mock = $this->getMock('Illuminate\Auth\Guard', ['getName', 'getRecaller'], [$provider, $session, $request]);
+        $mock->setCookieJar($cookies = m::mock('Illuminate\Cookie\CookieJar'));
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $user->shouldReceive('setRememberToken')->once();
+        $mock->expects($this->once())->method('getName')->will($this->returnValue('foo'));
+        $mock->expects($this->once())->method('getRecaller')->will($this->returnValue(null));
+        $provider->shouldReceive('updateRememberToken')->once();
+
+        $cookie = m::mock('Symfony\Component\HttpFoundation\Cookie');
         $mock->getSession()->shouldReceive('remove')->once()->with('foo');
         $mock->setUser($user);
         $mock->logout();

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -180,7 +180,6 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $mock->expects($this->once())->method('getRecaller')->will($this->returnValue(null));
         $provider->shouldReceive('updateRememberToken')->once();
 
-        $cookie = m::mock('Symfony\Component\HttpFoundation\Cookie');
         $mock->getSession()->shouldReceive('remove')->once()->with('foo');
         $mock->setUser($user);
         $mock->logout();


### PR DESCRIPTION
Addresses #10896.
