### PR TITLE
[5.2] validateJson should fail on nonstringable values

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -887,7 +887,7 @@ class Validator implements ValidatorContract
         if (! is_scalar($value) && ! method_exists($value, '__toString')) {
             return false;
         }
-    
+
         json_decode($value);
 
         return json_last_error() === JSON_ERROR_NONE;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -884,6 +884,10 @@ class Validator implements ValidatorContract
      */
     protected function validateJson($attribute, $value)
     {
+        if (! is_scalar($value) && ! method_exists($value, '__toString')) {
+            return false;
+        }
+    
         json_decode($value);
 
         return json_last_error() === JSON_ERROR_NONE;


### PR DESCRIPTION
Under current behavior, all values are passed directly into `json_decode`, which will throw an `ErrorException` when its input cannot be coerced to string. Thus the `validateJson` method will sometimes generate exceptions when failures are expected. This is mostly a concern for arrays due to their prevalence (and misconceptions about valid JSON), but it could in general be caused by any object.

The rule has been modified to preemptively detect values that will throw this exception and return false for them.
