### PR TITLE
[5.1] ShareErrorsFromSession / Performances : useless instanciation

### DIFF
--- a/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
+++ b/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
@@ -39,7 +39,7 @@ class ShareErrorsFromSession
         // its value with all view instances so the views can easily access errors
         // without having to bind. An empty bag is set when there aren't errors.
         $this->view->share(
-            'errors', $request->session()->get('errors', new ViewErrorBag)
+            'errors', $request->session()->get('errors') ?: new ViewErrorBag
         );
 
         // Putting the errors in the view for every view allows the developer to just


### PR DESCRIPTION
No need to instantiate a new `ViewErrorBag` before calling `\Illuminate\Session\Store::get`
