### PR TITLE
[5.2] move response building in ResetsPasswords to controller action method

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -62,11 +62,34 @@ trait ResetsPasswords
 
         switch ($response) {
             case Password::RESET_LINK_SENT:
-                return redirect()->back()->with('status', trans($response));
+                return $this->getSendResetLinkEmailSuccessResponse($response);
 
             case Password::INVALID_USER:
-                return redirect()->back()->withErrors(['email' => trans($response)]);
+            default:
+                return $this->getSendResetLinkEmailFailureResponse($response);
         }
+    }
+
+    /**
+     * Get the response to send back after the reset link has been successfully sent.
+     *
+     * @param  string  $response
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    protected function getSendResetLinkEmailSuccessResponse($response)
+    {
+        return redirect()->back()->with('status', trans($response));
+    }
+
+    /**
+     * Get the response to send back after the reset link could not be sent.
+     *
+     * @param  string  $response
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    protected function getSendResetLinkEmailFailureResponse($response)
+    {
+        return redirect()->back()->withErrors(['email' => trans($response)]);
     }
 
     /**
@@ -152,13 +175,37 @@ trait ResetsPasswords
 
         switch ($response) {
             case Password::PASSWORD_RESET:
-                return redirect($this->redirectPath())->with('status', trans($response));
+                return $this->getResetSuccessResponse($response);
 
             default:
-                return redirect()->back()
-                            ->withInput($request->only('email'))
-                            ->withErrors(['email' => trans($response)]);
+                return $this->getResetFailureResponse($response, $request);
         }
+    }
+
+    /**
+     * Get the response to send back after a successful password reset.
+     *
+     * @param  mixed  $response
+     * @param  Request  $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    protected function getResetSuccessResponse($response)
+    {
+        return redirect($this->redirectPath())->with('status', trans($response));
+    }
+
+    /**
+     * Get the response to send back after a failing password reset.
+     *
+     * @param  string  $response
+     * @param  Request  $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    protected function getResetFailureResponse($response, Request $request)
+    {
+        return redirect()->back()
+            ->withInput($request->only('email'))
+            ->withErrors(['email' => trans($response)]);
     }
 
     /**


### PR DESCRIPTION
Prior to this change, modifying the behavior of the `ResetsPasswords` trait would look like this:

```
use ResetsPasswords;

public function postEmail(Request $request, Store $session)
{
    $response = $this->sendResetLinkEmail($request);

    if ($session->has('status')) {
        $this->notification->info(PasswordBroker::RESET_LINK_SENT);
    }

    return $response;
}

public function postReset(Request $request, Store $session)
{
    $response = $this->reset($request);

    if ($session->has('status')) {
        $this->notification->info(PasswordBroker::PASSWORD_RESET);
    }

    return $response;
}
```

Now it is easier (and feels cleaner) to implement custom behavior (as you do not have to work with the returned response, see above):

```
public function postReset(Request $request, Store $session)
{
    $response = $this->reset($request);

    if ($response === Password::PASSWORD_RESET) {
          // do something custom
    }

    return redirect()->back()
        ->withInput($request->only('email'))
        ->withErrors(['email' => $response]);
}
```

An alternative to making customization even easier, is to extract the statements executed in the `switch`-cases to individual methods which can then be overridden. This way you could have very specific customization. Would lead to additional method clutter (4) in the trait, but does make customization much easier:

```
public function postReset(Request $request)
{
    $response = $this->reset($request);

    switch ($response) {
        case Password::PASSWORD_RESET:
             return $this->postResetSuccess($request); // you would only have to override this method

        default:
            return $this->postResetFailure($request);
    }
}
```

Wonder what framework maintainers think, but adding the above has my preference.

related: #11559
