### PR TITLE
[5.2] We should remove parameters from route group prefix

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -211,7 +211,7 @@ class ResourceRegistrar
      */
     protected function getGroupResourceName($prefix, $resource, $method)
     {
-        $group = trim(str_replace('/', '.', $this->router->getLastGroupPrefix()), '.');
+        $group = trim(str_replace('/', '.', $this->router->getLastGroupPrefix(false)), '.');
 
         if (empty($group)) {
             return trim("{$prefix}{$resource}.{$method}", '.');

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -473,17 +473,37 @@ class Router implements RegistrarContract
     /**
      * Get the prefix from the last group on the stack.
      *
+     * @param boolean $forUrl
      * @return string
      */
-    public function getLastGroupPrefix()
+    public function getLastGroupPrefix($forUrl = true)
     {
         if (! empty($this->groupStack)) {
             $last = end($this->groupStack);
 
-            return isset($last['prefix']) ? $last['prefix'] : '';
+            if($forUrl) {
+                return isset($last['prefix']) ? $last['prefix'] : null;
+            }
+
+            return isset($last['prefix']) ? $this->removeGroupStackPrefixParameters($last['prefix']) : '';
         }
 
         return '';
+    }
+
+    /**
+     * Remove the assigned parameters to routes group prefix used for routes name
+     *
+     * @param string $prefix
+     * @return string
+     */
+    protected function removeGroupStackPrefixParameters($prefix)
+    {
+        if(strpos($prefix, '{') !== false && strpos($prefix, '}') !== false) {
+            return preg_replace('/(\/?\{.*?\})/', '', $prefix);
+        }
+
+        return $prefix;
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -473,7 +473,7 @@ class Router implements RegistrarContract
     /**
      * Get the prefix from the last group on the stack.
      *
-     * @param boolean $forUrl
+     * @param bool $forUrl
      * @return string
      */
     public function getLastGroupPrefix($forUrl = true)
@@ -481,7 +481,7 @@ class Router implements RegistrarContract
         if (! empty($this->groupStack)) {
             $last = end($this->groupStack);
 
-            if($forUrl) {
+            if ($forUrl) {
                 return isset($last['prefix']) ? $last['prefix'] : null;
             }
 
@@ -492,14 +492,14 @@ class Router implements RegistrarContract
     }
 
     /**
-     * Remove the assigned parameters to routes group prefix used for routes name
+     * Remove the assigned parameters to routes group prefix used for routes name.
      *
      * @param string $prefix
      * @return string
      */
     protected function removeGroupStackPrefixParameters($prefix)
     {
-        if(strpos($prefix, '{') !== false && strpos($prefix, '}') !== false) {
+        if (strpos($prefix, '{') !== false && strpos($prefix, '}') !== false) {
             return preg_replace('/(\/?\{.*?\})/', '', $prefix);
         }
 


### PR DESCRIPTION
Hi,

I found an issue that if you define a prefix to a route group:

``` php
Route::group(['prefix' => 'reports', 'namespace' => 'Reports'], function () {
    Route::group(['prefix' => 'publishers/{publisher_id}', 'namespace' => 'Publishers'], function () {
        Route::resource('accounts', 'AccountsController');
    });
});
```

The route name would be `reports.publishers.{publisher_id}.accounts.index`.
I Think this is wrong and the parameter name should be removed. Note that it's being done in resources names. for example: `accounts.edit => /accounts/{account}/edit`

I added a statement for if the prefix has braces, it should find them and remove from the prefix:

``` php
protected function removeGroupStackPrefixParameters($prefix)
{
    if(strpos($prefix, '{') !== false && strpos($prefix, '}') !== false) {
        return preg_replace('/(\/?\{.*?\})/', '', $prefix);
    }

    return $prefix;
}
```

The end result:

```
reports.publishers.accounts.index
```

This functionality should happen only in case the name is resolved. in case it's for URL resolvement, the previous prefix is returned

Thanks!
