### PR TITLE
[5.2] Allow jobs to return a value while testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -114,8 +114,9 @@ trait MocksApplicationServices
     /**
      * Specify a list of jobs that should be dispatched for the given operation.
      *
-     * These jobs will be mocked, so that handlers will not actually be executed. When the job is passed as an array,
-     * the first value must contain the job and the second value the value you want to return.
+     * These jobs will be mocked, so that handlers will not actually be executed.
+     * When the job is passed as an array, the first value must contain the
+     * job and the second value the value you want to return.
      *
      * @param  array|string  $jobs
      * @return $this

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -22,6 +22,13 @@ trait MocksApplicationServices
     protected $dispatchedJobs = [];
 
     /**
+     * Return values for specific jobs.
+     *
+     * @var array
+     */
+    protected $jobReturnValues = [];
+
+    /**
      * Specify a list of events that should be fired for the given operation.
      *
      * These events will be mocked, so that handlers will not actually be executed.
@@ -107,7 +114,8 @@ trait MocksApplicationServices
     /**
      * Specify a list of jobs that should be dispatched for the given operation.
      *
-     * These jobs will be mocked, so that handlers will not actually be executed.
+     * These jobs will be mocked, so that handlers will not actually be executed. When the job is passed as an array,
+     * the first value must contain the job and the second value the value you want to return.
      *
      * @param  array|string  $jobs
      * @return $this
@@ -115,13 +123,24 @@ trait MocksApplicationServices
     protected function expectsJobs($jobs)
     {
         $jobs = is_array($jobs) ? $jobs : func_get_args();
+        $jobList = [];
+        // Check if a return value is defined.
+        foreach ($jobs as $key => $job) {
+            if (is_array($job)) {
+                $this->jobReturnValues[$job[0]] = $job[1];
+                $jobList[] = $job[0];
+                continue;
+            }
+
+            $jobList[] = $job;
+        }
 
         $this->withoutJobs();
 
-        $this->beforeApplicationDestroyed(function () use ($jobs) {
-            $dispatched = $this->getDispatchedJobs($jobs);
+        $this->beforeApplicationDestroyed(function () use ($jobList) {
+            $dispatched = $this->getDispatchedJobs($jobList);
 
-            if ($jobsNotDispatched = array_diff($jobs, $dispatched)) {
+            if ($jobsNotDispatched = array_diff($jobList, $dispatched)) {
                 throw new Exception(
                     'These expected jobs were not dispatched: ['.implode(', ', $jobsNotDispatched).']'
                 );
@@ -157,7 +176,8 @@ trait MocksApplicationServices
     }
 
     /**
-     * Mock the job dispatcher so all jobs are silenced and collected.
+     * Mock the job dispatcher so all jobs are silenced and collected. When a return value is defined, return it when
+     * requested.
      *
      * @return $this
      */
@@ -167,6 +187,9 @@ trait MocksApplicationServices
 
         $mock->shouldReceive('dispatch')->andReturnUsing(function ($dispatched) {
             $this->dispatchedJobs[] = $dispatched;
+            if (isset($this->jobReturnValues[get_class($dispatched)])) {
+                return $this->jobReturnValues[get_class($dispatched)];
+            }
         });
 
         $this->app->instance(

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -176,8 +176,9 @@ trait MocksApplicationServices
     }
 
     /**
-     * Mock the job dispatcher so all jobs are silenced and collected. When a return value is defined, return it when
-     * requested.
+     * Mock the job dispatcher so all jobs are silenced and collected.
+     *
+     * When a return value is defined, return it when requested.
      *
      * @return $this
      */
@@ -187,8 +188,9 @@ trait MocksApplicationServices
 
         $mock->shouldReceive('dispatch')->andReturnUsing(function ($dispatched) {
             $this->dispatchedJobs[] = $dispatched;
-            if (isset($this->jobReturnValues[get_class($dispatched)])) {
-                return $this->jobReturnValues[get_class($dispatched)];
+            $dispatchedClass = is_string($dispatched) ? $dispatched : get_class($dispatched);
+            if (isset($this->jobReturnValues[$dispatchedClass])) {
+                return $this->jobReturnValues[$dispatchedClass];
             }
         });
 


### PR DESCRIPTION
While it isn't common practice to let (non-queued) jobs return a value, in some cases this is desired. At this moment there isn't a way to use `$this->expectJobs` with return values. 

This PR will add the possibility to pass the job as an array and when the job is dispatched, the defined object/string/array/etc is returned. It is fully backwards compatible with 
- `$this->expectsJobs(Job::class)`
- `$this->expectsJobs([Job1::class, Job2::class])`
- `$this->expectsJobs(Job1::class, Job2::class)`

Using this functionality:

``` php
$this->expectsJobs([
  [
    Job1::class,
    $returnObject1
  ],
  [
    Job2::class,
    $returnObject2
  ]
]);
```

A documentation PR can be found [here](https://github.com/laravel/docs/pull/2142)
