### PR TITLE
[5.1] ResetsPasswords removed redirectPath() and implemented redirectUsers

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 trait ResetsPasswords
 {
     use RedirectUsers;
-    
+
     /**
      * Display the form to request a password reset link.
      *

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -10,6 +10,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 trait ResetsPasswords
 {
+    use RedirectUsers;
+    
     /**
      * Display the form to request a password reset link.
      *
@@ -115,19 +117,5 @@ trait ResetsPasswords
         $user->save();
 
         Auth::login($user);
-    }
-
-    /**
-     * Get the post password reset redirect path.
-     *
-     * @return string
-     */
-    public function redirectPath()
-    {
-        if (property_exists($this, 'redirectPath')) {
-            return $this->redirectPath;
-        }
-
-        return property_exists($this, 'redirectTo') ? $this->redirectTo : '/home';
     }
 }


### PR DESCRIPTION
Not sure how often people would run into this but it seems the redirectUsers trait was created to avoid duplicating the redirectPath() method. ~~This change will make it so we no longer have to resolve naming conflicts~~ Still have to deal with conflict resolution but atleast we dont have a duplicate method in resetsPasswords anymore :)

use AuthenticatesUsers, ThrottlesLogins, ResetsPasswords {
    AuthenticatesUsers::redirectPath insteadof ResetsPasswords;
}
