### PR TITLE
fix when use function Cache::tags, can't find tags function in class FileStore

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Contracts\Cache\Store;
 
-class FileStore implements Store
+class FileStore extends TaggableStore implements Store
 {
     /**
      * The Illuminate Filesystem instance.


### PR DESCRIPTION
This PR aims to fix a bug below:
1.  configure default cache driver is file in config/cache.php;
2.  use Illuminate\Support\Facades\Cache::tags function, will throw a exception: This cache store does not support tagging.

This bug not only exist in version 5.1,  but also exist in versions 5.2, 4.2 . 
