### PR TITLE
[5.2] Modified DatabaseTransactions to work with multiple connections

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -25,14 +25,16 @@ trait DatabaseTransactions
 
     public function beginDatabaseTransaction()
     {
+        $db = $this->app->make('db');
         foreach ($this->connectionsToTransact() as $name) {
-            $this->transacting[$name] = $this->app->make('db')->connection($name);
+            $this->transacting[$name] = $db->connection($name);
             $this->transacting[$name]->beginConnection();
         }
 
         $this->beforeApplicationDestroyed(function () {
+            $db = $this->app->make('db');
             foreach ($this->connectionsToTransact() as $name) {
-                $this->app->make('db')->connection($name)->rollBack();
+                $db->connection($name)->rollBack();
             }
         });
     }

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -5,13 +5,6 @@ namespace Illuminate\Foundation\Testing;
 trait DatabaseTransactions
 {
     /**
-     * The connections currently affected by the transaction. Indexed by connection name.
-     *
-     * @var array
-     */
-    protected $transacting = [];
-
-    /**
      * Retrieve the names of the database connections that should be included in the transaction.
      *
      * The default value of empty string will cause only the default database connection to be included in the transaction.
@@ -26,9 +19,9 @@ trait DatabaseTransactions
     public function beginDatabaseTransaction()
     {
         $db = $this->app->make('db');
+
         foreach ($this->connectionsToTransact() as $name) {
-            $this->transacting[$name] = $db->connection($name);
-            $this->transacting[$name]->beginConnection();
+            $db->connection($name)->beginTransaction();
         }
 
         $this->beforeApplicationDestroyed(function () {

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -4,12 +4,36 @@ namespace Illuminate\Foundation\Testing;
 
 trait DatabaseTransactions
 {
+    /**
+     * The connections currently affected by the transaction. Indexed by connection name.
+     *
+     * @var array
+     */
+    protected $transacting = [];
+
+    /**
+     * Retrieve the names of the database connections that should be included in the transaction.
+     *
+     * The default value of empty string will cause only the default database connection to be included in the transaction.
+     *
+     * @return array
+     */
+    protected function connectionsToTransact()
+    {
+        return [''];
+    }
+
     public function beginDatabaseTransaction()
     {
-        $this->app->make('db')->beginTransaction();
+        foreach ($this->connectionsToTransact() as $name) {
+            $this->transacting[$name] = $this->app->make('db')->connection($name);
+            $this->transacting[$name]->beginConnection();
+        }
 
         $this->beforeApplicationDestroyed(function () {
-            $this->app->make('db')->rollBack();
+            foreach ($this->connectionsToTransact() as $name) {
+                $this->app->make('db')->connection($name)->rollBack();
+            }
         });
     }
 }


### PR DESCRIPTION
[Resubmitting, accidentally submitted previous one against 5.1]

This feature is fully backwards-compatible.

If a user is using DatabaseTransactions but the tests involve multiple database connections, they can now override the connectionsToTransact() method and return an array of their database names.

I also added a protected property transactingConnections because if one needs to select some data that has been inserted into a table that is undergoing a transaction using \DB::connection($connectionName) will return a new connection instead, and the data won't be there. This seemed like a better solution to me than registering singletons, etc.

If this PR is accepted, I'd be happy to submit a subsequent pull to update the docs.
