### PR TITLE
[5.2] Blade `or` behaviour

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -345,7 +345,9 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function compileEchoDefaults($value)
     {
-        return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s', 'isset($1) ? $1 : $2', $value);
+        $expression = 'isset($1) && !is_null($1) ? $1 : $2';
+
+        return preg_replace('/^(?=\$)(.+?)(?:\s+or\s+)(.+?)$/s', $expression, $value);
     }
 
     /**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -92,7 +92,7 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{!!
             $name
         !!}'));
-        $this->assertEquals('<?php echo isset($name) ? $name : \'foo\'; ?>', $compiler->compileString('{!! $name or \'foo\' !!}'));
+        $this->assertEquals('<?php echo isset($name) && !is_null($name) ? $name : \'foo\'; ?>', $compiler->compileString('{!! $name or \'foo\' !!}'));
 
         $this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{{$name}}}'));
         $this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{$name}}'));
@@ -105,22 +105,22 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("<?php echo e(\$name); ?>\n\n", $compiler->compileString("{{ \$name }}\n"));
         $this->assertEquals("<?php echo e(\$name); ?>\r\n\r\n", $compiler->compileString("{{ \$name }}\r\n"));
 
-        $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>', $compiler->compileString('{{ $name or "foo" }}'));
-        $this->assertEquals('<?php echo e(isset($user->name) ? $user->name : "foo"); ?>', $compiler->compileString('{{ $user->name or "foo" }}'));
-        $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>', $compiler->compileString('{{$name or "foo"}}'));
-        $this->assertEquals('<?php echo e(isset($name) ? $name : "foo"); ?>', $compiler->compileString('{{
+        $this->assertEquals('<?php echo e(isset($name) && !is_null($name) ? $name : "foo"); ?>', $compiler->compileString('{{ $name or "foo" }}'));
+        $this->assertEquals('<?php echo e(isset($user->name) && !is_null($user->name) ? $user->name : "foo"); ?>', $compiler->compileString('{{ $user->name or "foo" }}'));
+        $this->assertEquals('<?php echo e(isset($name) && !is_null($name) ? $name : "foo"); ?>', $compiler->compileString('{{$name or "foo"}}'));
+        $this->assertEquals('<?php echo e(isset($name) && !is_null($name) ? $name : "foo"); ?>', $compiler->compileString('{{
             $name or "foo"
         }}'));
 
-        $this->assertEquals('<?php echo e(isset($name) ? $name : \'foo\'); ?>', $compiler->compileString('{{ $name or \'foo\' }}'));
-        $this->assertEquals('<?php echo e(isset($name) ? $name : \'foo\'); ?>', $compiler->compileString('{{$name or \'foo\'}}'));
-        $this->assertEquals('<?php echo e(isset($name) ? $name : \'foo\'); ?>', $compiler->compileString('{{
+        $this->assertEquals('<?php echo e(isset($name) && !is_null($name) ? $name : \'foo\'); ?>', $compiler->compileString('{{ $name or \'foo\' }}'));
+        $this->assertEquals('<?php echo e(isset($name) && !is_null($name) ? $name : \'foo\'); ?>', $compiler->compileString('{{$name or \'foo\'}}'));
+        $this->assertEquals('<?php echo e(isset($name) && !is_null($name) ? $name : \'foo\'); ?>', $compiler->compileString('{{
             $name or \'foo\'
         }}'));
 
-        $this->assertEquals('<?php echo e(isset($age) ? $age : 90); ?>', $compiler->compileString('{{ $age or 90 }}'));
-        $this->assertEquals('<?php echo e(isset($age) ? $age : 90); ?>', $compiler->compileString('{{$age or 90}}'));
-        $this->assertEquals('<?php echo e(isset($age) ? $age : 90); ?>', $compiler->compileString('{{
+        $this->assertEquals('<?php echo e(isset($age) && !is_null($age) ? $age : 90); ?>', $compiler->compileString('{{ $age or 90 }}'));
+        $this->assertEquals('<?php echo e(isset($age) && !is_null($age) ? $age : 90); ?>', $compiler->compileString('{{$age or 90}}'));
+        $this->assertEquals('<?php echo e(isset($age) && !is_null($age) ? $age : 90); ?>', $compiler->compileString('{{
             $age or 90
         }}'));
 


### PR DESCRIPTION
This is a proposal that brings to `or` operator the same ideia (but not the behavior, of course) of the `Null Coalesce Operator`.

The ideia of `or` in Blade is to **echo** a variable if exists, otherwise a default value is printed. And, of course, all of this using a ternary statement. So, instead of:

```
{{ isset($name) ? $name : 'Default' }}
```

We just write:

```
{{ $name or 'Default' }}
```

Cool!

But, knowing the ideia of `or` is to be a short-cut to **print** data, **maybe** is a good thing it also verify if the value is **not null**. Something like:

```
{{ isset($name) && !is_null($name) ? $name : 'Default' }}
```

If this change is a breaking change? I don't think so. Who needs to print a null value?

What you guys think?
