### PR TITLE
[5.2] Validation - Fix for Exists and Unique

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1085,9 +1085,7 @@ class Validator implements ValidatorContract
         // data store like Redis, etc. We will use it to determine uniqueness.
         $verifier = $this->getPresenceVerifier();
 
-        if (! is_null($connection)) {
-            $verifier->setConnection($connection);
-        }
+        $verifier->setConnection($connection);
 
         $extra = $this->getUniqueExtra($parameters);
 
@@ -1175,9 +1173,7 @@ class Validator implements ValidatorContract
     {
         $verifier = $this->getPresenceVerifier();
 
-        if (! is_null($connection)) {
-            $verifier->setConnection($connection);
-        }
+        $verifier->setConnection($connection);
 
         $extra = $this->getExtraExistConditions($parameters);
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -193,11 +193,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $trans = $this->getRealTranslator();
         $trans->addResource('array', ['validation.in' => ':attribute must be included in :values.'], 'en', 'messages');
         $customValues = [
-                 'type' => [
-                     '5'   => 'Short',
-                     '300' => 'Long',
-                    ],
-                ];
+            'type' => [
+                '5'   => 'Short',
+                '300' => 'Long',
+            ],
+        ];
         $v = new Validator($trans, ['type' => '4'], ['type' => 'in:5,300']);
         $v->addCustomValues($customValues);
         $this->assertFalse($v->passes());
@@ -208,11 +208,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $trans = $this->getRealTranslator();
         $trans->addResource('array', ['validation.in' => ':attribute must be included in :values.'], 'en', 'messages');
         $customValues = [
-                 'type' => [
-                     '5'   => 'Short',
-                     '300' => 'Long',
-                    ],
-                ];
+            'type' => [
+                '5'   => 'Short',
+                '300' => 'Long',
+            ],
+        ];
         $v = new Validator($trans, ['type' => '4'], ['type' => 'in:5,300']);
         $v->setValueNames($customValues);
         $this->assertFalse($v->passes());
@@ -993,6 +993,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $trans = $this->getRealTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(0);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
@@ -1006,21 +1007,24 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,1']);
-        $mock2 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock2->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id', [])->andReturn(1);
-        $v->setPresenceVerifier($mock2);
+        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id', [])->andReturn(1);
+        $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,1,id_col']);
-        $mock3 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock3->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id_col', [])->andReturn(2);
-        $v->setPresenceVerifier($mock3);
+        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id_col', [])->andReturn(2);
+        $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,NULL,id_col,foo,bar']);
-        $mock3 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock3->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', null, 'id_col', ['foo' => 'bar'])->andReturn(2);
-        $v->setPresenceVerifier($mock3);
+        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', null, 'id_col', ['foo' => 'bar'])->andReturn(2);
+        $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
     }
 
@@ -1029,34 +1033,38 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $trans = $this->getRealTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(true);
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $trans = $this->getRealTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users,email,account_id,1,name,taylor']);
-        $mock4 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock4->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, ['account_id' => 1, 'name' => 'taylor'])->andReturn(true);
-        $v->setPresenceVerifier($mock4);
+        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, ['account_id' => 1, 'name' => 'taylor'])->andReturn(true);
+        $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:users,email_addr']);
-        $mock2 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock2->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', null, null, [])->andReturn(false);
-        $v->setPresenceVerifier($mock2);
+        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', null, null, [])->andReturn(false);
+        $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => ['foo']], ['email' => 'Exists:users,email_addr']);
-        $mock3 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock3->shouldReceive('getMultiCount')->once()->with('users', 'email_addr', ['foo'], [])->andReturn(false);
-        $v->setPresenceVerifier($mock3);
+        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('getMultiCount')->once()->with('users', 'email_addr', ['foo'], [])->andReturn(false);
+        $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Exists:connection.users']);
-        $mock5 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock5->shouldReceive('setConnection')->once()->with('connection');
-        $mock5->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(true);
-        $v->setPresenceVerifier($mock5);
+        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('setConnection')->once()->with('connection');
+        $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', null, null, [])->andReturn(true);
+        $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
     }
 
@@ -1064,16 +1072,17 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     {
         $trans = $this->getRealTranslator();
         $v = new Validator($trans, ['id' => 'foo'], ['id' => 'Integer|Exists:users,id']);
-        $mock2 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock2->shouldReceive('getCount')->never();
-        $v->setPresenceVerifier($mock2);
+        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('getCount')->never();
+        $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 
         $trans = $this->getRealTranslator();
         $v = new Validator($trans, ['id' => '1'], ['id' => 'Integer|Exists:users,id']);
-        $mock2 = m::mock('Illuminate\Validation\PresenceVerifierInterface');
-        $mock2->shouldReceive('getCount')->once()->with('users', 'id', '1', null, null, [])->andReturn(true);
-        $v->setPresenceVerifier($mock2);
+        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('getCount')->once()->with('users', 'id', '1', null, null, [])->andReturn(true);
+        $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
When using a non default connection with a default connection at same time, the last connection name is used for the subsequent validations.

Example:

```
$validator = validator($request->all(), [
    'author' => ['required', 'integer', 'exists:connection2.author,id'],
    'id' => ['required', 'integer', 'exists:user,id']
]);
```

It will try to validate the `id` using the `connection2` (connection2.user).

To solve this issue we always need to call `setConnection()` (using a valid connection name or just a null value):

https://github.com/laravel/framework/blob/5.2/src/Illuminate/Validation/Validator.php#L1179

The `parseTable()` method returns `null` if a connection name doesn't exist:

https://github.com/laravel/framework/blob/5.2/src/Illuminate/Validation/Validator.php#L1152

As you can see:

https://github.com/laravel/framework/blob/5.2/src/Illuminate/Validation/Validator.php#L1109

And the `ConnectionResolver` always will use the default connection name, If necessary:

https://github.com/laravel/framework/blob/5.2/src/Illuminate/Database/ConnectionResolver.php#L42
