### PR TITLE
[5.2] Allow Validator Interaction on ValidatesRequests

### DIFF
--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -24,11 +24,16 @@ trait ValidatesRequests
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
+     * @param  callable  $callback
      * @return void
      */
-    public function validate(Request $request, array $rules, array $messages = [], array $customAttributes = [])
+    public function validate(Request $request, array $rules, array $messages = [], array $customAttributes = [], callable $callback = null)
     {
-        $validator = $this->getValidationFactory()->make($request->all(), $rules, $messages, $customAttributes);
+        $validator = $this->getValidationFactory()->make($data, $rules, $messages, $customAttributes);
+
+        if ($callback) {
+            call_user_func($callback, $validator);
+        }
 
         if ($validator->fails()) {
             $this->throwValidationException($request, $validator);
@@ -47,10 +52,10 @@ trait ValidatesRequests
      *
      * @throws \Illuminate\Foundation\Validation\ValidationException
      */
-    public function validateWithBag($errorBag, Request $request, array $rules, array $messages = [], array $customAttributes = [])
+    public function validateWithBag($errorBag, Request $request, array $rules, array $messages = [], array $customAttributes = [], callable $callback = null)
     {
         $this->withErrorBag($errorBag, function () use ($request, $rules, $messages, $customAttributes) {
-            $this->validate($request, $rules, $messages, $customAttributes);
+            $this->validate($request, $rules, $messages, $customAttributes, $callback);
         });
     }
 

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -11,13 +11,6 @@ use Illuminate\Contracts\Validation\Validator;
 trait ValidatesRequests
 {
     /**
-     * Conditional validation rules based on a Closure.
-     *
-     * @var array
-     */
-    protected $validatesRequestSometimes = [];
-
-    /**
      * The default error bag.
      *
      * @var string

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -15,7 +15,7 @@ trait ValidatesRequests
      *
      * @var array
      */
-    protected $sometimes = [];
+    protected $validatesRequestSometimes = [];
 
     /**
      * The default error bag.
@@ -34,7 +34,7 @@ trait ValidatesRequests
      */
     public function sometimes($attribute, $rules, callable $callback)
     {
-        array_push($this->sometimes, compact('attribute', 'rules', 'callback'));
+        array_push($this->validatesRequestSometimes, compact('attribute', 'rules', 'callback'));
 
         return $this;
     }
@@ -144,11 +144,11 @@ trait ValidatesRequests
     {
         $validator = $this->getValidationFactory()->make($data, $rules, $messages, $customAttributes);
 
-        foreach ($this->sometimes as $sometimes) {
+        foreach ($this->validatesRequestSometimes as $sometimes) {
             $validator->sometimes($sometimes['attribute'], $sometimes['rules'], $sometimes['callback']);
         }
 
-        $this->sometimes = [];
+        $this->validatesRequestSometimes = [];
 
         return $validator;
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -245,7 +245,7 @@ class Validator implements ValidatorContract
     /**
      * Add conditions to a given field based on a Closure.
      *
-     * @param  string  $attribute
+     * @param  string|array  $attribute
      * @param  string|array  $rules
      * @param  callable  $callback
      * @return void


### PR DESCRIPTION
Allow interaction with the Validator instance on ValidatesRequests by calling passing a callback as last parameter in `validate` or `validateWithBag`.

Example:

``` php
/**
 * Store a new game collector.
 *
 * @param  Request  $request
 * @return Response
 */
public function store(Request $request)
{
    $this->validate($request, [
        'email' => 'required|email',
        'games' => 'required|numeric',
    ], [], [], function($validator) {
        $validator->sometimes('reason', 'required|max:500', function($input) {
            return $input->games >= 100;
        });
    });

    // The game collector is valid, store in database...
}
```
