### PR TITLE
[5.3] Introduce a Response contract

### DIFF
--- a/src/Illuminate/Contracts/Http/Response.php
+++ b/src/Illuminate/Contracts/Http/Response.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Contracts\Http;
+
+interface Response
+{
+    /**
+     * Get the status code for the response.
+     *
+     * @return int
+     */
+    public function status();
+
+    /**
+     * Get the content of the response.
+     *
+     * @return string
+     */
+    public function content();
+
+    /**
+     * Get the headers of the response.
+     *
+     * @return \Symfony\Component\HttpFoundation\HeaderBag
+     */
+    public function headers();
+}

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -6,9 +6,10 @@ use JsonSerializable;
 use InvalidArgumentException;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Http\Response as ResponseContract;
 use Symfony\Component\HttpFoundation\JsonResponse as BaseJsonResponse;
 
-class JsonResponse extends BaseJsonResponse
+class JsonResponse extends BaseJsonResponse implements ResponseContract
 {
     use ResponseTrait;
 

--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -7,9 +7,10 @@ use ArrayObject;
 use JsonSerializable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Contracts\Http\Response as ResponseContract;
 use Symfony\Component\HttpFoundation\Response as BaseResponse;
 
-class Response extends BaseResponse
+class Response extends BaseResponse implements ResponseContract
 {
     use ResponseTrait;
 

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -15,13 +15,23 @@ trait ResponseTrait
     }
 
     /**
-     * Get the content of the response.
+     * Get the content for the response.
      *
      * @return string
      */
     public function content()
     {
         return $this->getContent();
+    }
+
+    /**
+     * Get the headers for the response.
+     *
+     * @return \Symfony\Component\HttpFoundation\ResponseHeaderBag
+     */
+    public function headers()
+    {
+        return $this->headers;
     }
 
     /**


### PR DESCRIPTION
`\Illuminate\Http\JsonResponse` extend `\Symfony\Component\HttpFoundation\JsonResponse`, not `\Illuminate\Http\Response`.

A response contract would allows to match both `\Illuminate\Http\Response` and `\Illuminate\Http\JsonResponse`, as these two types of response should always be handled by Laravel middlewares

Note: in some ways this interface could also be completely empty, just as `\Illuminate\Contracts\Queue\ShouldQueue` is.

---

Related : #12313 #12309
