### PR TITLE
[5.1] Fix BC break from #11015

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -130,6 +130,72 @@ class Builder
     }
 
     /**
+     * Find a model by its primary key or return fresh model instance.
+     *
+     * @param  mixed  $id
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function findOrNew($id, $columns = ['*'])
+    {
+        if (! is_null($model = $this->find($id, $columns))) {
+            return $model;
+        }
+
+        return $this->newModel();
+    }
+
+    /**
+     * Get the first record matching the attributes or instantiate it.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function firstOrNew(array $attributes)
+    {
+        if (! is_null($instance = $this->where($attributes)->first())) {
+            return $instance;
+        }
+
+        return $this->newModel($attributes);
+    }
+
+    /**
+     * Get the first record matching the attributes or create it.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function firstOrCreate(array $attributes)
+    {
+        if (! is_null($instance = $this->where($attributes)->first())) {
+            return $instance;
+        }
+
+        $instance = $this->newModel($attributes);
+
+        $instance->save();
+
+        return $instance;
+    }
+
+    /**
+     * Create or update a record matching the attributes, and fill it with values.
+     *
+     * @param  array  $attributes
+     * @param  array  $values
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function updateOrCreate(array $attributes, array $values = [])
+    {
+        $instance = $this->firstOrNew($attributes);
+
+        $instance->fill($values)->save();
+
+        return $instance;
+    }
+
+    /**
      * Execute the query and get the first result.
      *
      * @param  array  $columns
@@ -889,6 +955,19 @@ class Builder
     public function getModel()
     {
         return $this->model;
+    }
+
+    /**
+     * Get a fresh instance of a model instance being queried.
+     *
+     * @param  array  $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function newModel(array $attributes = [])
+    {
+        $class = get_class($this->model);
+
+        return new $class($attributes);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -567,52 +567,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Get the first record matching the attributes or create it.
-     *
-     * @param  array  $attributes
-     * @return static
-     */
-    public static function firstOrCreate(array $attributes)
-    {
-        if (! is_null($instance = (new static)->newQueryWithoutScopes()->where($attributes)->first())) {
-            return $instance;
-        }
-
-        return static::create($attributes);
-    }
-
-    /**
-     * Get the first record matching the attributes or instantiate it.
-     *
-     * @param  array  $attributes
-     * @return static
-     */
-    public static function firstOrNew(array $attributes)
-    {
-        if (! is_null($instance = (new static)->newQueryWithoutScopes()->where($attributes)->first())) {
-            return $instance;
-        }
-
-        return new static($attributes);
-    }
-
-    /**
-     * Create or update a record matching the attributes, and fill it with values.
-     *
-     * @param  array  $attributes
-     * @param  array  $values
-     * @return static
-     */
-    public static function updateOrCreate(array $attributes, array $values = [])
-    {
-        $instance = static::firstOrNew($attributes);
-
-        $instance->fill($values)->save();
-
-        return $instance;
-    }
-
-    /**
      * Begin querying the model.
      *
      * @return \Illuminate\Database\Eloquent\Builder
@@ -665,22 +619,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $instance = new static;
 
         return $instance->newQuery()->get($columns);
-    }
-
-    /**
-     * Find a model by its primary key or return new static.
-     *
-     * @param  mixed  $id
-     * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|static
-     */
-    public static function findOrNew($id, $columns = ['*'])
-    {
-        if (! is_null($model = static::find($id, $columns))) {
-            return $model;
-        }
-
-        return new static;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -124,12 +124,54 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         $this->assertEquals(1, $users->first()->id);
     }
 
-    public function testFirstOrNewIgnoresSoftDelete()
+    public function testFirstOrNew()
     {
         $this->createUsers();
 
-        $taylor = SoftDeletesTestUser::firstOrNew(['id' => 1]);
-        $this->assertEquals('taylorotwell@gmail.com', $taylor->email);
+        $result = SoftDeletesTestUser::firstOrNew(['email' => 'taylorotwell@gmail.com']);
+        $this->assertNull($result->id);
+
+        $result = SoftDeletesTestUser::withTrashed()->firstOrNew(['email' => 'taylorotwell@gmail.com']);
+        $this->assertEquals(1, $result->id);
+    }
+
+    public function testFindOrNew()
+    {
+        $this->createUsers();
+
+        $result = SoftDeletesTestUser::findOrNew(1);
+        $this->assertNull($result->id);
+
+        $$result = SoftDeletesTestUser::withTrashed()->findOrNew(1);
+        $this->assertNull($result->id);
+    }
+
+    public function testFirstOrCreate()
+    {
+        $this->createUsers();
+
+        $result = SoftDeletesTestUser::withTrashed()->firstOrCreate(['email' => 'taylorotwell@gmail.com']);
+        $this->assertEquals('taylorotwell@gmail.com', $result->email);
+        $this->assertCount(1, SoftDeletesTestUser::all());
+
+        $result = SoftDeletesTestUser::firstOrCreate(['email' => 'foo@bar.com']);
+        $this->assertEquals('foo@bar.com', $result->email);
+        $this->assertCount(2, SoftDeletesTestUser::all());
+        $this->assertCount(3, SoftDeletesTestUser::withTrashed()->get());
+    }
+
+    public function testUpdateOrCreate()
+    {
+        $this->createUsers();
+
+        $result = SoftDeletesTestUser::updateOrCreate(['email' => 'foo@bar.com'], ['email' => 'bar@baz.com']);
+        $this->assertEquals('bar@baz.com', $result->email);
+        $this->assertCount(2, SoftDeletesTestUser::all());
+
+        $result = SoftDeletesTestUser::withTrashed()->updateOrCreate(['email' => 'taylorotwell@gmail.com'], ['email' => 'foo@bar.com']);
+        $this->assertEquals('foo@bar.com', $result->email);
+        $this->assertCount(2, SoftDeletesTestUser::all());
+        $this->assertCount(3, SoftDeletesTestUser::withTrashed()->get());
     }
 
     /**

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -142,8 +142,8 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
         $result = SoftDeletesTestUser::findOrNew(1);
         $this->assertNull($result->id);
 
-        $$result = SoftDeletesTestUser::withTrashed()->findOrNew(1);
-        $this->assertNull($result->id);
+        $result = SoftDeletesTestUser::withTrashed()->findOrNew(1);
+        $this->assertEquals(1, $result->id);
     }
 
     public function testFirstOrCreate()


### PR DESCRIPTION
This is my attempt to fix BC break caused with https://github.com/laravel/framework/pull/11015 and discussed here: https://github.com/laravel/framework/issues/11268

The original PR removed global scopes when using `firstOrNew` and `firstOrCreate` methods. But that seemed to create even more problems.

My idea to fix this issue for both cases is to move all `firstOr*` methods from the `Model` to the `Builder`. That way we let developers decide if they want to keep global scopes or not:

``` php
User::firstOrNew(['email' => 'foo@bar.com']); // ignores trashed records
User::withTrashed()->firstOrNew(['email' => 'foo@bar.com']); // includes trashed records
```

What do you guys think? @rkgrep @artemsk @barryvdh @Stayallive
