### PR TITLE
[5.2] Eloquent Route::model() use getRouteQualifiedKeyName when resolving

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -17,4 +17,11 @@ interface UrlRoutable
      * @return string
      */
     public function getRouteKeyName();
+
+    /**
+     * Get the qualified route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteQualifiedKeyName();
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2065,6 +2065,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Get the qualified route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteQualifiedKeyName()
+    {
+        return $this->getTable().'.'.$this->getRouteKeyName();
+    }
+
+    /**
      * Determine if the model uses timestamps.
      *
      * @return bool

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -846,7 +846,7 @@ class Router implements RegistrarContract
 
                 $route->setParameter(
                     $parameter->name, $model->where(
-                        $model->getRouteKeyName(), $parameters[$parameter->name]
+                        $model->getRouteQualifiedKeyName(), $parameters[$parameter->name]
                     )->{$method}()
                 );
             }
@@ -937,7 +937,7 @@ class Router implements RegistrarContract
             // throw a not found exception otherwise we will return the instance.
             $instance = $this->container->make($class);
 
-            if ($model = $instance->where($instance->getRouteKeyName(), $value)->first()) {
+            if ($model = $instance->where($instance->getRouteQualifiedKeyName(), $value)->first()) {
                 return $model;
             }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -921,6 +921,11 @@ class RouteModelBindingStub
         return 'id';
     }
 
+    public function getRouteQualifiedKeyName()
+    {
+        return 'table.'.$this->getRouteKeyName();
+    }
+
     public function where($key, $value)
     {
         $this->value = $value;
@@ -939,6 +944,11 @@ class RouteModelBindingNullStub
     public function getRouteKeyName()
     {
         return 'id';
+    }
+
+    public function getRouteQualifiedKeyName()
+    {
+        return 'table.'.$this->getRouteKeyName();
     }
 
     public function where($key, $value)

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -384,4 +384,9 @@ class RoutableInterfaceStub implements UrlRoutable
     {
         return 'key';
     }
+
+    public function getRouteQualifiedKeyName()
+    {
+        return 'table.'.$this->getRouteKeyName();
+    }
 }


### PR DESCRIPTION
**Brief review**
I have extended Eloquent model class and added $translatable functionality into my models. It is an easy way to pull locale based translations for a particular model in one go.

``` php
class Website extends Model
{
    protected $table = 'websites';
    protected $primaryKey = 'id';
    protected $guarded = [];

    protected $translatable = [
        'title',
        'description'
    ];
}
```

So when the following code is executed:

``` php
$website = Website::find(28);
```

The following SQL query is generated by Laravel (joins are added internally by an extended Eloquent/Builder class based on attributes defined in Model's $translatable):

``` sql
select `websites`.*, `trans_724990059`.`language_string` AS `--translatable-title`, `trans_1843675174`.`language_string` AS `--translatable-description`  from `websites` left join `EN_string_language` as `trans_724990059` on `title` = `trans_724990059`.`interface_string_id` left join `EN_string_language` as `trans_1843675174` on `description` = `trans_1843675174`.`interface_string_id` where `websites`.`id` = 28 limit 1
```

**Problem**
Everything works fine except one use-case scenario - when trying to inject model via `Route::model()` and this results in `Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous` error.

**Solution**
I did try to investigate why does `Website::find(28)` work but `Route::model()` fail ... even the use-case internally should be nearly identical for both. It looks like first method uses `getQualifiedKeyName()` (qualified keyname) and the later one - `getRouteKeyName()` (non-qualified keyname).

In order to address this and even I have implemented `getRouteQualifiedKeyName()` method in my PR.

Looking forward!
