### PR TITLE
[5.2] Define routes using an array as the action

### DIFF
--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -808,6 +808,32 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('home/foo', 'GET'))->getContent());
     }
 
+    public function testArrayActionDefinitionWithControllerInstance()
+    {
+        $router = $this->getRouter();
+        $TestControllerStub = new RouteTestControllerStub;
+
+        $router->get('foo', ['uses' => [$TestControllerStub, 'index']]);
+        $this->assertEquals('Hello World', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+    }
+
+    public function testArrayActionDefinitionWithControllerClassname()
+    {
+        $router = $this->getRouter();
+        $router->get('foo', ['uses' => [RouteStaticTestControllerStub::class, 'index']]);
+        $this->assertEquals('Hello World', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+    }
+
+    public function testActionDefinitionWithClosure()
+    {
+        $router = $this->getRouter();
+        $router->get('foo', ['uses' => function () {
+            return 'Hello World';
+        }]);
+
+        $this->assertEquals('Hello World', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+    }
+
     protected function getRouter()
     {
         return new Router(new Illuminate\Events\Dispatcher);
@@ -825,6 +851,14 @@ class RouteTestControllerStub extends Illuminate\Routing\Controller
     }
 
     public function index()
+    {
+        return 'Hello World';
+    }
+}
+
+class RouteStaticTestControllerStub extends Illuminate\Routing\Controller
+{
+    public static function index()
     {
         return 'Hello World';
     }


### PR DESCRIPTION
This is addressed in 2 issues, #11300 and #12187.

The `Illuminate\Routing\Route` class is assuming that any route action that is not defined as a string is a closure. Unfortunately, the Reflection API doesn't automatically handle the difference between a closure, or a string (function name), or an array (used for defining static method calls, or instance method calls).

To address the issue, we need to test what type of callable the user is defining, and instantiate an instance of the appropriate Reflection API class (`ReflectionFunction` or `ReflectionMethod`).

The Routing core was already doing this, partially, in the `signatureParameters` method. However, it was being assumed that any non-string definition was a closure (as the `ReflectionFunction` will only take a string or a closure as a constructor parameter).

I extracted the Reflection Object creation and handle the different string, array, and closure cases appropriately.
