### PR TITLE
[5.2] Translator : fix docblock return type

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -91,7 +91,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * @param  array   $replace
      * @param  string|null  $locale
      * @param  bool  $fallback
-     * @return string
+     * @return string|array|null
      */
     public function get($key, array $replace = [], $locale = null, $fallback = true)
     {
@@ -205,7 +205,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * @param  array   $parameters
      * @param  string  $domain
      * @param  string  $locale
-     * @return string
+     * @return string|array|null
      */
     public function trans($id, array $parameters = [], $domain = 'messages', $locale = null)
     {


### PR DESCRIPTION
fix docblock return type
see `\Illuminate\Translation\Translator::get` return type
