### PR TITLE
[5.1] Default redirect path was pointing to a missing location

### DIFF
--- a/src/Illuminate/Foundation/Auth/RedirectsUsers.php
+++ b/src/Illuminate/Foundation/Auth/RedirectsUsers.php
@@ -15,6 +15,6 @@ trait RedirectsUsers
             return $this->redirectPath;
         }
 
-        return property_exists($this, 'redirectTo') ? $this->redirectTo : '/home';
+        return property_exists($this, 'redirectTo') ? $this->redirectTo : '/';
     }
 }


### PR DESCRIPTION
Follow-up to commit [Remove auth scaffolding to make it opt-in.](https://github.com/laravel/laravel/commit/5e11f87de2c8f9303e6e296d74ec5f7f2093fd9b) (huge page loading!)

For the record, Laravel 5.2 has added this property to AuthController: https://github.com/laravel/laravel/commit/58bc5273b8cfc559de7804fb294ed5940ea1776e, https://github.com/laravel/laravel/pull/3606
