### PR TITLE
[5.2] Fix FormRequest tests

### DIFF
--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -3,27 +3,25 @@
 use Mockery as m;
 use Illuminate\Container\Container;
 
-class FoundationFormRequestTestCase extends PHPUnit_Framework_TestCase
+class FoundationFormRequestTest extends PHPUnit_Framework_TestCase
 {
     public function tearDown()
     {
         m::close();
-        unset($_SERVER['__request.validated']);
     }
 
     public function testValidateFunctionRunsValidatorOnSpecifiedRules()
     {
         $request = FoundationTestFormRequestStub::create('/', 'GET', ['name' => 'abigail']);
-        $request->setContainer(new Container);
+        $request->setContainer($container = new Container);
         $factory = m::mock('Illuminate\Validation\Factory');
-        $factory->shouldReceive('make')->once()->with(['name' => 'abigail'], ['name' => 'required'])->andReturn(
+        $factory->shouldReceive('make')->once()->with(['name' => 'abigail'], ['name' => 'required'], [], [])->andReturn(
             $validator = m::mock('Illuminate\Validation\Validator')
         );
-        $validator->shouldReceive('fails')->once()->andReturn(false);
+        $container->instance('Illuminate\Contracts\Validation\Factory', $factory);
+        $validator->shouldReceive('passes')->once()->andReturn(true);
 
         $request->validate($factory);
-
-        $this->assertTrue($_SERVER['__request.validated']);
     }
 
     /**
@@ -33,14 +31,15 @@ class FoundationFormRequestTestCase extends PHPUnit_Framework_TestCase
     {
         $request = m::mock('FoundationTestFormRequestStub[response]');
         $request->initialize(['name' => null]);
-        $request->setContainer(new Container);
+        $request->setContainer($container = new Container);
         $factory = m::mock('Illuminate\Validation\Factory');
-        $factory->shouldReceive('make')->once()->with(['name' => null], ['name' => 'required'])->andReturn(
+        $factory->shouldReceive('make')->once()->with(['name' => null], ['name' => 'required'], [], [])->andReturn(
             $validator = m::mock('Illuminate\Validation\Validator')
         );
-        $validator->shouldReceive('fails')->once()->andReturn(true);
-        $validator->shouldReceive('errors')->once()->andReturn($messages = m::mock('StdClass'));
-        $messages->shouldReceive('all')->once()->andReturn([]);
+        $container->instance('Illuminate\Contracts\Validation\Factory', $factory);
+        $validator->shouldReceive('passes')->once()->andReturn(false);
+        $validator->shouldReceive('getMessageBag')->once()->andReturn($messages = m::mock('Illuminate\Support\MessageBag'));
+        $messages->shouldReceive('toArray')->once()->andReturn(['name' => ['Name required']]);
         $request->shouldReceive('response')->once()->andReturn(new Illuminate\Http\Response);
 
         $request->validate($factory);
@@ -53,12 +52,13 @@ class FoundationFormRequestTestCase extends PHPUnit_Framework_TestCase
     {
         $request = m::mock('FoundationTestFormRequestForbiddenStub[forbiddenResponse]');
         $request->initialize(['name' => null]);
-        $request->setContainer(new Container);
+        $request->setContainer($container = new Container);
         $factory = m::mock('Illuminate\Validation\Factory');
-        $factory->shouldReceive('make')->once()->with(['name' => null], ['name' => 'required'])->andReturn(
+        $factory->shouldReceive('make')->once()->with(['name' => null], ['name' => 'required'], [], [])->andReturn(
             $validator = m::mock('Illuminate\Validation\Validator')
         );
-        $validator->shouldReceive('fails')->once()->andReturn(false);
+        $container->instance('Illuminate\Contracts\Validation\Factory', $factory);
+        $validator->shouldReceive('passes')->never();
         $request->shouldReceive('forbiddenResponse')->once()->andReturn(new Illuminate\Http\Response);
 
         $request->validate($factory);
@@ -72,7 +72,7 @@ class FoundationFormRequestTestCase extends PHPUnit_Framework_TestCase
         $redirector->shouldReceive('getUrlGenerator')->andReturn($url = m::mock('StdClass'));
         $url->shouldReceive('previous')->once()->andReturn('previous');
         $response->shouldReceive('withInput')->andReturn($response);
-        $response->shouldReceive('withErrors')->with(['errors'])->andReturn($response);
+        $response->shouldReceive('withErrors')->with(['errors'], 'default')->andReturn($response);
 
         $request->response(['errors']);
     }
@@ -80,19 +80,14 @@ class FoundationFormRequestTestCase extends PHPUnit_Framework_TestCase
 
 class FoundationTestFormRequestStub extends Illuminate\Foundation\Http\FormRequest
 {
-    public function rules(StdClass $dep)
+    public function rules()
     {
         return ['name' => 'required'];
     }
 
-    public function authorize(StdClass $dep)
+    public function authorize()
     {
         return true;
-    }
-
-    public function validated(StdClass $dep)
-    {
-        $_SERVER['__request.validated'] = true;
     }
 }
 


### PR DESCRIPTION
`FoundationFormRequestTestCase` tests never run because of typo in file name `FoundationFormRequestTestCase` instead of `FoundationFormRequestTest`.

**PR contains**
- change the name of test file
- change tests for FormRequest current implementation
