### PR TITLE
[5.2] Fix `seeJsonStructure` which wasn't returning `$this`.

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -267,6 +267,8 @@ trait MakesHttpRequests
                 $this->assertArrayHasKey($value, $responseData);
             }
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Fix `seeJsonStructure` in `Illuminate\Foundation\Testing\Concerns\MakesHttpRequests` which is missing `return $this` and breaks chaining.

Not sure how to add a test unit for a piece of the testing framework, but this snippet illustrates the type of test I was writing which didn't work because `seeJsonStructure` didn't return `$this`.

```
<?php

use Illuminate\Foundation\Testing\WithoutMiddleware;

class ExampleTest extends TestCase
{

    use WithoutMiddleware;

    public function test_seeJsonStructure()
    {
        $data = ['foo' => 'bar', 'biz' => 'baz'];
        $this->json('POST', "test/uri", $data)
            ->seeJsonStructure(['foo', 'biz'])
            ->seeJson(['foo' => 'bar']);
    }
}
```
