### PR TITLE
[5.2] Allow extra conditions using HTTP basic auth

### DIFF
--- a/src/Illuminate/Contracts/Auth/SupportsBasicAuth.php
+++ b/src/Illuminate/Contracts/Auth/SupportsBasicAuth.php
@@ -8,15 +8,17 @@ interface SupportsBasicAuth
      * Attempt to authenticate using HTTP Basic Auth.
      *
      * @param  string  $field
+     * @param  array  $extraConditions
      * @return \Symfony\Component\HttpFoundation\Response|null
      */
-    public function basic($field = 'email');
+    public function basic($field = 'email', $extraConditions = []);
 
     /**
      * Perform a stateless HTTP Basic login attempt.
      *
      * @param  string  $field
+     * @param  array  $extraConditions
      * @return \Symfony\Component\HttpFoundation\Response|null
      */
-    public function onceBasic($field = 'email');
+    public function onceBasic($field = 'email', $extraConditions = []);
 }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -32,7 +32,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $request = Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
         $guard->setRequest($request);
 
-        $guard->basic('email', $request);
+        $guard->basic('email');
     }
 
     public function testBasicReturnsResponseOnFailure()
@@ -43,7 +43,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret'])->andReturn(false);
         $request = Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
         $guard->setRequest($request);
-        $response = $guard->basic('email', $request);
+        $response = $guard->basic('email');
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
         $this->assertEquals(401, $response->getStatusCode());

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -49,6 +49,18 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(401, $response->getStatusCode());
     }
 
+    public function testBasicWithExtraConditions()
+    {
+        list($session, $provider, $request, $cookie) = $this->getMocks();
+        $guard = m::mock('Illuminate\Auth\SessionGuard[check,attempt]', ['default', $provider, $session]);
+        $guard->shouldReceive('check')->once()->andReturn(false);
+        $guard->shouldReceive('attempt')->once()->with(['email' => 'foo@bar.com', 'password' => 'secret', 'active' => 1])->andReturn(true);
+        $request = Symfony\Component\HttpFoundation\Request::create('/', 'GET', [], [], [], ['PHP_AUTH_USER' => 'foo@bar.com', 'PHP_AUTH_PW' => 'secret']);
+        $guard->setRequest($request);
+
+        $guard->basic('email', ['active' => 1]);
+    }
+
     public function testAttemptCallsRetrieveByCredentials()
     {
         $guard = $this->getGuard();


### PR DESCRIPTION
Similarly to the example at [Specifying Additional Conditions](https://laravel.com/docs/5.2/authentication#authenticating-users), with HTTP basic auth:

```
if ($errorResponse = Auth::basic('email', ['active' => 1])) {
    return $errorResponse;
}
return $next($request);
```
