### PR TITLE
[5.2] Add abstract keyword to User class

### DIFF
--- a/src/Illuminate/Foundation/Auth/User.php
+++ b/src/Illuminate/Foundation/Auth/User.php
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 
-class User extends Model implements
+abstract class User extends Model implements
     AuthenticatableContract,
     AuthorizableContract,
     CanResetPasswordContract


### PR DESCRIPTION
I think it would be better to add the `abstract` keyword to this class since it doesn't have any implementation aside the traits. Also it shouldn't be much of a difference for the traits itself
