### PR TITLE
Maintain created_by and updated_by on model

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -297,6 +297,16 @@ class Blueprint
     }
 
     /**
+     * Indicate that the userstamp columns should be dropped.
+     *
+     * @return void
+     */
+    public function dropUserstamps()
+    {
+        $this->dropColumn('created_by', 'updated_by');
+    }
+
+    /**
      * Indicate that the timestamp columns should be dropped.
      *
      * @return void
@@ -806,6 +816,18 @@ class Blueprint
         $this->timestampTz('created_at');
 
         $this->timestampTz('updated_at');
+    }
+
+    /**
+     * Add creation and update userstamps to the table.
+     *
+     * @return void
+     */
+    public function userstamps()
+    {
+        $this->unsignedInteger('created_by')->nullable();
+
+        $this->unsignedInteger('updated_by')->nullable();
     }
 
     /**


### PR DESCRIPTION
The proposed would fix #966 

At the time (2.5 years ago) this was considered unnecessary - but since then Laravel has introduced a lot more automatic handling of various authentication and authorisation features, and maintaining who created and updated models seems in a similar vein.

Currently, it would only return the ID of the user who had created or updated. Perhaps it would be better if it were automatically returning the user?

I've used the variable $userstamp for lack of a better single word to define this functionality - defaults to false so enabling it would be optional.

**Update:** Made available as package instead - https://github.com/WildSideUK/Laravel-Userstamps
