### PR TITLE
[5.1] Bug: last insert id not working on ubuntu and table with triggers

### DIFF
--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -19,7 +19,8 @@ class SqlServerProcessor extends Processor
     {
         $query->getConnection()->insert($sql, $values);
 
-        $id = $query->getConnection()->getPdo()->lastInsertId();
+        //$id = $query->getConnection()->getPdo()->lastInsertId(); this is not working on linux pdo driver and a sql server table with a trigger inserting a new record. It brings me the id of insert trigger made, not the id of the main table. Its a bug on PDO linux driver (on windows it works fine)
+        $id = $query->selectRaw("SCOPE_IDENTITY() AS lastId")->first()->lastId; //this works fine for everyone.
 
         return is_numeric($id) ? (int) $id : $id;
     }

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -18,7 +18,7 @@ class SqlServerProcessor extends Processor
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {
         $query->getConnection()->insert($sql, $values);
-        $id = $query->selectRaw("SCOPE_IDENTITY() AS lastId")->first()->lastId;
+        $id = $query->selectRaw('SCOPE_IDENTITY() AS lastId')->first()->lastId;
 
         return is_numeric($id) ? (int) $id : $id;
     }

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -18,7 +18,7 @@ class SqlServerProcessor extends Processor
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {
         $query->getConnection()->insert($sql, $values);
-        $id = $query->selectRaw("SCOPE_IDENTITY() AS lastId")->first()->lastId; 
+        $id = $query->selectRaw("SCOPE_IDENTITY() AS lastId")->first()->lastId;
 
         return is_numeric($id) ? (int) $id : $id;
     }

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -18,9 +18,7 @@ class SqlServerProcessor extends Processor
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {
         $query->getConnection()->insert($sql, $values);
-
-        //$id = $query->getConnection()->getPdo()->lastInsertId(); this is not working on linux pdo driver and a sql server table with a trigger inserting a new record. It brings me the id of insert trigger made, not the id of the main table. Its a bug on PDO linux driver (on windows it works fine)
-        $id = $query->selectRaw("SCOPE_IDENTITY() AS lastId")->first()->lastId; //this works fine for everyone.
+        $id = $query->selectRaw("SCOPE_IDENTITY() AS lastId")->first()->lastId; 
 
         return is_numeric($id) ? (int) $id : $id;
     }


### PR DESCRIPTION
Sql server pdo driver for linux is not working when you insert on a table using trigger. This correction only replaces the @@IDENTITY pdo driver uses for SCOPE_IDENTITY() wich is the correct way to retrieve the last insert id of a table.
Please, accept it, or teach me how to make laravel use my own pdo instead of native one. Here is my issue: http://stackoverflow.com/q/34380700/1825590
