### PR TITLE
[5.1] Fixed deprecation notice

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -262,7 +262,7 @@ class Repository implements CacheContract, ArrayAccess
      * @param  string  $name
      * @return \Illuminate\Cache\TaggedCache
      *
-     * @deprecated since version 5.1. Use tags instead.
+     * @deprecated since version 5.1.28. Use tags instead.
      */
     public function section($name)
     {


### PR DESCRIPTION
This method was only added to the repository class in 5.1.28, so can't have been deprecated before it existed.
