### PR TITLE
[5.2] Delayed the call to fitersPass() to when scheduled task is run

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -247,7 +247,6 @@ class Event
         }
 
         return $this->expressionPasses() &&
-               $this->filtersPass($app) &&
                $this->runsInEnvironment($app->environment());
     }
 
@@ -273,7 +272,7 @@ class Event
      * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return bool
      */
-    protected function filtersPass($app)
+    public function filtersPass($app)
     {
         foreach ($this->filters as $callback) {
             if (! $app->call($callback)) {

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -49,13 +49,20 @@ class ScheduleRunCommand extends Command
     {
         $events = $this->schedule->dueEvents($this->laravel);
 
+        $runEventsCount = 0;
         foreach ($events as $event) {
+            if (!$event->filtersPass($this->laravel)) {
+                continue;
+            }
+
             $this->line('<info>Running scheduled command:</info> '.$event->getSummaryForDisplay());
 
             $event->run($this->laravel);
+
+            ++$runEventsCount;
         }
 
-        if (count($events) === 0) {
+        if (count($events) === 0 || $runEventsCount === 0) {
             $this->info('No scheduled commands are ready to run.');
         }
     }

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -35,7 +35,8 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
         $event = new Event('php foo');
         $this->assertEquals('* * * * * *', $event->getExpression());
         $this->assertTrue($event->isDue($app));
-        $this->assertFalse($event->skip(function () { return true; })->isDue($app));
+        $this->assertTrue($event->skip(function () { return true; })->isDue($app));
+        $this->assertFalse($event->skip(function () { return true; })->filtersPass($app));
 
         $event = new Event('php foo');
         $this->assertEquals('* * * * * *', $event->getExpression());
@@ -43,7 +44,7 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
 
         $event = new Event('php foo');
         $this->assertEquals('* * * * * *', $event->getExpression());
-        $this->assertFalse($event->when(function () { return false; })->isDue($app));
+        $this->assertFalse($event->when(function () { return false; })->filtersPass($app));
 
         $event = new Event('php foo');
         $this->assertEquals('*/5 * * * * *', $event->everyFiveMinutes()->getExpression());


### PR DESCRIPTION
I've come upon this issue when trying to executing multiple time-consuming tasks while using **withoutOverlapping()** - as a result 2 instances of given task were executed even though **withoutOverlapping()** was called.

When **artisan schedule:run** is run, first the list of tasks that are due to be run is built. **withoutOverlapping()** checks for existence of a mutex file for given task in **storage/framework/** - if it does not exist, a task is scheduled to be run. All scheduled tasks are executed in a sequence and that mutex file is created the moment the task starts executing. Therefore there is a delay between checking if the mutex file exists and the moment the task gets executed. This may cause time-consuming tasks to be run in parallel even though they should not overlap.

Sample scenario:
- tasks T1 and T2 should run every minute without overlapping
- first instance of schedule:run - S1 - is executed and schedules T1 and T2 to be run
- S1 executes T1, mutex file for T1 is created, T1 takes more than a minute to finish
- in the meanwhile second instance of schedule:run - S2 - is executed a minute later
- S2 sees that there is a mutex file for T1 that is still running, so S2 starts T2
- T1 started by S1 finishes, therefore S1, having previously scheduled T2 to run, starts T2
- **two instances of T2 are running at the same time even thought they are not supposed to overlap**

It can happen in other scenarios as well, whenever multiple tasks are scheduled and application state can change between the moment **schedule:run** is triggered and the moment when scheduled task is executed.

When **schedule:run** is executed, schedule is built using expressions, filters, rejects and current environment. While expressions and current environment won't change while scheduled tasks are running, state that is checked by filters and rejects is likely to change. Therefore it makes sense to do those checks when the task is about to run, not when **schedule:run** is triggered.
