### PR TITLE
[5.2] [Auth] Remove unused variable

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -413,8 +413,6 @@ class SessionGuard implements StatefulGuard
     protected function fireAttemptEvent(array $credentials, $remember, $login)
     {
         if ($this->events) {
-            $payload = [$credentials, $remember, $login];
-
             $this->events->fire(new Events\Attempting(
                 $credentials, $remember, $login
             ));


### PR DESCRIPTION
The `$payload` variable is not used.  
