### PR TITLE
[5.2] Add method for getting the column type

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -94,7 +94,6 @@ class Builder
      *
      * @param  string  $table
      * @param  string  $column
-     *
      * @return string
      */
     public function getColumnType($table, $column)

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -90,6 +90,19 @@ class Builder
     }
 
     /**
+     * Return the data type for the passed column name.
+     *
+     * @param  string  $table
+     * @param  string  $column
+     *
+     * @return string
+     */
+    public function getColumnType($table, $column)
+    {
+        return $this->connection->getDoctrineColumn($table, $column)->getType()->getName();
+    }
+
+    /**
      * Get the column listing for a given table.
      *
      * @param  string  $table


### PR DESCRIPTION
Add method for getting the database agnostic datatype of a column. Almost like an inverse of migration. For example, if the migration of a users table column looks like:

```
...
$table->integer('age')
...
```

So a call to `Schema::getColumnType('users', 'age');` will return 'integer'.
