### PR TITLE
[5.2] Fixed trait double definition

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesAndRegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesAndRegistersUsers.php
@@ -6,5 +6,6 @@ trait AuthenticatesAndRegistersUsers
 {
     use AuthenticatesUsers, RegistersUsers {
         AuthenticatesUsers::redirectPath insteadof RegistersUsers;
+        AuthenticatesUsers::getGuard insteadof RegistersUsers;
     }
 }


### PR DESCRIPTION
Method `getGuard()` was introduced  method in [AuthenticatesUsers](https://github.com/laravel/framework/commit/491d43f7abdf008ccc095a302830383a4e8f76e4#diff-5f4a6b48485f00d665a4ebaebce984c3R181), but not used `insteadof` in AuthenticatesAndRegistersUsers, while `getGuard()` in [RegistersUsers](https://github.com/laravel/framework/pull/11684/files#diff-b8bc14b26b488ea6052eaf7c4a564f91R73) was introduced in #11684.
