### PR TITLE
[5.2] Added support for mixed primary key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1751,10 +1751,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $key = $this->getKeyName();
         $v = $this->getKeyForSaveQuery();
-        if (!is_array($key)) {
+        if (! ($key)) {
             $key = [$key];
         }
-        if (!is_array($v)) {
+        if (! is_array($v)) {
             $v = [$key[0] => $v];
         }
         foreach ($key as $k) {
@@ -1772,7 +1772,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected function getKeyForSaveQuery()
     {
         $key = $this->getKeyName();
-        if (!is_array($key)) {
+        if (! is_array($key)) {
             $key = [$key];
         }
         $r = [];

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1751,12 +1751,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $key = $this->getKeyName();
         $v = $this->getKeyForSaveQuery();
-        if (!is_array($key))
+        if (!is_array($key)) {
             $key = [$key];
-        if (!is_array($v))
+        }
+        if (!is_array($v)) {
             $v = [$key[0] => $v];
-        foreach ($key as $k)
+        }
+        foreach ($key as $k) {
             $query->where($k, '=', $v[$k]);
+        }
 
         return $query;
     }
@@ -1769,13 +1772,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected function getKeyForSaveQuery()
     {
         $key = $this->getKeyName();
-        if (!is_array($key))
+        if (!is_array($key)) {
             $key = [$key];
+        }
         $r = [];
-        foreach ($key as $i => $k)
+        foreach ($key as $i => $k) {
             $r[$k] = isset($this->original[$k]) ? $this->original[$k] : $this->getAttribute($k);
-        if (count($r) == 1)
+        }
+        if (count($r) == 1) {
             $r = $r[$key[0]];
+        }
 
         return $r;
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1749,7 +1749,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function setKeysForSaveQuery(Builder $query)
     {
-        $query->where($this->getKeyName(), '=', $this->getKeyForSaveQuery());
+        $key = $this->getKeyName();
+        $v = $this->getKeyForSaveQuery();
+        if (!is_array($key))
+            $key = [$key];
+        if (!is_array($v))
+            $v = [$key[0] => $v];
+        foreach ($key as $k)
+            $query->where($k, '=', $v[$k]);
 
         return $query;
     }
@@ -1761,11 +1768,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function getKeyForSaveQuery()
     {
-        if (isset($this->original[$this->getKeyName()])) {
-            return $this->original[$this->getKeyName()];
-        }
+        $key = $this->getKeyName();
+        if (!is_array($key))
+            $key = [$key];
+        $r = [];
+        foreach ($key as $i => $k)
+            $r[$k] = isset($this->original[$k]) ? $this->original[$k] : $this->getAttribute($k);
+        if (count($r) == 1)
+            $r = $r[$key[0]];
 
-        return $this->getAttribute($this->getKeyName());
+        return $r;
     }
 
     /**


### PR DESCRIPTION
In eloquent we couldn't have a mixed primary key in a model; like this:

`public $primaryKey = ['key1', 'key2'];`

Sometimes it's really necessary to use two or more keys at the same time (mixed).
