### PR TITLE
Revert "[5.1] Allow multi-dimentional arrays in pagination"

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -128,7 +128,7 @@ abstract class AbstractPaginator
         }
 
         return $this->path.'?'
-                        .urldecode(http_build_query($parameters, null, '&'))
+                        .http_build_query($parameters, null, '&')
                         .$this->buildFragment();
     }
 


### PR DESCRIPTION
The paginator does not handle unsafe characters supplied by the appends method.

URL decoding of the http_build_query output generates broken query strings when any values contain ampersands or other unsafe characters. e.g. 

`App\User::paginate(10)->appends(['keywords' => 'mac & cheese'])->links();`

Generates links like this:

`http://localhost?keywords=mac &amp; cheese&amp;page=2`

instead of:

`http://localhost?keywords=mac+%26+cheese&amp;page=2`

I also note that URL decoding is unnecessary for supporting multi-dimensional arrays, which appears to be the reason that the call to urldecode was added originally.  PHP decodes the encoded square bracket characters in the parameter name and builds the array correctly.
