### PR TITLE
[5.2] Add input into the current request's input array

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -614,6 +614,25 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Add input into the current request's input array.
+     *
+     * @param  array  $inputs
+     * @return $this
+     */
+    public function add(array $inputs)
+    {
+        $results = $this->all();
+
+        foreach($inputs as $key => $value){
+            Arr::set($results, $key, $value);
+        }
+
+        $this->replace($results);
+
+        return $this;
+    }
+
+    /**
      * Determines whether the current requests accepts a given content type.
      *
      * @param  string|array  $contentTypes

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -623,7 +623,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $results = $this->all();
 
-        foreach($inputs as $key => $value){
+        foreach ($inputs as $key => $value) {
             Arr::set($results, $key, $value);
         }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -640,7 +640,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
     public function testAddMethod()
     {
-        $request = Request::create('/', 'GET', [ 'foo' => ['bar' => ['qux']]]);
+        $request = Request::create('/', 'GET', ['foo' => ['bar' => ['qux']]]);
         $request->add(['baz' => 'quz']);
         $this->assertEquals('quz', $request->input('baz'));
         $request->add(['foo.baz' => ['quz'], 'foo.bar.someting' => 'value']);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -637,4 +637,14 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $request->shouldReceive('flash')->once()->with('except', ['key1', 'key2']);
         $request->flashExcept(['key1', 'key2']);
     }
+
+    public function testAddMethod()
+    {
+        $request = Request::create('/', 'GET', [ 'foo' => ['bar' => ['qux']]]);
+        $request->add(['baz' => 'quz']);
+        $this->assertEquals('quz', $request->input('baz'));
+        $request->add(['foo.baz' => ['quz'], 'foo.bar.someting' => 'value']);
+        $this->assertEquals(['quz'], $request->input('foo.baz'));
+        $this->assertEquals('value', $request->input('foo.bar.someting'));
+    }
 }


### PR DESCRIPTION
This proposal allows add input into current input array

Why use add and not merge?
- Add maintains the current input array
- Allows the use of segmentation

Example:

``` php
    // current request's input array
    // ['foo' => ['bar' => ['qux' => 'v1']]]

    // with merge
    $request->merge(['foo' => ['baz' => ['qux' => 'v2']]]);
    // ['foo' => ['baz' => ['qux' => 'v2']]]

    // with add
    $request->add(['foo.baz.qux' => 'v2']);
    //  ['foo' => ['bar' => ['qux' => 'v1'], 'baz' => ['qux' => 'v2']]]
```
