### PR TITLE
[5.1] Add 'relation' fieldtype to Schema

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -651,6 +651,17 @@ class Blueprint
     }
 
     /**
+     * Create a new unsigned integer column on the table.
+     *
+     * @param  string $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function relation($column)
+    {
+        return $this->integer($column, false, true);
+    }
+
+    /**
      * Create a new boolean column on the table.
      *
      * @param  string  $column


### PR DESCRIPTION
This provides a shorthand syntax for generating relationship columns in schema, a frequent practice in development (at least in my experience).

The function makes an assumption that you are using unsigned integers for IDs. I realise that this might be a bit short-sighted, so if there are any suggestions on how to handle this better (perhaps also implementing `bigRelation` and the like) I will gladly work on this further.
