### PR TITLE
Updated for compatibility with MongoDB id

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2874,7 +2874,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         switch ($this->getCastType($key)) {
             case 'int':
             case 'integer':
-                return (int) $value;
+                return (is_int($value))?(int) $value:(string) $value;
             case 'real':
             case 'float':
             case 'double':


### PR DESCRIPTION
Fixes the following problem when using MongoDB:

ErrorException in Model.php line 2877: Object of class MongoId could not be converted to int
