### PR TITLE
[5.1] Check for an empty string in the attributes and make it explicitly null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2890,6 +2890,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $value = $this->asJson($value);
         }
 
+        // If the value is an empty string, convert it to be explicity null.  This
+        // prevents errors when inserting into a postgres database where the column
+        // constraint is non null but an empty string is passed.
+        if ($value === '') {
+            $value = null;
+        }
+
         $this->attributes[$key] = $value;
 
         return $this;


### PR DESCRIPTION
Currently Illuminate\Database\Eloquent\Model does not convert empty strings to null values. This poses an issue when inserting values through mass assignment in PostgreSQL.

As it stands, if a column is of the type integer and is nullable or default(0), an empty string ('') will caused an exception for the following reason Invalid text representation: 7 ERROR: invalid input syntax for integer: "". Explicitly setting empty strings to null will fix this problem.
