### PR TITLE
[5.2] Command::hasOption

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -239,7 +239,7 @@ class Command extends SymfonyCommand
      */
     public function hasOption($key)
     {
-        return $this->input->hasParameterOption('--' . $key);
+        return $this->input->hasParameterOption('--'.$key);
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -232,6 +232,17 @@ class Command extends SymfonyCommand
     }
 
     /**
+     * Check if a command option is set.
+     *
+     * @param  string  $key
+     * @return string|array
+     */
+    public function hasOption($key)
+    {
+        return $this->input->hasParameterOption('--' . $key);
+    }
+
+    /**
      * Confirm a question with the user.
      *
      * @param  string  $question


### PR DESCRIPTION
Checks if the option flag with a key has been passed to the command, regardless of any value that may or may not be set of the option. This can be used the distinguish between `command`, `command --option` and `command --option=value`.

This is an implementation of the issue raised in symfony/symfony#12773.
If the PR mentioned above is merged this could easily be modified to make use of the native symfony/symfony method.

Usage:

``` php
if ($this->hasOption('github') {
   $repo = $this->option('github') ?: $this->argument('name');

   // Create repo named $repo through github API
}
```
