### PR TITLE
[5.2] Throw exception for unsupported types

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use RuntimeException;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
@@ -459,10 +460,12 @@ class MySqlGrammar extends Grammar
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function typeJsonb(Fluent $column)
     {
-        return 'json';
+        throw new RuntimeException('Jsonb types are not supported by MySql.');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use RuntimeException;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
@@ -445,10 +446,12 @@ class SQLiteGrammar extends Grammar
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function typeEnum(Fluent $column)
     {
-        return 'varchar';
+        throw new RuntimeException('Enum types are not supported by SQLite.');
     }
 
     /**
@@ -456,10 +459,12 @@ class SQLiteGrammar extends Grammar
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function typeJson(Fluent $column)
     {
-        return 'text';
+        throw new RuntimeException('Json types are not supported by SQLite.');
     }
 
     /**
@@ -467,10 +472,12 @@ class SQLiteGrammar extends Grammar
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function typeJsonb(Fluent $column)
     {
-        return 'text';
+        throw new RuntimeException('Jsonb types are not supported by SQLite.');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema\Grammars;
 
+use RuntimeException;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Schema\Blueprint;
 
@@ -391,10 +392,12 @@ class SqlServerGrammar extends Grammar
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function typeEnum(Fluent $column)
     {
-        return 'nvarchar(255)';
+        throw new RuntimeException('Enum types are not supported by SqlServer.');
     }
 
     /**
@@ -402,10 +405,12 @@ class SqlServerGrammar extends Grammar
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function typeJson(Fluent $column)
     {
-        return 'nvarchar(max)';
+        throw new RuntimeException('Json types are not supported by SqlServer.');
     }
 
     /**
@@ -413,10 +418,12 @@ class SqlServerGrammar extends Grammar
      *
      * @param  \Illuminate\Support\Fluent  $column
      * @return string
+     *
+     * @throws \RuntimeException
      */
     protected function typeJsonb(Fluent $column)
     {
-        return 'nvarchar(max)';
+        throw new RuntimeException('Jsonb types are not supported by SqlServer.');
     }
 
     /**


### PR DESCRIPTION
In laravel 5.2, we allowed the json type, only supported on mysql 5.7, which breaks all earlier versions. I propose we change the behaviour of our migrations so that unsupported types don't fallback to something poorer, and, instead, just fail, so the behaviour is now consistent.
