### PR TITLE
[5.2] Ensure namespace is kept on make:auth

### DIFF
--- a/src/Illuminate/Auth/Console/MakeAuthCommand.php
+++ b/src/Illuminate/Auth/Console/MakeAuthCommand.php
@@ -2,10 +2,13 @@
 
 namespace Illuminate\Auth\Console;
 
+use Illuminate\Console\AppNamespaceDetectorTrait;
 use Illuminate\Console\Command;
 
 class MakeAuthCommand extends Command
 {
+    use AppNamespaceDetectorTrait;
+
     /**
      * The name and signature of the console command.
      *
@@ -50,9 +53,10 @@ class MakeAuthCommand extends Command
         if (! $this->option('views')) {
             $this->info('Installed HomeController.');
 
-            copy(
-                __DIR__.'/stubs/make/controllers/HomeController.stub',
-                app_path('Http/Controllers/HomeController.php')
+            file_put_contents(
+                app_path('Http/Controllers/HomeController.php'),
+                $this->compileControllerStub(),
+                FILE_TEXT
             );
 
             $this->info('Updated Routes File.');
@@ -101,5 +105,19 @@ class MakeAuthCommand extends Command
 
             copy(__DIR__.'/stubs/make/views/'.$key, $path);
         }
+    }
+
+    /**
+     * Compiles the HomeController stub.
+     *
+     * @return string
+     */
+    protected function compileControllerStub()
+    {
+        return str_replace(
+            '{{namespace}}',
+            $this->getAppNamespace(),
+            file_get_contents(__DIR__.'/stubs/make/controllers/HomeController.stub')
+        );
     }
 }

--- a/src/Illuminate/Auth/Console/MakeAuthCommand.php
+++ b/src/Illuminate/Auth/Console/MakeAuthCommand.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Auth\Console;
 
-use Illuminate\Console\AppNamespaceDetectorTrait;
 use Illuminate\Console\Command;
+use Illuminate\Console\AppNamespaceDetectorTrait;
 
 class MakeAuthCommand extends Command
 {

--- a/src/Illuminate/Auth/Console/stubs/make/controllers/HomeController.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/controllers/HomeController.stub
@@ -1,8 +1,8 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace {{namespace}}Http\Controllers;
 
-use App\Http\Requests;
+use {{namespace}}Http\Requests;
 use Illuminate\Http\Request;
 
 class HomeController extends Controller


### PR DESCRIPTION
When generating auth scaffolding with make:auth
the namespace of the application is not respected.
