### PR TITLE
[5.2] Adding getConnection value to passthru properties of the Illuminate\Database\Eloquent\Builder Class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -55,7 +55,7 @@ class Builder
      */
     protected $passthru = [
         'insert', 'insertGetId', 'getBindings', 'toSql',
-        'exists', 'count', 'min', 'max', 'avg', 'sum',
+        'exists', 'count', 'min', 'max', 'avg', 'sum', 'getConnection'
     ];
 
     /**


### PR DESCRIPTION
Adding getConnection value to passthru properties of the Illuminate\Database\Eloquent\Builder Class to allow get Illuminate\Database\Connection Object using method getConnection of Illuminate\Database\Eloquent\Builder, so can change fetch style to FETCH_NUM ( Laravel Default - PDO::FETCH_OBJ ) or do other functionality using Illuminate\Database\Connection Object. I'm using it to support DataTables format.

<pre>
<code>
namespace Illuminate\Database\Eloquent;
...
class Builder
...
/**
 * The methods that should be returned from query builder.
 *
 * @var array
 */
protected $passthru = [
    'insert', 'insertGetId', 'getBindings', 'toSql',
    'exists', 'count', 'min', 'max', 'avg', 'sum', 'getConnection'
];
</code>
</pre>
