### PR TITLE
[5.1] Allow to pass array into selectRaw

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -237,12 +237,15 @@ class Builder
     /**
      * Add a new "raw" select expression to the query.
      *
-     * @param  string  $expression
+     * @param  string|array $expression
      * @param  array   $bindings
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function selectRaw($expression, array $bindings = [])
     {
+        if (is_array($expression)) {
+            $expression = implode(', ', $expression);
+        }
         $this->addSelect(new Expression($expression));
 
         if ($bindings) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -237,12 +237,16 @@ class Builder
     /**
      * Add a new "raw" select expression to the query.
      *
-     * @param  string  $expression
+     * @param  string|array  $expression
      * @param  array   $bindings
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function selectRaw($expression, array $bindings = [])
     {
+        if (is_array($expression)) {
+            $expression = implode(', ', $expression);
+        }
+        
         $this->addSelect(new Expression($expression));
 
         if ($bindings) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -238,7 +238,7 @@ class Builder
      * Add a new "raw" select expression to the query.
      *
      * @param  string|array  $expression
-     * @param  array   $bindings
+     * @param  array  $bindings
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function selectRaw($expression, array $bindings = [])
@@ -246,7 +246,7 @@ class Builder
         if (is_array($expression)) {
             $expression = implode(', ', $expression);
         }
-        
+
         $this->addSelect(new Expression($expression));
 
         if ($bindings) {


### PR DESCRIPTION
It would be nice to pass into selectRaw also `array` to let Laravel to create string from array. Now it has to be done manually each time when I create array of columns and if I use many columns it is much more cleaner to have them as array than creating long string with columns
