### PR TITLE
[5.3] Fix blob type for doctrine columns (binary to blob).

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -395,6 +395,9 @@ abstract class Grammar extends BaseGrammar
             case 'longtext':
                 $type = 'text';
                 break;
+            case 'binary':
+                $type = 'blob';
+                break;
         }
 
         return Type::getType($type);


### PR DESCRIPTION
Fix for issue #12043 

Doctrine using `VARBINARY` instead of `BLOB` when using `$table->binary()->change();` withing a migration.

Only tested on MySQL.
