### PR TITLE
[5.2] Add dependency injection to test classes

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -71,7 +71,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
 
         $this->setUpHasRun = true;
 
-        if(method_exists($this, 'before')) {
+        if (method_exists($this, 'before')) {
             $this->app->call([$this, 'before']);
         }
     }
@@ -144,7 +144,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         $this->afterApplicationCreatedCallbacks = [];
         $this->beforeApplicationDestroyedCallbacks = [];
 
-        if(method_exists($this, 'after')) {
+        if (method_exists($this, 'after')) {
             $this->app->call([$this, 'after']);
         }
     }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -70,6 +70,10 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         }
 
         $this->setUpHasRun = true;
+
+        if(method_exists($this, 'before')) {
+            $this->app->call([$this, 'before']);
+        }
     }
 
     /**
@@ -139,6 +143,10 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
 
         $this->afterApplicationCreatedCallbacks = [];
         $this->beforeApplicationDestroyedCallbacks = [];
+
+        if(method_exists($this, 'after')) {
+            $this->app->call([$this, 'after']);
+        }
     }
 
     /**


### PR DESCRIPTION
Not sure what you think of this but it would allow users to inject their dependencies into their tests and have them resolved. Also by adding these new methods, it avoids the issue of forgetting to call `parent::setUp()` when overriding that method.

e.g.

``` php
class ExampleTest extends TestCase
{
    public function before(User $user)
    {
        $this->user = $user;
    }

    /**
     * @test
     */
    public function it_works()
    {
        $this->assertInstanceOf(User::class, $this->user);
    }
}
```
