### PR TITLE
[5.1] Adds the ability to pass Builder object in whereIn Builder method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -765,6 +765,10 @@ class Builder
     {
         $type = $not ? 'NotIn' : 'In';
 
+        if ($values instanceof Builder) {
+            return $this->whereInSubQuery($column, $values, $boolean, $not);
+        }
+
         // If the value of the where in clause is actually a Closure, we will assume that
         // the developer is using a full sub-select for this "in" statement, and will
         // execute those Closures, then we can re-construct the entire sub-selects.
@@ -837,6 +841,26 @@ class Builder
         // provided callback with the query so the developer may set any of the query
         // conditions they want for the in clause, then we'll put it in this array.
         call_user_func($callback, $query = $this->newQuery());
+
+        $this->wheres[] = compact('type', 'column', 'query', 'boolean');
+
+        $this->addBinding($query->getBindings(), 'where');
+
+        return $this;
+    }
+
+    /**
+     * Add a external sub-select to the query.
+     *
+     * @param  string   $column
+     * @param  \Illuminate\Database\Query\Builder|static $query
+     * @param  string   $boolean
+     * @param  bool     $not
+     * @return $this
+     */
+    protected function whereInSubQuery($column, $query, $boolean, $not)
+    {
+        $type = $not ? 'NotInSub' : 'InSub';
 
         $this->wheres[] = compact('type', 'column', 'query', 'boolean');
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -765,7 +765,7 @@ class Builder
     {
         $type = $not ? 'NotIn' : 'In';
 
-        if ($values instanceof Builder) {
+        if ($values instanceof self) {
             return $this->whereInSubQuery($column, $values, $boolean, $not);
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -853,7 +853,7 @@ class Builder
      * Add a external sub-select to the query.
      *
      * @param  string   $column
-     * @param  \Illuminate\Database\Query\Builder|static $query
+     * @param  \Illuminate\Database\Query\Builder|static  $query
      * @param  string   $boolean
      * @param  bool     $not
      * @return $this


### PR DESCRIPTION
```
    $shops = \App\Shop::open();
    $shopQuery  =  $shops->getQuery()->select('street');
    $houses = \App\House::whereIn('street', $shopQuery)->get();
```

instead of

```
    $shops = \App\Shop::open();
    $shopQuery  =  $shops->getQuery()->select('street');
    $houses = \App\House::whereIn('street', function($query) use ($shopQuery) {
        $query->select($shopQuery->columns)->from($shopQuery->from)->mergeWheres($shopQuery->wheres, $shopQuery->getBindings());
    })->get();
```

```
select * from `houses` where `street` in (select `street` from `shops` where `is_open` = '1')
```
