### PR TITLE
[5.1] Escape path in sendOutputTo()

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -9,6 +9,7 @@ use Cron\CronExpression;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Contracts\Mail\Mailer;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessUtils;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 
@@ -652,7 +653,7 @@ class Event
      */
     public function sendOutputTo($location, $append = false)
     {
-        $this->output = $location;
+        $this->output = ProcessUtils::escapeArgument($location);
 
         $this->shouldAppendOutput = $append;
 

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -12,11 +12,24 @@ class EventTest extends PHPUnit_Framework_TestCase
         $this->assertSame("php -i > {$defaultOutput} 2>&1 &", $event->buildCommand());
     }
 
+    public function testBuildCommandSendOutputTo()
+    {
+        $event = new Event('php -i');
+
+        $event->sendOutputTo('/dev/null');
+        $this->assertSame("php -i > '/dev/null' 2>&1 &", $event->buildCommand());
+
+        $event = new Event('php -i');
+
+        $event->sendOutputTo('/my folder/foo.log');
+        $this->assertSame("php -i > '/my folder/foo.log' 2>&1 &", $event->buildCommand());
+    }
+
     public function testBuildCommandAppendOutput()
     {
         $event = new Event('php -i');
 
         $event->appendOutputTo('/dev/null');
-        $this->assertSame('php -i >> /dev/null 2>&1 &', $event->buildCommand());
+        $this->assertSame("php -i >> '/dev/null' 2>&1 &", $event->buildCommand());
     }
 }


### PR DESCRIPTION
Closes #11321
