### PR TITLE
[5.3] Cache: add increment and decrement to \Illuminate\Contracts\Cache\Repository

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -496,4 +496,28 @@ class Repository implements CacheContract, ArrayAccess
     {
         $this->store = clone $this->store;
     }
+
+    /**
+     * Increment the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int|bool
+     */
+    public function increment($key, $value = 1)
+    {
+        return $this->store->increment($key, $value);
+    }
+
+    /**
+     * Decrement the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int|bool
+     */
+    public function decrement($key, $value = 1)
+    {
+        return $this->store->decrement($key, $value);
+    }
 }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -259,6 +259,30 @@ class Repository implements CacheContract, ArrayAccess
     }
 
     /**
+     * Increment the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int|bool
+     */
+    public function increment($key, $value = 1)
+    {
+        return $this->store->increment($key, $value);
+    }
+
+    /**
+     * Decrement the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int|bool
+     */
+    public function decrement($key, $value = 1)
+    {
+        return $this->store->decrement($key, $value);
+    }
+
+    /**
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key
@@ -495,29 +519,5 @@ class Repository implements CacheContract, ArrayAccess
     public function __clone()
     {
         $this->store = clone $this->store;
-    }
-
-    /**
-     * Increment the value of an item in the cache.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return int|bool
-     */
-    public function increment($key, $value = 1)
-    {
-        return $this->store->increment($key, $value);
-    }
-
-    /**
-     * Decrement the value of an item in the cache.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return int|bool
-     */
-    public function decrement($key, $value = 1)
-    {
-        return $this->store->decrement($key, $value);
     }
 }

--- a/src/Illuminate/Contracts/Cache/Repository.php
+++ b/src/Illuminate/Contracts/Cache/Repository.php
@@ -53,6 +53,24 @@ interface Repository
     public function add($key, $value, $minutes);
 
     /**
+     * Increment the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int|bool
+     */
+    public function increment($key, $value = 1);
+
+    /**
+     * Decrement the value of an item in the cache.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return int|bool
+     */
+    public function decrement($key, $value = 1);
+
+    /**
      * Store an item in the cache indefinitely.
      *
      * @param  string  $key


### PR DESCRIPTION
`increment` (and thus `decrement`) are missing in`\Illuminate\Contracts\Cache\Repository`

See https://github.com/laravel/framework/blob/5.2/src/Illuminate/Cache/RateLimiter.php#L61

---

Replace #12285
