### PR TITLE
[WIP] [5.2] Cache: add increment and decrement to \Illuminate\Contracts\Cache\Repository

### DIFF
--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -53,6 +53,24 @@ interface Repository
     public function add($key, $value, $minutes);
 
     /**
+     * Increment the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return int|bool
+     */
+    public function increment($key, $value = 1);
+
+    /**
+     * Decrement the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return int|bool
+     */
+    public function decrement($key, $value = 1);
+
+    /**
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key


### PR DESCRIPTION
`increment` (and thus `decrement`) are missing in`\Illuminate\Contracts\Cache\Repository`

See https://github.com/laravel/framework/blob/5.2/src/Illuminate/Cache/RateLimiter.php#L61
