### PR TITLE
[5.3] Make resource routes singular

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -53,7 +53,7 @@ class ResourceRegistrar
         // We need to extract the base resource from the resource name. Nested resources
         // are supported in the framework, but we need to know what name to use for a
         // place-holder on the route wildcards, which should be the base resources.
-        $base = $this->getResourceWildcard(last(explode('.', $name)));
+        $base = str_singular($this->getResourceWildcard(last(explode('.', $name))));
 
         $defaults = $this->resourceDefaults;
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -418,6 +418,13 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testImplicitModelBinding()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{user}', function (ImplicitModelBindingStub $user) { return $user->value; });
+        $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+    }
+
     /**
      * @expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
@@ -651,21 +658,21 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foo-bars/{foo_bars}', $routes[0]->getUri());
+        $this->assertEquals('foo-bars/{foo_bar}', $routes[0]->getUri());
 
         $router = $this->getRouter();
         $router->resource('foo-bars.foo-bazs', 'FooController', ['only' => ['show']]);
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foo-bars/{foo_bars}/foo-bazs/{foo_bazs}', $routes[0]->getUri());
+        $this->assertEquals('foo-bars/{foo_bars}/foo-bazs/{foo_baz}', $routes[0]->getUri());
 
         $router = $this->getRouter();
         $router->resource('foo-bars', 'FooController', ['only' => ['show'], 'as' => 'prefix']);
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foo-bars/{foo_bars}', $routes[0]->getUri());
+        $this->assertEquals('foo-bars/{foo_bar}', $routes[0]->getUri());
         $this->assertEquals('prefix.foo-bars.show', $routes[0]->getName());
     }
 
@@ -909,6 +916,28 @@ class RouteModelBindingStub
     public function first()
     {
         return strtoupper($this->value);
+    }
+}
+
+class ImplicitModelBindingStub extends \Illuminate\Database\Eloquent\Model
+{
+    public $value;
+
+    public function getRouteKeyName()
+    {
+        return 'id';
+    }
+
+    public function where($key, $value)
+    {
+        $this->value = strtoupper($value);
+
+        return $this;
+    }
+
+    public function firstOrFail()
+    {
+        return $this;
     }
 }
 


### PR DESCRIPTION
Currently, the resource's name will be used for the route wildcards to the `show`, `update` and `delete` methods. This PR modifies this behaviour to use the singular form of the resource name. The reason for it is that implicit route model binding requires you to use the same variable name as the name of the wildcard. Hence, this PR allows for more sane (aka singular) variable naming.

Example:

``` php
routes.php

Route::resource('users', 'UsersController');

----------------------------------------
UsersController.php

public function show(User $user)
{
    //
}
```

In the example above, prior to this PR, the variable would have to be named `$users` to be implicitly bound to its model.
