### PR TITLE
[5.2] fix make:auth scaffolding views,routes and behaviour

### DIFF
--- a/src/Illuminate/Auth/Console/MakeAuthCommand.php
+++ b/src/Illuminate/Auth/Console/MakeAuthCommand.php
@@ -55,6 +55,13 @@ class MakeAuthCommand extends Command
                 app_path('Http/Controllers/HomeController.php')
             );
 
+            $this->info('Installed WelcomeController.');
+
+            copy(
+                __DIR__.'/stubs/make/controllers/WelcomeController.stub',
+                app_path('Http/Controllers/WelcomeController.php')
+            );
+
             $this->info('Updated Routes File.');
 
             file_put_contents(

--- a/src/Illuminate/Auth/Console/stubs/make/controllers/WelcomeController.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/controllers/WelcomeController.stub
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests;
+use Illuminate\Http\Request;
+
+class WelcomeController extends Controller
+{
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Show the application dashboard.
+     *
+     * @return Response
+     */
+    public function index()
+    {
+        return view('welcome');
+    }
+}

--- a/src/Illuminate/Auth/Console/stubs/make/routes.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/routes.stub
@@ -3,4 +3,5 @@ Route::group(['middleware' => 'web'], function () {
     Route::auth();
 
     Route::get('/home', 'HomeController@index');
+    Route::get('/', 'WelcomeController@index');
 });

--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -47,7 +47,11 @@
             <div class="collapse navbar-collapse" id="spark-navbar-collapse">
                 <!-- Left Side Of Navbar -->
                 <ul class="nav navbar-nav">
-                    <li><a href="{{ url('/') }}">Home</a></li>
+                    @if (Auth::guest())                    
+                        <li><a href="{{ url('/') }}">Home</a></li>
+                    @else
+                        <li><a href="{{ url('/home') }}">Home</a></li>
+                    @endif
                 </ul>
 
                 <!-- Right Side Of Navbar -->


### PR DESCRIPTION
I totally agree with [acacha](https://github.com/acacha) in issue [#11580](https://github.com/laravel/framework/issues/11580) and [hiendv](https://github.com/hiendv) in issue [#11592](https://github.com/laravel/framework/pull/11592), the behaviour of the generator `make:auth` is confusing:

Current behaviour:
1. When I `login` and press `home`
   - then I see **`welcome page`** and **`login/register`** option in nav bar.
     - Welcome page is not my home. I am already logged in.  No link to return home.
2.  When I login and press brand logo `Laravel`  
   - then I see **`welcome page`** and **`login/register`** option in nav bar.
     - I am already logged in. No link to return home.

Expected behaviour:
1. When I `login` and press `home`
   - then I see my **`home page`** and **`my profile`** option in nav bar.
2. When I `login` and press brand logo `Laravel`
   - then I see **`welcome page`** and **`my profile`** option in nav bar.

This is pull is fixing to expected behaviour:
1. Fix the links in nav bar
2. Fix the route to {'/'} with web guard
3. Creates a Welcome Controller to handle {'/'} without middleware 
4. Fix the Make:auth to copy new controller. 
