### PR TITLE
[5.2] Sort replace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,8 @@
     },
     "replace": {
         "illuminate/auth": "self.version",
-        "illuminate/bus": "self.version",
         "illuminate/broadcasting": "self.version",
+        "illuminate/bus": "self.version",
         "illuminate/cache": "self.version",
         "illuminate/config": "self.version",
         "illuminate/console": "self.version",

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -17,8 +17,8 @@
         "php": ">=5.5.9",
         "illuminate/contracts": "5.2.*",
         "illuminate/support": "5.2.*",
-        "symfony/console": "2.8.*|3.0.*",
-        "nesbot/carbon": "~1.20"
+        "nesbot/carbon": "~1.20",
+        "symfony/console": "2.8.*|3.0.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -17,8 +17,8 @@
         "php": ">=5.5.9",
         "illuminate/contracts": "5.2.*",
         "illuminate/support": "5.2.*",
-        "symfony/http-kernel": "2.8.*|3.0.*",
-        "symfony/http-foundation": "2.8.*|3.0.*"
+        "symfony/http-foundation": "2.8.*|3.0.*",
+        "symfony/http-kernel": "2.8.*|3.0.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -16,11 +16,11 @@
     "require": {
         "php": ">=5.5.9",
         "illuminate/console": "5.2.*",
-        "illuminate/contracts": "5.2.*",
         "illuminate/container": "5.2.*",
+        "illuminate/contracts": "5.2.*",
         "illuminate/support": "5.2.*",
-        "symfony/process": "2.8.*|3.0.*",
-        "nesbot/carbon": "~1.20"
+        "nesbot/carbon": "~1.20",
+        "symfony/process": "2.8.*|3.0.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": ">=5.5.9",
         "ext-mbstring": "*",
-        "illuminate/contracts": "5.2.*",
-        "doctrine/inflector": "~1.0"
+        "doctrine/inflector": "~1.0",
+        "illuminate/contracts": "5.2.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
All require/require-dev & replace are sorted.
But not these ones.
I suppose it was not on purpose
