### PR TITLE
[5.2] Validator: Replace asterisks with digits or an asterisk only

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -274,8 +274,11 @@ class Validator implements ValidatorContract
     {
         $data = Arr::dot($this->initializeAttributeOnData($attribute));
 
+        // Match only digits and asterisks in place of an asterisk
+        $pattern = str_replace('\*', '[0-9*]+', preg_quote($attribute));
+
         foreach ($data as $key => $value) {
-            if (Str::startsWith($key, $attribute) || Str::is($attribute, $key)) {
+            if (Str::startsWith($key, $attribute) || (bool) preg_match('/^'.$pattern.'\z/', $key)) {
                 foreach ((array) $rules as $ruleKey => $ruleValue) {
                     if (! is_string($ruleKey) || Str::endsWith($key, $ruleKey)) {
                         $this->mergeRules($key, $ruleValue);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1893,7 +1893,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
 
         $data = ['people' => [
-            ['cars' => [['model' => 2005], ['name' => 'alpha']]],
+            ['cars' => [['model' => 2005], []]],
         ]];
         $v = new Validator($trans, $data, ['people.*.cars.*.model' => 'required']);
         $this->assertFalse($v->passes());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1893,7 +1893,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
 
         $data = ['people' => [
-            ['cars' => [['model' => 2005], []]],
+            ['cars' => [['model' => 2005], ['name' => 'alpha']]],
         ]];
         $v = new Validator($trans, $data, ['people.*.cars.*.model' => 'required']);
         $this->assertFalse($v->passes());
@@ -1941,6 +1941,30 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         ];
         $v = new Validator($trans, $data, ['people.*.cars.*.model' => 'required']);
         $this->assertFalse($v->passes());
+    }
+
+    public function testValidateNestedArrayWithCommonParentChildKey()
+    {
+        $trans = $this->getRealTranslator();
+
+        $data = [
+            'products' => [
+                [
+                    'price' => 2,
+                    'options' => [
+                        ['price' => 1],
+                    ],
+                ],
+                [
+                    'price' => 2,
+                    'options' => [
+                        ['price' => 0],
+                    ],
+                ],
+            ],
+        ];
+        $v = new Validator($trans, $data, ['products.*.price' => 'numeric|min:1']);
+        $this->assertTrue($v->passes());
     }
 
     public function testValidateEachWithNonIndexedArray()


### PR DESCRIPTION
**Problem**: Using `Str::is()` to match a key for a rule like `products.*.price` will also match `products.*.modifiers.*.price`.

This is because `Str::is()` replaces the asterisk with `.*` ANY character (including alpha & dot).

**Solution**:  Use a pattern that matches only digits & asterisks.

**Note**: The match will include asterisks as well because the `initializeAttributeOnData()` only replaces the last (*) in a key of a nested array when building an empty value for a required key that is not present in the input array, so sometimes the final key will contain an asterisk.
