### PR TITLE
[5.2] Add windows support for withoutOverlapping in scheduled tasks

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -115,8 +115,7 @@ class Event
     /**
      * Create a new event instance.
      *
-     * @param  string  $command
-     * @return void
+     * @param string $command
      */
     public function __construct($command)
     {
@@ -137,8 +136,7 @@ class Event
     /**
      * Run the given event.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
-     * @return void
+     * @param \Illuminate\Contracts\Container\Container $container
      */
     public function run(Container $container)
     {
@@ -148,8 +146,7 @@ class Event
     /**
      * Run the command in the foreground.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
-     * @return void
+     * @param \Illuminate\Contracts\Container\Container $container
      */
     protected function runCommandInForeground(Container $container)
     {
@@ -165,8 +162,7 @@ class Event
     /**
      * Call all of the "before" callbacks for the event.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
-     * @return void
+     * @param \Illuminate\Contracts\Container\Container $container
      */
     protected function callBeforeCallbacks(Container $container)
     {
@@ -178,8 +174,7 @@ class Event
     /**
      * Call all of the "after" callbacks for the event.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
-     * @return void
+     * @param \Illuminate\Contracts\Container\Container $container
      */
     protected function callAfterCallbacks(Container $container)
     {
@@ -200,8 +195,8 @@ class Event
         $redirect = $this->shouldAppendOutput ? ' >> ' : ' > ';
 
         if ($this->withoutOverlapping) {
-            if ($this->isWindowsEnvironment()){
-                $command = '(echo \'\' > "'.$this->mutexPath().'" & '.$this->command.' & del "'.$this->mutexPath().'")'. $redirect.$output.' 2>&1 &';
+            if ($this->isWindowsEnvironment()) {
+                $command = '(echo \'\' > "'.$this->mutexPath().'" & '.$this->command.' & del "'.$this->mutexPath().'")'.$redirect.$output.' 2>&1 &';
             } else {
                 $command = '(touch '.$this->mutexPath().'; '.$this->command.'; rm '.$this->mutexPath().')'.$redirect.$output.' 2>&1 &';
             }
@@ -213,13 +208,13 @@ class Event
     }
 
     /**
-     * Determine if the current enviroment is windows
+     * Determine if the current enviroment is windows.
      *
-     * @return boolean
+     * @return bool
      */
     protected function isWindowsEnvironment()
     {
-        return (substr(strtoupper(php_uname('s')), 0, 3) === 'WIN');
+        return substr(strtoupper(php_uname('s')), 0, 3) === 'WIN';
     }
 
     /**
@@ -229,18 +224,19 @@ class Event
      */
     protected function mutexPath()
     {
-        return storage_path('framework' . DIRECTORY_SEPARATOR . 'schedule-'.sha1($this->expression.$this->command));
+        return storage_path('framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->expression.$this->command));
     }
 
     /**
      * Determine if the given event should run based on the Cron expression.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     *
      * @return bool
      */
     public function isDue($app)
     {
-        if (! $this->runsInMaintenanceMode() && $app->isDownForMaintenance()) {
+        if (!$this->runsInMaintenanceMode() && $app->isDownForMaintenance()) {
             return false;
         }
 
@@ -267,13 +263,14 @@ class Event
     /**
      * Determine if the filters pass for the event.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     *
      * @return bool
      */
     public function filtersPass($app)
     {
         foreach ($this->filters as $callback) {
-            if (! $app->call($callback)) {
+            if (!$app->call($callback)) {
                 return false;
             }
         }
@@ -290,7 +287,8 @@ class Event
     /**
      * Determine if the event runs in the given environment.
      *
-     * @param  string  $environment
+     * @param string $environment
+     *
      * @return bool
      */
     public function runsInEnvironment($environment)
@@ -311,7 +309,8 @@ class Event
     /**
      * The Cron expression representing the event's frequency.
      *
-     * @param  string  $expression
+     * @param string $expression
+     *
      * @return $this
      */
     public function cron($expression)
@@ -344,7 +343,8 @@ class Event
     /**
      * Schedule the command at a given time.
      *
-     * @param  string  $time
+     * @param string $time
+     *
      * @return $this
      */
     public function at($time)
@@ -355,7 +355,8 @@ class Event
     /**
      * Schedule the event to run daily at a given time (10:00, 19:30, etc).
      *
-     * @param  string  $time
+     * @param string $time
+     *
      * @return $this
      */
     public function dailyAt($time)
@@ -369,8 +370,9 @@ class Event
     /**
      * Schedule the event to run twice daily.
      *
-     * @param  int  $first
-     * @param  int  $second
+     * @param int $first
+     * @param int $second
+     *
      * @return $this
      */
     public function twiceDaily($first = 1, $second = 13)
@@ -474,8 +476,9 @@ class Event
     /**
      * Schedule the event to run weekly on a given day and time.
      *
-     * @param  int  $day
-     * @param  string  $time
+     * @param int    $day
+     * @param string $time
+     *
      * @return $this
      */
     public function weeklyOn($day, $time = '0:0')
@@ -558,7 +561,8 @@ class Event
     /**
      * Set the days of the week the command should run on.
      *
-     * @param  array|mixed  $days
+     * @param array|mixed $days
+     *
      * @return $this
      */
     public function days($days)
@@ -571,7 +575,8 @@ class Event
     /**
      * Set the timezone the date should be evaluated on.
      *
-     * @param  \DateTimeZone|string  $timezone
+     * @param \DateTimeZone|string $timezone
+     *
      * @return $this
      */
     public function timezone($timezone)
@@ -584,7 +589,8 @@ class Event
     /**
      * Set which user the command should run as.
      *
-     * @param  string  $user
+     * @param string $user
+     *
      * @return $this
      */
     public function user($user)
@@ -597,7 +603,8 @@ class Event
     /**
      * Limit the environments the command should run in.
      *
-     * @param  array|mixed  $environments
+     * @param array|mixed $environments
+     *
      * @return $this
      */
     public function environments($environments)
@@ -636,7 +643,8 @@ class Event
     /**
      * Register a callback to further filter the schedule.
      *
-     * @param  \Closure  $callback
+     * @param \Closure $callback
+     *
      * @return $this
      */
     public function when(Closure $callback)
@@ -649,7 +657,8 @@ class Event
     /**
      * Register a callback to further filter the schedule.
      *
-     * @param  \Closure  $callback
+     * @param \Closure $callback
+     *
      * @return $this
      */
     public function skip(Closure $callback)
@@ -662,8 +671,9 @@ class Event
     /**
      * Send the output of the command to a given location.
      *
-     * @param  string  $location
-     * @param  bool  $append
+     * @param string $location
+     * @param bool   $append
+     *
      * @return $this
      */
     public function sendOutputTo($location, $append = false)
@@ -678,7 +688,8 @@ class Event
     /**
      * Append the output of the command to a given location.
      *
-     * @param  string  $location
+     * @param string $location
+     *
      * @return $this
      */
     public function appendOutputTo($location)
@@ -689,8 +700,9 @@ class Event
     /**
      * E-mail the results of the scheduled operation.
      *
-     * @param  array|mixed  $addresses
-     * @param  bool  $onlyIfOutputExists
+     * @param array|mixed $addresses
+     * @param bool        $onlyIfOutputExists
+     *
      * @return $this
      *
      * @throws \LogicException
@@ -711,7 +723,8 @@ class Event
     /**
      * E-mail the results of the scheduled operation if it produces output.
      *
-     * @param  array|mixed  $addresses
+     * @param array|mixed $addresses
+     *
      * @return $this
      *
      * @throws \LogicException
@@ -724,10 +737,9 @@ class Event
     /**
      * E-mail the output of the event to the recipients.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailer  $mailer
-     * @param  array  $addresses
-     * @param  bool  $includeEmpty
-     * @return void
+     * @param \Illuminate\Contracts\Mail\Mailer $mailer
+     * @param array                             $addresses
+     * @param bool                              $includeEmpty
      */
     protected function emailOutput(Mailer $mailer, $addresses, $onlyIfOutputExists = false)
     {
@@ -763,20 +775,22 @@ class Event
     /**
      * Register a callback to ping a given URL before the job runs.
      *
-     * @param  string  $url
+     * @param string $url
+     *
      * @return $this
      */
     public function pingBefore($url)
     {
         return $this->before(function () use ($url) {
-            (new HttpClient)->get($url);
+            (new HttpClient())->get($url);
         });
     }
 
     /**
      * Register a callback to be called before the operation.
      *
-     * @param  \Closure  $callback
+     * @param \Closure $callback
+     *
      * @return $this
      */
     public function before(Closure $callback)
@@ -789,20 +803,22 @@ class Event
     /**
      * Register a callback to ping a given URL after the job runs.
      *
-     * @param  string  $url
+     * @param string $url
+     *
      * @return $this
      */
     public function thenPing($url)
     {
         return $this->then(function () use ($url) {
-            (new HttpClient)->get($url);
+            (new HttpClient())->get($url);
         });
     }
 
     /**
      * Register a callback to be called after the operation.
      *
-     * @param  \Closure  $callback
+     * @param \Closure $callback
+     *
      * @return $this
      */
     public function after(Closure $callback)
@@ -813,7 +829,8 @@ class Event
     /**
      * Register a callback to be called after the operation.
      *
-     * @param  \Closure  $callback
+     * @param \Closure $callback
+     *
      * @return $this
      */
     public function then(Closure $callback)
@@ -826,7 +843,8 @@ class Event
     /**
      * Set the human-friendly description of the event.
      *
-     * @param  string  $description
+     * @param string $description
+     *
      * @return $this
      */
     public function name($description)
@@ -837,7 +855,8 @@ class Event
     /**
      * Set the human-friendly description of the event.
      *
-     * @param  string  $description
+     * @param string $description
+     *
      * @return $this
      */
     public function description($description)
@@ -850,8 +869,9 @@ class Event
     /**
      * Splice the given value into the given position of the expression.
      *
-     * @param  int  $position
-     * @param  string  $value
+     * @param int    $position
+     * @param string $value
+     *
      * @return $this
      */
     protected function spliceIntoPosition($position, $value)

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -200,12 +200,26 @@ class Event
         $redirect = $this->shouldAppendOutput ? ' >> ' : ' > ';
 
         if ($this->withoutOverlapping) {
-            $command = '(touch '.$this->mutexPath().'; '.$this->command.'; rm '.$this->mutexPath().')'.$redirect.$output.' 2>&1 &';
+            if ($this->isWindowsEnvironment()){
+                $command = '(echo \'\' > "'.$this->mutexPath().'" & '.$this->command.' & del "'.$this->mutexPath().'")'. $redirect.$output.' 2>&1 &';
+            } else {
+                $command = '(touch '.$this->mutexPath().'; '.$this->command.'; rm '.$this->mutexPath().')'.$redirect.$output.' 2>&1 &';
+            }
         } else {
             $command = $this->command.$redirect.$output.' 2>&1 &';
         }
 
         return $this->user ? 'sudo -u '.$this->user.' '.$command : $command;
+    }
+
+    /**
+     * Determine if the current enviroment is windows
+     *
+     * @return boolean
+     */
+    protected function isWindowsEnvironment()
+    {
+        return (substr(strtoupper(php_uname('s')), 0, 3) === 'WIN');
     }
 
     /**
@@ -215,7 +229,7 @@ class Event
      */
     protected function mutexPath()
     {
-        return storage_path('framework/schedule-'.sha1($this->expression.$this->command));
+        return storage_path('framework' . DIRECTORY_SEPARATOR . 'schedule-'.sha1($this->expression.$this->command));
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -236,7 +236,7 @@ class Event
      */
     public function isDue($app)
     {
-        if (!$this->runsInMaintenanceMode() && $app->isDownForMaintenance()) {
+        if (! $this->runsInMaintenanceMode() && $app->isDownForMaintenance()) {
             return false;
         }
 
@@ -270,7 +270,7 @@ class Event
     public function filtersPass($app)
     {
         foreach ($this->filters as $callback) {
-            if (!$app->call($callback)) {
+            if (! $app->call($callback)) {
                 return false;
             }
         }


### PR DESCRIPTION
Fix for issue in windows when using withoutOverlapping().

Simply changed buildCommand() to return the windows equivalent when running in a windows environment.
