### PR TITLE
[5.2] Allowed the password email & password reset views to be configurable

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -28,6 +28,10 @@ trait ResetsPasswords
      */
     public function showLinkRequestForm()
     {
+        if (property_exists($this, 'passwordEmailView')) {
+            return view($this->passwordEmailView);
+        }
+
         if (view()->exists('auth.passwords.email')) {
             return view('auth.passwords.email');
         }
@@ -134,6 +138,10 @@ trait ResetsPasswords
         }
 
         $email = $request->input('email');
+
+        if (property_exists($this, 'passwordResetView')) {
+            return view($this->passwordResetView)->with(compact('token', 'email'));
+        }
 
         if (view()->exists('auth.passwords.reset')) {
             return view('auth.passwords.reset')->with(compact('token', 'email'));


### PR DESCRIPTION
 This is similar to how the AuthenticatesUser trait handles the login view. It removes the need to override two methods if the views are not at their default locations.
