### PR TITLE
[5.3] Match 'as' option functionality in route resources to the functionality of route group's 'as' option.

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -189,10 +189,14 @@ class ResourceRegistrar
             return $options['names'][$method];
         }
 
+        if (isset($options['as'])) {
+            return $options['as'].'.'.$method;
+        }
+
         // If a global prefix has been assigned to all names for this resource, we will
         // grab that so we can prepend it onto the name when we create this name for
         // the resource action. Otherwise we'll just use an empty string for here.
-        $prefix = isset($options['as']) ? $options['as'].'.' : '';
+        $prefix = isset($options['prefix']) ? $options['prefix'].'.' : '';
 
         if (! $this->router->hasGroupStack()) {
             return $prefix.$resource.'.'.$method;

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -666,6 +666,14 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $routes = $routes->getRoutes();
 
         $this->assertEquals('foo-bars/{foo_bars}', $routes[0]->getUri());
+        $this->assertEquals('prefix.show', $routes[0]->getName());
+
+        $router = $this->getRouter();
+        $router->resource('foo-bars', 'FooController', ['only' => ['show'], 'prefix' => 'prefix']);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertEquals('foo-bars/{foo_bars}', $routes[0]->getUri());
         $this->assertEquals('prefix.foo-bars.show', $routes[0]->getName());
     }
 


### PR DESCRIPTION
Old functionality is still available using option 'prefix'. See #12068
for a deeper explanation.

```
Route::group(['prefix' => 'admin', 'as' => 'admin::'], function () {
    Route::resource('user', 'UserController', ['as' => 'user']);
});
```

Gives `admin::user.index` rather than `admin::user.admin.user.index`,
it is still possible to get the second output by using 'prefix' option,
a better suited name for such functionality.
