### PR TITLE
[5.2] Resolve parameter fields with asterisks when validating arrays

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -541,7 +541,7 @@ class Validator implements ValidatorContract
      * Replace each field which has asterisks with the numeric keys of the given attribute.
      *
      * @param  array  $fields
-     * @param  string $attribute
+     * @param  string  $attribute
      * @return array
      */
     protected function replaceParameterFields(array $fields, $attribute)
@@ -560,7 +560,7 @@ class Validator implements ValidatorContract
      *
      * E.g. 'foo.1.bar.2.baz' -> [1, 2]
      *
-     * @param  string $attribute
+     * @param  string  $attribute
      * @return array
      */
     protected function getAttributeKeys($attribute)
@@ -579,7 +579,7 @@ class Validator implements ValidatorContract
      *
      * E.g. 'foo.*.bar.*.baz', [1, 2] -> foo.1.bar.2.baz
      *
-     * @param  strint $field
+     * @param  string  $field
      * @param  array  $keys
      * @return string
      */

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2367,9 +2367,7 @@ class Validator implements ValidatorContract
     protected function getNumericKeys($attribute)
     {
         if (preg_match_all('/\.(\d+)\./', $attribute, $keys)) {
-            array_shift($keys);
-
-            return Arr::collapse($keys);
+            return $keys[1];
         }
 
         return [];

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1850,39 +1850,65 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $trans = $this->getRealTranslator();
         $data = ['foo' => [5, 10, 15]];
 
-        $v = new Validator($trans, $data, ['foo' => 'Array', 'foo.*' => 'Numeric|Min:6|Max:16']);
+        // pipe rules fails
+        $v = new Validator($trans, $data, [
+            'foo' => 'Array',
+            'foo.*' => 'Numeric|Min:6|Max:16',
+        ]);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, $data, ['foo' => 'Array', 'foo.*' => 'Numeric|Min:4|Max:16']);
+        // pipe passes
+        $v = new Validator($trans, $data, [
+            'foo' => 'Array',
+            'foo.*' => 'Numeric|Min:4|Max:16',
+        ]);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, $data, ['foo' => 'Array', 'foo.*' => ['Numeric', 'Min:6', 'Max:16']]);
+        // array rules fails
+        $v = new Validator($trans, $data, [
+            'foo' => 'Array',
+            'foo.*' => ['Numeric', 'Min:6', 'Max:16'],
+        ]);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, $data, ['foo' => 'Array', 'foo.*' => ['Numeric', 'Min:4', 'Max:16']]);
+        // array rules passes
+        $v = new Validator($trans, $data, [
+            'foo' => 'Array',
+            'foo.*' => ['Numeric', 'Min:4', 'Max:16'],
+        ]);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => [['name' => 'first'], ['name' => 'second']]],
+        // string passes
+        $v = new Validator($trans,
+            ['foo' => [['name' => 'first'], ['name' => 'second']]],
             ['foo' => 'Array', 'foo.*.name' => 'Required|String']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => [['name' => 'first'], ['name' => 'second']]],
+        // numeric fails
+        $v = new Validator($trans,
+            ['foo' => [['name' => 'first'], ['name' => 'second']]],
             ['foo' => 'Array', 'foo.*.name' => 'Required|Numeric']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
+        // nested array fails
+        $v = new Validator($trans,
+            ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
             ['foo' => 'Array', 'foo.*.name' => 'Required|String', 'foo.*.votes.*' => 'Required|Integer']);
         $this->assertFalse($v->passes());
 
+        // multiple items passes
         $v = new Validator($trans, ['foo' => [['name' => 'first'], ['name' => 'second']]],
             ['foo' => 'Array', 'foo.*.name' => ['Required', 'String']]);
         $this->assertTrue($v->passes());
 
+        // multiple items fails
         $v = new Validator($trans, ['foo' => [['name' => 'first'], ['name' => 'second']]],
             ['foo' => 'Array', 'foo.*.name' => ['Required', 'Numeric']]);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
+        // nested arrays fails
+        $v = new Validator($trans,
+            ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
             ['foo' => 'Array', 'foo.*.name' => ['Required', 'String'], 'foo.*.votes.*' => ['Required', 'Integer']]);
         $this->assertFalse($v->passes());
     }
@@ -1990,6 +2016,408 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, $data, ['item_amounts.*' => 'numeric|min:5']);
         $this->assertFalse($v->passes());
+    }
+
+    public function testValidateImplicitEachWithAsterisksConfirmed()
+    {
+        $trans = $this->getRealTranslator();
+
+        // confirmed passes
+        $v = new Validator($trans, ['foo' => [
+            ['password' => 'foo0', 'password_confirmation' => 'foo0'],
+            ['password' => 'foo1', 'password_confirmation' => 'foo1'],
+        ]], ['foo.*.password' => 'confirmed']);
+        $this->assertTrue($v->passes());
+
+        // nested confirmed passes
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['password' => 'bar0', 'password_confirmation' => 'bar0'],
+                ['password' => 'bar1', 'password_confirmation' => 'bar1'],
+            ]],
+            ['bar' => [
+                ['password' => 'bar2', 'password_confirmation' => 'bar2'],
+                ['password' => 'bar3', 'password_confirmation' => 'bar3'],
+            ]],
+        ]], ['foo.*.bar.*.password' => 'confirmed']);
+        $this->assertTrue($v->passes());
+
+        // confirmed fails
+        $v = new Validator($trans, ['foo' => [
+            ['password' => 'foo0', 'password_confirmation' => 'bar0'],
+            ['password' => 'foo1'],
+        ]], ['foo.*.password' => 'confirmed']);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.password'));
+        $this->assertTrue($v->messages()->has('foo.1.password'));
+
+        // nested confirmed fails
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['password' => 'bar0'],
+                ['password' => 'bar1', 'password_confirmation' => 'bar2'],
+            ]],
+        ]], ['foo.*.bar.*.password' => 'confirmed']);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.bar.0.password'));
+        $this->assertTrue($v->messages()->has('foo.0.bar.1.password'));
+    }
+
+    public function testValidateImplicitEachWithAsterisksDifferent()
+    {
+        $trans = $this->getRealTranslator();
+
+        // different passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'foo', 'last' => 'bar'],
+            ['name' => 'bar', 'last' => 'foo'],
+        ]], ['foo.*.name' => ['different:foo.*.last']]);
+        $this->assertTrue($v->passes());
+
+        // nested different passes
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['name' => 'foo', 'last' => 'bar'],
+                ['name' => 'bar', 'last' => 'foo'],
+            ]],
+        ]], ['foo.*.bar.*.name' => ['different:foo.*.bar.*.last']]);
+        $this->assertTrue($v->passes());
+
+        // different fails
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'foo', 'last' => 'foo'],
+            ['name' => 'bar', 'last' => 'bar'],
+        ]], ['foo.*.name' => ['different:foo.*.last']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.name'));
+        $this->assertTrue($v->messages()->has('foo.1.name'));
+
+        // nested different fails
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['name' => 'foo', 'last' => 'foo'],
+                ['name' => 'bar', 'last' => 'bar'],
+            ]],
+        ]], ['foo.*.bar.*.name' => ['different:foo.*.bar.*.last']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.bar.0.name'));
+        $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
+    }
+
+    public function testValidateImplicitEachWithAsterisksSame()
+    {
+        $trans = $this->getRealTranslator();
+
+        // same passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'foo', 'last' => 'foo'],
+            ['name' => 'bar', 'last' => 'bar'],
+        ]], ['foo.*.name' => ['same:foo.*.last']]);
+        $this->assertTrue($v->passes());
+
+        // nested same passes
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['name' => 'foo', 'last' => 'foo'],
+                ['name' => 'bar', 'last' => 'bar'],
+            ]],
+        ]], ['foo.*.bar.*.name' => ['same:foo.*.bar.*.last']]);
+        $this->assertTrue($v->passes());
+
+        // same fails
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'foo', 'last' => 'bar'],
+            ['name' => 'bar', 'last' => 'foo'],
+        ]], ['foo.*.name' => ['same:foo.*.last']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.name'));
+        $this->assertTrue($v->messages()->has('foo.1.name'));
+
+        // nested same fails
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['name' => 'foo', 'last' => 'bar'],
+                ['name' => 'bar', 'last' => 'foo'],
+            ]],
+        ]], ['foo.*.bar.*.name' => ['same:foo.*.bar.*.last']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.bar.0.name'));
+        $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
+    }
+
+    public function testValidateImplicitEachWithAsterisksRequired()
+    {
+        $trans = $this->getRealTranslator();
+
+        // required passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'first'],
+            ['name' => 'second'],
+        ]], ['foo.*.name' => ['Required']]);
+        $this->assertTrue($v->passes());
+
+        // nested required passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'first'],
+            ['name' => 'second'],
+        ]], ['foo.*.name' => ['Required']]);
+        $this->assertTrue($v->passes());
+
+        // required fails
+        $v = new Validator($trans, ['foo' => [
+            ['name' => null],
+            ['name' => null, 'last' => 'last'],
+        ]], ['foo.*.name' => ['Required']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.name'));
+        $this->assertTrue($v->messages()->has('foo.1.name'));
+
+        // nested required fails
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['name' => null],
+                ['name' => null],
+            ]],
+        ]], ['foo.*.bar.*.name' => ['Required']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.bar.0.name'));
+        $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
+    }
+
+    public function testValidateImplicitEachWithAsterisksRequiredIf()
+    {
+        $trans = $this->getRealTranslator();
+
+        // required_if passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'first', 'last' => 'foo'],
+            ['last' => 'bar'],
+        ]], ['foo.*.name' => ['Required_if:foo.*.last,foo']]);
+        $this->assertTrue($v->passes());
+
+        // nested required_if passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'first', 'last' => 'foo'],
+            ['last' => 'bar'],
+        ]], ['foo.*.name' => ['Required_if:foo.*.last,foo']]);
+        $this->assertTrue($v->passes());
+
+        // required_if fails
+        $v = new Validator($trans, ['foo' => [
+            ['name' => null, 'last' => 'foo'],
+            ['name' => null, 'last' => 'foo'],
+        ]], ['foo.*.name' => ['Required_if:foo.*.last,foo']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.name'));
+        $this->assertTrue($v->messages()->has('foo.1.name'));
+
+        // nested required_if fails
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['name' => null, 'last' => 'foo'],
+                ['name' => null, 'last' => 'foo'],
+            ]],
+        ]], ['foo.*.bar.*.name' => ['Required_if:foo.*.bar.*.last,foo']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.bar.0.name'));
+        $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
+    }
+
+    public function testValidateImplicitEachWithAsterisksRequiredUnless()
+    {
+        $trans = $this->getRealTranslator();
+
+        // required_unless passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => null, 'last' => 'foo'],
+            ['name' => 'second', 'last' => 'bar'],
+        ]], ['foo.*.name' => ['Required_unless:foo.*.last,foo']]);
+        $this->assertTrue($v->passes());
+
+        // nested required_unless passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => null, 'last' => 'foo'],
+            ['name' => 'second', 'last' => 'foo'],
+        ]], ['foo.*.bar.*.name' => ['Required_unless:foo.*.bar.*.last,foo']]);
+        $this->assertTrue($v->passes());
+
+        // required_unless fails
+        $v = new Validator($trans, ['foo' => [
+            ['name' => null, 'last' => 'baz'],
+            ['name' => null, 'last' => 'bar'],
+        ]], ['foo.*.name' => ['Required_unless:foo.*.last,foo']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.name'));
+        $this->assertTrue($v->messages()->has('foo.1.name'));
+
+        // nested required_unless fails
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['name' => null, 'last' => 'bar'],
+                ['name' => 'second', 'last' => 'bar'],
+            ]],
+        ]], ['foo.*.bar.*.name' => ['Required_unless:foo.*.bar.*.last,foo']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.bar.0.name'));
+        $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
+    }
+
+    public function testValidateImplicitEachWithAsterisksRequiredWith()
+    {
+        $trans = $this->getRealTranslator();
+
+        // required_with passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'first', 'last' => 'last'],
+            ['name' => 'second', 'last' => 'last'],
+        ]], ['foo.*.name' => ['Required_with:foo.*.last']]);
+        $this->assertTrue($v->passes());
+
+        // nested required_with passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'first', 'last' => 'last'],
+            ['name' => 'second', 'last' => 'last'],
+        ]], ['foo.*.name' => ['Required_with:foo.*.last']]);
+        $this->assertTrue($v->passes());
+
+        // required_with fails
+        $v = new Validator($trans, ['foo' => [
+            ['name' => null, 'last' => 'last'],
+            ['name' => null, 'last' => 'last'],
+        ]], ['foo.*.name' => ['Required_with:foo.*.last']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.name'));
+        $this->assertTrue($v->messages()->has('foo.1.name'));
+
+        // nested required_with fails
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['name' => null, 'last' => 'last'],
+                ['name' => null, 'last' => 'last'],
+            ]],
+        ]], ['foo.*.bar.*.name' => ['Required_with:foo.*.bar.*.last']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.bar.0.name'));
+        $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
+    }
+
+    public function testValidateImplicitEachWithAsterisksRequiredWithAll()
+    {
+        $trans = $this->getRealTranslator();
+
+        // required_with_all passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'first', 'last' => 'last', 'middle' => 'middle'],
+            ['name' => 'second', 'last' => 'last', 'middle' => 'middle'],
+        ]], ['foo.*.name' => ['Required_with_all:foo.*.last,foo.*.middle']]);
+        $this->assertTrue($v->passes());
+
+        // nested required_with_all passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'first', 'last' => 'last', 'middle' => 'middle'],
+            ['name' => 'second', 'last' => 'last', 'middle' => 'middle'],
+        ]], ['foo.*.name' => ['Required_with_all:foo.*.last,foo.*.middle']]);
+        $this->assertTrue($v->passes());
+
+        // required_with_all fails
+        $v = new Validator($trans, ['foo' => [
+            ['name' => null, 'last' => 'last', 'middle' => 'middle'],
+            ['name' => null, 'last' => 'last', 'middle' => 'middle'],
+        ]], ['foo.*.name' => ['Required_with_all:foo.*.last,foo.*.middle']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.name'));
+        $this->assertTrue($v->messages()->has('foo.1.name'));
+
+        // nested required_with_all fails
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['name' => null, 'last' => 'last', 'middle' => 'middle'],
+                ['name' => null, 'last' => 'last', 'middle' => 'middle'],
+            ]],
+        ]], ['foo.*.bar.*.name' => ['Required_with_all:foo.*.bar.*.last,foo.*.bar.*.middle']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.bar.0.name'));
+        $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
+    }
+
+    public function testValidateImplicitEachWithAsterisksRequiredWithout()
+    {
+        $trans = $this->getRealTranslator();
+
+        // required_without passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'first', 'middle' => 'middle'],
+            ['name' => 'second', 'last' => 'last'],
+        ]], ['foo.*.name' => ['Required_without:foo.*.last,foo.*.middle']]);
+        $this->assertTrue($v->passes());
+
+        // nested required_without passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'first', 'middle' => 'middle'],
+            ['name' => 'second', 'last' => 'last'],
+        ]], ['foo.*.name' => ['Required_without:foo.*.last,foo.*.middle']]);
+        $this->assertTrue($v->passes());
+
+        // required_without fails
+        $v = new Validator($trans, ['foo' => [
+            ['name' => null, 'last' => 'last'],
+            ['name' => null, 'middle' => 'middle'],
+        ]], ['foo.*.name' => ['Required_without:foo.*.last,foo.*.middle']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.name'));
+        $this->assertTrue($v->messages()->has('foo.1.name'));
+
+        // nested required_without fails
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['name' => null, 'last' => 'last'],
+                ['name' => null, 'middle' => 'middle'],
+            ]],
+        ]], ['foo.*.bar.*.name' => ['Required_without:foo.*.bar.*.last,foo.*.bar.*.middle']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.bar.0.name'));
+        $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
+    }
+
+    public function testValidateImplicitEachWithAsterisksRequiredWithoutAll()
+    {
+        $trans = $this->getRealTranslator();
+
+        // required_without_all passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'first'],
+            ['name' => null, 'middle' => 'middle'],
+            ['name' => null, 'middle' => 'middle', 'last' => 'last'],
+        ]], ['foo.*.name' => ['Required_without_all:foo.*.last,foo.*.middle']]);
+        $this->assertTrue($v->passes());
+
+        // required_without_all fails
+        // nested required_without_all passes
+        $v = new Validator($trans, ['foo' => [
+            ['name' => 'first'],
+            ['name' => null, 'middle' => 'middle'],
+            ['name' => null, 'middle' => 'middle', 'last' => 'last'],
+        ]], ['foo.*.name' => ['Required_without_all:foo.*.last,foo.*.middle']]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => [
+            ['name' => null, 'foo' => 'foo', 'bar' => 'bar'],
+            ['name' => null, 'foo' => 'foo', 'bar' => 'bar'],
+        ]], ['foo.*.name' => ['Required_without_all:foo.*.last,foo.*.middle']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.name'));
+        $this->assertTrue($v->messages()->has('foo.1.name'));
+
+        // nested required_without_all fails
+        $v = new Validator($trans, ['foo' => [
+            ['bar' => [
+                ['name' => null, 'foo' => 'foo', 'bar' => 'bar'],
+                ['name' => null, 'foo' => 'foo', 'bar' => 'bar'],
+            ]],
+        ]], ['foo.*.bar.*.name' => ['Required_without_all:foo.*.bar.*.last,foo.*.bar.*.middle']]);
+        $this->assertFalse($v->passes());
+        $this->assertTrue($v->messages()->has('foo.0.bar.0.name'));
+        $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
     }
 
     public function testValidateEachWithNonIndexedArray()


### PR DESCRIPTION
When validating arrays with rules that accept other fields as parameters, like `required_*`, the field names should reflect the structure of the array we are validating against. E.g.:

``` php
'person.*.first_name' => 'required_with:last_name'
```

This rule would **NOT** check if `last_name` is present in _each_ person, but if it is present in the root array data. While this is a useful feature, we need a way to accept fields as parameters which are scoped to the current item when we perform array validation.

The most natural way would be to specify the fields with `*` character like we do in the rule keys. Unfortunately this doesn't work in 5.2, so this PR addresses and fixes that issue. It also works on multidimentional (multiple `*`) array structures. Here is an example:

``` php
'person.*.first_name' => 'required_with:person.*.last_name'
```

There is also the issue of the missing array keys, that should be addressed in #11885 .
For now all my tests are specifying `'field' => null` when we need to check for a field, but this should be fixed to work even if the needed field is missing from the data.
