### PR TITLE
[5.2] IronMQ driver is no longer shipped with the core framework.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,6 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "~3.0",
-        "iron-io/iron_mq": "~2.0",
         "mockery/mockery": "~0.9.2",
         "pda/pheanstalk": "~3.0",
         "phpunit/phpunit": "~4.1",

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -10,7 +10,6 @@ use Illuminate\Queue\Console\RestartCommand;
 use Illuminate\Queue\Connectors\SqsConnector;
 use Illuminate\Queue\Connectors\NullConnector;
 use Illuminate\Queue\Connectors\SyncConnector;
-use Illuminate\Queue\Connectors\IronConnector;
 use Illuminate\Queue\Connectors\RedisConnector;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Queue\Connectors\DatabaseConnector;
@@ -147,7 +146,7 @@ class QueueServiceProvider extends ServiceProvider
      */
     public function registerConnectors($manager)
     {
-        foreach (['Null', 'Sync', 'Database', 'Beanstalkd', 'Redis', 'Sqs', 'Iron'] as $connector) {
+        foreach (['Null', 'Sync', 'Database', 'Beanstalkd', 'Redis', 'Sqs'] as $connector) {
             $this->{"register{$connector}Connector"}($manager);
         }
     }
@@ -229,21 +228,6 @@ class QueueServiceProvider extends ServiceProvider
     {
         $manager->addConnector('sqs', function () {
             return new SqsConnector;
-        });
-    }
-
-    /**
-     * Register the IronMQ queue connector.
-     *
-     * @param  \Illuminate\Queue\QueueManager  $manager
-     * @return void
-     */
-    protected function registerIronConnector($manager)
-    {
-        $app = $this->app;
-
-        $manager->addConnector('iron', function () use ($app) {
-            return new IronConnector($app['encrypter']);
         });
     }
 


### PR DESCRIPTION
As stated in the docs, IronMQ driver is no longer shipped with the core framework. Removed any references in the QueueServiceProvider.
