### PR TITLE
Added SoftDelete Trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/SoftDeletes.php
+++ b/src/Illuminate/Foundation/Testing/SoftDeletes.php
@@ -1,0 +1,52 @@
+<?php 
+
+namespace Illuminate\Foundation\Testing;
+
+trait SoftDeletes {
+    
+    /**
+     * Assert that a given where condition does not matches a soft deleted record
+     *
+     * @param  string $table
+     * @param  array  $data
+     * @param  string $connection
+     * @return $this
+     */
+    protected function seeIsNotSoftDeletedInDatabase($table, array $data, $connection = null)
+    {
+        $database = $this->app->make('db');
+        $connection = $connection ?: $database->getDefaultConnection();
+        $count = $database->connection($connection)
+            ->table($table)
+            ->where($data)
+            ->whereNull('deleted_at')
+            ->count();
+        $this->assertGreaterThan(0, $count, sprintf(
+            'Found unexpected records in database table [%s] that matched attributes [%s].', $table, json_encode($data)
+        ));
+        return $this;
+    }
+
+    /**
+     * Assert that a given where condition matches a soft deleted record
+     *
+     * @param  string $table
+     * @param  array  $data
+     * @param  string $connection
+     * @return $this
+     */
+    protected function seeIsSoftDeletedInDatabase($table, array $data, $connection = null)
+    {
+        $database = $this->app->make('db');
+        $connection = $connection ?: $database->getDefaultConnection();
+        $count = $database->connection($connection)
+            ->table($table)
+            ->where($data)
+            ->whereNotNull('deleted_at')
+            ->count();
+        $this->assertGreaterThan(0, $count, sprintf(
+            'Found unexpected records in database table [%s] that matched attributes [%s].', $table, json_encode($data)
+        ));
+        return $this;
+    }
+}

--- a/src/Illuminate/Foundation/Testing/SoftDeletes.php
+++ b/src/Illuminate/Foundation/Testing/SoftDeletes.php
@@ -1,15 +1,16 @@
-<?php 
+<?php
 
 namespace Illuminate\Foundation\Testing;
 
-trait SoftDeletes {
-    
+trait SoftDeletes
+{
     /**
-     * Assert that a given where condition does not matches a soft deleted record
+     * Assert that a given where condition does not matches a soft deleted record.
      *
-     * @param  string $table
-     * @param  array  $data
-     * @param  string $connection
+     * @param string $table
+     * @param array  $data
+     * @param string $connection
+     *
      * @return $this
      */
     protected function seeIsNotSoftDeletedInDatabase($table, array $data, $connection = null)
@@ -24,15 +25,17 @@ trait SoftDeletes {
         $this->assertGreaterThan(0, $count, sprintf(
             'Found unexpected records in database table [%s] that matched attributes [%s].', $table, json_encode($data)
         ));
+
         return $this;
     }
 
     /**
-     * Assert that a given where condition matches a soft deleted record
+     * Assert that a given where condition matches a soft deleted record.
      *
-     * @param  string $table
-     * @param  array  $data
-     * @param  string $connection
+     * @param string $table
+     * @param array  $data
+     * @param string $connection
+     *
      * @return $this
      */
     protected function seeIsSoftDeletedInDatabase($table, array $data, $connection = null)
@@ -47,6 +50,7 @@ trait SoftDeletes {
         $this->assertGreaterThan(0, $count, sprintf(
             'Found unexpected records in database table [%s] that matched attributes [%s].', $table, json_encode($data)
         ));
+
         return $this;
     }
 }


### PR DESCRIPTION
I've added a trait to check that something was soft deleted in the database for better acceptance tests.

Example Usage:

``` php
<?php

use Illuminate\Foundation\Testing\SoftDeletes;

class MyControllerTest extends TestCase
{

    use SoftDeletes;

    ....

    public function test_delete_a_user_successfully()
    {
        $user = new User();
        $user->name = "Test User";
        $user->save();
        $this->seeInDatabase("users", ["name" => "Test User"]);

        $response = $this->call('delete', '/users/'.$user->id, []);
        $this->assertEquals(HTTP::OK, $response->status());
        $this->seeInDatabase("users", ["name" => "Test User"]);
        $this->seeIsSoftDeletedInDatabase("users", ["name" => "Test User");
    }

```

This thoroughly tests that the api endpoint is working as intended.

I just wrapped the code in a trait and submitted the pull request.  The actual code was written on SO here: http://stackoverflow.com/questions/33117746/laravel-unit-testing-how-to-seeindatabase-soft-deleted-row.

This also seems compatible with 5.2, but I am working in 5.1.
