### PR TITLE
[5.2] Let PHPUnit handles the system timezone.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "aws/aws-sdk-php": "~3.0",
         "mockery/mockery": "~0.9.2",
         "pda/pheanstalk": "~3.0",
-        "phpunit/phpunit": "~4.1",
+        "phpunit/phpunit": "~4.4",
         "predis/predis": "~1.0",
         "symfony/css-selector": "2.8.*|3.0.*",
         "symfony/dom-crawler": "2.8.*|3.0.*"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,6 +27,4 @@ use Carbon\Carbon;
 |
 */
 
-date_default_timezone_set('UTC');
-
-Carbon::setTestNow(Carbon::now());
+Carbon::setTestNow(Carbon::now('UTC'));


### PR DESCRIPTION
PHPUnit already sets the system timezone since version 4.4
See https://github.com/sebastianbergmann/phpunit/commit/df99fb88cb8d23bfebbded239f6dc2b12c6001e2
