### PR TITLE
[5.2] Fix with validating value is of a specific type while input is a file

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -852,7 +852,7 @@ class Validator implements ValidatorContract
      */
     protected function validateArray($attribute, $value)
     {
-        if (! Arr::has($this->data, $attribute)) {
+        if (! Arr::has(array_merge($this->data, $this->files), $attribute)) {
             return true;
         }
 
@@ -868,7 +868,7 @@ class Validator implements ValidatorContract
      */
     protected function validateBoolean($attribute, $value)
     {
-        if (! Arr::has($this->data, $attribute)) {
+        if (! Arr::has(array_merge($this->data, $this->files), $attribute)) {
             return true;
         }
 
@@ -886,7 +886,7 @@ class Validator implements ValidatorContract
      */
     protected function validateInteger($attribute, $value)
     {
-        if (! Arr::has($this->data, $attribute)) {
+        if (! Arr::has(array_merge($this->data, $this->files), $attribute)) {
             return true;
         }
 
@@ -902,7 +902,7 @@ class Validator implements ValidatorContract
      */
     protected function validateNumeric($attribute, $value)
     {
-        if (! Arr::has($this->data, $attribute)) {
+        if (! Arr::has(array_merge($this->data, $this->files), $attribute)) {
             return true;
         }
 
@@ -918,7 +918,7 @@ class Validator implements ValidatorContract
      */
     protected function validateString($attribute, $value)
     {
-        if (! Arr::has($this->data, $attribute)) {
+        if (! Arr::has(array_merge($this->data, $this->files), $attribute)) {
             return true;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -290,6 +290,17 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('all must be required!', $v->messages()->first('name.1'));
     }
 
+    public function testValidateArray()
+    {
+        $trans = $this->getRealTranslator();
+
+        $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => new \Symfony\Component\HttpFoundation\File\File('/tmp/foo', false)], ['foo' => 'Array']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateRequired()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
The fix is based on the problem in this issue https://github.com/laravel/framework/issues/12269

For example:

``` php
protected function validateBoolean($attribute, $value)
{
    if (! Arr::has($this->data, $attribute)) {
        return true;
    }
    // ...
}
```

Here `$this->data` only includes non-file values, so if the value provided was a file while the rule is to check for a boolean, `Array::has()` will return false as the provided key won't be found in the `$this->data` since it is a file which is stored separately in `$this->files`.
