### PR TITLE
[5.2] Revert to usage of rawurlencode over urlencode

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -330,7 +330,7 @@ class UrlGenerator implements UrlGeneratorContract
             throw UrlGenerationException::forMissingParameters($route);
         }
 
-        $uri = strtr(urlencode($uri), $this->dontEncode);
+        $uri = strtr(rawurlencode($uri), $this->dontEncode);
 
         return $absolute ? $uri : '/'.ltrim(str_replace($root, '', $uri), '/');
     }


### PR DESCRIPTION
To address routing issues involving spaces.

---

Closes #11747.
