### PR TITLE
[5.3] Bypass ThrottleRequests for ANY NotModified response.

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -82,6 +82,10 @@ class ThrottleRequests
      */
     protected function shouldBypassLimiterHit($response)
     {
-        return $response instanceof Response && $response->getStatusCode() === 304;
+        if ($response instanceof Response) {
+            return $response->getStatusCode() === 304;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
When using `\Illuminate\Http\Middleware\CheckResponseForModifications` and `\Illuminate\Routing\Middleware\ThrottleRequests`, it is not possible (unless extending `ThrottleRequests`) to bypass request-throttling for `304` responses.

Bypassing not modified response is quite common with API:
- https://developer.github.com/v3/#conditional-requests
- https://developers.facebook.com/docs/marketing-api/etags

**The rate-limiter will never be hit for 304 responses**
But still the `X-Limit-*` headers will be available. 

---

Replace #11834
