### PR TITLE
[5.3] Maintenance mode

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -7,11 +7,12 @@ use Illuminate\Console\Command;
 class DownCommand extends Command
 {
     /**
-     * The console command name.
+     * The console command signature.
      *
      * @var string
      */
-    protected $name = 'down';
+    protected $signature = 'down {--message? : The message for the maintenance mode. }
+            {--retry? : The number of seconds after which the request may be retried.}';
 
     /**
      * The console command description.
@@ -27,7 +28,15 @@ class DownCommand extends Command
      */
     public function fire()
     {
-        touch($this->laravel->storagePath().'/framework/down');
+        $data = [
+            'time' => time(),
+            'message' => $this->argument('message'),
+        ];
+
+        $retry = $this->argument('retry');
+        $data['retry'] = is_numeric($retry) && $retry > 0 ? (int) $retry : null;
+
+        file_put_contents($this->laravel->storagePath().'/framework/down', json_encode($data, JSON_PRETTY_PRINT));
 
         $this->comment('Application is now in maintenance mode.');
     }

--- a/src/Illuminate/Foundation/Http/Exceptions/MaintenanceModeException.php
+++ b/src/Illuminate/Foundation/Http/Exceptions/MaintenanceModeException.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Exceptions;
+
+use Exception;
+use Carbon\Carbon;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
+
+class MaintenanceModeException extends ServiceUnavailableHttpException
+{
+    /**
+     * The timestamp corresponding to the moment when the application was put in maintenance mode.
+     *
+     * @var int
+     */
+    protected $time;
+
+    /**
+     * The retry in seconds.
+     *
+     * @var int
+     */
+    protected $retry;
+
+    /**
+     * Constructor.
+     *
+     * @param  int  $time
+     * @param  int  $retryAfter
+     * @param  string  $message
+     * @param  \Exception  $previous
+     * @param  int  $code
+     * @return void
+     */
+    public function __construct($time, $retryAfter = null, $message = null, Exception $previous = null, $code = 0)
+    {
+        parent::__construct($retryAfter, $message, $previous, $code);
+        $this->setTime($time);
+        $this->setRetry($retryAfter);
+    }
+
+    /**
+     * Set the time property.
+     *
+     * @param  int  $time
+     * @return $this
+     */
+    public function setTime($time)
+    {
+        $this->time = $time;
+
+        return $this;
+    }
+
+    /**
+     * Get the time property.
+     *
+     * @return int
+     */
+    public function getTime()
+    {
+        return $this->time;
+    }
+
+    /**
+     * Set the retry.
+     *
+     * @param  int  $retry
+     * @return $this
+     */
+    public function setRetry($retry)
+    {
+        $this->retry = $retry;
+
+        return $this;
+    }
+
+    /**
+     * Get the retry property.
+     *
+     * @return int
+     */
+    public function getRetry()
+    {
+        return $this->retry;
+    }
+
+    /**
+     * Get the planned availability if the retry is set or false otherwise.
+     *
+     * @return \Carbon\Carbon|bool
+     */
+    public function getAvailability()
+    {
+        if ($this->retry !== null) {
+            return Carbon::createFromTimestampUTC($this->time)->addSeconds($this->retry);
+        }
+
+        return false;
+    }
+}

--- a/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
@@ -4,7 +4,7 @@ namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
 use Illuminate\Contracts\Foundation\Application;
-use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
 
 class CheckForMaintenanceMode
 {
@@ -38,7 +38,9 @@ class CheckForMaintenanceMode
     public function handle($request, Closure $next)
     {
         if ($this->app->isDownForMaintenance()) {
-            throw new HttpException(503);
+            $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
+
+            throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
         }
 
         return $next($request);


### PR DESCRIPTION
This PR aims to provide the following features:
- throws a `MaintenanceModeException` (503) so that it's easier to determine if this 503 HTTP exception is due to a manual operation `DownCommand`, or something else (another reason).
- Let the down command store the curent timestamp, so that we know when the application has been put in maintenance.
- Let the user set optional `retry` and `message` parameters: we can then set the `Retry-After` HTTP header, and the message can be used for other purposes, for instance displaying it in a custom error view.

This makes it much easier to get relevant information in the logs and could also be used to interact with  StatusPage, Cachet, and so on
