### PR TITLE
[5.2] Boot Traits in Http Kernel and Console Kernel

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -77,7 +77,7 @@ class Kernel implements KernelContract
     }
 
     /**
-     * The "booting" Console Kernel method.
+     * Boot the console kernel.
      *
      * @return void
      */
@@ -91,7 +91,7 @@ class Kernel implements KernelContract
     }
 
     /**
-     * Calls bootable methods of traits.
+     * Boot the traits.
      *
      * @return void
      */

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -73,9 +73,37 @@ class Kernel implements KernelContract
         $this->app = $app;
         $this->events = $events;
 
+        $this->boot();
+    }
+
+    /**
+     * The "booting" Console Kernel method.
+     *
+     * @return void
+     */
+    protected function boot()
+    {
+        $this->bootTraits();
+
         $this->app->booted(function () {
             $this->defineConsoleSchedule();
         });
+    }
+
+    /**
+     * Calls bootable methods of traits.
+     *
+     * @return void
+     */
+    protected function bootTraits()
+    {
+        // Loops through all the class traits.
+        foreach (class_uses_recursive(get_class($this)) as $trait) {
+            // Calls the method if it exists.
+            if (method_exists(get_called_class(), $method = 'boot'.class_basename($trait))) {
+                $this->{$method}();
+            }
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -86,15 +86,15 @@ class Kernel implements KernelContract
      */
     protected function boot()
     {
-      $this->bootTraits();
+        $this->bootTraits();
 
-      foreach ($this->middlewareGroups as $key => $middleware) {
-          $this->router->middlewareGroup($key, $middleware);
-      }
+        foreach ($this->middlewareGroups as $key => $middleware) {
+            $this->router->middlewareGroup($key, $middleware);
+        }
 
-      foreach ($this->routeMiddleware as $key => $middleware) {
-          $this->router->middleware($key, $middleware);
-      }
+        foreach ($this->routeMiddleware as $key => $middleware) {
+            $this->router->middleware($key, $middleware);
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -76,12 +76,30 @@ class Kernel implements KernelContract
         $this->app = $app;
         $this->router = $router;
 
+        $this->bootTraits();
+
         foreach ($this->middlewareGroups as $key => $middleware) {
             $router->middlewareGroup($key, $middleware);
         }
 
         foreach ($this->routeMiddleware as $key => $middleware) {
             $router->middleware($key, $middleware);
+        }
+    }
+
+    /**
+     * Calls bootable methods of traits.
+     *
+     * @return void
+     */
+    protected function bootTraits()
+    {
+        // Loops through all the class traits.
+        foreach (class_uses_recursive(get_class($this)) as $trait) {
+            // Calls the method if it exists.
+            if (method_exists(get_called_class(), $method = 'boot'.class_basename($trait))) {
+                $this->{$method}();
+            }
         }
     }
 

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -80,7 +80,7 @@ class Kernel implements KernelContract
     }
 
     /**
-     * The "booting" Http Kernel method.
+     * Boot the http kernel.
      *
      * @return void
      */
@@ -98,7 +98,7 @@ class Kernel implements KernelContract
     }
 
     /**
-     * Calls bootable methods of traits.
+     * Boot the traits.
      *
      * @return void
      */

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -76,15 +76,25 @@ class Kernel implements KernelContract
         $this->app = $app;
         $this->router = $router;
 
-        $this->bootTraits();
+        $this->boot();
+    }
 
-        foreach ($this->middlewareGroups as $key => $middleware) {
-            $router->middlewareGroup($key, $middleware);
-        }
+    /**
+     * The "booting" Http Kernel method.
+     *
+     * @return void
+     */
+    protected function boot()
+    {
+      $this->bootTraits();
 
-        foreach ($this->routeMiddleware as $key => $middleware) {
-            $router->middleware($key, $middleware);
-        }
+      foreach ($this->middlewareGroups as $key => $middleware) {
+          $this->router->middlewareGroup($key, $middleware);
+      }
+
+      foreach ($this->routeMiddleware as $key => $middleware) {
+          $this->router->middleware($key, $middleware);
+      }
     }
 
     /**


### PR DESCRIPTION
This modification is intended to facilitate the distribution of packages / modules.
When you need to interact or register code in HttpKernel, the process needs to be manual.

The change follows exactly the same principle as the Eloquent.

``` php
namespace MyBusiness\Applications\MemberSection\Http;

trait HttpMemberSectionTrait
{
    protected function bootHttpMemberSectionTraits()
    {
        $this->middlewareGroups['members-sections'] = [
            'auth:member'
        ];

        // other actions
    }
}
```

``` php
namespace App\Http;

use Illuminate\Foundation\Http\Kernel as HttpKernel;
use MyBusiness\Applications\MemberSection\Http\HttpMemberSectionTrait;
use MyBusiness\Applications\Forum\Http\HttpForumTrait;

class Kernel extends HttpKernel
{
  use HttpMemberSectionTrait, HttpForumTrait;
 // ...
}
```
