### PR TITLE
[5.2] Add concat method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -91,6 +91,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Concat the collection with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function concat($items)
+    {
+        return new static($this->getArrayableItems($items) + $this->items);
+    }
+
+    /**
      * Determine if an item exists in the collection.
      *
      * @param  mixed  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1075,7 +1075,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $c = new Collection(['10000' => 'Scratch Lottery']);
         $this->assertEquals([
             '10000' => 'Scratch Lottery',
-            '1000000' => 'Power Ball'
+            '1000000' => 'Power Ball',
         ], $c->concat(['1000000' => 'Power Ball'])->all());
     }
 
@@ -1084,7 +1084,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $c = new Collection(['1000000' => 'Power Ball']);
         $this->assertEquals([
             '1000000' => 'Mega',
-            '10000000' => 'Millions'
+            '10000000' => 'Millions',
         ], $c->concat(new Collection(['1000000' => 'Mega', '10000000' => 'Millions']))->all());
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1063,6 +1063,30 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             'baz',
         ], $c->jsonSerialize());
     }
+
+    public function testConcatNull()
+    {
+        $c = new Collection(['10000' => 'Scratch Lottery']);
+        $this->assertEquals(['10000' => 'Scratch Lottery'], $c->concat(null)->all());
+    }
+
+    public function testConcatArray()
+    {
+        $c = new Collection(['10000' => 'Scratch Lottery']);
+        $this->assertEquals([
+            '10000' => 'Scratch Lottery',
+            '1000000' => 'Power Ball',
+        ], $c->concat(['1000000' => 'Power Ball'])->all());
+    }
+
+    public function testConcatCollection()
+    {
+        $c = new Collection(['1000000' => 'Power Ball']);
+        $this->assertEquals([
+            '1000000' => 'Mega',
+            '10000000' => 'Millions',
+        ], $c->concat(new Collection(['1000000' => 'Mega', '10000000' => 'Millions']))->all());
+    }
 }
 
 class TestAccessorEloquentTestStub

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1063,6 +1063,30 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             'baz',
         ], $c->jsonSerialize());
     }
+
+    public function testConcatNull()
+    {
+        $c = new Collection(['10000' => 'Scratch Lottery']);
+        $this->assertEquals(['10000' => 'Scratch Lottery'], $c->concat(null)->all());
+    }
+
+    public function testConcatArray()
+    {
+        $c = new Collection(['10000' => 'Scratch Lottery']);
+        $this->assertEquals([
+            '10000' => 'Scratch Lottery',
+            '1000000' => 'Power Ball'
+        ], $c->concat(['1000000' => 'Power Ball'])->all());
+    }
+
+    public function testConcatCollection()
+    {
+        $c = new Collection(['1000000' => 'Power Ball']);
+        $this->assertEquals([
+            '1000000' => 'Mega',
+            '10000000' => 'Millions'
+        ], $c->concat(new Collection(['1000000' => 'Mega', '10000000' => 'Millions']))->all());
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
This PR allows for merging collections without losing numeric keys.

``` php
$collection = collect(['1000' => 'Scratch Lotto', '1000000' => 'Powerball']);

$concatenate = $collection->concat([ '1000000' => 'Mega',  '10000000' => 'Millions']);

$concatenate->all();

//['1000' => 'Scratch Lotto', '1000000' => 'Mega',  '10000000' => 'Millions']
```
