### PR TITLE
[5.1] Use the current timestamp as default value

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -791,9 +791,9 @@ class Blueprint
      */
     public function timestamps()
     {
-        $this->timestamp('created_at');
+        $this->timestamp('created_at')->useCurrent();
 
-        $this->timestamp('updated_at');
+        $this->timestamp('updated_at')->useCurrent();
     }
 
     /**


### PR DESCRIPTION
Add the current timestamp as default value for **created_at** & **updated_at** columns when calling $table->timestamps() function.
