### PR TITLE
[5.3] Chunk should require orderBy

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use RuntimeException;
 
 class Builder
 {
@@ -261,9 +262,15 @@ class Builder
      * @param  int  $count
      * @param  callable  $callback
      * @return void
+     *
+     * @throws \RuntimeException
      */
     public function chunk($count, callable $callback)
     {
+        if (is_null($this->getOrderBys())) {
+            throw new RuntimeException('Chunk requires an orderby clause.');
+        }
+
         $results = $this->forPage($page = 1, $count)->get();
 
         while (count($results) > 0) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -14,6 +14,7 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Query\Processors\Processor;
+use RuntimeException;
 
 class Builder
 {
@@ -1545,9 +1546,15 @@ class Builder
      * @param  int  $count
      * @param  callable  $callback
      * @return bool
+     *
+     * @throws \RuntimeException
      */
     public function chunk($count, callable $callback)
     {
+        if (is_null($this->getOrderBys())) {
+            throw new RuntimeException('Chunk requires an orderby clause.');
+        }
+
         $results = $this->forPage($page = 1, $count)->get();
 
         while (count($results) > 0) {
@@ -1564,6 +1571,18 @@ class Builder
         }
 
         return true;
+    }
+
+    /**
+     * Returns the currently set ordering.
+     *
+     * @return array|null
+     */
+    public function getOrderBys()
+    {
+        $property = $this->unions ? 'unionOrders' : 'orders';
+
+        return $this->{$property};
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1356,6 +1356,26 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('select * from "users" where "name" = ?', $builder->toSql());
     }
 
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testChunkThrowsExceptionWithoutOrderBy()
+    {
+        $builder = $this->getBuilder();
+        $builder->chunk(10, function () { return true; });
+    }
+
+    public function testChunkWithOrderBy()
+    {
+        $builder = $this->getBuilder();
+        $query = 'select * from "users" order by "sort_order" asc limit 10 offset 0';
+        $builder->getConnection()->shouldReceive('select')->once()->with($query, [], true)->andReturn([]);
+        $builder->getProcessor()->shouldReceive('processSelect')->once()->andReturn([]);
+        $builder->select('*')->from('users')->orderBy('sort_order')->chunk(10, function () {return true; });
+
+        $this->assertEquals($query, $builder->toSql());
+    }
+
     protected function getBuilder()
     {
         $grammar = new Illuminate\Database\Query\Grammars\Grammar;


### PR DESCRIPTION
This is in reference to #11302 

This change makes sure that before chunking the results an `orderBy` has been set. If nothing was set by the user then the function will default to setting it to `id`. This can cause issues if a table doesn't have an `id` field.

The alternative would be to throw an exception if no `orderBy` has been set, but that would possibly be a huge breaking change.

I've added some tests to make sure that an `order by` statement is added to the SQL that's generated, but I'm not sure if the tests cover enough (there currently aren't any tests at all for the `chunk` method).

I'm open to all suggestions as to better/different ways to fix this.

Related to: #11490, #11489 
