### PR TITLE
[5.3] Ability to group routes by language

### DIFF
--- a/src/Illuminate/Contracts/Routing/LocaleManager.php
+++ b/src/Illuminate/Contracts/Routing/LocaleManager.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Contracts\Routing;
+
+/**
+ * Interface LocaleManager
+ *
+ * @package Illuminate\Contracts\Routing
+ */
+interface LocaleManager
+{
+    /**
+     * Get a list of common languages.
+     *
+     * @return array
+     */
+    public function getLanguages();
+
+    /**
+     * Add language to common languages list.
+     *
+     * @param  string  $language
+     */
+    public function addLanguages($language);
+
+    /**
+     * Replace common languages list.
+     *
+     * @param  array  $languages
+     */
+    public function setLanguages(array $languages);
+
+    /**
+     * Get active application language.
+     *
+     * @return string
+     */
+    public function getActiveLocale();
+}

--- a/src/Illuminate/Routing/LocaleManager.php
+++ b/src/Illuminate/Routing/LocaleManager.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Contracts\Routing\LocaleManager as LocaleManagerContract;
+use Illuminate\Foundation\Application;
+
+class LocaleManager implements LocaleManagerContract
+{
+    /**
+     * Application instance.
+     *
+     * @var \Illuminate\Foundation\Application
+     */
+    protected $app;
+
+    /**
+     * Common languages that are merged for routes.
+     *
+     * @var array
+     */
+    protected $languages = ['*'];
+
+    /**
+     * LocaleManager constructor.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Get a list of common languages.
+     *
+     * @return array
+     */
+    public function getLanguages()
+    {
+        return array_unique(array_merge($this->languages, [$this->getActiveLocale()]));
+    }
+
+    /**
+     * Add language to common languages list.
+     *
+     * @param  string|array  $language
+     */
+    public function addLanguages($language)
+    {
+        if (is_string($language)) {
+            $language = func_get_args();
+        }
+
+        $this->languages = array_unique(array_merge($this->languages, $language));
+    }
+
+    /**
+     * replace common languages list.
+     *
+     * @param  array  $languages
+     */
+    public function setLanguages(array $languages)
+    {
+        $this->languages = $languages;
+    }
+
+    /**
+     * Get active application language.
+     *
+     * @return string
+     */
+    public function getActiveLocale()
+    {
+        return $this->app->getLocale();
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -841,6 +841,20 @@ class Route
     }
 
     /**
+     * Get route locale.
+     *
+     * @return string|null
+     */
+    public function getLocale()
+    {
+        if (isset($this->action['lang'])) {
+            return $this->action['lang'];
+        }
+
+        return '*';
+    }
+
+    /**
      * Prepare the route instance for serialization.
      *
      * @return void

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -95,7 +95,7 @@ class RouteCollection implements Countable, IteratorAggregate
     /**
      * Add the route to any look-up tables if necessary.
      *
-     * @param  \Illuminate\Routing\Route $route
+     * @param  \Illuminate\Routing\Route  $route
      * @return void
      */
     protected function addLookups($route)

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -10,15 +10,16 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use \Illuminate\Contracts\Routing\LocaleManager as LocaleManagerContract;
 
 class RouteCollection implements Countable, IteratorAggregate
 {
     /**
-     * An array of the routes keyed by method.
+     * Application locale manager.
      *
-     * @var array
+     * @var \Illuminate\Contracts\Routing\LocaleManager
      */
-    protected $routes = [];
+    protected $localeManager;
 
     /**
      * An flattened array of all of the routes.
@@ -28,18 +29,35 @@ class RouteCollection implements Countable, IteratorAggregate
     protected $allRoutes = [];
 
     /**
-     * A look-up table of routes by their names.
-     *
-     * @var array
-     */
-    protected $nameList = [];
-
-    /**
      * A look-up table of routes by controller action.
      *
      * @var array
      */
     protected $actionList = [];
+
+    /**
+     * A look-up table of routes by language.
+     *
+     * @var array
+     */
+    protected $localizedRoutes = [];
+
+    /**
+     * A look-up table of routes by language grouped by method.
+     *
+     * @var array
+     */
+    protected $localizedRoutesMethods = [];
+
+    /**
+     * RouteCollection constructor.
+     *
+     * @param  \Illuminate\Contracts\Routing\LocaleManager  $localeManager
+     */
+    public function __construct(LocaleManagerContract $localeManager)
+    {
+        $this->localeManager = $localeManager;
+    }
 
     /**
      * Add a Route instance to the collection.
@@ -65,18 +83,19 @@ class RouteCollection implements Countable, IteratorAggregate
     protected function addToCollections($route)
     {
         $domainAndUri = $route->domain().$route->getUri();
+        $routeLocale = $route->getLocale();
 
         foreach ($route->methods() as $method) {
-            $this->routes[$method][$domainAndUri] = $route;
+            $this->localizedRoutesMethods[$routeLocale][$method][$domainAndUri] = $route;
         }
 
-        $this->allRoutes[$method.$domainAndUri] = $route;
+        $this->allRoutes[$method.$routeLocale.$domainAndUri] = $route;
     }
 
     /**
      * Add the route to any look-up tables if necessary.
      *
-     * @param  \Illuminate\Routing\Route  $route
+     * @param  \Illuminate\Routing\Route $route
      * @return void
      */
     protected function addLookups($route)
@@ -86,8 +105,12 @@ class RouteCollection implements Countable, IteratorAggregate
         // to iterate through every route every time we need to perform a look-up.
         $action = $route->getAction();
 
+        $routeLocale = $route->getLocale();
+
         if (isset($action['as'])) {
-            $this->nameList[$action['as']] = $route;
+            $this->localizedRoutes[$routeLocale][$action['as']] = $route;
+        } else {
+            $this->localizedRoutes[$routeLocale][$route->domain() . $route->getUri()] = $route;
         }
 
         // When the route is routing to a controller we will also store the action that
@@ -107,11 +130,11 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     public function refreshNameLookups()
     {
-        $this->nameList = [];
+        $this->localizedRoutes = [];
 
         foreach ($this->allRoutes as $route) {
             if ($route->getName()) {
-                $this->nameList[$route->getName()] = $route;
+                $this->localizedRoutes[$this->getRouteLocale($route)][$route->getName()] = $route;
             }
         }
     }
@@ -132,13 +155,14 @@ class RouteCollection implements Countable, IteratorAggregate
      * Find the first route matching a given request.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  string|null $locale
      * @return \Illuminate\Routing\Route
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
-    public function match(Request $request)
+    public function match(Request $request, $locale = null)
     {
-        $routes = $this->get($request->getMethod());
+        $routes = $this->get($request->getMethod(), $locale);
 
         // First, we will see if we can find a matching route for this current request
         // method. If we can, great, we can just return it so that it can be called
@@ -242,11 +266,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     protected function get($method = null)
     {
-        if (is_null($method)) {
-            return $this->getRoutes();
-        }
-
-        return Arr::get($this->routes, $method, []);
+        return $method ? $this->getRoutesByMethod($method) : $this->getRoutes();
     }
 
     /**
@@ -264,11 +284,24 @@ class RouteCollection implements Countable, IteratorAggregate
      * Get a route instance by its name.
      *
      * @param  string  $name
+     * @param  string|array|null  $locales
      * @return \Illuminate\Routing\Route|null
      */
-    public function getByName($name)
+    public function getByName($name, $locales = null)
     {
-        return isset($this->nameList[$name]) ? $this->nameList[$name] : null;
+        if ($locales) {
+            $locales = array_unique(array_merge((array) $locales, ['*']));
+        } else {
+            $locales = $this->localeManager->getLanguages();
+        }
+
+        foreach ($locales as $locale) {
+            if (isset($this->localizedRoutes[$locale][$name])) {
+                return $this->localizedRoutes[$locale][$name];
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -289,7 +322,34 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     public function getRoutes()
     {
-        return array_values($this->allRoutes);
+        $routes = [];
+
+        foreach ($this->localeManager->getLanguages() as $language) {
+            if (isset($this->localizedRoutes[$language])) {
+                $routes[] = $this->localizedRoutes[$language];
+            }
+        }
+
+        return Arr::flatten($routes);
+    }
+
+    /**
+     * Get all of the routes in the collection by method.
+     *
+     * @param  string  $method
+     * @return array
+     */
+    public function getRoutesByMethod($method)
+    {
+        $routes = [];
+
+        foreach ($this->localeManager->getLanguages() as $language) {
+            if (isset($this->localizedRoutesMethods[$language][$method])) {
+                $routes[] = $this->localizedRoutesMethods[$language][$method];
+            }
+        }
+
+        return Arr::flatten($routes);
     }
 
     /**
@@ -299,7 +359,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     public function getIterator()
     {
-        return new ArrayIterator($this->getRoutes());
+        return new ArrayIterator(array_values($this->allRoutes));
     }
 
     /**
@@ -309,6 +369,6 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     public function count()
     {
-        return count($this->getRoutes());
+        return count($this->allRoutes);
     }
 }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing;
 
 use Closure;
+use Illuminate\Contracts\Routing\LocaleManager as LocaleManagerContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
@@ -21,6 +22,13 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class Router implements RegistrarContract
 {
     use Macroable;
+
+    /**
+     * The locale manager for handling language specific actions.
+     *
+     * @var LocaleManager
+     */
+    protected $localeManager;
 
     /**
      * The event dispatcher instance.
@@ -104,13 +112,15 @@ class Router implements RegistrarContract
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @param  \Illuminate\Container\Container  $container
+     * @param  \Illuminate\Contracts\Routing\LocaleManager  $localeManager
      * @return void
      */
-    public function __construct(Dispatcher $events, Container $container = null)
+    public function __construct(Dispatcher $events, Container $container = null, LocaleManagerContract $localeManager = null)
     {
         $this->events = $events;
-        $this->routes = new RouteCollection;
         $this->container = $container ?: new Container;
+        $this->localeManager = $localeManager ?: $this->container->make(LocaleManagerContract::class);
+        $this->routes = new RouteCollection($this->localeManager);
 
         $this->bind('_missing', function ($v) {
             return explode('/', $v);
@@ -1133,5 +1143,25 @@ class Router implements RegistrarContract
     public function getPatterns()
     {
         return $this->patterns;
+    }
+
+    /**
+     * Get current router locale manager.
+     *
+     * @return \Illuminate\Contracts\Routing\LocaleManager|\Illuminate\Routing\LocaleManager
+     */
+    public function getLocaleManager()
+    {
+        return $this->localeManager;
+    }
+
+    /**
+     * Set new locale manager for router.
+     *
+     * @param  \Illuminate\Contracts\Routing\LocaleManager  $manager
+     */
+    public function setLocaleManager(LocaleManagerContract $manager)
+    {
+        $this->localeManager = $manager;
     }
 }

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -17,6 +17,8 @@ class RoutingServiceProvider extends ServiceProvider
     {
         $this->registerRouter();
 
+        $this->registerLocaleManager();
+
         $this->registerUrlGenerator();
 
         $this->registerRedirector();
@@ -142,6 +144,18 @@ class RoutingServiceProvider extends ServiceProvider
     {
         $this->app->singleton('Illuminate\Contracts\Routing\ResponseFactory', function ($app) {
             return new ResponseFactory($app['Illuminate\Contracts\View\Factory'], $app['redirect']);
+        });
+    }
+
+    /**
+     * Register router locale manager.
+     *
+     * @return void
+     */
+    protected function registerLocaleManager()
+    {
+        $this->app->singleton('Illuminate\Contracts\Routing\LocaleManager', function ($app) {
+            return new LocaleManager($app);
         });
     }
 }


### PR DESCRIPTION
This expands on the multilingual aspect of the framework, allowing to group routes by language (and have global routes, of course). By that I mean, it would allow specifying routes for different languages with different url, but keeping the same name. For example:

```
// Global route, is checked for every language
Route::get('global', function () {})

// Route that is available only when LocaleManager (can be custom user implementation) returns active language as 'en'
Route::get('only/en', ['lang' => 'en', 'as' => 'home', function () {}])

// Route that is available only when LocaleManager (can be custom user implementation) returns active language as 'de'
Route::get('only/de', ['lang' => 'de', 'as' => 'home', function () {}])
```

in both cases, the `/global` route is accessible, and `only/*` is available depending on your language. If global and language route has the same name, then global route would override it. The `route('home')` would return the route based on the language (todo, test). There are more cases where it could be extended upon, for example reading application lang from request, and modifying pathInfo for route resolving to avoid tedious and buggy route grouping by language, e.g. `/en/*`, `/de/*` (which I've solved by modifying Request in my app to trim language prefix, but this would be more appropriate solution). 

This is more of a proposal (it's not fully tested and not finished, but existing tests, apart router constructor change, didn't break ). In any case, I'll have to replace this in the core for my needs, but figured this could be useful.
