### PR TITLE
[5.2] Big performance increase for has() queries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -655,7 +655,7 @@ class Builder
     }
 
     /**
-     * Add a relationship count condition to the query.
+     * Add a relationship count/exists condition to the query.
      *
      * @param  string  $relation
      * @param  string  $operator
@@ -672,7 +672,12 @@ class Builder
 
         $relation = $this->getHasRelationQuery($relation);
 
-        $query = $relation->getRelationCountQuery($relation->getRelated()->newQuery(), $this);
+        // If we only need to check for the existence of the relation, then we can
+        // optimize the subquery to only run a "where exists" clause instead of
+        // the full "count" clause. This will make the query run much faster.
+        $queryType = $this->shouldRunExistsQuery($operator, $count) ? 'getRelationQuery' : 'getRelationCountQuery';
+
+        $query = $relation->$queryType($relation->getRelated()->newQuery(), $this);
 
         if ($callback) {
             call_user_func($callback, $query);
@@ -684,7 +689,7 @@ class Builder
     }
 
     /**
-     * Add nested relationship count conditions to the query.
+     * Add nested relationship count/exists conditions to the query.
      *
      * @param  string  $relations
      * @param  string  $operator
@@ -712,7 +717,7 @@ class Builder
     }
 
     /**
-     * Add a relationship count condition to the query.
+     * Add a relationship count/exists condition to the query.
      *
      * @param  string  $relation
      * @param  string  $boolean
@@ -725,7 +730,7 @@ class Builder
     }
 
     /**
-     * Add a relationship count condition to the query with where clauses.
+     * Add a relationship count/exists condition to the query with where clauses.
      *
      * @param  string    $relation
      * @param  \Closure  $callback
@@ -739,7 +744,7 @@ class Builder
     }
 
     /**
-     * Add a relationship count condition to the query with where clauses.
+     * Add a relationship count/exists condition to the query with where clauses.
      *
      * @param  string  $relation
      * @param  \Closure|null  $callback
@@ -751,7 +756,7 @@ class Builder
     }
 
     /**
-     * Add a relationship count condition to the query with an "or".
+     * Add a relationship count/exists condition to the query with an "or".
      *
      * @param  string  $relation
      * @param  string  $operator
@@ -764,7 +769,7 @@ class Builder
     }
 
     /**
-     * Add a relationship count condition to the query with where clauses and an "or".
+     * Add a relationship count/exists condition to the query with where clauses and an "or".
      *
      * @param  string    $relation
      * @param  \Closure  $callback
@@ -791,11 +796,45 @@ class Builder
     {
         $this->mergeModelDefinedRelationWheresToHasQuery($hasQuery, $relation);
 
+        if($this->shouldRunExistsQuery($operator, $count)) {
+            $not = ($operator === '<' && $count === 1);
+
+            return $this->whereExistsQuery($hasQuery->toBase(), $boolean, $not);
+        }
+
+        return $this->whereCountQuery($hasQuery->toBase(), $operator, $count, $boolean);
+    }
+
+    /**
+     * Check if we can run an "exists" query to optimize performance.
+     *
+     * @param  string  $operator
+     * @param  int  $count
+     * @return bool
+     */
+    protected function shouldRunExistsQuery($operator, $count)
+    {
+        return ($operator === '>=' && $count === 1) || ($operator === '<' && $count === 1);
+    }
+
+    /**
+     * Add a sub query count clause to the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  string  $operator
+     * @param  int  $count
+     * @param  string  $boolean
+     * @return $this
+     */
+    protected function whereCountQuery(QueryBuilder $query, $operator = '>=', $count = 1, $boolean = 'and')
+    {
         if (is_numeric($count)) {
             $count = new Expression($count);
         }
 
-        return $this->where(new Expression('('.$hasQuery->toSql().')'), $operator, $count, $boolean);
+        $this->query->addBinding($query->getBindings(), 'where');
+
+        return $this->where(new Expression('('.$query->toSql().')'), $operator, $count, $boolean);
     }
 
     /**
@@ -815,8 +854,6 @@ class Builder
         $hasQuery->mergeWheres(
             $relationQuery->wheres, $relationQuery->getBindings()
         );
-
-        $this->query->addBinding($hasQuery->getBindings(), 'where');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -77,19 +77,20 @@ class BelongsTo extends Relation
     }
 
     /**
-     * Add the constraints for a relationship count query.
+     * Add the constraints for a relationship query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Illuminate\Database\Eloquent\Builder  $parent
+     * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function getRelationCountQuery(Builder $query, Builder $parent)
+    public function getRelationQuery(Builder $query, Builder $parent, $columns = ['*'])
     {
         if ($parent->getQuery()->from == $query->getQuery()->from) {
-            return $this->getRelationCountQueryForSelfRelation($query, $parent);
+            return $this->getRelationQueryForSelfRelation($query, $parent, $columns);
         }
 
-        $query->select(new Expression('count(*)'));
+        $query->select($columns);
 
         $otherKey = $this->wrap($query->getModel()->getTable().'.'.$this->otherKey);
 
@@ -97,15 +98,16 @@ class BelongsTo extends Relation
     }
 
     /**
-     * Add the constraints for a relationship count query on the same table.
+     * Add the constraints for a relationship query on the same table.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Illuminate\Database\Eloquent\Builder  $parent
+     * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function getRelationCountQueryForSelfRelation(Builder $query, Builder $parent)
+    public function getRelationQueryForSelfRelation(Builder $query, Builder $parent, $columns = ['*'])
     {
-        $query->select(new Expression('count(*)'));
+        $query->select($columns);
 
         $query->from($query->getModel()->getTable().' as '.$hash = $this->getRelationCountHash());
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -299,33 +299,35 @@ class BelongsToMany extends Relation
     }
 
     /**
-     * Add the constraints for a relationship count query.
+     * Add the constraints for a relationship query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Illuminate\Database\Eloquent\Builder  $parent
+     * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function getRelationCountQuery(Builder $query, Builder $parent)
+    public function getRelationQuery(Builder $query, Builder $parent, $columns = ['*'])
     {
         if ($parent->getQuery()->from == $query->getQuery()->from) {
-            return $this->getRelationCountQueryForSelfJoin($query, $parent);
+            return $this->getRelationQueryForSelfJoin($query, $parent, $columns);
         }
 
         $this->setJoin($query);
 
-        return parent::getRelationCountQuery($query, $parent);
+        return parent::getRelationQuery($query, $parent, $columns);
     }
 
     /**
-     * Add the constraints for a relationship count query on the same table.
+     * Add the constraints for a relationship query on the same table.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Illuminate\Database\Eloquent\Builder  $parent
+     * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function getRelationCountQueryForSelfJoin(Builder $query, Builder $parent)
+    public function getRelationQueryForSelfJoin(Builder $query, Builder $parent, $columns = ['*'])
     {
-        $query->select(new Expression('count(*)'));
+        $query->select($columns);
 
         $query->from($this->table.' as '.$hash = $this->getRelationCountHash());
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -79,19 +79,20 @@ class HasManyThrough extends Relation
     }
 
     /**
-     * Add the constraints for a relationship count query.
+     * Add the constraints for a relationship query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Illuminate\Database\Eloquent\Builder  $parent
+     * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function getRelationCountQuery(Builder $query, Builder $parent)
+    public function getRelationQuery(Builder $query, Builder $parent, $columns = '*')
     {
         $parentTable = $this->parent->getTable();
 
         $this->setJoin($query);
 
-        $query->select(new Expression('count(*)'));
+        $query->select($columns);
 
         $key = $this->wrap($parentTable.'.'.$this->firstKey);
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -86,7 +86,7 @@ class HasManyThrough extends Relation
      * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function getRelationQuery(Builder $query, Builder $parent, $columns = '*')
+    public function getRelationQuery(Builder $query, Builder $parent, $columns = ['*'])
     {
         $parentTable = $this->parent->getTable();
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -55,31 +55,33 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
-     * Add the constraints for a relationship count query.
+     * Add the constraints for a relationship query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Illuminate\Database\Eloquent\Builder  $parent
+     * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function getRelationCountQuery(Builder $query, Builder $parent)
+    public function getRelationQuery(Builder $query, Builder $parent, $columns = ['*'])
     {
         if ($parent->getQuery()->from == $query->getQuery()->from) {
-            return $this->getRelationCountQueryForSelfRelation($query, $parent);
+            return $this->getRelationQueryForSelfRelation($query, $parent, $columns);
         }
 
-        return parent::getRelationCountQuery($query, $parent);
+        return parent::getRelationQuery($query, $parent, $columns);
     }
 
     /**
-     * Add the constraints for a relationship count query on the same table.
+     * Add the constraints for a relationship query on the same table.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Illuminate\Database\Eloquent\Builder  $parent
+     * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function getRelationCountQueryForSelfRelation(Builder $query, Builder $parent)
+    public function getRelationQueryForSelfRelation(Builder $query, Builder $parent, $columns = ['*'])
     {
-        $query->select(new Expression('count(*)'));
+        $query->select($columns);
 
         $query->from($query->getModel()->getTable().' as '.$hash = $this->getRelationCountHash());
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -55,15 +55,16 @@ abstract class MorphOneOrMany extends HasOneOrMany
     }
 
     /**
-     * Get the relationship count query.
+     * Get the relationship query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Illuminate\Database\Eloquent\Builder  $parent
+     * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function getRelationCountQuery(Builder $query, Builder $parent)
+    public function getRelationQuery(Builder $query, Builder $parent, $columns = ['*'])
     {
-        $query = parent::getRelationCountQuery($query, $parent);
+        $query = parent::getRelationQuery($query, $parent, $columns);
 
         return $query->where($this->morphType, $this->morphClass);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Arr;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
@@ -72,11 +73,12 @@ class MorphToMany extends BelongsToMany
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Illuminate\Database\Eloquent\Builder  $parent
+     * @param  array|mixed  $columns
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function getRelationCountQuery(Builder $query, Builder $parent)
+    public function getRelationQuery(Builder $query, Builder $parent, $columns = ['*'])
     {
-        $query = parent::getRelationCountQuery($query, $parent);
+        $query = parent::getRelationQuery($query, $parent, $columns);
 
         return $query->where($this->table.'.'.$this->morphType, $this->morphClass);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -149,7 +149,7 @@ abstract class Relation
     }
 
     /**
-     * Add the constraints for a relationship count query.
+     * Add the constraints for a relationship query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  \Illuminate\Database\Eloquent\Builder  $parent

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -145,7 +145,20 @@ abstract class Relation
      */
     public function getRelationCountQuery(Builder $query, Builder $parent)
     {
-        $query->select(new Expression('count(*)'));
+        return $this->getRelationQuery($query, $parent, new Expression('count(*)'));
+    }
+
+    /**
+     * Add the constraints for a relationship count query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $parent
+     * @param  array|mixed $columns
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function getRelationQuery(Builder $query, Builder $parent, $columns = ['*'])
+    {
+        $query->select($columns);
 
         $key = $this->wrap($this->getQualifiedParentKeyName());
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -708,8 +708,6 @@ class Builder
      */
     public function whereExists(Closure $callback, $boolean = 'and', $not = false)
     {
-        $type = $not ? 'NotExists' : 'Exists';
-
         $query = $this->newQuery();
 
         // Similar to the sub-select clause, we will create a new query instance so
@@ -717,11 +715,7 @@ class Builder
         // compile the whole thing in the grammar and insert it into the SQL.
         call_user_func($callback, $query);
 
-        $this->wheres[] = compact('type', 'operator', 'query', 'boolean');
-
-        $this->addBinding($query->getBindings(), 'where');
-
-        return $this;
+        return $this->whereExistsQuery($query, $boolean, $not);
     }
 
     /**
@@ -746,6 +740,25 @@ class Builder
     public function whereNotExists(Closure $callback, $boolean = 'and')
     {
         return $this->whereExists($callback, $boolean, true);
+    }
+
+    /**
+     * Add an exists clause to the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
+     */
+    public function whereExistsQuery(Builder $query, $boolean = 'and', $not = false)
+    {
+        $type = $not ? 'NotExists' : 'Exists';
+
+        $this->wheres[] = compact('type', 'operator', 'query', 'boolean');
+
+        $this->addBinding($query->getBindings(), 'where');
+
+        return $this;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -438,7 +438,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
             $q->having('bam', '>', 'qux');
         })->where('quux', 'quuux');
 
-        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" having "bam" > ?) >= 1 and "quux" = ?', $builder->toSql());
+        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" having "bam" > ?) and "quux" = ?', $builder->toSql());
         $this->assertEquals(['baz', 'qux', 'quuux'], $builder->getBindings());
     }
 
@@ -453,7 +453,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
             $q->having('bam', '>', 'qux');
         })->where('quux', 'quuux');
 
-        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and (select count(*) from "eloquent_builder_test_model_close_related_stubs" inner join "quuuux" on "quuuuux" = ? where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" having "bam" > ?) >= 1 and "quux" = ?', $builder->toSql());
+        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" inner join "quuuux" on "quuuuux" = ? where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" having "bam" > ?) and "quux" = ?', $builder->toSql());
         $this->assertEquals(['baz', 'quuuuuux', 'qux', 'quuux'], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -457,6 +457,19 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['baz', 'quuuuuux', 'qux', 'quuux'], $builder->getBindings());
     }
 
+    public function testHasWithContraintsAndHavingInSubqueryWithCount()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->where('bar', 'baz');
+        $builder->whereHas('foo', function ($q) {
+            $q->having('bam', '>', 'qux');
+        }, '>=', 2)->where('quux', 'quuux');
+
+        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" having "bam" > ?) >= 2 and "quux" = ?', $builder->toSql());
+        $this->assertEquals(['baz', 'qux', 'quuux'], $builder->getBindings());
+    }
+
     public function testHasNestedWithConstraints()
     {
         $model = new EloquentBuilderTestModelParentStub;

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -86,8 +86,8 @@ class DatabaseEloquentGlobalScopesTest extends PHPUnit_Framework_TestCase
     {
         $query = EloquentGlobalScopesWithRelationModel::has('related')->where('bar', 'baz');
 
-        $subQuery = 'select count(*) from "table" where "table"."related_id" = "table2"."id" and "foo" = ? and "active" = ?';
-        $mainQuery = 'select * from "table2" where ('.$subQuery.') >= 1 and "bar" = ? and "active" = ? order by "name" asc';
+        $subQuery = 'select * from "table" where "table"."related_id" = "table2"."id" and "foo" = ? and "active" = ?';
+        $mainQuery = 'select * from "table2" where exists ('.$subQuery.') and "bar" = ? and "active" = ? order by "name" asc';
 
         $this->assertEquals($mainQuery, $query->toSql());
         $this->assertEquals(['bar', 1, 'baz', 1], $query->getBindings());


### PR DESCRIPTION
As you know, has() queries in Eloquent are really slow on big data sets. This has been discussed at length in the past: https://github.com/laravel/framework/issues/8720 https://github.com/laravel/framework/issues/3543 https://github.com/laravel/framework/issues/5328

We even had a PR, but it was quite "hacky": https://github.com/laravel/framework/pull/8748

But in fact there is a simple solution. Instead of:

``` sql
where (select count(*) from table) >= 1
where (select count(*) from table) < 1
```

We can simply run:

``` sql
where exists(select * from table)
where not exists(select * from table)
```

Of course, if we are doing anything else than `>=1` or `<1` the behaviour remains unchanged.

I had to add a new parameter (`$columns`) to `getRelationCountQuery` on all relation classes  to make it work, but it's actually a pretty simple change. In my tests i managed to get between 5X and 60X faster performance. If you have lots of data in the related table, the performance increase will be much more noticable.

Oh, and happy new year everyone :) :fireworks:
