### PR TITLE
[5.1] Fluent Routing

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -627,7 +627,7 @@ class Route
     {
         if (is_null($action)) {
             return ['uses' => function () {
-                throw new RoutingException("The route has no action");
+                throw (new RoutingException("The route has no action."))->setRoute($this);
             }];
         }
         // If the action is already a Closure instance, we will just set that instance

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -625,6 +625,11 @@ class Route
      */
     protected function parseAction($action)
     {
+        if (is_null($action)) {
+            return ['uses' => function () {
+                throw new RoutingException("The route has no action");
+            }];
+        }
         // If the action is already a Closure instance, we will just set that instance
         // as the "uses" property, because there is nothing else we need to do when
         // it is available. Otherwise we will need to find it in the action list.
@@ -935,6 +940,11 @@ class Route
         $this->action['as'] = isset($this->action['as']) ? $this->action['as'].$name : $name;
 
         return $this;
+    }
+
+    public function using($action)
+    {
+        $this->setAction(array_merge($this->action, $this->parseAction($action)));
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -950,7 +950,7 @@ class Route
      */
     public function using($action)
     {
-        $this->setAction(array_merge($this->action, $this->parseAction($action)));
+        return $this->setAction(array_merge($this->action, $this->parseAction($action)));
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -948,7 +948,7 @@ class Route
      * @param  \Closure|array  $action
      * @return $this
      */
-    public function using($action)
+    public function uses($action)
     {
         return $this->setAction(array_merge($this->action, $this->parseAction($action)));
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -942,6 +942,12 @@ class Route
         return $this;
     }
 
+    /**
+     * Set the handler for the route.
+     *
+     * @param  \Closure|array  $action
+     * @return $this
+     */
     public function using($action)
     {
         $this->setAction(array_merge($this->action, $this->parseAction($action)));

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -627,7 +627,7 @@ class Route
     {
         if (is_null($action)) {
             return ['uses' => function () {
-                throw (new RoutingException("The route has no action."))->setRoute($this);
+                throw (new RoutingException('The route has no action.'))->setRoute($this);
             }];
         }
         // If the action is already a Closure instance, we will just set that instance

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -131,7 +131,7 @@ class Router implements RegistrarContract
      * @param  \Closure|array|string  $action
      * @return \Illuminate\Routing\Route
      */
-    public function get($uri, $action)
+    public function get($uri, $action = null)
     {
         return $this->addRoute(['GET', 'HEAD'], $uri, $action);
     }
@@ -143,7 +143,7 @@ class Router implements RegistrarContract
      * @param  \Closure|array|string  $action
      * @return \Illuminate\Routing\Route
      */
-    public function post($uri, $action)
+    public function post($uri, $action = null)
     {
         return $this->addRoute('POST', $uri, $action);
     }
@@ -155,7 +155,7 @@ class Router implements RegistrarContract
      * @param  \Closure|array|string  $action
      * @return \Illuminate\Routing\Route
      */
-    public function put($uri, $action)
+    public function put($uri, $action = null)
     {
         return $this->addRoute('PUT', $uri, $action);
     }
@@ -167,7 +167,7 @@ class Router implements RegistrarContract
      * @param  \Closure|array|string  $action
      * @return \Illuminate\Routing\Route
      */
-    public function patch($uri, $action)
+    public function patch($uri, $action = null)
     {
         return $this->addRoute('PATCH', $uri, $action);
     }
@@ -179,7 +179,7 @@ class Router implements RegistrarContract
      * @param  \Closure|array|string  $action
      * @return \Illuminate\Routing\Route
      */
-    public function delete($uri, $action)
+    public function delete($uri, $action = null)
     {
         return $this->addRoute('DELETE', $uri, $action);
     }
@@ -191,7 +191,7 @@ class Router implements RegistrarContract
      * @param  \Closure|array|string  $action
      * @return \Illuminate\Routing\Route
      */
-    public function options($uri, $action)
+    public function options($uri, $action = null)
     {
         return $this->addRoute('OPTIONS', $uri, $action);
     }
@@ -203,7 +203,7 @@ class Router implements RegistrarContract
      * @param  \Closure|array|string  $action
      * @return \Illuminate\Routing\Route
      */
-    public function any($uri, $action)
+    public function any($uri, $action = null)
     {
         $verbs = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'];
 
@@ -218,7 +218,7 @@ class Router implements RegistrarContract
      * @param  \Closure|array|string  $action
      * @return \Illuminate\Routing\Route
      */
-    public function match($methods, $uri, $action)
+    public function match($methods, $uri, $action = null)
     {
         return $this->addRoute(array_map('strtoupper', (array) $methods), $uri, $action);
     }

--- a/src/Illuminate/Routing/RoutingException.php
+++ b/src/Illuminate/Routing/RoutingException.php
@@ -7,5 +7,13 @@ use RuntimeException;
 
 class RoutingException extends RuntimeException
 {
+    protected $route;
 
+    public function setRoute(Route $route)
+    {
+        $this->route = $route;
+        $this->message .= " Failed for route ".$route->uri();
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Routing/RoutingException.php
+++ b/src/Illuminate/Routing/RoutingException.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Routing;
 
-use Exception;
 use RuntimeException;
 
 class RoutingException extends RuntimeException

--- a/src/Illuminate/Routing/RoutingException.php
+++ b/src/Illuminate/Routing/RoutingException.php
@@ -11,7 +11,7 @@ class RoutingException extends RuntimeException
     public function setRoute(Route $route)
     {
         $this->route = $route;
-        $this->message .= " Failed for route ".$route->uri();
+        $this->message .= ' Failed for route '.$route->uri();
 
         return $this;
     }

--- a/src/Illuminate/Routing/RoutingException.php
+++ b/src/Illuminate/Routing/RoutingException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Exception;
+use RuntimeException;
+
+class RoutingException extends RuntimeException
+{
+
+}

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -94,7 +94,7 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Illuminate\Routing\RoutingException
-     * @expectedExceptionMessage The route has no action
+     * @expectedExceptionMessage The route has no action. Failed for route foo/bar
      */
     public function testFluentRouting()
     {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -92,6 +92,24 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('closure', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
+    /**
+     * @expectedException \Illuminate\Routing\RoutingException
+     * @expectedExceptionMessage The route has no action
+     */
+    public function testFluentRouting()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/bar');
+        $router->dispatch(Request::create('foo/bar', 'GET'));
+
+        $router->get('foo/bar')->using(function () { return 'hello'; });
+        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+
+        $router->get('foo/bar')->using(function () { return 'middleware'; })->middleware('RouteTestControllerMiddleware');
+        $this->assertEquals('middleware', $router->dispatch(Request::create('foo/bar'))->getContent());
+        $this->assertContains('RouteTestControllerMiddleware', $router->getMiddleware());
+    }
+
     public function testFluentRouteNamingWithinAGroup()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -99,15 +99,19 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
     public function testFluentRouting()
     {
         $router = $this->getRouter();
-        $router->get('foo/bar');
-        $router->dispatch(Request::create('foo/bar', 'GET'));
 
         $router->get('foo/bar')->using(function () { return 'hello'; });
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
+        $router->post('foo/bar')->using(function () { return 'hello'; });
+        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'POST'))->getContent());
+
         $router->get('foo/bar')->using(function () { return 'middleware'; })->middleware('RouteTestControllerMiddleware');
         $this->assertEquals('middleware', $router->dispatch(Request::create('foo/bar'))->getContent());
-        $this->assertContains('RouteTestControllerMiddleware', $router->getMiddleware());
+        $this->assertContains('RouteTestControllerMiddleware', $router->getCurrentRoute()->middleware());
+
+        $router->get('foo/bar');
+        $router->dispatch(Request::create('foo/bar', 'GET'));
     }
 
     public function testFluentRouteNamingWithinAGroup()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -100,13 +100,13 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
     {
         $router = $this->getRouter();
 
-        $router->get('foo/bar')->using(function () { return 'hello'; });
+        $router->get('foo/bar')->uses(function () { return 'hello'; });
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
-        $router->post('foo/bar')->using(function () { return 'hello'; });
+        $router->post('foo/bar')->uses(function () { return 'hello'; });
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'POST'))->getContent());
 
-        $router->get('foo/bar')->using(function () { return 'middleware'; })->middleware('RouteTestControllerMiddleware');
+        $router->get('foo/bar')->uses(function () { return 'middleware'; })->middleware('RouteTestControllerMiddleware');
         $this->assertEquals('middleware', $router->dispatch(Request::create('foo/bar'))->getContent());
         $this->assertContains('RouteTestControllerMiddleware', $router->getCurrentRoute()->middleware());
 


### PR DESCRIPTION
This brings a full circle to fluent routing definitions by allowing users to set an action fluently. This can be done like follows:

```
$router->get('foo/bar')->uses('YourController@action');
```

Chaining with other methods works exactly like before, meaning you can do:

```
$router->get('foo/bar')->uses('YourController@action')->middleware('auth')->name('foo.bar');
```

If a user does not provide an action, an exception will be thrown informing the user of this, with the route URI as part of the exception message.

This is currently targeting 5.1, but I can of course do the merges for 5.2 and 5.3 in case of merge conflicts.
