### PR TITLE
[5.2] Add seeAuthentication test methods

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+trait InteractsWithAuthentication
+{
+    /**
+     * Return true if the user is authenticated, false otherwise.
+     *
+     * @param  string|null  $guard
+     * @return bool
+     */
+    protected function isAuthenticated($guard = null)
+    {
+        return $this->app->make('auth')->guard($guard)->check();
+    }
+
+    /**
+     * Assert that the user is authenticated.
+     *
+     * @param string|null  $guard
+     * @return $this
+     */
+    public function seeIsAuthenticated($guard = null)
+    {
+        $this->assertTrue($this->isAuthenticated($guard), 'The user is not authenticated');
+
+        return $this;
+    }
+
+    /**
+     * Assert that the user is not authenticated.
+     *
+     * @param  string|null  $guard
+     * @return $this
+     */
+    public function dontSeeIsAuthenticated($guard = null)
+    {
+        $this->assertFalse($this->isAuthenticated($guard), 'The user is authenticated');
+
+        return $this;
+    }
+
+    /**
+     * Assert that the user is authenticated as the given user.
+     *
+     * @param  $user
+     * @param  string|null  $guard
+     * @return $this
+     */
+    public function seeIsAuthenticatedAs($user, $guard = null)
+    {
+        $this->assertSame(
+            $this->app->make('auth')->guard($guard)->user(), $user,
+            'The logged in user is not the same'
+        );
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -10,6 +10,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
     use Concerns\InteractsWithContainer,
         Concerns\MakesHttpRequests,
         Concerns\ImpersonatesUsers,
+        Concerns\InteractsWithAuthentication,
         Concerns\InteractsWithConsole,
         Concerns\InteractsWithDatabase,
         Concerns\InteractsWithSession,

--- a/tests/Foundation/FoundationAuthenticationTest.php
+++ b/tests/Foundation/FoundationAuthenticationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use Mockery as m;
+use Illuminate\Auth\AuthManager;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithAuthentication;
+
+class FoundationAuthenticationTest extends PHPUnit_Framework_TestCase
+{
+    use InteractsWithAuthentication;
+
+    /**
+     * @var \Mockery
+     */
+    protected $app;
+
+    /**
+     * @var \Mockery
+     */
+    protected $auth;
+
+    /**
+     * @var \Mockery
+     */
+    protected $guard;
+
+    public function setUp()
+    {
+        $this->guard = m::mock(Guard::class);
+
+        $this->auth = m::mock(AuthManager::class);
+        $this->auth->shouldReceive('guard')
+            ->once()
+            ->andReturn($this->guard);
+
+        $this->app = m::mock(Application::class);
+        $this->app->shouldReceive('make')
+            ->once()
+            ->withArgs(['auth'])
+            ->andReturn($this->auth);
+    }
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testSeeIsAuthenticated()
+    {
+        $this->guard->shouldReceive('check')
+            ->once()
+            ->andReturn(true);
+
+        $this->seeIsAuthenticated();
+    }
+
+    public function testDontSeeIsAuthenticated()
+    {
+        $this->guard->shouldReceive('check')
+            ->once()
+            ->andReturn(false);
+
+        $this->dontSeeIsAuthenticated();
+    }
+
+    public function testSeeIsAuthenticatedAs()
+    {
+        $this->guard->shouldReceive('user')
+            ->once()
+            ->andReturn('Someone');
+
+        $this->seeIsAuthenticatedAs('Someone');
+    }
+}


### PR DESCRIPTION
The seeAuthentication method is useful to test login forms, the dontSeeAuthentication is useful to test logout forms and you can use seeIsAuthenticatedAs to test masquerade functionalities (for example check that an administrator was logged in as a particular user).
