### PR TITLE
[5.2] Stop supporting badly formatted class names

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -120,8 +120,6 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function when($concrete)
     {
-        $concrete = $this->normalize($concrete);
-
         return new ContextualBindingBuilder($this, $concrete);
     }
 
@@ -133,8 +131,6 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function bound($abstract)
     {
-        $abstract = $this->normalize($abstract);
-
         return isset($this->bindings[$abstract]) || isset($this->instances[$abstract]) || $this->isAlias($abstract);
     }
 
@@ -146,8 +142,6 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function resolved($abstract)
     {
-        $abstract = $this->normalize($abstract);
-
         if ($this->isAlias($abstract)) {
             $abstract = $this->getAlias($abstract);
         }
@@ -163,7 +157,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function isAlias($name)
     {
-        return isset($this->aliases[$this->normalize($name)]);
+        return isset($this->aliases[$name]);
     }
 
     /**
@@ -176,10 +170,6 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function bind($abstract, $concrete = null, $shared = false)
     {
-        $abstract = $this->normalize($abstract);
-
-        $concrete = $this->normalize($concrete);
-
         // If the given types are actually an array, we will assume an alias is being
         // defined and will grab this "real" abstract class name and register this
         // alias with the container so that it can be used as a shortcut for it.
@@ -241,7 +231,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function addContextualBinding($concrete, $abstract, $implementation)
     {
-        $this->contextual[$this->normalize($concrete)][$this->normalize($abstract)] = $this->normalize($implementation);
+        $this->contextual[$concrete][$abstract] = $implementation;
     }
 
     /**
@@ -304,7 +294,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function extend($abstract, Closure $closure)
     {
-        $abstract = $this->normalize($abstract);
+        $abstract = $abstract;
 
         if (isset($this->instances[$abstract])) {
             $this->instances[$abstract] = $closure($this->instances[$abstract], $this);
@@ -324,7 +314,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function instance($abstract, $instance)
     {
-        $abstract = $this->normalize($abstract);
+        $abstract = $abstract;
 
         // First, we will extract the alias from the abstract if it is an array so we
         // are using the correct name when binding the type. If we get an alias it
@@ -366,7 +356,7 @@ class Container implements ArrayAccess, ContainerContract
             }
 
             foreach ((array) $abstracts as $abstract) {
-                $this->tags[$tag][] = $this->normalize($abstract);
+                $this->tags[$tag][] = $abstract;
             }
         }
     }
@@ -399,7 +389,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function alias($abstract, $alias)
     {
-        $this->aliases[$alias] = $this->normalize($abstract);
+        $this->aliases[$alias] = $abstract;
     }
 
     /**
@@ -422,7 +412,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function rebinding($abstract, Closure $callback)
     {
-        $this->reboundCallbacks[$this->normalize($abstract)][] = $callback;
+        $this->reboundCallbacks[$abstract][] = $callback;
 
         if ($this->bound($abstract)) {
             return $this->make($abstract);
@@ -439,7 +429,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function refresh($abstract, $target, $method)
     {
-        return $this->rebinding($this->normalize($abstract), function ($app, $instance) use ($target, $method) {
+        return $this->rebinding($abstract, function ($app, $instance) use ($target, $method) {
             $target->{$method}($instance);
         });
     }
@@ -613,7 +603,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function make($abstract, array $parameters = [])
     {
-        $abstract = $this->getAlias($this->normalize($abstract));
+        $abstract = $this->getAlias($abstract);
 
         // If an instance of the type is currently being managed as a singleton we'll
         // just return an existing instance instead of instantiating new instances
@@ -687,17 +677,6 @@ class Container implements ArrayAccess, ContainerContract
         if (isset($this->contextual[end($this->buildStack)][$abstract])) {
             return $this->contextual[end($this->buildStack)][$abstract];
         }
-    }
-
-    /**
-     * Normalize the given class name by removing leading slashes.
-     *
-     * @param  mixed  $service
-     * @return mixed
-     */
-    protected function normalize($service)
-    {
-        return is_string($service) ? ltrim($service, '\\') : $service;
     }
 
     /**
@@ -881,7 +860,7 @@ class Container implements ArrayAccess, ContainerContract
         if ($callback === null && $abstract instanceof Closure) {
             $this->resolvingCallback($abstract);
         } else {
-            $this->resolvingCallbacks[$this->normalize($abstract)][] = $callback;
+            $this->resolvingCallbacks[$abstract][] = $callback;
         }
     }
 
@@ -897,7 +876,7 @@ class Container implements ArrayAccess, ContainerContract
         if ($abstract instanceof Closure && $callback === null) {
             $this->afterResolvingCallback($abstract);
         } else {
-            $this->afterResolvingCallbacks[$this->normalize($abstract)][] = $callback;
+            $this->afterResolvingCallbacks[$abstract][] = $callback;
         }
     }
 
@@ -1028,8 +1007,6 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function isShared($abstract)
     {
-        $abstract = $this->normalize($abstract);
-
         if (isset($this->bindings[$abstract]['shared'])) {
             $shared = $this->bindings[$abstract]['shared'];
         } else {
@@ -1091,7 +1068,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function forgetInstance($abstract)
     {
-        unset($this->instances[$this->normalize($abstract)]);
+        unset($this->instances[$abstract]);
     }
 
     /**
@@ -1146,7 +1123,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function offsetExists($key)
     {
-        return isset($this->bindings[$this->normalize($key)]);
+        return isset($this->bindings[$key]);
     }
 
     /**
@@ -1189,8 +1166,6 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function offsetUnset($key)
     {
-        $key = $this->normalize($key);
-
         unset($this->bindings[$key], $this->instances[$key], $this->resolved[$key]);
     }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -34,13 +34,6 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ContainerConcreteStub', $container->make('ContainerConcreteStub'));
     }
 
-    public function testSlashesAreHandled()
-    {
-        $container = new Container;
-        $container->bind('\Foo', function () { return 'hello'; });
-        $this->assertEquals('hello', $container->make('Foo'));
-    }
-
     public function testParametersCanOverrideDependencies()
     {
         $container = new Container;
@@ -445,31 +438,6 @@ return $obj; });
 
         $this->assertInstanceOf('ContainerImplementationStub', $one->impl);
         $this->assertInstanceOf('ContainerImplementationStubTwo', $two->impl);
-    }
-
-    public function testContextualBindingWorksRegardlessOfLeadingBackslash()
-    {
-        $container = new Container;
-
-        $container->bind('IContainerContractStub', 'ContainerImplementationStub');
-
-        $container->when('\ContainerTestContextInjectOne')->needs('IContainerContractStub')->give('ContainerImplementationStubTwo');
-        $container->when('ContainerTestContextInjectTwo')->needs('\IContainerContractStub')->give('ContainerImplementationStubTwo');
-
-        $this->assertInstanceOf(
-            'ContainerImplementationStubTwo',
-            $container->make('ContainerTestContextInjectOne')->impl
-        );
-
-        $this->assertInstanceOf(
-            'ContainerImplementationStubTwo',
-            $container->make('ContainerTestContextInjectTwo')->impl
-        );
-
-        $this->assertInstanceOf(
-            'ContainerImplementationStubTwo',
-            $container->make('\ContainerTestContextInjectTwo')->impl
-        );
     }
 
     public function testContainerTags()


### PR DESCRIPTION
Class names are defined without a leading slash. Anyone that tries to include one is wrong. Their only purpose is to escape the namespace in actual code.

This yields a large performance improvement in an out of the box laravel app.
