### PR TITLE
[5.2] KeyGeneratorCommand : no need to replace $content

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputOption;
 
 class KeyGenerateCommand extends Command
@@ -23,6 +24,26 @@ class KeyGenerateCommand extends Command
     protected $description = 'Set the application key';
 
     /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * Create a new KeyGenerateCommand command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @return void
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
      * Execute the console command.
      *
      * @return void
@@ -35,21 +56,31 @@ class KeyGenerateCommand extends Command
             return $this->line('<comment>'.$key.'</comment>');
         }
 
-        $path = base_path('.env');
-
-        if (file_exists($path)) {
-            $content = str_replace('APP_KEY='.$this->laravel['config']['app.key'], 'APP_KEY='.$key, file_get_contents($path));
-
-            if (! str_contains($content, 'APP_KEY')) {
-                $content = sprintf("%s\nAPP_KEY=%s\n", $content, $key);
-            }
-
-            file_put_contents($path, $content);
+        if ($this->files->exists($path = base_path('.env'))) {
+            $this->updateEnvironmentFile($path, $key);
         }
 
         $this->laravel['config']['app.key'] = $key;
 
         $this->info("Application key [$key] set successfully.");
+    }
+
+    /**
+     * Update the environment file.
+     *
+     * @param  string  $path
+     * @param  string  $key
+     * @return bool
+     */
+    protected function updateEnvironmentFile($path, $key)
+    {
+        $data = 'APP_KEY='.$key;
+
+        if (Str::contains($content = $this->files->get($path), 'APP_KEY')) {
+            return $this->files->put($path, str_replace('APP_KEY='.$this->laravel['config']['app.key'], $data, $content));
+        }
+
+        return $this->files->append($path, $data);
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -305,8 +305,8 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected function registerKeyGenerateCommand()
     {
-        $this->app->singleton('command.key.generate', function () {
-            return new KeyGenerateCommand;
+        $this->app->singleton('command.key.generate', function ($app) {
+            return new KeyGenerateCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
No need to generate replace `$content` when it doesn't containt `APP_KEY=`.

Also:
- Use `\Illuminate\Contracts\Filesystem\Filesystem`
- Extract update command
