### PR TITLE
[5.1] BelongsToMany : fix pivot timestamps docblocks.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -57,14 +57,14 @@ class BelongsToMany extends Relation
     /**
      * The custom pivot table column for the created_at timestamp.
      *
-     * @var array
+     * @var string
      */
     protected $pivotCreatedAt;
 
     /**
      * The custom pivot table column for the updated_at timestamp.
      *
-     * @var array
+     * @var string
      */
     protected $pivotUpdatedAt;
 


### PR DESCRIPTION
Fix pivot timestamps docblocks for `\Illuminate\Database\Eloquent\Relations\BelongsToMany::$pivotCreatedAt` and `\Illuminate\Database\Eloquent\Relations\BelongsToMany::$pivotUpdatedAt`.

Note: these were added in #8715

---

Replace #11991 
