### PR TITLE
[5.2] Fixed bad branch merge

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -345,19 +345,6 @@ class Repository implements CacheContract, ArrayAccess
     /**
      * Begin executing a new tags operation if the store supports it.
      *
-     * @param  string  $name
-     * @return \Illuminate\Cache\TaggedCache
-     *
-     * @deprecated since version 5.1. Use tags instead.
-     */
-    public function section($name)
-    {
-        return $this->tags($name);
-    }
-
-    /**
-     * Begin executing a new tags operation if the store supports it.
-     *
      * @param  array|mixed  $names
      * @return \Illuminate\Cache\TaggedCache
      *


### PR DESCRIPTION
The repository class was refactored in 5.1.28 and this method was meant to be removed on merge into 5.2.
