### PR TITLE
[5.2] Use random_int rather than mt_rand

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -159,7 +159,7 @@ class StartSession
      */
     protected function configHitsLottery(array $config)
     {
-        return mt_rand(1, $config['lottery'][1]) <= $config['lottery'][0];
+        return random_int(1, $config['lottery'][1]) <= $config['lottery'][0];
     }
 
     /**


### PR DESCRIPTION
Not only is it more "random", but it's actually faster.

NB Sent to 5.2 rather than 5.1 because it's a BC break for php 5 users using the session component as a a stand alone component due to the new suggested dependency to bring that php 7 function in for use.
