### PR TITLE
[5.2] Fixes resource routes collision with 'prefix' and 'as'

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -211,13 +211,7 @@ class ResourceRegistrar
      */
     protected function getGroupResourceName($prefix, $resource, $method)
     {
-        $group = trim(str_replace('/', '.', $this->router->getLastGroupPrefix()), '.');
-
-        if (empty($group)) {
-            return trim("{$prefix}{$resource}.{$method}", '.');
-        }
-
-        return trim("{$prefix}{$group}.{$resource}.{$method}", '.');
+        return trim("{$prefix}{$resource}.{$method}", '.');
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -180,6 +180,20 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo.bar.show', $routes[0]->getName());
         $this->assertEquals('foo/bar/{bar}', $routes[0]->getUri());
+
+        // Two groups with 'prefix' and 'as'
+        $router = $this->getRouter();
+        $router->group(['as' => 'foo.', 'prefix' => 'bar'], function () use ($router) {
+            $router->group(['as' => 'bar.', 'prefix' => 'foo'], function () use ($router) {
+                $router->resource('foo', 'FooController', ['only' => ['show']]);
+            });
+        });
+
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo.bar.foo.show', $routes[0]->getName());
+        $this->assertEquals('bar/foo/foo/{foo}', $routes[0]->getUri());
     }
 
     public function testMacro()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -143,6 +143,45 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo.bar', $router->currentRouteName());
     }
 
+    public function testFluentResourceRouteNamingWithinAGroup()
+    {
+        // With 'as' on group
+        $router = $this->getRouter();
+        $router->group(['as' => 'foo.'], function () use ($router) {
+            $router->resource('bar', 'FooController', ['only' => ['show']]);
+        });
+
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo.bar.show', $routes[0]->getName());
+        $this->assertEquals('bar/{bar}', $routes[0]->getUri());
+
+        // With 'prefix' on group
+        $router = $this->getRouter();
+        $router->group(['prefix' => 'foo'], function () use ($router) {
+            $router->resource('bar', 'FooController', ['only' => ['show']]);
+        });
+
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('bar.show', $routes[0]->getName());
+        $this->assertEquals('foo/bar/{bar}', $routes[0]->getUri());
+
+        // With 'prefix' and 'as' on group
+        $router = $this->getRouter();
+        $router->group(['prefix' => 'foo', 'as' => 'foo.'], function () use ($router) {
+            $router->resource('bar', 'FooController', ['only' => ['show']]);
+        });
+
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo.bar.show', $routes[0]->getName());
+        $this->assertEquals('foo/bar/{bar}', $routes[0]->getUri());
+    }
+
     public function testMacro()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
Please see #11657 for details.
