### PR TITLE
[5.3] Feature proposal: $maps on Model for rapid column attribute mappings

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -119,6 +119,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $appends = [];
 
     /**
+     * Attribute to column mapping.
+     *
+     * @var array
+     */
+    protected $maps = [];
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array
@@ -2139,7 +2146,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getHidden()
     {
-        return $this->hidden;
+        return array_merge($this->hidden, array_values($this->maps));
     }
 
     /**
@@ -2228,6 +2235,29 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->appends = $appends;
 
         return $this;
+    }
+
+    /**
+     * Set the attribute column mapping array.
+     *
+     * @param  array  $maps
+     * @return $this
+     */
+    public function setMaps(array $maps)
+    {
+        $this->maps = $maps;
+
+        return $this;
+    }
+
+    /**
+     * Get the attribute column mappings array.
+     *
+     * @return array
+     */
+    public function getMaps()
+    {
+        return $this->maps;
     }
 
     /**
@@ -2551,12 +2581,14 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function getArrayableAppends()
     {
-        if (! count($this->appends)) {
+        $appends = array_merge($this->appends, array_keys($this->maps));
+
+        if (! count($appends)) {
             return [];
         }
 
         return $this->getArrayableItems(
-            array_combine($this->appends, $this->appends)
+            array_combine($appends, $appends)
         );
     }
 
@@ -2744,7 +2776,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function hasGetMutator($key)
     {
-        return method_exists($this, 'get'.Str::studly($key).'Attribute');
+        if (method_exists($this, 'get'.Str::studly($key).'Attribute')) {
+            return true;
+        }
+
+        return isset($this->maps[$key]);
     }
 
     /**
@@ -2756,7 +2792,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function mutateAttribute($key, $value)
     {
-        return $this->{'get'.Str::studly($key).'Attribute'}($value);
+        $method = 'get'.Str::studly($key).'Attribute';
+
+        if (method_exists($this, $method)) {
+            return $this->{$method}($value);
+        }
+
+        return $this->attributes[$this->maps[$key]];
     }
 
     /**
@@ -2896,7 +2938,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if ($this->hasSetMutator($key)) {
             $method = 'set'.Str::studly($key).'Attribute';
 
-            return $this->{$method}($value);
+            if (method_exists($this, $method)) {
+                return $this->{$method}($value);
+            }
+
+            $this->attributes[$this->maps[$key]] = $value;
+
+            return $this;
         }
 
         // If an attribute is listed as a "date", we'll convert it from a DateTime
@@ -2923,7 +2971,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function hasSetMutator($key)
     {
-        return method_exists($this, 'set'.Str::studly($key).'Attribute');
+        if (method_exists($this, 'set'.Str::studly($key).'Attribute')) {
+            return true;
+        }
+
+        return isset($this->maps[$key]);
     }
 
     /**
@@ -3392,7 +3444,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             static::cacheMutatedAttributes($class);
         }
 
-        return static::$mutatorCache[$class];
+        return array_merge(static::$mutatorCache[$class], array_keys($this->maps));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1085,6 +1085,21 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['firstName', 'middleName', 'lastName'], $model->getMutatedAttributes());
     }
 
+    public function testMappedAttributes()
+    {
+        $model = new EloquentModelStub;
+
+        $model->setRawAttributes(['badly_named_column__name' => 'Foo']);
+        $model->setMaps(['name' => 'badly_named_column__name']);
+
+        $this->assertEquals(['name' => 'Foo'], $model->toArray());
+        $this->assertEquals('Foo', $model->name);
+        $model->name = 'Bar';
+
+        $this->assertEquals(['name' => 'Bar'], $model->toArray());
+        $this->assertEquals(['badly_named_column__name' => 'Bar'], $model->getAttributes());
+    }
+
     public function testReplicateCreatesANewModelInstanceWithSameAttributeValues()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
This code adds a `protected $maps` member variable on `Eloquent\Model` that makes it easier to deal with badly named columns or table schemas in another language. It _only_ affects the array/json representation of the model.
### Example

this code:

```
class PostalCodes extends Model {
    protected $table = 'postnummer';

    // Mappings for the norwegian column names in the table:
    protected $maps = [
        'name' => 'navn',
        'code' => 'postnummer',
    ];
}
```

will be the same as doing:

```
class PostalCodes extends Model {
    protected $table = 'postnummer';

    // Hide the norwegian columns
    protected $hidden = ['navn', 'postnummer'];

    // And append the english names instead
    protected $append = ['name', 'code'];

    // Need to make getters and setters for each and every attribute.
    public getNameAttribute() { return $this->attributes['navn']; }
    public getCodeAttribute() { return $this->attributes['postnummer']; }

    public setNameAttribute($value) { $this->attributes['navn'] = $value; }
    public setCodeAttribute($value) { $this->attributes['postnummer'] = $value; }
}
```

It saves you a lot of coding. This example model only have two attributes, but in real world you will often have tens of them.
### so

I honestly don't expect this code to be pulled. But I just want to see what your immediate thoughts are about things like this. Eloquent is a wonderful ORM when you have the privilege to design the physical data models as you go, but it could be more convenient when dealing with legacy databases.
