### PR TITLE
[5.3] Support custom build path in elixir helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -282,20 +282,21 @@ if (! function_exists('elixir')) {
      * Get the path to a versioned Elixir file.
      *
      * @param  string  $file
+     * @param  string  $buildPath
      * @return string
      *
      * @throws \InvalidArgumentException
      */
-    function elixir($file)
+    function elixir($file, $buildPath = 'build')
     {
         static $manifest = null;
 
-        if (is_null($manifest)) {
-            $manifest = json_decode(file_get_contents(public_path('build/rev-manifest.json')), true);
+        if (! isset($manifest[$buildPath])) {
+            $manifest[$buildPath] = json_decode(file_get_contents(public_path($buildPath . '/rev-manifest.json')), true);
         }
 
-        if (isset($manifest[$file])) {
-            return '/build/'.$manifest[$file];
+        if (isset($manifest[$buildPath][$file])) {
+            return '/' . $buildPath . '/'.$manifest[$buildPath][$file];
         }
 
         throw new InvalidArgumentException("File {$file} not defined in asset manifest.");


### PR DESCRIPTION
Hi,

I found an issue that if you choose a custom build path in the `version` method in elixir:

``` javascript
elixir(function(mix) {
    mix.version(['css/default.css', 'js/default.js']);
    mix.version(['css/first.css', 'js/first.js'], 'public/first-path');
    mix.version(['css/second.css', 'js/second.js'], 'public/second-path');
});
```

You will not be able to use `elixir` helper function for first-path & second-path

I added an optional $buildPath parameter to `elixir` helper function

Now we can use `elixir` helper function in a view like:

``` html
<link href="{{ elixir('css/default.css') }}" rel="stylesheet" type="text/css">
<link href="{{ elixir('css/first.css', 'first-path') }}" rel="stylesheet" type="text/css">
<link href="{{ elixir('css/second.css', 'second-path') }}" rel="stylesheet" type="text/css">
```

Thanks
