### PR TITLE
[5.2] Add possibility to set ApplicationIntent=readonly for SqlServer

### DIFF
--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -90,6 +90,10 @@ class SqlServerConnector extends Connector implements ConnectorInterface
             $arguments['APP'] = $config['appname'];
         }
 
+        if (isset($config['readonly'])) {
+            $arguments['ApplicationIntent'] = 'ReadOnly';
+        }
+
         return $this->buildConnectString('sqlsrv', $arguments);
     }
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -146,7 +146,7 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase
 
     public function testSqlServerConnectCallsCreateConnectionWithOptionalArguments()
     {
-        $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'appname' => 'baz', 'charset' => 'utf-8'];
+        $config = ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'appname' => 'baz', 'readonly' => true, 'charset' => 'utf-8'];
         $dsn = $this->getDsn($config);
         $connector = $this->getMock('Illuminate\Database\Connectors\SqlServerConnector', ['createConnection', 'getOptions']);
         $connection = m::mock('stdClass');
@@ -170,8 +170,9 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase
         } else {
             $port = isset($config['port']) ? ','.$port : '';
             $appname = isset($config['appname']) ? ';APP='.$config['appname'] : '';
+            $readonly = isset($config['readonly']) ? ';ApplicationIntent=ReadOnly' : '';
 
-            return "sqlsrv:Server={$host}{$port};Database={$database}{$appname}";
+            return "sqlsrv:Server={$host}{$port};Database={$database}{$appname}{$readonly}";
         }
     }
 }


### PR DESCRIPTION
If you use a Microsoft SQL Server availability group you can route readonly connections to the slave replicas. This can be done if you add ApplicationIntent=readonly to the database connection.
