### PR TITLE
[5.2] Ability to assign items to multiple groups when grouping a collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -327,7 +327,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Group an associative array by a field or using a callback.
      *
      * @param  callable|string  $groupBy
-     * @param  bool             $preserveKeys
+     * @param  bool $preserveKeys
      * @return static
      */
     public function groupBy($groupBy, $preserveKeys = false)
@@ -351,6 +351,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 $results[$groupKey]->offsetSet($preserveKeys ? $key : null, $value);
             }
         }
+
         return new static($results);
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -327,7 +327,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Group an associative array by a field or using a callback.
      *
      * @param  callable|string  $groupBy
-     * @param  bool $preserveKeys
+     * @param  bool  $preserveKeys
      * @return static
      */
     public function groupBy($groupBy, $preserveKeys = false)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -339,7 +339,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         foreach ($this->items as $key => $value) {
             $groupKeys = $groupBy($value, $key);
 
-            if(! is_array($groupKeys)) {
+            if (! is_array($groupKeys)) {
                 $groupKeys = [$groupKeys];
             }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -327,6 +327,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Group an associative array by a field or using a callback.
      *
      * @param  callable|string  $groupBy
+     * @param  bool             $preserveKeys
      * @return static
      */
     public function groupBy($groupBy, $preserveKeys = false)
@@ -336,15 +337,20 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $results = [];
 
         foreach ($this->items as $key => $value) {
-            $groupKey = $groupBy($value, $key);
+            $groupKeys = $groupBy($value, $key);
 
-            if (! array_key_exists($groupKey, $results)) {
-                $results[$groupKey] = new static;
+            if( ! is_array($groupKeys)){
+                $groupKeys = [$groupKeys];
             }
 
-            $results[$groupKey]->offsetSet($preserveKeys ? $key : null, $value);
-        }
+            foreach($groupKeys as $groupKey) {
+                if ( ! array_key_exists( $groupKey, $results ) ) {
+                    $results[$groupKey] = new static;
+                }
 
+                $results[$groupKey]->offsetSet($preserveKeys ? $key : null, $value);
+            }
+        }
         return new static($results);
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -339,12 +339,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         foreach ($this->items as $key => $value) {
             $groupKeys = $groupBy($value, $key);
 
-            if( ! is_array($groupKeys)){
+            if(! is_array($groupKeys)) {
                 $groupKeys = [$groupKeys];
             }
 
-            foreach($groupKeys as $groupKey) {
-                if ( ! array_key_exists( $groupKey, $results ) ) {
+            foreach ($groupKeys as $groupKey) {
+                if (! array_key_exists($groupKey, $results)) {
                     $results[$groupKey] = new static;
                 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -798,6 +798,108 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]], $result->toArray());
     }
 
+    public function testGroupByAttributePreservingKeys()
+    {
+        $data = new Collection([ 10 => ['rating' => 1, 'url' => '1'],  20 => ['rating' => 1, 'url' => '1'],  30 => ['rating' => 2, 'url' => '2']]);
+
+        $result = $data->groupBy('rating', true);
+
+        $expected_result = [
+            1 => [10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1']],
+            2 => [30 => ['rating' => 2, 'url' => '2']]
+        ];
+
+        $this->assertEquals($expected_result, $result->toArray());
+    }
+
+    public function testGroupByClosureWhereItemsHaveSingleGroup()
+    {
+        $data = new Collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
+
+        $result = $data->groupBy(function($item)
+        {
+            return $item['rating'];
+        });
+
+        $this->assertEquals([1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]], $result->toArray());
+    }
+
+    public function testGroupByClosureWhereItemsHaveSingleGroupPreservingKeys()
+    {
+        $data = new Collection([10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1'], 30 => ['rating' => 2, 'url' => '2']]);
+
+        $result = $data->groupBy(function($item)
+        {
+            return $item['rating'];
+        }, true);
+
+        $expected_result = [
+            1 => [10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1']],
+            2 => [30 => ['rating' => 2, 'url' => '2']]
+        ];
+
+        $this->assertEquals($expected_result, $result->toArray());    }
+
+    public function testGroupByClosureWhereItemsHaveMultipleGroups()
+    {
+        $data = new Collection([
+            ['user' => 1, 'roles' => ['Role_1', 'Role_3'],],
+            ['user' => 2, 'roles' => ['Role_1', 'Role_2'],],
+            ['user' => 3, 'roles' => ['Role_1'],]
+        ]);
+
+        $result = $data->groupBy(function($item)
+        {
+            return $item['roles'];
+        });
+
+        $expected_result = [
+            'Role_1' => [
+                ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
+                ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
+                ['user' => 3, 'roles' => ['Role_1']]
+            ],
+            'Role_2' => [
+                ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
+            ],
+            'Role_3' => [
+                ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
+            ],
+        ];
+
+        $this->assertEquals($expected_result, $result->toArray());
+    }
+
+    public function testGroupByClosureWhereItemsHaveMultipleGroupsPreservingKeys()
+    {
+        $data = new Collection([
+            10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'],],
+            20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2'],],
+            30 => ['user' => 3, 'roles' => ['Role_1'],]
+        ]);
+
+        $result = $data->groupBy(function($item)
+        {
+            return $item['roles'];
+        }, true);
+
+        $expected_result = [
+            'Role_1' => [
+                10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
+                20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
+                30 => ['user' => 3, 'roles' => ['Role_1']]
+            ],
+            'Role_2' => [
+                20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
+            ],
+            'Role_3' => [
+                10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
+            ],
+        ];
+
+        $this->assertEquals($expected_result, $result->toArray());
+    }
+
     public function testKeyByAttribute()
     {
         $data = new Collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -836,7 +836,8 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             2 => [30 => ['rating' => 2, 'url' => '2']],
         ];
 
-        $this->assertEquals($expected_result, $result->toArray());    }
+        $this->assertEquals($expected_result, $result->toArray());
+    }
 
     public function testGroupByClosureWhereItemsHaveMultipleGroups()
     {
@@ -846,7 +847,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             ['user' => 3, 'roles' => ['Role_1']],
         ]);
 
-        $result = $data->groupBy( function($item) {
+        $result = $data->groupBy(function($item) {
             return $item['roles'];
         });
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -800,13 +800,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
     public function testGroupByAttributePreservingKeys()
     {
-        $data = new Collection([ 10 => ['rating' => 1, 'url' => '1'],  20 => ['rating' => 1, 'url' => '1'],  30 => ['rating' => 2, 'url' => '2']]);
+        $data = new Collection([10 => ['rating' => 1, 'url' => '1'],  20 => ['rating' => 1, 'url' => '1'],  30 => ['rating' => 2, 'url' => '2']]);
 
         $result = $data->groupBy('rating', true);
 
         $expected_result = [
             1 => [10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1']],
-            2 => [30 => ['rating' => 2, 'url' => '2']]
+            2 => [30 => ['rating' => 2, 'url' => '2']],
         ];
 
         $this->assertEquals($expected_result, $result->toArray());
@@ -816,8 +816,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     {
         $data = new Collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
 
-        $result = $data->groupBy(function($item)
-        {
+        $result = $data->groupBy(function ($item) {
             return $item['rating'];
         });
 
@@ -828,14 +827,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     {
         $data = new Collection([10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1'], 30 => ['rating' => 2, 'url' => '2']]);
 
-        $result = $data->groupBy(function($item)
-        {
+        $result = $data->groupBy(function ($item) {
             return $item['rating'];
         }, true);
 
         $expected_result = [
             1 => [10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1']],
-            2 => [30 => ['rating' => 2, 'url' => '2']]
+            2 => [30 => ['rating' => 2, 'url' => '2']],
         ];
 
         $this->assertEquals($expected_result, $result->toArray());    }
@@ -843,13 +841,12 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     public function testGroupByClosureWhereItemsHaveMultipleGroups()
     {
         $data = new Collection([
-            ['user' => 1, 'roles' => ['Role_1', 'Role_3'],],
-            ['user' => 2, 'roles' => ['Role_1', 'Role_2'],],
-            ['user' => 3, 'roles' => ['Role_1'],]
+            ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
+            ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
+            ['user' => 3, 'roles' => ['Role_1']],
         ]);
 
-        $result = $data->groupBy(function($item)
-        {
+        $result = $data->groupBy( function($item) {
             return $item['roles'];
         });
 
@@ -857,7 +854,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             'Role_1' => [
                 ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
                 ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
-                ['user' => 3, 'roles' => ['Role_1']]
+                ['user' => 3, 'roles' => ['Role_1']],
             ],
             'Role_2' => [
                 ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
@@ -873,13 +870,12 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     public function testGroupByClosureWhereItemsHaveMultipleGroupsPreservingKeys()
     {
         $data = new Collection([
-            10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3'],],
-            20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2'],],
-            30 => ['user' => 3, 'roles' => ['Role_1'],]
+            10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
+            20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
+            30 => ['user' => 3, 'roles' => ['Role_1']],
         ]);
 
-        $result = $data->groupBy(function($item)
-        {
+        $result = $data->groupBy(function ($item) {
             return $item['roles'];
         }, true);
 
@@ -887,7 +883,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             'Role_1' => [
                 10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
                 20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
-                30 => ['user' => 3, 'roles' => ['Role_1']]
+                30 => ['user' => 3, 'roles' => ['Role_1']],
             ],
             'Role_2' => [
                 20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2']],

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -847,7 +847,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             ['user' => 3, 'roles' => ['Role_1']],
         ]);
 
-        $result = $data->groupBy(function($item) {
+        $result = $data->groupBy(function ($item) {
             return $item['roles'];
         });
 


### PR DESCRIPTION
Example:

`
$collection->groupBy(function($item) 
{
    return ['group_1', 'group_2'];
});
`

Or

`
$collection->groupBy('roles');
`

(if the 'roles' attribute is an array)
