### PR TITLE
[5.2] Return sqlsrv in place of dblib driver

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -270,7 +270,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function supportedDrivers()
     {
-        return ['mysql', 'pgsql', 'sqlite', 'dblib', 'sqlsrv'];
+        return ['mysql', 'pgsql', 'sqlite', 'sqlsrv'];
     }
 
     /**
@@ -280,7 +280,7 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function availableDrivers()
     {
-        return array_intersect($this->supportedDrivers(), PDO::getAvailableDrivers());
+        return array_intersect($this->supportedDrivers(), str_replace('dblib', 'sqlsrv', PDO::getAvailableDrivers()));
     }
 
     /**


### PR DESCRIPTION
Return sqlsrv in place of dblib driver. Fix #11281 
