### PR TITLE
Implemented fix for #9967 removing standard tagged cache items aswell as forever (Redis)

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -5,6 +5,19 @@ namespace Illuminate\Cache;
 class RedisTaggedCache extends TaggedCache
 {
     /**
+     * Forever reference key.
+     *
+     * @var string
+     */
+    const REFERENCE_KEY_FOREVER = 'forever';
+    /**
+     * Standard reference key.
+     *
+     * @var string
+     */
+    const REFERENCE_KEY_STANDARD = 'standard';
+
+    /**
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
@@ -19,6 +32,21 @@ class RedisTaggedCache extends TaggedCache
     }
 
     /**
+     * Store an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @param  \DateTime|int  $minutes
+     * @return void
+     */
+    public function put($key, $value, $minutes = null)
+    {
+        $this->pushStandardKeys($this->tags->getNamespace(), $key);
+
+        parent::put($key, $value, $minutes);
+    }
+
+    /**
      * Remove all items from the cache.
      *
      * @return void
@@ -26,12 +54,13 @@ class RedisTaggedCache extends TaggedCache
     public function flush()
     {
         $this->deleteForeverKeys();
+        $this->deleteStandardKeys();
 
         parent::flush();
     }
 
     /**
-     * Store a copy of the full key for each namespace segment.
+     * Store forever key references into store.
      *
      * @param  string  $namespace
      * @param  string  $key
@@ -39,10 +68,35 @@ class RedisTaggedCache extends TaggedCache
      */
     protected function pushForeverKeys($namespace, $key)
     {
+        $this->pushKeys($namespace, $key, self::REFERENCE_KEY_FOREVER);
+    }
+
+    /**
+     * Store standard key references into store.
+     *
+     * @param  string  $namespace
+     * @param  string  $key
+     * @return void
+     */
+    protected function pushStandardKeys($namespace, $key)
+    {
+        $this->pushKeys($namespace, $key, self::REFERENCE_KEY_STANDARD);
+    }
+
+    /**
+     * Store a reference to the cache key against the reference key.
+     *
+     * @param  string  $namespace
+     * @param  string  $key
+     * @param  string  $reference
+     * @return void
+     */
+    protected function pushKeys($namespace, $key, $reference)
+    {
         $fullKey = $this->getPrefix().sha1($namespace).':'.$key;
 
         foreach (explode('|', $namespace) as $segment) {
-            $this->store->connection()->lpush($this->foreverKey($segment), $fullKey);
+            $this->store->connection()->lpush($this->referenceKey($segment, $reference), $fullKey);
         }
     }
 
@@ -53,36 +107,59 @@ class RedisTaggedCache extends TaggedCache
      */
     protected function deleteForeverKeys()
     {
+        $this->deleteKeysByReference(self::REFERENCE_KEY_FOREVER);
+    }
+
+    /**
+     * Delete all standard items.
+     *
+     * @return void
+     */
+    protected function deleteStandardKeys()
+    {
+        $this->deleteKeysByReference(self::REFERENCE_KEY_STANDARD);
+    }
+
+    /**
+     * Find and delete all of the items that were stored against a reference.
+     *
+     * @param  string  $reference
+     * @return void
+     */
+    protected function deleteKeysByReference($reference)
+    {
         foreach (explode('|', $this->tags->getNamespace()) as $segment) {
-            $this->deleteForeverValues($segment = $this->foreverKey($segment));
+            // Now we've found the reference, delete it's items
+            $this->deleteValues($segment = $this->referenceKey($segment, $reference));
 
             $this->store->connection()->del($segment);
         }
     }
 
     /**
-     * Delete all of the keys that have been stored forever.
+     * Delete item keys that have been stored against a reference.
      *
-     * @param  string  $foreverKey
+     * @param  string  $referenceKey
      * @return void
      */
-    protected function deleteForeverValues($foreverKey)
+    protected function deleteValues($referenceKey)
     {
-        $forever = array_unique($this->store->connection()->lrange($foreverKey, 0, -1));
+        $values = array_unique($this->store->connection()->lrange($referenceKey, 0, -1));
 
-        if (count($forever) > 0) {
-            call_user_func_array([$this->store->connection(), 'del'], $forever);
+        if (count($values) > 0) {
+            call_user_func_array([$this->store->connection(), 'del'], $values);
         }
     }
 
     /**
-     * Get the forever reference key for the segment.
+     * Get the reference key for the segment.
      *
      * @param  string  $segment
+     * @param  string  $suffix
      * @return string
      */
-    protected function foreverKey($segment)
+    protected function referenceKey($segment, $suffix)
     {
-        return $this->getPrefix().$segment.':forever';
+        return $this->getPrefix().$segment.':'.$suffix;
     }
 }


### PR DESCRIPTION
Hi guys

This bugfix removes standard Redis tagged cache items, as mentioned in #9967. 

Currently only forever tags are removed. To preserve functionality I've separated out "standard" and "forever" tags (forever already had an array item to track keys), therefore each one can be individually flushed if desired. 
