### PR TITLE
issue#12064: fix html escaping bug

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -463,7 +463,7 @@ if (! function_exists('e')) {
             return $value->toHtml();
         }
 
-        return htmlentities($value, ENT_QUOTES, 'UTF-8', false);
+        return htmlentities($value, ENT_QUOTES, 'UTF-8', true);
     }
 }
 


### PR DESCRIPTION
bugfix for this issue[12064](https://github.com/laravel/framework/issues/12064)
- htmlentities doc : http://php.net/manual/en/function.htmlentities.php
- before bugfix, code `{{ "<br>&lt;br&gt;" }}` in the view will be displayed as `<br><br>`.
- after bugfix, code `{{ "<br>&lt;br&gt;" }}` in the view will be displayed as `<br>&lt;br&gt;`.
