### PR TITLE
Feature: Add `loadIfNeeded` function to Model.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -750,11 +750,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return !$this->relationLoaded($relation);
         });
 
-        $query = $this->newQuery()->with($unloadedRelations);
-
-        $query->eagerLoadRelations([$this]);
-
-        return $this;
+        if (empty($unloadedRelations)) {
+            return $this;
+        } else {
+            return $this->load($unloadedRelations);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -747,7 +747,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
 
         $unloadedRelations = array_filter($relations, function($relation) {
-            return !$this->relationLoaded($relation);
+            return ! $this->relationLoaded($relation);
         });
 
         if (empty($unloadedRelations)) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -735,6 +735,29 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Eager load relations on the model if they're not already loaded.
+     *
+     * @param array|string  $relations
+     * @return $this
+     */
+    public function loadIfNeeded($relations)
+    {
+        if (is_string($relations)) {
+            $relations = func_get_args();
+        }
+
+        $unloadedRelations = array_filter($relations, function($relation) {
+            return !$this->relationLoaded($relation);
+        });
+
+        $query = $this->newQuery()->with($unloadedRelations);
+
+        $query->eagerLoadRelations([$this]);
+
+        return $this;
+    }
+
+    /**
      * Begin querying a model with eager loading.
      *
      * @param  array|string  $relations

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -746,7 +746,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $relations = func_get_args();
         }
 
-        $unloadedRelations = array_filter($relations, function($relation) {
+        $unloadedRelations = array_filter($relations, function ($relation) {
             return ! $this->relationLoaded($relation);
         });
 


### PR DESCRIPTION
`loadIfNeeded` is a utility function that reduces boilerplate required in loading relations if they aren't already loaded. 

Example:

```
$user = User::query()->find(1);
if (!$user->relationLoaded('someRelation')) {
    $user->load('someRelation');
}
if (!$user->relationLoaded('someOtherRelation')) {
    $user->load('someOtherRelation');
}
```

With `loadIfNeeded`:

```
$user = User::query()->find(1);
$user->loadIfNeeded(['someRelation', 'someOtherRelation]);
```
