### PR TITLE
[5.2] Checking value in isJsonCastable function

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2845,7 +2845,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function isJsonCastable($key, $value)
     {
-        return $this->hasCast($key, ['array', 'json', 'object', 'collection']) && (is_array($value) || $value instanceOf JsonSerializable);
+        return $this->hasCast($key, ['array', 'json', 'object', 'collection']) &&
+                (is_array($value) || is_object($value));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2840,11 +2840,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * Determine whether a value is JSON castable for inbound manipulation.
      *
      * @param  string  $key
+     * @param  mixed  $value
      * @return bool
      */
-    protected function isJsonCastable($key)
+    protected function isJsonCastable($key, $value)
     {
-        return $this->hasCast($key, ['array', 'json', 'object', 'collection']);
+        return $this->hasCast($key, ['array', 'json', 'object', 'collection']) && (is_array($value) || $value instanceOf JsonSerializable);
     }
 
     /**
@@ -2926,7 +2927,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $value = $this->fromDateTime($value);
         }
 
-        if ($this->isJsonCastable($key) && ! is_null($value)) {
+        if ($this->isJsonCastable($key, $value) && ! is_null($value)) {
             $value = $this->asJson($value);
         }
 


### PR DESCRIPTION
# Situation

We need to store some json data in pivot table. And for that we decide to use Eloquent attribute casting functionality, for more easily setting and getting data.

For that we must create custom pivot model and set `protected $casting` property.

---
#### expected:

attribute setted in `$casting` property as `json` or `array` will be automaticaly casted in array by accesing that property on our custom pivot model and any setted `array` or `JsonSerializable` object will be json encoded for storing in database.
#### actually:

when pivot model loading, values in castable properties will be double encoded and therefore can not be correctly decoded as we expect.
#10533 and partially #8972

---
##### how to reproduce:
- You can clone prepared by me app for demonstrating this issue. https://github.com/evsign/laravelpivotissue.git/
- Or follow instructions:

create new laravel project

```
php artisan make:migration create_students_table --create=students 
php artisan make:migration create_subjects_table --create=subjects
php artisan make:migration create_student_subject_table --create=student_subject
php artisan make:model Student
php artisan make:model Subject
php artisan make:model StudentSubjectPivot
```

Migrations

``` php
students:
    $table->increments('id');
    $table->string('name');
    $table->string('email');
    $table->timestamps();
subjects:
    $table->increments('id');
    $table->string('name');
    $table->string('description');
    $table->timestamps();
student_subject:
    $table->unsignedInteger('student_id');
    $table->unsignedInteger('subject_id');
    $table->text('marks'); //or $table->json('marks');
    $table->timestamps();
```

Student.php model

``` php
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;

class Student extends Model
{
    protected $fillable = [
        'name',
        'email'
    ];

    public function subjects()
    {
        return $this->belongsToMany('App\Subject')->withPivot('marks');
    }

    public function newPivot(Model $parent, array $attributes, $table, $exists)
    {
        if ($parent instanceof Subject) {
            return new StudentSubjectPivot($parent, $attributes, $table, $exists);
        }

        return parent::newPivot($parent, $attributes, $table, $exists);
    }
}
```

Subject.php model

``` php
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;

class Subject extends Model
{
    protected $fillable = [
        'name',
        'description'
    ];

    public function students()
    {
        return $this->belongsToMany('App\Student')->withPivot('marks');
    }

    public function newPivot(Model $parent, array $attributes, $table, $exists)
    {
        if ($parent instanceof Student) {
            return new StudentSubjectPivot($parent, $attributes, $table, $exists);
        }

        return parent::newPivot($parent, $attributes, $table, $exists);
    }
}
```

StudentSubjectPivot.php model

``` php
<?php

namespace App;

use Illuminate\Database\Eloquent\Relations\Pivot;
use Illuminate\Database\Eloquent\Model;

class StudentSubjectPivot extends Pivot
{
    protected $casts = [
        'marks' => 'array'
    ];

}
```

Then fill database with test data including pivot marks column with json

``` php
$student = App\Student::create(['name' => 'evsign', 'email' => 'evsign@live.ru']);
$subject = App\Subject::create(['name' => 'mathematics', 'description' => 'language of the universe']);
$student->subjects()->attach([$subject->id => [ 'marks' => '[{"date":"2009-12-29 03:01:18","mark":"D"},{"date":"2009-12-29 03:00:40","mark":"F"},{"date":"2009-12-29 03:01:00","mark":"B"},{"date":"2009-12-29 03:00:33","mark":"C"},{"date":"2009-12-29 03:01:09","mark":"A"},{"date":"2009-12-29 03:00:27","mark":"A"},{"date":"2009-12-29 03:00:37","mark":"A"},{"date":"2009-12-29 03:00:25","mark":"F"}]']]);
dd(App\Student::find($student->id)->subjects()->first()->pivot->marks); // will be string instead of array
```

---
### For fix this issue

Use accessors and mutators with checking values

or

I suggest to send and check values for `array` or `object` in isJsonCastable function in `Illuminate\Database\Eloquen\Model.php`.  :relaxed:
