### PR TITLE
[5.2] Defaults MySQL timestamp Values to 0

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -638,6 +638,10 @@ class MySqlGrammar extends Grammar
         if (! is_null($column->default)) {
             return ' default '.$this->getDefaultValue($column->default);
         }
+
+        if (! $column->nullable && ! $column->useCurrent && in_array($column->type, ['timestamp', 'timestampTz'])) {
+            return ' default 0';
+        }
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -555,7 +555,17 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add `foo` timestamp not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` timestamp not null default 0', $statements[0]);
+    }
+
+    public function testAddingTimeStampNullable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestamp('foo')->nullable();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('alter table `users` add `foo` timestamp null', $statements[0]);
     }
 
     public function testAddingTimeStampWithDefault()
@@ -575,7 +585,17 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add `foo` timestamp not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `foo` timestamp not null default 0', $statements[0]);
+    }
+
+    public function testAddingTimeStampTzNullable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->timestampTz('foo')->nullable();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('alter table `users` add `foo` timestamp null', $statements[0]);
     }
 
     public function testAddingTimeStampTzWithDefault()
@@ -595,7 +615,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add `created_at` timestamp not null, add `updated_at` timestamp not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` timestamp not null default 0, add `updated_at` timestamp not null default 0', $statements[0]);
     }
 
     public function testAddingTimeStampsTz()
@@ -605,7 +625,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add `created_at` timestamp not null, add `updated_at` timestamp not null', $statements[0]);
+        $this->assertEquals('alter table `users` add `created_at` timestamp not null default 0, add `updated_at` timestamp not null default 0', $statements[0]);
     }
 
     public function testAddingRememberToken()


### PR DESCRIPTION
This sets the default values of timestamps in mysql to 0. This should be required because mysql has the most insane defaults for timestamps.

Take the following create statement:

```
create table `test` (
    `id` int unsigned not null auto_increment primary key, 
    `created_at` timestamp, 
    `updated_at` timestamp,
    `deleted_at` timestamp default 0
);
```

If you then run `show create table test` you'll get the following table structure:

```
CREATE TABLE `test` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
  `updated_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
  `deleted_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;
```

As you can see the `created_at` timestamp gets stuck with `ON UPDATE CURRENT_TIMESTAMP`, which likely isn't what anybody wants.

The following is from the MySQL documentation:

`TIMESTAMP` and `DATETIME` columns have no automatic properties unless they are specified explicitly, with this exception: By default, the **_first_** `TIMESTAMP` column has both `DEFAULT CURRENT_TIMESTAMP` and `ON UPDATE CURRENT_TIMESTAMP` if neither is specified explicitly. To suppress automatic properties for the first `TIMESTAMP` column, use one of these strategies:
- Enable the `explicit_defaults_for_timestamp` system variable. If this variable is enabled, the `DEFAULT CURRENT_TIMESTAMP` and `ON UPDATE CURRENT_TIMESTAMP` clauses that specify automatic initialization and updating are available, but are not assigned to any `TIMESTAMP` column unless explicitly included in the column definition.
- Alternatively, if `explicit_defaults_for_timestamp` is disabled (the default), do either of the following:
  - Define the column with a `DEFAULT` clause that specifies a constant default value.
  - Specify the `NULL` attribute. This also causes the column to permit `NULL` values, which means that you cannot assign the current timestamp by setting the column to `NULL`. Assigning `NULL` sets the column to `NULL`. 

&mdash; [Timestamp Initialization](http://dev.mysql.com/doc/refman/5.6/en/timestamp-initialization.html)
