### PR TITLE
[5.2] Allow the use of wildcards to forget array item

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -203,6 +203,12 @@ class Arr
             while (count($parts) > 1) {
                 $part = array_shift($parts);
 
+                if ($part === '*') {
+                    foreach ($array as &$item) {
+                        static::forget($item, implode('.', $parts));
+                    }
+                }
+
                 if (isset($array[$part]) && is_array($array[$part])) {
                     $array = &$array[$part];
                 } else {
@@ -210,7 +216,13 @@ class Arr
                 }
             }
 
-            unset($array[array_shift($parts)]);
+            $first = array_shift($parts);
+
+            if ($first === '*') {
+                $array = null;
+            }
+
+            unset($array[$first]);
         }
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -311,5 +311,13 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $array = ['products' => ['desk' => ['price' => 50], null => 'something']];
         Arr::forget($array, ['products.amount.all', 'products.desk.price']);
         $this->assertEquals(['products' => ['desk' => [], null => 'something']], $array);
+
+        $array = ['products' => ['desk' => ['id' => 1, 'price' => 50], 'note' => ['id' => 2, 'price' => 100]]];
+        Arr::forget($array, 'products.*.id');
+        $this->assertEquals(['products' => ['desk' => ['price' => 50], 'note' => ['price' => 100]]], $array);
+
+        $array = ['products' => ['desk' => ['id' => 1, 'price' => 50, 'taxes' => ['id' => 1, 'value' => 10]], 'note' => ['id' => 2, 'price' => 100]]];
+        Arr::forget($array, ['products.*.id', 'products.*.*.id']);
+        $this->assertEquals(['products' => ['desk' => ['price' => 50, 'taxes' => ['value' => 10]], 'note' => ['price' => 100]]], $array);
     }
 }


### PR DESCRIPTION
This PR allows the use of wildcards to forget items of an array

Examples:

``` php
    $array = [
        'products' => [
            'desk' => [
                'id' => 1,
                'price' => 50,
                'taxes' => [
                    'id' => 1,
                    'value' => 10
                ]
            ],
            'notebook' => [
                'id' => 2,
                'price' => 100,
                'taxes' => [
                    'id' => 1,
                    'value' => 50
                ],
                'something' => []
            ]
        ]
    ];

    Arr::forget($array, 'products.*.something');
    //[
    //    'products' => [
    //        'desk' => [
    //            'id' => 1,
    //            'price' => 50,
    //            'taxes' => [
    //                'id' => 1,
    //                'value' => 10,
    //            ],
    //        ],
    //        'notebook' => [
    //            'id' => 2,
    //            'price' => 100,
    //            'taxes' => [
    //                'id' => 1,
    //                'value' => 50,
    //            ],
    //        ],
    //    ],
    //]

    Arr::forget($array, 'products.*.taxes.*');
    //[
    //    'products' => [
    //        'desk' => [
    //            'id' => 1,
    //            'price' => 50,
    //            'taxes' => null
    //        ],
    //        'notebook' => [
    //            'id' => 2,
    //            'price' => 100,
    //            'taxes' => null,
    //            'something' => []
    //        ],
    //    ],
    //]

    Arr::forget($array, ['products.*.id', 'products.*.*.id']);
    //[
    //    'products' => [
    //        'desk' => [
    //            'price' => 50,
    //            'taxes' => [
    //                'value' => 10,
    //            ],
    //        ],
    //        'notebook' => [
    //            'price' => 100,
    //            'taxes' => [
    //                'value' => 50,
    //            ],
    //        ],
    //    ],
    //]

    Arr::forget($array, ['products.*.something', 'products.*.*.id']);
    //[
    //    'products' => [
    //        'desk' => [
    //            'id' => 1,
    //            'price' => 50,
    //            'taxes' => [
    //                'value' => 10,
    //            ],
    //        ],
    //        'notebook' => [
    //            'id' => 2,
    //            'price' => 100,
    //            'taxes' => [
    //                'value' => 50,
    //            ],
    //        ],
    //    ],
    //]
```

> This is my proposal, it may not be the best way to implement, but I would give the cutting edge initial foot.
