### PR TITLE
[5.2] Allow Model::event type listeners

### DIFF
--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -37,12 +37,18 @@ class EventGenerateCommand extends Command
                 continue;
             }
 
-            $this->callSilent('make:event', ['name' => $event]);
+            if (Str::contains($event, '::')) {
+                list($model) = explode('::', $event);
+
+                $this->callSilent('make:model', ['name' => $model]);
+            } else {
+                $this->callSilent('make:event', ['name' => $event]);
+            }
 
             foreach ($listeners as $listener) {
                 $listener = preg_replace('/@.+$/', '', $listener);
 
-                $this->callSilent('make:listener', ['name' => $listener, '--event' => $event]);
+                $this->callSilent('make:listener', ['name' => $listener, '--event' => isset($model) ? $model : $event]);
             }
         }
 

--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -38,17 +38,20 @@ class EventGenerateCommand extends Command
             }
 
             if (Str::contains($event, '::')) {
-                list($model) = explode('::', $event);
+                list($event) = explode('::', $event);
+                $option = '--model';
 
-                $this->callSilent('make:model', ['name' => $model]);
+                $this->callSilent('make:model', ['name' => $event]);
             } else {
+                $option = '--event';
+
                 $this->callSilent('make:event', ['name' => $event]);
             }
 
             foreach ($listeners as $listener) {
                 $listener = preg_replace('/@.+$/', '', $listener);
 
-                $this->callSilent('make:listener', ['name' => $listener, '--event' => isset($model) ? $model : $event]);
+                $this->callSilent('make:listener', ['name' => $listener, $option => $event]);
             }
         }
 

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -36,8 +36,8 @@ class ListenerMakeCommand extends GeneratorCommand
      */
     public function fire()
     {
-        if (! $this->option('event')) {
-            return $this->error('Missing required option: --event');
+        if (! $this->option('event') && ! $this->option('model')) {
+            return $this->error('You must set either the --event or the --model option.');
         }
 
         parent::fire();
@@ -53,10 +53,10 @@ class ListenerMakeCommand extends GeneratorCommand
     {
         $stub = parent::buildClass($name);
 
-        $event = $this->option('event');
+        $event = $this->option('event') ?: $this->option('model');
 
         if (! Str::startsWith($event, $this->laravel->getNamespace()) && ! Str::startsWith($event, 'Illuminate')) {
-            $event = $this->laravel->getNamespace().'Events\\'.$event;
+            $event = $this->laravel->getNamespace().($this->option('event') ? 'Events\\' : '').$event;
         }
 
         $stub = str_replace(
@@ -78,9 +78,17 @@ class ListenerMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         if ($this->option('queued')) {
-            return __DIR__.'/stubs/listener-queued.stub';
+            if ($this->option('event')) {
+                return __DIR__.'/stubs/listener-queued.stub';
+            } else {
+                return __DIR__.'/stubs/listener-eloquent-queued.stub';
+            }
         } else {
-            return __DIR__.'/stubs/listener.stub';
+            if ($this->option('event')) {
+                return __DIR__.'/stubs/listener.stub';
+            } else {
+                return __DIR__.'/stubs/listener.stub';
+            }
         }
     }
 
@@ -104,6 +112,7 @@ class ListenerMakeCommand extends GeneratorCommand
     {
         return [
             ['event', null, InputOption::VALUE_REQUIRED, 'The event class being listened for.'],
+            ['model', null, InputOption::VALUE_REQUIRED, 'The model that is being listened to.'],
 
             ['queued', null, InputOption::VALUE_NONE, 'Indicates the event listener should be queued.'],
         ];

--- a/src/Illuminate/Foundation/Console/stubs/listener-eloquent-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-eloquent-queued.stub
@@ -1,0 +1,33 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyFullEvent;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DummyClass implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  DummyEvent  $model
+     * @return void
+     */
+    public function handle(DummyEvent $model)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/listener-eloquent.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-eloquent.stub
@@ -1,0 +1,31 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyFullEvent;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DummyClass
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  DummyEvent  $model
+     * @return void
+     */
+    public function handle(DummyEvent $model)
+    {
+        //
+    }
+}

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -61,21 +61,6 @@ class EventServiceProvider extends ServiceProvider
      */
     public function listens()
     {
-        $listens = [];
-
-        foreach ($this->listen as $event => $listeners) {
-            if (Str::contains($event, '::')) {
-                list($model) = explode('::', $event);
-                $event = $model;
-            }
-
-            if (array_key_exists($event, $listens)) {
-                $listens[$event] = array_merge($listens[$event], $listeners);
-            } else {
-                $listens[$event] = $listeners;
-            }
-        }
-
-        return $listens;
+        return $this->listen;
     }
 }

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -33,7 +33,7 @@ class EventServiceProvider extends ServiceProvider
         foreach ($this->listen as $event => $listeners) {
             if (Str::contains($event, '::')) {
                 list($model, $eloquent_event) = explode('::', $event);
-                $event = 'eloquent.' . $eloquent_event . ': ' . $model;
+                $event = 'eloquent.'.$eloquent_event.': '.$model;
             }
 
             foreach ($listeners as $listener) {

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Support\Providers;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
@@ -30,6 +31,11 @@ class EventServiceProvider extends ServiceProvider
     public function boot(DispatcherContract $events)
     {
         foreach ($this->listen as $event => $listeners) {
+            if (Str::contains($event, '::')) {
+                list($model, $eloquent_event) = explode('::', $event);
+                $event = 'eloquent.' . $eloquent_event . ': ' . $model;
+            }
+
             foreach ($listeners as $listener) {
                 $events->listen($event, $listener);
             }
@@ -55,6 +61,21 @@ class EventServiceProvider extends ServiceProvider
      */
     public function listens()
     {
-        return $this->listen;
+        $listens = [];
+
+        foreach ($this->listen as $event => $listeners) {
+            if (Str::contains($event, '::')) {
+                list($model) = explode('::', $event);
+                $event = $model;
+            }
+
+            if (array_key_exists($event, $listens)) {
+                $listens[$event] = array_merge($listens[$event], $listeners);
+            } else {
+                $listens[$event] = $listeners;
+            }
+        }
+
+        return $listens;
     }
 }


### PR DESCRIPTION
Allows defining eloquent listeners as `Model::event` rather than manually having to call `$events->listen()` like so:

``` php
class EventServiceProvider extends ServiceProvider
{
    /**
     * The event handler mappings for the application.
     *
     * @var array
     */
    protected $listen = [
        'App\User::created' => [
            'App\Listeners\EmailSignedUpConfirmation',
        ],
    ];
}
```
