### PR TITLE
[5.1] Fixes session.store missing when making a test request.

### DIFF
--- a/src/Illuminate/Foundation/Testing/CrawlerTrait.php
+++ b/src/Illuminate/Foundation/Testing/CrawlerTrait.php
@@ -391,6 +391,10 @@ trait CrawlerTrait
             $cookies, $files, array_replace($this->serverVariables, $server), $content
         );
 
+        if ($this->app['session']->isStarted()) {
+            $request->setSession($this->app['session.store']);
+        }
+
         $response = $kernel->handle($request);
 
         $kernel->terminate($request, $response);


### PR DESCRIPTION
The request are executed on a "new" request object and doesn't have the
session that we boot using bootstrap/middleware/service provider.

This solved related issue such as #7328 and orchestral/testbench#102

Signed-off-by: crynobone crynobone@gmail.com
