### PR TITLE
[5.2] TokenGuard missing column 'api_token' (storageKey)

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -867,6 +867,26 @@ class Blueprint
     }
 
     /**
+     * Adds the `api_token` column to the table.
+     *
+     * @return \Illuminate\Support\Fluent
+     */
+    public function apiToken()
+    {
+        return $this->string('api_token', 100)->unique();
+    }
+
+    /**
+     * Indicate that the api token column should be dropped.
+     *
+     * @return void
+     */
+    public function dropApiToken()
+    {
+        $this->dropColumn('api_token');
+    }
+
+    /**
      * Create a new drop index command on the blueprint.
      *
      * @param  string  $command

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -873,7 +873,7 @@ class Blueprint
      */
     public function apiToken()
     {
-        return $this->string('api_token', 100)->unique();
+        return $this->string('api_token', 32)->unique();
     }
 
     /**


### PR DESCRIPTION
When trying to use the middleware '**auth:api**' on a fresh 5.2 project, the TokenGuard is performing the following SQL query (example):

``` sql
select * from `users` where `api_token` = uDn2LP7IWO limit 1
-- error: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'api_token' in 'where clause' 
```

However the column '**api_token**' is missing from the 'users' table, unless manually added.

I suggest we add helper methods to add/drop this column to the Blueprint, in the same way we add the 'remember_token' column, so we can do something like this:

``` php
public function up()
{
    Schema::create('users', function (Blueprint $table) {
        $table->increments('id');
        $table->string('name');
        $table->string('email')->unique();
        $table->string('password', 60);
        $table->rememberToken();
        $table->apiToken();
        $table->timestamps();
    });
}
```
