### PR TITLE
[5.3] Use singular string for resource route parameter bindings

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -228,7 +228,7 @@ class ResourceRegistrar
      */
     public function getResourceWildcard($value)
     {
-        return str_replace('-', '_', $value);
+        return str_replace('-', '_', str_singular($value));
     }
 
     /**


### PR DESCRIPTION
A pretty simple change that hopefully makes implicit model binding more intuitive for `Route::resource('regions')`

So rather than having `GET regions/{regions}` this would be `GET regions/{region}` and allow for implicit model binding like so:

``` php
public function show(Region $region)
{
    return view('region', compact('region'));
}
```
