### PR TITLE
[5.2] Moved prepend/push group middleware to Router.

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -222,42 +222,6 @@ class Kernel implements KernelContract
     }
 
     /**
-     * Add a middleware to the beginning of a middleware group.
-     *
-     * If the middleware is already in the group, it will not be added again.
-     *
-     * @param  string  $group
-     * @param  string  $middleware
-     * @return $this
-     */
-    public function prependMiddlewareToGroup($group, $middleware)
-    {
-        if (isset($this->middlewareGroups[$group]) && ! in_array($middleware, $this->middlewareGroups[$group])) {
-            array_unshift($this->middlewareGroups[$group], $middleware);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Add a middleware to the end of a middleware group.
-     *
-     * If the middleware is already in the group, it will not be added again.
-     *
-     * @param  string  $group
-     * @param  string  $middleware
-     * @return $this
-     */
-    public function pushMiddlewareToGroup($group, $middleware)
-    {
-        if (isset($this->middlewareGroups[$group]) && ! in_array($middleware, $this->middlewareGroups[$group])) {
-            $this->middlewareGroups[$group][] = $middleware;
-        }
-
-        return $this;
-    }
-
-    /**
      * Bootstrap the application for HTTP requests.
      *
      * @return void

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -916,6 +916,42 @@ class Router implements RegistrarContract
     }
 
     /**
+     * Add a middleware to the beginning of a middleware group.
+     *
+     * If the middleware is already in the group, it will not be added again.
+     *
+     * @param  string  $group
+     * @param  string  $middleware
+     * @return $this
+     */
+    public function prependMiddlewareToGroup($group, $middleware)
+    {
+        if (isset($this->middlewareGroups[$group]) && ! in_array($middleware, $this->middlewareGroups[$group])) {
+            array_unshift($this->middlewareGroups[$group], $middleware);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a middleware to the end of a middleware group.
+     *
+     * If the middleware is already in the group, it will not be added again.
+     *
+     * @param  string  $group
+     * @param  string  $middleware
+     * @return $this
+     */
+    public function pushMiddlewareToGroup($group, $middleware)
+    {
+        if (isset($this->middlewareGroups[$group]) && ! in_array($middleware, $this->middlewareGroups[$group])) {
+            $this->middlewareGroups[$group][] = $middleware;
+        }
+
+        return $this;
+    }
+
+    /**
      * Register a model binder for a wildcard.
      *
      * @param  string  $key


### PR DESCRIPTION
After #12325 has been committed and I was able to update my packages, I realized that the code I've suggested had no way to actually change middleware groups (that's a shame).

This is because Kernel updates router middlewareGroups just once, in its constructor (https://github.com/laravel/framework/blob/5.2/src/Illuminate/Foundation/Http/Kernel.php#L79). So, if you call any methods after that, you won't actually update router's middleware groups.

I guess, the proper way to fix the problem is to move these functions to the Router itself. This pull request does just that.

P.S. What do you think about adding a getter to access $middlewareGroups in Router? There is a getter for $middleware array, but not for the $middlewareGroups. This might be useful to replace existing stuff in middleware list if needed.
