### PR TITLE
Fix session:table command generated output

### DIFF
--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -14,6 +14,9 @@ class CreateSessionsTable extends Migration
     {
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->unique();
+            $table->integer('user_id')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
             $table->text('payload');
             $table->integer('last_activity');
         });


### PR DESCRIPTION
Since there is separated command for old session table, this command should generate the new structure, isn't it?
