### PR TITLE
[5.2] Allow incrementing/decrementing multiple columns at once

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1905,21 +1905,50 @@ class Builder
     }
 
     /**
-     * Increment a column's value by a given amount.
+     * Increment a column or a group of columns values by given amounts.
      *
-     * @param  string|array  $column
-     * @param  int|array  $amount
-     * @param  array  $extra
-     * @param  string  $operator
      * @return int
      */
-    public function increment($column, $amount = null, array $extra = [], $operator = '+')
+    public function increment()
     {
-        if (is_array($column)) {
-            $columns = $column;
-            $extra = is_array($amount) ? $amount : [];
+        $arguments = func_get_args();
+
+        if (empty($arguments)) {
+            throw new InvalidArgumentException('Missing argument 1 for increment().');
+        }
+
+        return $this->incrementOrDecrement($arguments, '+');
+    }
+
+    /**
+     * Decrement a column or a group of columns values by given amounts.
+     *
+     * @return int
+     */
+    public function decrement()
+    {
+        $arguments = func_get_args();
+
+        if (empty($arguments)) {
+            throw new InvalidArgumentException('Missing argument 1 for decrement().');
+        }
+
+        return $this->incrementOrDecrement($arguments, '-');
+    }
+
+    /**
+     * @param  string  $operator
+     * @param  array  $arguments
+     * @return int
+     */
+    private function incrementOrDecrement(array $arguments, $operator = '+')
+    {
+        if (is_array($arguments[0])) {
+            $columns = $arguments[0];
+            $extra = isset($arguments[1]) ? $arguments[1] : [];
         } else {
-            $columns = [$column => $amount ?: 1];
+            $columns = [$arguments[0] => isset($arguments[1]) ? $arguments[1] : 1];
+            $extra = isset($arguments[2]) ? $arguments[2] : [];
         }
 
         array_walk($columns, function (&$amount, $column) use ($operator) {
@@ -1931,19 +1960,6 @@ class Builder
         $columns = array_merge($columns, $extra);
 
         return $this->update($columns);
-    }
-
-    /**
-     * Decrement a column's value by a given amount.
-     *
-     * @param  string|array  $column
-     * @param  int|array  $amount
-     * @param  array  $extra
-     * @return int
-     */
-    public function decrement($column, $amount = 1, array $extra = [])
-    {
-        return $this->increment($column, $amount, $extra, '-');
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1090,6 +1090,53 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testIncrementMethod()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('raw')->once()->with('"level" + 2')->andReturn('level+2');
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ? where "id" = ?', ['level+2', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->increment('level', 2);
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('raw')->once()->with('"level" + 1')->andReturn('level+1');
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ? where "id" = ?', ['level+1', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->increment('level');
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('raw')->with('"level" + 2')->andReturn('level+2');
+        $builder->getConnection()->shouldReceive('raw')->with('"score" + 200')->andReturn('score+200');
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ?, "score" = ? where "id" = ?', ['level+2', 'score+200', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->increment(['level' => 2, 'score' => 200]);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testIncrementMethodWithExtras()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('raw')->once()->with('"level" + 2')->andReturn('level+2');
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ?, "rank" = ? where "id" = ?', ['level+2', 'General', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->increment('level', 2, ['rank' => 'General']);
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('raw')->with('"level" + 2')->andReturn('level+2');
+        $builder->getConnection()->shouldReceive('raw')->with('"score" + 200')->andReturn('score+200');
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ?, "score" = ?, "rank" = ? where "id" = ?', ['level+2', 'score+200', 'General', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->increment(['level' => 2, 'score' => 200], ['rank' => 'General']);
+        $this->assertEquals(1, $result);
+    }
+
+    public function testDecrementMethod()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('raw')->once()->with('"level" - 2')->andReturn('level-2');
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ? where "id" = ?', ['level-2', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->decrement('level', 2);
+        $this->assertEquals(1, $result);
+    }
+
     public function testDeleteMethod()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1090,14 +1090,18 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testIncrementMethod()
+    /**
+     * @expectedException  InvalidArgumentException
+     * @expectedExceptionMessage  Missing argument 1 for increment().
+     */
+    public function testCallingIncrementWithNoArgumentsRaisesException()
     {
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('raw')->once()->with('"level" + 2')->andReturn('level+2');
-        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ? where "id" = ?', ['level+2', 1])->andReturn(1);
-        $result = $builder->from('users')->where('id', '=', 1)->increment('level', 2);
-        $this->assertEquals(1, $result);
+        $builder->from('users')->where('id', '=', 1)->increment();
+    }
 
+    public function testIncrementMethod()
+    {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('raw')->once()->with('"level" + 1')->andReturn('level+1');
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ? where "id" = ?', ['level+1', 1])->andReturn(1);
@@ -1105,19 +1109,22 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $result);
 
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('raw')->with('"level" + 2')->andReturn('level+2');
-        $builder->getConnection()->shouldReceive('raw')->with('"score" + 200')->andReturn('score+200');
-        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ?, "score" = ? where "id" = ?', ['level+2', 'score+200', 1])->andReturn(1);
-        $result = $builder->from('users')->where('id', '=', 1)->increment(['level' => 2, 'score' => 200]);
+        $builder->getConnection()->shouldReceive('raw')->once()->with('"level" + 2')->andReturn('level+2');
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ? where "id" = ?', ['level+2', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->increment('level', 2);
         $this->assertEquals(1, $result);
-    }
 
-    public function testIncrementMethodWithExtras()
-    {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('raw')->once()->with('"level" + 2')->andReturn('level+2');
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ?, "rank" = ? where "id" = ?', ['level+2', 'General', 1])->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->increment('level', 2, ['rank' => 'General']);
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('raw')->with('"level" + 2')->andReturn('level+2');
+        $builder->getConnection()->shouldReceive('raw')->with('"score" + 200')->andReturn('score+200');
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ?, "score" = ? where "id" = ?', ['level+2', 'score+200', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->increment(['level' => 2, 'score' => 200]);
         $this->assertEquals(1, $result);
 
         $builder = $this->getBuilder();
@@ -1131,9 +1138,35 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
     public function testDecrementMethod()
     {
         $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('raw')->once()->with('"level" - 1')->andReturn('level-1');
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ? where "id" = ?', ['level-1', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->decrement('level');
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('raw')->once()->with('"level" - 2')->andReturn('level-2');
         $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ? where "id" = ?', ['level-2', 1])->andReturn(1);
         $result = $builder->from('users')->where('id', '=', 1)->decrement('level', 2);
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('raw')->once()->with('"level" - 2')->andReturn('level-2');
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ?, "rank" = ? where "id" = ?', ['level-2', 'General', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->decrement('level', 2, ['rank' => 'General']);
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('raw')->with('"level" - 2')->andReturn('level-2');
+        $builder->getConnection()->shouldReceive('raw')->with('"score" - 200')->andReturn('score-200');
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ?, "score" = ? where "id" = ?', ['level-2', 'score-200', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->decrement(['level' => 2, 'score' => 200]);
+        $this->assertEquals(1, $result);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('raw')->with('"level" - 2')->andReturn('level-2');
+        $builder->getConnection()->shouldReceive('raw')->with('"score" - 200')->andReturn('score-200');
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" set "level" = ?, "score" = ?, "rank" = ? where "id" = ?', ['level-2', 'score-200', 'General', 1])->andReturn(1);
+        $result = $builder->from('users')->where('id', '=', 1)->decrement(['level' => 2, 'score' => 200], ['rank' => 'General']);
         $this->assertEquals(1, $result);
     }
 


### PR DESCRIPTION
This PR allows developers to increment/decrement DB columns using a single method call and in one SQL statement.

Examples:

``` php
// Before
DB::table('users')->increment('score', 100);
DB::table('users')->increment('level', 1);
// Resulting 2 SQL queries

// Now
DB::table('users')->increment(['score' => 100, 'level' => 1]);
// Resulting a single query

// Also with updating additional columns
DB::table('users')->increment(['score' => 100, 'level' => 1], ['rank' => 'Sergeant']);

// Same with decrement
DB::table('users')->decrement(['score' => 100, 'level' => 1]);

// This is still available
DB::table('users')->increment('votes'); // Increment by 1
DB::table('users')->increment('votes', 2);
DB::table('users')->increment('votes', 1, ['name' => 'John']);

DB::table('users')->decrement('votes'); // Increment by 1
DB::table('users')->decrement('votes', 2);
DB::table('users')->decrement('votes', 1, ['name' => 'John']);
```
