### PR TITLE
check for config item: ignore_previous_url

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -128,7 +128,8 @@ class StartSession
      */
     protected function storeCurrentUrl(Request $request, $session)
     {
-        if ($request->method() === 'GET' && $request->route() && ! $request->ajax()) {
+        $ignorePrevousUrl = Arr::get($this->manager->getSessionConfig(), 'ignore_previous_url', array());
+        if ($request->method() === 'GET' && $request->route() && ! $request->ajax() && ! in_array($request->route()->getUri(), $ignorePrevousUrl) && ! in_array($request->route()->getName(), $ignorePrevousUrl)){
             $session->setPreviousUrl($request->fullUrl());
         }
     }


### PR DESCRIPTION
this option lets developer specify some routes that must not be stored
as previous url in the session
