### PR TITLE
[5.2] Added Command::isRunning method

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -498,4 +498,42 @@ class Command extends SymfonyCommand
     {
         $this->laravel = $laravel;
     }
+
+    /**
+     * Determines if a task is running, and can alter the state of the current task.
+     * Called without an argument, returns timestamp from when the current task is running, or false if not.
+     * Called with a boolean, sets the running state of the current task.
+     * Called with a string/class, returns timestamp/false for whether that task is running.
+     *
+     * Based on Laravel's App:up and App:down functionality
+     *
+     * @param  mixed  $param
+     * @return bool
+     */
+    protected function isRunning($param = null)
+    {
+        // Defaults
+        $target = get_class($this);
+        $func = 'filemtime';
+
+        switch (gettype($param)) {
+            case 'boolean':
+                $func = $param
+                    ? 'touch'
+                    : 'unlink';
+                break;
+
+            case 'string':
+                $target = $param;
+                break;
+
+            case 'object':
+                $target = get_class($param);
+                break;
+        }
+
+        $file = $this->laravel['config']['app.manifest'].'/Task-'.str_replace('\\', '-', $target);
+
+        return @$func($file);
+    }
 }


### PR DESCRIPTION
Simple mechanism to determine whether a task is running - useful when running conflicting concurrent tasks (e.g. two tasks that lock the database, etc) to ensure only one runs at a time.

```
public function handle()
{
    $this->isRunning(true); // sets this task as running
    $this->isRunning(); // returns timestamp of when the task started, or false if not running
    $this->isRunning(false); // sets task as not running
    $this->isRunning('SomeOtherCommand'); // returns timestamp/false if SomeOtherCommand is running
}
```
