### PR TITLE
[5.3] Add emailOutputIfExistsTo method to Event scheduler that only sends an email when output exists

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -700,21 +700,47 @@ class Event
     }
 
     /**
+     * E-mail the results of the scheduled operation only when it produces output.
+     *
+     * @param  array|mixed $addresses
+     * @return $this
+     *
+     * @throws \LogicException
+     */
+    public function emailOutputIfExistsTo($addresses)
+    {
+        if (is_null($this->output) || $this->output == $this->getDefaultOutput()) {
+            throw new LogicException('Must direct output to a file in order to e-mail results.');
+        }
+
+        $addresses = is_array($addresses) ? $addresses : func_get_args();
+
+        return $this->then(function (Mailer $mailer) use ($addresses) {
+            $this->emailOutput($mailer, $addresses, false);
+        });
+    }
+
+    /**
      * E-mail the output of the event to the recipients.
      *
      * @param  \Illuminate\Contracts\Mail\Mailer  $mailer
      * @param  array  $addresses
+     * @param  bool  $includeEmpty
      * @return void
      */
-    protected function emailOutput(Mailer $mailer, $addresses)
+    protected function emailOutput(Mailer $mailer, $addresses, $includeEmpty = true)
     {
-        $mailer->raw(file_get_contents($this->output), function ($m) use ($addresses) {
-            $m->subject($this->getEmailSubject());
+        $text = file_get_contents($this->output);
 
-            foreach ($addresses as $address) {
-                $m->to($address);
-            }
-        });
+        if ($includeEmpty || ! empty($text)) {
+            $mailer->raw($text, function ($m) use ($addresses) {
+                $m->subject($this->getEmailSubject());
+
+                foreach ($addresses as $address) {
+                    $m->to($address);
+                }
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Currently, when emailing the output of a scheduled job with emailOutputTo(), an email is sent even if the command returns no output (typically a successful condition).  This adds an additional method, emailOutputIfExistsTo(), which first checks whether the output is empty and does not send an email in that case.

The method is a duplicate and could certainly be refactored.  I just tried to change the least amount of code and stay backward-compatible.
