### PR TITLE
[5.2] Container can get contextual dependency for method by looking at declaring class

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -492,6 +492,20 @@ return $obj; });
         );
     }
 
+    public function testContextualBindingWorksForObjectMethods()
+    {
+        $container = new Container;
+
+        $container->bind('IContainerContractStub', 'ContainerImplementationStub');
+
+        $container->when('ContainerTestMethodContext')->needs('IContainerContractStub')->give('ContainerImplementationStubTwo');
+
+        $this->assertInstanceOf(
+            'ContainerImplementationStubTwo',
+            $container->call('ContainerTestMethodContext@foo')
+        );
+    }
+
     public function testContainerTags()
     {
         $container = new Container;
@@ -700,6 +714,14 @@ class ContainerTestContextInjectTwo
     public function __construct(IContainerContractStub $impl)
     {
         $this->impl = $impl;
+    }
+}
+
+class ContainerTestMethodContext
+{
+    public function foo(IContainerContractStub $impl)
+    {
+        return $impl;
     }
 }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -455,6 +455,20 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testContextualRouteMethodBindingThroughIOC()
+    {
+        $router = new Router(new Dispatcher, $container = new Container);
+
+        $concreteClassname = RoutingTestDependencyConcretion::class;
+
+        $container->when(RoutingTestMethodDependencyController::class)
+            ->needs(RoutingTestDependencyInterface::class)
+            ->give($concreteClassname);
+
+        $router->get('foo', 'RoutingTestMethodDependencyController@get');
+        $this->assertEquals($concreteClassname, $router->dispatch(Request::create('foo', 'GET'))->getContent());
+    }
+
     public function testGroupMerging()
     {
         $old = ['prefix' => 'foo/bar/'];
@@ -956,5 +970,21 @@ class RoutingTestMiddlewareGroupTwo
     public function handle($request, $next, $parameter = null)
     {
         return new \Illuminate\Http\Response('caught '.$parameter);
+    }
+}
+
+interface RoutingTestDependencyInterface
+{
+}
+
+class RoutingTestDependencyConcretion implements RoutingTestDependencyInterface
+{
+}
+
+class RoutingTestMethodDependencyController extends \Illuminate\Routing\Controller
+{
+    public function get(RoutingTestDependencyInterface $foo)
+    {
+        return get_class($foo);
     }
 }


### PR DESCRIPTION
Usage:

``` php
class Foo
{
    public function bar(QueueContract $queue)
    {
        ...
    }
}

$container->when(Foo::class)->needs(QueueContract::class)->give(Queue::class);

$container->call('Foo@bar');
```

Works in controller methods as well.
