### PR TITLE
[5.1] Support blade comments longer than 1024 char

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -196,7 +196,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileComments($value)
     {
-        $pattern = sprintf('/%s--((.|\s)*?)--%s/', $this->contentTags[0], $this->contentTags[1]);
+        $pattern = sprintf('/%s--(.*?)--%s/s', $this->contentTags[0], $this->contentTags[1]);
 
         return preg_replace($pattern, '<?php /*$1*/ ?>', $value);
     }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -209,6 +209,15 @@ this is a comment
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testLongCommentsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $longCode = str_repeat('_', 1024);
+        $string = '{{--' . $longCode . '--}}';
+        $expected = '<?php /*' . $longCode . '*/ ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     public function testIfStatementsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -213,8 +213,8 @@ this is a comment
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $longCode = str_repeat('_', 1024);
-        $string = '{{--' . $longCode . '--}}';
-        $expected = '<?php /*' . $longCode . '*/ ?>';
+        $string = '{{--'.$longCode.'--}}';
+        $expected = '<?php /*'.$longCode.'*/ ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 


### PR DESCRIPTION
Under PHP 7.0.1with pcre.jit enabled, if the comment is longer than 1024, preg_replace will return NULL.
