### PR TITLE
[5.2] Remove unused variable $declaringClass

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -814,8 +814,6 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function resolveNonClass(ReflectionParameter $parameter)
     {
-        $declaringClass = $parameter->getDeclaringClass();
-
         if (! is_null($concrete = $this->getContextualConcrete('$'.$parameter->name))) {
             if ($concrete instanceof Closure) {
                 return call_user_func($concrete, $this);


### PR DESCRIPTION
Looks like a remnant from a69d0f52bad4c25ecc974a4c4203233eba948cf3
