### PR TITLE
[5.2] Use extended Routing Pipeline in Kernel

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -5,7 +5,7 @@ namespace Illuminate\Foundation\Http;
 use Exception;
 use Throwable;
 use Illuminate\Routing\Router;
-use Illuminate\Pipeline\Pipeline;
+use Illuminate\Routing\Pipeline;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Debug\ExceptionHandler;


### PR DESCRIPTION
I'm not sure if this is left intentionally out or not, from commit https://github.com/laravel/framework/commit/c711448531244bb2b6d619469d145e12134a96a4

Also, should that commit make Exception responses run through the middleware? Because I still can't modify the response in my middleware, when an Exception is thrown (eg. in Controller or routes)
