### PR TITLE
[5.2] Validator integer rule no longer uses FILTER_VALIDATE_INT

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -890,7 +890,7 @@ class Validator implements ValidatorContract
             return true;
         }
 
-        return is_null($value) || ctype_digit(ltrim((string)$value, '-'));
+        return is_null($value) || ctype_digit(ltrim((string) $value, '-'));
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -890,7 +890,7 @@ class Validator implements ValidatorContract
             return true;
         }
 
-        return is_null($value) || filter_var($value, FILTER_VALIDATE_INT) !== false;
+        return is_null($value) || ctype_digit(ltrim((string)$value, '-'));
     }
 
     /**


### PR DESCRIPTION
FILTER_VALIDATE_INT allows value such as "123", "0" and "+123" but doesn't allow values such as "0123" and "000" which are perfectly legitimate integers. is_int behaves quite differently and would correctly return true but we can't use is_int since it will return false for strings and obviously we can't just blindly cast everything to an integer.

This PR will allow values such as "-0", "0123", "000". The main change from FILTER_VALIDATE_INT is that it will now block strings with a positive sign eg "+123" - but we can add in another ltrim for the positive sign if we want to allow that. The latter is more a judgement call someone needs to make.

Overall, the goal of this PR is to bring the integer validation rule more in line with is_int behaviour (which most users would be familiar with), rather than FILTER_VALIDATE_INT
