### PR TITLE
[5.2] Call refreshRememberToken only if required

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -534,7 +534,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // listening for anytime a user signs out of this application manually.
         $this->clearUserDataFromStorage();
 
-        if (! is_null($this->user)) {
+        if (! is_null($user) && ! is_null($user->getRememberToken())) {
             $this->refreshRememberToken($user);
         }
 


### PR DESCRIPTION
See https://github.com/laravel/framework/issues/12054

`refreshRememberToken` is called on every logout. I don't know why it's called (maybe we have to remove everything from uncommented line 537 to 539), but I'm (almost) sure it's not required if user has no `remember_token` attribute.
