### PR TITLE
[5.3] JsonResponse : let setData support more implementations

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Http;
 
+use JsonSerializable;
 use InvalidArgumentException;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
 use Symfony\Component\HttpFoundation\JsonResponse as BaseJsonResponse;
 
 class JsonResponse extends BaseJsonResponse
@@ -49,9 +51,15 @@ class JsonResponse extends BaseJsonResponse
      */
     public function setData($data = [])
     {
-        $this->data = $data instanceof Jsonable
-                                   ? $data->toJson($this->jsonOptions)
-                                   : json_encode($data, $this->jsonOptions);
+        if ($data instanceof Arrayable) {
+            $this->data = json_encode($data->toArray(), $this->jsonOptions);
+        } elseif ($data instanceof Jsonable) {
+            $this->data = $data->toJson($this->jsonOptions);
+        } elseif ($data instanceof JsonSerializable) {
+            $this->data = json_encode($data->jsonSerialize(), $this->jsonOptions);
+        } else {
+            $this->data = json_encode($data, $this->jsonOptions);
+        }
 
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new InvalidArgumentException(json_last_error_msg());

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -7,7 +7,7 @@ class HttpJsonResponseTest extends PHPUnit_Framework_TestCase
 {
     public function testSeAndRetrieveJsonableData()
     {
-        $response = new Illuminate\Http\JsonResponse(new JsonableObject);
+        $response = new Illuminate\Http\JsonResponse(new JsonResponseTestJsonableObject);
         $data = $response->getData();
         $this->assertInstanceOf('StdClass', $data);
         $this->assertEquals('bar', $data->foo);
@@ -15,7 +15,7 @@ class HttpJsonResponseTest extends PHPUnit_Framework_TestCase
 
     public function testSeAndRetrieveJsonSerializeData()
     {
-        $response = new Illuminate\Http\JsonResponse(new JsonSerializeObject);
+        $response = new Illuminate\Http\JsonResponse(new JsonResponseTestJsonSerializeObject);
         $data = $response->getData();
         $this->assertInstanceOf('StdClass', $data);
         $this->assertEquals('bar', $data->foo);
@@ -23,7 +23,7 @@ class HttpJsonResponseTest extends PHPUnit_Framework_TestCase
 
     public function testSeAndRetrieveArrayableData()
     {
-        $response = new Illuminate\Http\JsonResponse(new ArrayableObject);
+        $response = new Illuminate\Http\JsonResponse(new JsonResponseTestArrayableObject);
         $data = $response->getData();
         $this->assertInstanceOf('StdClass', $data);
         $this->assertEquals('bar', $data->foo);
@@ -55,7 +55,7 @@ class HttpJsonResponseTest extends PHPUnit_Framework_TestCase
     }
 }
 
-class JsonableObject implements Jsonable
+class JsonResponseTestJsonableObject implements Jsonable
 {
     public function toJson($options = 0)
     {
@@ -63,7 +63,7 @@ class JsonableObject implements Jsonable
     }
 }
 
-class JsonSerializeObject implements JsonSerializable
+class JsonResponseTestJsonSerializeObject implements JsonSerializable
 {
     public function jsonSerialize()
     {
@@ -71,7 +71,7 @@ class JsonSerializeObject implements JsonSerializable
     }
 }
 
-class ArrayableObject implements Arrayable
+class JsonResponseTestArrayableObject implements Arrayable
 {
     public function toArray()
     {

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -1,7 +1,34 @@
 <?php
 
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
+
 class HttpJsonResponseTest extends PHPUnit_Framework_TestCase
 {
+    public function testSeAndRetrieveJsonableData()
+    {
+        $response = new Illuminate\Http\JsonResponse(new JsonableObject);
+        $data = $response->getData();
+        $this->assertInstanceOf('StdClass', $data);
+        $this->assertEquals('bar', $data->foo);
+    }
+
+    public function testSeAndRetrieveJsonSerializeData()
+    {
+        $response = new Illuminate\Http\JsonResponse(new JsonSerializeObject);
+        $data = $response->getData();
+        $this->assertInstanceOf('StdClass', $data);
+        $this->assertEquals('bar', $data->foo);
+    }
+
+    public function testSeAndRetrieveArrayableData()
+    {
+        $response = new Illuminate\Http\JsonResponse(new ArrayableObject);
+        $data = $response->getData();
+        $this->assertInstanceOf('StdClass', $data);
+        $this->assertEquals('bar', $data->foo);
+    }
+
     public function testSetAndRetrieveData()
     {
         $response = new Illuminate\Http\JsonResponse(['foo' => 'bar']);
@@ -25,5 +52,29 @@ class HttpJsonResponseTest extends PHPUnit_Framework_TestCase
         $response = new Illuminate\Http\JsonResponse(['foo' => 'bar']);
         $response->setStatusCode(404);
         $this->assertSame(404, $response->getStatusCode());
+    }
+}
+
+class JsonableObject implements Jsonable
+{
+    public function toJson($options = 0)
+    {
+        return '{"foo":"bar"}';
+    }
+}
+
+class JsonSerializeObject implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return ['foo' => 'bar'];
+    }
+}
+
+class ArrayableObject implements Arrayable
+{
+    public function toArray()
+    {
+        return ['foo' => 'bar'];
     }
 }


### PR DESCRIPTION
Let `\Illuminate\Http\JsonResponse::setData` also support data implementing `\Illuminate\Contracts\Support\Arrayable` or `\JsonSerializable`

Targeting `master`, as `\Illuminate\Http\JsonResponse::setData` could be extended in a custom class.
