### PR TITLE
[5.1] Provide better exception in managers for non-existent connectors

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -99,7 +99,13 @@ class BroadcastManager implements FactoryContract
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($config);
         } else {
-            return $this->{'create'.ucfirst($config['driver']).'Driver'}($config);
+            $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
+
+            if (method_exists($this, $driverMethod)) {
+                return $this->{$driverMethod}($config);
+            } else {
+                throw new InvalidArgumentException("Driver [{$config['driver']}] not supported.");
+            }
         }
     }
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -82,6 +82,8 @@ class CacheManager implements FactoryContract
      *
      * @param  string  $name
      * @return \Illuminate\Contracts\Cache\Repository
+     *
+     * @throws \InvalidArgumentException
      */
     protected function resolve($name)
     {
@@ -94,7 +96,13 @@ class CacheManager implements FactoryContract
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($config);
         } else {
-            return $this->{'create'.ucfirst($config['driver']).'Driver'}($config);
+            $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
+
+            if (method_exists($this, $driverMethod)) {
+                return $this->{$driverMethod}($config);
+            } else {
+                throw new InvalidArgumentException("Driver [{$config['driver']}] not supported.");
+            }
         }
     }
 

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -6,6 +6,7 @@ use Closure;
 use Aws\S3\S3Client;
 use OpenCloud\Rackspace;
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\FilesystemInterface;
 use League\Flysystem\Filesystem as Flysystem;
@@ -89,6 +90,8 @@ class FilesystemManager implements FactoryContract
      *
      * @param  string  $name
      * @return \Illuminate\Contracts\Filesystem\Filesystem
+     *
+     * @throws \InvalidArgumentException
      */
     protected function resolve($name)
     {
@@ -98,7 +101,13 @@ class FilesystemManager implements FactoryContract
             return $this->callCustomCreator($config);
         }
 
-        return $this->{'create'.ucfirst($config['driver']).'Driver'}($config);
+        $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
+
+        if (method_exists($this, $driverMethod)) {
+            return $this->{$driverMethod}($config);
+        } else {
+            throw new InvalidArgumentException("Driver [{$config['driver']}] not supported.");
+        }
     }
 
     /**


### PR DESCRIPTION
Encountered this when I was setting up my database cache.  In config/cache.php under stores.database I set the driver as mysql since that's what I thought would make sense.  In doing so, it returned a 500 error with no message or clue.  I had to knowingly break other parts of the code ( like using an unknown cache store ) to get an actual error message telling me at which file to look at.  I was then able to diagnose and fix the problem.

The error, with no message, seems to happen when a valid cache store was selected and an invalid driver was set.

I thought this would be helpful to those that have and will encounter this or a similar error.
