### PR TITLE
[5.3] Use argument unpacking in facades

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -210,24 +210,6 @@ abstract class Facade
             throw new RuntimeException('A facade root has not been set.');
         }
 
-        switch (count($args)) {
-            case 0:
-                return $instance->$method();
-
-            case 1:
-                return $instance->$method($args[0]);
-
-            case 2:
-                return $instance->$method($args[0], $args[1]);
-
-            case 3:
-                return $instance->$method($args[0], $args[1], $args[2]);
-
-            case 4:
-                return $instance->$method($args[0], $args[1], $args[2], $args[3]);
-
-            default:
-                return call_user_func_array([$instance, $method], $args);
-        }
+        return $instance->$method(...$args);
     }
 }


### PR DESCRIPTION
See https://wiki.php.net/rfc/argument_unpacking for more info and https://gist.github.com/nikic/6390366 for benchmarks. Argument unpacking seems to be twice as fast (but you can run the script in your setup)

Implemented in 5.6 so can be used now. (Followup on #12119)
