### PR TITLE
[5.2] Add array_trim helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -803,6 +803,7 @@ if (! function_exists('array_trim')) {
             }
             $result .= $entity.$sep;
         }
+        
         return trim($result, $sep);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -803,7 +803,7 @@ if (! function_exists('array_trim')) {
             }
             $result .= $entity.$sep;
         }
-        
+
         return trim($result, $sep);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -784,3 +784,25 @@ if (! function_exists('with')) {
         return $object;
     }
 }
+
+if (! function_exists('array_trim')) {
+    /**
+     * Return the comma separated representation of an array.
+     *
+     * @param  string  $array
+     * @param  string  $sep
+     * @param  string  $property
+     * @return string
+     */
+    function array_trim($array, $sep = ", ", $property = null)
+    {
+        $result = "";
+        foreach ($array as $entity) {
+            if ($property != null) {
+                $entity = $entity->{$property};
+            }
+            $result .= $entity . $sep;
+        }
+        return trim($result, $sep);
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -789,19 +789,19 @@ if (! function_exists('array_trim')) {
     /**
      * Return the comma separated representation of an array.
      *
-     * @param  string  $array
+     * @param  array   $array
      * @param  string  $sep
      * @param  string  $property
      * @return string
      */
-    function array_trim($array, $sep = ", ", $property = null)
+    function array_trim($array, $sep = ', ', $property = null)
     {
-        $result = "";
+        $result = '';
         foreach ($array as $entity) {
             if ($property != null) {
                 $entity = $entity->{$property};
             }
-            $result .= $entity . $sep;
+            $result .= $entity.$sep;
         }
         return trim($result, $sep);
     }


### PR DESCRIPTION
```
    $users = array(
            array('id' => 1, 'name' => 'John'),
            array('id' => 2, 'name' => 'Jane')
    );
    $fruits = ['banana', 'orange', 'apple'];

    array_trim($users, 'name');    // "John, Jane"
    array_trim($fruits);                // "banana, orange, apple"
```
