### PR TITLE
[5.2] Email verification

### DIFF
--- a/src/Illuminate/Auth/VerifyEmails/CanVerifyEmail.php
+++ b/src/Illuminate/Auth/VerifyEmails/CanVerifyEmail.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Illuminate\Auth\VerifyEmails;
+
+use Illuminate\Mail\Message;
+use Illuminate\Support\Facades\VerifyEmail;
+
+trait CanVerifyEmail
+{
+    /**
+     * Get the email address that we're verifying.
+     *
+     * @return string
+     */
+    public function getEmailToVerify()
+    {
+        return $this->email;
+    }
+
+    /**
+     * Get the email verification boolean.
+     *
+     * @return string
+     */
+    public function getVerified()
+    {
+        return $this->{$this->getVerifiedName()};
+    }
+
+    /**
+     * Set the email verification boolean.
+     *
+     * @param  bool  $value
+     * @return void
+     */
+    public function setVerified($value)
+    {
+        $this->{$this->getVerifiedName()} = $value;
+    }
+
+    /**
+     * Get the column name for the email verification boolean.
+     *
+     * @return string
+     */
+    public function getVerifiedName()
+    {
+        return 'verified';
+    }
+
+    /**
+     * Get the email subject line to be used for the verification email.
+     *
+     * @return string
+     */
+    public function getVerifyEmailSubject()
+    {
+        return property_exists($this, 'subject') ? $this->subject : 'Your Email Verification Link';
+    }
+
+    /**
+     * Unverify the user's email address.
+     *
+     * @return void
+     */
+    public function unverify()
+    {
+        VerifyEmail::sendVerificationLink($this, function (Message $message) {
+            $message->subject($this->getVerifyEmailSubject());
+        });
+
+        $this->setVerified(false);
+    }
+
+    /**
+     * Check if the email address is verified.
+     *
+     * @return bool
+     */
+    public function isVerified()
+    {
+        return (bool) $this->getVerified();
+    }
+}

--- a/src/Illuminate/Auth/VerifyEmails/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/VerifyEmails/DatabaseTokenRepository.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Illuminate\Auth\VerifyEmails;
+
+use Carbon\Carbon;
+use Illuminate\Support\Str;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Contracts\Auth\CanVerifyEmail as CanVerifyEmailContract;
+
+class DatabaseTokenRepository implements TokenRepositoryInterface
+{
+    /**
+     * The database connection instance.
+     *
+     * @var \Illuminate\Database\ConnectionInterface
+     */
+    protected $connection;
+
+    /**
+     * The token database table.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * The hashing key.
+     *
+     * @var string
+     */
+    protected $hashKey;
+
+    /**
+     * The number of seconds a token should last.
+     *
+     * @var int
+     */
+    protected $expires;
+
+    /**
+     * Create a new token repository instance.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
+     * @param  string  $table
+     * @param  string  $hashKey
+     * @param  int  $expires
+     * @return void
+     */
+    public function __construct(ConnectionInterface $connection, $table, $hashKey, $expires = 60)
+    {
+        $this->table = $table;
+        $this->hashKey = $hashKey;
+        $this->expires = $expires * 60;
+        $this->connection = $connection;
+    }
+
+    /**
+     * Create a new token record.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanVerifyEmail  $user
+     * @return string
+     */
+    public function create(CanVerifyEmailContract $user)
+    {
+        $email = $user->getEmailToVerify();
+
+        $this->deleteExisting($user);
+
+        // We will create a new, random token for the user so that we can e-mail them
+        // a safe link to verify their email address. Then we will insert a record in
+        // the database so that we can verify the token later.
+        $token = $this->createNewToken();
+
+        $this->getTable()->insert($this->getPayload($email, $token));
+
+        return $token;
+    }
+
+    /**
+     * Delete all existing tokens from the database.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanVerifyEmail  $user
+     * @return int
+     */
+    protected function deleteExisting(CanVerifyEmailContract $user)
+    {
+        return $this->getTable()->where('email', $user->getEmailToVerify())->delete();
+    }
+
+    /**
+     * Build the record payload for the table.
+     *
+     * @param  string  $email
+     * @param  string  $token
+     * @return array
+     */
+    protected function getPayload($email, $token)
+    {
+        return ['email' => $email, 'token' => $token, 'created_at' => new Carbon];
+    }
+
+    /**
+     * Determine if a token record exists and is valid.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanVerifyEmail  $user
+     * @param  string  $token
+     * @return bool
+     */
+    public function exists(CanVerifyEmailContract $user, $token)
+    {
+        $email = $user->getEmailToVerify();
+
+        $token = (array) $this->getTable()->where('email', $email)->where('token', $token)->first();
+
+        return $token && ! $this->tokenExpired($token);
+    }
+
+    /**
+     * Determine if the token has expired.
+     *
+     * @param  array  $token
+     * @return bool
+     */
+    protected function tokenExpired($token)
+    {
+        $expirationTime = strtotime($token['created_at']) + $this->expires;
+
+        return $expirationTime < $this->getCurrentTime();
+    }
+
+    /**
+     * Get the current UNIX timestamp.
+     *
+     * @return int
+     */
+    protected function getCurrentTime()
+    {
+        return time();
+    }
+
+    /**
+     * Delete a token record by token.
+     *
+     * @param  string  $token
+     * @return void
+     */
+    public function delete($token)
+    {
+        $this->getTable()->where('token', $token)->delete();
+    }
+
+    /**
+     * Delete expired tokens.
+     *
+     * @return void
+     */
+    public function deleteExpired()
+    {
+        $expiredAt = Carbon::now()->subSeconds($this->expires);
+
+        $this->getTable()->where('created_at', '<', $expiredAt)->delete();
+    }
+
+    /**
+     * Create a new token for the user.
+     *
+     * @return string
+     */
+    public function createNewToken()
+    {
+        return hash_hmac('sha256', Str::random(40), $this->hashKey);
+    }
+
+    /**
+     * Begin a new database query against the table.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    protected function getTable()
+    {
+        return $this->connection->table($this->table);
+    }
+
+    /**
+     * Get the database connection instance.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+}

--- a/src/Illuminate/Auth/VerifyEmails/TokenRepositoryInterface.php
+++ b/src/Illuminate/Auth/VerifyEmails/TokenRepositoryInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Auth\VerifyEmails;
+
+use Illuminate\Contracts\Auth\CanVerifyEmail as CanVerifyEmailContract;
+
+interface TokenRepositoryInterface
+{
+    /**
+     * Create a new token.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanVerifyEmail  $user
+     * @return string
+     */
+    public function create(CanVerifyEmailContract $user);
+
+    /**
+     * Determine if a token record exists and is valid.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanVerifyEmail  $user
+     * @param  string  $token
+     * @return bool
+     */
+    public function exists(CanVerifyEmailContract $user, $token);
+
+    /**
+     * Delete a token record.
+     *
+     * @param  string  $token
+     * @return void
+     */
+    public function delete($token);
+
+    /**
+     * Delete expired tokens.
+     *
+     * @return void
+     */
+    public function deleteExpired();
+}

--- a/src/Illuminate/Auth/VerifyEmails/VerifyEmailBroker.php
+++ b/src/Illuminate/Auth/VerifyEmails/VerifyEmailBroker.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Illuminate\Auth\VerifyEmails;
+
+use Closure;
+use Illuminate\Contracts\Mail\Mailer as MailerContract;
+use Illuminate\Contracts\Auth\VerifyEmailBroker as VerifyEmailBrokerContract;
+use Illuminate\Contracts\Auth\CanVerifyEmail as CanVerifyEmailContract;
+
+class VerifyEmailBroker implements VerifyEmailBrokerContract
+{
+    /**
+     * The token repository.
+     *
+     * @var \Illuminate\Auth\VerifyEmails\TokenRepositoryInterface
+     */
+    protected $tokens;
+
+    /**
+     * The mailer instance.
+     *
+     * @var \Illuminate\Contracts\Mail\Mailer
+     */
+    protected $mailer;
+
+    /**
+     * The view of the verify email link e-mail.
+     *
+     * @var string
+     */
+    protected $emailView;
+
+    /**
+     * Create a new verify email broker instance.
+     *
+     * @param  \Illuminate\Auth\Passwords\TokenRepositoryInterface  $tokens
+     * @param  \Illuminate\Contracts\Mail\Mailer  $mailer
+     * @param  string  $emailView
+     * @return void
+     */
+    public function __construct(TokenRepositoryInterface $tokens, MailerContract $mailer, $emailView)
+    {
+        $this->mailer = $mailer;
+        $this->tokens = $tokens;
+        $this->emailView = $emailView;
+    }
+
+    /**
+     * Send an email verification link to a user.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanVerifyEmail  $user
+     * @param  \Closure|null  $callback
+     * @return string
+     */
+    public function sendVerificationLink(CanVerifyEmailContract $user, Closure $callback = null)
+    {
+        // Once we have the verify token, we are ready to send the message out to this
+        // user with a link to verify their email. We will then redirect back to
+        // the current URI having nothing set in the session to indicate errors.
+        $token = $this->tokens->create($user);
+
+        $this->emailVerificationLink($user, $token, $callback);
+
+        return VerifyEmailBrokerContract::VERIFY_LINK_SENT;
+    }
+
+    /**
+     * Send the email verification link via e-mail.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanVerifyEmail  $user
+     * @param  string  $token
+     * @param  \Closure|null  $callback
+     * @return int
+     */
+    public function emailVerificationLink(CanVerifyEmailContract $user, $token, Closure $callback = null)
+    {
+        // We will use the view that was given to the broker to display the
+        // verification e-mail. We'll pass a "token" variable into the views
+        // so that it may be displayed for an user to click to verify.
+        $view = $this->emailView;
+
+        return $this->mailer->send($view, compact('token', 'user'), function ($m) use ($user, $token, $callback) {
+            $m->to($user->getEmailToVerify());
+
+            if (! is_null($callback)) {
+                call_user_func($callback, $m, $user, $token);
+            }
+        });
+    }
+
+    /**
+     * Verify the email address for the given token.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanVerifyEmail  $user
+     * @param  string  $token
+     * @return mixed
+     */
+    public function verify(CanVerifyEmailContract $user, $token)
+    {
+        // If the responses from the validate method is not a user instance, we will
+        // assume that it is a redirect and simply return it from this method and
+        // the user is properly redirected having an error message on the post.
+        $user = $this->validateVerification($user, $token);
+
+        if (! $user instanceof CanVerifyEmailContract) {
+            return $user;
+        }
+
+        $this->tokens->delete($token);
+
+        $user->setVerified(true);
+
+        $user->save();
+
+        return VerifyEmailBrokerContract::EMAIL_VERIFIED;
+    }
+
+    /**
+     * Validate a verification for the given credentials.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanVerifyEmail  $user
+     * @param  string  $token
+     * @return \Illuminate\Contracts\Auth\CanVerifyEmail
+     */
+    protected function validateVerification(CanVerifyEmailContract $user, $token)
+    {
+        if (! $this->tokens->exists($user, $token)) {
+            return VerifyEmailBrokerContract::INVALID_TOKEN;
+        }
+
+        return $user;
+    }
+
+    /**
+     * Get the email verification token repository implementation.
+     *
+     * @return \Illuminate\Auth\Passwords\TokenRepositoryInterface
+     */
+    protected function getRepository()
+    {
+        return $this->tokens;
+    }
+}

--- a/src/Illuminate/Auth/VerifyEmails/VerifyEmailServiceProvider.php
+++ b/src/Illuminate/Auth/VerifyEmails/VerifyEmailServiceProvider.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Illuminate\Auth\VerifyEmails;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Auth\VerifyEmails\DatabaseTokenRepository as DbRepository;
+
+class VerifyEmailServiceProvider extends ServiceProvider
+{
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = true;
+
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->registerVerifyEmailBroker();
+
+        $this->registerTokenRepository();
+    }
+
+    /**
+     * Register the verify email broker instance.
+     *
+     * @return void
+     */
+    protected function registerVerifyEmailBroker()
+    {
+        $this->app->singleton('auth.verify_email', function ($app) {
+            // The token repository is responsible for storing the email addresses and
+            // email verification tokens. It will be used to verify the tokens are valid
+            // for the given e-mail addresses. We will resolve an implementation here.
+            $tokens = $app['auth.verify_email.tokens'];
+
+            $users = $app['auth']->driver()->getProvider();
+
+            $view = $app['config']['auth.verify_email.email'];
+
+            // The verify email broker uses a token repository to validate tokens, as well
+            // as validating that email verification process as an aggregate service of
+            // sorts providing a convenient interface for verification.
+            return new VerifyEmailBroker($tokens, $users, $app['mailer'], $view);
+        });
+    }
+
+    /**
+     * Register the token repository implementation.
+     *
+     * @return void
+     */
+    protected function registerTokenRepository()
+    {
+        $this->app->singleton('auth.verify_email.tokens', function ($app) {
+            $connection = $app['db']->connection();
+
+            // The database token repository is an implementation of the token repository
+            // interface, and is responsible for the actual storing of auth tokens and
+            // their e-mail addresses. We will inject this table and hash key to it.
+            $table = $app['config']['auth.verify_email.table'];
+
+            $key = $app['config']['app.key'];
+
+            $expire = $app['config']->get('auth.verify_email.expire', 60);
+
+            return new DbRepository($connection, $table, $key, $expire);
+        });
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return ['auth.verify_email', 'auth.verify_email.tokens'];
+    }
+}

--- a/src/Illuminate/Contracts/Auth/CanVerifyEmail.php
+++ b/src/Illuminate/Contracts/Auth/CanVerifyEmail.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Contracts\Auth;
+
+interface CanVerifyEmail
+{
+    /**
+     * Get the email address that we're verifying.
+     *
+     * @return string
+     */
+    public function getEmailToVerify();
+
+    /**
+     * Get the email verification boolean.
+     *
+     * @return string
+     */
+    public function getVerified();
+
+    /**
+     * Set the email verification boolean.
+     *
+     * @param  string  $value
+     * @return void
+     */
+    public function setVerified($value);
+
+    /**
+     * Get the column name for the email verification boolean.
+     *
+     * @return string
+     */
+    public function getVerifiedName();
+
+    /**
+     * Unverify the user's email address.
+     *
+     * @return void
+     */
+    public function unverify();
+
+    /**
+     * Check if the email address is verified.
+     *
+     * @return bool
+     */
+    public function isVerified();
+}

--- a/src/Illuminate/Contracts/Auth/VerifyEmailBroker.php
+++ b/src/Illuminate/Contracts/Auth/VerifyEmailBroker.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Contracts\Auth;
+
+use Closure;
+use Illuminate\Contracts\Auth\CanVerifyEmail as CanVerifyEmailContract;
+
+interface VerifyEmailBroker
+{
+    /**
+     * Constant representing a successfully sent verification link.
+     *
+     * @var string
+     */
+    const VERIFY_LINK_SENT = 'verify_email.sent';
+
+    /**
+     * Constant representing a successfully verified email address.
+     *
+     * @var string
+     */
+    const EMAIL_VERIFIED = 'verify_email.verified';
+
+    /**
+     * Constant representing an invalid token.
+     *
+     * @var string
+     */
+    const INVALID_TOKEN = 'verify_email.token';
+
+    /**
+     * Send an email verification link to a user.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanVerifyEmail  $user
+     * @param  \Closure|null  $callback
+     * @return string
+     */
+    public function sendVerificationLink(CanVerifyEmailContract $user, Closure $callback = null);
+
+    /**
+     * Verify the email address for the given token.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanVerifyEmail  $user
+     * @param  string  $token
+     * @return mixed
+     */
+    public function verify(CanVerifyEmailContract $user, $token);
+}

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Foundation\Auth;
+
+use Illuminate\Http\Request;
+use Illuminate\Mail\Message;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\VerifyEmail;
+
+trait VerifiesEmails
+{
+    /**
+     * Display a message about the user's unverified email address.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function getUnverified()
+    {
+        return view('auth.unverified-email');
+    }
+
+    /**
+     * Send another verification email.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function postResend(Request $request)
+    {
+        $user = Auth::user();
+
+        if ($user->getVerified()) {
+            return redirect()->back();
+        }
+
+        $response = VerifyEmail::sendVerificationLink($user, function (Message $message) use ($user) {
+            $message->subject($user->getVerifyEmailSubject());
+        });
+
+        switch ($response) {
+            case VerifyEmail::VERIFY_LINK_SENT:
+                return redirect()->back()->with('status', trans($response));
+        }
+    }
+
+    /**
+     * Attempt to verify a user.
+     *
+     * @param  string  $token
+     * @return \Illuminate\Http\Response
+     */
+    public function getVerify($token)
+    {
+        $response = VerifyEmail::verify(Auth::user(), $token);
+
+        switch ($response) {
+            case VerifyEmail::EMAIL_VERIFIED:
+                return redirect($this->redirectPath())->with('status', trans($response));
+
+            default:
+                return redirect()->back()
+                            ->withErrors(['email' => trans($response)]);
+        }
+    }
+
+    /**
+     * Get the post register / login redirect path.
+     *
+     * @return string
+     */
+    public function redirectPath()
+    {
+        return property_exists($this, 'redirectTo') ? $this->redirectTo : '/home';
+    }
+}

--- a/src/Illuminate/Support/Facades/VerifyEmail.php
+++ b/src/Illuminate/Support/Facades/VerifyEmail.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+/**
+ * @see \Illuminate\Auth\Emails\VerifyEmailBroker
+ */
+class VerifyEmail extends Facade
+{
+    /**
+     * Constant representing a successfully sent verification link.
+     *
+     * @var string
+     */
+    const VERIFY_LINK_SENT = 'verify_email.sent';
+
+    /**
+     * Constant representing a successfully verified email address.
+     *
+     * @var string
+     */
+    const EMAIL_VERIFIED = 'verify_email.verified';
+
+    /**
+     * Constant representing an invalid token.
+     *
+     * @var string
+     */
+    const INVALID_TOKEN = 'verify_email.token';
+
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'auth.verify_email';
+    }
+}

--- a/tests/Auth/AuthVerifyEmailBrokerTest.php
+++ b/tests/Auth/AuthVerifyEmailBrokerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Contracts\Auth\VerifyEmailBroker;
+
+class AuthVerifyEmailBrokerTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testBrokerCreatesTokenAndRedirectsWithoutError()
+    {
+        $mocks = $this->getMocks();
+        $broker = $this->getMock('Illuminate\Auth\VerifyEmails\VerifyEmailBroker', ['emailVerificationLink', 'getUri'], array_values($mocks));
+        $user = m::mock('Illuminate\Contracts\Auth\CanVerifyEmail');
+        $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
+        $callback = function () {};
+        $broker->expects($this->once())->method('emailVerificationLink')->with($this->equalTo($user), $this->equalTo('token'), $this->equalTo($callback));
+
+        $this->assertEquals(VerifyEmailBroker::VERIFY_LINK_SENT, $broker->sendVerificationLink($user, $callback));
+    }
+
+    public function testMailerIsCalledWithProperViewTokenAndCallback()
+    {
+        unset($_SERVER['__email.verify.test']);
+        $broker = $this->getBroker($mocks = $this->getMocks());
+        $callback = function ($message, $user) { $_SERVER['__email.verify.test'] = true; };
+        $user = m::mock('Illuminate\Contracts\Auth\CanVerifyEmail');
+        $mocks['mailer']->shouldReceive('send')->once()->with('verifyLinkView', ['token' => 'token', 'user' => $user], m::type('Closure'))->andReturnUsing(function ($view, $data, $callback) {
+            return $callback;
+        });
+        $user->shouldReceive('getEmailToVerify')->once()->andReturn('email');
+        $message = m::mock('StdClass');
+        $message->shouldReceive('to')->once()->with('email');
+        $result = $broker->emailVerificationLink($user, 'token', $callback);
+        call_user_func($result, $message);
+
+        $this->assertTrue($_SERVER['__email.verify.test']);
+    }
+
+    public function testRedirectReturnedByVerifyWhenRecordDoesntExistInTable()
+    {
+        $creds = ['token' => 'token'];
+        $broker = $this->getBroker($mocks = $this->getMocks());
+        $user = m::mock('Illuminate\Contracts\Auth\CanVerifyEmail');
+        $mocks['tokens']->shouldReceive('exists')->with($user, 'token')->andReturn(false);
+
+        $this->assertEquals(VerifyEmailBroker::INVALID_TOKEN, $broker->verify($user, 'token'));
+    }
+
+    public function testVerifyRemovesRecordOnReminderTableAndCallsSetVerify()
+    {
+        $broker = $this->getMock('Illuminate\Auth\VerifyEmails\VerifyEmailBroker', ['validateVerification', 'getToken'], array_values($mocks = $this->getMocks()));
+        $user = m::mock('Illuminate\Contracts\Auth\CanVerifyEmail');
+        $user->shouldReceive('setVerified')->once();
+        $user->shouldReceive('save')->once();
+        $broker->expects($this->once())->method('validateVerification')->will($this->returnValue($user));
+        $mocks['tokens']->shouldReceive('delete')->once()->with('token');
+
+        $this->assertEquals(VerifyEmailBroker::EMAIL_VERIFIED, $broker->verify($user, 'token'));
+    }
+
+    protected function getBroker($mocks)
+    {
+        return new \Illuminate\Auth\VerifyEmails\VerifyEmailBroker($mocks['tokens'], $mocks['mailer'], $mocks['view']);
+    }
+
+    protected function getMocks()
+    {
+        $mocks = [
+            'tokens' => m::mock('Illuminate\Auth\VerifyEmails\TokenRepositoryInterface'),
+            'mailer'    => m::mock('Illuminate\Contracts\Mail\Mailer'),
+            'view'      => 'verifyLinkView',
+        ];
+
+        return $mocks;
+    }
+}


### PR DESCRIPTION
This adds a boilerplate for verifying emails in applications - in my experience something that's required in almost every application, and has been requested in #3651 and #4211.

It follows the exact same pattern as password resets, except that it doesn't match a user by credentials - they have to be logged in (this is largely to avoid the need for them typing in their email, as with a password reset, since this isn't standard practice).

It's also intended that the same token table is used as with password resets. As with password resets, this requires a migration, as well as lines in the auth config and some views. I'll gladly create pull requests for the app template and docs if this is accepted.
