### PR TITLE
[5.1] Add missing mbstring extension require

### DIFF
--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "ext-mbstring": "*",
         "illuminate/contracts": "5.1.*",
         "illuminate/http": "5.1.*",
         "illuminate/session": "5.1.*",

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "ext-mbstring": "*",
         "illuminate/container": "5.1.*",
         "illuminate/contracts": "5.1.*",
         "illuminate/http": "5.1.*",

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "ext-mbstring": "*",
         "illuminate/filesystem": "5.1.*",
         "illuminate/support": "5.1.*",
         "symfony/translation": "2.7.*"

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "ext-mbstring": "*",
         "illuminate/container": "5.1.*",
         "illuminate/contracts": "5.1.*",
         "illuminate/support": "5.1.*",


### PR DESCRIPTION
For these Illuminate packages, the mbstring extension is required
