### PR TITLE
[5.2] Make the validator match asterisks with any character but dot

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -274,7 +274,7 @@ class Validator implements ValidatorContract
     {
         $data = Arr::dot($this->initializeAttributeOnData($attribute));
 
-        $pattern = str_replace('\*', '[0-9*]+', preg_quote($attribute));
+        $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute));
 
         foreach ($data as $key => $value) {
             if (Str::startsWith($key, $attribute) || (bool) preg_match('/^'.$pattern.'\z/', $key)) {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1977,6 +1977,19 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, $data, ['products.*.price' => 'numeric|min:1']);
         $this->assertTrue($v->passes());
     }
+    
+    public function testValidateNestedArrayWithNonNumericKeys(){
+        $trans = $this->getRealTranslator();
+
+        $data = [
+            'item_amounts' => [
+                'item_123' => 2
+            ]
+        ];
+
+        $v = new Validator($trans, $data, ['item_amounts.*' => 'numeric|min:5']);
+        $this->assertFalse($v->passes());
+    }
 
     public function testValidateEachWithNonIndexedArray()
     {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1977,14 +1977,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, $data, ['products.*.price' => 'numeric|min:1']);
         $this->assertTrue($v->passes());
     }
-    
-    public function testValidateNestedArrayWithNonNumericKeys(){
+
+    public function testValidateNestedArrayWithNonNumericKeys()
+    {
         $trans = $this->getRealTranslator();
 
         $data = [
             'item_amounts' => [
-                'item_123' => 2
-            ]
+                'item_123' => 2,
+            ],
         ];
 
         $v = new Validator($trans, $data, ['item_amounts.*' => 'numeric|min:5']);


### PR DESCRIPTION
In a previous pull request (https://github.com/laravel/framework/pull/12251) I replaced `Str::is()` with a custom regular expression to replace asterisks with only numerical values.

In this pull request I modified the regex to match any character but dots, that way validation will work on non-numeric keys as well.
