### PR TITLE
[5.2] Better implementation of tooManyAttempts() for RateLimiter class

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -34,12 +34,12 @@ class RateLimiter
      */
     public function tooManyAttempts($key, $maxAttempts, $decayMinutes = 1)
     {
-        $lockedOut = $this->cache->has($key.':lockout');
+        if ($this->cache->has($key.':lockout')) {
+            return true;
+        }
 
-        if ($this->attempts($key) > $maxAttempts || $lockedOut) {
-            if (! $lockedOut) {
-                $this->cache->add($key.':lockout', time() + ($decayMinutes * 60), $decayMinutes);
-            }
+        if ($this->attempts($key) > $maxAttempts) {
+            $this->cache->add($key.':lockout', time() + ($decayMinutes * 60), $decayMinutes);
 
             return true;
         }

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -14,7 +14,6 @@ class CacheRateLimiterTest extends PHPUnit_Framework_TestCase
     public function testTooManyAttemptsReturnTrueIfAlreadyLockedOut()
     {
         $cache = m::mock(Cache::class);
-        $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(0);
         $cache->shouldReceive('has')->once()->with('key:lockout')->andReturn(true);
         $cache->shouldReceive('add')->never();
         $rateLimiter = new RateLimiter($cache);


### PR DESCRIPTION
This commit improves the `tooManyAttempts()` method in terms of logic and readability. The commit message is self-explanatory.
