### PR TITLE
[5.2] Routing - fix docblock

### DIFF
--- a/src/Illuminate/Routing/Pipeline.php
+++ b/src/Illuminate/Routing/Pipeline.php
@@ -61,8 +61,11 @@ class Pipeline extends BasePipeline
     /**
      * Handle the given exception.
      *
+     * @param  mixed  $passable
      * @param  \Exception  $e
      * @return mixed
+     *
+     * @throws \Exception
      */
     protected function handleException($passable, Exception $e)
     {


### PR DESCRIPTION
Fix `\Illuminate\Routing\Pipeline::handleException` docblock
