### PR TITLE
[5.2] Update docblock for dropForeign to accept an array as well as string

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -278,7 +278,7 @@ class Blueprint
     /**
      * Indicate that the given foreign key should be dropped.
      *
-     * @param  string  $index
+     * @param  string|array  $index
      * @return \Illuminate\Support\Fluent
      */
     public function dropForeign($index)


### PR DESCRIPTION
The `dropForeign()` method can accept an array of columns as well as the index name.

```
$table->dropForeign(['user_id']);
```

This PR modifies the `$Index` type in the docblock of the `dropForeign()` method to be `String|Array`
