### PR TITLE
[5.2] Use blade comments in order to do not require asset builds

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -12,7 +12,7 @@
     <link href="https://fonts.googleapis.com/css?family=Lato:100,300,400,700" rel='stylesheet' type='text/css'>
 
     <!-- Styles -->
-    <!-- <link href="{{ elixir('css/app.css') }}" rel="stylesheet"> -->
+    {{-- <link href="{{ elixir('css/app.css') }}" rel="stylesheet"> --}}
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
 
     <style>
@@ -75,7 +75,7 @@
     @yield('content')
 
     <!-- JavaScripts -->
-    <!-- <script src="{{ elixir('js/app.js') }}"></script> -->
+    {{-- <script src="{{ elixir('js/app.js') }}"></script> --}}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
 </body>


### PR DESCRIPTION
I got this error after fresh installation followed by `php make:auth`command.

I changed HTML comments in both link and script imports to Blade comments.

```
ErrorException in helpers.php line 301:
File js/app.js not defined in asset manifest. (View: /home/vagrant/Shop/resources/views/layouts/app.blade.php) (View: /home/vagrant/Shop/resources/views/layouts/app.blade.php)
```
