### PR TITLE
[5.2] Make trans_choice receive arrays and countable objects

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -664,7 +664,7 @@ if (! function_exists('trans_choice')) {
      * Translates the given message based on a count.
      *
      * @param  string  $id
-     * @param  int     $number
+     * @param  int|array|Countable  $number
      * @param  array   $parameters
      * @param  string  $domain
      * @param  string  $locale

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -664,7 +664,7 @@ if (! function_exists('trans_choice')) {
      * Translates the given message based on a count.
      *
      * @param  string  $id
-     * @param  int|array|Countable  $number
+     * @param  int|array|\Countable  $number
      * @param  array   $parameters
      * @param  string  $domain
      * @param  string  $locale

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Translation;
 
-use Countable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
@@ -185,7 +184,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * Get a translation according to an integer value.
      *
      * @param  string  $key
-     * @param  int|array|Countable  $number
+     * @param  int|array|\Countable  $number
      * @param  array   $replace
      * @param  string  $locale
      * @return string
@@ -194,7 +193,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
     {
         $line = $this->get($key, $replace, $locale = $locale ?: $this->locale ?: $this->fallback);
 
-        if (is_array($number) || $number instanceof Countable) {
+        if (is_array($number) || $number instanceof \Countable) {
             $number = count($number);
         }
 
@@ -221,7 +220,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * Get a translation according to an integer value.
      *
      * @param  string  $id
-     * @param  int|array|Countable  $number
+     * @param  int|array|\Countable  $number
      * @param  array   $parameters
      * @param  string  $domain
      * @param  string  $locale

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Translation;
 
+use Countable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
@@ -184,7 +185,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * Get a translation according to an integer value.
      *
      * @param  string  $key
-     * @param  int     $number
+     * @param  int|array|Countable  $number
      * @param  array   $replace
      * @param  string  $locale
      * @return string
@@ -192,6 +193,10 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
     public function choice($key, $number, array $replace = [], $locale = null)
     {
         $line = $this->get($key, $replace, $locale = $locale ?: $this->locale ?: $this->fallback);
+
+        if (is_array($number) || $number instanceof Countable) {
+            $number = count($number);
+        }
 
         $replace['count'] = $number;
 
@@ -216,7 +221,7 @@ class Translator extends NamespacedItemResolver implements TranslatorInterface
      * Get a translation according to an integer value.
      *
      * @param  string  $id
-     * @param  int     $number
+     * @param  int|array|Countable  $number
      * @param  array   $parameters
      * @param  string  $domain
      * @param  string  $locale

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -72,6 +72,20 @@ class TranslationTranslatorTest extends PHPUnit_Framework_TestCase
         $t->choice('foo', 10, ['replace']);
     }
 
+    public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
+    {
+        $t = $this->getMock('Illuminate\Translation\Translator', ['get'], [$this->getLoader(), 'en']);
+        $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->will($this->returnValue('line'));
+        $t->setSelector($selector = m::mock('Symfony\Component\Translation\MessageSelector'));
+        $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
+
+        $values = ['foo', 'bar', 'baz'];
+        $t->choice('foo', $values, ['replace']);
+
+        $values = new Illuminate\Support\Collection(['foo', 'bar', 'baz']);
+        $t->choice('foo', $values, ['replace']);
+    }
+
     protected function getLoader()
     {
         return m::mock('Illuminate\Translation\LoaderInterface');


### PR DESCRIPTION
`trans_choice` function or `Translator::transChoice` method can receive only integers to make a proper translation selection. But when you are using this functions, most of the time you are using them with collections and arrays, so you have to always surround your variables with count() like this:

`{{ trans_choice('pages', count($pages)) }}`

This PR helps this functions to receive arrays and `Countable` objects too and they will count elements for you.
