### PR TITLE
[5.2] Non-existent model updates don't perform global updates

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1478,7 +1478,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function update(array $attributes = [], array $options = [])
     {
         if (! $this->exists) {
-            return $this->newQuery()->update($attributes);
+            return false;
         }
 
         return $this->fill($attributes)->save($options);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1274,6 +1274,12 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertNull($array['timestampAttribute']);
     }
 
+    public function testUpdatingNonExistentModelFails()
+    {
+        $model = new EloquentModelStub;
+        $this->assertFalse($model->update());
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));


### PR DESCRIPTION
Consider the following code:

```
$record = SomeModel::first(['foo' => 'bar']);
$record->delete(); // sets $record->exists = false
$record->update([''foo' => 'baz']); // executes "update some_models set foo = 'bar'", updating all records
```

As you can see, the above is a disaster situation, specifically for records that don't have PK's.

Whilst no-one would legitimately write code _exactly_ like the above, the same effect can be achieved through various observers/events that perform an update on a model passed through, assuming it to still exist, not realising it'd been deleted already.

If someone legitimately wants to perform a global update, they can perform:

```
SomeModel::getQuery()->update(['foo' => 'bar']);
```

which goes through the Query builder and works as expected
