### PR TITLE
Replaced "@return void" in stub constructor phpdocs with "@return self"

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/controllers/HomeController.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/controllers/HomeController.stub
@@ -10,7 +10,7 @@ class HomeController extends Controller
     /**
      * Create a new controller instance.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {

--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -23,7 +23,7 @@ class DummyClass extends Command
     /**
      * Create a new command instance.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {

--- a/src/Illuminate/Foundation/Console/stubs/event-handler-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event-handler-queued.stub
@@ -13,7 +13,7 @@ class DummyClass implements ShouldQueue
     /**
      * Create the event handler.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {

--- a/src/Illuminate/Foundation/Console/stubs/event-handler.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event-handler.stub
@@ -11,7 +11,7 @@ class DummyClass
     /**
      * Create the event handler.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {

--- a/src/Illuminate/Foundation/Console/stubs/event.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event.stub
@@ -13,7 +13,7 @@ class DummyClass extends Event
     /**
      * Create a new event instance.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {

--- a/src/Illuminate/Foundation/Console/stubs/job-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job-queued.stub
@@ -14,7 +14,7 @@ class DummyClass extends Job implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {

--- a/src/Illuminate/Foundation/Console/stubs/job.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.stub
@@ -9,7 +9,7 @@ class DummyClass extends Job
     /**
      * Create a new job instance.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {

--- a/src/Illuminate/Foundation/Console/stubs/listener-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-queued.stub
@@ -13,7 +13,7 @@ class DummyClass implements ShouldQueue
     /**
      * Create the event listener.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {

--- a/src/Illuminate/Foundation/Console/stubs/listener.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener.stub
@@ -11,7 +11,7 @@ class DummyClass
     /**
      * Create the event listener.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -11,7 +11,7 @@ class DummyClass
     /**
      * Create a new policy instance.
      *
-     * @return void
+     * @return self
      */
     public function __construct()
     {


### PR DESCRIPTION
The phpDocumentor documentation states that the **@return** tag for a constructor must either be omitted or have a description of **self**. Laravel incorrectly uses **@return void**, which causes syntax warnings in IDEs such as PHPStorm.

http://www.phpdoc.org/docs/latest/references/phpdoc/tags/return.html

For the time being I've only corrected this for the stub files; it will be quite a task to fix up every class in the the framework.

I'll also be submitting a PR for the _laravel/laravel_ repository as a couple of the bundled controllers suffer from the same issue.
