### PR TITLE
[5.2] Inject Request instance to getReset

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -84,12 +84,13 @@ trait ResetsPasswords
      *
      * If no token is present, display the link request form.
      *
+     * @param Request $request
      * @param  string|null  $token
      * @return \Illuminate\Http\Response
      */
-    public function getReset($token = null)
+    public function getReset(Request $request, $token = null)
     {
-        return $this->showResetForm($token);
+        return $this->showResetForm($request, $token);
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -84,7 +84,7 @@ trait ResetsPasswords
      *
      * If no token is present, display the link request form.
      *
-     * @param Request $request
+     * @param  \Illuminate\Http\Request  $request
      * @param  string|null  $token
      * @return \Illuminate\Http\Response
      */


### PR DESCRIPTION
`showResetForm`'s signature requires a `Request` object which wasn't passed in `getReset` causing the following exception:

```
Argument 1 passed to PasswordsController::showResetForm() must be an instance of Illuminate\Http\Request, string given, called in /vagrant/vendor/laravel/framework/src/Illuminate/Foundation/Auth/ResetsPasswords.php on line 92 and defined
```
