### PR TITLE
[5.3] Fix blade parent keyword escaping

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -450,6 +450,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Compile the parent statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileParent($expression)
+    {
+        return '<?php $__env->appendParent(); ?>';
+    }
+
+    /**
      * Compile the unless statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -92,6 +92,20 @@ class Factory implements FactoryContract
     protected $sectionStack = [];
 
     /**
+     * The marks in section for @parent section embedding.
+     *
+     * @var array
+     */
+    protected $parentMarks = [];
+
+    /**
+     * The marks in last captured section for @parent section embedding.
+     *
+     * @var array
+     */
+    protected $parentMarksLast = [];
+
+    /**
      * The number of active rendering operations.
      *
      * @var int
@@ -516,6 +530,8 @@ class Factory implements FactoryContract
      */
     public function startSection($section, $content = '')
     {
+        $this->parentMarksLast[$section] = [];
+
         if ($content === '') {
             if (ob_start()) {
                 $this->sectionStack[] = $section;
@@ -535,6 +551,18 @@ class Factory implements FactoryContract
     public function inject($section, $content)
     {
         return $this->startSection($section, $content);
+    }
+
+    /**
+     * Create mark for parent section content.
+     *
+     * @return void
+     */
+    public function appendParent()
+    {
+        $last = end($this->sectionStack);
+
+        $this->parentMarksLast[$last][] = ob_get_length();
     }
 
     /**
@@ -567,6 +595,7 @@ class Factory implements FactoryContract
         $last = array_pop($this->sectionStack);
 
         if ($overwrite) {
+            $this->parentMarks[$last] = $this->parentMarksLast[$last];
             $this->sections[$last] = ob_get_clean();
         } else {
             $this->extendSection($last, ob_get_clean());
@@ -590,8 +619,15 @@ class Factory implements FactoryContract
         $last = array_pop($this->sectionStack);
 
         if (isset($this->sections[$last])) {
+            $len = strlen($this->sections[$last]);
+
+            foreach ($this->parentMarksLast[$last] as $mark) {
+                $this->parentMarks[$last][] = $mark + $len;
+            }
+
             $this->sections[$last] .= ob_get_clean();
         } else {
+            $this->parentMarks[$last] = $this->parentMarksLast[$last];
             $this->sections[$last] = ob_get_clean();
         }
 
@@ -608,10 +644,25 @@ class Factory implements FactoryContract
     protected function extendSection($section, $content)
     {
         if (isset($this->sections[$section])) {
-            $content = str_replace('@parent', $content, $this->sections[$section]);
-        }
+            $marks = [];
+            $offset = 0;
+            $len = strlen($content);
 
-        $this->sections[$section] = $content;
+            foreach ($this->parentMarks[$section] as $mark) {
+                $this->sections[$section] = substr_replace($this->sections[$section], $content, $mark + $offset, 0);
+
+                foreach ($this->parentMarksLast[$section] as $markLast) {
+                    $marks[] = $mark + $markLast + $offset;
+                }
+                
+                $offset += $len;
+            }
+
+            $this->parentMarks[$section] = $marks;
+        } else {
+            $this->sections[$section] = $content;
+            $this->parentMarks[$section] = $this->parentMarksLast[$section];
+        }
     }
 
     /**
@@ -623,17 +674,7 @@ class Factory implements FactoryContract
      */
     public function yieldContent($section, $default = '')
     {
-        $sectionContent = $default;
-
-        if (isset($this->sections[$section])) {
-            $sectionContent = $this->sections[$section];
-        }
-
-        $sectionContent = str_replace('@@parent', '--parent--holder--', $sectionContent);
-
-        return str_replace(
-            '--parent--holder--', '@parent', str_replace('@parent', '', $sectionContent)
-        );
+        return isset($this->sections[$section]) ? $this->sections[$section] : $default;
     }
 
     /**
@@ -646,6 +687,10 @@ class Factory implements FactoryContract
         $this->sections = [];
 
         $this->sectionStack = [];
+
+        $this->parentMarks = [];
+
+        $this->parentMarksLast = [];       
     }
 
     /**

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -654,7 +654,7 @@ class Factory implements FactoryContract
                 foreach ($this->parentMarksLast[$section] as $markLast) {
                     $marks[] = $mark + $markLast + $offset;
                 }
-                
+
                 $offset += $len;
             }
 
@@ -690,7 +690,7 @@ class Factory implements FactoryContract
 
         $this->parentMarks = [];
 
-        $this->parentMarksLast = [];       
+        $this->parentMarksLast = [];
     }
 
     /**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -483,6 +483,12 @@ empty
         $this->assertEquals('<?php $__env->stopSection(); ?>', $compiler->compileString('@endsection'));
     }
 
+    public function testParentsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertEquals('<?php $__env->appendParent(); ?>', $compiler->compileString('@parent'));
+    }
+
     public function testAppendSectionsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -238,7 +238,8 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
-        echo 'hi @parent';
+        echo 'hi ';
+        $factory->appendParent();
         $factory->stopSection();
         $factory->startSection('foo');
         echo 'there';
@@ -249,16 +250,49 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
     public function testSectionMultipleExtending()
     {
         $factory = $this->getFactory();
+        
         $factory->startSection('foo');
-        echo 'hello @parent nice to see you @parent';
+        echo 'hello ';
+        $factory->appendParent();
+        echo ' nice to see you ';
+        $factory->appendParent();
+        echo ' again';
         $factory->stopSection();
+        
         $factory->startSection('foo');
-        echo 'my @parent';
+        echo 'my ';
+        $factory->appendParent();
+        echo ' ';
+        $factory->appendParent();
+        echo ' ever';
         $factory->stopSection();
+        
+        $factory->startSection('foo');
+        echo 'best ';
+        $factory->appendParent();
+        $factory->stopSection();
+
         $factory->startSection('foo');
         echo 'friend';
         $factory->stopSection();
-        $this->assertEquals('hello my friend nice to see you my friend', $factory->yieldContent('foo'));
+
+        $factory->startSection('foo');
+        echo 'this is not appended';
+        $factory->stopSection();
+        
+        $this->assertEquals('hello my best friend best friend ever nice to see you my best friend best friend ever again', $factory->yieldContent('foo'));
+    }
+
+    public function testParentKeywordEscaping()
+    {
+        $factory = $this->getFactory();
+        $factory->startSection('foo');
+        echo 'hi @parent';
+        $factory->stopSection();
+        $factory->startSection('foo');
+        echo 'there';
+        $factory->stopSection();
+        $this->assertEquals('hi @parent', $factory->yieldContent('foo'));
     }
 
     public function testSingleStackPush()
@@ -282,7 +316,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('hi, Hello!', $factory->yieldContent('foo'));
     }
 
-    public function testSessionAppending()
+    public function testSectionAppending()
     {
         $factory = $this->getFactory();
         $factory->startSection('foo');
@@ -292,6 +326,61 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         echo 'there';
         $factory->appendSection();
         $this->assertEquals('hithere', $factory->yieldContent('foo'));
+    }
+
+    public function testSectionAppendingCorrectlyHandlesParents()
+    {
+        $factory = $this->getFactory();
+        
+        $factory->startSection('foo');
+        echo 'hello ';
+        $factory->appendParent();
+        $factory->appendSection();
+        
+        $factory->startSection('foo');
+        echo ' nice to see you ';
+        $factory->appendParent();
+        $factory->appendSection();
+
+        $factory->startSection('foo');
+        echo 'my ';
+        $factory->appendParent();
+        $factory->stopSection();
+
+        $factory->startSection('foo');
+        echo 'friend';
+        $factory->stopSection();
+
+        $this->assertEquals('hello my friend nice to see you my friend', $factory->yieldContent('foo'));
+    }
+
+    public function testSectionOverwriting()
+    {
+        $factory = $this->getFactory();
+        $factory->startSection('foo');
+        echo 'hi';
+        $factory->stopSection(true);
+        $factory->startSection('foo');
+        echo 'hello';
+        $factory->stopSection(true);
+        $this->assertEquals('hello', $factory->yieldContent('foo'));
+    }
+
+    public function testSectionOverwritingWithParents()
+    {
+        $factory = $this->getFactory();
+        $factory->startSection('foo');
+        echo 'hi ';
+        $factory->appendParent();
+        $factory->stopSection(true);
+        $factory->startSection('foo');
+        echo 'hello ';
+        $factory->appendParent();
+        $factory->stopSection(true);
+        $factory->startSection('foo');
+        echo 'there';
+        $factory->stopSection();
+        $this->assertEquals('hello there', $factory->yieldContent('foo'));
     }
 
     public function testYieldSectionStopsAndYields()

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -250,7 +250,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
     public function testSectionMultipleExtending()
     {
         $factory = $this->getFactory();
-        
+
         $factory->startSection('foo');
         echo 'hello ';
         $factory->appendParent();
@@ -258,7 +258,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $factory->appendParent();
         echo ' again';
         $factory->stopSection();
-        
+
         $factory->startSection('foo');
         echo 'my ';
         $factory->appendParent();
@@ -266,7 +266,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $factory->appendParent();
         echo ' ever';
         $factory->stopSection();
-        
+
         $factory->startSection('foo');
         echo 'best ';
         $factory->appendParent();
@@ -279,7 +279,7 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
         $factory->startSection('foo');
         echo 'this is not appended';
         $factory->stopSection();
-        
+
         $this->assertEquals('hello my best friend best friend ever nice to see you my best friend best friend ever again', $factory->yieldContent('foo'));
     }
 
@@ -331,12 +331,12 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
     public function testSectionAppendingCorrectlyHandlesParents()
     {
         $factory = $this->getFactory();
-        
+
         $factory->startSection('foo');
         echo 'hello ';
         $factory->appendParent();
         $factory->appendSection();
-        
+
         $factory->startSection('foo');
         echo ' nice to see you ';
         $factory->appendParent();


### PR DESCRIPTION
This PR is fix for issue https://github.com/laravel/framework/issues/10068 and it's trying to properly handle `@parent` keywords in Blade sections and ensure proper section extending. The solution is hardly based on previously reverted commit https://github.com/laravel/framework/pull/10122 with a few tweaks.
## TODO list:
- [x] Fix original issue https://github.com/laravel/framework/issues/10068.
- [x] Add test to ensure `@parent` keyword is properly handled.
- [x] Edit test for multiple section extending to ensure we will not introduce bugs like https://github.com/laravel/framework/issues/10156.
- [x] Fix `@append` behaviour to properly handle parent marks.
- [x] Add tests for section appending.
- [x] Add tests for section overwriting.
- [x] Confirmation from @abhimanyusharma003 `@parent` keyword is properly escaped.
- [ ] Confirmation form @atmediauk this fix is working as expected and has no side effects for him.

Thank you guys. Special thanks to @mspiderv for helping me with figuring out how to fix it and @dmgawel for previous try to fix this issue.
