### PR TITLE
[5.2] Fix ServiceProvider pathsToPublish

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -135,7 +135,7 @@ abstract class ServiceProvider
                 return [];
             }
 
-            return array_intersect(static::$publishes[$provider], static::$publishGroups[$group]);
+            return array_intersect_key(static::$publishes[$provider], static::$publishGroups[$group]);
         }
 
         if ($group && array_key_exists($group, static::$publishGroups)) {

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -32,11 +32,13 @@ class SupportServiceProviderTest extends PHPUnit_Framework_TestCase
         $toPublish = ServiceProvider::pathsToPublish('ServiceProviderForTestingTwo');
         $this->assertArrayHasKey('source/unmarked/two/a', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/unmarked/two/b', $toPublish, 'Service provider does not return expected published path key.');
+        $this->assertArrayHasKey('source/unmarked/two/c', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/tagged/two/a', $toPublish, 'Service provider does not return expected published path key.');
         $this->assertArrayHasKey('source/tagged/two/b', $toPublish, 'Service provider does not return expected published path key.');
         $expected = [
             'source/unmarked/two/a' => 'destination/unmarked/two/a',
             'source/unmarked/two/b' => 'destination/unmarked/two/b',
+            'source/unmarked/two/c' => 'destination/tagged/two/a',
             'source/tagged/two/a' => 'destination/tagged/two/a',
             'source/tagged/two/b' => 'destination/tagged/two/b',
         ];
@@ -58,6 +60,7 @@ class SupportServiceProviderTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('source/tagged/two/a', $toPublish, 'Service provider does not return expected tagged path key.');
         $this->assertArrayHasKey('source/tagged/two/b', $toPublish, 'Service provider does not return expected tagged path key.');
         $this->assertArrayNotHasKey('source/tagged/one', $toPublish, 'Service provider does return unexpected tagged path key.');
+        $this->assertArrayNotHasKey('source/unmarked/two/c', $toPublish, 'Service provider does return unexpected tagged path key.');
         $expected = [
             'source/tagged/two/a' => 'destination/tagged/two/a',
             'source/tagged/two/b' => 'destination/tagged/two/b',
@@ -71,6 +74,7 @@ class SupportServiceProviderTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('source/tagged/two/a', $toPublish, 'Service provider does not return expected tagged path key.');
         $this->assertArrayHasKey('source/tagged/two/b', $toPublish, 'Service provider does not return expected tagged path key.');
         $this->assertArrayHasKey('source/tagged/one', $toPublish, 'Service provider does not return expected tagged path key.');
+        $this->assertArrayNotHasKey('source/unmarked/two/c', $toPublish, 'Service provider does return unexpected tagged path key.');
         $expected = [
             'source/tagged/one' => 'destination/tagged/one',
             'source/tagged/two/a' => 'destination/tagged/two/a',
@@ -103,6 +107,7 @@ class ServiceProviderForTestingTwo extends ServiceProvider
     {
         $this->publishes(['source/unmarked/two/a' => 'destination/unmarked/two/a']);
         $this->publishes(['source/unmarked/two/b' => 'destination/unmarked/two/b']);
+        $this->publishes(['source/unmarked/two/c' => 'destination/tagged/two/a']);
         $this->publishes(['source/tagged/two/a' => 'destination/tagged/two/a'], 'some_tag');
         $this->publishes(['source/tagged/two/b' => 'destination/tagged/two/b'], 'some_tag');
     }


### PR DESCRIPTION
In the `Illuminate\Support\ServiceProvider` class the `pathsToPublish()` function does not provide the correct set of folders when a provider and a $group/tag are supplied by the artisan command.

For example, the `array_intersect()` causes untagged/differently tagged folders that publish to the migrations folder to be included with any other tag that publishes to the migrations folder. 

This should not be a breaking change and I have updated the tests.
