### PR TITLE
Redirect output in quiet mode

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -38,6 +38,8 @@ class ServeCommand extends Command
         $host = $this->input->getOption('host');
 
         $port = $this->input->getOption('port');
+        
+        $quiet = $this->input->getOption('quiet') ? ' >& /dev/null' : '';
 
         $base = ProcessUtils::escapeArgument($this->laravel->basePath());
 
@@ -52,7 +54,7 @@ class ServeCommand extends Command
                 throw new Exception("HHVM's built-in server requires HHVM >= 3.8.0.");
             }
         } else {
-            passthru("{$binary} -S {$host}:{$port} {$base}/server.php");
+            passthru("{$binary} -S {$host}:{$port} {$base}/server.php{$quiet}");
         }
     }
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -38,7 +38,7 @@ class ServeCommand extends Command
         $host = $this->input->getOption('host');
 
         $port = $this->input->getOption('port');
-        
+
         $quiet = $this->input->getOption('quiet') ? ' >& /dev/null' : '';
 
         $base = ProcessUtils::escapeArgument($this->laravel->basePath());


### PR DESCRIPTION
I find it annoying to have all the requests logged into the console sometimes. So I think in quiet mode that's a good idea to not output anything.

I wasn't sure about the naming though, maybe a seperate option would be better? Like `--dont-log-requests`, maybe a little verbose...
