### PR TITLE
Improvement Route facade with a currentActionUses

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1089,6 +1089,27 @@ class Router implements RegistrarContract
     }
 
     /**
+     * Determine if the current action matches a given action.
+     * 
+     * This take in account the namespace of the application.
+     * 
+     * @param string $action
+     *
+     * @return bool
+     */
+    public function currentActionUses($action)
+    {
+        $currentAction = $this->getCurrentRoute()->getAction();
+        if (starts_with($currentAction['namespace'], Container::getInstance()->getNamespace())) {
+            $currentAction = str_replace($currentAction['namespace'].'\\', '', $currentAction['controller']);
+        } else {
+            $currentAction = $currentAction['controller'];
+        }
+
+        return $currentAction == $action;
+    }
+
+    /**
      * Get the request currently being dispatched.
      *
      * @return \Illuminate\Http\Request

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1090,16 +1090,15 @@ class Router implements RegistrarContract
 
     /**
      * Determine if the current action matches a given action.
-     * 
      * This take in account the namespace of the application.
      * 
      * @param string $action
-     *
      * @return bool
      */
     public function currentActionUses($action)
     {
         $currentAction = $this->getCurrentRoute()->getAction();
+
         if (starts_with($currentAction['namespace'], Container::getInstance()->getNamespace())) {
             $currentAction = str_replace($currentAction['namespace'].'\\', '', $currentAction['controller']);
         } else {


### PR DESCRIPTION
This PR follow my issue  #10761 (please read it carefully).

This Introduce the new method _currentActionUses_ on facade _Route_.

So the idea is to have something like this:
- Route::currentRouteUses('App\Http\Controllers\Controller@action'); //  true
- Route::uses('App\Http\Controllers\Controller@action'); //  true
- Route::currentRouteUses('Controller@action'); // false
- Route::uses('Controller@action'); // false
- Route::currentActionUses('Controller@action'); // true

This works also for controller in a subdirectory (and so in a sub namespace).
