### PR TITLE
[5.2] VerifyPostSize Middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyPostSize.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyPostSize.php
@@ -34,18 +34,17 @@ class VerifyPostSize
     {
         $postMaxSize = ini_get('post_max_size');
 
-        switch (substr($postMaxSize, -1)) {
-            case 'M':
-            case 'm':
-                return (int) $postMaxSize * 1048576;
-            case 'K':
-            case 'k':
-                return (int) $postMaxSize * 1024;
-            case 'G':
-            case 'g':
-                return (int) $postMaxSize * 1073741824;
-        }
+        $metric = strtoupper(substr($postMaxSize, -1));
 
-        return (int) $postMaxSize;
+        switch ($metric) {
+            case 'K':
+                return (int) $postMaxSize * 1024;
+            case 'M':
+                return (int) $postMaxSize * 1048576;
+            case 'G':
+                return (int) $postMaxSize * 1073741824;
+            default:
+                return (int) $postMaxSize;
+        }
     }
 }


### PR DESCRIPTION
Not a functional change. Just for a better readability.

Original implementation:

```
/**
* Determine the server 'post_max_size' as bytes.
*
* @return int
*/
protected function getPostMaxSize()
{
   $postMaxSize = ini_get('post_max_size');

   switch (substr($postMaxSize, -1)) {
    case 'M':
    case 'm':
        return (int) $postMaxSize * 1048576;
    case 'K':
    case 'k':
        return (int) $postMaxSize * 1024;
    case 'G':
    case 'g':
        return (int) $postMaxSize * 1073741824;
    }

   return (int) $postMaxSize;
}
```

New one:

```
/**
 * Determine the server 'post_max_size' as bytes.
 *
 * @return int
 */
protected function getPostMaxSize()
{
    $postMaxSize = ini_get('post_max_size');

    $metric = strtoupper(substr($postMaxSize, -1));

    switch ($metric) {
        case 'K':
            return (int) $postMaxSize * 1024;
        case 'M':
            return (int) $postMaxSize * 1048576;
        case 'G':
            return (int) $postMaxSize * 1073741824;
        default:
            return (int) $postMaxSize;
    }
}
```
