### PR TITLE
[5.2] Container - Minor Change

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -801,7 +801,7 @@ class Container implements ArrayAccess, ContainerContract
             }
         }
 
-        return (array) $dependencies;
+        return $dependencies;
     }
 
     /**


### PR DESCRIPTION
No need to cast `$dependencies` because it's already an array.
