### PR TITLE
[5.2] Add a testing method to ensure events are not fired

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -45,6 +45,43 @@ trait MocksApplicationServices
     }
 
     /**
+     * Specify a list of events that should not be fired for the given operation.
+     *
+     * These events will be mocked, so that handlers will not actually be executed.
+     *
+     * @param  array|string  $events
+     * @return $this
+     */
+    public function dontSeeEvents($events)
+    {
+        $events = is_array($events) ? $events : func_get_args();
+        $calledEvents = [];
+
+        $mock = Mockery::spy('Illuminate\Contracts\Events\Dispatcher');
+
+        $mock->shouldReceive('fire')->andReturnUsing(function ($called) use ($events, &$calledEvents) {
+            foreach ($events as $event) {
+                if ((is_string($called) && ($called === $event || is_subclass_of($called, $event))) ||
+                    (is_object($called) && $called instanceof $event)) {
+                    $calledEvents[] = $event;
+                }
+            }
+        });
+
+        $this->beforeApplicationDestroyed(function () use (&$calledEvents) {
+            if (! empty($calledEvents)) {
+                throw new Exception(
+                    'The following events were fired: ['.implode(', ', $calledEvents).']'
+                );
+            }
+        });
+
+        $this->app->instance('events', $mock);
+
+        return $this;
+    }
+
+    /**
      * Mock the event dispatcher so all events are silenced.
      *
      * @return $this


### PR DESCRIPTION
#11379 removing merge commit

---

We've encountered a situation during our development that requires that an event is not fired during a particular execution. This addition should help with these cases.

Essentially a copy of expectsEvents() above, instead we append the given events to a separate array if they are fired. Upon application close, we confirm that the fired array is empty. If it's not, the events we should not have seen were actually fired, so we throw an exception.
