### PR TITLE
[5.2] Asserting links with relative URLs

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -333,10 +333,11 @@ trait InteractsWithPages
             return true;
         }
 
-        $url = $this->addRootToRelativeUrl($url);
+        $absoluteUrl = $this->addRootToRelativeUrl($url);
 
         foreach ($links as $link) {
-            if ($link->getAttribute('href') == $url) {
+            $linkHref = $link->getAttribute('href');
+            if ($linkHref == $url || $linkHref == $absoluteUrl) {
                 return true;
             }
         }


### PR DESCRIPTION
When you have a page with relative links, there's no way to assert their existence with hasLink() since $url parameter is always converted to absolute URL.
