### PR TITLE
[5.2] add wildcard support to seeJsonStructure

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -260,7 +260,13 @@ trait MakesHttpRequests
         }
 
         foreach ($structure as $key => $value) {
-            if (is_array($value)) {
+            if (is_array($value) && $key === '*') {
+                $this->assertInternalType('array', $responseData);
+
+                foreach ($responseData as $responseDataItem) {
+                    $this->seeJsonStructure($structure['*'], $responseDataItem);
+                }
+            } elseif (is_array($value)) {
                 $this->assertArrayHasKey($key, $responseData);
                 $this->seeJsonStructure($structure[$key], $responseData[$key]);
             } else {

--- a/tests/Foundation/FoundationCrawlerTraitJsonTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitJsonTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Foundation\Testing\Concerns\MakesHttpRequests;
+
+class FoundationCrawlerTraitJsonTest extends PHPUnit_Framework_TestCase
+{
+    use MakesHttpRequests;
+
+    public function testSeeJsonStructure()
+    {
+        $this->response = new \Illuminate\Http\Response(new JsonSerializableMixedResourcesStub);
+
+        // At root
+        $this->seeJsonStructure(['foo']);
+
+        // Nested
+        $this->seeJsonStructure(['foobar' => ['foobar_foo', 'foobar_bar']]);
+
+        // Wildcard (repeating structure)
+        $this->seeJsonStructure(['bars' => ['*' => ['bar', 'foo']]]);
+
+        // Nested after wildcard
+        $this->seeJsonStructure(['baz' => ['*' => ['foo', 'bar' => ['foo', 'bar']]]]);
+
+        // Wildcard (repeating structure) at root
+        $this->response = new \Illuminate\Http\Response(new JsonSerializableSingleResourceStub);
+        $this->seeJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
+    }
+}
+
+class JsonSerializableMixedResourcesStub implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return [
+            'foo' => 'bar',
+            'foobar' => [
+                'foobar_foo' => 'foo',
+                'foobar_bar' => 'bar',
+            ],
+            'bars' => [
+                ['bar' => 'foo 0', 'foo' => 'bar 0'],
+                ['bar' => 'foo 1', 'foo' => 'bar 1'],
+                ['bar' => 'foo 2', 'foo' => 'bar 2'],
+            ],
+            'baz' => [
+                ['foo' => 'bar 0', 'bar' => ['foo' => 'bar 0', 'bar' => 'foo 0']],
+                ['foo' => 'bar 1', 'bar' => ['foo' => 'bar 1', 'bar' => 'foo 1']],
+            ],
+        ];
+    }
+}
+
+class JsonSerializableSingleResourceStub implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return [
+            ['foo' => 'foo 0', 'bar' => 'bar 0', 'foobar' => 'foobar 0'],
+            ['foo' => 'foo 1', 'bar' => 'bar 1', 'foobar' => 'foobar 1'],
+            ['foo' => 'foo 2', 'bar' => 'bar 2', 'foobar' => 'foobar 2'],
+            ['foo' => 'foo 3', 'bar' => 'bar 3', 'foobar' => 'foobar 3'],
+        ];
+    }
+}


### PR DESCRIPTION
This allows for a wildcard key to validate a recurring structure.

For example, an action might return a list of users:

```
/users
[
    ['id' => 1, 'name' => 'Foo'],
    ['id' => 2, 'name' => 'Bar']
]
```

You can now test this as follows:

```
$this->get('/users')->seeJsonStructure(['*' => ['id', 'name']]);
```

It also works with nested recurring structures:

```
/user/1 (each user has many pets)
[
    'id' => 1, 
    'name' => 'Foo', 
    'pets' => [['age' => 10, 'name' => 'Foo'], ['age' => 11, 'name' => 'Bar']]
],

$this->get('/users')->seeJsonStructure(['id', 'name', 'pets' => ['*' => ['age', 'name']]]);
```

I have also added a new unit test class in the name of `FoundationCrawlerTraitJsonTest` (inspired by the other test cases for the traits) for this method - as a `seeJsonStructure` test didn't exist in any form yet(?).
