### PR TITLE
[5.2] Add a `map` method to the `AbstractPaginator`

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -436,7 +436,7 @@ abstract class AbstractPaginator implements Htmlable
     public function map(callable $callback)
     {
         $this->items = $this->items->map($callback);
-        
+
         return $this;
     }
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -428,6 +428,18 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Run a map over each of the items in underlying collection.
+     * 
+     * @param callable callback function
+     * @return $this
+     */
+    public function map(callable $callback)
+    {
+        $this->items = $this->items->map($callback);
+        return $this;
+    }
+
+    /**
      * Determine if the given item exists.
      *
      * @param  mixed  $key

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -436,6 +436,7 @@ abstract class AbstractPaginator implements Htmlable
     public function map(callable $callback)
     {
         $this->items = $this->items->map($callback);
+        
         return $this;
     }
 


### PR DESCRIPTION
This will allow a user to modify collection data before rendering paginator, or returning its value.

Say, you're creating an api resource for `User` model, and you want every returned entity to contain URL, created by `route()` function.

Right now it might be a pain, but with adding `map()` method to `Paginator`, things become much more pretty.

Thanks.
