### PR TITLE
[5.2] Drop Spark classes and IDs from auth scaffold

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/home.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/home.stub
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container spark-screen">
+<div class="container">
     <div class="row">
         <div class="col-md-10 col-md-offset-1">
             <div class="panel panel-default">

--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -31,7 +31,7 @@
             <div class="navbar-header">
 
                 <!-- Collapsed Hamburger -->
-                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#spark-navbar-collapse">
+                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#app-navbar-collapse">
                     <span class="sr-only">Toggle Navigation</span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
@@ -44,7 +44,7 @@
                 </a>
             </div>
 
-            <div class="collapse navbar-collapse" id="spark-navbar-collapse">
+            <div class="collapse navbar-collapse" id="app-navbar-collapse">
                 <!-- Left Side Of Navbar -->
                 <ul class="nav navbar-nav">
                     <li><a href="{{ url('/home') }}">Home</a></li>

--- a/src/Illuminate/Auth/Console/stubs/make/views/welcome.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/welcome.stub
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="container spark-screen">
+<div class="container">
     <div class="row">
         <div class="col-md-10 col-md-offset-1">
             <div class="panel panel-default">


### PR DESCRIPTION
I'm thinking this was a holdover from when these views were copied from Spark. If I missed a place these classes are being used, though, please feel free to disregard.
