### PR TITLE
[5.2] Ability to disable attribute name beautifying in validation message

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -153,6 +153,13 @@ class Validator implements ValidatorContract
     ];
 
     /**
+     * When set to true, validation attribute name won't be beutified in validation message.
+     *
+     * @var bool
+     */
+    protected $disableAttributeBeautifier = false;
+
+    /**
      * Create a new Validator instance.
      *
      * @param  \Symfony\Component\Translation\TranslatorInterface  $translator
@@ -1817,8 +1824,21 @@ class Validator implements ValidatorContract
 
         // If no language line has been specified for the attribute all of the
         // underscores are removed from the attribute name and that will be
-        // used as default versions of the attribute's displayable names.
+        // used as default versions of the attribute's displayable names
+        // unless disableAttributeBeautifier() was called.
+        if ($this->disableAttributeBeautifier) {
+            return $attribute;
+        }
+
         return str_replace('_', ' ', Str::snake($attribute));
+    }
+
+    /**
+     * Disables beautifying of attribute name in validation message.
+     */
+    public function disableAttributeBeautifier()
+    {
+        $this->disableAttributeBeautifier = true;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1916,4 +1916,17 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
             new \Illuminate\Translation\ArrayLoader, 'en'
         );
     }
+
+    public function testAttributeNameBeautifier()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['res_url' => 'www.example'], ['res_url' => 'required|url'], ['res_url.url' => 'The :attribute format is invalid.']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals('The res url format is invalid.', $v->messages()->first('res_url'));
+
+        $v = new Validator($trans, ['resURL' => 'www.example'], ['resURL' => 'required|url'], ['resURL.url' => 'The :attribute format is invalid.']);
+        $v->disableAttributeBeautifier();
+        $this->assertFalse($v->passes());
+        $this->assertEquals('The resURL format is invalid.', $v->messages()->first('resURL'));
+    }
 }


### PR DESCRIPTION
When using Validator to validate input parameters like "resURL", 'FTPhost" etc. it doesn't make sense to beautify them in validation messages, because it will look like "The res u r l format is invalid." or "The f t p host format is invalid.". If these messages are only saved to log file you probably won't find the issue quickly, because you're looking for string "resURL".
This pull request ads ability to disable beautifier by calling disableAttributeBeautifier() on validator object. After that original attribute name will be used and message will look like "The resURL format is invalid."
