### PR TITLE
[5.2] .gitignore : ignore only project related files and folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-/vendor
-composer.phar
+vendor/
 composer.lock
 .php_cs.cache
-.DS_Store
-Thumbs.db


### PR DESCRIPTION
Only ignore project related files and folder in .gitignore, not system-wide files.

Also prefix `vendor/` as this syntax is supported by most IDE.

---

Replace https://github.com/laravel/framework/pull/11835
