### PR TITLE
[5.2] remove Builder's each() function

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Query;
 
 use Closure;
-use RuntimeException;
 use BadMethodCallException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -1609,30 +1608,6 @@ class Builder
         }
 
         return true;
-    }
-
-    /**
-     * Execute a callback over each item while chunking.
-     *
-     * @param  callable  $callback
-     * @param  int  $count
-     * @return bool
-     *
-     * @throws \RuntimeException
-     */
-    public function each(callable $callback, $count = 1000)
-    {
-        if (is_null($this->orders) && is_null($this->unionOrders)) {
-            throw new RuntimeException('You must specify an orderBy clause when using the "each" function.');
-        }
-
-        return $this->chunk($count, function ($results) use ($callback) {
-            foreach ($results as $key => $value) {
-                if ($callback($item, $key) === false) {
-                    return false;
-                }
-            }
-        });
     }
 
     /**


### PR DESCRIPTION
Just a minor cleanup. While digging through something I noticed that the `each()` function in Builder was referencing an undefined variable **(`$item`)**. When I looked further, I realized `each()` never actually gets called by anything (that I can find -- please correct me if wrong)

_(The `$item` variable is in the callback of the `foreach()` loop.)_

``` php
public function each(callable $callback, $count = 1000)
{
    if (is_null($this->orders) && is_null($this->unionOrders)) {
        throw new RuntimeException('You must specify an orderBy clause when using the "each" function.');
    }

    return $this->chunk($count, function ($results) use ($callback) {
        foreach ($results as $key => $value) {
            if ($callback($item, $key) === false) {
                return false;
            }
        }
    });
}
```
