### PR TITLE
[5.2] Improve behavior of MySQL  flag, add `modes` config

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Connectors;
 
+use PDO;
+
 class MySqlConnector extends Connector implements ConnectorInterface
 {
     /**
@@ -46,16 +48,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
             )->execute();
         }
 
-        // If the "strict" option has been configured for the connection we will setup
-        // strict mode for this session. Strict mode enforces some extra rules when
-        // using the MySQL database system and is a quicker way to enforce them.
-        if (isset($config['strict'])) {
-            if ($config['strict']) {
-                $connection->prepare("set session sql_mode='STRICT_ALL_TABLES'")->execute();
-            } else {
-                $connection->prepare("set session sql_mode=''")->execute();
-            }
-        }
+        $this->setModes($connection, $config);
 
         return $connection;
     }
@@ -108,5 +101,26 @@ class MySqlConnector extends Connector implements ConnectorInterface
         return isset($port)
                         ? "mysql:host={$host};port={$port};dbname={$database}"
                         : "mysql:host={$host};dbname={$database}";
+    }
+
+    /**
+     * Set the modes for the connection.
+     *
+     * @param  \PDO  $connection
+     * @param  array  $config
+     * @return void
+     */
+    protected function setModes(PDO $connection, array $config)
+    {
+        if (isset($config['modes'])) {
+            $modes = implode(',', $config['modes']);
+            $connection->prepare("set session sql_mode='".$modes."'")->execute();
+        } elseif (isset($config['strict'])) {
+            if ($config['strict']) {
+                $connection->prepare("set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'")->execute();
+            } else {
+                $connection->prepare("set session sql_mode='NO_ENGINE_SUBSTITUTION'")->execute();
+            }
+        }
     }
 }

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -22,7 +22,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase
     public function testMySqlConnectCallsCreateConnectionWithProperArguments($dsn, $config)
     {
         $connector = $this->getMock('Illuminate\Database\Connectors\MySqlConnector', ['createConnection', 'getOptions']);
-        $connection = m::mock('stdClass');
+        $connection = m::mock('PDO');
         $connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(['options']));
         $connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(['options']))->will($this->returnValue($connection));
         $connection->shouldReceive('prepare')->once()->with('set names \'utf8\' collate \'utf8_unicode_ci\'')->andReturn($connection);


### PR DESCRIPTION
_Re-opening #12012 against 5.2 branch_

This PR improves the behavior of the `strict` flag for the MySQL connector and adds a new `modes` config section for users who need more control than the `strict` flag allows.

Quick example:

``` php
'mysql' => [
    'database'  => env('DB_DATABASE', 'forge'),
    'username'  => env('DB_USERNAME', 'forge'),
    'password'  => env('DB_PASSWORD', ''),
    'charset'   => 'utf8',
    'collation' => 'utf8_unicode_ci',
    'prefix'    => '',

    // Behave like MySQL 5.6
    'strict'    => false,

    // Behave like MySQL 5.7
    'strict'    => true,

    // Ignore this key and rely on the `strict` key
    'modes'     => null,

    // Explicitly disable all modes, overrides `strict` setting
    'modes'     => [],

    // Explicitly enable specific modes, overrides `strict` setting
    'modes'     => [
        'STRICT_TRANS_TABLES',
        'ONLY_FULL_GROUP_BY',
    ],
],
```
- Setting `strict` to `true` now enables _all_ of the default MySQL 5.7 modes rather than just `STRICT_TRANS_TABLES`.
  
  Reasoning here is that MySQL 5.7 being "strict" isn't just defined by one mode, and is really a combination of many. The `strict` config setting in this case is being treated as a convenience toggle between MySQL 5.6's "loose" behavior and MySQL 5.7's "strict" behavior.
  
  In 5.7, `STRICT_TRANS_TABLES` does include many of these other strict settings by default, like `NO_ZERO_IN_DATE` for example, but to replicate that behavior in 5.6 and below requires enabling those modes explicitly.
  
  Read this long ass confusing page for more info: http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html
- Setting `strict` to `false` now enables juset the default MySQL 5.6 modes.
  
  Prior to this PR, setting `strict` to `false` actually _removed all modes_ that were enabled by the database, as you can see here:
  
  `$connection->prepare("set session sql_mode=''")->execute();`
  
  This PR just sets the mode to `NO_ENGINE_SUBSTITION` which was the default prior to 5.7.
- A new `modes` config key has been added
  
  This key is an array of the modes you would like to enable.
  - If it is not set or null, it has no effect.
  - If it is an empty array, it _overrides the strict flag_, and will explicitly set your `sql_mode` to `""`.
  - If it contains modes, those are the modes that will be enabled for the connection.
