### PR TITLE
[5.2] Internal request throttling

### DIFF
--- a/src/Illuminate/Http/InternalRequest.php
+++ b/src/Illuminate/Http/InternalRequest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Http;
+
+class InternalRequest extends Request
+{
+    //
+}

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -58,6 +58,16 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Indicates the request is internal.
+     *
+     * @return bool
+     */
+    final public function internal()
+    {
+        return $this instanceof InternalRequest;
+    }
+
+    /**
      * Get the request method.
      *
      * @return string

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -3,6 +3,7 @@
 use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
+use Illuminate\Http\InternalRequest;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class HttpRequestTest extends PHPUnit_Framework_TestCase
@@ -135,6 +136,19 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($request->pjax());
         $request->headers->set('X-PJAX', '');
         $this->assertFalse($request->pjax());
+    }
+
+    public function testInternalRequest()
+    {
+        $request = InternalRequest::create('/', 'GET', [], [], [], [], '{}');
+        $this->assertTrue($request->internal());
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertInstanceOf(InternalRequest::class, $request);
+
+        $request = Request::create('/', 'GET', [], [], [], [], '{}');
+        $this->assertFalse($request->internal());
+        $this->assertInstanceOf(Request::class, $request);
+        $this->assertNotInstanceOf(InternalRequest::class, $request);
     }
 
     public function testSecureMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -144,7 +144,10 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($request->internal());
         $this->assertInstanceOf(Request::class, $request);
         $this->assertInstanceOf(InternalRequest::class, $request);
+    }
 
+    public function testExternalRequest()
+    {
         $request = Request::create('/', 'GET', [], [], [], [], '{}');
         $this->assertFalse($request->internal());
         $this->assertInstanceOf(Request::class, $request);


### PR DESCRIPTION
This PR provides the possibility an internal request to skip `\Illuminate\Routing\Middleware\ThrottleRequests`.

Also the request comes with the `internal()`method which makes it easy to handle it differently in your own middleware.

Note:

There is no "guessing" about the fact a request is internal or external. For internal requests, `\Illuminate\Http\InternalRequest` must be used explicitly.

---

Related:

https://github.com/dingo/api/issues/751
https://github.com/dingo/api/pull/752
https://github.com/dingo/api/issues/767
