### PR TITLE
[5.3] Add tests for Str::replaceArray

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -141,6 +141,8 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
     public function testReplaceArray()
     {
         $this->assertEquals('foo/bar/baz', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?'));
+        $this->assertEquals('foo/bar/baz/?', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?/?'));
+        $this->assertEquals('foo/bar', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?'));
         $this->assertEquals('?/?/?', Str::replaceArray('x', ['foo', 'bar', 'baz'], '?/?/?'));
     }
 


### PR DESCRIPTION
Follow-up to #12259.
- To ensure there is no errors if the array has less items than the number of matches.
- Also added a test for when the array has more items. Can't harm.
