### PR TITLE
[5.3] Add url method to Cloud filesystem interface

### DIFF
--- a/src/Illuminate/Contracts/Filesystem/Cloud.php
+++ b/src/Illuminate/Contracts/Filesystem/Cloud.php
@@ -4,5 +4,11 @@ namespace Illuminate\Contracts\Filesystem;
 
 interface Cloud extends Filesystem
 {
-    //
+    /**
+     * Get the URL for the file at the given path.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function url($path);
 }


### PR DESCRIPTION
The url method was added to FilesystemAdapter in commit ef81c53. It should be added to the interface for sanity. Since url is more relevant for cloud filesystems, it is added to the Cloud filesystem interface
instead of Filesystem.
