### PR TITLE
[5.3] Include query string in url is check

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -157,7 +157,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $path = $this->decodedPath();
 
-        if (!empty($this->getQueryString())) {
+        if (! empty($this->getQueryString())) {
             $path .= '?'.urldecode($this->getQueryString());
         }
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -155,8 +155,14 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function is()
     {
+        $path = $this->decodedPath();
+
+        if (!empty($this->getQueryString())) {
+            $path .= '?'.urldecode($this->getQueryString());
+        }
+
         foreach (func_get_args() as $pattern) {
-            if (Str::is($pattern, urldecode($this->path()))) {
+            if (Str::is($pattern, $path)) {
                 return true;
             }
         }


### PR DESCRIPTION
Currently if you run a test on whether or not a URL matches a pattern using `Illuminate\Http\Request::is()` the query string is ignored. It would be useful to be able to include the query string in this test since `/foo` != `/foo?bar=123`.

This PR proposes a change to the `is()` method in `Illuminate\Http\Request` so it includes the query string in it's checks.
