### PR TITLE
[5.2] Add within() method to InteractWithPages

### DIFF
--- a/tests/Foundation/FoundationInteractsWithPagesTest.php
+++ b/tests/Foundation/FoundationInteractsWithPagesTest.php
@@ -7,18 +7,20 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 {
     use MakesHttpRequests;
 
+    protected function setCrawler($html)
+    {
+        $this->crawler = new Crawler($html);
+    }
+
     public function testSeeInElement()
     {
-        $this->crawler = new Crawler(
-            '<div>Laravel was created by <strong>Taylor Otwell</strong></div>'
-        );
-
+        $this->setCrawler('<div>Laravel was created by <strong>Taylor Otwell</strong></div>');
         $this->seeInElement('strong', 'Taylor');
     }
 
     public function testSeeInElementSearchInAllElements()
     {
-        $this->crawler = new Crawler(
+        $this->setCrawler(
             '<div>
                 Laravel is a <strong>PHP framework</strong>
                 created by <strong>Taylor Otwell</strong>
@@ -30,7 +32,7 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testSeeInElementSearchInHtmlTags()
     {
-        $this->crawler = new Crawler(
+        $this->setCrawler(
             '<div id="mytable">
                 <img src="image.jpg">
             </div>'
@@ -41,7 +43,7 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testdontSeeInElement()
     {
-        $this->crawler = new Crawler(
+        $this->setCrawler(
             '<div>Laravel was created by <strong>Taylor Otwell</strong></div>'
         );
 
@@ -51,7 +53,7 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testSeeLink()
     {
-        $this->crawler = new Crawler(
+        $this->setCrawler(
             '<a href="https://laravel.com">Laravel</a>'
         );
 
@@ -61,7 +63,7 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testDontSeeLink()
     {
-        $this->crawler = new Crawler(
+        $this->setCrawler(
             '<a href="https://laravel.com">Laravel</a>'
         );
 
@@ -76,13 +78,13 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testSeeInInput()
     {
-        $this->crawler = new Crawler($this->getInputHtml());
+        $this->setCrawler($this->getInputHtml());
         $this->seeInField('framework', 'Laravel');
     }
 
     public function testDontSeeInInput()
     {
-        $this->crawler = new Crawler($this->getInputHtml());
+        $this->setCrawler($this->getInputHtml());
         $this->dontSeeInField('framework', 'Rails');
     }
 
@@ -93,13 +95,13 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testSeeInInputArray()
     {
-        $this->crawler = new Crawler($this->getInputArrayHtml());
+        $this->setCrawler($this->getInputArrayHtml());
         $this->seeInField('framework[]', 'Laravel');
     }
 
     public function testDontSeeInInputArray()
     {
-        $this->crawler = new Crawler($this->getInputArrayHtml());
+        $this->setCrawler($this->getInputArrayHtml());
         $this->dontSeeInField('framework[]', 'Rails');
     }
 
@@ -110,13 +112,13 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testSeeInTextarea()
     {
-        $this->crawler = new Crawler($this->getTextareaHtml());
+        $this->setCrawler($this->getTextareaHtml());
         $this->seeInField('description', 'Laravel is awesome');
     }
 
     public function testDontSeeInTextarea()
     {
-        $this->crawler = new Crawler($this->getTextareaHtml());
+        $this->setCrawler($this->getTextareaHtml());
         $this->dontSeeInField('description', 'Rails is awesome');
     }
 
@@ -131,13 +133,13 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testSeeOptionIsSelected()
     {
-        $this->crawler = new Crawler($this->getSelectHtml());
+        $this->setCrawler($this->getSelectHtml());
         $this->seeIsSelected('availability', 'full_time');
     }
 
     public function testDontSeeOptionIsSelected()
     {
-        $this->crawler = new Crawler($this->getSelectHtml());
+        $this->setCrawler($this->getSelectHtml());
         $this->dontSeeIsSelected('availability', 'partial_time');
     }
 
@@ -150,13 +152,13 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testSeeRadioIsChecked()
     {
-        $this->crawler = new Crawler($this->getRadiosHtml());
+        $this->setCrawler($this->getRadiosHtml());
         $this->seeIsSelected('availability', 'full_time');
     }
 
     public function testDontSeeRadioIsChecked()
     {
-        $this->crawler = new Crawler($this->getRadiosHtml());
+        $this->setCrawler($this->getRadiosHtml());
         $this->dontSeeIsSelected('availability', 'partial_time');
     }
 
@@ -169,13 +171,63 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
 
     public function testSeeCheckboxIsChecked()
     {
-        $this->crawler = new Crawler($this->getCheckboxesHtml());
+        $this->setCrawler($this->getCheckboxesHtml());
         $this->seeIsChecked('terms');
     }
 
     public function testDontSeeCheckboxIsChecked()
     {
-        $this->crawler = new Crawler($this->getCheckboxesHtml());
+        $this->setCrawler($this->getCheckboxesHtml());
         $this->dontSeeIsChecked('list');
+    }
+
+    protected function getLayoutHtml()
+    {
+        return
+            '<header>
+                <h1>Laravel</h1>
+            </header>
+            <section id="features">
+	            <h2>The PHP Framework For Web Artisans</h2>
+	            <p>Elegant applications delivered at warp speed.</p>
+            </section>
+            <footer>
+                <a href="docs">Documentation</a>
+            </footer>';
+    }
+
+    public function testWithin()
+    {
+        $this->setCrawler($this->getLayoutHtml());
+
+        // Limit the search to the "header" area
+        $this->within('header', function () {
+            $this->see('Laravel')
+                 ->dontSeeInElement('h2', 'PHP Framework');
+        });
+
+        // Make sure we are out of the within context
+        $this->seeLink('Documentation');
+
+        // Test other methods as well
+        $this->within('#features', function () {
+            $this->seeInElement('h2', 'PHP Framework')
+                ->dontSee('Laravel')
+                ->dontSeeLink('Documentation');
+        });
+    }
+
+    public function testNestedWithin()
+    {
+        $this->setCrawler($this->getLayoutHtml());
+
+        $this->within('#features', function () {
+            $this->dontSee('Laravel')
+                ->see('Web Artisans')
+                ->within('h2', function () {
+                    $this->see('PHP Framework')
+                        ->dontSee('Elegant applications');
+                });
+        });
     }
 }


### PR DESCRIPTION
I have needed this several times when writing tests for complex markups.

This method allows to narrow the test assertions or actions to specific areas of the web page.

For example, you have 2 links with the same text in the same page, but you want to make sure you click the one inside the content area:

```
        <header>
            <a href="link1">Link</a>
        </header>
        <div class="container">
            <a href="link2">Link</a>
        </div>
```

```
    $this->within('.container', function () {
        $this->seeLink('Link')
                ->click('Link');
        });
    });
```

Same if you want to make sure you see several texts / elements within a certain area of the page (see tests in the commit).
