### PR TITLE
[5.1] Added use of EXTR_SKIP flag in extract function to meet security scan…

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -103,7 +103,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
      */
     protected function getHostDsn(array $config)
     {
-        extract($config);
+        extract($config, EXTR_SKIP);
 
         return isset($port)
                         ? "mysql:host={$host};port={$port};dbname={$database}"

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -80,7 +80,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
         // First we will create the basic DSN setup as well as the port if it is in
         // in the configuration options. This will give us the basic DSN we will
         // need to establish the PDO connections and return them back for use.
-        extract($config);
+        extract($config, EXTR_SKIP);
 
         $host = isset($host) ? "host={$host};" : '';
 

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -33,7 +33,7 @@ class PhpEngine implements EngineInterface
 
         ob_start();
 
-        extract($__data);
+        extract($__data, EXTR_SKIP);
 
         // We'll evaluate the contents of the view inside a try/catch block so we can
         // flush out any stray output that might get out before an error occurs or

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -159,7 +159,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase
 
     protected function getDsn(array $config)
     {
-        extract($config);
+        extract($config, EXTR_SKIP);
 
         if (in_array('dblib', PDO::getAvailableDrivers())) {
             $port = isset($config['port']) ? ':'.$port : '';


### PR DESCRIPTION
In a Hewlett Packard Enterprise Fortify on Demand Security Review, our application had some issues under the title of 'Possible Variable Overwrite: Global Scope' and referenced PCI 3.0: Requirement 6.5.6. 

The suggested recommendation was - _Invoke extract() with the second argument set to EXTR_SKIP, which prevents the function from overwriting global variables that are already defined._

Although the code does not override any variables, is does have the potential and by including this flag the security scans will not have an issue. 
