### PR TITLE
[5.1] Refactor info helper function to handle null message

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -402,10 +402,14 @@ if (! function_exists('info')) {
      *
      * @param  string  $message
      * @param  array   $context
-     * @return void
+     * @return \Illuminate\Contracts\Logging\Log|null
      */
-    function info($message, $context = [])
+    function info($message = null, $context = [])
     {
+        if (is_null($message)) {
+            return app('log');
+        }
+
         return app('log')->info($message, $context);
     }
 }


### PR DESCRIPTION
There are two log helper functions, `info` and `logger`.

When the `info` function is used without passing in any message, the web page loads continously/forever until you get this:

<img width="1103" alt="screen shot 2015-12-28 at 8 46 54 am" src="https://cloud.githubusercontent.com/assets/2946769/12015725/f5d98f12-ad40-11e5-9961-8f40efb1423e.png">

This PR introduces better error handling just like the way `logger` handles it properly.
