### PR TITLE
[5.1] Support checking JSON responses for a subset of data

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -303,6 +303,25 @@ trait MakesHttpRequests
     }
 
     /**
+     * Assert that the response is a superset of the given JSON.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    protected function seeJsonSubset(array $data)
+    {
+        $actual = json_decode($this->response->getContent(), true);
+
+        if (is_null($actual) || $actual === false) {
+            return $this->fail('Invalid JSON was returned from the route. Perhaps an exception was thrown?');
+        }
+
+        $this->assertArraySubset($data, $actual);
+
+        return $this;
+    }
+
+    /**
      * Format the given key and value into a JSON string for expectation checks.
      *
      * @param  string  $key

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -280,14 +280,8 @@ trait MakesHttpRequests
     {
         $method = $negate ? 'assertFalse' : 'assertTrue';
 
-        $actual = json_decode($this->response->getContent(), true);
-
-        if (is_null($actual) || $actual === false) {
-            return $this->fail('Invalid JSON was returned from the route. Perhaps an exception was thrown?');
-        }
-
         $actual = json_encode(Arr::sortRecursive(
-            (array) $actual
+            (array) $this->decodeResponseJson()
         ));
 
         foreach (Arr::sortRecursive($data) as $key => $value) {
@@ -310,15 +304,25 @@ trait MakesHttpRequests
      */
     protected function seeJsonSubset(array $data)
     {
-        $actual = json_decode($this->response->getContent(), true);
-
-        if (is_null($actual) || $actual === false) {
-            return $this->fail('Invalid JSON was returned from the route. Perhaps an exception was thrown?');
-        }
-
-        $this->assertArraySubset($data, $actual);
+        $this->assertArraySubset($data, $this->decodeResponseJson());
 
         return $this;
+    }
+
+    /**
+     * Validate and return the decoded response JSON.
+     *
+     * @return array
+     */
+    protected function decodeResponseJson()
+    {
+        $decodedResponse = json_decode($this->response->getContent(), true);
+
+        if (is_null($decodedResponse) || $decodedResponse === false) {
+            $this->fail('Invalid JSON was returned from the route. Perhaps an exception was thrown?');
+        }
+
+        return $decodedResponse;
     }
 
     /**


### PR DESCRIPTION
This allows you to use the `seeJsonSubset($data)` assertion to check if a JSON response is a superset of the given data. Easiest to understand via example...

Say you have a route that returns some JSON like this:

``` php
Route::get('test', function () {
    return response()->json([
        "meta" => [
            "some", "unimportant", "stuff",
        ],
        "data" => [
            [
                "id" => 15,
                "name" => "Bob",
                "occupation" => "Plumber",
                "created_at" => "2015-08-09 08:52:42",
            ],
            [
                "id" => 21,
                "name" => "Jane",
                "occupation" => "Doctor",
                "created_at" => "2015-10-09 08:52:42",
            ],
            [
                "id" => 32,
                "name" => "Phil",
                "occupation" => "Dentist",
                "created_at" => "2015-11-09 08:52:42",
            ],
        ],
    ]);
});
```

...you can now write a test to check only the details you care about like this:

``` php
public function testBasicExample()
{
    $this->get('test')->seeJsonSubset([
        'data' => [
            [
                'name' => 'Bob',
                'occupation' => 'Plumber'
            ],
            [
                'name' => 'Jane',
                'occupation' => 'Doctor'
            ],
            [
                'name' => 'Phil',
                'occupation' => 'Dentist'
            ],
        ]
    ]);
}
```

It's essentially just a thin layer over using PHPUnit's `assertArraySubset` functionality, but lets you write really clean tests that don't force you to assert against things you're not necessarily interested in, like metadata, timestamps, or IDs.

I think it would be a good candidate for replacing the current `seeJsonContains` assertion, but it would be a BC break because it removes the ability to do something like this:

``` php
public function testBasicExample()
{
    $this->get('test')->seeJsonContains(['name' => 'Bob']);
}
```

...since the subset you are checking for needs to follow the same "shape" as the response (you'd need the top-level `data` key in this example.)

If the BC break is tolerable, I think it would be worth discussing since I can't see a reason why I would personally use `seeJsonContains` anymore if this gets merged.
