### PR TITLE
[5.1] [Encryption] remove ext-mbstring from require

### DIFF
--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "ext-mbstring": "*",
         "ext-openssl": "*",
         "illuminate/contracts": "5.1.*",
         "illuminate/support": "5.1.*"


### PR DESCRIPTION
illuminate/encryption already requires illuminate/support, that requires ext-mbstring

See https://github.com/laravel/framework/pull/11289#issuecomment-163633868
