### PR TITLE
[5.2] Added Validator:required_if_not rule

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -148,7 +148,7 @@ class Validator implements ValidatorContract
      */
     protected $implicitRules = [
         'Required', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
-        'RequiredIf', 'RequiredUnless', 'Accepted',
+        'RequiredIf', 'RequiredIfNot', 'RequiredUnless', 'Accepted',
         // 'Array', 'Boolean', 'Integer', 'Numeric', 'String',
     ];
 
@@ -714,6 +714,29 @@ class Validator implements ValidatorContract
         $values = array_slice($parameters, 1);
 
         if (in_array($data, $values)) {
+            return $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that an attribute exists when another attribute has a given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    protected function validateRequiredIfNot($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'required_if_not');
+
+        $data = array_get($this->data, $parameters[0]);
+
+        $values = array_slice($parameters, 1);
+
+        if (! in_array($data, $values)) {
             return $this->validateRequired($attribute, $value);
         }
 
@@ -2074,6 +2097,20 @@ class Validator implements ValidatorContract
         $parameters[0] = $this->getAttribute($parameters[0]);
 
         return str_replace([':other', ':value'], $parameters, $message);
+    }
+
+    /**
+     * Replace all place-holders for the required_if_not rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function replaceRequiredIfNot($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceRequiredIf($message, $attribute, $rule, $parameters);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -504,6 +504,36 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('The last field is required when first is dayle.', $v->messages()->first('last'));
     }
 
+    public function testRequiredIfNot()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'required_if_not:first,taylor']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['first' => 'shady', 'last' => 'otwell'], ['last' => 'required_if_not:first,taylor']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'required_if_not:first,taylor,dayle']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['first' => 'dayle'], ['last' => 'required_if_not:first,taylor,dayle']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['first' => 'shady'], ['last' => 'required_if_not:first,taylor,dayle']);
+        $this->assertTrue($v->fails());
+
+        // error message when passed multiple values (required_if_not:foo,bar,baz)
+        $trans = $this->getRealTranslator();
+        $trans->addResource('array', ['validation.required_if_not' => 'The :attribute field is required when :other is not :value.'], 'en', 'messages');
+        $v = new Validator($trans, ['first' => 'shady', 'last' => ''], ['last' => 'RequiredIfNot:first,taylor,dayle']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals('The last field is required when first is not shady.', $v->messages()->first('last'));
+    }
+
     public function testRequiredUnless()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
Added a validator rule to force certain fields to be required if other fields have been left empty.

Can be used in combinations to make sure that at least one field (from a range of different fields) have been selected.
