### PR TITLE
[5.2] Change exception handler to use laravel's logging class

### DIFF
--- a/src/Illuminate/Contracts/Logging/Log.php
+++ b/src/Illuminate/Contracts/Logging/Log.php
@@ -2,81 +2,10 @@
 
 namespace Illuminate\Contracts\Logging;
 
-interface Log
+use Psr\Log\LoggerInterface;
+
+interface Log extends LoggerInterface
 {
-    /**
-     * Log an alert message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function alert($message, array $context = []);
-
-    /**
-     * Log a critical message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function critical($message, array $context = []);
-
-    /**
-     * Log an error message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function error($message, array $context = []);
-
-    /**
-     * Log a warning message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function warning($message, array $context = []);
-
-    /**
-     * Log a notice to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function notice($message, array $context = []);
-
-    /**
-     * Log an informational message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function info($message, array $context = []);
-
-    /**
-     * Log a debug message to the logs.
-     *
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function debug($message, array $context = []);
-
-    /**
-     * Log a message to the logs.
-     *
-     * @param  string  $level
-     * @param  string  $message
-     * @param  array  $context
-     * @return void
-     */
-    public function log($level, $message, array $context = []);
-
     /**
      * Register a file log handler.
      *

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Foundation\Exceptions;
 
 use Exception;
-use Psr\Log\LoggerInterface;
+use Illuminate\Contracts\Logging\Log;
 use Illuminate\Http\Response;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Exception\HttpResponseException;
@@ -22,7 +22,7 @@ class Handler implements ExceptionHandlerContract
     /**
      * The log implementation.
      *
-     * @var \Psr\Log\LoggerInterface
+     * @var \Illuminate\Contracts\Logging\Log
      */
     protected $log;
 
@@ -36,10 +36,10 @@ class Handler implements ExceptionHandlerContract
     /**
      * Create a new exception handler instance.
      *
-     * @param  \Psr\Log\LoggerInterface  $log
+     * @param  \Illuminate\Contracts\Logging\Log  $log
      * @return void
      */
-    public function __construct(LoggerInterface $log)
+    public function __construct(Log $log)
     {
         $this->log = $log;
     }

--- a/src/Illuminate/Log/Writer.php
+++ b/src/Illuminate/Log/Writer.php
@@ -14,10 +14,9 @@ use Monolog\Handler\RotatingFileHandler;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
-use Psr\Log\LoggerInterface as PsrLoggerInterface;
 use Illuminate\Contracts\Logging\Log as LogContract;
 
-class Writer implements LogContract, PsrLoggerInterface
+class Writer implements LogContract
 {
     /**
      * The Monolog logger instance.


### PR DESCRIPTION
Currently, `Illuminate\Foundation\Exceptions\Handler` uses the Monolog instance as its log implementation. This seems strange, as `Illuminate\Log\Writer` would work as a drop-in replacement here, but with the important difference that any log event listeners are fired, which is important so that e.g. a Rollbar service provider can just attach to the log listener, without the user having to modify the handler `report` method.

Also, I changed `Illuminate\Contracts\Logging\Log` to extend `Psr\Log\LoggerInterface`, in order to reduce the redundancy of having two almost identical interfaces.
