### PR TITLE
Pre and Post methods to saving

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3521,7 +3521,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  Object $original
      * @return void
      */
-    public function beforeSave($original) {}
+    public function beforeSave($original)
+    {
+    }
 
     /**
      * Return the comparative values after a save
@@ -3530,7 +3532,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  Object $after
      * @return void
      */
-    public function afterSave($original, $after) {}
+    public function afterSave($original, $after)
+    {
+    }
 
     /**
      * Determine if an attribute exists on the model.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1548,6 +1548,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $this->finishSave($options);
         }
 
+        $afterAttributes = $query->first()->attributes;
 
         $this->afterSave($originalAttributes, $afterAttributes);
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3516,9 +3516,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Return value before a save
+     * Return value before a save.
      *
-     * @param  Object $original
+     * @param  object $original
      * @return void
      */
     public function beforeSave($original)
@@ -3526,10 +3526,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Return the comparative values after a save
+     * Return the comparative values after a save.
      *
-     * @param  Object $original
-     * @param  Object $after
+     * @param  object $original
+     * @param  object $after
      * @return void
      */
     public function afterSave($original, $after)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1519,9 +1519,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $query = $this->newQueryWithoutScopes();
 
-        $originalAttributes = $query->first()->attributes;
-
-        $this->beforeSave($originalAttributes);
+        $originalAttributes = $this->attributes;
 
         // If the "saving" event returns false we'll bail out of the save and return
         // false, indicating that the save failed. This provides a chance for any
@@ -1534,6 +1532,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // that is already in this database using the current IDs in this "where"
         // clause to only update this model. Otherwise, we'll just insert them.
         if ($this->exists) {
+            $this->beforeSave($originalAttributes);
             $saved = $this->performUpdate($query, $options);
         }
 
@@ -1546,11 +1545,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         if ($saved) {
             $this->finishSave($options);
+            $afterAttributes = $this->attributes;
+            $this->afterSave($originalAttributes, $afterAttributes);
         }
-
-        $afterAttributes = $query->first()->attributes;
-
-        $this->afterSave($originalAttributes, $afterAttributes);
 
         return $saved;
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1519,6 +1519,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $query = $this->newQueryWithoutScopes();
 
+        $originalAttributes = $query->first()->attributes;
+
+        $this->beforeSave($originalAttributes);
+
         // If the "saving" event returns false we'll bail out of the save and return
         // false, indicating that the save failed. This provides a chance for any
         // listeners to cancel save operations if validations fail or whatever.
@@ -1543,6 +1547,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if ($saved) {
             $this->finishSave($options);
         }
+
+
+        $this->afterSave($originalAttributes, $afterAttributes);
 
         return $saved;
     }
@@ -3506,6 +3513,23 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         unset($this->$offset);
     }
+
+    /**
+     * Return value before a save
+     *
+     * @param  Object $original
+     * @return void
+     */
+    public function beforeSave($original) {}
+
+    /**
+     * Return the comparative values after a save
+     *
+     * @param  Object $original
+     * @param  Object $after
+     * @return void
+     */
+    public function afterSave($original, $after) {}
 
     /**
      * Determine if an attribute exists on the model.

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -134,6 +134,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     {
         $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $query->shouldReceive('first')->once()->andReturn($model);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -157,6 +158,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     {
         $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $query->shouldReceive('first')->once()->andReturn($model);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['created_at' => 'foo', 'updated_at' => 'bar'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -188,6 +190,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     {
         $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $query->shouldReceive('first')->once()->andReturn($model);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
         $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(true);
@@ -203,6 +206,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'fireModelEvent']);
         $model->timestamps = false;
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $query->shouldReceive('first')->once()->andReturn($model);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -220,6 +224,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     {
         $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $query->shouldReceive('first')->once()->andReturn($model);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['id' => 2, 'foo' => 'bar'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -1149,6 +1154,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     {
         $model = m::mock('EloquentModelStub[newQueryWithoutScopes]');
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $query->shouldReceive('first')->once()->andReturn($model);
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
         $model->shouldReceive('newQueryWithoutScopes')->once()->andReturn($query);


### PR DESCRIPTION
Allows comparison between after and pre-emptive interruption of data on
the model. The intent is to allow an aftermath comparison of a model - without the loss of a save. 
