### PR TITLE
[5.2] Fix to validator() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -673,7 +673,7 @@ if (! function_exists('validator')) {
      * @param  array  $customAttributes
      * @return \Illuminate\Contracts\Validation\Validator
      */
-    function validator(array $data, array $rules, array $messages = [], array $customAttributes = [])
+    function validator(array $data = [], array $rules = [], array $messages = [], array $customAttributes = [])
     {
         $factory = app(ValidationFactory::class);
 


### PR DESCRIPTION
Fix to validator() helper so that a new ValidationFactory can successfully be returned when no arguments are provided.
