### PR TITLE
[5.2] Allow asterisk wildcard in see()

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -181,7 +181,7 @@ trait InteractsWithPages
         // Asterisks are translated into zero-or-more regular expression wildcards
         // to make it convenient to check if the strings starts with the given
         // pattern such as "library/*", making any string check convenient.
-        $pattern = str_replace('*', '.*', $text).'\z';
+        $pattern = str_replace('*', '.*', $text);
 
         $rawPattern = preg_quote($pattern, '/');
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -178,7 +178,12 @@ trait InteractsWithPages
     {
         $method = $negate ? 'assertNotRegExp' : 'assertRegExp';
 
-        $rawPattern = preg_quote($text, '/');
+        // Asterisks are translated into zero-or-more regular expression wildcards
+        // to make it convenient to check if the strings starts with the given
+        // pattern such as "library/*", making any string check convenient.
+        $pattern = str_replace('\*', '.*', $pattern).'\z';
+
+        $rawPattern = preg_quote($pattern, '/');
 
         $escapedPattern = preg_quote(e($text), '/');
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -181,7 +181,7 @@ trait InteractsWithPages
         // Asterisks are translated into zero-or-more regular expression wildcards
         // to make it convenient to check if the strings starts with the given
         // pattern such as "library/*", making any string check convenient.
-        $pattern = str_replace('\*', '.*', $pattern).'\z';
+        $pattern = str_replace('\*', '.*', $text).'\z';
 
         $rawPattern = preg_quote($pattern, '/');
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -181,7 +181,7 @@ trait InteractsWithPages
         // Asterisks are translated into zero-or-more regular expression wildcards
         // to make it convenient to check if the strings starts with the given
         // pattern such as "library/*", making any string check convenient.
-        $pattern = str_replace('\*', '.*', $text).'\z';
+        $pattern = str_replace('*', '.*', $text).'\z';
 
         $rawPattern = preg_quote($pattern, '/');
 


### PR DESCRIPTION
As mentioned earlier in #11347, this PR allows you to use an `*` as a wildcard with the `see()` method when testing. There is precedence for this sort of functionality in the `Str::is()` method ([see here](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Support/Str.php#L113-L133)).
