### PR TITLE
[5.2] If a collection is an indexed array before sorting, return an indexed array after sorting

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -827,12 +827,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $results[$key] = $this->items[$key];
         }
 
-        // Determine if the original collection was an indexed collection and we should
-        // return an indexed collection.
-        $indexed = array_keys($this->items) === range(0, count($this->items) - 1);
+        $instance = new static($results);
 
-        return $indexed ? new static(array_values($results))
-                        : new static($results);
+        return $this->isAssoc() ? $instance
+                                : $instance->values();
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -829,8 +829,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $instance = new static($results);
 
-        return $this->isAssoc() ? $instance
-                                : $instance->values();
+        return Arr::isAssoc($this->items) ? $instance : $instance->values();
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -827,7 +827,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $results[$key] = $this->items[$key];
         }
 
-        return new static($results);
+        // Determine if the original collection was an indexed collection and we should
+        // return an indexed collection.
+        $indexed = array_keys($this->items) === range(0, count($this->items) - 1);
+
+        return $indexed ? new static(array_values($results))
+                        : new static($results);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -494,6 +494,22 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['taylor', 'dayle'], array_values($data->all()));
     }
 
+    public function testSortByOnAssoc()
+    {
+        $data = new Collection(['first' => ['order' => 2], 'second' => ['order' => 1]]);
+        $data = $data->sortBy('order');
+
+        $this->assertEquals(['second' => ['order' => 1], 'first' => ['order' => 2]], $data->toArray());
+    }
+
+    public function testSortByOnIndexed()
+    {
+        $data = new Collection([['order' => 2], ['order' => 1]]);
+        $data = $data->sortBy('order');
+
+        $this->assertEquals([['order' => 1], ['order' => 2]], $data->toArray());
+    }
+
     public function testSortByString()
     {
         $data = new Collection([['name' => 'taylor'], ['name' => 'dayle']]);


### PR DESCRIPTION
I, along with some [others](https://laracasts.com/forum/?p=1181-sort-eloquent-collection-via-sortby/0), have been running into an interesting issue with `Collections`, specifically operating on sorted collections. The issue is that the sort method is currently maintaining the keys from the unsorted collection, this causes the items array to change from an indexed array to an associative array (if the order actually changes), which causes things like toJSON() to act differently. Note will only happen when the original collection is an indexed array. Here is an example:

``` php
$collection = new \Illuminate\Support\Collection([
    ['order' => 1],
    ['order' => 2],
    ['order' => 3]
]);
$collection->toJSON();
```

Will return:

``` json
[{"order":1},{"order":2},{"order":3}]
```

``` php
$sorted_collection = new \Illuminate\Support\Collection([
    ['order' => 1],
    ['order' => 2],
    ['order' => 3]
]);
$sorted_collection->sortBy('order')->toJSON();
```

Will return:

``` json
{"2":{"order":3},"1":{"order":2},"0":{"order":1}}
```

I believe this inconsistency to be a bug, and this PR will resolve it. 
