### PR TITLE
[5.2] Fix 12309

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Routing\Middleware;
 
 use Closure;
-use Illuminate\Http\Response;
 use Illuminate\Cache\RateLimiter;
+use Symfony\Component\HttpFoundation\Response;
 
 class ThrottleRequests
 {
@@ -85,7 +85,7 @@ class ThrottleRequests
     /**
      * Add the limit header information to the given response.
      *
-     * @param  \Illuminate\Http\Response  $response
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
      * @param  int  $maxAttempts
      * @param  int  $remainingAttempts
      * @param  int|null  $retryAfter


### PR DESCRIPTION
Fix #12309 introduced in #12274
Response type should be `\Symfony\Component\HttpFoundation\Response`
