### PR TITLE
[5.1] Queue RetryCommand's resetAttempts() set attempts to 1

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -77,7 +77,7 @@ class RetryCommand extends Command
         $payload = json_decode($payload, true);
 
         if (isset($payload['attempts'])) {
-            $payload['attempts'] = 0;
+            $payload['attempts'] = 1;
         }
 
         return json_encode($payload);


### PR DESCRIPTION
Queue Manager (`Illuminate\Queue\Capsule\Manager`) static `push()` calling `push()` on specific connection (`RedisQueue`, `DatabaseQueue`...).
Connection's `push()` creates a payload from job with `createPayload()`.
`createPayload()` sets attempts to 1 (so the **attempts’ index starts from 1**)

When calling `queue:retry` the `Illuminate\Queue\Console\RetryCommand` will `fire()`.
`fire()` calls `retryJob()` which calls `resetAttempts()` before `pushRaw()` the payload to the connection.
But the `resetAttempts()` currently sets the attempts to zero, so when executing again the job the **attempts’ index starts from 0**. (The `pushRaw()` doesn't do anything with the `attempts`.)

This **will cause a +1 attempt** when `Illuminate\Queue\Worker` checks this condition before calling `logFailedJob()`

``` php
if ($maxTries > 0 && $job->attempts() > $maxTries) {
  return $this->logFailedJob($connection, $job);
}
```
