### PR TITLE
Ability to group routes by language.

### DIFF
--- a/src/Illuminate/Contracts/Routing/LocaleManager.php
+++ b/src/Illuminate/Contracts/Routing/LocaleManager.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Contracts\Routing;
+
+/**
+ * Interface LocaleManager
+ *
+ * @package Illuminate\Contracts\Routing
+ */
+interface LocaleManager
+{
+    /**
+     * Get a list of common languages.
+     *
+     * @return array
+     */
+    public function getLanguages();
+
+    /**
+     * Add language to common languages list.
+     *
+     * @param  string  $language
+     */
+    public function addLanguages($language);
+
+    /**
+     * Replace common languages list.
+     *
+     * @param  array  $languages
+     */
+    public function setLanguages(array $languages);
+
+    /**
+     * Get active application language.
+     *
+     * @return string
+     */
+    public function getActiveLocale();
+}

--- a/src/Illuminate/Routing/LocaleManager.php
+++ b/src/Illuminate/Routing/LocaleManager.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Contracts\Routing\LocaleManager as LocaleManagerContract;
+use Illuminate\Foundation\Application;
+
+class LocaleManager implements LocaleManagerContract
+{
+    /**
+     * Application instance.
+     *
+     * @var \Illuminate\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * Common languages that are merged for routes.
+     *
+     * @var array
+     */
+    protected $languages = ['*'];
+
+    /**
+     * LocaleManager constructor.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Get a list of common languages.
+     *
+     * @return array
+     */
+    public function getLanguages()
+    {
+        return array_unique(array_merge($this->languages, [$this->getActiveLocale()]));
+    }
+
+    /**
+     * Add language to common languages list.
+     *
+     * @param  string|array  $language
+     */
+    public function addLanguages($language)
+    {
+        if (is_string($language)) {
+            $language = func_get_args();
+        }
+
+        $this->languages = array_unique(array_merge($this->languages, $language));
+    }
+
+    /**
+     * replace common languages list.
+     *
+     * @param  array  $languages
+     */
+    public function setLanguages(array $languages)
+    {
+        $this->languages = $languages;
+    }
+
+    /**
+     * Get active application language.
+     *
+     * @return string
+     */
+    public function getActiveLocale()
+    {
+        return $this->app->getLocale();
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -841,6 +841,20 @@ class Route
     }
 
     /**
+     * Get route locale.
+     *
+     * @return string|null
+     */
+    public function getLocale()
+    {
+        if (isset($this->action['lang'])) {
+            return $this->action['lang'];
+        }
+
+        return '*';
+    }
+
+    /**
      * Prepare the route instance for serialization.
      *
      * @return void

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -17,6 +17,8 @@ class RoutingServiceProvider extends ServiceProvider
     {
         $this->registerRouter();
 
+        $this->registerLocaleManager();
+
         $this->registerUrlGenerator();
 
         $this->registerRedirector();
@@ -142,6 +144,13 @@ class RoutingServiceProvider extends ServiceProvider
     {
         $this->app->singleton('Illuminate\Contracts\Routing\ResponseFactory', function ($app) {
             return new ResponseFactory($app['Illuminate\Contracts\View\Factory'], $app['redirect']);
+        });
+    }
+
+    private function registerLocaleManager()
+    {
+        $this->app->singleton('Illuminate\Contracts\Routing\LocaleManager', function ($app) {
+            return new LocaleManager($app);
         });
     }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -447,7 +447,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
 
     public function testModelBindingThroughIOC()
     {
-        $router = new Router(new Dispatcher, $container = new Container);
+        $router = new Router(new Dispatcher, $container = $this->getContainer());
 
         $container->bind('RouteModelInterface', 'RouteModelBindingStub');
         $router->get('foo/{bar}', function ($name) { return $name; });
@@ -706,7 +706,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
     public function testRouterFiresRoutedEvent()
     {
         $events = new Illuminate\Events\Dispatcher();
-        $router = new Router($events);
+        $router = new Router($events, $this->getContainer());
         $router->get('foo/bar', function () { return ''; });
 
         $request = Request::create('http://foo.com/foo/bar', 'GET');
@@ -783,10 +783,59 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Illuminate\Http\Response', $_SERVER['route.test.controller.middleware.class']);
     }
 
-    protected function getRouter()
+    public function testMultilingualRoutes()
     {
-        return new Router(new Illuminate\Events\Dispatcher);
+        $router = $this->getRouter();
+
+
     }
+
+    protected function getRouter($defaultLocale = 'en')
+    {
+        return new Router(new Illuminate\Events\Dispatcher, $this->getContainer($defaultLocale));
+    }
+
+    protected function getContainer($defaultLocale = 'en')
+    {
+        $container = new ApplicationStub();
+        $container->singleton(\Illuminate\Foundation\Application::class, function ($app) {
+            return $app;
+        });
+        $container->bind(\Illuminate\Contracts\Routing\LocaleManager::class, function ($app) {
+            return new LocaleManagerStub($app);
+        });
+        $container->singleton('config', function() use ($defaultLocale) {
+            return new \Illuminate\Config\Repository([
+                'app' => [
+                    'locale' => $defaultLocale
+                ]
+            ]);
+        });
+
+        return $container;
+    }
+}
+
+class ApplicationStub extends \Illuminate\Foundation\Application
+{
+    protected $locale = 'en';
+
+    public function __construct() { }
+
+    public function getLocale()
+    {
+        return $this->locale;
+    }
+
+    public function setLocale($locale)
+    {
+        $this->locale = $locale;
+    }
+}
+
+class LocaleManagerStub extends \Illuminate\Routing\LocaleManager
+{
+
 }
 
 class RouteTestControllerStub extends Illuminate\Routing\Controller


### PR DESCRIPTION
This expands on the multilingual aspect of the framework, allowing to group routes by language (and have global routes, of course). By that I mean, it would allow specifying routes for different languages with different url, but keeping the same name. For example:

```
// Global route, is checked for every language
Route::get('global', function () {})

// Route that is available only when LocaleManager (can be custom user implementation) returns active language as 'en'
Route::get('only/en', ['lang' => 'en', 'as' => 'home', function () {}])

// Route that is available only when LocaleManager (can be custom user implementation) returns active language as 'de'
Route::get('only/de', ['lang' => 'de', 'as' => 'home', function () {}])
```

in both cases, the `/global` route is accessible, and `only/*` is available depending on your language. If global and language route has the same name, then global route would override it. The `route('home')` would return the route based on the language (todo, test). There are more cases where it could be extended upon, for example reading application lang from request, and modifying pathInfo for route resolving to avoid tedious and buggy route grouping by language, e.g. `/en/*`, `/de/*` (which I've solved by modifying Request in my app to trim language prefix, but this would be more appropriate solution). 

This is more of a proposal (it's not fully tested and not finished, but existing tests, apart router constructor change, didn't break ). In any case, I'll have to replace this in the core for my needs, but figured this could be useful.
