### PR TITLE
[5.2] Adjust ResourceRegistrar to take wildcards options

### DIFF
--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -5,6 +5,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
+use Illuminate\Routing\ResourceRegistrar;
 use Symfony\Component\HttpFoundation\Response;
 
 class RoutingRouteTest extends PHPUnit_Framework_TestCase
@@ -667,6 +668,48 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo-bars/{foo_bars}', $routes[0]->getUri());
         $this->assertEquals('prefix.foo-bars.show', $routes[0]->getName());
+    }
+
+    public function testResourceRoutingWildcards()
+    {
+        ResourceRegistrar::singularWildcards();
+
+        $router = $this->getRouter();
+        $router->resource('foos', 'FooController');
+        $router->resource('foos.bars', 'FooController');
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foos/{foo}', $routes[3]->getUri());
+        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[10]->getUri());
+
+        ResourceRegistrar::setWildcards(['foos' => 'oof', 'bazs' => 'b']);
+
+        $router = $this->getRouter();
+        $router->resource('bars.foos.bazs', 'FooController');
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('bars/{bar}/foos/{oof}/bazs/{b}', $routes[3]->getUri());
+
+        ResourceRegistrar::setWildcards();
+        ResourceRegistrar::singularWildcards(false);
+
+        $router = $this->getRouter();
+        $router->resource('foos', 'FooController', ['wildcards' => 'singular']);
+        $router->resource('foos.bars', 'FooController', ['wildcards' => 'singular']);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foos/{foo}', $routes[3]->getUri());
+        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[10]->getUri());
+
+        $router = $this->getRouter();
+        $router->resource('foos.bars', 'FooController', ['wildcards' => ['foos' => 'foo', 'bars' => 'bar']]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[3]->getUri());
     }
 
     public function testResourceRouteNaming()


### PR DESCRIPTION
Adjustment to ResourceRegistrar to allow for 'wildcards' to be set via the options array.

Allows for this.

``` php
Route::resource('users.photos', 'PhotoController', ['wildcards' => [
    'users' => 'person', 'photos' => 'image'
]]);
// or
Route::resource('users', 'UserController', ['wildcards' => 'singular']);
```

**Updated**

Global wildcard state and mapping.

``` php
ResourceRegistrar::setWildcards(['users' => 'person']); // set map
ResourceRegistrar::setWildcards(); // unset map
ResourceRegistrar::singularWildcards(); // set singular
ResourceRegistrar::singularWildcards(false); // unset singular
```
