### PR TITLE
[5.2] json_encode error checking

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -52,6 +52,10 @@ class JsonResponse extends BaseJsonResponse
                                    ? $data->toJson($this->jsonOptions)
                                    : json_encode($data, $this->jsonOptions);
 
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new \InvalidArgumentException(json_last_error_msg());
+        }
+
         return $this->update();
     }
 


### PR DESCRIPTION
As Symfony does, it would be good to have a descriptive error message when json_encode fails (and returns false: http://php.net/manual/en/function.json-encode.php).
Without this checking, I was having the error "The Response content must be a string or object implementing __toString()" in Symfony\Component\HttpFoundation\JsonResponse::update due to content ($this->data) was false.
