### PR TITLE
[5.2] Remove auth.password and auth.password.broker duplicated aliases

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1029,8 +1029,6 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'app'                  => ['Illuminate\Foundation\Application', 'Illuminate\Contracts\Container\Container', 'Illuminate\Contracts\Foundation\Application'],
             'auth'                 => ['Illuminate\Auth\AuthManager', 'Illuminate\Contracts\Auth\Factory'],
             'auth.driver'          => ['Illuminate\Contracts\Auth\Guard'],
-            'auth.password'        => ['Illuminate\Contracts\Auth\PasswordBrokerFactory'],
-            'auth.password.broker' => ['Illuminate\Contracts\Auth\PasswordBroker'],
             'blade.compiler'       => ['Illuminate\View\Compilers\BladeCompiler'],
             'cache'                => ['Illuminate\Cache\CacheManager', 'Illuminate\Contracts\Cache\Factory'],
             'cache.store'          => ['Illuminate\Cache\Repository', 'Illuminate\Contracts\Cache\Repository'],


### PR DESCRIPTION
See:
https://github.com/laravel/framework/blob/1a4f967fd4388d6fa1e28680a625b448962489f6/src/Illuminate/Foundation/Application.php#L1032-L1033
https://github.com/laravel/framework/blob/1a4f967fd4388d6fa1e28680a625b448962489f6/src/Illuminate/Foundation/Application.php#L1051-L1052
