### PR TITLE
[5.1] Escape path directly in build command

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -212,12 +212,13 @@ class Event
      */
     public function buildCommand()
     {
+        $output = ProcessUtils::escapeArgument($this->output);
         $redirect = $this->shouldAppendOutput ? ' >> ' : ' > ';
 
         if ($this->withoutOverlapping) {
-            $command = '(touch '.$this->mutexPath().'; '.$this->command.'; rm '.$this->mutexPath().')'.$redirect.$this->output.' 2>&1 &';
+            $command = '(touch '.$this->mutexPath().'; '.$this->command.'; rm '.$this->mutexPath().')'.$redirect.$output.' 2>&1 &';
         } else {
-            $command = $this->command.$redirect.$this->output.' 2>&1 &';
+            $command = $this->command.$redirect.$output.' 2>&1 &';
         }
 
         return $this->user ? 'sudo -u '.$this->user.' '.$command : $command;
@@ -653,7 +654,7 @@ class Event
      */
     public function sendOutputTo($location, $append = false)
     {
-        $this->output = ProcessUtils::escapeArgument($location);
+        $this->output = $location;
 
         $this->shouldAppendOutput = $append;
 

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -9,7 +9,7 @@ class EventTest extends PHPUnit_Framework_TestCase
         $event = new Event('php -i');
 
         $defaultOutput = (DIRECTORY_SEPARATOR == '\\') ? 'NUL' : '/dev/null';
-        $this->assertSame("php -i > {$defaultOutput} 2>&1 &", $event->buildCommand());
+        $this->assertSame("php -i > '{$defaultOutput}' 2>&1 &", $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()
@@ -31,5 +31,16 @@ class EventTest extends PHPUnit_Framework_TestCase
 
         $event->appendOutputTo('/dev/null');
         $this->assertSame("php -i >> '/dev/null' 2>&1 &", $event->buildCommand());
+    }
+
+    /**
+     * @expectedException LogicException
+     */
+    public function testEmailOutputToThrowsExceptionIfOutputFileWasNotSpecified()
+    {
+        $event = new Event('php -i');
+        $event->emailOutputTo('foo@example.com');
+
+        $event->buildCommand();
     }
 }


### PR DESCRIPTION
Closes #11517

I've managed to replicate the issue and test it locally

We added output path escaping in late 5.1.\* version.

But it should not be escaped in setter because some other stuff want to use it as it is.
For example `file_get_contents()` in `emailOutputTo()` doesn't play nice with escaped path.

Escaping right before building a crontab command is much safer.

We really lack test coverage here, but all those `file_get_contents` are not easy to test. 

Sigh.
