### PR TITLE
[5.2] Make "getCasts" method public

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2800,7 +2800,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  array|string|null  $types
      * @return bool
      */
-    protected function hasCast($key, $types = null)
+    public function hasCast($key, $types = null)
     {
         if (array_key_exists($key, $this->getCasts())) {
             return $types ? in_array($this->getCastType($key), (array) $types, true) : true;
@@ -2814,7 +2814,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      *
      * @return array
      */
-    protected function getCasts()
+    public function getCasts()
     {
         if ($this->incrementing) {
             return array_merge([


### PR DESCRIPTION
I'm suggesting to make "getCasts" method public. I'm writing a package, and it must get all attributes of model with their types. I think it can be useful to other package developers too.
