### PR TITLE
Small mistake in dummy file

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -23,7 +23,7 @@ class DummyClass extends Command
     /**
      * Create a new command instance.
      *
-     * @return void
+     * @return DummyClass
      */
     public function __construct()
     {


### PR DESCRIPTION
A constructor does not return void but it returns an instance of the class.
