### PR TITLE
[5.3] Add additional arguments to setFetchMode in Database/Connection.

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -79,6 +79,20 @@ class Connection implements ConnectionInterface
     protected $fetchMode = PDO::FETCH_OBJ;
 
     /**
+     * Argument for fetch mode when using column, class, or func fetch modes.
+     *
+     * @var mixed
+     */
+    protected $fetchArgument;
+
+    /**
+     * Constructor arguments when using the PDO::FETCH_CLASS fetch mode.
+     *
+     * @var array
+     */
+    protected $fetchCtorArgs = [];
+
+    /**
      * The number of active transactions.
      *
      * @var int
@@ -320,7 +334,11 @@ class Connection implements ConnectionInterface
 
             $statement->execute($me->prepareBindings($bindings));
 
-            return $statement->fetchAll($me->getFetchMode());
+            $fetchArg = $me->getFetchArgument();
+
+            return isset($fetchArg) ?
+                $statement->fetchAll($me->getFetchMode(), $fetchArg, $me->getFetchCtorArgs()) :
+                $statement->fetchAll($me->getFetchMode());
         });
     }
 
@@ -1044,14 +1062,38 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Set the default fetch mode for the connection.
+     * Get the optional fetch argument applied when using PDO FETCH_COLUMN, FETCH_CLASS, and FETCH_FUNC fetch modes.
+     *
+     * @return mixed
+     */
+    public function getFetchArgument()
+    {
+        return $this->fetchArgument;
+    }
+
+    /**
+     * Get custom class constructor arguments when using the PDO::FETCH_CLASS fetch mode.
+     *
+     * @return array
+     */
+    public function getFetchCtorArgs()
+    {
+        return $this->fetchCtorArgs;
+    }
+
+    /**
+     * Set the default fetch mode for the connection, and optional arguments for the given fetch mode.
      *
      * @param  int  $fetchMode
+     * @param  mixed  $fetchArgument
+     * @param  array  $ctorArgs
      * @return int
      */
-    public function setFetchMode($fetchMode)
+    public function setFetchMode($fetchMode, $fetchArgument = null, array $ctorArgs = [])
     {
         $this->fetchMode = $fetchMode;
+        $this->fetchArgument = $fetchArgument;
+        $this->fetchCtorArgs = $ctorArgs;
     }
 
     /**

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -234,6 +234,25 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertSame($connection, $schema->getConnection());
     }
 
+    public function testAlternateFetchModes()
+    {
+        $stmt = $this->getMock('PDOStatement');
+        $stmt->expects($this->exactly(3))->method('fetchAll')->withConsecutive(
+            [PDO::FETCH_ASSOC],
+            [PDO::FETCH_COLUMN, 3, []],
+            [PDO::FETCH_CLASS, 'stdClass', [1, 2, 3]]
+        );
+        $pdo = $this->getMock('DatabaseConnectionTestMockPDO');
+        $pdo->expects($this->any())->method('prepare')->will($this->returnValue($stmt));
+        $connection = $this->getMockConnection([], $pdo);
+        $connection->setFetchMode(PDO::FETCH_ASSOC);
+        $connection->select('SELECT * FROM foo');
+        $connection->setFetchMode(PDO::FETCH_COLUMN, 3);
+        $connection->select('SELECT * FROM foo');
+        $connection->setFetchMode(PDO::FETCH_CLASS, 'stdClass', [1, 2, 3]);
+        $connection->select('SELECT * FROM foo');
+    }
+
     protected function getMockConnection($methods = [], $pdo = null)
     {
         $pdo = $pdo ?: new DatabaseConnectionTestMockPDO;


### PR DESCRIPTION
## Summary

This PR adds support for more of PDO's underlying fetch modes.

The fetch mode setters/getters can pretty trivially support a wider range of fetch modes as supported by PDO, and in a backwards compatible way. Additional fetch modes can offer performance advantages. 

The additional fetch mode availability is of no direct benefit to Laravel or the Eloquent ORM, but it can offer benefits to those using the query builder that could use additional fetch modes. In my particular case, I need the performance of `PDO::FETCH_CLASS` over copying object properties.

This pull request is not complete. I'm submitting it for discussion, and to gauge interest. If this is something that the Laravel framework would want, I can complete the work (tests) and make whatever style changes are necessary to have the PR accepted. If this isn't of interest, I'll drop it and go another route.
## Benchmark

To demonstrate the potential performance advantages, I performed a simple retrieval of 10000 rows of an example users table using three different methods:
- Direct fetch to `stdClass` using `Capsule::table('example_users')->get()`
- Eloquent ORM `ExampleUsers::get()`
- Direct fetch to a custom class using `Capsule::table('example_users')->get()` and the `PDO::FETCH_CLASS` fetch mode. (AFAIK, this is not possible in vanilla Laravel. That's what this patch enables.)
### Result Summary

An average of three runs of each retrieval yields:
- `get()` 10000 rows to stdClass: 0.084053 seconds
- `get()` 10000 rows to an Eloquent class: 0.293689 seconds (pretty amazing for a dynamic ORM)
- `get()` 10000 rows to a custom class: 0.077157 seconds

Yep... _`stdClass` is slower_ than using a custom class.
### Benchmark Method

A dummy table with several rows was created and populated with dummy data:

``` php
Capsule::schema()->create('example_users', function($table) {
    $table->increments('id');
    $table->string('email')->unique();
    $table->string('first_name');
    $table->string('middle_name');
    $table->string('last_name');
    $table->string('favorite_color');
    $table->timestamps();
});

$users = [];
for ($i = 0; $i < 10000; $i++) {
    $users[] = [
        'email' => hash('sha256', mt_rand()), // any unique string.
        'first_name' => hash('sha256', mt_rand()),
        'middle_name' => hash('sha256', mt_rand()),
        'last_name' => hash('sha256', mt_rand()),
        'favorite_color' => hash('sha256', mt_rand()),
    ];
}
Capsule::table('example_users')->insert($users);
```

A test script for each retrieval method was then used:

**Direct `stdClass` get (default fetch mode - relevant portion):**

``` php
class EloquentExample extends Illuminate\Database\Eloquent\Model
{   
    protected $table = 'example_users';
}

$start = microtime(true);
Capsule::table('example_users')->get();
$end = microtime(true);
printf("Query builder took %0.6f seconds. Memory: %d\n", $end - $start, memory_get_usage());
```

**Eloquent (default fetch mode - relevant portion):**

``` php
$start = microtime(true);
EloquentExample::get();
$end = microtime(true);
printf("Eloquent took %0.6f seconds\n", $end - $start);
```

**Direct to class (`PDO::FETCH_CLASS` fetch mode - new functionality):**

``` php
class BareExample
{
    public $id;
    public $email;
    public $first_name;
    public $last_name;
    public $favorite_color;
    public $created_at;
    public $updated_at;
}

$conn = $capsule->getConnection();
$conn->setFetchMode(PDO::FETCH_CLASS, BareExample::class);
$start = microtime(true);
$conn->table('example_users')->get();
$end = microtime(true);
printf("Hack-up took %0.6f seconds. Memory: %d\n", $end - $start, memory_get_usage());
assert($conn->table('example_users')->first() instanceof BareExample);
```
### Results

Tested each method with several warm-up runs (not counted), then 3 "real" runs.
- stdClass: 0.082275, 0.084942, 0.084942. Average of 0.084053s.
- Eloquent: 0.283799, 0.308291, 0.288976. Average of 0.293689s.
- Custom class: 0.073394, 0.083544, 0.074533. Average of 0.077157s.

Using `PDO::FETCH_CLASS` has a slight performance edge over fetching to stdClass, and a significant advantage over anything that has to copy object properties. (This is the thing I need for my particular use case. :-)
