### PR TITLE
[5.2] Mock the events dispatcher listen method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -30,6 +30,7 @@ trait MocksApplicationServices
                 }
             }
         });
+        $mock->shouldReceive('listen');
 
         $this->beforeApplicationDestroyed(function () use (&$events) {
             if ($events) {
@@ -54,6 +55,7 @@ trait MocksApplicationServices
         $mock = Mockery::mock('Illuminate\Contracts\Events\Dispatcher');
 
         $mock->shouldReceive('fire');
+        $mock->shouldReceive('listen');
 
         $this->app->instance('events', $mock);
 


### PR DESCRIPTION
Currently, the withoutEvents and expectsEvents mock methods
from the MocksApplicationServices trait only expect fire.

If an application contains a component calling the listen
method to subscribe to new events, the test will fail, as
the mock doesn't expect this method call.

Based on https://laravel.com/docs/master/events, both the
fire and listen methods could reasonnably be expected to be
mocked.

This change allows the listen method to be called zero or more times.

**Use case**

Integration tests sending a request to a route and validating
server reply is as expected, without firing actual events.
