### PR TITLE
[5.2] Use the proper application namespace in HomeController when "make:auth"

### DIFF
--- a/src/Illuminate/Auth/Console/MakeAuthCommand.php
+++ b/src/Illuminate/Auth/Console/MakeAuthCommand.php
@@ -55,6 +55,15 @@ class MakeAuthCommand extends Command
                 app_path('Http/Controllers/HomeController.php')
             );
 
+            file_put_contents(
+                app_path('Http/Controllers/HomeController.php'),
+                str_replace(
+                    'App\\',
+                    $this->laravel->getNamespace(),
+                    file_get_contents(app_path('Http/Controllers/HomeController.php'))
+                )
+            );
+
             $this->info('Updated Routes File.');
 
             file_put_contents(


### PR DESCRIPTION
Hi all,

Something that I noticed when we generate an authentication scaffolding (a.k.a _php artisan make:auth_) is the fact to create the HomeController.php file based on the stub located in _src/Illuminate/Auth/Console/stubs/make/controllers/HomeController.stub_ .

This stub uses the **App** application name which is the default one:

``` php
namespace App\Http\Controllers;

use App\Http\Requests;
use Illuminate\Http\Request;
```

But in some cases people could have changed that app name before this step. (a.k.a _php artisan app:name Whatever_)

This PR purposes to change the **App** by the proper application name right after the stub are copied as HomeController.php, so we can rename that namespace automatically, without affect the stub which content are correct.
