### PR TITLE
Removes duplicate CSRF field

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
@@ -11,8 +11,6 @@
                     <form class="form-horizontal" role="form" method="POST" action="{{ url('/password/reset') }}">
                         {!! csrf_field() !!}
 
-                        <input type="hidden" name="token" value="{{ $token }}">
-
                         <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
                             <label class="col-md-4 control-label">E-Mail Address</label>
 


### PR DESCRIPTION
The view included both the `{!! csrf_field() !!}`and the `<input type="hidden" name="token" value="{{ $token }}">` code
