### PR TITLE
[5.1] Fix for tagged cache events

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -13,9 +13,9 @@ class RedisTaggedCache extends TaggedCache
      */
     public function forever($key, $value)
     {
-        $this->pushForeverKeys($namespace = $this->tags->getNamespace(), $key);
+        $this->pushForeverKeys($this->tags->getNamespace(), $key);
 
-        $this->store->forever(sha1($namespace).':'.$key, $value);
+        parent::forever($key, $value);
     }
 
     /**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -95,7 +95,7 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function get($key, $default = null)
     {
-        $value = $this->store->get($key);
+        $value = $this->store->get($this->itemKey($key));
 
         if (is_null($value)) {
             $this->fireCacheEvent('missed', [$key]);
@@ -137,7 +137,7 @@ class Repository implements CacheContract, ArrayAccess
         $minutes = $this->getMinutes($minutes);
 
         if (! is_null($minutes)) {
-            $this->store->put($key, $value, $minutes);
+            $this->store->put($this->itemKey($key), $value, $minutes);
 
             $this->fireCacheEvent('write', [$key, $value, $minutes]);
         }
@@ -160,7 +160,7 @@ class Repository implements CacheContract, ArrayAccess
         }
 
         if (method_exists($this->store, 'add')) {
-            return $this->store->add($key, $value, $minutes);
+            return $this->store->add($this->itemKey($key), $value, $minutes);
         }
 
         if (is_null($this->get($key))) {
@@ -181,7 +181,7 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function forever($key, $value)
     {
-        $this->store->forever($key, $value);
+        $this->store->forever($this->itemKey($key), $value);
 
         $this->fireCacheEvent('write', [$key, $value, 0]);
     }
@@ -249,7 +249,7 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function forget($key)
     {
-        $success = $this->store->forget($key);
+        $success = $this->store->forget($this->itemKey($key));
 
         $this->fireCacheEvent('delete', [$key]);
 
@@ -384,6 +384,17 @@ class Repository implements CacheContract, ArrayAccess
         }
 
         return is_string($duration) ? (int) $duration : $duration;
+    }
+
+    /**
+     * Get the key to be used with the store.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function itemKey($key)
+    {
+        return $key;
     }
 
     /**

--- a/src/Illuminate/Cache/TagSet.php
+++ b/src/Illuminate/Cache/TagSet.php
@@ -97,4 +97,14 @@ class TagSet
     {
         return 'tag:'.$name.':key';
     }
+
+    /**
+     * Get all of the names in the set.
+     *
+     * @return array
+     */
+    public function getNames()
+    {
+        return $this->names;
+    }
 }

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -2,20 +2,10 @@
 
 namespace Illuminate\Cache;
 
-use Closure;
-use DateTime;
-use Carbon\Carbon;
 use Illuminate\Contracts\Cache\Store;
 
-class TaggedCache implements Store
+class TaggedCache extends Repository
 {
-    /**
-     * The cache store implementation.
-     *
-     * @var \Illuminate\Contracts\Cache\Store
-     */
-    protected $store;
-
     /**
      * The tag set instance.
      *
@@ -32,69 +22,50 @@ class TaggedCache implements Store
      */
     public function __construct(Store $store, TagSet $tags)
     {
+        parent::__construct($store);
+
         $this->tags = $tags;
-        $this->store = $store;
     }
 
     /**
-     * Determine if an item exists in the cache.
-     *
-     * @param  string  $key
-     * @return bool
+     * {@inheritdoc}
      */
-    public function has($key)
+    protected function fireCacheEvent($event, $payload)
     {
-        return ! is_null($this->get($key));
+        if (preg_match('/^'.sha1($this->tags->getNamespace()).':(.*)$/', $payload[0], $matches) === 1) {
+            $payload[0] = $matches[1];
+        }
+        $payload[] = $this->tags->getNames();
+
+        parent::fireCacheEvent($event, $payload);
     }
 
     /**
-     * Retrieve an item from the cache by key.
-     *
-     * @param  string  $key
-     * @param  mixed   $default
-     * @return mixed
+     * {@inheritdoc}
      */
     public function get($key, $default = null)
     {
-        $value = $this->store->get($this->taggedItemKey($key));
-
-        return ! is_null($value) ? $value : value($default);
+        return parent::get($this->taggedItemKey($key), $default);
     }
 
     /**
-     * Store an item in the cache for a given number of minutes.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @param  \DateTime|int  $minutes
-     * @return void
+     * {@inheritdoc}
      */
     public function put($key, $value, $minutes)
     {
-        $minutes = $this->getMinutes($minutes);
-
-        if (! is_null($minutes)) {
-            $this->store->put($this->taggedItemKey($key), $value, $minutes);
-        }
+        parent::put($this->taggedItemKey($key), $value, $minutes);
     }
 
     /**
-     * Store an item in the cache if the key does not exist.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @param  \DateTime|int  $minutes
-     * @return bool
+     * {@inheritdoc}
      */
     public function add($key, $value, $minutes)
     {
-        if (is_null($this->get($key))) {
-            $this->put($key, $value, $minutes);
-
-            return true;
+        if (method_exists($this->store, 'add')) {
+            $key = $this->taggedItemKey($key);
         }
 
-        return false;
+        return parent::add($key, $value, $minutes);
     }
 
     /**
@@ -122,26 +93,19 @@ class TaggedCache implements Store
     }
 
     /**
-     * Store an item in the cache indefinitely.
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return void
+     * {@inheritdoc}
      */
     public function forever($key, $value)
     {
-        $this->store->forever($this->taggedItemKey($key), $value);
+        parent::forever($this->taggedItemKey($key), $value);
     }
 
     /**
-     * Remove an item from the cache.
-     *
-     * @param  string  $key
-     * @return bool
+     * {@inheritdoc}
      */
     public function forget($key)
     {
-        return $this->store->forget($this->taggedItemKey($key));
+        return parent::forget($this->taggedItemKey($key));
     }
 
     /**
@@ -155,61 +119,6 @@ class TaggedCache implements Store
     }
 
     /**
-     * Get an item from the cache, or store the default value.
-     *
-     * @param  string  $key
-     * @param  \DateTime|int  $minutes
-     * @param  \Closure  $callback
-     * @return mixed
-     */
-    public function remember($key, $minutes, Closure $callback)
-    {
-        // If the item exists in the cache we will just return this immediately
-        // otherwise we will execute the given Closure and cache the result
-        // of that execution for the given number of minutes in storage.
-        if (! is_null($value = $this->get($key))) {
-            return $value;
-        }
-
-        $this->put($key, $value = $callback(), $minutes);
-
-        return $value;
-    }
-
-    /**
-     * Get an item from the cache, or store the default value forever.
-     *
-     * @param  string    $key
-     * @param  \Closure  $callback
-     * @return mixed
-     */
-    public function sear($key, Closure $callback)
-    {
-        return $this->rememberForever($key, $callback);
-    }
-
-    /**
-     * Get an item from the cache, or store the default value forever.
-     *
-     * @param  string    $key
-     * @param  \Closure  $callback
-     * @return mixed
-     */
-    public function rememberForever($key, Closure $callback)
-    {
-        // If the item exists in the cache we will just return this immediately
-        // otherwise we will execute the given Closure and cache the result
-        // of that execution for an indefinite amount of time. It's easy.
-        if (! is_null($value = $this->get($key))) {
-            return $value;
-        }
-
-        $this->forever($key, $value = $callback());
-
-        return $value;
-    }
-
-    /**
      * Get a fully qualified key for a tagged item.
      *
      * @param  string  $key
@@ -218,32 +127,5 @@ class TaggedCache implements Store
     public function taggedItemKey($key)
     {
         return sha1($this->tags->getNamespace()).':'.$key;
-    }
-
-    /**
-     * Get the cache key prefix.
-     *
-     * @return string
-     */
-    public function getPrefix()
-    {
-        return $this->store->getPrefix();
-    }
-
-    /**
-     * Calculate the number of minutes with the given duration.
-     *
-     * @param  \DateTime|int  $duration
-     * @return int|null
-     */
-    protected function getMinutes($duration)
-    {
-        if ($duration instanceof DateTime) {
-            $fromNow = Carbon::now()->diffInMinutes(Carbon::instance($duration), false);
-
-            return $fromNow > 0 ? $fromNow : null;
-        }
-
-        return is_string($duration) ? (int) $duration : $duration;
     }
 }

--- a/src/Illuminate/Cache/TaggedCache.php
+++ b/src/Illuminate/Cache/TaggedCache.php
@@ -32,40 +32,9 @@ class TaggedCache extends Repository
      */
     protected function fireCacheEvent($event, $payload)
     {
-        if (preg_match('/^'.sha1($this->tags->getNamespace()).':(.*)$/', $payload[0], $matches) === 1) {
-            $payload[0] = $matches[1];
-        }
         $payload[] = $this->tags->getNames();
 
         parent::fireCacheEvent($event, $payload);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function get($key, $default = null)
-    {
-        return parent::get($this->taggedItemKey($key), $default);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function put($key, $value, $minutes)
-    {
-        parent::put($this->taggedItemKey($key), $value, $minutes);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function add($key, $value, $minutes)
-    {
-        if (method_exists($this->store, 'add')) {
-            $key = $this->taggedItemKey($key);
-        }
-
-        return parent::add($key, $value, $minutes);
     }
 
     /**
@@ -77,7 +46,7 @@ class TaggedCache extends Repository
      */
     public function increment($key, $value = 1)
     {
-        $this->store->increment($this->taggedItemKey($key), $value);
+        $this->store->increment($this->itemKey($key), $value);
     }
 
     /**
@@ -89,23 +58,7 @@ class TaggedCache extends Repository
      */
     public function decrement($key, $value = 1)
     {
-        $this->store->decrement($this->taggedItemKey($key), $value);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function forever($key, $value)
-    {
-        parent::forever($this->taggedItemKey($key), $value);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function forget($key)
-    {
-        return parent::forget($this->taggedItemKey($key));
+        $this->store->decrement($this->itemKey($key), $value);
     }
 
     /**
@@ -127,5 +80,13 @@ class TaggedCache extends Repository
     public function taggedItemKey($key)
     {
         return sha1($this->tags->getNamespace()).':'.$key;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function itemKey($key)
+    {
+        return $this->taggedItemKey($key);
     }
 }

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -1,0 +1,163 @@
+<?php
+
+use Mockery as m;
+
+class CacheEventTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testHasTriggersEvents()
+    {
+        $dispatcher = $this->getDispatcher();
+        $repository = $this->getRepository($dispatcher);
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.missed', ['foo']);
+        $this->assertFalse($repository->has('foo'));
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.hit', ['baz', 'qux']);
+        $this->assertTrue($repository->has('baz'));
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.missed', ['foo', ['taylor']]);
+        $dispatcher->shouldReceive('fire')->never();
+        $this->assertFalse($repository->tags('taylor')->has('foo'));
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.hit', ['baz', 'qux', ['taylor']]);
+        $this->assertTrue($repository->tags('taylor')->has('baz'));
+    }
+
+    public function testGetTriggersEvents()
+    {
+        $dispatcher = $this->getDispatcher();
+        $repository = $this->getRepository($dispatcher);
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.missed', ['foo']);
+        $this->assertNull($repository->get('foo'));
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.hit', ['baz', 'qux']);
+        $this->assertEquals('qux', $repository->get('baz'));
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.missed', ['foo', ['taylor']]);
+        $this->assertNull($repository->tags('taylor')->get('foo'));
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.hit', ['baz', 'qux', ['taylor']]);
+        $this->assertEquals('qux', $repository->tags('taylor')->get('baz'));
+    }
+
+    public function testPullTriggersEvents()
+    {
+        $dispatcher = $this->getDispatcher();
+        $repository = $this->getRepository($dispatcher);
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.hit', ['baz', 'qux']);
+        $dispatcher->shouldReceive('fire')->once()->with('cache.delete', ['baz']);
+        $this->assertEquals('qux', $repository->pull('baz'));
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.hit', ['baz', 'qux', ['taylor']]);
+        $dispatcher->shouldReceive('fire')->once()->with('cache.delete', ['baz', ['taylor']]);
+        $this->assertEquals('qux', $repository->tags('taylor')->pull('baz'));
+    }
+
+    public function testPutTriggersEvents()
+    {
+        $dispatcher = $this->getDispatcher();
+        $repository = $this->getRepository($dispatcher);
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.write', ['foo', 'bar', 99]);
+        $repository->put('foo', 'bar', 99);
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.write', ['foo', 'bar', 99, ['taylor']]);
+        $repository->tags('taylor')->put('foo', 'bar', 99);
+    }
+
+    public function testAddTriggersEvents()
+    {
+        $dispatcher = $this->getDispatcher();
+        $repository = $this->getRepository($dispatcher);
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.missed', ['foo']);
+        $dispatcher->shouldReceive('fire')->once()->with('cache.write', ['foo', 'bar', 99]);
+        $this->assertTrue($repository->add('foo', 'bar', 99));
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.missed', ['foo', ['taylor']]);
+        $dispatcher->shouldReceive('fire')->once()->with('cache.write', ['foo', 'bar', 99, ['taylor']]);
+        $this->assertTrue($repository->tags('taylor')->add('foo', 'bar', 99));
+    }
+
+    public function testForeverTriggersEvents()
+    {
+        $dispatcher = $this->getDispatcher();
+        $repository = $this->getRepository($dispatcher);
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.write', ['foo', 'bar', 0]);
+        $repository->forever('foo', 'bar');
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.write', ['foo', 'bar', 0, ['taylor']]);
+        $repository->tags('taylor')->forever('foo', 'bar');
+    }
+
+    public function testRememberTriggersEvents()
+    {
+        $dispatcher = $this->getDispatcher();
+        $repository = $this->getRepository($dispatcher);
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.missed', ['foo']);
+        $dispatcher->shouldReceive('fire')->once()->with('cache.write', ['foo', 'bar', 99]);
+        $this->assertEquals('bar', $repository->remember('foo', 99, function () {
+            return 'bar';
+        }));
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.missed', ['foo', ['taylor']]);
+        $dispatcher->shouldReceive('fire')->once()->with('cache.write', ['foo', 'bar', 99, ['taylor']]);
+        $this->assertEquals('bar', $repository->tags('taylor')->remember('foo', 99, function () {
+            return 'bar';
+        }));
+    }
+
+    public function testRememberForeverTriggersEvents()
+    {
+        $dispatcher = $this->getDispatcher();
+        $repository = $this->getRepository($dispatcher);
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.missed', ['foo']);
+        $dispatcher->shouldReceive('fire')->once()->with('cache.write', ['foo', 'bar', 0]);
+        $this->assertEquals('bar', $repository->rememberForever('foo', function () {
+            return 'bar';
+        }));
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.missed', ['foo', ['taylor']]);
+        $dispatcher->shouldReceive('fire')->once()->with('cache.write', ['foo', 'bar', 0, ['taylor']]);
+        $this->assertEquals('bar', $repository->tags('taylor')->rememberForever('foo', function () {
+            return 'bar';
+        }));
+    }
+
+    public function testForgetTriggersEvents()
+    {
+        $dispatcher = $this->getDispatcher();
+        $repository = $this->getRepository($dispatcher);
+
+        $dispatcher->shouldReceive('fire')->once()->with('cache.delete', ['baz']);
+        $this->assertTrue($repository->forget('baz'));
+
+        // $dispatcher->shouldReceive('fire')->once()->with('cache.delete', ['baz', ['taylor']]);
+        // $this->assertTrue($repository->tags('taylor')->forget('baz'));
+    }
+
+    protected function getDispatcher()
+    {
+        return m::mock('Illuminate\Events\Dispatcher');
+    }
+
+    protected function getRepository($dispatcher)
+    {
+        $repository = new \Illuminate\Cache\Repository(new \Illuminate\Cache\ArrayStore());
+        $repository->put('baz', 'qux', 99);
+        $repository->tags('taylor')->put('baz', 'qux', 99);
+        $repository->setEventDispatcher($dispatcher);
+
+        return $repository;
+    }
+}

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -70,6 +70,7 @@ class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase
         $store = m::mock('Illuminate\Contracts\Cache\Store');
         $tagSet = m::mock('Illuminate\Cache\TagSet', [$store, ['foo', 'bar']]);
         $tagSet->shouldReceive('getNamespace')->andReturn('foo|bar');
+        $tagSet->shouldReceive('getNames')->andReturn(['foo', 'bar']);
         $redis = new Illuminate\Cache\RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');
         $store->shouldReceive('connection')->andReturn($conn = m::mock('StdClass'));


### PR DESCRIPTION
This is a possible way to fix #10423. The problem lies in the `TaggedCache` class which calls the stores directly, bypassing the `Repository` class entirely, which contains all the code for triggering events.

The approach I took in fixing this was to have the `TaggedCache` class extend the `Repository` class and then call the corresponding methods in the parent using the generated cache key for the tags used. This way the code for firing the events is not duplicated.

When an event is fired from a tagged cache an array of the tag names is also passed in the payload now. 

This PR is meant to demonstrate what the issue is and a possible solution. This also has a set of new tests which determine whether the expected events are fired for both tagged and non-tagged caches.
