### PR TITLE
[5.2] Allow to separate urls from resource name and wildcard

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -53,7 +53,7 @@ class ResourceRegistrar
         // We need to extract the base resource from the resource name. Nested resources
         // are supported in the framework, but we need to know what name to use for a
         // place-holder on the route wildcards, which should be the base resources.
-        $base = $this->getResourceWildcard(last(explode('.', $name)));
+        $base = $this->getResourceWildcard(last(explode('.', $name)), $options);
 
         $defaults = $this->resourceDefaults;
 
@@ -194,6 +194,10 @@ class ResourceRegistrar
         // the resource action. Otherwise we'll just use an empty string for here.
         $prefix = isset($options['as']) ? $options['as'].'.' : '';
 
+        // If we set explicit resource name, let's use it instead of default
+        // resource name
+        $resource = $this->getResourceGroupName($resource, $options);
+
         if (! $this->router->hasGroupStack()) {
             return $prefix.$resource.'.'.$method;
         }
@@ -224,10 +228,13 @@ class ResourceRegistrar
      * Format a resource wildcard for usage.
      *
      * @param  string  $value
+     * @param  array  $options
      * @return string
      */
-    public function getResourceWildcard($value)
+    public function getResourceWildcard($value, array $options = [])
     {
+        $value = $this->getResourceGroupName($value, $options);
+
         return str_replace('-', '_', $value);
     }
 
@@ -260,7 +267,7 @@ class ResourceRegistrar
      */
     protected function addResourceCreate($name, $base, $controller, $options)
     {
-        $uri = $this->getResourceUri($name).'/create';
+        $uri = $this->getResourceUri($name).'/'.$this->getCreateUrlSuffix();
 
         $action = $this->getResourceAction($name, $controller, 'create', $options);
 
@@ -314,7 +321,7 @@ class ResourceRegistrar
      */
     protected function addResourceEdit($name, $base, $controller, $options)
     {
-        $uri = $this->getResourceUri($name).'/{'.$base.'}/edit';
+        $uri = $this->getResourceUri($name).'/{'.$base.'}/'.$this->getEditUrlSuffix();
 
         $action = $this->getResourceAction($name, $controller, 'edit', $options);
 
@@ -355,5 +362,37 @@ class ResourceRegistrar
         $action = $this->getResourceAction($name, $controller, 'destroy', $options);
 
         return $this->router->delete($uri, $action);
+    }
+
+    /**
+     * Get create url suffix.
+     *
+     * @return  string
+     */
+    protected function getCreateUrlSuffix()
+    {
+        return 'create';
+    }
+
+    /**
+     * Get edit url suffix.
+     *
+     * @return  string
+     */
+    protected function getEditUrlSuffix()
+    {
+        return 'edit';
+    }
+
+    /**
+     * Get resource group name.
+     *
+     * @param  string  $resource
+     * @param  array  $options
+     * @return string
+     */
+    protected function getResourceGroupName($resource, array $options)
+    {
+        return isset($options['name']) ? $options['name'] : $resource;
     }
 }


### PR DESCRIPTION
At the moment when creating resource, resource name must be the same as resource url + urls for create and edit are stored inside more complex function so they cannot be easy change.

Let's assume we want to create route resource for `invoices` but we want url name to be in different language (for example Polish in my case), we cannot simply do:

``` php
Route::resource('faktury', 'InvoiceController', ['name' => 'invoices']);
```

what would be the best and shortest options, but we need to create each route separately this way:

``` php
Route::get('faktury', 'InvoiceController@index')->name('invoices.index');
Route::get('faktury/dodaj', 'InvoiceController@create')->name('invoices.create');
Route::post('faktury/', 'InvoiceController@store')->name('invoices.store');
Route::get('faktury/{invoices}', 'InvoiceController@show')->name('invoices.show');
Route::get('faktury/{invoices}/edytuj', 'InvoiceController@edit')->name('invoices.edit');
Route::put('faktury/{invoices}', 'InvoiceController@update')->name('invoices.update');
Route::delete('faktury', 'InvoiceController@destroy')->name('invoices.destroy'); 
```

It's quite a lot of code while this could be replaced just by single line.

It would be much easier when we could use:

``` php
Route::resource('faktury', 'InvoiceController', ['name' => 'invoices']);
```

syntax + override just 2 methods from `\Illuminate\Routing\ResourceRegistrar` just to set custom url suffixes for `create` and `edit`.

Someone could say, that we could in this case just use:

``` php
Route::resource('faktury', 'InvoiceController');
```

and use in app `faktury.create` if we need to create route for this but it's not best solution. We want to use in app rather English names and separate this from urls that could be completely different and could even change because of many reasons that should not affect application itself.
