### PR TITLE
[5.2] Sql Server Grammar accepts TVF as a table name

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -321,4 +321,24 @@ class SqlServerGrammar extends Grammar
 
         return trim("update {$table}{$joins} set $columns $where");
     }
+
+    /**
+     * Wrap a table in keyword identifiers.
+     *
+     * @param  string|\Illuminate\Database\Query\Expression  $table
+     * @return string
+     */
+    public function wrapTable($table)
+    {
+        $table = parent::wrapTable($table);
+
+        if (preg_match('/^(.+?)(\(.*?\))?]$/', $table, $matches) === 1) {
+            $table = $matches[1].']';
+            $parameters = isset($matches[2]) ? $matches[2] : '';
+
+            return $table.$parameters;
+        }
+
+        return $table;
+    }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1364,6 +1364,17 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('select * from "users" where "name" = ?', $builder->toSql());
     }
 
+    public function testTableValuedFunctionInFromSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users()');
+        $this->assertEquals('select * from [users]()', $builder->toSql());
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->select('*')->from('users(1,2)');
+        $this->assertEquals('select * from [users](1,2)', $builder->toSql());
+    }
+
     protected function getBuilder()
     {
         $grammar = new Illuminate\Database\Query\Grammars\Grammar;


### PR DESCRIPTION
Permits to use a Table Valued Function as a table name
