### PR TITLE
[5.2] Convert cache query result to object when database returns array

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -160,6 +160,10 @@ class DatabaseStore implements Store
                 return false;
             }
 
+            if (is_array($cache)) {
+                $cache = (object) $cache;
+            }
+            
             $current = $this->encrypter->decrypt($cache->value);
             $new = $callback($current, $value);
 


### PR DESCRIPTION
Query results doesn’t be converted from array
 to object when cache of Database store using
 FETCH_ASSOC fetch style.
