### PR TITLE
[5.2] Populate the email field from the password reset email

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/emails/password.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/emails/password.stub
@@ -1,1 +1,1 @@
-Click here to reset your password: {{ url('password/reset', [$token, $user->getEmailForPasswordReset()]) }}
+Click here to reset your password: {{ url('password/reset', $token).'?email='.urlencode($user->getEmailForPasswordReset()) }}

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/emails/password.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/emails/password.stub
@@ -1,1 +1,1 @@
-Click here to reset your password: {{ url('password/reset/'.$token) }}
+Click here to reset your password: {{ url('password/reset', [$token, $user->getEmailForPasswordReset()]) }}

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/passwords/reset.stub
@@ -17,7 +17,7 @@
                             <label class="col-md-4 control-label">E-Mail Address</label>
 
                             <div class="col-md-6">
-                                <input type="email" class="form-control" name="email" value="{{ old('email') }}">
+                                <input type="email" class="form-control" name="email" value="{{ $email or old('email') }}">
 
                                 @if ($errors->has('email'))
                                     <span class="help-block">

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -98,14 +98,16 @@ trait ResetsPasswords
      * If no token is present, display the link request form.
      *
      * @param  string|null  $token
-     * @param  string|null  $email
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function showResetForm($token = null, $email = null)
+    public function showResetForm($token = null, Request $request)
     {
         if (is_null($token)) {
             return $this->getEmail();
         }
+
+        $email = $request->input('email');
 
         if (view()->exists('auth.passwords.reset')) {
             return view('auth.passwords.reset')->with(compact('token', 'email'));

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -98,16 +98,17 @@ trait ResetsPasswords
      * If no token is present, display the link request form.
      *
      * @param  string|null  $token
+     * @param  string|null  $email
      * @return \Illuminate\Http\Response
      */
-    public function showResetForm($token = null)
+    public function showResetForm($token = null, $email = null)
     {
         if (is_null($token)) {
             return $this->getEmail();
         }
 
         if (view()->exists('auth.passwords.reset')) {
-            return view('auth.passwords.reset')->with('token', $token);
+            return view('auth.passwords.reset')->with(compact('token', 'email'));
         }
 
         return view('auth.reset')->with('token', $token);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -355,7 +355,7 @@ class Router implements RegistrarContract
         $this->post('register', 'Auth\AuthController@register');
 
         // Password Reset Routes...
-        $this->get('password/reset/{token?}/{email?}', 'Auth\PasswordController@showResetForm');
+        $this->get('password/reset/{token?}', 'Auth\PasswordController@showResetForm');
         $this->post('password/email', 'Auth\PasswordController@sendResetLinkEmail');
         $this->post('password/reset', 'Auth\PasswordController@reset');
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -355,7 +355,7 @@ class Router implements RegistrarContract
         $this->post('register', 'Auth\AuthController@register');
 
         // Password Reset Routes...
-        $this->get('password/reset/{token?}', 'Auth\PasswordController@showResetForm');
+        $this->get('password/reset/{token?}/{email?}', 'Auth\PasswordController@showResetForm');
         $this->post('password/email', 'Auth\PasswordController@sendResetLinkEmail');
         $this->post('password/reset', 'Auth\PasswordController@reset');
     }


### PR DESCRIPTION
This change will append the URL encoded email address of the user to the reset password link that is emailed to them. This is used to pre-populate the email field on the reset password form. This makes it easier for legitimate users who are trying to reset their password while continuing to make it difficult to brute-force a reset token.
