### PR TITLE
[5.1] ServiceProvider::loadViewsFrom() transforms namespace dots to folder structure

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -78,46 +78,13 @@ abstract class ServiceProvider
         $appBasePath = $this->app->basePath();
         $namespacePath = str_replace('.', '/', $namespace);
 
-        $overridingPath = $this->getValidDirectory([
-            "{$appBasePath}/resources/views/vendor/{$namespace}",
-            "{$appBasePath}/resources/views/vendor/{$namespacePath}",
-        ]);
-
-        if ($overridingPath !== null) {
-            $this->app['view']->addNamespace($namespace, $overridingPath);
+        if ($this->app['files']->isDirectory($appPath = "{$appBasePath}/resources/views/vendor/{$namespace}")) {
+            $this->app['view']->addNamespace($namespace, $appPath);
+        } elseif ($this->app['files']->isDirectory($appPath = "{$appBasePath}/resources/views/vendor/{$namespacePath}")) {
+            $this->app['view']->addNamespace($namespace, $appPath);
         }
 
         $this->app['view']->addNamespace($namespace, $path);
-    }
-
-    /**
-     * Checks whether there exists a valid directory in the given
-     * array and returns the directory path.
-     * It stops searching after the first valid directory is found.
-     * Returns null if it doesn't find any valid directory.
-     *
-     * @param  array  $paths
-     * @return string|null
-     */
-    protected function getValidDirectory(array $paths)
-    {
-        foreach ($paths as $path) {
-            if ($this->isValidDirectory($path)) {
-                return $path;
-            }
-        }
-
-        return;
-    }
-
-    /**
-     * Check if the given path is a valid directory.
-     * @param  string $path
-     * @return bool
-     */
-    protected function isValidDirectory($path)
-    {
-        return is_dir($path);
     }
 
     /**

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -75,11 +75,49 @@ abstract class ServiceProvider
      */
     protected function loadViewsFrom($path, $namespace)
     {
-        if (is_dir($appPath = $this->app->basePath().'/resources/views/vendor/'.$namespace)) {
-            $this->app['view']->addNamespace($namespace, $appPath);
+        $appBasePath = $this->app->basePath();
+        $namespacePath = str_replace('.', '/', $namespace);
+
+        $overridingPath = $this->getValidDirectory([
+            "{$appBasePath}/resources/views/vendor/{$namespace}",
+            "{$appBasePath}/resources/views/vendor/{$namespacePath}",
+        ]);
+
+        if ($overridingPath !== null) {
+            $this->app['view']->addNamespace($namespace, $overridingPath);
         }
 
         $this->app['view']->addNamespace($namespace, $path);
+    }
+
+    /**
+     * Checks whether there exists a valid directory in the given
+     * array and returns the directory path.
+     * It stops searching after the first valid directory is found.
+     * Returns null if it doesn't find any valid directory.
+     *
+     * @param  array  $paths
+     * @return string|null
+     */
+    protected function getValidDirectory(array $paths)
+    {
+        foreach ($paths as $path) {
+            if ($this->isValidDirectory($path)) {
+                return $path;
+            }
+        }
+
+        return;
+    }
+
+    /**
+     * Check if the given path is a valid directory.
+     * @param  string $path
+     * @return bool
+     */
+    protected function isValidDirectory($path)
+    {
+        return is_dir($path);
     }
 
     /**

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -78,6 +78,43 @@ class SupportServiceProviderTest extends PHPUnit_Framework_TestCase
         ];
         $this->assertEquals($expected, $toPublish, 'Service provider does not return expected set of published tagged paths.');
     }
+
+    public function testLoadViewsFromAddsOverridingDirectoryFromAppIfExists1()
+    {
+        $app = m::mock('Illuminate\\Foundation\\Application')->makePartial();
+        $viewFinder = m::mock('Illuminate\\View\\FileViewFinder');
+        $provider = m::mock('ServiceProviderForTestingThree[isValidDirectory]', [$app])->makePartial();
+
+        $app->shouldReceive('basePath')->once()->andReturn(__DIR__.'/zaz');
+        $app->shouldReceive('offsetGet')->twice()->with('view')->andReturn($viewFinder);
+
+        $viewFinder->shouldReceive('addNamespace')->once()->with('name.space', __DIR__.'/zaz/resources/views/vendor/name.space');
+        $viewFinder->shouldReceive('addNamespace')->once()->with('name.space', __DIR__.'/foo');
+
+        $provider->shouldAllowMockingProtectedMethods();
+        $provider->shouldReceive('isValidDirectory')->once()->andReturn(true);
+
+        $provider->boot();
+    }
+
+    public function testLoadViewsFromAddsOverridingDirectoryFromAppIfExists2()
+    {
+        $app = m::mock('Illuminate\\Foundation\\Application')->makePartial();
+        $viewFinder = m::mock('Illuminate\\View\\FileViewFinder');
+        $provider = m::mock('ServiceProviderForTestingThree[isValidDirectory]', [$app])->makePartial();
+
+        $app->shouldReceive('basePath')->once()->andReturn(__DIR__.'/zaz');
+        $app->shouldReceive('offsetGet')->twice()->with('view')->andReturn($viewFinder);
+
+        $viewFinder->shouldReceive('addNamespace')->once()->with('name.space', __DIR__.'/zaz/resources/views/vendor/name/space');
+        $viewFinder->shouldReceive('addNamespace')->once()->with('name.space', __DIR__.'/foo');
+
+        $provider->shouldAllowMockingProtectedMethods();
+        $provider->shouldReceive('isValidDirectory')->once()->with(__DIR__.'/zaz/resources/views/vendor/name.space')->andReturn(false);
+        $provider->shouldReceive('isValidDirectory')->once()->with(__DIR__.'/zaz/resources/views/vendor/name/space')->andReturn(true);
+
+        $provider->boot();
+    }
 }
 
 class ServiceProviderForTestingOne extends ServiceProvider
@@ -105,5 +142,17 @@ class ServiceProviderForTestingTwo extends ServiceProvider
         $this->publishes(['source/unmarked/two/b' => 'destination/unmarked/two/b']);
         $this->publishes(['source/tagged/two/a' => 'destination/tagged/two/a'], 'some_tag');
         $this->publishes(['source/tagged/two/b' => 'destination/tagged/two/b'], 'some_tag');
+    }
+}
+
+class ServiceProviderForTestingThree extends ServiceProvider
+{
+    public function register()
+    {
+    }
+
+    public function boot()
+    {
+        $this->loadViewsFrom(__DIR__.'/foo', 'name.space');
     }
 }

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -83,16 +83,17 @@ class SupportServiceProviderTest extends PHPUnit_Framework_TestCase
     {
         $app = m::mock('Illuminate\\Foundation\\Application')->makePartial();
         $viewFinder = m::mock('Illuminate\\View\\FileViewFinder');
+        $files = m::mock('Illuminate\\Filesystem\\Filesystem');
         $provider = m::mock('ServiceProviderForTestingThree[isValidDirectory]', [$app])->makePartial();
 
         $app->shouldReceive('basePath')->once()->andReturn(__DIR__.'/zaz');
         $app->shouldReceive('offsetGet')->twice()->with('view')->andReturn($viewFinder);
+        $app->shouldReceive('offsetGet')->once()->with('files')->andReturn($files);
 
         $viewFinder->shouldReceive('addNamespace')->once()->with('name.space', __DIR__.'/zaz/resources/views/vendor/name.space');
         $viewFinder->shouldReceive('addNamespace')->once()->with('name.space', __DIR__.'/foo');
 
-        $provider->shouldAllowMockingProtectedMethods();
-        $provider->shouldReceive('isValidDirectory')->once()->andReturn(true);
+        $files->shouldReceive('isDirectory')->once()->andReturn(true);
 
         $provider->boot();
     }
@@ -101,17 +102,18 @@ class SupportServiceProviderTest extends PHPUnit_Framework_TestCase
     {
         $app = m::mock('Illuminate\\Foundation\\Application')->makePartial();
         $viewFinder = m::mock('Illuminate\\View\\FileViewFinder');
+        $files = m::mock('Illuminate\\Filesystem\\Filesystem');
         $provider = m::mock('ServiceProviderForTestingThree[isValidDirectory]', [$app])->makePartial();
 
         $app->shouldReceive('basePath')->once()->andReturn(__DIR__.'/zaz');
         $app->shouldReceive('offsetGet')->twice()->with('view')->andReturn($viewFinder);
+        $app->shouldReceive('offsetGet')->twice()->with('files')->andReturn($files);
 
         $viewFinder->shouldReceive('addNamespace')->once()->with('name.space', __DIR__.'/zaz/resources/views/vendor/name/space');
         $viewFinder->shouldReceive('addNamespace')->once()->with('name.space', __DIR__.'/foo');
 
-        $provider->shouldAllowMockingProtectedMethods();
-        $provider->shouldReceive('isValidDirectory')->once()->with(__DIR__.'/zaz/resources/views/vendor/name.space')->andReturn(false);
-        $provider->shouldReceive('isValidDirectory')->once()->with(__DIR__.'/zaz/resources/views/vendor/name/space')->andReturn(true);
+        $files->shouldReceive('isDirectory')->once()->with(__DIR__.'/zaz/resources/views/vendor/name.space')->andReturn(false);
+        $files->shouldReceive('isDirectory')->once()->with(__DIR__.'/zaz/resources/views/vendor/name/space')->andReturn(true);
 
         $provider->boot();
     }

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -84,7 +84,7 @@ class SupportServiceProviderTest extends PHPUnit_Framework_TestCase
         $app = m::mock('Illuminate\\Foundation\\Application')->makePartial();
         $viewFinder = m::mock('Illuminate\\View\\FileViewFinder');
         $files = m::mock('Illuminate\\Filesystem\\Filesystem');
-        $provider = m::mock('ServiceProviderForTestingThree[isValidDirectory]', [$app])->makePartial();
+        $provider = new ServiceProviderForTestingThree($app);
 
         $app->shouldReceive('basePath')->once()->andReturn(__DIR__.'/zaz');
         $app->shouldReceive('offsetGet')->twice()->with('view')->andReturn($viewFinder);
@@ -103,7 +103,7 @@ class SupportServiceProviderTest extends PHPUnit_Framework_TestCase
         $app = m::mock('Illuminate\\Foundation\\Application')->makePartial();
         $viewFinder = m::mock('Illuminate\\View\\FileViewFinder');
         $files = m::mock('Illuminate\\Filesystem\\Filesystem');
-        $provider = m::mock('ServiceProviderForTestingThree[isValidDirectory]', [$app])->makePartial();
+        $provider = new ServiceProviderForTestingThree($app);
 
         $app->shouldReceive('basePath')->once()->andReturn(__DIR__.'/zaz');
         $app->shouldReceive('offsetGet')->twice()->with('view')->andReturn($viewFinder);


### PR DESCRIPTION
Addresses #11177.
##### Example

Let's say we have a service provider that register views in a namespace called `admin.foo`

We can now override package views in two manners:
- The ServiceProvider **will search first** for the folder <br>`[app_root]/resources/views/vendor/admin.foo` <br>(this keeps backward compatibility);<br><br>
- If the the folder described above **does not exist**, ServiceProvider will search for the folder <br>`[app_root]/resources/views/vendor/admin/foo`.

I also did some refactoring in order to make `loadViewsFrom` method testable.
