### PR TITLE
[5.2] Message::to method should always return Message instance.

### DIFF
--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -77,7 +77,9 @@ class Message
     public function to($address, $name = null, $override = false)
     {
         if ($override) {
-            return $this->swift->setTo($address, $name);
+            $this->swift->setTo($address, $name);
+
+            return $this;
         }
 
         return $this->addAddresses($address, $name, 'To');


### PR DESCRIPTION
When overriding the recipient, the to() method returns the Swift_Message instance rather than Illuminate\Message instance.
