### PR TITLE
[5.2] Add hasParameters to Route

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -279,6 +279,10 @@ class Route
      */
     public function hasParameter($name)
     {
+        if(! $this->hasParameters()) {
+	        return false;
+        }
+
         return array_key_exists($name, $this->parameters());
     }
 
@@ -331,6 +335,16 @@ class Route
         $this->parameters();
 
         unset($this->parameters[$name]);
+    }
+
+    /**
+     * Determine if the route has parameters
+     *
+     * @return bool
+     */
+    public function hasParameters()
+    {
+        return isset($this->parameters);
     }
 
     /**


### PR DESCRIPTION
Route->parameters() throws an exception if the route has none, this helper function allows developers to check the presence of parameters and avoid the exception where none are set.

A personal preference would to be remove the "Route not bound" exception but this is an inbetween work around.
