### PR TITLE
Proposal: Return Empty Array if Can has not results

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -279,6 +279,7 @@ class Gate implements GateContract
      */
     protected function callBeforeCallbacks($user, $ability, array $arguments)
     {
+    
         $arguments = array_merge([$user, $ability], $arguments);
 
         foreach ($this->beforeCallbacks as $before) {
@@ -286,6 +287,8 @@ class Gate implements GateContract
                 return $result;
             }
         }
+        
+        return [];
     }
 
     /**


### PR DESCRIPTION
Case:
I have a @can('foo') in a view. But then that Gate is removed. Instead of crashing the app this view could just return and empty result and not show the element.

This could even go for Cant if it is worth it.
