### PR TITLE
[5.2] Prevent related models proliferation on ModelFactory

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -130,18 +130,17 @@ class FactoryBuilder
             }
 
             $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker, $attributes);
-            
+
             $evaluated = $this->evaluateClosures(array_merge($definition, $attributes));
 
             return new $this->class($evaluated);
         });
     }
-    
+
     /**
      * Delay closures evaluation after merging to avoid duplication.
      *
      * @param  array  $attributes
-     *
      * @return array
      */
     protected function evaluateClosures(array $attributes)

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -130,8 +130,28 @@ class FactoryBuilder
             }
 
             $definition = call_user_func($this->definitions[$this->class][$this->name], $this->faker, $attributes);
+            
+            $evaluated = $this->evaluateClosures(array_merge($definition, $attributes));
 
-            return new $this->class(array_merge($definition, $attributes));
+            return new $this->class($evaluated);
         });
+    }
+    
+    /**
+     * Delay closures evaluation after merging to avoid duplication.
+     *
+     * @param  array  $attributes
+     *
+     * @return array
+     */
+    protected function evaluateClosures(array $attributes)
+    {
+        foreach ($attributes as &$attribute) {
+            if ($attribute instanceof \Closure) {
+                $attribute = $attribute($attributes);
+            }
+        }
+
+        return $attributes;
     }
 }

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -145,12 +145,8 @@ class FactoryBuilder
      */
     protected function evaluateClosures(array $attributes)
     {
-        foreach ($attributes as &$attribute) {
-            if ($attribute instanceof \Closure) {
-                $attribute = $attribute($attributes);
-            }
-        }
-
-        return $attributes;
+        return array_map(function ($attribute) use ($attributes) {
+            return $attribute instanceof \Closure ? $attribute($attributes) : $attribute;
+        }, $attributes);
     }
 }

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Closure;
 use Faker\Generator as Faker;
 use InvalidArgumentException;
 
@@ -146,7 +147,7 @@ class FactoryBuilder
     protected function evaluateClosures(array $attributes)
     {
         return array_map(function ($attribute) use ($attributes) {
-            return $attribute instanceof \Closure ? $attribute($attributes) : $attribute;
+            return $attribute instanceof Closure ? $attribute($attributes) : $attribute;
         }, $attributes);
     }
 }

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -146,8 +146,10 @@ class FactoryBuilder
      */
     protected function evaluateClosures(array $attributes)
     {
-        return array_map(function ($attribute) use ($attributes) {
-            return $attribute instanceof Closure ? $attribute($attributes) : $attribute;
-        }, $attributes);
+        foreach ($attributes as &$attribute) {
+            $attribute = $attribute instanceof Closure ? $attribute($attributes) : $attribute;
+        }
+
+        return $attributes;
     }
 }


### PR DESCRIPTION
Allows to define closures within the model factory definition in order to avoid unused models to be written to the database when overriding the model attributes. (See #9245)

Here's a model definition example:

``` php
$factory->define(App\Post::class, function ($faker) {
    return [
        'title' => $faker->title,
        'content' => $faker->paragraph,
        'user_id' => factory(App\User::class)->create()->id
    ];
});
```

If you overwrite the `user_id` attribute when creating an instance of the model:

``` php
$post = factory(App\Post::class)->create([ 'user_id' => App\User::find(1)]);
```

You'll end up having written an unused `App\User` model to the database as the attribute merging happens after the evaluation of the definition.

The first fix has been provided by @devinfd with #9387 and looked something like this:

``` php
$factory->define(App\Post::class, function ($faker, $attributes) {
    $userId = isset($attributes['user_id']) ? $attributes['user_id']: factory(App\User::class)->create()->id;
    return [
        'title' => $faker->title,
        'content' => $faker->paragraph,
        'user_id' => $userId
    ];
});
```

This works but as you start defining more complex model relationship becomes ugly as hell.

My solution is to provide the ability to insert relationship model definition inside a closure and evaluate the closure only after the attributes merging.

So you will declare the definition as follow:

``` php
$factory->define(App\Post::class, function ($faker) {
    return [
        'title' => $faker->title,
        'content' => $faker->paragraph,
        'user_id' => function () {
            return factory(App\User::class)->create()->id;
        }
    ];
});
```

An array of evaluated definition is passed to the  closure in order to define complex relationships:

``` php
$factory->define(App\Post::class, function ($faker) {
    return [
        'title' => $faker->title,
        'content' => $faker->paragraph,
        'user_id' => function () {
            return factory(App\User::class)->create()->id;
        },
        'user_type' => function (array $evaluated) {
            return App\User::find($evaluated['user_id'])->type;
        }
    ];
});
```
