### PR TITLE
[Minor] tweak eloquent's paginate()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -270,7 +270,7 @@ class Builder
      */
     public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
     {
-        $total = $this->query->getCountForPagination();
+        $total = $this->query->getCountForPagination($columns);
 
         $this->query->forPage(
             $page = $page ?: Paginator::resolveCurrentPage($pageName),


### PR DESCRIPTION
by default, eloquent model will execute `select count(`*`) as aggregate from `$tablename` ...;` when you call

```
$eloquentModel->paginate($perPage);
```

even if you call it like this 

```
$eloquentModel->paginate($perPage, 'id');
```

the resulting query still remains same.

---

I added the missing piece so the second function will produce a different SQL query. something like this:

```
select count(`id`) as aggregate from `$tablename` ...;
```
