### PR TITLE
[5.1] No need to export CONTRIBUTING.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,5 +8,6 @@
 .nitpick.json export-ignore
 .php_cs export-ignore
 .travis.yml export-ignore
+CONTRIBUTING.md export-ignore
 phpunit.php export-ignore
 phpunit.xml export-ignore


### PR DESCRIPTION
No need to export `CONTRIBUTING.md`
Targeting `5.1` on purpose.

---

To be closed if #12364 is merged.
