### PR TITLE
[5.2] Add support for defining root folder in the filesystem rackspace adapter

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -221,8 +221,10 @@ class FilesystemManager implements FactoryContract
             'username' => $config['username'], 'apiKey' => $config['key'],
         ]);
 
+        $root = isset($config['root']) ? $config['root'] : null;
+
         return $this->adapt($this->createFlysystem(
-            new RackspaceAdapter($this->getRackspaceContainer($client, $config)), $config
+            new RackspaceAdapter($this->getRackspaceContainer($client, $config), $root), $config
         ));
     }
 


### PR DESCRIPTION
Just like the Flysystem S3 adapter, the Rackspace adapter can take a root path to [set as a path prefix](https://github.com/thephpleague/flysystem-rackspace/blob/master/src/RackspaceAdapter.php#L38). I noticed the S3 driver in Laravel [already accepts this](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Filesystem/FilesystemManager.php#L188), but it's missing from the Rackspace driver.
