### PR TITLE
[5.2] Add validateLogin function for easy override.

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -47,7 +47,7 @@ trait AuthenticatesUsers
     {
         return $this->login($request);
     }
-    
+
     /**
      * Validate user login attributes.
      *

--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -47,6 +47,18 @@ trait AuthenticatesUsers
     {
         return $this->login($request);
     }
+    
+    /**
+     * Validate user login attributes
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return null
+     */
+    protected function validateLogin($request){
+        $this->validate($request, [
+            $this->loginUsername() => 'required', 'password' => 'required',
+        ]);
+    }
 
     /**
      * Handle a login request to the application.
@@ -56,9 +68,7 @@ trait AuthenticatesUsers
      */
     public function login(Request $request)
     {
-        $this->validate($request, [
-            $this->loginUsername() => 'required', 'password' => 'required',
-        ]);
+        $this->validateLogin($request);
 
         // If the class is using the ThrottlesLogins trait, we can automatically throttle
         // the login attempts for this application. We'll key this by the username and

--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -49,12 +49,13 @@ trait AuthenticatesUsers
     }
     
     /**
-     * Validate user login attributes
+     * Validate user login attributes.
      *
      * @param  \Illuminate\Http\Request  $request
      * @return null
      */
-    protected function validateLogin($request){
+    protected function validateLogin($request)
+    {
         $this->validate($request, [
             $this->loginUsername() => 'required', 'password' => 'required',
         ]);


### PR DESCRIPTION
I have added a function validateLogin split from the login function. So that I can override it in my AuthController to add some other data such as costom attribute.Like this:

``` php
    protected function validateLogin($request){
        $this->validate($request, [
            $this->loginUsername() => 'required', 'password' => 'required',
        ],[],[
            'name' => '用户名',
            'password' => '密码',
            'email' => '邮箱'
        ]);
    }
```

I don't think it only for 5.2 version,5,1  also can be used.My english is very very poor.Hope you can understand :).
