### PR TITLE
Reserved jobs shouldn't be expired

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -163,8 +163,6 @@ class RedisQueue extends Queue implements QueueContract
     protected function migrateAllExpiredJobs($queue)
     {
         $this->migrateExpiredJobs($queue.':delayed', $queue);
-
-        $this->migrateExpiredJobs($queue.':reserved', $queue);
     }
 
     /**


### PR DESCRIPTION
Hey,

I don't understand why reserved (mean processed?) jobs can be moved on the pending jobs queue.
Now all jobs with execution time greater than 60sec (default) will be repeated.
This can create infinite loop of duplicated queued jobs.

If attempt to reestablish the task should be performed only if job fails?
https://laravel.com/docs/5.1/queues#dealing-with-failed-jobs ?
