### PR TITLE
Encrypter::compare method

### DIFF
--- a/src/Illuminate/Encryption/BaseEncrypter.php
+++ b/src/Illuminate/Encryption/BaseEncrypter.php
@@ -14,6 +14,41 @@ abstract class BaseEncrypter
     protected $key;
 
     /**
+     * Compare two encrypted values.
+     *
+     * @param  mixed  $e1
+     * @param  mixed  $e2
+     * @param  bool  $loose
+     * @return bool
+     */
+    public function compare($e1, $e2, $loose = false)
+    {
+        $v1 = $this->getCompareValue($e1);
+        $v2 = $this->getCompareValue($e2);
+
+        if ($loose) {
+            return $v1 == $v2;
+        } else {
+            return $v1 === $v2;
+        }
+    }
+
+    /**
+     * Get the decrypted value of a possibly encrypted variable.
+     * 
+     * @param  mixed  $encrypted
+     * @return mixed
+     */
+    protected function getCompareValue($encrypted)
+    {
+        try {
+            return $this->decrypt($encrypted);
+        } catch (DecryptException $e) {
+            return $encrypted;
+        }
+    }
+
+    /**
      * Create a MAC for the given value.
      *
      * @param  string  $iv

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -100,7 +100,7 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
         $encrypted1 = $e->encrypt('foo');
         $encrypted2 = $e->encrypt('foo');
         $encrypted3 = $e->encrypt('bar');
-        
+
         $this->assertTrue($e->compare($encrypted1, $encrypted2));
         $this->assertTrue($e->compare($encrypted1, 'foo'));
         $this->assertFalse($e->compare($encrypted1, $encrypted3));

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -93,4 +93,16 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo', $openSslEncrypter->decrypt($encrypted));
     }
+
+    public function testCompareEncryptedValues()
+    {
+        $e = new Encrypter(str_repeat('a', 16));
+        $encrypted1 = $e->encrypt('foo');
+        $encrypted2 = $e->encrypt('foo');
+        $encrypted3 = $e->encrypt('bar');
+        
+        $this->assertTrue($e->compare($encrypted1, $encrypted2));
+        $this->assertTrue($e->compare($encrypted1, 'foo'));
+        $this->assertFalse($e->compare($encrypted1, $encrypted3));
+    }
 }


### PR DESCRIPTION
Adds a `compare` method to the base Encrypter to compare encrypted values to each other. Any of the arguments can also be an unencrypted value. Test below to illustrate functionality.

``` php
    public function testCompareEncryptedValues()
    {
        $e = new Encrypter(str_repeat('a', 16));
        $encrypted1 = $e->encrypt('foo');
        $encrypted2 = $e->encrypt('foo');
        $encrypted3 = $e->encrypt('bar');

        $this->assertTrue($e->compare($encrypted1, $encrypted2));
        $this->assertTrue($e->compare($encrypted1, 'foo'));
        $this->assertFalse($e->compare($encrypted1, $encrypted3));
    }
```
