### PR TITLE
[5.2] Allow users to request more random entries than exist

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -604,13 +604,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Get one or more items randomly from the collection.
      *
      * @param  int  $amount
+     * @param  bool  $alwaysReturn
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
-    public function random($amount = 1)
+    public function random($amount = 1, $alwaysReturn = false)
     {
         if ($amount > ($count = $this->count())) {
+            if ($alwaysReturn) {
+                return $this;
+            }
+
             throw new InvalidArgumentException("You requested {$amount} items, but there are only {$count} items in the collection");
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -586,6 +586,14 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         (new Collection)->random();
     }
 
+    public function testRandomCanReturnAllItemsWhenRequestingMoreThanAvailable()
+    {
+        $data = new Collection([1, 2, 3, 4, 5, 6]);
+
+        $random = $data->random(10, true);
+        $this->assertEquals($data, $random);
+    }
+
     public function testTakeLast()
     {
         $data = new Collection(['taylor', 'dayle', 'shawn']);


### PR DESCRIPTION
This will allow a user to call

```
$collection->random(10, true);
```

regardless of the size of the collection. If the collection has fewer than 10 items, all items will be return with the optional second flag, rather than throwing an error.

This was requested in #11588. I wouldn’t really call this one necessary, but it only took a couple minutes anyway.
