### PR TITLE
[5.1] [WIP] Chunk should require orderBy

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1564,6 +1564,10 @@ class Builder
      */
     public function chunk($count, callable $callback)
     {
+        if ($this->getOrderBys() === null) {
+            $this->orderBy('id', 'asc');
+        }
+
         $results = $this->forPage($page = 1, $count)->get();
 
         while (count($results) > 0) {
@@ -1580,6 +1584,18 @@ class Builder
         }
 
         return true;
+    }
+
+    /**
+     * Returns the currently set ordering.
+     *
+     * @return array|null
+     */
+    public function getOrderBys()
+    {
+        $property = $this->unions ? 'unionOrders' : 'orders';
+
+        return $this->{$property};
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1335,6 +1335,28 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('select * from "users" where "name" = ?', $builder->toSql());
     }
 
+    public function testChunkWithoutOrderBy()
+    {
+        $builder = $this->getBuilder();
+        $query = 'select * from "users" order by "id" asc limit 10 offset 0';
+        $builder->getConnection()->shouldReceive('select')->once()->with($query, [], true)->andReturn([]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturn([]);
+        $builder->select('*')->from('users')->chunk(10, function () {return true; });
+
+        $this->assertEquals($query, $builder->toSql());
+    }
+
+    public function testChunkWithOrderBy()
+    {
+        $builder = $this->getBuilder();
+        $query = 'select * from "users" order by "sort_order" asc limit 10 offset 0';
+        $builder->getConnection()->shouldReceive('select')->once()->with($query, [], true)->andReturn([]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturn([]);
+        $builder->select('*')->from('users')->orderBy('sort_order')->chunk(10, function () {return true; });
+
+        $this->assertEquals($query, $builder->toSql());
+    }
+
     protected function getBuilder()
     {
         $grammar = new Illuminate\Database\Query\Grammars\Grammar;


### PR DESCRIPTION
This is in reference to #11302 

This change makes sure that before chunking the results an `orderBy` has been set. If nothing was set by the user then the function will default to setting it to `id`. This can cause issues if a table doesn't have an `id` field.

The alternative would be to throw an exception if no `orderBy` has been set, but that would possibly be a huge breaking change.

I've added some tests to make sure that an `order by` statement is added to the SQL that's generated, but I'm not sure if the tests cover enough (there currently aren't any tests at all for the `chunk` method).

I'm open to all suggestions as to better/different ways to fix this.
