### PR TITLE
[5.2] SessionDatabaseHandler confirm existence before committing 

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -89,6 +89,10 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
     {
         $payload = $this->getDefaultPayload($data);
 
+        if (! $this->exists) {
+            $this->read($sessionId);
+        }
+
         if ($this->exists) {
             $this->getQuery()->where('id', $sessionId)->update($payload);
         } else {


### PR DESCRIPTION
To resolve this issue: 

> SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'af5d46ed1a5399b59f186fa59c98d734a04cc5be' for key 'sessions_id_unique'
