### PR TITLE
[5.3] Support array in Collection::where

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -222,16 +222,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $conditions = is_array($key) ? $key : [$key => $value];
 
-        return $this->filter(function ($item) use ($conditions) {
-
-            foreach ($conditions as $key => $value) {
-                if (data_get($item, $key) !== $value) {
-                    return false;
-                }
-            }
-
-            return true;
-        });
+        return $this->doWhere($conditions, true);
     }
 
     /**
@@ -245,10 +236,22 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $conditions = is_array($key) ? $key : [$key => $value];
 
-        return $this->filter(function ($item) use ($conditions) {
+        return $this->doWhere($conditions, false);
+    }
+
+    /**
+     * Filter items by the given array of key value pairs.
+     *
+     * @param  array  $conditions
+     * @param  bool  $strict
+     * @return static
+     */
+    protected function doWhere($conditions, $strict)
+    {
+        return $this->filter(function ($item) use ($conditions, $strict) {
 
             foreach ($conditions as $key => $value) {
-                if (data_get($item, $key) != $value) {
+                if ($strict ? data_get($item, $key) !== $value : data_get($item, $key) != $value) {
                     return false;
                 }
             }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -212,31 +212,49 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Filter items by the given key value pair.
+     * Filter items by the given key value pair (or array of pairs).
      *
-     * @param  string  $key
+     * @param  string|array  $key
      * @param  mixed  $value
-     * @param  bool  $strict
      * @return static
      */
-    public function where($key, $value, $strict = true)
+    public function where($key, $value = null)
     {
-        return $this->filter(function ($item) use ($key, $value, $strict) {
-            return $strict ? data_get($item, $key) === $value
-                           : data_get($item, $key) == $value;
+        $conditions = is_array($key) ? $key : [$key => $value];
+
+        return $this->filter(function ($item) use ($conditions) {
+
+            foreach ($conditions as $key => $value) {
+                if (data_get($item, $key) !== $value) {
+                    return false;
+                }
+            }
+
+            return true;
         });
     }
 
     /**
-     * Filter items by the given key value pair using loose comparison.
+     * Filter items by the given key value pair (or array of pairs) using loose comparison.
      *
-     * @param  string  $key
+     * @param  string|array  $key
      * @param  mixed  $value
      * @return static
      */
-    public function whereLoose($key, $value)
+    public function whereLoose($key, $value = null)
     {
-        return $this->where($key, $value, false);
+        $conditions = is_array($key) ? $key : [$key => $value];
+
+        return $this->filter(function ($item) use ($conditions) {
+
+            foreach ($conditions as $key => $value) {
+                if (data_get($item, $key) != $value) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -215,14 +215,20 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Filter items by the given key value pair (or array of pairs).
      *
      * @param  string|array  $key
-     * @param  mixed  $value
+     * @param  mixed|bool  $value
+     * @param  bool  $strict
      * @return static
      */
-    public function where($key, $value = null)
+    public function where($key, $value = null, $strict = true)
     {
-        $conditions = is_array($key) ? $key : [$key => $value];
+        if (is_array($key)) {
+            $conditions = $key;
+            $strict = $value;
+        } else {
+            $conditions = [$key => $value];
+        }
 
-        return $this->doWhere($conditions, true);
+        return $this->doWhere($conditions, $strict);
     }
 
     /**
@@ -234,7 +240,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function whereLoose($key, $value = null)
     {
-        $conditions = is_array($key) ? $key : [$key => $value];
+        if (is_array($key)) {
+            $conditions = $key;
+        } else {
+            $conditions = [$key => $value];
+        }
 
         return $this->doWhere($conditions, false);
     }


### PR DESCRIPTION
A first draft to get your opinion on this. Support array in `Collection::where` and `whereLoose`.

Considering this data:

```
$collection = collect([
    ['id'=>1, 'brand'=>'Honda', 'color'=>'yellow'],
    ['id'=>2, 'brand'=>'Honda', 'color'=>'blue'],
    ['id'=>3, 'brand'=>'Honda', 'color'=>'yellow'],
]);
$conditions = ['brand'=>'Honda', 'color'=>'yellow'];
```

As in `DB::where`, etc. would allow this:

```
$collection->where($conditions);
```

Instead of this:

```
$collection->filter(function ($item) use ($conditions) {
    foreach ($conditions as $key => $value) {
        if (data_get($item, $key) !== $value) {
            return false;
        }
    }
    return true;
});
```

Note I removed the `$strict` parameter of `where` method, otherwise it becomes messy (multiple method signatures).
