### PR TITLE
[5.3] Add a validate method to the validator

### DIFF
--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -112,6 +112,22 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Validate the given data against the provided rules.
+     *
+     * @param  array  $data
+     * @param  array  $rules
+     * @param  array  $messages
+     * @param  array  $customAttributes
+     * @return void
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function validate(array $data, array $rules, array $messages = [], array $customAttributes = [])
+    {
+        $this->make($data, $rules, $messages, $customAttributes)->validate();
+    }
+
+    /**
      * Add the extensions to a validator instance.
      *
      * @param  \Illuminate\Validation\Validator  $validator

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -9,7 +9,7 @@ class ValidationException extends Exception
     /**
      * The validator instance.
      *
-     * @var \Illuminate\Validation\Validator
+     * @var \Illuminate\Contracts\Validation\Validator
      */
     public $validator;
 
@@ -23,7 +23,7 @@ class ValidationException extends Exception
     /**
      * Create a new exception instance.
      *
-     * @param  \Illuminate\Validation\Validator  $validator
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
      * @param  \Illuminate\Http\Response  $response
      * @return void
      */
@@ -38,7 +38,7 @@ class ValidationException extends Exception
     /**
      * Get the underlying response instance.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \Symfony\Component\HttpFoundation\Response|null
      */
     public function getResponse()
     {

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -334,7 +334,7 @@ class Validator implements ValidatorContract
         // the other error messages, returning true if we don't have messages.
         foreach ($this->rules as $attribute => $rules) {
             foreach ($rules as $rule) {
-                $this->validate($attribute, $rule);
+                $this->validateAttribute($attribute, $rule);
 
                 if ($this->shouldStopValidating($attribute)) {
                     break;
@@ -363,13 +363,27 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Run the validator's rules against its data.
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function validate()
+    {
+        if ($this->fails()) {
+            throw new ValidationException($this);
+        }
+    }
+
+    /**
      * Validate a given attribute against a rule.
      *
      * @param  string  $attribute
      * @param  string  $rule
      * @return void
      */
-    protected function validate($attribute, $rule)
+    protected function validateAttribute($attribute, $rule)
     {
         list($rule, $parameters) = $this->parseRule($rule);
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -50,6 +50,25 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
     }
 
+    /**
+     * @expectedException \Illuminate\Validation\ValidationException
+     */
+    public function testValidateThrowsOnFail()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => 'bar'], ['baz' => 'required']);
+
+        $v->validate();
+    }
+
+    public function testValidateDoesntThrowOnPass()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'required']);
+
+        $v->validate();
+    }
+
     public function testHasFailedValidationRules()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
Add a `validate` method to both the validator and the validation factory. If validation fails, it'll throw a `ValidationException`, which will be converted to a response in the global exception handler.

``` php
$validator = Validator::make($data, $rules);

// Do anything you need with the validator

$validator->validate();

// validation passed
```

Or:

``` php
Validator::validate($data, $rules);

// validation passed
```

And if you're into using the global helpers:

``` php
validator($data, $rules)->validate();

// validation passed
```
