### PR TITLE
Replaced func_get_args with ellipses token in with() function

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -861,15 +861,11 @@ class Builder
     /**
      * Set the relationships that should be eager loaded.
      *
-     * @param  mixed  $relations
+     * @param  mixed  ...$relations
      * @return $this
      */
-    public function with($relations)
+    public function with(...$relations)
     {
-        if (is_string($relations)) {
-            $relations = func_get_args();
-        }
-
         $eagers = $this->parseWithRelations($relations);
 
         $this->eagerLoad = array_merge($this->eagerLoad, $eagers);


### PR DESCRIPTION
PHP 5.6 supports the ... token to denote variable length argument lists; refactoring shortens the function and eliminates IDE warnings.
