### PR TITLE
[5.2] Make password reset url a link

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/emails/password.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/emails/password.stub
@@ -1,1 +1,1 @@
-Click here to reset your password: {{ url('password/reset', $token).'?email='.urlencode($user->getEmailForPasswordReset()) }}
+Click here to reset your password: <a href="{{ url('password/reset', $token).'?email='.urlencode($user->getEmailForPasswordReset()) }}"> {{ url('password/reset', $token).'?email='.urlencode($user->getEmailForPasswordReset()) }} </a>

--- a/src/Illuminate/Auth/Console/stubs/make/views/auth/emails/password.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/auth/emails/password.stub
@@ -1,1 +1,1 @@
-Click here to reset your password: <a href="{{ url('password/reset', $token).'?email='.urlencode($user->getEmailForPasswordReset()) }}"> {{ url('password/reset', $token).'?email='.urlencode($user->getEmailForPasswordReset()) }} </a>
+Click here to reset your password: <a href="{{ $link = url('password/reset', $token).'?email='.urlencode($user->getEmailForPasswordReset()) }}"> {{ $link }} </a>


### PR DESCRIPTION
Small change to format the auth password reset url as a hyper-link

This has the same result as https://github.com/laravel/framework/pull/11741 but without with the dependency issue. ( Sorry couldn't see how to reopen that PR )

Keith
