### PR TITLE
[5.2] Add setCollection method to the AbstractPaginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -428,6 +428,19 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Set the paginator's underlying collection.
+     *
+     * @param  \Illuminate\Support\Collection $collection
+     * @return $this
+     */
+    public function setCollection(\Illuminate\Support\Collection $collection)
+    {
+        $this->items = $collection;
+
+        return $this;
+    }
+
+    /**
      * Determine if the given item exists.
      *
      * @param  mixed  $key


### PR DESCRIPTION
Following the steps of [this PR](https://github.com/laravel/framework/pull/12346).

This change will allow a user to modify collection data before rendering paginator, or returning its value.

Say, you're creating an api resource for `User` model, and you want every returned entity to contain URL, created by `route()` function. Right now it might be a pain.

Though I decided to name it `setCollection()` instead of `setItems()`. It seems to make more sense in terms of already existing methods. (`getCollection()` returns collection, and `items()` returns array).

Thanks.
