### PR TITLE
[5.1] Add support for "always on" pipes to the (Job) Bus Dispatcher

### DIFF
--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -51,4 +51,12 @@ interface Dispatcher
      * @return $this
      */
     public function pipeThrough(array $pipes);
+
+    /**
+     * Set the pipes through which commands should always be piped before dispatching.
+     *
+     * @param  array  $alwaysPipes
+     * @return $this
+     */
+    public function alwaysPipeThrough(array $alwaysPipes);
 }


### PR DESCRIPTION
I've been using the Bus Dispatcher as a command bus, and I'm trying to find a way to log every command (`Job`) upon dispatch. I've been doing the following, for example:

``` php
 public function store(CreateThing $createThingJob, BusDispatcher $busDispatcher) {
     $thing = $busDispatcher->pipeThrough([CommandLoggingPipe::class])->dispatch($createThingJob);
//...
```

As my application has a lot of Jobs, it's a bit cumbersome to call `pipeThrough()` with my logging pipe on every `dispatch()`. Instead, it would be really nice to be able to declare a set of pipes that can be used on _all_ Jobs, while maintaining the existing `pipeThrough()` functionality, so that additional pipes can be added on a per-Job basis. So, then I could have a `ServiceProvider` where these "always on" pipes are configured:

``` php
final class JobsServiceProvider extends ServiceProvider
{
    public function boot(BusDispatcher $busDispatcher)
    {
        $busDispatcher->alwaysPipeThrough([CommandLoggingPipe::class]);
    }
//...
```

I was unable to find any Job-related events (outside of those that are queued), which I could listen for. So I came up with this solution, adding an `alwaysPipeThrough()` method to the Dispatcher and its corresponding contract. 

I'm interested in getting feedback on this. Perhaps I've missed something that already provides this functionality, or maybe there's a better way?
