### PR TITLE
[5.2] fix typo in ValidatesWhenResolvedTrait docblock

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -42,7 +42,7 @@ trait ValidatesWhenResolvedTrait
      * @param  \Illuminate\Validation\Validator  $validator
      * @return mixed
      *
-     * @throws \Illuminate\Contracts\Validation\ValidationExceptio
+     * @throws \Illuminate\Contracts\Validation\ValidationException
      */
     protected function failedValidation(Validator $validator)
     {


### PR DESCRIPTION
This fixes a missing „n” in @throws docblock
