### PR TITLE
[5.1] Handle InnoDB Deadlocks By Re-Attempting Transactions

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -25,6 +25,7 @@ trait DetectsLostConnections
             'Error while sending',
             'decryption failed or bad record mac',
             'SSL connection has been closed unexpectedly',
+            'Deadlock found when trying to get lock',
         ]);
     }
 }


### PR DESCRIPTION
Cherry-picking the fix from https://github.com/laravel/framework/pull/12151 into 5.1.
