### PR TITLE
[5.2] Ability to prepend and push middleware to a middleware group.

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -222,6 +222,38 @@ class Kernel implements KernelContract
     }
 
     /**
+     * Add a new middleware to beginning of a middleware group if it does not already exist.
+     *
+     * @param  string  $group
+     * @param  string  $middleware
+     * @return $this
+     */
+    public function prependGroupMiddleware($group, $middleware)
+    {
+        if (isset($this->middlewareGroups[$group]) && array_search($middleware, $this->middlewareGroups[$group]) === false) {
+            array_unshift($this->middlewareGroups[$group], $middleware);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a new middleware to end of a middleware group if it does not already exist.
+     *
+     * @param  string  $group
+     * @param  string  $middleware
+     * @return $this
+     */
+    public function pushGroupMiddleware($group, $middleware)
+    {
+        if (isset($this->middlewareGroups[$group]) && array_search($middleware, $this->middlewareGroups[$group]) === false) {
+            $this->middlewareGroups[$group][] = $middleware;
+        }
+
+        return $this;
+    }
+
+    /**
      * Bootstrap the application for HTTP requests.
      *
      * @return void


### PR DESCRIPTION
In my case, I need this to add my custom middleware (as a package) after a session midleware. It was working great using pushMiddleware() prior to 5.2, but it is no longer possible in 5.2, since default route middlewares have been moved to a 'web' group. Currently, there's no other way to put anything in a middleware groups, other than just reassign it completelly, which is a no-no for a package.
