### PR TITLE
[5.2] Issue #11285 - Ability to capitalize translation placeholders

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -149,7 +149,9 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
         $replace = $this->sortReplacements($replace);
 
         foreach ($replace as $key => $value) {
-            $line = str_replace(':'.$key, $value, $line);
+            $search = [':'.strtoupper($key), ':'.ucfirst($key), ':'.$key];
+            $replace = [strtoupper($value), ucfirst($value), $value];
+            $line = str_replace($search, $replace, $line);
         }
 
         return $line;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1748,9 +1748,8 @@ class Validator implements ValidatorContract
      */
     protected function doReplacements($message, $attribute, $rule, $parameters)
     {
-        $search = [':ATTRIBUTE', ':Attribute', ':attribute'];
-        $replace = [strtoupper($this->getAttribute($attribute)), ucfirst($this->getAttribute($attribute)), $this->getAttribute($attribute)];
-        $message = str_replace($search, $replace, $message);
+        $value = $this->getAttribute($attribute);
+        $message = str_replace([':ATTRIBUTE', ':Attribute', ':attribute'], [strtoupper($value), ucfirst($value), $value], $message);
 
         if (isset($this->replacers[Str::snake($rule)])) {
             $message = $this->callReplacer($message, $attribute, Str::snake($rule), $parameters);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1748,7 +1748,9 @@ class Validator implements ValidatorContract
      */
     protected function doReplacements($message, $attribute, $rule, $parameters)
     {
-        $message = str_replace(':attribute', $this->getAttribute($attribute), $message);
+        $search = [':ATTRIBUTE', ':Attribute', ':attribute'];
+        $replace = [strtoupper($this->getAttribute($attribute)), ucfirst($this->getAttribute($attribute)), $this->getAttribute($attribute)];
+        $message = str_replace($search, $replace, $message);
 
         if (isset($this->replacers[Str::snake($rule)])) {
             $message = $this->callReplacer($message, $attribute, Str::snake($rule), $parameters);


### PR DESCRIPTION
Ability to capitalize translation placeholders for both Validation Rules and Strings.

As suggested in Issue #11285. 

The makeReplacements method (on the Translator) and the doReplacements() method (on the Validator) now first check and string replace all capital attributes/placeholders with the same case (all capital) replacement, followed by uppercased attributes/placeholders and finally replacing the lowercase attributes/placeholders as before.
