### PR TITLE
[5.1] Fix fluent interface on Route->middleware()

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -261,7 +261,7 @@ class Route
      * Get or set the middlewares attached to the route.
      *
      * @param  array|string|null $middleware
-     * @return array|$this
+     * @return $this|array
      */
     public function middleware($middleware = null)
     {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -261,7 +261,7 @@ class Route
      * Get or set the middlewares attached to the route.
      *
      * @param  array|string|null $middleware
-     * @return array
+     * @return array|$this
      */
     public function middleware($middleware = null)
     {


### PR DESCRIPTION
Fix for `5.1` LTE. This is still present in `5.2` and `master`.

PhpStorm doesn't correctly resolve the fluent interface following the call to `middleware()`:

``` php
Route::get('/{subs?}', [function () {
    return view('layout');
}])
    ->middleware('auth')
    ->where(['subs' => '.*']) // Method 'where' not found in class array
    ->name('dashboard');
```

cc: @danielstqry
