### PR TITLE
[5.1] Type hint app instance in DatabaseManager

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Database\Connectors\ConnectionFactory;
+use Illuminate\Contracts\Container\Container;
 
 class DatabaseManager implements ConnectionResolverInterface
 {
@@ -40,11 +41,11 @@ class DatabaseManager implements ConnectionResolverInterface
     /**
      * Create a new database manager instance.
      *
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Container\Container  $app
      * @param  \Illuminate\Database\Connectors\ConnectionFactory  $factory
      * @return void
      */
-    public function __construct($app, ConnectionFactory $factory)
+    public function __construct(Container $app, ConnectionFactory $factory)
     {
         $this->app = $app;
         $this->factory = $factory;


### PR DESCRIPTION
Type-hint the application instance in `Illuminate\Database\DatabaseManager` to the `Illuminate\Contracts\Container\Container` contract.

This also fix an error when injecting `Illuminate\Database\DatabaseManager` through a constructor in Lumen 5.1, and `$app` cannot be resolved.

```
Unresolvable dependency resolving [Parameter #0 [ <required> $app ]] in class Illuminate\Database\DatabaseManager
```
