### PR TITLE
[5.1] Use tinyint(1) for boolean type definition

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -437,7 +437,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function typeBoolean(Fluent $column)
     {
-        return 'tinyint';
+        return 'tinyint(1)';
     }
 
     /**

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -324,7 +324,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" add column "foo" tinyint not null', $statements[0]);
+        $this->assertEquals('alter table "users" add column "foo" tinyint(1) not null', $statements[0]);
     }
 
     public function testAddingEnum()


### PR DESCRIPTION
Using tinyint(1) instead of just tinyint for SQLite boolean type works better. SQLite doesn't natively support boolean data type. A tinyint field without a size could be an integer but when using tinyint(1) then it's much safer to treat this as boolean.

Currently when I am running my app using MySql database I can easily identify my boolean fields with the type tinyint(1). However, when running my app using SQLite the same field shows up with type tinyint. So, basically getting different results when switching databases.
