### PR TITLE
[5.2] Ability to recursively replace parameters in array of Language Lines

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -132,6 +132,18 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
         $line = Arr::get($this->loaded[$namespace][$group][$locale], $item);
         $replace = $this->sortReplacements($replace)->toArray();
 
+        return $this->determineReplacements($line, $replace);
+    }
+
+    /**
+     * Determines whether to make Array or String place-holder replacements.
+     *
+     * @param  string  $line
+     * @param  array   $replace
+     * @return string|array
+     */
+    protected function determineReplacements($line, array $replace)
+    {
         if (is_string($line)) {
             return $this->makeReplacements($line, $replace);
         } elseif (is_array($line) && count($line) > 0) {
@@ -168,15 +180,11 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * @param  array   $replace
      * @return string
      */
-    protected function makeArrayReplacements(array $lines, $replace)
+    protected function makeArrayReplacements(array $lines, array $replace)
     {
         $replaced = [];
         foreach ($lines as $string => $line) {
-            if (is_array($line)) {
-                $replaced[$string] = $this->makeArrayReplacements($line, $replace);
-            } else {
-                $replaced[$string] = $this->makeReplacements($line, $replace);
-            }
+            $replaced[$string] = $this->determineReplacements($line, $replace);
         }
 
         return $replaced;

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -134,7 +134,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
         if (is_string($line)) {
             return $this->makeReplacements($line, $replace);
         } elseif (is_array($line) && count($line) > 0) {
-            return $line;
+            return $this->makeArrayReplacements($line, $replace);
         }
     }
 
@@ -158,6 +158,33 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
         }
 
         return $line;
+    }
+
+    /**
+     * Make the place-holder replacements to all lines provided by the array.
+     *
+     * @param  array   $lines
+     * @param  \Illuminate\Support\Collection|array   $replace
+     * @return string
+     */
+    protected function makeArrayReplacements(array $lines, $replace, $sorted = false)
+    {
+        if (!$sorted) {
+            $replace = $this->sortReplacements($replace);
+        }
+
+        $replaced = [];
+        foreach ($lines as $string => $line) {
+            if (is_array($line)) {
+                $replaced[$string] = $this->makeArrayReplacements($line, $replace, true);
+            } else {
+                foreach ($replace as $key => $value) {
+                    $replaced[$string] = str_replace(':'.$key, $value, $line);
+                }
+            }
+        }
+
+        return $replaced;
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -130,6 +130,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
     protected function getLine($namespace, $group, $locale, $item, array $replace)
     {
         $line = Arr::get($this->loaded[$namespace][$group][$locale], $item);
+        $replace = $this->sortReplacements($replace)->toArray();
 
         if (is_string($line)) {
             return $this->makeReplacements($line, $replace);
@@ -164,23 +165,17 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * Make the place-holder replacements to all lines provided by the array.
      *
      * @param  array   $lines
-     * @param  \Illuminate\Support\Collection|array   $replace
+     * @param  array   $replace
      * @return string
      */
-    protected function makeArrayReplacements(array $lines, $replace, $sorted = false)
+    protected function makeArrayReplacements(array $lines, $replace)
     {
-        if (!$sorted) {
-            $replace = $this->sortReplacements($replace);
-        }
-
         $replaced = [];
         foreach ($lines as $string => $line) {
             if (is_array($line)) {
-                $replaced[$string] = $this->makeArrayReplacements($line, $replace, true);
+                $replaced[$string] = $this->makeArrayReplacements($line, $replace);
             } else {
-                foreach ($replace as $key => $value) {
-                    $replaced[$string] = str_replace(':'.$key, $value, $line);
-                }
+                $replaced[$string] = $this->makeReplacements($line, $replace);
             }
         }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -129,10 +129,10 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      */
     protected function getLine($namespace, $group, $locale, $item, array $replace)
     {
-        $line = Arr::get($this->loaded[$namespace][$group][$locale], $item);
-        $replace = $this->sortReplacements($replace)->toArray();
-
-        return $this->determineReplacements($line, $replace);
+        return $this->determineReplacements(
+            Arr::get($this->loaded[$namespace][$group][$locale], $item),
+            $this->sortReplacements($replace)->toArray()
+        );
     }
 
     /**


### PR DESCRIPTION
I think this could be quite helpful (certainly would be for a project I'm working on at the moment), so if this is seen as useful and a worthy addition, I will create some tests for the functionality to ensure it's working correctly. 

Recursively cycles through all lines returned, and if the line is a string the makeReplacements() method is used to make replacements else the recursion continues. No parameter replacements are done on keys, since that would open up the possibility of overriding values etc.

Thoughts?
