### PR TITLE
[5.2] Include build stack in BindingResolutionException message.

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -744,7 +744,12 @@ class Container implements ArrayAccess, ContainerContract
         // an abstract type such as an Interface of Abstract Class and there is
         // no binding registered for the abstractions so we need to bail out.
         if (! $reflector->isInstantiable()) {
-            $message = "Target [$concrete] is not instantiable.";
+            if (! empty($this->buildStack)) {
+                $previous = implode(', ', $this->buildStack);
+                $message = "Target [$concrete] is not instantiable while building [$previous].";
+            } else {
+                $message = "Target [$concrete] is not instantiable.";
+            }
 
             throw new BindingResolutionContractException($message);
         }

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -328,6 +328,26 @@ return $obj; });
         $container->make('ContainerMixedPrimitiveStub', []);
     }
 
+    /**
+     * @expectedException Illuminate\Contracts\Container\BindingResolutionException
+     * @expectedExceptionMessage Target [IContainerContractStub] is not instantiable.
+     */
+    public function testBindingResolutionExceptionMessage()
+    {
+        $container = new Container;
+        $container->make('IContainerContractStub', []);
+    }
+
+    /**
+     * @expectedException Illuminate\Contracts\Container\BindingResolutionException
+     * @expectedExceptionMessage Target [IContainerContractStub] is not instantiable while building [ContainerTestContextInjectOne].
+     */
+    public function testBindingResolutionExceptionMessageIncludesBuildStack()
+    {
+        $container = new Container;
+        $container->make('ContainerTestContextInjectOne', []);
+    }
+
     public function testCallWithDependencies()
     {
         $container = new Container;


### PR DESCRIPTION
Time and time again I'll run into issues where some dependency of a dependency cannot be met and I am given very little to work with other than the actual name of the service/class/interface that was requested. This is nice if it is obvious, but more often than not it is an instance of a very generic interface for which there are countless services trying to have that interface injected.

This PR includes the current build stack in the message if there is a build stack available. This will hopefully provide more clues as to what was needing the missing dependency in order to track it down more quickly.

Here is an example of this PR in action:

[![image](https://cloud.githubusercontent.com/assets/191200/12123271/ad94307a-b3a5-11e5-8aaa-6c211171efd4.png)](http://d.pr/i/Fpxd)
