### PR TITLE
[5.2] Filesystem : no need to call getAdapter 3 times

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -225,13 +225,15 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      */
     public function url($path)
     {
-        if (! $this->driver->getAdapter() instanceof AwsS3Adapter) {
+        $adapter = $this->driver->getAdapter();
+
+        if (! $adapter instanceof AwsS3Adapter) {
             throw new RuntimeException('This driver does not support retrieving URLs.');
         }
 
-        $bucket = $this->driver->getAdapter()->getBucket();
+        $bucket = $adapter->getBucket();
 
-        return $this->driver->getAdapter()->getClient()->getObjectUrl($bucket, $path);
+        return $adapter->getClient()->getObjectUrl($bucket, $path);
     }
 
     /**


### PR DESCRIPTION
Store the adapter in a variable : https://github.com/laravel/framework/commit/ef81c531512de75214e3723fa0725c2b64ad6395#commitcomment-15994732

Good catch @phanan
