### PR TITLE
[5.2] Proper phpunit hooks access

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -58,7 +58,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp()
     {
         if (! $this->app) {
             $this->refreshApplication();
@@ -116,7 +116,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown()
     {
         if (class_exists('Mockery')) {
             Mockery::close();


### PR DESCRIPTION
Getting fatal error when using together with phpunit/dbunit

```
Fatal error: Access level to PHPUnit_Extensions_Database_TestCase_Trait::setUp() must be public (as in class Illuminate\Foundation\Testing\TestCase) in /apps/.../tests/TestCase.php on line 36
```

Original (phpunit) methods are protected:
- https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/TestCase.php#L2024
- https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/TestCase.php#L2056

Fixed methods access in framework test case
