### PR TITLE
Removes reference to initial keys in collection after sorting, to ensure the items remain in an indexed array

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -827,8 +827,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $results[$key] = $this->items[$key];
         }
 
-        $is_indexed = array_keys($this->items) === range(0, count($arr) - 1);
-        return $is_indexed ? new static(array_values($results)) : new static($results);
+        $isIndexed = array_keys($this->items) === range(0, count($arr) - 1);
+        return $isIndexed ? new static(array_values($results)) : new static($results);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -827,7 +827,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $results[$key] = $this->items[$key];
         }
 
-        return new static($results);
+        return new static(array_values($results));
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -827,7 +827,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $results[$key] = $this->items[$key];
         }
 
-        return new static(array_values($results));
+        $is_indexed = array_keys($this->items) === range(0, count($arr) - 1);
+        return $is_indexed ? new static(array_values($results)) : new static($results);
     }
 
     /**


### PR DESCRIPTION
I, along with some [others](https://laracasts.com/forum/?p=1181-sort-eloquent-collection-via-sortby/0), have been running into an interesting issue with `Collections`, specifically operating on sorted collections. The issue is that the sort method is currently maintaining the keys from the unsorted collection, this causes the items array to change from an indexed array to an associative array (if the order actually changes), which causes things like toJSON() to act differently. Here is an example:

``` php
$collection = new \Illuminate\Support\Collection([
    ['order' => 1],
    ['order' => 2],
    ['order' => 3]
]);
$collection->toJSON();
```

Will return:

``` json
[{"order":1},{"order":2},{"order":3}]
```

``` php
$sorted_collection = new \Illuminate\Support\Collection([
    ['order' => 1],
    ['order' => 2],
    ['order' => 3]
]);
$sorted_collection->sortBy('order')->toJSON();
```

Will return:

``` json
{"2":{"order":3},"1":{"order":2},"0":{"order":1}}
```

I believe this inconsistency to be a bug, and this PR will resolve it. 
