### PR TITLE
[5.2] Allow for implicit model binding with arbitrary variable names

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -834,20 +834,29 @@ class Router implements RegistrarContract
     protected function substituteImplicitBindings($route)
     {
         $parameters = $route->parameters();
+        $toBind = [];
+        $count = 0;
 
-        foreach ($route->signatureParameters(Model::class) as $parameter) {
+        foreach ($route->signatureParameters() as $parameter) {
             $class = $parameter->getClass();
+            if (! $class || $class->isSubclassOf(Model::class)) {
+                $toBind[] = $parameter;
+            } else {
+                $count++;
+            }
+        }
 
-            if (array_key_exists($parameter->name, $parameters) &&
-                ! $route->getParameter($parameter->name) instanceof Model) {
+        foreach ($toBind as $i => $parameter) {
+            $class = $parameter->getClass();
+            if ($class && ! $parameters[$route->parameterNames()[$i]] instanceof Model) {
                 $method = $parameter->isDefaultValueAvailable() ? 'first' : 'firstOrFail';
 
                 $model = $class->newInstance();
 
                 $route->setParameter(
-                    $parameter->name, $model->where(
-                        $model->getRouteKeyName(), $parameters[$parameter->name]
-                    )->{$method}()
+                    $route->parameterNames()[$i], $model->where(
+                    $model->getRouteKeyName(), $parameters[$route->parameterNames()[$i]]
+                )->{$method}()
                 );
             }
         }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -835,14 +835,11 @@ class Router implements RegistrarContract
     {
         $parameters = $route->parameters();
         $toBind = [];
-        $count = 0;
 
         foreach ($route->signatureParameters() as $parameter) {
             $class = $parameter->getClass();
             if (! $class || $class->isSubclassOf(Model::class)) {
                 $toBind[] = $parameter;
-            } else {
-                $count++;
             }
         }
 


### PR DESCRIPTION
Basically, previously, if we wanted to use implicit model binding, we had to use the same name for our variable as for the wildcard name. With this PR, we can use any variable name, and, as long as we type hint our model, it will be implicitly bound.

As a side effect, this makes #11984 non-breaking, meaning it could then be done for 5.2 instead of 5.3, success.

This works in several steps, since we don't know exactly what's bound and what isn't.
1. Loop through all function signature parameters
2. If it is typehinted with something that’s not a class (or not at all) or a model, add it to an array
3. We now have a list of items that should be mapped to route variables, so just do that, and if an item is already bound or not a Model, ignore it and go ahead with the next

Step 2 is necessary so that we don't accidentally include something that should have been bound by the IOC container. The reason for including non-models, rather than just doing `$route->signatureParameters(Model::class)` is so that we can keep our array of wildcards aligned with that of the function signature of the called method. Basically, a route `foo/{bar}/{baz}` needs to map `bar` and `baz`, so we keep track of all things that should be mapped, even those that are done so explicitly, and those that aren't at all, in order to determine to which route parameter we should bind the model.
