### PR TITLE
[5.2] Add loadIfNeeded function to Model.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -760,11 +760,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return !$this->relationLoaded($relation);
         });
 
-        $query = $this->newQuery()->with($unloadedRelations);
-
-        $query->eagerLoadRelations([$this]);
-
-        return $this;
+        if (empty($unloadedRelations)) {
+            return $this;
+        } else {
+            return $this->load($unloadedRelations);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -757,7 +757,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
 
         $unloadedRelations = array_filter($relations, function($relation) {
-            return !$this->relationLoaded($relation);
+            return ! $this->relationLoaded($relation);
         });
 
         if (empty($unloadedRelations)) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -745,6 +745,29 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Eager load relations on the model if they're not already loaded.
+     *
+     * @param array|string  $relations
+     * @return $this
+     */
+    public function loadIfNeeded($relations)
+    {
+        if (is_string($relations)) {
+            $relations = func_get_args();
+        }
+
+        $unloadedRelations = array_filter($relations, function($relation) {
+            return !$this->relationLoaded($relation);
+        });
+
+        $query = $this->newQuery()->with($unloadedRelations);
+
+        $query->eagerLoadRelations([$this]);
+
+        return $this;
+    }
+
+    /**
      * Begin querying a model with eager loading.
      *
      * @param  array|string  $relations

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -756,7 +756,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $relations = func_get_args();
         }
 
-        $unloadedRelations = array_filter($relations, function($relation) {
+        $unloadedRelations = array_filter($relations, function ($relation) {
             return ! $this->relationLoaded($relation);
         });
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1603,6 +1603,7 @@ class EloquentModelLoadIfNeededStub extends Illuminate\Database\Eloquent\Model
         foreach ($relations as $relation) {
             $this->relations[$relation] = true;
         }
+
         return 'load called';
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1598,14 +1598,16 @@ class EloquentModelLoadIfNeededStub extends Illuminate\Database\Eloquent\Model
     protected $table = 'stub';
     protected $guarded = [];
 
-    public function load($relations) {
+    public function load($relations)
+    {
         foreach ($relations as $relation) {
             $this->relations[$relation] = true;
         }
         return 'load called';
     }
 
-    public function loadIfNeeded($relations) {
+    public function loadIfNeeded($relations)
+    {
         if (is_string($relations)) {
             $relations = func_get_args();
         }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1280,6 +1280,32 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($model->update());
     }
 
+    public function testLoadIfNeededFiltersLoadedAndUnloadedRelationsCorrectly()
+    {
+        // Benchmark result for relations, foo and bar
+        $model = new EloquentModelLoadIfNeededStub;
+        $this->assertFalse($model->relationLoaded('foo'));
+        $this->assertFalse($model->relationLoaded('bar'));
+
+        // Call load foo for the first time
+        $result = $model->loadIfNeeded('foo');
+        $this->assertEquals('load called', $result);
+        $this->assertTrue($model->relationLoaded('foo'));
+        $this->assertFalse($model->relationLoaded('bar'));
+
+        // Call load foo a second time
+        $result = $model->loadIfNeeded('foo');
+        $this->assertEquals('loaded nothing', $result);
+        $this->assertTrue($model->relationLoaded('foo'));
+        $this->assertFalse($model->relationLoaded('bar'));
+
+        // Load foo and bar
+        $result = $model->loadIfNeeded(['foo', 'bar']);
+        $this->assertEquals('load called', $result);
+        $this->assertTrue($model->relationLoaded('foo'));
+        $this->assertTrue($model->relationLoaded('bar'));
+    }
+
     protected function addMockConnection($model)
     {
         $model->setConnectionResolver($resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'));
@@ -1565,4 +1591,33 @@ class EloquentModelNonIncrementingStub extends Illuminate\Database\Eloquent\Mode
     protected $table = 'stub';
     protected $guarded = [];
     public $incrementing = false;
+}
+
+class EloquentModelLoadIfNeededStub extends Illuminate\Database\Eloquent\Model
+{
+    protected $table = 'stub';
+    protected $guarded = [];
+
+    public function load($relations) {
+        foreach ($relations as $relation) {
+            $this->relations[$relation] = true;
+        }
+        return 'load called';
+    }
+
+    public function loadIfNeeded($relations) {
+        if (is_string($relations)) {
+            $relations = func_get_args();
+        }
+
+        $unloadedRelations = array_filter($relations, function ($relation) {
+            return ! $this->relationLoaded($relation);
+        });
+
+        if (empty($unloadedRelations)) {
+            return 'loaded nothing';
+        } else {
+            return $this->load($unloadedRelations);
+        }
+    }
 }


### PR DESCRIPTION
Note: Moved from #12261 

`loadIfNeeded` is a utility function that reduces boilerplate required in loading relations if they aren't already loaded. 

Example:

```
$user = User::query()->find(1);
if (!$user->relationLoaded('someRelation')) {
    $user->load('someRelation');
}
if (!$user->relationLoaded('someOtherRelation')) {
    $user->load('someOtherRelation');
}
```

With `loadIfNeeded`:

```
$user = User::query()->find(1);
$user->loadIfNeeded(['someRelation', 'someOtherRelation]);
```
