### PR TITLE
[5.1] More phpdoc inconsistencies fixes

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -305,7 +305,7 @@ class Command extends SymfonyCommand
      * Format input to textual table.
      *
      * @param  array   $headers
-     * @param  array|\Illuminate\Contracts\Support\Arrayable  $rows
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
      * @param  string  $style
      * @return void
      */

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -60,7 +60,7 @@ class JoinClause
      *
      * on `contacts`.`user_id` = `users`.`id`  and `contacts`.`info_id` = `info`.`id`
      *
-     * @param  string|\Closure  $first
+     * @param  \Closure|string  $first
      * @param  string|null  $operator
      * @param  string|null  $second
      * @param  string  $boolean
@@ -97,7 +97,7 @@ class JoinClause
     /**
      * Add an "or on" clause to the join.
      *
-     * @param  string|\Closure  $first
+     * @param  \Closure|string  $first
      * @param  string|null  $operator
      * @param  string|null  $second
      * @return \Illuminate\Database\Query\JoinClause
@@ -110,7 +110,7 @@ class JoinClause
     /**
      * Add an "on where" clause to the join.
      *
-     * @param  string|\Closure  $first
+     * @param  \Closure|string  $first
      * @param  string|null  $operator
      * @param  string|null  $second
      * @param  string  $boolean
@@ -124,7 +124,7 @@ class JoinClause
     /**
      * Add an "or on where" clause to the join.
      *
-     * @param  string|\Closure  $first
+     * @param  \Closure|string  $first
      * @param  string|null  $operator
      * @param  string|null  $second
      * @return \Illuminate\Database\Query\JoinClause

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -48,7 +48,7 @@ class Arr
     /**
      * Collapse an array of arrays into a single array.
      *
-     * @param  array|\ArrayAccess  $array
+     * @param  \ArrayAccess|array  $array
      * @return array
      */
     public static function collapse($array)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -62,7 +62,7 @@ if (! function_exists('array_collapse')) {
     /**
      * Collapse an array of arrays into a single array.
      *
-     * @param  array|\ArrayAccess  $array
+     * @param  \ArrayAccess|array  $array
      * @return array
      */
     function array_collapse($array)


### PR DESCRIPTION
Ran the followinf regexp on the src folder to find the inconsistencies in this commit:

```
 @param\s+(string|int|integer|bool|boolean|float|double|null|array)\|\\
```
