### PR TITLE
[5.3] Use isset() to improve consistency

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -412,7 +412,7 @@ class SessionGuard implements StatefulGuard
      */
     protected function fireAttemptEvent(array $credentials, $remember, $login)
     {
-        if ($this->events) {
+        if (isset($this->events)) {
             $this->events->fire(new Events\Attempting(
                 $credentials, $remember, $login
             ));
@@ -427,7 +427,7 @@ class SessionGuard implements StatefulGuard
      */
     public function attempting($callback)
     {
-        if ($this->events) {
+        if (isset($this->events)) {
             $this->events->listen(Events\Attempting::class, $callback);
         }
     }


### PR DESCRIPTION
Just noticed that elsewhere in this file, `isset()` is used to check if instance variables have been set. This PR updates two checks to see if the event dispatcher exists to also use `isset()` to improve consistency.
