### PR TITLE
[5.2] Add an `exists` method to the Arr class

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -121,6 +121,22 @@ class Arr
     }
 
     /**
+     * Determine if the given key exists in the provided array.
+     *
+     * @param  array|\ArrayAccess  $array
+     * @param  string|int  $key
+     * @return bool
+     */
+    public static function exists($array, $key)
+    {
+        if (is_array($array)) {
+            return array_key_exists($key, $array);
+        }
+
+        return $array->offsetExists($key);
+    }
+
+    /**
      * Return the first element in an array passing a given truth test.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrayTest.php
+++ b/tests/Support/SupportArrayTest.php
@@ -31,6 +31,20 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['name' => 'Desk'], $array);
     }
 
+    public function testExists()
+    {
+        $this->assertTrue(Arr::exists([1], 0));
+        $this->assertTrue(Arr::exists([null], 0));
+        $this->assertTrue(Arr::exists(['a' => 1], 'a'));
+        $this->assertTrue(Arr::exists(['a' => null], 'a'));
+        $this->assertTrue(Arr::exists(new Collection(['a' => null]), 'a'));
+
+        $this->assertFalse(Arr::exists([1], 1));
+        $this->assertFalse(Arr::exists([null], 1));
+        $this->assertFalse(Arr::exists(['a' => 1], 0));
+        $this->assertFalse(Arr::exists(new Collection(['a' => null]), 'b'));
+    }
+
     public function testFirst()
     {
         $array = [100, 200, 300];


### PR DESCRIPTION
Allows for checking whether a key exists in an array:

``` php
if (Arr::exists($array, $key)) {
    //
}
```

---

PHP has a weird bug (that was supposed to be fixed a long time ago). If you call `array_key_exists($key, $array)` on an object that implements `ArrayAccess`, PHP will _not_ call `offsetExists` on the object; a simple `isset` check will instead be executed, which means that a falsy value being present will be reported as nonexistent.

This PR aims to provide a single method to determine if an array-like object has the given key.
