### PR TITLE
[5.2] Fix 'Authentication user provider is not defined' when custom auth driver specified

### DIFF
--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -25,9 +25,9 @@ trait CreatesUserProviders
     {
         $config = $this->app['config']['auth.providers.'.$provider];
 
-        if (isset($this->customProviderCreators[$provider])) {
+        if (isset($this->customProviderCreators[$config["driver"]])) {
             return call_user_func(
-                $this->customProviderCreators[$provider], $this->app, $config
+                $this->customProviderCreators[$config["driver"]], $this->app, $config
             );
         }
 


### PR DESCRIPTION
Custom User Provider implementation according to the Laravel 5.2 docs (http://laravel.com/docs/5.2/authentication#adding-custom-user-providers) will not work as specified.

Exception 'Authentication user provider [riak] is not defined' will always be thrown.

The reason for that is that lookup is always done using the $provider name and not the driver specified.

Either the documentation has to be updated how to implement it differently or the issue should fixed in the CreatesUserProviders.php file.

Test project:
https://github.com/fednep/LaravelAuthProviderIssue

Commit in test project with changes to all neccessary files:
https://github.com/fednep/LaravelAuthProviderIssue/commit/f646a5e3557606c3d79826a948a6b9178a4bd098
