### PR TITLE
[5.1] Allow `Illuminate\Database\Eloquent\Factory` to include path during runtime

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -44,15 +44,7 @@ class Factory implements ArrayAccess
     {
         $pathToFactories = $pathToFactories ?: database_path('factories');
 
-        $factory = new static($faker);
-
-        if (is_dir($pathToFactories)) {
-            foreach (Finder::create()->files()->in($pathToFactories) as $file) {
-                require $file->getRealPath();
-            }
-        }
-
-        return $factory;
+        return (new static($faker))->load($pathToFactories);
     }
 
     /**
@@ -104,6 +96,23 @@ class Factory implements ArrayAccess
     public function createAs($class, $name, array $attributes = [])
     {
         return $this->of($class, $name)->create($attributes);
+    }
+
+    /**
+     * Load factories from path.
+     *
+     * @param  string  $path
+     * @return $this
+     */
+    public function load($path)
+    {
+        if (is_dir($path)) {
+            foreach (Finder::create()->files()->in($path) as $file) {
+                require $file->getRealPath();
+            }
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -106,13 +106,15 @@ class Factory implements ArrayAccess
      */
     public function load($path)
     {
+        $factory = $this;
+
         if (is_dir($path)) {
             foreach (Finder::create()->files()->in($path) as $file) {
                 require $file->getRealPath();
             }
         }
 
-        return $this;
+        return $factory;
     }
 
     /**


### PR DESCRIPTION
While it not mainly have any use on application development, it would make it easier to attach factories on/for packages testing environment (encourage integration testing instead of mocking everything).

Signed-off-by: crynobone crynobone@gmail.com
