### PR TITLE
[5.2] Fix for trait method collision

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesAndRegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesAndRegistersUsers.php
@@ -6,5 +6,6 @@ trait AuthenticatesAndRegistersUsers
 {
     use AuthenticatesUsers, RegistersUsers {
         AuthenticatesUsers::redirectPath insteadof RegistersUsers;
+        AuthenticatesUsers::getGuard insteadof RegistersUsers;
     }
 }


### PR DESCRIPTION
Without this there is exception:

> FatalErrorException in AuthenticatesAndRegistersUsers.php line 5: Trait method getGuard has not been applied, because there are collisions with other trait methods on Illuminate\Foundation\Auth\AuthenticatesAndRegistersUsers
