### PR TITLE
[5.2] Consistant docblock types

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -134,7 +134,7 @@ class Arr
     /**
      * Determine if the given key exists in the provided array.
      *
-     * @param  array|\ArrayAccess  $array
+     * @param  \ArrayAccess|array  $array
      * @param  string|int  $key
      * @return bool
      */


### PR DESCRIPTION
The regex to check all inconsistencies is `@(param|return|throws|var)\s+(string|int|integer|bool|boolean|float|double|null|array)\|\\`
