### PR TITLE
[5.2] Function to manage multiple SQL where clauses in array

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -522,6 +522,32 @@ class Builder
     }
 
     /**
+     * Adds multiple where clauses to the query.
+     *
+     * @param array $conditions
+     * @return $this
+     */
+    public function whereAll($conditions)
+    {
+        foreach ($conditions as $condition) {
+            if (count($condition) == 2) {
+                list($column, $value) = $condition;
+            } else {
+                list($column, $operator, $value, $clause) = $condition;
+            }
+
+            $this->where(
+                $column,
+                ! empty($operator) ? $operator : '=',
+                ! empty($value) ? $value : null,
+                ! empty($clause) ? $clause : 'and'
+            );
+        }
+
+        return $this;
+    }
+
+    /**
      * Determine if the given operator and value combination is legal.
      *
      * @param  string  $operator


### PR DESCRIPTION
Created method to add multiple SQL where clauses inside an multi-dimensional array instead of chaining multiple where function calls for eloquent. 

Normal where function calls assume '=' operator by default if multiple where clauses are in an array. 

```
$users = App\User::where([
    'status' => '1'
    'subscribed' => '1',
])->get();
```

This PR changes the above to

```
$users = App\User::whereAll([
['status','1'],
['subscribed','1'],
])->get();
```

If any other operator needs to be specified:

```
$users = App\User::whereAll([
['status','=','1'],
['subscribed','<>','1'],
])->get();
```
