### PR TITLE
[5.2] Remove deprecated $deep param

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -510,7 +510,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             return $this->$source->all();
         }
 
-        return $this->$source->get($key, $default, true);
+        return $this->$source->get($key, $default);
     }
 
     /**


### PR DESCRIPTION
The third `$deep` parameter on the `get()` method of Symfony's `ParameterBag` class has been deprecated as of `v2.8` and removed completely as of `v3.0`

See here:
(version 2.8) - https://github.com/symfony/http-foundation/blob/2.8/ParameterBag.php#L78-L90
(version 3.0) - https://github.com/symfony/http-foundation/blob/3.0/ParameterBag.php#L88

So since laravel 5.2 requires `symfony/http-foundation` 2.8 or 3.0 then this needs patching right?
