### PR TITLE
[5.2] Skip mcrypt tests if the extension is not loaded

### DIFF
--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -82,6 +82,10 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
 
     public function testOpenSslEncrypterCanDecryptMcryptedData()
     {
+        if (! extension_loaded('mcrypt')) {
+            $this->markTestSkipped('Mcrypt module not installed');
+        }
+
         $key = Str::random(32);
         $encrypter = new Illuminate\Encryption\McryptEncrypter($key);
         $encrypted = $encrypter->encrypt('foo');


### PR DESCRIPTION
Since the mcrypt extension is not required the testsuite should not fail when mcrypt is not installed.

Duplicate of #11705, but based on 5.1.

~~Whoops, forgot to change the target branch...~~
