### PR TITLE
[5.2] Trigger a "Lockout" event when authentication is throttled

### DIFF
--- a/src/Illuminate/Auth/Events/Lockout.php
+++ b/src/Illuminate/Auth/Events/Lockout.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Auth\Events;
+
+use Illuminate\Http\Request;
+
+class Lockout
+{
+    /**
+     * The throttled request.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+}

--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -66,6 +66,8 @@ trait AuthenticatesUsers
         $throttles = $this->isUsingThrottlesLoginsTrait();
 
         if ($throttles && $this->hasTooManyLoginAttempts($request)) {
+            $this->fireLockoutEvent($request);
+
             return $this->sendLockoutResponse($request);
         }
 

--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Http\Request;
 use Illuminate\Cache\RateLimiter;
+use Illuminate\Auth\Events\Lockout;
 use Illuminate\Support\Facades\Lang;
 
 trait ThrottlesLogins
@@ -93,6 +94,17 @@ trait ThrottlesLogins
         app(RateLimiter::class)->clear(
             $this->getThrottleKey($request)
         );
+    }
+
+    /**
+     * Fire an event when a lockout occurs.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function fireLockoutEvent(Request $request)
+    {
+        event(new Lockout($request));
     }
 
     /**


### PR DESCRIPTION
Would be very useful to have an event fired when a user is throttled for logging / audit purposes.
