### PR TITLE
[5.2] Contract : add missing methods to the Job contract.

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -46,4 +46,32 @@ interface Job
      * @return string
      */
     public function getQueue();
+
+    /**
+     * Determine if the job has been deleted or released.
+     *
+     * @return bool
+     */
+    public function isDeletedOrReleased();
+
+    /**
+     * Determine if the job has been deleted.
+     *
+     * @return bool
+     */
+    public function isDeleted();
+
+     /**
+      * Get the raw body string for the job.
+      *
+      * @return string
+      */
+     public function getRawBody();
+
+    /**
+     * Call the failed method on the job instance.
+     *
+     * @return void
+     */
+    public function failed();
 }


### PR DESCRIPTION
Add 4 missing methods to the Job contract.

---
- \Illuminate\Contracts\Queue\Job::isDeletedOrReleased:
  - \Illuminate\Events\CallQueuedHandler::call
- \Illuminate\Contracts\Queue\Job::isDeleted
  - \Illuminate\Queue\Worker::process
- \Illuminate\Contracts\Queue\Job::getRawBody
  - \Illuminate\Queue\SyncQueue::raiseFailedJobEvent
  - \Illuminate\Queue\Worker::logFailedJob
  - \Illuminate\Queue\Worker::raiseAfterJobEvent
  - \Illuminate\Queue\Worker::raiseFailedJobEvent
  - \Illuminate\Queue\Jobs\BeanstalkdJob::fire
  - \Illuminate\Queue\Jobs\RedisJob::fire
  - \Illuminate\Queue\Jobs\SqsJob::fire
- \Illuminate\Contracts\Queue\Job::failed
  - \Illuminate\Queue\SyncQueue::handleFailedJob
  - \Illuminate\Queue\Worker::logFailedJob
