### PR TITLE
[5.2] Arr::flatten optimization

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -161,21 +161,26 @@ class Arr
      */
     public static function flatten($array, $depth = INF)
     {
-        return array_reduce($array, function ($result, $item) use ($depth) {
+        $result = [];
+
+        foreach ($array as $item) {
             $item = $item instanceof Collection ? $item->all() : $item;
 
             if (is_array($item)) {
                 if ($depth === 1) {
-                    return array_merge($result, $item);
+                    $result = array_merge($result, $item);
+                    continue;
                 }
 
-                return array_merge($result, static::flatten($item, $depth - 1));
+                $flatten = static::flatten($item, $depth - 1);
+                $result = array_merge($result, $flatten);
+                continue;
             }
 
             $result[] = $item;
+        }
 
-            return $result;
-        }, []);
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Found that `Arr::flatten` method is pretty slow due to `array_reduce` function, replaced it with `foreach`.
As for critical use case for me: `Arr:flatten` is used in `Builder`'s `getBindings` method, so query with many parameters (e.g. `whereIn` on many ids) runs badly.
