### PR TITLE
[5.2] Fix eager loading within global scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -513,7 +513,7 @@ class Builder
      */
     public function eagerLoadRelations(array $models)
     {
-        foreach ($this->eagerLoad as $name => $constraints) {
+        foreach ($this->applyScopes()->eagerLoad as $name => $constraints) {
             // For nested eager loads we'll skip loading them here and they will be set as an
             // eager load on the query to retrieve the relation so that they will be eager
             // loaded on that query, because that is where they get hydrated as models.

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -598,6 +598,16 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertInternalType('string', $user->id);
     }
 
+    public function testRelationsArePreloadedInGlobalScope()
+    {
+        $user = EloquentTestUserWithGlobalScope::create(['email' => 'taylorotwell@gmail.com']);
+        $user->posts()->create(['name' => 'My Post']);
+
+        $result = EloquentTestUserWithGlobalScope::first();
+
+        $this->assertCount(1, $result->getRelations());
+    }
+
     /**
      * Helpers...
      */
@@ -649,6 +659,18 @@ class EloquentTestUser extends Eloquent
     public function photos()
     {
         return $this->morphMany('EloquentTestPhoto', 'imageable');
+    }
+}
+
+class EloquentTestUserWithGlobalScope extends EloquentTestUser
+{
+    public static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope(function($builder) {
+           $builder->with('posts');
+        });
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/11764

I don't really like that we call `applyScopes` twice now (once for query execution and once for eager loading), but since both `getModels()` and `eagerLoadRelations()` are public, any other solution would be backwards incompatible (we'd need to pass the builder into both methods). I can refactor this for 5.3.
