### PR TITLE
[5.3] Explicit route model binding specific to a route group

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -44,6 +44,13 @@ class Route
     protected $action;
 
     /**
+     * The route group it belongs to.
+     *
+     * @var /Illuminate/Routing/RouteGroup
+     */
+    protected $group;
+
+    /**
      * The default values for the route.
      *
      * @var array
@@ -105,13 +112,15 @@ class Route
      * @param  array   $methods
      * @param  string  $uri
      * @param  \Closure|array  $action
+     * @param  \Illuminate\Routing\RouteGroup  $group
      * @return void
      */
-    public function __construct($methods, $uri, $action)
+    public function __construct($methods, $uri, $action, RouteGroup $group = null)
     {
         $this->uri = $uri;
         $this->methods = (array) $methods;
         $this->action = $this->parseAction($action);
+        $this->group = $group;
 
         if (in_array('GET', $this->methods) && ! in_array('HEAD', $this->methods)) {
             $this->methods[] = 'HEAD';
@@ -390,6 +399,16 @@ class Route
         }
 
         return $this->parameterNames = $this->compileParameterNames();
+    }
+
+    /**
+     * Get the group the route belongs to.
+     *
+     * @return \Illuminate\Routing\RouteGroup
+     */
+    public function getGroup()
+    {
+        return $this->group;
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -46,7 +46,7 @@ class Route
     /**
      * The route group it belongs to.
      *
-     * @var /Illuminate/Routing/RouteGroup
+     * @var /Illuminate/Routing/RouteGroup|null
      */
     protected $group;
 
@@ -112,7 +112,7 @@ class Route
      * @param  array   $methods
      * @param  string  $uri
      * @param  \Closure|array  $action
-     * @param  \Illuminate\Routing\RouteGroup  $group
+     * @param  \Illuminate\Routing\RouteGroup|null  $group
      * @return void
      */
     public function __construct($methods, $uri, $action, RouteGroup $group = null)
@@ -404,7 +404,7 @@ class Route
     /**
      * Get the group the route belongs to.
      *
-     * @return \Illuminate\Routing\RouteGroup
+     * @return \Illuminate\Routing\RouteGroup|null
      */
     public function getGroup()
     {

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Illuminate\Routing;
+
+class RouteGroup
+{
+    /**
+     * The parent of the group.
+     *
+     * @var /Illuminate/Routing/RouteGroup
+     */
+    protected $parent;
+
+    /**
+     * The registered route value binders.
+     *
+     * @var array
+     */
+    protected $binders = [];
+
+    /**
+     * Create a new RouteGroup instance.
+     *
+     * @param /Illuminate/Routing/RouteGroup  $parent
+     * @return void
+     */
+    public function __construct(RouteGroup $parent = null)
+    {
+        $this->parent = $parent;
+    }
+
+    /**
+     * Add a new route parameter binder for this group.
+     *
+     * @param  string  $key
+     * @param  callable  $binder
+     * @return void
+     */
+    public function bind($key, $binder)
+    {
+        $this->binders[str_replace('-', '_', $key)] = $binder;
+    }
+
+    /**
+     * Get the route group binders.
+     *
+     * @return array
+     */
+    public function getBinders()
+    {
+        $parentBinders = $this->parent ? $this->parent->getBinders() : [];
+
+        return array_merge($parentBinders, $this->binders);
+    }
+}

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -7,7 +7,7 @@ class RouteGroup
     /**
      * The parent of the group.
      *
-     * @var /Illuminate/Routing/RouteGroup
+     * @var /Illuminate/Routing/RouteGroup|null
      */
     protected $parent;
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -313,8 +313,23 @@ class Router implements RegistrarContract
 
         $this->groupAttributeStack[] = $attributes;
 
-        $group = new RouteGroup();
+        $group = new RouteGroup($this->getCurrentGroup());
         $this->groupStack[] = $group;
+
+        return $group;
+    }
+
+    /**
+     * Get the current group from the stack.
+     *
+     * @return \Illuminate\Routing\RouteGroup
+     */
+    protected function getCurrentGroup()
+    {
+        $group = null;
+        if (! empty($this->groupStack)) {
+            $group = end($this->groupStack);
+        }
 
         return $group;
     }
@@ -441,13 +456,8 @@ class Router implements RegistrarContract
             $action = $this->convertToControllerAction($action);
         }
 
-        $group = null;
-        if (! empty($this->groupStack)) {
-            $group = end($this->groupStack);
-        }
-
         $route = $this->newRoute(
-            $methods, $this->prefix($uri), $action, $group
+            $methods, $this->prefix($uri), $action, $this->getCurrentGroup()
         );
 
         // If we have groups that need to be merged, we will merge them now after this

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -322,7 +322,7 @@ class Router implements RegistrarContract
     /**
      * Get the current group from the stack.
      *
-     * @return \Illuminate\Routing\RouteGroup
+     * @return \Illuminate\Routing\RouteGroup|null
      */
     protected function getCurrentGroup()
     {
@@ -478,7 +478,7 @@ class Router implements RegistrarContract
      * @param  array|string  $methods
      * @param  string  $uri
      * @param  mixed   $action
-     * @param  \Illuminate\Routing\RouteGroup  $group
+     * @param  \Illuminate\Routing\RouteGroup|null  $group
      * @return \Illuminate\Routing\Route
      */
     protected function newRoute($methods, $uri, $action, $group)

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -499,6 +499,21 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
             });
 
             $router->get('bee/{baz}', function ($name) { return $name; });
+
+            $router->group(['prefix' => 'meep'], function ($router, $group) {
+                $router->get('bar/{baz}', function ($name) { return $name; });
+
+                $router->group(['prefix' => 'moot'], function ($router, $group) {
+                    $group->bind('baz', function ($value) { return 'MOOTMOOT'; });
+                    $router->get('bar/{baz}', function ($name) { return $name; });
+                });
+
+                $router->group(['prefix' => 'super'], function ($router, $group) {
+                    $router->get('bar/{baz}', function ($name) { return $name; });
+                });
+
+                $router->get('bee/{baz}', function ($name) { return $name; });
+            });
         });
 
         $this->assertEquals('TAYLOROMG', $router->dispatch(Request::create('foo/bar/whatever', 'GET'))->getContent());
@@ -509,6 +524,9 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('NOOTNOOT', $router->dispatch(Request::create('foo/joo/noot/bar/whatever', 'GET'))->getContent());
         $this->assertEquals('DAMNSON', $router->dispatch(Request::create('foo/joo/bee/whatever', 'GET'))->getContent());
         $this->assertEquals('TAYLOROMG', $router->dispatch(Request::create('foo/bee/whatever', 'GET'))->getContent());
+        $this->assertEquals('TAYLOROMG', $router->dispatch(Request::create('foo/meep/bar/whatever', 'GET'))->getContent());
+        $this->assertEquals('MOOTMOOT', $router->dispatch(Request::create('foo/meep/moot/bar/whatever', 'GET'))->getContent());
+        $this->assertEquals('TAYLOROMG', $router->dispatch(Request::create('foo/meep/super/bar/whatever', 'GET'))->getContent());
 
         /*
          * Precedence over global explicit bindings

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -430,9 +430,6 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
 
     public function testRouteGroupBindings()
     {
-        /*
-         * Basic functionality
-         */
         $router = $this->getRouter();
 
         $router->get('blah/{baz}', function ($name) { return $name; });
@@ -447,10 +444,10 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('TAYLOROMG', $router->dispatch(Request::create('foo/bar/whatever', 'GET'))->getContent());
         $this->assertEquals('whatever', $router->dispatch(Request::create('blah/whatever', 'GET'))->getContent());
         $this->assertEquals('whatever', $router->dispatch(Request::create('boo/whatever', 'GET'))->getContent());
+    }
 
-        /*
-         * Alternative syntax
-         */
+    public function testRouteGroupBindingsAlternativeSyntax()
+    {
         $router = $this->getRouter();
 
         $router->get('blah/{baz}', function ($name) { return $name; });
@@ -464,10 +461,10 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('TAYLOROMG', $router->dispatch(Request::create('foo/bar/whatever', 'GET'))->getContent());
         $this->assertEquals('whatever', $router->dispatch(Request::create('blah/whatever', 'GET'))->getContent());
         $this->assertEquals('whatever', $router->dispatch(Request::create('boo/whatever', 'GET'))->getContent());
+    }
 
-        /*
-         * Nested groups
-         */
+    public function testRouteGroupBindingsWithNestedGroups()
+    {
         $router = $this->getRouter();
 
         $router->group(['prefix' => 'foo'], function ($router, $group) {
@@ -527,10 +524,10 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('TAYLOROMG', $router->dispatch(Request::create('foo/meep/bar/whatever', 'GET'))->getContent());
         $this->assertEquals('MOOTMOOT', $router->dispatch(Request::create('foo/meep/moot/bar/whatever', 'GET'))->getContent());
         $this->assertEquals('TAYLOROMG', $router->dispatch(Request::create('foo/meep/super/bar/whatever', 'GET'))->getContent());
+    }
 
-        /*
-         * Precedence over global explicit bindings
-         */
+    public function testRouteGroupBindingsPrecedenceOverGlobalBindings()
+    {
         $router = $this->getRouter();
 
         $router->bind('baz', function ($value) { return $value; });
@@ -543,10 +540,10 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('TAYLOROMG', $router->dispatch(Request::create('foo/bar/whatever', 'GET'))->getContent());
         $this->assertEquals('whatever', $router->dispatch(Request::create('bar/whatever', 'GET'))->getContent());
+    }
 
-        /*
-         * Precedence over implicit model bindings
-         */
+    public function testRouteGroupBindingsPrecedenceOverImplicitModelBindings()
+    {
         $router = $this->getRouter();
 
         $router->model('baz', 'RouteModelBindingStub');


### PR DESCRIPTION
Refer to issue #12334. This PR allows defining explicit binding specific to a route group:

``` php
$router->group(['namespace' => 'Foo'], function ($router, $group) {
    $group->bind('user', function($value) {
        // ...
    });

    $router->get('users/{user}', 'FooController@show');
    // ...
});
```

Do tell me if this should go to `5.2` branch instead, since it's not breaking (I think).
