### PR TITLE
[5.2] Scopes has() fix

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -655,7 +655,7 @@ class Builder
         }
 
         return $this->addHasWhere(
-            $query->applyScopes(), $relation, $operator, $count, $boolean
+            $query, $relation, $operator, $count, $boolean
         );
     }
 
@@ -771,7 +771,7 @@ class Builder
             $count = new Expression($count);
         }
 
-        return $this->where(new Expression('('.$hasQuery->getQuery()->toSql().')'), $operator, $count, $boolean);
+        return $this->where(new Expression('('.$hasQuery->toSql().')'), $operator, $count, $boolean);
     }
 
     /**
@@ -792,7 +792,7 @@ class Builder
             $relationQuery->wheres, $relationQuery->getBindings()
         );
 
-        $this->query->addBinding($hasQuery->getQuery()->getBindings(), 'where');
+        $this->query->addBinding($hasQuery->getBindings(), 'where');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -771,7 +771,7 @@ class Builder
             $count = new Expression($count);
         }
 
-        return $this->where(new Expression('('.$hasQuery->toSql().')'), $operator, $count, $boolean);
+        return $this->where(new Expression('('.$hasQuery->getQuery()->toSql().')'), $operator, $count, $boolean);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -86,11 +86,11 @@ class DatabaseEloquentGlobalScopesTest extends PHPUnit_Framework_TestCase
     {
         $query = EloquentGlobalScopesWithRelationModel::has('related')->where('bar', 'baz');
 
-        $subQuery = 'select count(*) from "table" where "table"."related_id" = "table2"."id" and "active" = ? and "foo" = ?';
+        $subQuery = 'select count(*) from "table" where "table"."related_id" = "table2"."id" and "foo" = ? and "active" = ?';
         $mainQuery = 'select * from "table2" where ('.$subQuery.') >= 1 and "bar" = ? and "active" = ? order by "name" asc';
 
         $this->assertEquals($mainQuery, $query->toSql());
-        $this->assertEquals([1, 'bar', 'baz', 1], $query->getBindings());
+        $this->assertEquals(['bar', 1, 'baz', 1], $query->getBindings());
     }
 }
 


### PR DESCRIPTION
@taylorotwell It turns out that `has()` query applied scopes twice, but added bindings only once.

The problem is that we were calling `toSql` after already applying global scopes and it applied them again.

This fixes https://github.com/laravel/framework/issues/11261
