### PR TITLE
[5.2] Adjust ThrottleRequests for Symfony Response

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -49,10 +49,12 @@ class ThrottleRequests
 
         $this->limiter->hit($key, $decayMinutes);
 
-        return $next($request)->withHeaders([
+        ($response = $next($request))->headers->add([
             'X-RateLimit-Limit' => $maxAttempts,
             'X-RateLimit-Remaining' => $maxAttempts - $this->limiter->attempts($key) + 1,
         ]);
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
Removed the use of withHeaders to compensate for Symfony Responses.
