### PR TITLE
[5.1] SessionGuard and SessionHelpers needs to alias the Authenticatable interface

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Auth;
 
-use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 
 /**
  * These methods are typically the same across all guards.
@@ -61,7 +61,7 @@ trait GuardHelpers
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    public function setUser(Authenticatable $user)
+    public function setUser(AuthenticatableContract $user)
     {
         $this->user = $user;
     }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\SupportsBasicAuth;
 use Illuminate\Contracts\Cookie\QueueingFactory as CookieJar;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -408,7 +408,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  bool  $remember
      * @return void
      */
-    public function login(Authenticatable $user, $remember = false)
+    public function login(AuthenticatableContract $user, $remember = false)
     {
         $this->updateSession($user->getAuthIdentifier());
 
@@ -495,7 +495,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    protected function queueRecallerCookie(Authenticatable $user)
+    protected function queueRecallerCookie(AuthenticatableContract $user)
     {
         $value = $user->getAuthIdentifier().'|'.$user->getRememberToken();
 
@@ -565,7 +565,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    protected function refreshRememberToken(Authenticatable $user)
+    protected function refreshRememberToken(AuthenticatableContract $user)
     {
         $user->setRememberToken($token = Str::random(60));
 
@@ -578,7 +578,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    protected function createRememberTokenIfDoesntExist(Authenticatable $user)
+    protected function createRememberTokenIfDoesntExist(AuthenticatableContract $user)
     {
         if (empty($user->getRememberToken())) {
             $this->refreshRememberToken($user);
@@ -680,7 +680,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    public function setUser(Authenticatable $user)
+    public function setUser(AuthenticatableContract $user)
     {
         $this->user = $user;
 


### PR DESCRIPTION
Since the Authenticatable trait is in the same namespace, it is defaulting to it. Aliasing to AuthenticatableContract makes it work properly.

Otherwise, I get this error running phpunit:

```
PHP Fatal error:  Cannot use Illuminate\Contracts\Auth\Authenticatable as Authenticatable because the name is already in use in /PhpStorm/Projects/ProjectManagement/vendor/laravel/framework/src/Illuminate/Auth/SessionGuard.php on line 12
PHP Fatal error:  Uncaught Illuminate\Contracts\Container\BindingResolutionException: Target [Illuminate\Contracts\Debug\ExceptionHandler] is not instantiable. in /PhpStorm/Projects/ProjectManagement/vendor/laravel/framework/src/Illuminate/Container/Container.php:744
Stack trace:
#0 /PhpStorm/Projects/ProjectManagement/vendor/laravel/framework/src/Illuminate/Container/Container.php(631): Illuminate\Container\Container->build('Illuminate\\Cont...', Array)
#1 /PhpStorm/Projects/ProjectManagement/vendor/laravel/framework/src/Illuminate/Foundation/Application.php(674): Illuminate\Container\Container->make('Illuminate\\Cont...', Array)
#2 /PhpStorm/Projects/ProjectManagement/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(154): Illuminate\Foundation\Application->make('Illuminate\\Cont...')
#3 /PhpStorm/Projects/ProjectManagement/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(79): Illuminate\Foundation\Bootstrap\HandleExceptions->getExceptionHandler()
#4 /PhpStorm/ in /PhpStorm/Projects/ProjectManagement/vendor/laravel/framework/src/Illuminate/Container/Container.php on line 744
```
