### PR TITLE
[5.3] Add Redirector contract

### DIFF
--- a/src/Illuminate/Contracts/Routing/Redirector.php
+++ b/src/Illuminate/Contracts/Routing/Redirector.php
@@ -2,9 +2,6 @@
 
 namespace Illuminate\Contracts\Routing;
 
-use Illuminate\Http\RedirectResponse;
-use Illuminate\Session\Store as SessionStore;
-
 interface Redirector
 {
     /**

--- a/src/Illuminate/Contracts/Routing/Redirector.php
+++ b/src/Illuminate/Contracts/Routing/Redirector.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Illuminate\Contracts\Routing;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Session\Store as SessionStore;
+
+interface Redirector
+{
+    /**
+     * Create a new redirect response to the "home" route.
+     *
+     * @param  int  $status
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function home($status = 302);
+
+    /**
+     * Create a new redirect response to the previous location.
+     *
+     * @param  int    $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function back($status = 302, $headers = []);
+
+    /**
+     * Create a new redirect response to the current URI.
+     *
+     * @param  int    $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function refresh($status = 302, $headers = []);
+
+    /**
+     * Create a new redirect response, while putting the current URL in the session.
+     *
+     * @param  string  $path
+     * @param  int     $status
+     * @param  array   $headers
+     * @param  bool    $secure
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function guest($path, $status = 302, $headers = [], $secure = null);
+
+    /**
+     * Create a new redirect response to the previously intended location.
+     *
+     * @param  string  $default
+     * @param  int     $status
+     * @param  array   $headers
+     * @param  bool    $secure
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function intended($default = '/', $status = 302, $headers = [], $secure = null);
+
+    /**
+     * Create a new redirect response to the given path.
+     *
+     * @param  string  $path
+     * @param  int     $status
+     * @param  array   $headers
+     * @param  bool    $secure
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function to($path, $status = 302, $headers = [], $secure = null);
+
+    /**
+     * Create a new redirect response to an external URL (no validation).
+     *
+     * @param  string  $path
+     * @param  int     $status
+     * @param  array   $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function away($path, $status = 302, $headers = []);
+
+    /**
+     * Create a new redirect response to the given HTTPS path.
+     *
+     * @param  string  $path
+     * @param  int     $status
+     * @param  array   $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function secure($path, $status = 302, $headers = []);
+
+    /**
+     * Create a new redirect response to a named route.
+     *
+     * @param  string  $route
+     * @param  array   $parameters
+     * @param  int     $status
+     * @param  array   $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function route($route, $parameters = [], $status = 302, $headers = []);
+
+    /**
+     * Create a new redirect response to a controller action.
+     *
+     * @param  string  $action
+     * @param  array   $parameters
+     * @param  int     $status
+     * @param  array   $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function action($action, $parameters = [], $status = 302, $headers = []);
+}

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1050,7 +1050,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'auth.password.broker' => ['Illuminate\Auth\Passwords\PasswordBroker', 'Illuminate\Contracts\Auth\PasswordBroker'],
             'queue'                => ['Illuminate\Queue\QueueManager', 'Illuminate\Contracts\Queue\Factory', 'Illuminate\Contracts\Queue\Monitor'],
             'queue.connection'     => ['Illuminate\Contracts\Queue\Queue'],
-            'redirect'             => ['Illuminate\Routing\Redirector'],
+            'redirect'             => ['Illuminate\Routing\Redirector', 'Illuminate\Contracts\Routing\Redirector'],
             'redis'                => ['Illuminate\Redis\Database', 'Illuminate\Contracts\Redis\Database'],
             'request'              => ['Illuminate\Http\Request', 'Symfony\Component\HttpFoundation\Request'],
             'router'               => ['Illuminate\Routing\Router', 'Illuminate\Contracts\Routing\Registrar'],

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -5,7 +5,7 @@ namespace Illuminate\Foundation\Http;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Routing\Redirector;
+use Illuminate\Contracts\Routing\Redirector;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exception\HttpResponseException;
@@ -27,7 +27,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * The redirector instance.
      *
-     * @var \Illuminate\Routing\Redirector
+     * @var \Illuminate\Contracts\Routing\Redirector
      */
     protected $redirector;
 
@@ -186,7 +186,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Set the Redirector instance.
      *
-     * @param  \Illuminate\Routing\Redirector  $redirector
+     * @param  \Illuminate\Contracts\Routing\Redirector  $redirector
      * @return \Illuminate\Foundation\Http\FormRequest
      */
     public function setRedirector(Redirector $redirector)

--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Foundation\Providers;
 
-use Illuminate\Routing\Redirector;
+use Illuminate\Contracts\Routing\Redirector;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Routing\Events\RouteMatched;

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -495,7 +495,7 @@ if (! function_exists('redirect')) {
      * @param  int     $status
      * @param  array   $headers
      * @param  bool    $secure
-     * @return \Illuminate\Routing\Redirector|\Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Contracts\Routing\Redirector|\Illuminate\Http\RedirectResponse
      */
     function redirect($to = null, $status = 302, $headers = [], $secure = null)
     {

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -4,8 +4,9 @@ namespace Illuminate\Routing;
 
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Session\Store as SessionStore;
+use Illuminate\Contracts\Routing\Redirector as RedirectorContract;
 
-class Redirector
+class Redirector implements RedirectorContract
 {
     /**
      * The URL generator instance.

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -27,7 +27,7 @@ class ResponseFactory implements FactoryContract
     /**
      * The redirector instance.
      *
-     * @var \Illuminate\Routing\Redirector
+     * @var \Illuminate\Contracts\Routing\Redirector
      */
     protected $redirector;
 
@@ -35,7 +35,7 @@ class ResponseFactory implements FactoryContract
      * Create a new response factory instance.
      *
      * @param  \Illuminate\Contracts\View\Factory  $view
-     * @param  \Illuminate\Routing\Redirector  $redirector
+     * @param  \Illuminate\Contracts\Routing\Redirector  $redirector
      * @return void
      */
     public function __construct(ViewFactory $view, Redirector $redirector)

--- a/src/Illuminate/Support/Facades/Redirect.php
+++ b/src/Illuminate/Support/Facades/Redirect.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @see \Illuminate\Routing\Redirector
+ * @see \Illuminate\Contracts\Routing\Redirector
  */
 class Redirect extends Facade
 {

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -67,7 +67,7 @@ class FoundationFormRequestTest extends PHPUnit_Framework_TestCase
     public function testRedirectResponseIsProperlyCreatedWithGivenErrors()
     {
         $request = FoundationTestFormRequestStub::create('/', 'GET');
-        $request->setRedirector($redirector = m::mock('Illuminate\Routing\Redirector'));
+        $request->setRedirector($redirector = m::mock('Illuminate\Contracts\Routing\Redirector'));
         $redirector->shouldReceive('to')->once()->with('previous')->andReturn($response = m::mock('Illuminate\Http\RedirectResponse'));
         $redirector->shouldReceive('getUrlGenerator')->andReturn($url = m::mock('StdClass'));
         $url->shouldReceive('previous')->once()->andReturn('previous');


### PR DESCRIPTION
This PR adds `Illuminate\Contracts\Routing\Redirector`, which is implemented by `Illuminate\Routing\Redirector`. Also, all classes which depend on `Illuminate\Routing\Redirector` now depends on `Illuminate\Contracts\Routing\Redirector` instead.

This is done to enforce design by contract.
