### PR TITLE
[5.2] Update eloquent fromDateTime to allow dates without leading zero

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2945,7 +2945,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // If the value is in simply year, month, day format, we will instantiate the
         // Carbon instances from that format. Again, this provides for simple date
         // fields on the database, while still supporting Carbonized conversion.
-        if (preg_match('/^(\d{4})-(\d{2})-(\d{2})$/', $value)) {
+        if (preg_match('/^(\d{4})-(\d{1,2})-(\d{1,2})$/', $value)) {
             return Carbon::createFromFormat('Y-m-d', $value)->startOfDay();
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -333,6 +333,9 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $value = '2015-04-17';
         $this->assertEquals('2015-04-17 00:00:00', $model->fromDateTime($value));
 
+        $value = '2015-4-17';
+        $this->assertEquals('2015-04-17 00:00:00', $model->fromDateTime($value));
+
         $value = '1429311541';
         $this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
     }


### PR DESCRIPTION
Currently the `asDateTime` method on the eloquent model will fail when parsing a simple date without leading zeroes (e.g. `2016-1-9`) because the regex test expects the month and date part to consists of 2 characters.

This shouldn't be the case as the actual parsing is using the `Y-m-d` format that accepts format with or without leading zero.
