### PR TITLE
[5.2] Change Model::fresh() parameter type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -648,10 +648,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Reload a fresh model instance from the database.
      *
-     * @param  array  $with
+     * @param  array|string  $with
      * @return $this|null
      */
-    public function fresh(array $with = [])
+    public function fresh($with = [])
     {
         if (! $this->exists) {
             return;


### PR DESCRIPTION
Right now we can use `Model::with('relation')`

However, `$model->fresh('relation')` throws an error:

> Argument 1 passed to Model::fresh() must be of the type array, string given

The parameter _always_ gets sent to `Model::with()` so it makes sense to be consistent and mirror the type.
