### PR TITLE
[5.1] Arr/Collection Only and Except for "columned" arrays

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -108,6 +108,12 @@ class Arr
      */
     public static function except($array, $keys)
     {
+        if (self::isColumned($array)) {
+            return array_map(function ($array) use ($keys) {
+                return self::except($array, $keys);
+            }, $array);
+        }
+
         static::forget($array, $keys);
 
         return $array;
@@ -298,6 +304,34 @@ class Arr
     }
 
     /**
+     * Determines if an array is columned.
+     *
+     * An array is "columned" if it is index, and it's items are associative arrays using the same keys.
+     *
+     * @param  array  $array
+     * @return bool
+     */
+    public static function isColumned(array $array)
+    {
+        if (count($array) && ! self::isAssoc($array) && is_array($array[0]) && self::isAssoc($array[0])) {
+            if (count($array) > 1) {
+                $item_keys = array_map(function($item) {
+                    $keys = array_keys($item);
+                    sort($keys);
+
+                    return implode('|', $keys);
+                }, $array);
+
+                return count(array_unique($item_keys)) === 1;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Get a subset of the items from the given array.
      *
      * @param  array  $array
@@ -306,6 +340,12 @@ class Arr
      */
     public static function only($array, $keys)
     {
+        if (self::isColumned($array)) {
+            return array_map(function ($array) use ($keys) {
+                return self::only($array, $keys);
+            }, $array);
+        }
+
         return array_intersect_key($array, array_flip((array) $keys));
     }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -315,7 +315,7 @@ class Arr
     {
         if (count($array) && ! self::isAssoc($array) && is_array($array[0]) && self::isAssoc($array[0])) {
             if (count($array) > 1) {
-                $item_keys = array_map(function($item) {
+                $item_keys = array_map(function ($item) {
                     $keys = array_keys($item);
                     sort($keys);
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -28,6 +28,10 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $array = ['name' => 'Desk', 'price' => 100];
         $array = Arr::except($array, ['price']);
         $this->assertEquals(['name' => 'Desk'], $array);
+
+        $array = [['name' => 'Desk', 'price' => 100], ['name' => 'Chair', 'price' => 50]];
+        $array = Arr::except($array, ['price']);
+        $this->assertEquals([['name' => 'Desk'], ['name' => 'Chair']], $array);
     }
 
     public function testFirst()
@@ -80,11 +84,24 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(Arr::isAssoc(['a', 'b']));
     }
 
+    public function testIsColumned()
+    {
+        $this->assertTrue(Arr::isColumned([['a' => 'a'], ['a' => 'b']]));
+        $this->assertTrue(Arr::isColumned([[1 => 'a', 2 => 'b'], [2 => 'a', 1 => 'b']]));
+        $this->assertFalse(Arr::isColumned(['a', 'b']));
+        $this->assertFalse(Arr::isColumned([['a'], ['b']]));
+        $this->assertFalse(Arr::isColumned([['a' => 'a'], ['b' => 'b']]));
+    }
+
     public function testOnly()
     {
         $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];
         $array = Arr::only($array, ['name', 'price']);
         $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
+
+        $array = [['name' => 'Desk', 'price' => 100, 'orders' => 10], ['name' => 'Chair', 'price' => 50, 'orders' => 5]];
+        $array = Arr::only($array, ['name', 'price']);
+        $this->assertEquals([['name' => 'Desk', 'price' => 100], ['name' => 'Chair', 'price' => 50]], $array);
     }
 
     public function testPluck()


### PR DESCRIPTION
Adds the ability to use the `only` and `except` methods on "columned" arrays and collections.

Example:

``` php
$products = [
   ['name' => 'Chair', 'price' => 50],
   ['name' => 'Desk', 'price' => 100],
];

$product_names = Arr::only($products, 'name');
// $product_names == [
//    ['name' => 'Chair'],
//    ['name' => 'Desk'],
// ];
```

An example use case is filtering an array of this type read from a json file / api call.

I'm not 100% sure if this should be 5.1 or 5.2, since this is technically a breaking change. It's just very unlikely that someone uses the `only`/`except` methods for indexed arrays.
