### PR TITLE
[5.1] Added ability to reference actions via an array

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -578,8 +578,8 @@ class Router implements RegistrarContract
         if (! is_array($action)) {
             return false;
         }
-
-        list($class, $method) = each($action);
+        
+        $class = key($action);
 
         return class_exists($class);
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -486,6 +486,12 @@ class Router implements RegistrarContract
      */
     protected function createRoute($methods, $uri, $action)
     {
+        // If the action is referenced as an array we will
+        // convert the array to a regular action string.
+        if ($this->actionIsReferencedAsArray($action)) {
+            $action = $this->convertToActionString($action);
+        }
+
         // If the route is routing to a controller we will parse the route action into
         // an acceptable array format before registering it and creating this route
         // instance itself. We need to build the Closure that will call this out.
@@ -559,6 +565,36 @@ class Router implements RegistrarContract
         $action = $this->mergeWithLastGroup($route->getAction());
 
         $route->setAction($action);
+    }
+
+    /**
+     * Determine if action is referenced as an array.
+     *
+     * @param  string|array  $action
+     * @return bool
+     */
+    private function actionIsReferencedAsArray($action)
+    {
+        if (! is_array($action)) {
+            return false;
+        }
+
+        list($class, $method) = each($action);
+
+        return class_exists($class);
+    }
+
+    /**
+     * Convert action array to action string.
+     *
+     * @param  array  $action
+     * @return string
+     */
+    private function convertToActionString($action)
+    {
+        list($class, $method) = each($action);
+
+        return '\\'.$class.'@'.$method;
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -568,15 +568,20 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Get the URL to a controller action.
      *
-     * @param  string  $action
-     * @param  mixed   $parameters
-     * @param  bool    $absolute
+     * @param  array|string  $action
+     * @param  mixed  $parameters
+     * @param  bool  $absolute
      * @return string
      *
      * @throws \InvalidArgumentException
      */
     public function action($action, $parameters = [], $absolute = true)
     {
+        if (is_array($action)) {
+            list($class, $method) = each($action);
+            $action = '\\'.$class.'@'.$method;
+        }
+
         if ($this->rootNamespace && ! (strpos($action, '\\') === 0)) {
             $action = $this->rootNamespace.'\\'.$action;
         } else {

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -125,6 +125,13 @@ class RoutingRedirectorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
     }
 
+    public function testActionAsArray()
+    {
+        $this->url->shouldReceive('action')->with([bar::class => 'index'], [])->andReturn('http://foo.com/bar');
+        $response = $this->redirect->action([bar::class => 'index']);
+        $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
+    }
+
     public function testRoute()
     {
         $this->url->shouldReceive('route')->with('home')->andReturn('http://foo.com/bar');

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -928,6 +928,13 @@ return 'foo!'; });
         $this->assertEquals('hello', $router->dispatch(Request::create('home/foo', 'GET'))->getContent());
     }
 
+    public function testRouterActionReferencedAsArray()
+    {
+        $router = $this->getRouter();
+        $router->get('home/foo', [RouteTestInspectedControllerStub::class => 'getFoo']);
+        $this->assertEquals('hello', $router->dispatch(Request::create('home/foo', 'GET'))->getContent());
+    }
+
     protected function getRouter()
     {
         return new Router(new Illuminate\Events\Dispatcher);


### PR DESCRIPTION
This pr adds the ability to reference actions via an array as followed:

``` php
return redirect()->action([OtherController::class => 'getIndex']);
```

instead of

``` php
return redirect()->action('\\' . OtherController::class . '@getIndex');
```

This is way cleaner and obvious in my opinion.

Also works in the routes.php

``` php
use App\Http\Controllers\OtherController;

Route::get('other', [OtherController::class => 'getIndex']);
```
