### PR TITLE
Show Dotenv exception

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -20,7 +20,7 @@ class DetectEnvironment
             try {
                 (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
             } catch (InvalidArgumentException $e) {
-                //
+                die($e->getMessage());
             }
         }
     }


### PR DESCRIPTION
Environment file exceptions are too important to be ignored.

If you have an error in the first half of your .env file, the second half will be not loaded, but the first half will and your app will probably have a problem.
