### PR TITLE
[5.2] Makes the authorize method not required on FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -110,7 +110,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
             return $this->container->call([$this, 'authorize']);
         }
 
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Makes the 'authorize' method not required on FormRequest.
If this method not exists, assumes that the authorization was passed.
