### PR TITLE
[5.2] Eloquent Model::getDirty() is now date safe

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3212,7 +3212,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             if (! array_key_exists($key, $this->original)) {
                 $dirty[$key] = $value;
             } elseif ($value !== $this->original[$key] &&
-                                 ! $this->originalIsNumericallyEquivalent($key)) {
+                                 ! $this->originalIsEquivalent($key)) {
                 $dirty[$key] = $value;
             }
         }
@@ -3221,18 +3221,54 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Determine if the new and old values for a given key are numerically equivalent.
+     * Determine if the new and old values for a given key are equivalent, though not necessarily identical.
      *
      * @param  string  $key
      * @return bool
      */
-    protected function originalIsNumericallyEquivalent($key)
+    protected function originalIsEquivalent($key)
     {
         $current = $this->attributes[$key];
 
         $original = $this->original[$key];
 
+        // if they're not the same state (set/unset), they're not equivalent
+        if (empty($current) != empty($original)) {
+            return false;
+        }
+
+        return $this->isNumericallyEquivalent($current, $original)
+            || $this->isDateEquivalent($key, $current, $original);
+    }
+
+    /**
+     * Determine if the new and old values for a given key are numerically equivalent.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isNumericallyEquivalent($current, $original)
+    {
         return is_numeric($current) && is_numeric($original) && strcmp((string) $current, (string) $original) === 0;
+    }
+
+    /**
+     * Determine if the new and old values for a given key have the same date.
+     *
+     * The $dates property converts all incoming data into datetime, whereas we may only be storing the date.
+     * Thus, any update for the same time would always show as dirty because 2016-01-01 != 2016-01 01 00:00:00
+     *
+     * Note: This means Eloquent can never add the time, if the time was missing, but we assume the database adds
+     * 00:00:00 if there was no time supplied anyway. Eloquent can overwrite the wrong time, so no problem here.
+     *
+     * @param  string  $key
+     * @param  string|int  $current
+     * @param  string  $original
+     * @return bool
+     */
+    protected function isDateEquivalent($key, $current, $original)
+    {
+        return in_array($key, $this->getDates()) && starts_with($this->fromDateTime($current), $original);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -33,16 +33,23 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     public function testDirtyAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
+        // bypass mutators
+        $model->setAttributeDirectly('date', date('Y-m-d'));
+        $model->setAttributeDirectly('datetime', date('Y-m-d H:i:s'));
         $model->syncOriginal();
         $model->foo = 1;
         $model->bar = 20;
         $model->baz = 30;
+        $model->date = date('Y-m-d H:i:s');
+        $model->datetime = date('Y-m-d H:i:s', time() + 10);
 
         $this->assertTrue($model->isDirty());
         $this->assertFalse($model->isDirty('foo'));
         $this->assertTrue($model->isDirty('bar'));
         $this->assertTrue($model->isDirty('foo', 'bar'));
         $this->assertTrue($model->isDirty(['foo', 'bar']));
+        $this->assertFalse($model->isDirty('date')); // date is still the same
+        $this->assertTrue($model->isDirty('datetime'));
     }
 
     public function testCalculatedAttributes()
@@ -1347,7 +1354,17 @@ class EloquentModelStub extends Model
 
     public function getDates()
     {
-        return [];
+        return ['date', 'datetime'];
+    }
+
+    public function setAttributeDirectly($key, $value)
+    {
+        $this->attributes[$key] = $value;
+    }
+
+    protected function getDateFormat()
+    {
+        return 'Y-m-d H:i:s';
     }
 
     public function getAppendableAttribute()


### PR DESCRIPTION
Model treats all dates (defined by the $dates property) as being of full datetime values, depending on what's returned from the database as a date format. This is also the case when we're literally just storing dates (e.g. date field in MySQL).

Unfortunately, this presents false positives when updating dates because Eloquent expands the value supplied to the full format, and then compares this against the original value.

```
$existing = Model::find(1); // date attribute = '2016-01-01'
$existing->date = '2016-01-01'; // set it to the exact same date...
```

Eloquent expands the value we added and adds the time, and then tries to compare '2016-01-01 00:00:00' == '2016-01-01'
This fails _every_ time, of course, which leads to unnecessary writes to the database, and unnecessary triggering of observers, etc

This update prevents these false positives by comparing the incoming value, against the value already stored. If only the date was extracted from the database, then only the date aspect is checked.
