### PR TITLE
[5.3] Use the validator's validate method in ValidatesRequests

### DIFF
--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -10,16 +10,22 @@ trait ValidatesRequests
      * Validate the given data with the given rules.
      *
      * @param  \Illuminate\Http\Request|array  $request
-     * @param  array  $rules
+     * @param  array|null  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
      * @return void
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function validate($request, array $rules, array $messages = [], array $customAttributes = [])
+    public function validate($request, array $rules = null, array $messages = [], array $customAttributes = [])
     {
-        $data = $request instanceof Request ? $request->all() : $request;
+        if (is_null($rules)) {
+            $data = request()->all();
+
+            $rules = $request;
+        } else {
+            $data = $request instanceof Request ? $request->all() : $request;
+        }
 
         validator($data, $rules, $messages, $customAttributes)->validate();
     }

--- a/src/Illuminate/Foundation/Validation/ValidatesRequests.php
+++ b/src/Illuminate/Foundation/Validation/ValidatesRequests.php
@@ -3,64 +3,13 @@
 namespace Illuminate\Foundation\Validation;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Routing\UrlGenerator;
-use Illuminate\Contracts\Validation\Factory;
-use Illuminate\Contracts\Validation\Validator;
-use Illuminate\Validation\ValidationException;
 
 trait ValidatesRequests
 {
     /**
-     * The default error bag.
+     * Validate the given data with the given rules.
      *
-     * @var string
-     */
-    protected $validatesRequestErrorBag;
-
-    /**
-     * Run the validation routine against the given validator.
-     *
-     * @param  \Illuminate\Contracts\Validation\Validator|array  $validator
-     * @param  \Illuminate\Http\Request|null  $request
-     * @return void
-     */
-    public function validateWith($validator, Request $request = null)
-    {
-        $request = $request ?: app('request');
-
-        if (is_array($validator)) {
-            $validator = $this->getValidationFactory()->make($request->all(), $validator);
-        }
-
-        if ($validator->fails()) {
-            $this->throwValidationException($request, $validator);
-        }
-    }
-
-    /**
-     * Validate the given request with the given rules.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  array  $rules
-     * @param  array  $messages
-     * @param  array  $customAttributes
-     * @return void
-     */
-    public function validate(Request $request, array $rules, array $messages = [], array $customAttributes = [])
-    {
-        $validator = $this->getValidationFactory()->make($request->all(), $rules, $messages, $customAttributes);
-
-        if ($validator->fails()) {
-            $this->throwValidationException($request, $validator);
-        }
-    }
-
-    /**
-     * Validate the given request with the given rules.
-     *
-     * @param  string  $errorBag
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request|array  $request
      * @param  array  $rules
      * @param  array  $messages
      * @param  array  $customAttributes
@@ -68,101 +17,10 @@ trait ValidatesRequests
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function validateWithBag($errorBag, Request $request, array $rules, array $messages = [], array $customAttributes = [])
+    public function validate($request, array $rules, array $messages = [], array $customAttributes = [])
     {
-        $this->withErrorBag($errorBag, function () use ($request, $rules, $messages, $customAttributes) {
-            $this->validate($request, $rules, $messages, $customAttributes);
-        });
-    }
+        $data = $request instanceof Request ? $request->all() : $request;
 
-    /**
-     * Throw the failed validation exception.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Contracts\Validation\Validator  $validator
-     * @return void
-     *
-     * @throws \Illuminate\Validation\ValidationException
-     */
-    protected function throwValidationException(Request $request, $validator)
-    {
-        throw new ValidationException($validator, $this->buildFailedValidationResponse(
-            $request, $this->formatValidationErrors($validator)
-        ));
-    }
-
-    /**
-     * Create the response for when a request fails validation.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  array  $errors
-     * @return \Illuminate\Http\Response
-     */
-    protected function buildFailedValidationResponse(Request $request, array $errors)
-    {
-        if (($request->ajax() && ! $request->pjax()) || $request->wantsJson()) {
-            return new JsonResponse($errors, 422);
-        }
-
-        return redirect()->to($this->getRedirectUrl())
-                        ->withInput($request->input())
-                        ->withErrors($errors, $this->errorBag());
-    }
-
-    /**
-     * Format the validation errors to be returned.
-     *
-     * @param  \Illuminate\Contracts\Validation\Validator  $validator
-     * @return array
-     */
-    protected function formatValidationErrors(Validator $validator)
-    {
-        return $validator->errors()->getMessages();
-    }
-
-    /**
-     * Get the URL we should redirect to.
-     *
-     * @return string
-     */
-    protected function getRedirectUrl()
-    {
-        return app(UrlGenerator::class)->previous();
-    }
-
-    /**
-     * Get a validation factory instance.
-     *
-     * @return \Illuminate\Contracts\Validation\Factory
-     */
-    protected function getValidationFactory()
-    {
-        return app(Factory::class);
-    }
-
-    /**
-     * Execute a Closure within with a given error bag set as the default bag.
-     *
-     * @param  string  $errorBag
-     * @param  callable  $callback
-     * @return void
-     */
-    protected function withErrorBag($errorBag, callable $callback)
-    {
-        $this->validatesRequestErrorBag = $errorBag;
-
-        call_user_func($callback);
-
-        $this->validatesRequestErrorBag = null;
-    }
-
-    /**
-     * Get the key to be used for the view error bag.
-     *
-     * @return string
-     */
-    protected function errorBag()
-    {
-        return $this->validatesRequestErrorBag ?: 'default';
+        validator($data, $rules, $messages, $customAttributes)->validate();
     }
 }


### PR DESCRIPTION
...since the validator now has a built-in `validate` method. No need to duplicate all that logic.

Any customization to the response will now be done in the global exception handler.

---

Also, the `validateWith` method now makes no sense, so it was removed. Compare the two:

``` php
$validator = Validator::make($request->all(), $rules);
// do something with the validator
$this->validateWith($validator);

// vs. what you'll do now:

$validator = Validator::make($request->all(), $rules);
// do something with the validator
$validator->validate();
```

You can also now call `validate` with just the `$rules`. The request will be resolved automatically and its data will be passed to the validator:

``` php
$this->validate(['foo' => 'required']);
```
