### PR TITLE
[5.3] Make str_replace_array() not interpret needle as a regex

### DIFF
--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -53,7 +53,7 @@ class QueryException extends PDOException
      */
     protected function formatMessage($sql, $bindings, $previous)
     {
-        return $previous->getMessage().' (SQL: '.str_replace_array('\?', $bindings, $sql).')';
+        return $previous->getMessage().' (SQL: '.str_replace_array('?', $bindings, $sql).')';
     }
 
     /**

--- a/src/Illuminate/Database/QueryException.php
+++ b/src/Illuminate/Database/QueryException.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database;
 
 use PDOException;
+use Illuminate\Support\Str;
 
 class QueryException extends PDOException
 {
@@ -53,7 +54,7 @@ class QueryException extends PDOException
      */
     protected function formatMessage($sql, $bindings, $previous)
     {
-        return $previous->getMessage().' (SQL: '.str_replace_array('?', $bindings, $sql).')';
+        return $previous->getMessage().' (SQL: '.Str::replaceArray('?', $bindings, $sql).')';
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -253,6 +253,23 @@ class Str
     }
 
     /**
+     * Replace a given value in the string sequentially with an array.
+     *
+     * @param  string  $search
+     * @param  array   $replace
+     * @param  string  $subject
+     * @return string
+     */
+    public static function replaceArray($search, array $replace, $subject)
+    {
+        foreach ($replace as $value) {
+            $subject = static::replaceFirst($search, $value, $subject);
+        }
+
+        return $subject;
+    }
+
+    /**
      * Replace the first occurrence of a given value in the string.
      *
      * @param  string  $search

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -730,11 +730,7 @@ if (! function_exists('str_replace_array')) {
      */
     function str_replace_array($search, array $replace, $subject)
     {
-        foreach ($replace as $value) {
-            $subject = Str::replaceFirst($search, $value, $subject);
-        }
-
-        return $subject;
+        return Str::replaceArray($search, $replace, $subject);
     }
 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -731,7 +731,7 @@ if (! function_exists('str_replace_array')) {
     function str_replace_array($search, array $replace, $subject)
     {
         foreach ($replace as $value) {
-            $subject = preg_replace('/'.$search.'/', $value, $subject, 1);
+            $subject = Str::replaceFirst($search, $value, $subject);
         }
 
         return $subject;

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -138,6 +138,12 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
         $this->assertInternalType('string', Str::random());
     }
 
+    public function testReplaceArray()
+    {
+        $this->assertEquals('foo/bar/baz', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?'));
+        $this->assertEquals('?/?/?', Str::replaceArray('x', ['foo', 'bar', 'baz'], '?/?/?'));
+    }
+
     public function testReplaceFirst()
     {
         $this->assertEquals('fooqux foobar', Str::replaceFirst('bar', 'qux', 'foobar foobar'));


### PR DESCRIPTION
- Targetting 5.3 as it's a breaking change. See https://github.com/vlakoff/framework/commit/3db6f2a664552efaa11f1c8444452902351bb4ce.
- Also adding a `Str::replaceArray` method for codebase consistency.
