### PR TITLE
[5.2] Change comment to reflect class name of Hub.

### DIFF
--- a/src/Illuminate/Pipeline/Hub.php
+++ b/src/Illuminate/Pipeline/Hub.php
@@ -23,7 +23,7 @@ class Hub implements HubContract
     protected $pipelines = [];
 
     /**
-     * Create a new Depot instance.
+     * Create a new Hub instance.
      *
      * @param  \Illuminate\Contracts\Container\Container  $container
      * @return void


### PR DESCRIPTION
Looks like the comment didn't get changed with the class name.
