### PR TITLE
[5.2] Fix @parent keyword escaping

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -730,6 +730,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Compile the parent statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileParent($expression)
+    {
+        return '<?php $__env->appendParent(); ?>';
+    }
+
+    /**
      * Compile the push statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -483,6 +483,12 @@ empty
         $this->assertEquals('<?php $__env->stopSection(); ?>', $compiler->compileString('@endsection'));
     }
 
+    public function testParentsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertEquals('<?php $__env->appendParent(); ?>', $compiler->compileString('@parent'));
+    }    
+
     public function testAppendSectionsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -238,7 +238,8 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
-        echo 'hi @parent';
+        echo 'hi ';
+        $factory->appendParent();
         $factory->stopSection();
         $factory->startSection('foo');
         echo 'there';
@@ -249,16 +250,49 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
     public function testSectionMultipleExtending()
     {
         $factory = $this->getFactory();
+        
         $factory->startSection('foo');
-        echo 'hello @parent nice to see you @parent';
+        echo 'hello ';
+        $factory->appendParent();
+        echo ' nice to see you ';
+        $factory->appendParent();
+        echo ' again';
         $factory->stopSection();
+        
         $factory->startSection('foo');
-        echo 'my @parent';
+        echo 'my ';
+        $factory->appendParent();
+        echo ' ';
+        $factory->appendParent();
+        echo ' ever';
         $factory->stopSection();
+        
+        $factory->startSection('foo');
+        echo 'best ';
+        $factory->appendParent();
+        $factory->stopSection();
+
         $factory->startSection('foo');
         echo 'friend';
         $factory->stopSection();
-        $this->assertEquals('hello my friend nice to see you my friend', $factory->yieldContent('foo'));
+
+        $factory->startSection('foo');
+        echo 'this is not appended';
+        $factory->stopSection();
+        
+        $this->assertEquals('hello my best friend best friend ever nice to see you my best friend best friend ever again', $factory->yieldContent('foo'));
+    }
+
+    public function testParentKeywordEscaping()
+    {
+        $factory = $this->getFactory();
+        $factory->startSection('foo');
+        echo 'hi @parent';
+        $factory->stopSection();
+        $factory->startSection('foo');
+        echo 'there';
+        $factory->stopSection();
+        $this->assertEquals('hi @parent', $factory->yieldContent('foo'));
     }
 
     public function testSingleStackPush()
@@ -282,7 +316,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('hi, Hello!', $factory->yieldContent('foo'));
     }
 
-    public function testSessionAppending()
+    public function testSectionAppending()
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');


### PR DESCRIPTION
This PR is fix for issue https://github.com/laravel/framework/issues/10068 and it's trying to properly handle `@parent` keywords in Blade sections and ensure proper section extending. The solution is hardly based on previously reverted commit https://github.com/laravel/framework/pull/10122 with a few tweaks.
## TODO list:
- [x] Fix original issue https://github.com/laravel/framework/issues/10068.
- [x] Add test to ensure `@parent` keyword is properly handled.
- [x] Edit test for multiple section extending to ensure we will not introduce bugs like https://github.com/laravel/framework/issues/10156.
- [ ] Fix `@append` behaviour to properly handle parent marks.
- [ ] Add tests for section appending.
- [x] Confirmation from @abhimanyusharma003 `@parent` keyword is properly escaped.
- [ ] Confirmation form @atmediauk this fix is working as expected and has no side effects for him.

Thank you guys. Special thanks to @mspiderv for helping me with figuring out how to fix it and @dmgawel for previous try to fix this issue.
