### PR TITLE
Eloquent\Model->getConnection should use getConnectionName

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3278,7 +3278,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getConnection()
     {
-        return static::resolveConnection($this->connection);
+        return static::resolveConnection($this->getConnectionName());
     }
 
     /**


### PR DESCRIPTION
I don't have a good use case for the moment, but I just think that since `Model::$connection` has a getter (`Model::getConnectionName()`), the getter should be used instead of direct accessing `Model::$connection`. Am I wrong?
