### PR TITLE
[5.2] Add file() method to response factory.

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -150,7 +150,7 @@ class ResponseFactory implements FactoryContract
 
 		$mime = $response->getFile()->getMimeType();
 
-		$headers['Content-Type'] = $mime;
+		$response->headers->set('Content-Type', $mime);
 
         return $response;
     }

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -138,6 +138,23 @@ class ResponseFactory implements FactoryContract
     }
 
     /**
+     * Return the raw contents of a binary file.
+     *
+     * @param \SplFileInfo|string $file
+     * @param string $mime
+     * @param array $headers
+     * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+     */
+    public function file($file, $mime, array $headers = [])
+    {
+        $headers['Content-Type'] = $mime;
+
+        $response = new BinaryFileResponse($file, 200, $headers, true);
+
+        return $response;
+    }
+
+    /**
      * Create a new redirect response to the given path.
      *
      * @param  string  $path

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -148,11 +148,11 @@ class ResponseFactory implements FactoryContract
     {
         $response = new BinaryFileResponse($file, 200, $headers, true);
 
-		$mime = $response->getFile()->getMimeType();
+        $mime = $response->getFile()->getMimeType();
 
-		$response->headers->set('Content-Type', $mime);
+        $response->headers->set('Content-Type', $mime);
 
-		return $response;
+        return $response;
     }
 
     /**

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -152,7 +152,7 @@ class ResponseFactory implements FactoryContract
 
 		$response->headers->set('Content-Type', $mime);
 
-        return $response;
+		return $response;
     }
 
     /**

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -140,16 +140,17 @@ class ResponseFactory implements FactoryContract
     /**
      * Return the raw contents of a binary file.
      *
-     * @param \SplFileInfo|string $file
-     * @param string $mime
-     * @param array $headers
-     * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+     * @param  \SplFileInfo|string $file
+     * @param  array $headers
+     * @return  \Symfony\Component\HttpFoundation\BinaryFileResponse
      */
-    public function file($file, $mime, array $headers = [])
+    public function file($file, array $headers = [])
     {
-        $headers['Content-Type'] = $mime;
-
         $response = new BinaryFileResponse($file, 200, $headers, true);
+
+		$mime = $response->getFile()->getMimeType();
+
+		$headers['Content-Type'] = $mime;
 
         return $response;
     }


### PR DESCRIPTION
The addition of this file method will allow the given file to be returned as a direct response, such as image files, and PDFs for example.

Example code:

```
Route::get('file/{file}', function($file) {
    return response()->file($file);
});
```

EDIT: Updated example code.
