### PR TITLE
[5.2] Create data_set and data_fill helper functions

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -378,6 +378,21 @@ if (! function_exists('collect')) {
     }
 }
 
+if (! function_exists('data_fill')) {
+    /**
+     * Fill in data where it's missing.
+     *
+     * @param  mixed   $target
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    function data_fill(&$target, $key, $value)
+    {
+        return data_set($target, $key, $value, false);
+    }
+}
+
 if (! function_exists('data_get')) {
     /**
      * Get an item from an array or object using "dot" notation.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -440,9 +440,10 @@ if (! function_exists('data_set')) {
      * @param  mixed  $target
      * @param  string|array  $key
      * @param  mixed  $value
+     * @param  bool  $overwrite
      * @return mixed
      */
-    function data_set(&$target, $key, $value)
+    function data_set(&$target, $key, $value, $overwrite = true)
     {
         $segments = is_array($key) ? $key : explode('.', $key);
 
@@ -451,7 +452,7 @@ if (! function_exists('data_set')) {
                 $target = [];
             } elseif ($segments) {
                 foreach ($target as &$inner) {
-                    data_set($inner, $segments, $value);
+                    data_set($inner, $segments, $value, $overwrite);
                 }
             } else {
                 foreach ($target as &$inner) {
@@ -464,8 +465,8 @@ if (! function_exists('data_set')) {
                     $target[$segment] = [];
                 }
 
-                data_set($target[$segment], $segments, $value);
-            } elseif (! Arr::exists($target, $segment)) {
+                data_set($target[$segment], $segments, $value, $overwrite);
+            } elseif ($overwrite || ! Arr::exists($target, $segment)) {
                 $target[$segment] = $value;
             }
         } elseif (is_object($target)) {
@@ -474,8 +475,8 @@ if (! function_exists('data_set')) {
                     $target->{$segment} = [];
                 }
 
-                data_set($target->{$segment}, $segments, $value);
-            } elseif (! isset($target->{$segment})) {
+                data_set($target->{$segment}, $segments, $value, $overwrite);
+            } elseif ($overwrite || ! isset($target->{$segment})) {
                 $target->{$segment} = $value;
             }
         }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -433,6 +433,57 @@ if (! function_exists('data_get')) {
     }
 }
 
+if (! function_exists('data_set')) {
+    /**
+     * Set an item on an array or object using dot notation.
+     *
+     * @param  mixed  $target
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    function data_set(&$target, $key, $value)
+    {
+        $segments = is_array($key) ? $key : explode('.', $key);
+
+        if (($segment = array_shift($segments)) === '*') {
+            if (! Arr::accessible($target)) {
+                $target = [];
+            } elseif ($segments) {
+                foreach ($target as &$inner) {
+                    data_set($inner, $segments, $value);
+                }
+            } else {
+                foreach ($target as &$inner) {
+                    $inner = $value;
+                }
+            }
+        } elseif (Arr::accessible($target)) {
+            if ($segments) {
+                if (! Arr::exists($target, $segment)) {
+                    $target[$segment] = [];
+                }
+
+                data_set($target[$segment], $segments, $value);
+            } elseif (! Arr::exists($target, $segment)) {
+                $target[$segment] = $value;
+            }
+        } elseif (is_object($target)) {
+            if ($segments) {
+                if (! isset($target->{$segment})) {
+                    $target->{$segment} = [];
+                }
+
+                data_set($target->{$segment}, $segments, $value);
+            } elseif (! isset($target->{$segment})) {
+                $target->{$segment} = $value;
+            }
+        }
+
+        return $target;
+    }
+}
+
 if (! function_exists('dd')) {
     /**
      * Dump the passed variables and end the script.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -400,6 +400,78 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([], data_get($array, 'posts.*.users.*.name'));
     }
 
+    public function testDataFill()
+    {
+        $data = ['foo' => 'bar'];
+
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], data_fill($data, 'baz', 'boom'));
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], data_fill($data, 'baz', 'noop'));
+        $this->assertEquals(['foo' => [], 'baz' => 'boom'], data_fill($data, 'foo.*', 'noop'));
+        $this->assertEquals(
+            ['foo' => ['bar' => 'kaboom'], 'baz' => 'boom'],
+            data_fill($data, 'foo.bar', 'kaboom')
+        );
+    }
+
+    public function testDataFillWithStar()
+    {
+        $data = ['foo' => 'bar'];
+
+        $this->assertEquals(
+            ['foo' => []],
+            data_fill($data, 'foo.*.bar', 'noop')
+        );
+
+        $this->assertEquals(
+            ['foo' => [], 'bar' => [['baz' => 'original'], []]],
+            data_fill($data, 'bar', [['baz' => 'original'], []])
+        );
+
+        $this->assertEquals(
+            ['foo' => [], 'bar' => [['baz' => 'original'], ['baz' => 'boom']]],
+            data_fill($data, 'bar.*.baz', 'boom')
+        );
+    }
+
+    public function testDataFillWithDoubleStar()
+    {
+        $data = [
+            'posts' => [
+                (object) [
+                    'comments' => [
+                        (object) ['name' => 'First'],
+                        (object) [],
+                    ],
+                ],
+                (object) [
+                    'comments' => [
+                        (object) [],
+                        (object) ['name' => 'Second'],
+                    ],
+                ],
+            ],
+        ];
+
+        data_fill($data, 'posts.*.comments.*.name', 'Filled');
+
+        $this->assertEquals([
+            'posts' => [
+                (object) [
+                    'comments' => [
+                        (object) ['name' => 'First'],
+                        (object) ['name' => 'Filled'],
+                    ],
+                ],
+                (object) [
+                    'comments' => [
+                        (object) ['name' => 'Filled'],
+                        (object) ['name' => 'Second'],
+                    ],
+                ],
+            ],
+        ], $data);
+    }
+
     public function testDataSet()
     {
         $data = ['foo' => 'bar'];

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -404,12 +404,24 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
     {
         $data = ['foo' => 'bar'];
 
-        $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], data_set($data, 'baz', 'boom'));
-        $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], data_set($data, 'baz', 'noop'));
-        $this->assertEquals(['foo' => [], 'baz' => 'boom'], data_set($data, 'foo.*', 'noop'));
         $this->assertEquals(
-            ['foo' => ['bar' => 'kaboom'], 'baz' => 'boom'],
-            data_set($data, 'foo.bar', 'kaboom')
+            ['foo' => 'bar', 'baz' => 'boom'],
+            data_set($data, 'baz', 'boom')
+        );
+
+        $this->assertEquals(
+            ['foo' => 'bar', 'baz' => 'kaboom'],
+            data_set($data, 'baz', 'kaboom')
+        );
+
+        $this->assertEquals(
+            ['foo' => [], 'baz' => 'kaboom'],
+            data_set($data, 'foo.*', 'noop')
+        );
+
+        $this->assertEquals(
+            ['foo' => ['bar' => 'boom'], 'baz' => 'kaboom'],
+            data_set($data, 'foo.bar', 'boom')
         );
     }
 
@@ -428,7 +440,7 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            ['foo' => [], 'bar' => [['baz' => 'original'], ['baz' => 'boom']]],
+            ['foo' => [], 'bar' => [['baz' => 'boom'], ['baz' => 'boom']]],
             data_set($data, 'bar.*.baz', 'boom')
         );
     }
@@ -458,14 +470,14 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
             'posts' => [
                 (object) [
                     'comments' => [
-                        (object) ['name' => 'First'],
+                        (object) ['name' => 'Filled'],
                         (object) ['name' => 'Filled'],
                     ],
                 ],
                 (object) [
                     'comments' => [
                         (object) ['name' => 'Filled'],
-                        (object) ['name' => 'Second'],
+                        (object) ['name' => 'Filled'],
                     ],
                 ],
             ],

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -400,6 +400,78 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([], data_get($array, 'posts.*.users.*.name'));
     }
 
+    public function testDataSet()
+    {
+        $data = ['foo' => 'bar'];
+
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], data_set($data, 'baz', 'boom'));
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], data_set($data, 'baz', 'noop'));
+        $this->assertEquals(['foo' => [], 'baz' => 'boom'], data_set($data, 'foo.*', 'noop'));
+        $this->assertEquals(
+            ['foo' => ['bar' => 'kaboom'], 'baz' => 'boom'],
+            data_set($data, 'foo.bar', 'kaboom')
+        );
+    }
+
+    public function testDataSetWithStar()
+    {
+        $data = ['foo' => 'bar'];
+
+        $this->assertEquals(
+            ['foo' => []],
+            data_set($data, 'foo.*.bar', 'noop')
+        );
+
+        $this->assertEquals(
+            ['foo' => [], 'bar' => [['baz' => 'original'], []]],
+            data_set($data, 'bar', [['baz' => 'original'], []])
+        );
+
+        $this->assertEquals(
+            ['foo' => [], 'bar' => [['baz' => 'original'], ['baz' => 'boom']]],
+            data_set($data, 'bar.*.baz', 'boom')
+        );
+    }
+
+    public function testDataSetWithDoubleStar()
+    {
+        $data = [
+            'posts' => [
+                (object) [
+                    'comments' => [
+                        (object) ['name' => 'First'],
+                        (object) [],
+                    ],
+                ],
+                (object) [
+                    'comments' => [
+                        (object) [],
+                        (object) ['name' => 'Second'],
+                    ],
+                ],
+            ],
+        ];
+
+        data_set($data, 'posts.*.comments.*.name', 'Filled');
+
+        $this->assertEquals([
+            'posts' => [
+                (object) [
+                    'comments' => [
+                        (object) ['name' => 'First'],
+                        (object) ['name' => 'Filled'],
+                    ],
+                ],
+                (object) [
+                    'comments' => [
+                        (object) ['name' => 'Filled'],
+                        (object) ['name' => 'Second'],
+                    ],
+                ],
+            ],
+        ], $data);
+    }
+
     public function testArraySort()
     {
         $array = [


### PR DESCRIPTION
This is the inverse of the `data_get` function.

This will currently not overwrite any values at the tail-end of the chain. Not sure whether that's the expected behavior.

**Update**: The `data_set` function will now overwrite existing values. A separate `data_fill` function is available to only fill in missing values.
