### PR TITLE
[5.2] Switched order of if statements

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -36,7 +36,7 @@ class RateLimiter
     {
         $lockedOut = $this->cache->has($key.':lockout');
 
-        if ($this->attempts($key) > $maxAttempts || $lockedOut) {
+        if ($lockedOut || $this->attempts($key) > $maxAttempts) {
             if (! $lockedOut) {
                 $this->cache->add($key.':lockout', time() + ($decayMinutes * 60), $decayMinutes);
             }


### PR DESCRIPTION
In the new RateLimiter.php file, the order of ifs can be reversed to avoid an unnecessary call to $this->attempts($key).  

We already have the $lockedOut boolean set, if it's true there is a (tiny) performance gain in avoiding the call to checking if the current amount of attempts is greater than max attempts. 
