### PR TITLE
[5.1] Carbon instance as mutator $value

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2654,14 +2654,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function getAttributeValue($key)
     {
         $value = $this->getAttributeFromArray($key);
-
-        // If the attribute has a get mutator, we will call that then return what
-        // it returns as the value, which is useful for transforming values on
-        // retrieval from the model to a form that is more useful for usage.
-        if ($this->hasGetMutator($key)) {
-            return $this->mutateAttribute($key, $value);
-        }
-
+        
         // If the attribute exists within the cast array, we will convert it to
         // an appropriate native PHP type dependant upon the associated value
         // given with the key in the pair. Dayle made this comment line up.
@@ -2674,8 +2667,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // date fields without having to create a mutator for each property.
         elseif (in_array($key, $this->getDates())) {
             if (! is_null($value)) {
-                return $this->asDateTime($value);
+                $value = $this->asDateTime($value);
             }
+        }
+        
+        // If the attribute has a get mutator, we will call that then return what
+        // it returns as the value, which is useful for transforming values on
+        // retrieval from the model to a form that is more useful for usage.
+        if ($this->hasGetMutator($key)) {
+            return $this->mutateAttribute($key, $value);
         }
 
         return $value;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2654,7 +2654,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function getAttributeValue($key)
     {
         $value = $this->getAttributeFromArray($key);
-        
+
         // If the attribute exists within the cast array, we will convert it to
         // an appropriate native PHP type dependant upon the associated value
         // given with the key in the pair. Dayle made this comment line up.
@@ -2670,7 +2670,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 $value = $this->asDateTime($value);
             }
         }
-        
+
         // If the attribute has a get mutator, we will call that then return what
         // it returns as the value, which is useful for transforming values on
         // retrieval from the model to a form that is more useful for usage.


### PR DESCRIPTION
 When you create a custom mutator method, a column defined as a date is no longer converted to a carbon instance. this is because <code>$model->getAttributeValue()</code> returns as soon as a mutator was found. Wouldnt it be nice to receive a carbon instance as a $value inside your mutator rather than having to create it manually? what else would you want to do with a date column besides mutating the format of the date?

This pull request fixes that by changing the order in which getAttributeValue() returns its value and gets the mutator defined by the client.

Incase anyone is wondering, this does not break when someone is manually instantiating a carbon instance. carbon converts anything to a <code>datetime</code> string inside the constructor before instantiating.

Thoughts?
