### PR TITLE
[5.2] Don't overwrite final array values when using a trailing * in data_fill

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -465,11 +465,13 @@ if (! function_exists('data_set')) {
         if (($segment = array_shift($segments)) === '*') {
             if (! Arr::accessible($target)) {
                 $target = [];
-            } elseif ($segments) {
+            }
+
+            if ($segments) {
                 foreach ($target as &$inner) {
                     data_set($inner, $segments, $value, $overwrite);
                 }
-            } else {
+            } elseif ($overwrite) {
                 foreach ($target as &$inner) {
                     $inner = $value;
                 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -431,6 +431,11 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
             ['foo' => [], 'bar' => [['baz' => 'original'], ['baz' => 'boom']]],
             data_fill($data, 'bar.*.baz', 'boom')
         );
+
+        $this->assertEquals(
+            ['foo' => [], 'bar' => [['baz' => 'original'], ['baz' => 'boom']]],
+            data_fill($data, 'bar.*', 'noop')
+        );
     }
 
     public function testDataFillWithDoubleStar()
@@ -514,6 +519,11 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             ['foo' => [], 'bar' => [['baz' => 'boom'], ['baz' => 'boom']]],
             data_set($data, 'bar.*.baz', 'boom')
+        );
+
+        $this->assertEquals(
+            ['foo' => [], 'bar' => ['overwritten', 'overwritten']],
+            data_set($data, 'bar.*', 'overwritten')
         );
     }
 


### PR DESCRIPTION
As discussed, this is the expected behavior.
