### PR TITLE
[5.2] Fix each when there's no order by

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -296,7 +296,7 @@ class Builder
     public function each(callable $callback, $count = 1000)
     {
         if (is_null($this->getOrderBys())) {
-            $this->orderBy('id', 'asc');
+            $this->orderBy($this->model->getQualifiedKeyName(), 'asc');
         }
 
         return $this->chunk($count, function ($results) use ($callback) {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -295,6 +295,10 @@ class Builder
      */
     public function each(callable $callback, $count = 1000)
     {
+        if (is_null($this->getOrderBys())) {
+            $this->orderBy('id', 'asc');
+        }
+
         return $this->chunk($count, function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($item, $key) === false) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1575,6 +1575,10 @@ class Builder
      */
     public function each(callable $callback, $count = 1000)
     {
+        if (is_null($this->getOrderBys())) {
+            $this->orderBy('id', 'asc');
+        }
+
         return $this->chunk($count, function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($item, $key) === false) {
@@ -1582,6 +1586,18 @@ class Builder
                 }
             }
         });
+    }
+
+    /**
+     * Returns the currently set ordering.
+     *
+     * @return array|null
+     */
+    public function getOrderBys()
+    {
+        $property = $this->unions ? 'unionOrders' : 'orders';
+
+        return $this->{$property};
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query;
 
 use Closure;
+use RuntimeException;
 use BadMethodCallException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -1572,11 +1573,13 @@ class Builder
      * @param  callable  $callback
      * @param  int  $count
      * @return bool
+     *
+     * @throws \RuntimeException
      */
     public function each(callable $callback, $count = 1000)
     {
         if (is_null($this->getOrderBys())) {
-            $this->orderBy('id', 'asc');
+            throw new RuntimeException('You must provided an ordering on the query.');
         }
 
         return $this->chunk($count, function ($results) use ($callback) {


### PR DESCRIPTION
Unless we add an orderby, the rows returned by chunk are undefined, the 2nd chunk could be the same as the first chunk for instance.
