### PR TITLE
[5.2] Added full URL is check

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -170,7 +170,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * @param  mixed  string
      * @return bool
      */
-    public function fullUrlIs()
+    public function fullIs()
     {
         $url = $this->fullUrl();
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -170,7 +170,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * @param  mixed  string
      * @return bool
      */
-    public function fullIs()
+    public function fullUrlIs()
     {
         $url = $this->fullUrl();
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -165,6 +165,25 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Determine if the current request URL and query string matches a pattern.
+     *
+     * @param  mixed  string
+     * @return bool
+     */
+    public function fullUrlIs()
+    {
+        $url = $this->fullUrl();
+
+        foreach (func_get_args() as $pattern) {
+            if (Str::is($pattern, $url)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Determine if the request is the result of an AJAX call.
      *
      * @return bool


### PR DESCRIPTION
Currently if you run a test on whether or not a URL matches a pattern using `Illuminate\Http\Request::is()` the query string is ignored. It would be useful to be able to include the query string in this test since `/foo` != `/foo?bar=123`.

This PR proposes a new method called `fullIs()` method in `Illuminate\Http\Request` which lets you compare the full URL with query string to a pattern or patterns, similar to the way the existing `is()` method works.
