### PR TITLE
[5.2] Fix validating empty arrays

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2304,7 +2304,7 @@ class Validator implements ValidatorContract
     protected function normalizeRule($rule)
     {
         switch ($rule) {
-            case 'Int' :
+            case 'Int':
                 return 'Integer';
             case 'Bool':
                 return 'Boolean';

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -301,7 +301,7 @@ class Validator implements ValidatorContract
 
         $query = implode('.', array_slice(explode('.', $attribute), 0, -1));
 
-        foreach (data_get($data = $this->data, $query) as $key => $value) {
+        foreach (data_get($data = $this->data, $query, []) as $key => $value) {
             if (! isset($value[$target])) {
                 array_set($data, str_replace_last('*', $key, $attribute), null);
             }
@@ -2304,7 +2304,7 @@ class Validator implements ValidatorContract
     protected function normalizeRule($rule)
     {
         switch ($rule) {
-            case 'Int':
+            case 'Int' :
                 return 'Integer';
             case 'Bool':
                 return 'Boolean';

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1879,47 +1879,41 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testValidateImplicitEachWithAsterisksForRequiredNonExistingKey()
     {
         $trans = $this->getRealTranslator();
+
         $data = ['names' => [['second' => 'I have no first']]];
         $v = new Validator($trans, $data, ['names.*.first' => 'required']);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getRealTranslator();
         $data = [];
         $v = new Validator($trans, $data, ['names.*.first' => 'required']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
         $data = ['names' => [['second' => 'I have no first']]];
         $v = new Validator($trans, $data, ['names.*.first' => 'required']);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getRealTranslator();
         $data = ['people' => [
             ['cars' => [['model' => 2005], []]],
         ]];
         $v = new Validator($trans, $data, ['people.*.cars.*.model' => 'required']);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getRealTranslator();
         $data = ['people' => [
             ['name' => 'test', 'cars' => [['model' => 2005], ['name' => 'test2']]],
         ]];
         $v = new Validator($trans, $data, ['people.*.cars.*.model' => 'required']);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getRealTranslator();
         $data = ['people' => [
             ['phones' => ['iphone', 'android'], 'cars' => [['model' => 2005], ['name' => 'test2']]],
         ]];
         $v = new Validator($trans, $data, ['people.*.cars.*.model' => 'required']);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getRealTranslator();
         $data = ['names' => [['second' => '2']]];
         $v = new Validator($trans, $data, ['names.*.first' => 'sometimes|required']);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
         $data = [
             'people' => [
                 ['name' => 'Jon', 'email' => 'a@b.c'],
@@ -1929,7 +1923,6 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, $data, ['people.*.email' => 'required']);
         $this->assertFalse($v->passes());
 
-        $trans = $this->getRealTranslator();
         $data = [
             'people' => [
                 [

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1884,6 +1884,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
 
         $trans = $this->getRealTranslator();
+        $data = [];
+        $v = new Validator($trans, $data, ['names.*.first' => 'required']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
         $data = ['names' => [['second' => 'I have no first']]];
         $v = new Validator($trans, $data, ['names.*.first' => 'required']);
         $this->assertFalse($v->passes());


### PR DESCRIPTION
This is a minor fix for the issue in [this comment](https://github.com/laravel/framework/pull/11885#issuecomment-182585210). 

Error exception was thrown if an empty data array was passed to a validator with asterisk rules:

```
$data = [];

Validator::make($data, [
    'persons.*.email' => 'required'
]);
```

Error:

```
[2016-02-10 21:08:17] production.ERROR: exception 'ErrorException' with message 'Invalid argument supplied for foreach()' in /home/vagrant/Code/test/vendor/laravel/framework/src/Illuminate/Validation/Validator.php:304
```
