### PR TITLE
[5.2] Handle InnoDB Deadlocks By Re-Attempting Transactions

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -25,6 +25,7 @@ trait DetectsLostConnections
             'Error while sending',
             'decryption failed or bad record mac',
             'SSL connection has been closed unexpectedly',
+            'Deadlock found when trying to get lock',
         ]);
     }
 }


### PR DESCRIPTION
On MySQL galera cluster, deadlocks happens very often. Fixes #5380
