### PR TITLE
[5.2] Always add APP_KEY to .env file when using key:generate

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -38,9 +38,13 @@ class KeyGenerateCommand extends Command
         $path = base_path('.env');
 
         if (file_exists($path)) {
-            file_put_contents($path, str_replace(
-                'APP_KEY='.$this->laravel['config']['app.key'], 'APP_KEY='.$key, file_get_contents($path)
-            ));
+            $content = str_replace('APP_KEY='.$this->laravel['config']['app.key'], 'APP_KEY='.$key, file_get_contents($path));
+
+            if (! str_contains($content, 'APP_KEY')) {
+                $content = sprintf("%s\nAPP_KEY=%s\n", $content, $key);
+            }
+
+            file_put_contents($path, $content);
         }
 
         $this->laravel['config']['app.key'] = $key;


### PR DESCRIPTION
When there is no _APP_KEY_ present in the _.env_ file, running `php artisan key:generate` does not insert generated key into the file nor provides any information.

This PR ensures that _APP_KEY_ is always set, which should be a desired result as there is a `--show` option for just displaying the key.
