### PR TITLE
[5.1] Reset global scopes when booted models get cleared

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -330,6 +330,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public static function clearBootedModels()
     {
         static::$booted = [];
+        static::$globalScopes = [];
     }
 
     /**


### PR DESCRIPTION
I don't believe this should be tested, correct me if I'm wrong here.

Why?

I have some global scopes that get triggered depending on some conditions. 
simple use case think: blog posts: admin no scope vs front: published only scope

For the duration of a single request, scopes remain the same. They can be different on different requests. (If not they probably shouldn't be globals anyway)

But when running my tests, scopes remain in there, even if the tests reboot the application which basically means the clearBootedModels get called. (Happens in \Illuminate\Database\DatabaseServiceProvider->register())

so if my front tests run first, my admin tests will fail since the global scopes are still applied from the front tests.

since the clearBootedModels only gets called at registration of the db-component, i don't see why the line couldn't be added? if someone manually called it, they'd not have any issues either, since using any model after the 'reset' would reboot that model and scopes would be reevaluated?
