### PR TITLE
[5.2] Add reset form to auth scaffold

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -355,8 +355,9 @@ class Router implements RegistrarContract
         $this->post('register', 'Auth\AuthController@register');
 
         // Password Reset Routes...
-        $this->get('password/reset/{token?}', 'Auth\PasswordController@showResetForm');
+        $this->get('password/email', 'Auth\PasswordController@showLinkRequestForm');
         $this->post('password/email', 'Auth\PasswordController@sendResetLinkEmail');
+        $this->get('password/reset/{token?}', 'Auth\PasswordController@showResetForm');
         $this->post('password/reset', 'Auth\PasswordController@reset');
     }
 


### PR DESCRIPTION
The "artisan make:auth" scaffold lacked a GET route for the password/email page, to request a reset link email. The view for this operation already exists and is installed by the scaffold.

I simply added this route to the scaffold so the view and the password reset functionality is usable.
