### PR TITLE
[5.2] Make 'withoutGlobalScopes()' function accept an array of scopes.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -114,15 +114,15 @@ class Builder
     }
 
     /**
-     * Remove all registered global scopes.
+     * Remove all or passed registered global scopes.
      *
-     * @param  array  $scopes
+     * @param  array|null  $scopes
      * @return $this
      */
-    public function withoutGlobalScopes($scopes = null)
+    public function withoutGlobalScopes(array $scopes = null)
     {
         if (is_array($scopes)) {
-            foreach($scopes as $scope) {
+            foreach ($scopes as $scope) {
                 $this->withoutGlobalScope($scope);
             }
         } else {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -116,11 +116,18 @@ class Builder
     /**
      * Remove all registered global scopes.
      *
+     * @param  array  $scopes
      * @return $this
      */
-    public function withoutGlobalScopes()
+    public function withoutGlobalScopes($scopes = null)
     {
-        $this->scopes = [];
+        if (is_array($scopes)) {
+            foreach($scopes as $scope) {
+                $this->withoutGlobalScope($scope);
+            }
+        } else {
+            $this->scopes = [];
+        }
 
         return $this;
     }


### PR DESCRIPTION
If the function `withoutGlobalScopes()` is passed an array of scopes, it will ignore those passed scopes only, not all scopes.

For example:

This will avoid extra code. So instead of doing this for removing two global scopes:

```
User::withoutGlobalScope(new SomeScope)->withoutGlobalScope(new AnotherScope)->get();
```

You will do this:

```
User::withoutGlobalScopes([new SomeScope, new AnotherScope])->get();
```
