### PR TITLE
[5.1] Fix cache database store increment and decrement return values

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -116,14 +116,12 @@ class DatabaseStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return void
+     * @return int|bool
      */
     public function increment($key, $value = 1)
     {
-        $this->connection->transaction(function () use ($key, $value) {
-            return $this->incrementOrDecrement($key, $value, function ($current) use ($value) {
-                return $current + $value;
-            });
+        return $this->incrementOrDecrement($key, $value, function ($current, $value) {
+            return $current + $value;
         });
     }
 
@@ -132,14 +130,12 @@ class DatabaseStore implements Store
      *
      * @param  string  $key
      * @param  mixed   $value
-     * @return void
+     * @return int|bool
      */
     public function decrement($key, $value = 1)
     {
-        $this->connection->transaction(function () use ($key, $value) {
-            return $this->incrementOrDecrement($key, $value, function ($current) use ($value) {
-                return $current - $value;
-            });
+        return $this->incrementOrDecrement($key, $value, function ($current, $value) {
+            return $current - $value;
         });
     }
 
@@ -149,23 +145,32 @@ class DatabaseStore implements Store
      * @param  string  $key
      * @param  mixed  $value
      * @param  \Closure  $callback
-     * @return void
+     * @return int|bool
      */
     protected function incrementOrDecrement($key, $value, Closure $callback)
     {
-        $prefixed = $this->prefix.$key;
+        return $this->connection->transaction(function () use ($key, $value, $callback) {
+            $prefixed = $this->prefix.$key;
 
-        $cache = $this->table()->where('key', $prefixed)->lockForUpdate()->first();
+            $cache = $this->table()->where('key', $prefixed)->lockForUpdate()->first();
 
-        if (! is_null($cache)) {
-            $current = $this->encrypter->decrypt($cache->value);
-
-            if (is_numeric($current)) {
-                $this->table()->where('key', $prefixed)->update([
-                    'value' => $this->encrypter->encrypt($callback($current)),
-                ]);
+            if (is_null($cache)) {
+                return false;
             }
-        }
+
+            $current = $this->encrypter->decrypt($cache->value);
+            $new = $callback($current, $value);
+
+            if (! is_numeric($current)) {
+                return false;
+            }
+
+            $this->table()->where('key', $prefixed)->update([
+                'value' => $this->encrypter->encrypt($new),
+            ]);
+
+            return $new;
+        });
     }
 
     /**


### PR DESCRIPTION
The [`Store` interface specifies](https://github.com/laravel/framework/blob/eaded36c61547365115c69cb85f8320bfa819e40/src/Illuminate/Contracts/Cache/Store.php#L25-L41) that the return values for the `increment` and `decrement` methods should be `int|bool`. All stores except `DatabaseStore` return either the newly incremented/decremented number or false if it couldn't be completed. This fixes the `DatabaseStore` to correctly follow the interface and match the functionality of the other stores.
