### PR TITLE
[5.2] Wrap returned default with value()

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -398,7 +398,7 @@ if (! function_exists('data_get')) {
         while (($segment = array_shift($key)) !== null) {
             if ($segment === '*') {
                 if (! is_array($target) && ! $target instanceof ArrayAccess) {
-                    return $default;
+                    return value($default);
                 }
 
                 $result = Arr::pluck($target, $key);


### PR DESCRIPTION
I'm using Illuminate/Support independently of Laravel itself, and I noticed that in `helpers.php`, `data_get` returns `$default` when using `*` to grab all the values from a non-array-like value, instead of `value($default)` - in all other cases, `value($default)` is returned. Seems like a simple oversight.

``` php
var_dump(data_get(['a' => null], 'a.*', [4, 5]));
// Returns [4, 5], as expected

var_dump(data_get(['a' => null], 'a.*', function () { return [4, 5]; }));
// Returns Closure instance
```

This PR fixes that.
