### PR TITLE
[5.1] Fire saved event when updating touched relation's timestamp

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1667,6 +1667,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $this->$relation()->touch();
 
             if ($this->$relation instanceof self) {
+                $this->$relation->fireModelEvent('saved', false);
                 $this->$relation->touchOwners();
             } elseif ($this->$relation instanceof Collection) {
                 $this->$relation->each(function (Model $relation) {


### PR DESCRIPTION
Fixes #11198 

The proposed would fire the saved event when the a model's timestamp is updated due to it being touched by another model.

It may also be desirable to call other events like saving, updating, etc.?
