### PR TITLE
[5.1] Remove case 4 args in Facade::__callStatic

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -221,9 +221,6 @@ abstract class Facade
             case 3:
                 return $instance->$method($args[0], $args[1], $args[2]);
 
-            case 4:
-                return $instance->$method($args[0], $args[1], $args[2], $args[3]);
-
             default:
                 return call_user_func_array([$instance, $method], $args);
         }


### PR DESCRIPTION
Should not pass more than 3 arguments to this... Or even less?
