### PR TITLE
[5.1] Allow to use . inside session key when explicit = true

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -360,28 +360,37 @@ class Store implements SessionInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Sets an attribute.
+     *
+     * @param  string  $name
+     * @param  mixed  $value
+     * @param  bool  $explicit
      */
-    public function set($name, $value)
+    public function set($name, $value, $explicit = false)
     {
-        Arr::set($this->attributes, $name, $value);
+        if (! $explicit) {
+            Arr::set($this->attributes, $name, $value);
+        } else {
+            $this->attributes[$name] = $value;
+        }
     }
 
     /**
      * Put a key / value pair or array of key / value pairs in the session.
      *
      * @param  string|array  $key
-     * @param  mixed       $value
+     * @param  mixed  $value
+     * @param  bool  $explicit
      * @return void
      */
-    public function put($key, $value = null)
+    public function put($key, $value = null, $explicit = false)
     {
         if (! is_array($key)) {
             $key = [$key => $value];
         }
 
         foreach ($key as $arrayKey => $arrayValue) {
-            $this->set($arrayKey, $arrayValue);
+            $this->set($arrayKey, $arrayValue, $explicit);
         }
     }
 

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -321,4 +321,19 @@ class SessionStoreTest extends PHPUnit_Framework_TestCase
     {
         return 'name';
     }
+
+    public function testSetRaw()
+    {
+        $session = $this->getSession();
+        $session->set('domain.com', ['foo' => 'bar'], true);
+        $session->set('something.else', ['qu' => 'ux']);
+        $this->assertEquals(['foo' => 'bar'], $session->get('domain.com'));
+        $this->assertEquals(null, $session->get('domain.com.foo'));
+        $this->assertEquals(['qu' => 'ux'], $session->get('something.else'));
+        $this->assertEquals('ux', $session->get('something.else.qu'));
+        $this->assertEquals([
+            'domain.com' => ['foo' => 'bar'],
+            'something' => ['else' => ['qu' => 'ux']],
+        ], $session->all());
+    }
 }


### PR DESCRIPTION
If you want to set as session key string with dot, Laravel automatically assumes it's dot notation and it will save key as array. When `Session::all()` is used, you won't get valid key for value you put into session. Adding 3rd parameter `$explicit` will allow to manually force to save key as string key without using dot notation
