### PR TITLE
[5.2] Added new validation rule to skip other rules on first validation rule fail

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -316,6 +316,9 @@ class Validator implements ValidatorContract
         foreach ($this->rules as $attribute => $rules) {
             foreach ($rules as $rule) {
                 $this->validate($attribute, $rule);
+                if ($this->shouldBreakOnFail($attribute)) {
+                    break;
+                }
             }
         }
 
@@ -524,6 +527,33 @@ class Validator implements ValidatorContract
     protected function validateSometimes()
     {
         return true;
+    }
+
+    /**
+     * "Break" on first validation fail.
+     *
+     * Always returns true, just lets us put failonfirst in rules.
+     *
+     * @return bool
+     */
+    protected function validateFailOnFirst()
+    {
+        return true;
+    }
+
+    /**
+     * Stop on error if failonfirst rule is given.
+     *
+     * @param string $attribute
+     * @return bool
+     */
+    protected function shouldBreakOnFail($attribute)
+    {
+        if (! $this->hasRule($attribute, ['Failonfirst'])) {
+            return false;
+        }
+
+        return $this->messages->has($attribute);
     }
 
     /**


### PR DESCRIPTION
Reference issue - #4789

New validation rule - <strong>bail</strong> (rule name updated by Taylorotwell)

When we use multiple rules, sometimes it is required to stop validating other rules on a specific rule fails.

For example, if you have an `int` field in database and you are using `numeric` rule and `unique` rule for the field. This may throw a Database error if the input is not numeric. Because validation checks both the rules. 
Numeric check will return false, but exists check will also execute with non-integer value.

``` php
'user_id' => 'numeric|unique:users'
```

In this case we can use this optional rule `bail` to execute validation in rule order and skip other rules if any of the rules fails. For example,

``` php
'user_id' => 'bail|numeric|unique:users'
```

Now only if the `numeric` rule pass, validation will check `unique` rule, that will avoid db error.
This rule can be optional. Validation will be skipped only if we use this rule.

You have to give the rules in <strong>proper order</strong> to execute on by one.

I am sure that this can help many!
