### PR TITLE
[5.2] Added support for not following redirections when testing so you can test for expected redirections outside of your site

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -35,7 +35,7 @@ trait InteractsWithPages
     protected $uploads = [];
 
     /**
-     * Stores the flag stating we should not test for redirections or page loads
+     * Stores the flag stating we should not test for redirections or page loads.
      *
      * @var bool
      */
@@ -68,9 +68,9 @@ trait InteractsWithPages
 
         $this->call($method, $uri, $parameters, $cookies, $files);
 
-        if($this->suspendFollowingRedirectionsFlag){
+        if ($this->suspendFollowingRedirectionsFlag) {
             $this->clearInputs();
-        }else{
+        } else {
             $this->clearInputs()->followRedirects()->assertPageLoaded($uri);
         }
 
@@ -125,41 +125,43 @@ trait InteractsWithPages
     }
 
     /**
-     * Allows expectation of redirections for assertions of redirect to other sites or pages
+     * Allows expectation of redirections for assertions of redirect to other sites or pages.
      *
      * @return $this
      */
-    public function suspendFollowingRedirections() {
-
+    public function suspendFollowingRedirections()
+    {
         $this->suspendFollowingRedirectionsFlag = true;
+
         return $this;
     }
 
     /**
-     * Disables the expected redirection previously activated by expectRedirection
+     * Disables the expected redirection previously activated by expectRedirection.
      *
      * @return $this
      */
-    public function restoreFollowingRedirections() {
-
+    public function restoreFollowingRedirections()
+    {
         $this->suspendFollowingRedirectionsFlag = false;
+
         return $this;
     }
 
     /**
      * Runs the included closures page interactions inside of a suspended redirection following state
-     * and checks if the response of these operations is a redirection. Perfect for scenarios like:
+     * and checks if the response of these operations is a redirection. Perfect for scenarios like:.
      *
      *      $this->visit('/login')->click('Sign in with Github')
      *
-     * @param \closure $on     The closure that will run and intercept the HttpRedirection response
-     * @param string   $target Target scheme://hostname/path that is expected in the redirection
-     * @param array    $params Parameters that must be found in the redirection target
+     * @param  \closure $on     The closure that will run and intercept the HttpRedirection response
+     * @param  string   $target Target scheme://hostname/path that is expected in the redirection
+     * @param  array    $params Parameters that must be found in the redirection target
      *
      * @return bool
      */
-    public function expectRedirectionTo(\closure $on, $target = null, $params = []) {
-
+    public function expectRedirectionTo(\closure $on, $target = null, $params = [])
+    {
         $this->suspendFollowingRedirections();
 
         $on($this);
@@ -179,7 +181,7 @@ trait InteractsWithPages
         }
 
         if ($target !== null) {
-            $targetCompareAgainst = $parsedUrl['scheme'] . '://' . $parsedUrl['host'] . $parsedUrl['path'];
+            $targetCompareAgainst = $parsedUrl['scheme'].'://'.$parsedUrl['host'].$parsedUrl['path'];
             $this->assertEquals(
                 $target,
                 $targetCompareAgainst,
@@ -201,6 +203,7 @@ trait InteractsWithPages
         }
 
         $this->restoreFollowingRedirections();
+
         return $this;
     }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -35,6 +35,13 @@ trait InteractsWithPages
     protected $uploads = [];
 
     /**
+     * Stores the flag stating we should not test for redirections or page loads
+     *
+     * @var bool
+     */
+    protected $suspendFollowingRedirectionsFlag;
+
+    /**
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri
@@ -61,7 +68,11 @@ trait InteractsWithPages
 
         $this->call($method, $uri, $parameters, $cookies, $files);
 
-        $this->clearInputs()->followRedirects()->assertPageLoaded($uri);
+        if($this->suspendFollowingRedirectionsFlag){
+            $this->clearInputs();
+        }else{
+            $this->clearInputs()->followRedirects()->assertPageLoaded($uri);
+        }
 
         $this->currentUri = $this->app->make('request')->fullUrl();
 
@@ -110,6 +121,86 @@ trait InteractsWithPages
             $this->makeRequest('GET', $this->response->getTargetUrl());
         }
 
+        return $this;
+    }
+
+    /**
+     * Allows expectation of redirections for assertions of redirect to other sites or pages
+     *
+     * @return $this
+     */
+    public function suspendFollowingRedirections() {
+
+        $this->suspendFollowingRedirectionsFlag = true;
+        return $this;
+    }
+
+    /**
+     * Disables the expected redirection previously activated by expectRedirection
+     *
+     * @return $this
+     */
+    public function restoreFollowingRedirections() {
+
+        $this->suspendFollowingRedirectionsFlag = false;
+        return $this;
+    }
+
+    /**
+     * Runs the included closures page interactions inside of a suspended redirection following state
+     * and checks if the response of these operations is a redirection. Perfect for scenarios like:
+     *
+     *      $this->visit('/login')->click('Sign in with Github')
+     *
+     * @param \closure $on     The closure that will run and intercept the HttpRedirection response
+     * @param string   $target Target scheme://hostname/path that is expected in the redirection
+     * @param array    $params Parameters that must be found in the redirection target
+     *
+     * @return bool
+     */
+    public function expectRedirectionTo(\closure $on, $target = null, $params = []) {
+
+        $this->suspendFollowingRedirections();
+
+        $on($this);
+
+        $this->assertInstanceOf(
+            RedirectResponse::class,
+            $this->response,
+            sprintf(
+                'Expected [%s] but got [%s]',
+                RedirectResponse::class,
+                get_class($this->response)
+            )
+        );
+
+        if ($target !== null || count($params) > 0) {
+            $parsedUrl = parse_url($this->response->getTargetUrl());
+        }
+
+        if ($target !== null) {
+            $targetCompareAgainst = $parsedUrl['scheme'] . '://' . $parsedUrl['host'] . $parsedUrl['path'];
+            $this->assertEquals(
+                $target,
+                $targetCompareAgainst,
+                sprintf(
+                    'The targetUrl [%s] doesn\'t match the expected targetUrl [%s]',
+                    $target,
+                    $targetCompareAgainst
+                )
+            );
+        }
+
+        if (count($params) > 0) {
+            parse_str($parsedUrl['query'], $parsedQuery);
+
+            $this->assertArraySubset(
+                $params,
+                $parsedQuery
+            );
+        }
+
+        $this->restoreFollowingRedirections();
         return $this;
     }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -160,7 +160,7 @@ trait InteractsWithPages
      *
      * @return bool
      */
-    public function expectRedirectionTo(\closure $on, $target = null, $params = [])
+    public function expectRedirectionTo(\Closure $on, $target = null, $params = [])
     {
         try {
             $this->suspendFollowingRedirections();


### PR DESCRIPTION
This is related to the following thread on Laracast: https://laracasts.com/discuss/channels/testing/testing-socialite-redirects

It adds support for testing for expected redirections. When redirecting outside of your site, you cannot test anything because it expects to be on a page of the site and throws a nasty 404. You can catch the 404 using @expectedException but it's quite ugly. So i added functions that allow the following construct for testing:

``` php

    public function testSignInWithGithubSendsMeToGithub() {

        $this
            ->visit(route('login'))
            ->seeLink('Sign in with Github')
            ->expectRedirectionTo(
                function(TestCase $on) {

                    $on->click('Sign in with Github');
                },
                'https://github.com/login/oauth/authorize',
                [
                    'client_id'    => "argsdgasdgasdf",
                    'redirect_uri' => "http://mysite/auth/github/callback",
                ]
            );

    }
```
