### PR TITLE
[5.1] DatabaseTransactions trait functionality to rollback multiple connections

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -4,12 +4,42 @@ namespace Illuminate\Foundation\Testing;
 
 trait DatabaseTransactions
 {
+    /**
+     * This property will store references to the connections currently affected by the transaction. They are stored
+     * as a key => value array of connection_name => ConnectionObject.
+     *
+     * @var array
+     */
+    protected $transactingConnections = [];
+
+    /**
+     * Get the names of the database connections that should be included in the transaction. The default value of empty
+     * string will cause only the default database connection to be included in the transaction.
+     *
+     * @return array
+     */
+    protected function connectionsToTransact()
+    {
+        return [''];
+    }
+
     public function beginDatabaseTransaction()
     {
-        $this->app->make('db')->beginTransaction();
+        $db = $this->app->make('db');
+
+        foreach ($this->connectionsToTransact() as $connectionName) {
+            $connection = $db->connection($connectionName);
+            $this->transactingConnections[$connectionName] = $connection;
+
+            $connection->beginTransaction();
+        }
 
         $this->beforeApplicationDestroyed(function () {
-            $this->app->make('db')->rollBack();
+            $db = $this->app->make('db');
+
+            foreach ($this->connectionsToTransact() as $connectionName) {
+                $db->connection($connectionName)->rollBack();
+            }
         });
     }
 }


### PR DESCRIPTION
This feature is fully backwards-compatible.

If a user is using `DatabaseTransactions` but the tests involve multiple database connections, they can now override the `connectionsToTransact()` method and return an array of their database names.

I also added a protected property `transactingConnections` because if one needs to select some data that has been inserted into a table that is undergoing a transaction using `\DB::connection($connectionName)` will return a new connection instead, and the data won't be there. This seemed like a better solution to me than registering singletons, etc.

If this PR is accepted, I'd be happy to submit a subsequent pull to update the docs.
