### PR TITLE
[5.2] Unify database chunk methods, and add each methods

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -264,7 +264,7 @@ class Builder
      *
      * @param  int  $count
      * @param  callable  $callback
-     * @return void
+     * @return bool
      */
     public function chunk($count, callable $callback)
     {
@@ -275,13 +275,35 @@ class Builder
             // developer take care of everything within the callback, which allows us to
             // keep the memory low for spinning through large result sets for working.
             if (call_user_func($callback, $results) === false) {
-                break;
+                return false;
             }
 
             $page++;
 
             $results = $this->forPage($page, $count)->get();
         }
+
+        return true;
+    }
+
+    /**
+     * Execute a callback over each item.
+     *
+     * We're also saving memory by chunking the results into memory.
+     *
+     * @param  callable  $callback
+     * @param  int  $count
+     * @return bool
+     */
+    public function each(callable $callback, $count = 1000)
+    {
+        return $this->chunk($count, function ($results) use ($callback) {
+            foreach ($results as $key => $value) {
+                if ($callback($item, $key) === false) {
+                    return false;
+                }
+            }
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -229,16 +229,16 @@ class BelongsToMany extends Relation
      *
      * @param  int  $count
      * @param  callable  $callback
-     * @return void
+     * @return bool
      */
     public function chunk($count, callable $callback)
     {
         $this->query->addSelect($this->getSelectColumns());
 
-        $this->query->chunk($count, function ($results) use ($callback) {
+        return $this->query->chunk($count, function ($results) use ($callback) {
             $this->hydratePivotRelation($results->all());
 
-            call_user_func($callback, $results);
+            return $callback($results);
         });
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1567,6 +1567,26 @@ class Builder
     }
 
     /**
+     * Execute a callback over each item.
+     *
+     * We're also saving memory by chunking the results into memory.
+     *
+     * @param  callable  $callback
+     * @param  int  $count
+     * @return bool
+     */
+    public function each(callable $callback, $count = 1000)
+    {
+        return $this->chunk($count, function ($results) use ($callback) {
+            foreach ($results as $key => $value) {
+                if ($callback($item, $key) === false) {
+                    return false;
+                }
+            }
+        });
+    }
+
+    /**
      * Get an array with the values of a given column.
      *
      * @param  string  $column


### PR DESCRIPTION
Now the eloquent chunk method works in the same way as the one one the basic query class.

I've also added an each method, so, rather like we can with collections, we can now iterate the results of a query, but it get's one step better: we can actually chunk the results into memory to allow us to iterate very large data sets with a low memory footprint. I choose chunks of size 1000 by default, so for small data sets, there might only be one query needed.
