### PR TITLE
[5.2] Fix 'No connector for []' null queue driver bug

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -182,6 +182,10 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     protected function getConfig($name)
     {
+        if ($name === null || $name === 'null') {
+            return ['driver' => 'null'];
+        }
+
         return $this->app['config']["queue.connections.{$name}"];
     }
 

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -51,4 +51,24 @@ class QueueManagerTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($queue, $manager->connection('foo'));
     }
+
+    public function testNullConnectionCanBeResolved()
+    {
+        $app = [
+            'config' => [
+                'queue.default' => 'null',
+            ],
+            'encrypter' => $encrypter = m::mock('Illuminate\Contracts\Encryption\Encrypter'),
+        ];
+
+        $manager = new QueueManager($app);
+        $connector = m::mock('StdClass');
+        $queue = m::mock('StdClass');
+        $connector->shouldReceive('connect')->once()->with(['driver' => 'null'])->andReturn($queue);
+        $manager->addConnector('null', function () use ($connector) { return $connector; });
+        $queue->shouldReceive('setContainer')->once()->with($app);
+        $queue->shouldReceive('setEncrypter')->once()->with($encrypter);
+
+        $this->assertSame($queue, $manager->connection('null'));
+    }
 }


### PR DESCRIPTION
Setting the queue configuration `default` to `null` throws an
`InvalidArgumentException` since there is not a `null` key in the
`connections` configuration.

To remain backwards compatible, I added the `null` connection
configuration to `QueueManager`.

Reference [Issue #11051](https://github.com/laravel/framework/issues/11051) for more details regarding this bug.
