### PR TITLE
[5.2] Add support to return route param value in Lumen

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -801,9 +801,11 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         if (is_null($route) || is_null($param)) {
             return $route;
-        } else {
-            return $route->parameter($param);
+        } elseif (is_array($route)) {
+            return Arr::get($route[2], $param);
         }
+
+        return $route->parameter($param);
     }
 
     /**


### PR DESCRIPTION
As discussed here: https://github.com/laravel/lumen-framework/issues/291

This PR fixes that long time no fix issue.

@GrahamCampbell Please review. Thanks!
