### PR TITLE
[5.1] Allow Arr::get from objects that implements ArrayAccess

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -244,7 +244,7 @@ class Arr
         }
 
         foreach (explode('.', $key) as $segment) {
-            if (! is_array($array) || ! array_key_exists($segment, $array)) {
+            if ((! is_array($array) || ! array_key_exists($segment, $array)) && ! $array instanceof \ArrayAccess) {
                 return value($default);
             }
 


### PR DESCRIPTION
Allow to use Arr::get method on objects that implement ArrayAccess. It's something that I stumbled upon and is really useful.
