### PR TITLE
[5.1] Transform JsonSerializable content to Json response

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http;
 
 use ArrayObject;
+use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Renderable;
 use Symfony\Component\HttpFoundation\Response as BaseResponse;
@@ -79,6 +80,7 @@ class Response extends BaseResponse
     {
         return $content instanceof Jsonable ||
                $content instanceof ArrayObject ||
+               $content instanceof JsonSerializable ||
                is_array($content);
     }
 

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -22,6 +22,10 @@ class HttpResponseTest extends PHPUnit_Framework_TestCase
         $response->setContent(['foo' => 'bar']);
         $this->assertEquals('{"foo":"bar"}', $response->getContent());
         $this->assertEquals('application/json', $response->headers->get('Content-Type'));
+
+        $response = new Illuminate\Http\Response(new JsonSerializableStub);
+        $this->assertEquals('{"foo":"bar"}', $response->getContent());
+        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
     }
 
     public function testRenderablesAreRendered()
@@ -149,5 +153,13 @@ class JsonableStub implements Jsonable
     public function toJson($options = 0)
     {
         return 'foo';
+    }
+}
+
+class JsonSerializableStub implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return ['foo' => 'bar'];
     }
 }


### PR DESCRIPTION
This pull request transforms objects implementing [`JsonSerializable`](http://php.net/manual/en/class.jsonserializable.php) to Json in the [`setContent()`](https://github.com/laravel/framework/blob/1fd5867bf9e88a89cdfe96db8c49e3c8fd5d0f7f/src/Illuminate/Http/Response.php#L34) method of [`Http/Response.php`](https://github.com/laravel/framework/blob/1fd5867bf9e88a89cdfe96db8c49e3c8fd5d0f7f/src/Illuminate/Http/Response.php). By adding a check for that interface in the [`shouldBeJson()`](https://github.com/laravel/framework/blob/1fd5867bf9e88a89cdfe96db8c49e3c8fd5d0f7f/src/Illuminate/Http/Response.php#L78) method.

Enabling us to do this:

``` php
// controller.php
public function index()
{
  $jsonSerializable = new classImplementingJsonSerializable;
  return $jsonSerializable;
}
```

Before this PR an `\UnexpectedValueException` with message `The Response content must be a string or object implementing __toString()` was thrown from Symfony's [`Response::setContent()`](https://github.com/symfony/symfony/blob/1509ec9d53ed8eb8afa8d7d2f653407d89372d62/src/Symfony/Component/HttpFoundation/Response.php#L395) method.
