### PR TITLE
[5.2] Add seeText and dontSeeText methods

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -208,7 +208,47 @@ trait InteractsWithPages
     }
 
     /**
-     * Assert that a given string is seen on the page.
+     * Get the HTML from the current context or the full response.
+     *
+     * @return string
+     */
+    protected function html()
+    {
+        return $this->crawler()
+            ? $this->crawler()->html()
+            : $this->response->getContent();
+    }
+
+    /**
+     * Get the plain text from the current context or the full response.
+     *
+     * @return string
+     */
+    protected function text()
+    {
+        return $this->crawler()
+            ? $this->crawler()->text()
+            : strip_tags($this->response->getContent());
+    }
+
+    /**
+     * Get the escaped text pattern.
+     *
+     * @param  string  $text
+     * @return string
+     */
+    protected function getEscapedPattern($text)
+    {
+        $rawPattern = preg_quote($text, '/');
+
+        $escapedPattern = preg_quote(e($text), '/');
+
+        return $rawPattern == $escapedPattern
+            ? $rawPattern : "({$rawPattern}|{$escapedPattern})";
+    }
+
+    /**
+     * Assert that a given string is seen on the current HTML.
      *
      * @param  string  $text
      * @param  bool  $negate
@@ -218,24 +258,15 @@ trait InteractsWithPages
     {
         $method = $negate ? 'assertNotRegExp' : 'assertRegExp';
 
-        $rawPattern = preg_quote($text, '/');
+        $pattern = $this->getEscapedPattern($text);
 
-        $escapedPattern = preg_quote(e($text), '/');
-
-        $pattern = $rawPattern == $escapedPattern
-                ? $rawPattern : "({$rawPattern}|{$escapedPattern})";
-
-        $html = $this->crawler()
-                    ? $this->crawler()->html()
-                    : $this->response->getContent();
-
-        $this->$method("/$pattern/i", $html);
+        $this->$method("/$pattern/i", $this->html());
 
         return $this;
     }
 
     /**
-     * Assert that a given string is not seen on the page.
+     * Assert that a given string is not seen on the current HTML.
      *
      * @param  string  $text
      * @return $this
@@ -243,6 +274,35 @@ trait InteractsWithPages
     protected function dontSee($text)
     {
         return $this->see($text, true);
+    }
+
+    /**
+     * Assert that a given string is seen on the current text.
+     *
+     * @param  string  $text
+     * @param  bool  $negate
+     * @return $this
+     */
+    protected function seeText($text, $negate = false)
+    {
+        $method = $negate ? 'assertNotRegExp' : 'assertRegExp';
+
+        $pattern = $this->getEscapedPattern($text);
+
+        $this->$method("/$pattern/i", $this->text());
+
+        return $this;
+    }
+
+    /**
+     * Assert that a given string is not seen on the current text.
+     *
+     * @param  string  $text
+     * @return $this
+     */
+    protected function dontSeeText($text)
+    {
+        return $this->seeText($text, true);
     }
 
     /**
@@ -295,12 +355,7 @@ trait InteractsWithPages
     {
         $elements = $this->crawler()->filter($element);
 
-        $rawPattern = preg_quote($text, '/');
-
-        $escapedPattern = preg_quote(e($text), '/');
-
-        $pattern = $rawPattern == $escapedPattern
-            ? $rawPattern : "({$rawPattern}|{$escapedPattern})";
+        $pattern = $this->getEscapedPattern($text);
 
         foreach ($elements as $element) {
             $element = new Crawler($element);

--- a/tests/Foundation/FoundationInteractsWithPagesTest.php
+++ b/tests/Foundation/FoundationInteractsWithPagesTest.php
@@ -52,6 +52,19 @@ class FoundationCrawlerTraitIntegrationTest extends PHPUnit_Framework_TestCase
         $this->dontSee('Webmasters');
     }
 
+    public function testSeeTextAndDontSeeText()
+    {
+        $this->setCrawler('<p>Laravel is a <strong>PHP Framework</strong>.');
+
+        // The methods see and dontSee compare against the HTML.
+        $this->see('strong');
+        $this->dontSee('Laravel is a PHP Framework');
+
+        // seeText and dontSeeText strip the HTML and compare against the plain text.
+        $this->seeText('Laravel is a PHP Framework.');
+        $this->dontSeeText('strong');
+    }
+
     public function testSeeInElement()
     {
         $this->setCrawler('<div>Laravel was created by <strong>Taylor Otwell</strong></div>');


### PR DESCRIPTION
With the `see` method you can do stuff like:

`$this->see('<image src="my-image.jpg>')` and this works. But sadly if you want to test this:

`$this->see('Laravel PHP Framework')` against this HTML:

`<p>Laravel <strong>PHP</strong> Framework</p>`

The test will fail because of the `<strong>` tag in the middle of the text.

I've found this annoying when trying to assert text that contain HTML tags. 

At this point, it is hard to change this behaviour because it could break a lot of tests (i.e. issue #12075) of current projects.

So, I'm adding `seeText` and `dontSeeText` to test against plain text instead of HTML.

You can see the examples in the unit test included with this PR.
