### PR TITLE
[5.2] Added RouteFound event

### DIFF
--- a/src/Illuminate/Routing/Events/RouteFound.php
+++ b/src/Illuminate/Routing/Events/RouteFound.php
@@ -2,6 +2,32 @@
 
 namespace Illuminate\Routing\Events;
 
-class RouteFound extends RouteMatched
+class RouteFound
 {
+    /**
+     * The route instance.
+     *
+     * @var \Illuminate\Routing\Route
+     */
+    public $route;
+
+    /**
+     * The request instance.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    public function __construct($route, $request)
+    {
+        $this->route = $route;
+        $this->request = $request;
+    }
 }

--- a/src/Illuminate/Routing/Events/RouteFound.php
+++ b/src/Illuminate/Routing/Events/RouteFound.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Routing\Events;
+
+class RouteFound extends RouteMatched
+{
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -803,6 +803,8 @@ class Router implements RegistrarContract
 
         $this->container->instance('Illuminate\Routing\Route', $route);
 
+        $this->events->fire(new Events\RouteFound($route, $request));
+
         return $this->substituteBindings($route);
     }
 
@@ -875,6 +877,17 @@ class Router implements RegistrarContract
     public function matched($callback)
     {
         $this->events->listen(Events\RouteMatched::class, $callback);
+    }
+
+    /**
+     * Register a route found event listener.
+     *
+     * @param  string|callable  $callback
+     * @return void
+     */
+    public function found($callback)
+    {
+        $this->events->listen(Events\RouteFound::class, $callback);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/11496

Basically I added a `RouteFound` event, so that we can inject Controller namespace based on the HTTP api-version header before implicit bindings are resolved (`RouteMatched` is fired too late).

``` php
Route::found(function(RouteFoundEvent $event) {
    // modify $event->route as needed
});
```
