### PR TITLE
[5.2] Load .env even if app configuration is cached

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -16,12 +16,10 @@ class DetectEnvironment
      */
     public function bootstrap(Application $app)
     {
-        if (! $app->configurationIsCached()) {
-            try {
-                (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
-            } catch (InvalidPathException $e) {
-                //
-            }
+        try {
+            (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
+        } catch (InvalidPathException $e) {
+            //
         }
     }
 }


### PR DESCRIPTION
New issue in 5.2. Having a `.env` file like this:

```
SOMETHING=1
```

Without config cache, I can call `env()` on this environment variable:

``` php
dd(env('SOMETHING')); // 1
```

Running `artisan config:cache`, this env var does not exists anymore:

``` php
dd(env('SOMETHING')); // null
```

Caching configuration must cache configuration file, not ignore the environment variables. So this PR does not ignore environment variables if config is cached.
