### PR TITLE
[5.2] Fix RequestGuard::user() returning void

### DIFF
--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -51,7 +51,7 @@ class RequestGuard implements Guard
             return $this->user;
         }
 
-        $this->user = call_user_func($this->callback, $this->request);
+        return $this->user = call_user_func($this->callback, $this->request);
     }
 
     /**


### PR DESCRIPTION
Broken since f8a8e775c79f012806c9bef4d0302b14d9e14a1f
