### PR TITLE
[5.2] Make $errors variable always available to views

### DIFF
--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View;
 
+use Illuminate\Support\ViewErrorBag;
 use Illuminate\View\Engines\PhpEngine;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Engines\CompilerEngine;
@@ -119,6 +120,7 @@ class ViewServiceProvider extends ServiceProvider
             $env->setContainer($app);
 
             $env->share('app', $app);
+            $env->share('errors', new ViewErrorBag);
 
             return $env;
         });


### PR DESCRIPTION
This works around an issue where `$errors` isn't available to be used in 4xx/5xx error pages that are generated before a route is matched. In the case of a 404 it's possible that an unmatched route is what generated the 404. This could result in an undefined variable error if your error page references `$errors` somewhere.  This happens because:
- Even if you are using the web middleware, the request is not run through it when a route is not matched.
- Or if using `abort()` in middleware which results in a rendered view.
- Or throwing an exception in middleware which results in a rendered view.
