### PR TITLE
Better exceptions for the integrated test package

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -61,8 +61,6 @@ trait InteractsWithPages
 
         $this->call($method, $uri, $parameters, $cookies, $files);
 
-        $this->clearInputs()->followRedirects()->assertPageLoaded($uri);
-
         $this->currentUri = $this->app->make('request')->fullUrl();
 
         $this->crawler = new Crawler($this->response->getContent(), $uri);
@@ -161,6 +159,10 @@ trait InteractsWithPages
             $this->assertEquals(200, $status);
         } catch (PHPUnitException $e) {
             $message = $message ?: "A request to [{$uri}] failed. Received status code [{$status}].";
+
+            if (! in_array('--verbose', $_SERVER['argv'])) {
+                $this->fail($message);
+            }
 
             $responseException = isset($this->response->exception)
                     ? $this->response->exception : null;

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -481,7 +481,11 @@ trait MakesHttpRequests
 
         $kernel->terminate($request, $response);
 
-        return $this->response = $response;
+        $this->response = $response;
+
+        $this->clearInputs()->followRedirects()->assertPageLoaded($uri);
+
+        return $this->response;
     }
 
     /**


### PR DESCRIPTION
This Pull Request fixes 2 issues: 
1. The methods get() post() etc. did not have the assertPageLoaded, so if an error is thrown, it does not notify the developer.
2. It reduces the default verbosity (unless the developer passes --verbose when executing the test). I have used this package a lot and it is really confusing or annoying when you get an error, having to scroll up a lot to see what happened.
