### PR TITLE
[5.2] Do scheduled events need to run in the background?

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -142,11 +142,7 @@ class Event
      */
     public function run(Container $container)
     {
-        if (count($this->afterCallbacks) > 0 || count($this->beforeCallbacks) > 0) {
-            $this->runCommandInForeground($container);
-        } else {
-            $this->runCommandInBackground();
-        }
+        $this->runCommandInForeground($container);
     }
 
     /**


### PR DESCRIPTION
I thought that I'd suggest this change to open discussion about how this currently runs.

It's being raised because we noticed that a scheduled task wasn't being run. It was only after we added before and after functions for logging that it started to work. When digging into it we see that it's run in a different way when before or after functions are present.

For consistency, could all scheduled tasks be run using the open_proc method rather than exec?
Alternatively, should an explicit "runInBackground" flag be made available?
