### PR TITLE
[5.2] Place slash in Request::fullUrl() after domain name when there is nothing, but query.

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -96,7 +96,10 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $query = $this->getQueryString();
 
-        return $query ? $this->url().'?'.$query : $this->url();
+        // If there is no path part in URL, there should be a slash before query (http://example.com/?a=b)
+        $slash = ($this->getBaseUrl().$this->getPathInfo() == '/') ? '/' : '';
+
+        return $query ? $this->url().$slash.'?'.$query : $this->url();
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -96,6 +96,9 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
         $request = Request::create('https://foo.com', 'GET');
         $this->assertEquals('https://foo.com', $request->fullUrl());
+
+        $request = Request::create('https://foo.com?a=b', 'GET');
+        $this->assertEquals('https://foo.com/?a=b', $request->fullUrl());
     }
 
     public function testIsMethod()


### PR DESCRIPTION
Here's some background about the problem:
http://stackoverflow.com/questions/2388920/query-string-after-the-domain-name

I encountered this problem during unit testing. When I tried to do this:

```
$this->visit('/?123')->seePageIs('/?123');
```

I've got this:

```
Failed asserting that two strings are equal.
Expected :'https://example.com/?123'
Actual   :'https://example.com?123'
```
