### PR TITLE
[5.2] Make "required" validation rule work even if array key is missing

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -276,7 +276,7 @@ class Validator implements ValidatorContract
 
         // We will check if the attribute is a nested key, if yes we bring the dot
         // address of that key as well as the key name itself, the matches will
-        // be use to fill the the key with null if it's not provided for the
+        // be use to fill the key with null if it's not provided for the
         // "required" rule to work effectively.
         preg_match("/(.*)\.\*\.([^\.\*]*)$/", $attribute, $matches);
         if ($matches) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1859,6 +1859,75 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateImplicitEachWithAsterisksForRequiredNonExistingKey()
+    {
+        $trans = $this->getRealTranslator();
+        $data = ['names' => [['second' => 'I have no first']]];
+        $v = new Validator($trans, $data, ['names.*.first' => 'required']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $data = ['names' => [['second' => 'I have no first']]];
+        $v = new Validator($trans, $data, ['names.*.first' => 'required']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $data = ['people' => [
+            ['cars' => [['model' => 2005], []]],
+        ]];
+        $v = new Validator($trans, $data, ['people.*.cars.*.model' => 'required']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $data = ['people' => [
+            ['name' => 'test', 'cars' => [['model' => 2005], ['name' => 'test2']]],
+        ]];
+        $v = new Validator($trans, $data, ['people.*.cars.*.model' => 'required']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $data = ['people' => [
+            ['phones' => ['iphone', 'android'], 'cars' => [['model' => 2005], ['name' => 'test2']]],
+        ]];
+        $v = new Validator($trans, $data, ['people.*.cars.*.model' => 'required']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $data = ['names' => [['second' => '2']]];
+        $v = new Validator($trans, $data, ['names.*.first' => 'sometimes|required']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $data = [
+            'people' => [
+                ['name' => 'Jon', 'email' => 'a@b.c'],
+                ['name' => 'Jon'],
+            ],
+        ];
+        $v = new Validator($trans, $data, ['people.*.email' => 'required']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $data = [
+            'people' => [
+                [
+                    'name' => 'Jon',
+                    'cars' => [
+                        ['model' => 2014],
+                    ],
+                ],
+                [
+                    'name' => 'Arya',
+                    'cars' => [
+                        ['name' => 'test'],
+                    ],
+                ],
+            ],
+        ];
+        $v = new Validator($trans, $data, ['people.*.cars.*.model' => 'required']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateEachWithNonIndexedArray()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
Currently this validation will pass although there's a person with no email.

``` php
$data = [
    'persons' => [
        [
            'name' => 'Jon Snow',
            'email' => 'jon@thewall.com',
        ],
        [
            'name' => 'Arya Stark',
        ]        
    ]
];

Validator::make($data, [
    'persons.*.email' => 'required'
]);
```

This is because `Arr::dot($this->data)` inside `Illuminate\Validation\Validator::each` flattens _only_ the existing keys and we pass them _only_ to the checks.

The proposed fix will create a null-value key if the key is missing so that it enters the validation checks and fail indicating that it's required but missing.

This fix is only taking care of the `required` rule, however the other `required_with`, `required_if`, `required_unless` and what's alike are addressed in the pull request https://github.com/laravel/framework/pull/11927
