### PR TITLE
Add trim() to validateUnique() $column variable

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1043,7 +1043,7 @@ class Validator implements ValidatorContract
         $column = isset($parameters[1]) ? $parameters[1] : $attribute;
         // In order to prevent an error caused by certain coding style
         // we will cut off the space from the column name
-        $column = trim($column)
+        $column = trim($column);
         
         list($idColumn, $id) = [null, null];
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1041,7 +1041,10 @@ class Validator implements ValidatorContract
         // be verified as unique. If this parameter isn't specified we will just
         // assume that this column to be verified shares the attribute's name.
         $column = isset($parameters[1]) ? $parameters[1] : $attribute;
-
+        // In order to prevent an error caused by certain coding style
+        // we will cut off the space from the column name
+        $column = trim($column)
+        
         list($idColumn, $id) = [null, null];
 
         if (isset($parameters[2])) {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1044,7 +1044,6 @@ class Validator implements ValidatorContract
         // In order to prevent an error caused by certain coding style
         // we will cut off the space from the column name
         $column = trim($column);
-        
         list($idColumn, $id) = [null, null];
 
         if (isset($parameters[2])) {


### PR DESCRIPTION
# Problem

When you use the `unique` validation key you can specify the table name, the column involved and other cool stuff. If you try to write a validation like this

``` PHP

"email" => "required|unique:users, email",

```

It will not works
# Error

The error thrown is about the fact that the application is not able to find the column `email` with a space in it

```
QueryException in Connection.php line 653:
SQLSTATE[42S22]: Column not found: Unknown column ' email' in 'where clause' (SQL: select count(*) as aggregate from `users` where ` email` = laravel@homestead and `id` <> 1)
```
# Suggested Fix

This is pretty straightforward and simple just add the `trim` function the current column inside `Validator.php`

``` PHP
 $column = isset($parameters[1]) ? $parameters[1] : $attribute;
 $column = trim($column);
```
# Suggested Fix 2

If the `trim` function seems over power for this task you could simply remove the space from the name by using replacing the first char like so

``` PHP
 $column = isset($parameters[1]) ? $parameters[1] : $attribute;
 $column[0] = null;
```

Let me know what do you think about this.
