### PR TITLE
[5.1] Update failed_jobs.stub

### DIFF
--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -17,7 +17,7 @@ class Create{{tableClassName}}Table extends Migration
             $table->text('connection');
             $table->text('queue');
             $table->longText('payload');
-            $table->timestamp('failed_at');
+            $table->timestamp('failed_at')->useCurrent();
         });
     }
 


### PR DESCRIPTION
Not having a default for mySQL 5.6 can cause migration issues.

Related to https://github.com/laravel/framework/issues/3602
