### PR TITLE
[5.2] Added 3rd param $headers of abort() to put on the response

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -152,7 +152,7 @@ class Handler implements ExceptionHandlerContract
         $status = $e->getStatusCode();
 
         if (view()->exists("errors.{$status}")) {
-            return response()->view("errors.{$status}", ['exception' => $e], $status);
+            return response()->view("errors.{$status}", ['exception' => $e], $status, $e->getHeaders());
         } else {
             return $this->convertExceptionToResponse($e);
         }


### PR DESCRIPTION
This PR is fixed for No effect HTTP BASIC Authentication.

```
return abort(401, 'Unauthorized', ['WWW-Authenticate' => 'Basic']);
```
