### PR TITLE
[5.2] Add tags property to the cache events

### DIFF
--- a/src/Illuminate/Cache/Events/CacheHit.php
+++ b/src/Illuminate/Cache/Events/CacheHit.php
@@ -19,15 +19,24 @@ class CacheHit
     public $value;
 
     /**
+     * Any tags that were used.
+     *
+     * @var array
+     */
+    public $tags;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $key
      * @param  mixed  $value
+     * @param  array  $tags
      * @return void
      */
-    public function __construct($key, $value)
+    public function __construct($key, $value, array $tags = [])
     {
         $this->key = $key;
         $this->value = $value;
+        $this->tags = $tags;
     }
 }

--- a/src/Illuminate/Cache/Events/CacheMissed.php
+++ b/src/Illuminate/Cache/Events/CacheMissed.php
@@ -12,13 +12,22 @@ class CacheMissed
     public $key;
 
     /**
+     * Any tags that were used.
+     *
+     * @var array
+     */
+    public $tags;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $event
+     * @param  array  $tags
      * @return void
      */
-    public function __construct($key)
+    public function __construct($key, array $tags = [])
     {
         $this->key = $key;
+        $this->tags = $tags;
     }
 }

--- a/src/Illuminate/Cache/Events/KeyForgotten.php
+++ b/src/Illuminate/Cache/Events/KeyForgotten.php
@@ -12,13 +12,22 @@ class KeyForgotten
     public $key;
 
     /**
+     * Any tags that were used.
+     *
+     * @var array
+     */
+    public $tags;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $key
+     * @param  array  $tags
      * @return void
      */
-    public function __construct($key)
+    public function __construct($key, $tags = [])
     {
         $this->key = $key;
+        $this->tags = $tags;
     }
 }

--- a/src/Illuminate/Cache/Events/KeyWritten.php
+++ b/src/Illuminate/Cache/Events/KeyWritten.php
@@ -26,17 +26,26 @@ class KeyWritten
     public $minutes;
 
     /**
+     * Any tags that were used.
+     *
+     * @var array
+     */
+    public $tags;
+
+    /**
      * Create a new event instance.
      *
      * @param  string  $key
      * @param  mixed  $value
      * @param  int  $minutes
+     * @param  array  $tags
      * @return void
      */
-    public function __construct($key, $value, $minutes)
+    public function __construct($key, $value, $minutes, $tags = [])
     {
         $this->key = $key;
         $this->value = $value;
         $this->minutes = $minutes;
+        $this->tags = $tags;
     }
 }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -76,13 +76,29 @@ class Repository implements CacheContract, ArrayAccess
 
         switch ($event) {
             case 'hit':
-                return $this->events->fire(new Events\CacheHit($payload[0], $payload[1]));
+                if (count($payload) == 2) {
+                    $payload[] = [];
+                }
+
+                return $this->events->fire(new Events\CacheHit($payload[0], $payload[1], $payload[2]));
             case 'missed':
-                return $this->events->fire(new Events\CacheMissed($payload[0]));
+                if (count($payload) == 1) {
+                    $payload[] = [];
+                }
+
+                return $this->events->fire(new Events\CacheMissed($payload[0], $payload[1]));
             case 'delete':
-                return $this->events->fire(new Events\KeyForgotten($payload[0]));
+                if (count($payload) == 1) {
+                    $payload[] = [];
+                }
+
+                return $this->events->fire(new Events\KeyForgotten($payload[0], $payload[1]));
             case 'write':
-                return $this->events->fire(new Events\KeyWritten($payload[0], $payload[1], $payload[2]));
+                if (count($payload) == 3) {
+                    $payload[] = [];
+                }
+
+                return $this->events->fire(new Events\KeyWritten($payload[0], $payload[1], $payload[2], $payload[3]));
         }
     }
 


### PR DESCRIPTION
This adds the `tags` property to the new `CacheHit`, `CacheMissed`, `KeyForgotten`, and `KeyWritten` event classes as requested in #11338. The events now match how they function in 5.1.

The tests were also updated so that the properties on the event classes can be tested.
