### PR TITLE
[5.2] Adding Bus Dispatch Helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -263,6 +263,19 @@ if (! function_exists('decrypt')) {
     }
 }
 
+if (! function_exists('dispatch')) {
+    /**
+     * Dispatch a job to its appropriate handler.
+     *
+     * @param  mixed  $job
+     * @return mixed
+     */
+    function dispatch($job)
+    {
+        return app('Illuminate\Contracts\Bus\Dispatcher')->dispatch($job);
+    }
+}
+
 if (! function_exists('elixir')) {
     /**
      * Get the path to a versioned Elixir file.


### PR DESCRIPTION
I know we have the `Illuminate\Foundation\Bus\DispatchesJobs` trait but we can't use that if we're using from an static method (model events for example)...
