### PR TITLE
[5.1] Make explicit that Collection::pull removes the item

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -586,7 +586,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Pulls an item from the collection.
+     * Get and remove an item from the collection.
      *
      * @param  mixed  $key
      * @param  mixed  $default


### PR DESCRIPTION
Emphasizes that the item is removed from the collection (as it's already the case in docblock of `Arr::pull`). No immutability here!
