### PR TITLE
[5.2] Fix withTrashed constraint on relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -852,7 +852,9 @@ class Builder
         // Here we have the "has" query and the original relation. We need to copy over any
         // where clauses the developer may have put in the relationship function over to
         // the has query, and then copy the bindings from the "has" query to the main.
-        $relationQuery = $relation->getBaseQuery();
+        $relationQuery = $relation->toBase();
+
+        $hasQuery = $hasQuery->withoutGlobalScopes();
 
         $hasQuery->mergeWheres(
             $relationQuery->wheres, $relationQuery->getBindings()

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -854,9 +854,7 @@ class Builder
         // the has query, and then copy the bindings from the "has" query to the main.
         $relationQuery = $relation->toBase();
 
-        $hasQuery = $hasQuery->withoutGlobalScopes();
-
-        $hasQuery->mergeWheres(
+        $hasQuery->withoutGlobalScopes()->mergeWheres(
             $relationQuery->wheres, $relationQuery->getBindings()
         );
     }

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -379,6 +379,21 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         $this->assertEquals(1, count($users));
     }
 
+    /**
+     * @group test
+     */
+    public function testWhereHasWithNestedDeletedRelationshipAndWithTrashedCondition()
+    {
+        $this->createUsers();
+
+        $abigail = SoftDeletesTestUserWithTrashedPosts::where('email', 'abigailotwell@gmail.com')->first();
+        $post = $abigail->posts()->create(['title' => 'First Title']);
+        $post->delete();
+
+        $users = SoftDeletesTestUserWithTrashedPosts::has('posts')->get();
+        $this->assertEquals(1, count($users));
+    }
+
     public function testOrWhereWithSoftDeleteConstraint()
     {
         $this->createUsers();
@@ -443,6 +458,20 @@ class SoftDeletesTestUser extends Eloquent
     public function group()
     {
         return $this->belongsTo(SoftDeletesTestGroup::class, 'group_id');
+    }
+}
+
+class SoftDeletesTestUserWithTrashedPosts extends Eloquent
+{
+    use SoftDeletes;
+
+    protected $dates = ['deleted_at'];
+    protected $table = 'users';
+    protected $guarded = [];
+
+    public function posts()
+    {
+        return $this->hasMany(SoftDeletesTestPost::class, 'user_id')->withTrashed();
     }
 }
 


### PR DESCRIPTION
If we define a `withTrashed()` constraint on a relation and run a `has()` query on it, it doesn't include trashed models but it should.

The problem was that we removed global scopes from the `$relationQuery` but kept them on the `$hasQuery` when in fact it should be the other way around. The reason is that the `$relationQuery` might already have some scopes removed and therefore they should not be re-applied in the `$hasQuery`.

This fixes https://github.com/laravel/framework/issues/11860
