### PR TITLE
[5.2] Switch case consistancy

### DIFF
--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -34,8 +34,11 @@ trait CreatesUserProviders
         switch ($config['driver']) {
             case 'database':
                 return $this->createDatabaseProvider($config);
+
             case 'eloquent':
+
                 return $this->createEloquentProvider($config);
+
             default:
                 throw new InvalidArgumentException("Authentication user provider [{$config['driver']}] is not defined.");
         }

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -81,18 +81,21 @@ class Repository implements CacheContract, ArrayAccess
                 }
 
                 return $this->events->fire(new Events\CacheHit($payload[0], $payload[1], $payload[2]));
+
             case 'missed':
                 if (count($payload) == 1) {
                     $payload[] = [];
                 }
 
                 return $this->events->fire(new Events\CacheMissed($payload[0], $payload[1]));
+
             case 'delete':
                 if (count($payload) == 1) {
                     $payload[] = [];
                 }
 
                 return $this->events->fire(new Events\KeyForgotten($payload[0], $payload[1]));
+
             case 'write':
                 if (count($payload) == 3) {
                     $payload[] = [];

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -783,8 +783,10 @@ class Connection implements ConnectionInterface
         switch ($event) {
             case 'beganTransaction':
                 return $this->events->fire(new Events\TransactionBeginning($this));
+
             case 'committed':
                 return $this->events->fire(new Events\TransactionCommitted($this));
+
             case 'rollingBack':
                 return $this->events->fire(new Events\TransactionRolledBack($this));
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2878,27 +2878,36 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             case 'int':
             case 'integer':
                 return (int) $value;
+
             case 'real':
             case 'float':
             case 'double':
                 return (float) $value;
+
             case 'string':
                 return (string) $value;
+
             case 'bool':
             case 'boolean':
                 return (bool) $value;
+
             case 'object':
                 return $this->fromJson($value, true);
+
             case 'array':
             case 'json':
                 return $this->fromJson($value);
+
             case 'collection':
                 return new BaseCollection($this->fromJson($value));
+
             case 'date':
             case 'datetime':
                 return $this->asDateTime($value);
+
             case 'timestamp':
                 return $this->asTimeStamp($value);
+
             default:
                 return $value;
         }

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -388,13 +388,16 @@ abstract class Grammar extends BaseGrammar
             case 'biginteger':
                 $type = 'bigint';
                 break;
+
             case 'smallinteger':
                 $type = 'smallint';
                 break;
+
             case 'mediumtext':
             case 'longtext':
                 $type = 'text';
                 break;
+
             case 'binary':
                 $type = 'blob';
                 break;

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyPostSize.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyPostSize.php
@@ -39,10 +39,13 @@ class VerifyPostSize
         switch ($metric) {
             case 'K':
                 return (int) $postMaxSize * 1024;
+
             case 'M':
                 return (int) $postMaxSize * 1048576;
+
             case 'G':
                 return (int) $postMaxSize * 1073741824;
+
             default:
                 return (int) $postMaxSize;
         }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2321,8 +2321,10 @@ class Validator implements ValidatorContract
         switch ($rule) {
             case 'Int':
                 return 'Integer';
+
             case 'Bool':
                 return 'Boolean';
+
             default:
                 return $rule;
         }


### PR DESCRIPTION
All `switch...case` are formatted with an empty line before `case` (excepted the first `case`), but these few ones.

No style fixer seems to exist for that.
