### PR TITLE
[5.2] Added ability to use singular resource wildcards and set custom wildc…

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -21,6 +21,20 @@ class ResourceRegistrar
     protected $resourceDefaults = ['index', 'create', 'store', 'show', 'edit', 'update', 'destroy'];
 
     /**
+     * Determines whether to use singular wildcards.
+     *
+     * @var bool
+     */
+    protected $singularWildcards = false;
+
+    /**
+     * The custom wildcards to use.
+     *
+     * @var array
+     */
+    protected $wildcards = [];
+
+    /**
      * Create a new resource registrar instance.
      *
      * @param  \Illuminate\Routing\Router  $router
@@ -50,6 +64,9 @@ class ResourceRegistrar
             return;
         }
 
+        // Set the custom wildcards to use if applicable.
+        $this->wildcards = isset($options['wildcards']) ? $options['wildcards'] : [];
+
         // We need to extract the base resource from the resource name. Nested resources
         // are supported in the framework, but we need to know what name to use for a
         // place-holder on the route wildcards, which should be the base resources.
@@ -60,6 +77,9 @@ class ResourceRegistrar
         foreach ($this->getResourceMethods($defaults, $options) as $m) {
             $this->{'addResource'.ucfirst($m)}($name, $base, $controller, $options);
         }
+
+        // Reset the custom wildcards for next register call.
+        $this->wildcards = [];
     }
 
     /**
@@ -221,6 +241,18 @@ class ResourceRegistrar
     }
 
     /**
+     * Use singular wildcards.
+     *
+     * @return $this
+     */
+    public function useSingularWildcards()
+    {
+        $this->singularWildcards = true;
+
+        return $this;
+    }
+
+    /**
      * Format a resource wildcard for usage.
      *
      * @param  string  $value
@@ -228,6 +260,14 @@ class ResourceRegistrar
      */
     public function getResourceWildcard($value)
     {
+        if (isset($this->wildcards[$value])) {
+            return $this->wildcards[$value];
+        }
+
+        if ($this->singularWildcards) {
+            $value = Str::singular($value);
+        }
+
         return str_replace('-', '_', $value);
     }
 

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -36,7 +36,7 @@ class RoutingServiceProvider extends ServiceProvider
     protected function registerRouter()
     {
         $this->app['router'] = $this->app->share(function ($app) {
-            return new Router($app['events'], $app);
+            return new Router($app['events'], $app, $app->make('Illuminate\Routing\ResourceRegistrar'));
         });
     }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -721,6 +721,41 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($router->getRoutes()->hasNamedRoute('bar'));
     }
 
+    public function testUseSingularResources()
+    {
+        $router = $this->getRouter();
+        $router->useSingularResources();
+        $router->resource('foos', 'FooController');
+
+        $routes = $router->getRoutes();
+        $this->assertEquals('foos', $routes->getByName('foos.index')->uri());
+        $this->assertEquals('foos/{foo}', $routes->getByName('foos.show')->uri());
+        $this->assertEquals('foos/create', $routes->getByName('foos.create')->uri());
+        $this->assertEquals('foos', $routes->getByName('foos.store')->uri());
+        $this->assertEquals('foos/{foo}/edit', $routes->getByName('foos.edit')->uri());
+        $this->assertEquals('foos/{foo}', $routes->getByName('foos.update')->uri());
+        $this->assertEquals('foos/{foo}', $routes->getByName('foos.destroy')->uri());
+    }
+
+    public function testResourceWildcards()
+    {
+        $router = $this->getRouter();
+
+        $router->resource('foos.boos', 'FooController', ['wildcards' => [
+            'foos' => 'fee',
+            'boos' => 'bee',
+        ]]);
+
+        $routes = $router->getRoutes();
+        $this->assertEquals('foos/{fee}/boos', $routes->getByName('foos.boos.index')->uri());
+        $this->assertEquals('foos/{fee}/boos/{bee}', $routes->getByName('foos.boos.show')->uri());
+        $this->assertEquals('foos/{fee}/boos/create', $routes->getByName('foos.boos.create')->uri());
+        $this->assertEquals('foos/{fee}/boos', $routes->getByName('foos.boos.store')->uri());
+        $this->assertEquals('foos/{fee}/boos/{bee}/edit', $routes->getByName('foos.boos.edit')->uri());
+        $this->assertEquals('foos/{fee}/boos/{bee}', $routes->getByName('foos.boos.update')->uri());
+        $this->assertEquals('foos/{fee}/boos/{bee}', $routes->getByName('foos.boos.destroy')->uri());
+    }
+
     public function testRouterFiresRoutedEvent()
     {
         $events = new Illuminate\Events\Dispatcher();


### PR DESCRIPTION
Allows you to:
- Use singular resource wildcards (fixes type hinting in controllers when using non-singular resources):
- Add custom wildcard mapping

``` php
Route::useSingularResources();
Route::resource('users', 'UserController'); // Will bind: `users/{user}`
```

Custom wildcard mapping:

``` php
Route::resource('users', 'UserController', ['wildcards' => ['users' => 'member']]); // Will bind: `users/{member}`
```

Ref #12061, #11984
