### PR TITLE
[5.2] Fix Eloquent Builder accessing $orders property

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -297,7 +297,7 @@ class Builder
      */
     public function each(callable $callback, $count = 1000)
     {
-        if (is_null($this->orders) && is_null($this->unionOrders)) {
+        if (is_null($this->query->orders) && is_null($this->query->unionOrders)) {
             $this->orderBy($this->model->getQualifiedKeyName(), 'asc');
         }
 


### PR DESCRIPTION
$orders and $unionOrders are properties of Illuminate\Database\Query\Builder and not defined in Illuminate\Database\Eloquent\Builder. Doing this solve my problem. Is there any problem doing this?
