### PR TITLE
[5.2] Custom Auth Provider Fix

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Auth\PasswordBrokerFactory as FactoryContract;
 
 class PasswordBrokerManager implements FactoryContract
 {
-    use CreatesUserProviders;
 
     /**
      * The application instance.
@@ -71,7 +70,7 @@ class PasswordBrokerManager implements FactoryContract
         // aggregate service of sorts providing a convenient interface for resets.
         return new PasswordBroker(
             $this->createTokenRepository($config),
-            $this->createUserProvider($config['provider']),
+            $this->app['auth']->createUserProvider($config['provider']),
             $this->app['mailer'],
             $config['email']
         );

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Auth\Passwords;
 
 use InvalidArgumentException;
-use Illuminate\Auth\CreatesUserProviders;
 use Illuminate\Contracts\Auth\PasswordBrokerFactory as FactoryContract;
 
 class PasswordBrokerManager implements FactoryContract


### PR DESCRIPTION
It looks like `PasswordBrokerManager.php` is not finding custom Authentication user providers. See issue #11649. It looks like on line 11 it uses `use CreatesUserProviders` then on line 73 it creates a new `PasswordBroker`. This issue arrises because `PasswordBrokerManager` is using a trait and referring to an array on the trait that is instantiated on `AuthManager`. Since it is a trait it is creating a brand new empty array on `PasswordBrokerManager` which causes issues. I am not familiar enough with the framework to know if this is the best way to fix this, but it works and will at least get you pointed in the right direction.

---

Closes #11649.
