### PR TITLE
[5.2] Prevent RateLimiter being hit multiple times in same request

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -47,7 +47,11 @@ class ThrottleRequests
             ]);
         }
 
-        $this->limiter->hit($key, $decayMinutes);
+        static $hit = false;
+
+        if ($hit === false) {
+            $hit = $this->limiter->hit($key, $decayMinutes);
+        }
 
         return $next($request)->withHeaders([
             'X-RateLimit-Limit' => $maxAttempts,


### PR DESCRIPTION
Suppose the following setup:

``` php
// In app/Http/Kernel.php
$middlewareGroups = [
    'api' => [ 'throttle:10', 'otherMiddleware', 'someOtherMiddleware' ]
];

// In routes.php
Route::group(['middleware' => 'api'], function() {
   Route::get('foo', 'SomeController@method');
   Route::get('bar', ['middleware' => 'throttle:5', 'uses' => 'SomeController@otherMethod']);
});
```

Route `foo` will behave as expected: 10 requests are allowed before being throttled.
Route `bar` to the contrary is already throttled after 3 times because the `RateLimiter` is hit twice.

This PR solves this by only hitting the RateLimiter once per request. As such any possible combination of throttlers will behave as expected, being the most stringent one.
