### PR TITLE
[5.2] Use ::class syntax instead of string

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class HasManyThrough extends Relation
@@ -123,7 +124,7 @@ class HasManyThrough extends Relation
      */
     public function parentSoftDeletes()
     {
-        return in_array('Illuminate\Database\Eloquent\SoftDeletes', class_uses_recursive(get_class($this->parent)));
+        return in_array(SoftDeletes::class, class_uses_recursive(get_class($this->parent)));
     }
 
     /**


### PR DESCRIPTION
I'm not sure if there has been a framework-wide push to start using the `::class` syntax or not, though it has started being used in the app config and all that. Makes sense because it would cause the code to actually fail instead of silently failing if the namespace/class name of the `SoftDeletes` trait was to ever be changed.
