### PR TITLE
[5.1] Added ability to get the pusher instance

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -32,4 +32,14 @@ class PusherBroadcaster implements Broadcaster
     {
         $this->pusher->trigger($channels, $event, $payload);
     }
+    
+    /**
+     * Get the Pusher SDK instance.
+     *
+     * @return \Pusher
+     */
+    public function getPusher()
+    {
+        return $this->pusher;
+    }
 }

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -32,7 +32,7 @@ class PusherBroadcaster implements Broadcaster
     {
         $this->pusher->trigger($channels, $event, $payload);
     }
-    
+
     /**
      * Get the Pusher SDK instance.
      *


### PR DESCRIPTION
Pusher SDK doesn't only have a trigger method.

There are another methods that can be useful like `get_channel_info` and `get_channels`.
