### PR TITLE
[5.2] Load custom .env file if it exists

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -17,11 +17,28 @@ class DetectEnvironment
     public function bootstrap(Application $app)
     {
         if (! $app->configurationIsCached()) {
+            $this->detectCustomEnvFile($app);
+
             try {
                 (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
             } catch (InvalidPathException $e) {
                 //
             }
+        }
+    }
+
+    /**
+     * Detect if a custom env file matching the APP_ENV exists.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    protected function detectCustomEnvFile($app)
+    {
+        $fileName = $app->environmentFile().'.'.env('APP_ENV');
+
+        if (file_exists($app->environmentPath().'/'.$fileName)) {
+            $app->loadEnvironmentFrom($fileName);
         }
     }
 }


### PR DESCRIPTION
This allows to define several .env file, for example .env.testing. That means we could remove the configuration in phpunit,xml and move it to a custom env file.
If a file matching the APP_ENV exists, Laravel will load this file. Else, load the usual .env.

I have found it useful to run behat tests in the browser on a specific database connection (set the APP_ENV on a vhost).
