### PR TITLE
[5.2] Eloquent Models is aware of written fields, prevents unnecessary/recursive updates

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -91,6 +91,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $original = [];
 
     /**
+     * The model attribute's state upon saving.
+     *
+     * @var array
+     */
+    protected $written = [];
+
+    /**
      * The loaded relationships for the model.
      *
      * @var array
@@ -1216,6 +1223,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected function performDeleteOnModel()
     {
         $this->setKeysForSaveQuery($this->newQueryWithoutScopes())->delete();
+
+        $this->written = [];
     }
 
     /**
@@ -1583,6 +1592,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Records data written to the database.
+     *
+     * @param  array  $data
+     * @return void
+     */
+    protected function registerWritten(array $data)
+    {
+        $this->written = array_merge($this->written, $data);
+    }
+
+    /**
      * Perform a model update operation.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -1591,7 +1611,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function performUpdate(Builder $query, array $options = [])
     {
-        $dirty = $this->getDirty();
+        $dirty = $this->getPending();
 
         if (count($dirty) > 0) {
             // If the updating event returns false, we will cancel the update operation so
@@ -1611,10 +1631,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             // Once we have run the update operation, we will fire the "updated" event for
             // this model instance. This will allow developers to hook into these after
             // models are updated, giving them a chance to do any special processing.
-            $dirty = $this->getDirty();
+            $dirty = $this->getPending();
 
             if (count($dirty) > 0) {
                 $numRows = $this->setKeysForSaveQuery($query)->update($dirty);
+
+                $this->registerWritten($dirty);
 
                 $this->fireModelEvent('updated', false);
             }
@@ -1657,6 +1679,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // there by the developer as the manually determined key for these models.
         else {
             $query->insert($attributes);
+
+            $this->registerWritten($attributes);
         }
 
         // We will go ahead and set the exists property to true, so that it is set when
@@ -1683,6 +1707,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $id = $query->insertGetId($attributes, $keyName = $this->getKeyName());
 
         $this->setAttribute($keyName, $id);
+
+        $this->registerWritten(array_merge($attributes, [$keyName => $id]));
     }
 
     /**
@@ -3206,13 +3232,35 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getDirty()
     {
+        return $this->getDifferences($this->attributes, $this->original);
+    }
+
+    /**
+     * Get the attributes that have changed since the last database write.
+     *
+     * @return array
+     */
+    public function getPending()
+    {
+        return $this->getDifferences($this->getDirty(), $this->written);
+    }
+
+    /**
+     * Returns all $current properties that don't match $original.
+     *
+     * @param  array  $current
+     * @param  array  $original
+     * @return array
+     */
+    protected function getDifferences(array $current, array $original)
+    {
         $dirty = [];
 
-        foreach ($this->attributes as $key => $value) {
-            if (! array_key_exists($key, $this->original)) {
+        foreach ($current as $key => $value) {
+            if (! array_key_exists($key, $original)) {
                 $dirty[$key] = $value;
-            } elseif ($value !== $this->original[$key] &&
-                                 ! $this->originalIsNumericallyEquivalent($key)) {
+            } elseif ($value !== $original[$key] &&
+                                ! $this->originalIsNumericallyEquivalent($value, $original[$key])) {
                 $dirty[$key] = $value;
             }
         }
@@ -3221,17 +3269,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Determine if the new and old values for a given key are numerically equivalent.
+     * Determine if two values are numerically equivalent.
      *
-     * @param  string  $key
+     * @param  string|int  $current
+     * @param  string|int  $original
      * @return bool
      */
-    protected function originalIsNumericallyEquivalent($key)
+    protected function originalIsNumericallyEquivalent($current, $original)
     {
-        $current = $this->attributes[$key];
-
-        $original = $this->original[$key];
-
         return is_numeric($current) && is_numeric($original) && strcmp((string) $current, (string) $original) === 0;
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -150,7 +150,9 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model->syncOriginal();
         $model->name = 'taylor';
         $model->exists = true;
+        $this->assertEquals(['name' => 'taylor'], $model->getPending());
         $this->assertTrue($model->save());
+        $this->assertEquals([], $model->getPending());
     }
 
     public function testUpdateProcessDoesntOverrideTimestamps()
@@ -169,7 +171,9 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model->created_at = 'foo';
         $model->updated_at = 'bar';
         $model->exists = true;
+        $this->assertEquals(['created_at' => 'foo', 'updated_at' => 'bar'], $model->getPending());
         $this->assertTrue($model->save());
+        $this->assertEquals([], $model->getPending());
     }
 
     public function testSaveIsCancelledIfSavingEventReturnsFalse()
@@ -180,8 +184,10 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model->setEventDispatcher($events = m::mock('Illuminate\Contracts\Events\Dispatcher'));
         $events->shouldReceive('until')->once()->with('eloquent.saving: '.get_class($model), $model)->andReturn(false);
         $model->exists = true;
-
+        $model->foo = 'bar';
+        $this->assertEquals(['foo' => 'bar'], $model->getPending());
         $this->assertFalse($model->save());
+        $this->assertEquals(['foo' => 'bar'], $model->getPending());
     }
 
     public function testUpdateIsCancelledIfUpdatingEventReturnsFalse()
@@ -194,8 +200,9 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $events->shouldReceive('until')->once()->with('eloquent.updating: '.get_class($model), $model)->andReturn(false);
         $model->exists = true;
         $model->foo = 'bar';
-
+        $this->assertEquals(['foo' => 'bar'], $model->getPending());
         $this->assertFalse($model->save());
+        $this->assertEquals(['foo' => 'bar'], $model->getPending());
     }
 
     public function testUpdateProcessWithoutTimestamps()
@@ -353,9 +360,11 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
         $model->name = 'taylor';
         $model->exists = false;
+        $this->assertEquals(['name' => 'taylor'], $model->getPending());
         $this->assertTrue($model->save());
         $this->assertEquals(1, $model->id);
         $this->assertTrue($model->exists);
+        $this->assertEquals([], $model->getPending());
 
         $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'refresh']);
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -372,9 +381,11 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
 
         $model->name = 'taylor';
         $model->exists = false;
+        $this->assertEquals(['name' => 'taylor'], $model->getPending());
         $this->assertTrue($model->save());
         $this->assertNull($model->id);
         $this->assertTrue($model->exists);
+        $this->assertEquals([], $model->getPending());
     }
 
     public function testInsertIsCancelledIfCreatingEventReturnsFalse()
@@ -401,6 +412,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model->exists = true;
         $model->id = 1;
         $model->delete();
+        $this->assertEquals(['id' => 1], $model->getPending());
     }
 
     public function testPushNoRelations()


### PR DESCRIPTION
Consider two Eloquent models, `Customer` and `Invoice`, each of which are configured with the following event observers:

```
Customer::updated(function($customer) {
    if ($customer->isDirty('gracePeriod')) { // number of days grace customer has to pay
        foreach($customer->invoices as $invoice) {
            $invoice->setRelation('customer', $customer)
                    ->update(['dueDate' => $invoice->date->addDays($customer->gracePeriod]);
        }
    }
});

Invoice::updated(function($invoice) {
    if ($invoice->isDirty('dueDate')) {
        $invoice->customer->update(['totalOverDue' => $customer->getTotalOverdue()]);
    }
})
```

**Note:** I'm doing a _slightly_ unusual thing here by setting the customer relation on $invoice in the Customer::updated() event method. This is because I have an update in my own installation that automatically links children back to the parent that extracted them, as to cause $parent->$child->$parent to return the original $parent, rather than a copy. It's quite possible that others would be doing this manually, as I have done above.

**Setting Up The Problem**

```
$customer->update(['gracePeriod' => 3]); // arbitrary number, just to trigger the updated event
```

This will call `Customer::updated()` as defined above, and the test will return `true`. Each invoice will then be updated.

The `Invoice::updated()` event also returns `true`, and causes the `$customer` to be updated (albeit another field this time).

**The Problem**
When the customer is being updated the second time, the `dueDate` field is still dirty, because `Model` only resets the flag _after_ all the events have been triggered. This means, under certain circumstances, it's possible to accidentally create an infinite loop, especially if you're using references to the same objects rather than pulling new ones out of the database each time.

**Fixes**
There are two options:
- Reset the dirty status **before** the events are triggered. I would submit that this would be a very bad solution. Many events are written on the basis of being able to discover what it was that was actually updated, and this would be a breaking backward change.
- Allow Model the ability to recognise when something is **actually** dirty for the purpose of writing back to the database. If a 'dirty' field has already been written back, Model can ignore it and not trigger any more events on that basis again.

This PR implements the latter solution.
