### PR TITLE
[5.2] Fixed phpdoc and condensed logic

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -218,7 +218,7 @@ class Arr
     /**
      * Get an item from an array using "dot" notation.
      *
-     * @param  array|\ArrayAccess   $array
+     * @param  \ArrayAccess|array  $array
      * @param  string  $key
      * @param  mixed   $default
      * @return mixed

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -234,12 +234,11 @@ class Arr
         }
 
         foreach (explode('.', $key) as $segment) {
-            if ((! is_array($array) || ! isset($array[$segment])) &&
-                (! $array instanceof ArrayAccess || ! isset($array[$segment]))) {
+            if ((is_array($array) || $array instanceof ArrayAccess) && isset($array[$segment])) {
+                $array = $array[$segment];
+            } else {
                 return value($default);
             }
-
-            $array = $array[$segment];
         }
 
         return $array;

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -234,8 +234,8 @@ class Arr
         }
 
         foreach (explode('.', $key) as $segment) {
-            if ((! is_array($array) || ! array_key_exists($segment, $array)) &&
-                (! $array instanceof ArrayAccess || ! $array->offsetExists($segment))) {
+            if ((! is_array($array) || ! isset($array[$segment])) &&
+                (! $array instanceof ArrayAccess || ! isset($array[$segment]))) {
                 return value($default);
             }
 


### PR DESCRIPTION
The logic condensing was done by first replacing the two unneededly different exists checks, then using distributivity and de morgan laws to condense it.
