### PR TITLE
[5.2] Pass array validation rules as array

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -216,7 +216,7 @@ class Validator implements ValidatorContract
     {
         foreach ($rules as $key => $rule) {
             if (Str::contains($key, '*')) {
-                $this->each($key, $rule);
+                $this->each($key, [$rule]);
 
                 unset($rules[$key]);
             } else {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1804,6 +1804,14 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, $data, ['foo' => 'Array']);
         $v->each('foo', 'numeric|min:4|max:16');
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, $data, ['foo' => 'Array']);
+        $v->each('foo', ['numeric','min:6','max:14']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, $data, ['foo' => 'Array']);
+        $v->each('foo', ['numeric','min:4','max:16']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateImplicitEachWithAsterisks()
@@ -1817,6 +1825,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, $data, ['foo' => 'Array', 'foo.*' => 'Numeric|Min:4|Max:16']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, $data, ['foo' => 'Array', 'foo.*' => ['Numeric','Min:6','Max:16']]);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, $data, ['foo' => 'Array', 'foo.*' => ['Numeric','Min:4','Max:16']]);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['foo' => [['name' => 'first'], ['name' => 'second']]],
             ['foo' => 'Array', 'foo.*.name' => 'Required|String']);
         $this->assertTrue($v->passes());
@@ -1827,6 +1841,18 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
             ['foo' => 'Array', 'foo.*.name' => 'Required|String', 'foo.*.votes.*' => 'Required|Integer']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['name' => 'first'], ['name' => 'second']]],
+            ['foo' => 'Array', 'foo.*.name' => ['Required','String']]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['name' => 'first'], ['name' => 'second']]],
+            ['foo' => 'Array', 'foo.*.name' => ['Required','Numeric']]);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
+            ['foo' => 'Array', 'foo.*.name' => ['Required','String'], 'foo.*.votes.*' => ['Required','Integer']]);
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
When using the regex validation rule, the documentation recomends to pass the rules as an array with the regex expression contains pipes.

Although if we test this route:

``` php
// test with http://localhost:8000/validation-test?phones[]=1234567890&numbers[]=8
\Route::get( 'validation-test', function ( \Illuminate\Http\Request $request ) {
    $validator = \Validator::make( $request->all(), [
        'phones'    => 'array',
        'phones.*'  => [
            'required',
            // I know it could be written as /^\d{10,11}$/
            // it is just a proof of concept
            'regex:/^(?:\d{10}|\d{11})$/'
        ],
        'numbers'   => 'array',
        'numbers.*' => 'numeric|min:1|max:10',
    ] );

    if ($validator->fails()) {
        dd( $validator->errors()->all() );
    }

    return 'OK';
} );
```

It will throw an `ErrorException` stating that: **_preg_match(): No ending delimiter '/' found**_.

This PR fix this issue.
