### PR TITLE
[5.1] Fix timestamps on update

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -422,7 +422,7 @@ class Builder
      */
     protected function addUpdatedAtColumn(array $values)
     {
-        if (! $this->model->usesTimestamps()) {
+        if (! $this->model->shouldUpdateTimestamps()) {
             return $values;
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -49,6 +49,13 @@ class Builder
     protected $onDelete;
 
     /**
+     * Indicates if timestamps are disabled for the current query.
+     *
+     * @var bool
+     */
+    protected $timestampsDisabled = false;
+
+    /**
      * The methods that should be returned from query builder.
      *
      * @var array
@@ -422,13 +429,25 @@ class Builder
      */
     protected function addUpdatedAtColumn(array $values)
     {
-        if (! $this->model->shouldUpdateTimestamps()) {
+        if (! $this->model->usesTimestamps() || $this->timestampsDisabled) {
             return $values;
         }
 
         $column = $this->model->getUpdatedAtColumn();
 
         return Arr::add($values, $column, $this->model->freshTimestampString());
+    }
+
+    /**
+     * Disable timestamps for the current query.
+     *
+     * @return $this
+     */
+    public function withoutTimestamps()
+    {
+        $this->timestampsDisabled = true;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -75,6 +75,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public $timestamps = true;
 
     /**
+     * Indicates if timestamps should be updated on next query.
+     *
+     * @var bool
+     */
+    protected $shouldUpdateTimestamps = true;
+
+    /**
      * The model's attributes.
      *
      * @var array
@@ -1515,6 +1522,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             // convenience. Then we will just continue saving the model instances.
             if ($this->timestamps && Arr::get($options, 'timestamps', true)) {
                 $this->updateTimestamps();
+            } else {
+                $this->shouldUpdateTimestamps = false;
             }
 
             // Once we have run the update operation, we will fire the "updated" event for
@@ -1527,6 +1536,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
                 $this->fireModelEvent('updated', false);
             }
+
+            $this->shouldUpdateTimestamps = true;
         }
 
         return true;
@@ -1550,6 +1561,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // convenience. After, we will just continue saving these model instances.
         if ($this->timestamps && Arr::get($options, 'timestamps', true)) {
             $this->updateTimestamps();
+        } else {
+            $this->shouldUpdateTimestamps = false;
         }
 
         // If the model has an incrementing key, we can use the "insertGetId" method on
@@ -1574,6 +1587,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->exists = true;
 
         $this->wasRecentlyCreated = true;
+
+        $this->shouldUpdateTimestamps = true;
 
         $this->fireModelEvent('created', false);
 
@@ -1709,6 +1724,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if (! $this->exists && ! $this->isDirty(static::CREATED_AT)) {
             $this->setCreatedAt($time);
         }
+    }
+
+    /**
+     * Determine if timestamps should be updated.
+     *
+     * @return void
+     */
+    public function shouldUpdateTimestamps()
+    {
+        return $this->usesTimestamps() && $this->shouldUpdateTimestamps;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -75,13 +75,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public $timestamps = true;
 
     /**
-     * Indicates if timestamps should be updated on next query.
-     *
-     * @var bool
-     */
-    protected $shouldUpdateTimestamps = true;
-
-    /**
      * The model's attributes.
      *
      * @var array
@@ -1523,7 +1516,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             if ($this->timestamps && Arr::get($options, 'timestamps', true)) {
                 $this->updateTimestamps();
             } else {
-                $this->shouldUpdateTimestamps = false;
+                $query->withoutTimestamps();
             }
 
             // Once we have run the update operation, we will fire the "updated" event for
@@ -1536,8 +1529,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
                 $this->fireModelEvent('updated', false);
             }
-
-            $this->shouldUpdateTimestamps = true;
         }
 
         return true;
@@ -1562,7 +1553,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if ($this->timestamps && Arr::get($options, 'timestamps', true)) {
             $this->updateTimestamps();
         } else {
-            $this->shouldUpdateTimestamps = false;
+            $query->withoutTimestamps();
         }
 
         // If the model has an incrementing key, we can use the "insertGetId" method on
@@ -1587,8 +1578,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->exists = true;
 
         $this->wasRecentlyCreated = true;
-
-        $this->shouldUpdateTimestamps = true;
 
         $this->fireModelEvent('created', false);
 
@@ -1724,16 +1713,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if (! $this->exists && ! $this->isDirty(static::CREATED_AT)) {
             $this->setCreatedAt($time);
         }
-    }
-
-    /**
-     * Determine if timestamps should be updated.
-     *
-     * @return void
-     */
-    public function shouldUpdateTimestamps()
-    {
-        return $this->usesTimestamps() && $this->shouldUpdateTimestamps;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -727,6 +727,24 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('05-12-12', $array['updated_at']);
     }
 
+    public function testTimestampsCanBeDisabledOnUpdate()
+    {
+        $model = new EloquentTestUser;
+        $model->email = 'taylor@laravel.com';
+        $model->created_at = '2016-01-01 00:00:00';
+        $model->updated_at = '2016-01-01 00:00:00';
+        $model->save();
+
+        $updatedAt = $model->updated_at->timestamp;
+        $model->email = 'otwell@laravel.com';
+        $model->save(['timestamps' => false]);
+        $this->assertEquals($updatedAt, $model->updated_at->timestamp);
+
+        $model->email = 'foo@bar.com';
+        $model->save();
+        $this->assertNotEquals($updatedAt, $model->updated_at->timestamp);
+    }
+
     /**
      * Helpers...
      */

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -200,6 +200,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $model = $this->getMock('EloquentModelStub', ['newQueryWithoutScopes', 'updateTimestamps', 'fireModelEvent']);
         $model->timestamps = false;
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $query->shouldReceive('withoutTimestamps')->once();
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
         $model->expects($this->once())->method('newQueryWithoutScopes')->will($this->returnValue($query));
@@ -1146,6 +1147,7 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
     {
         $model = m::mock('EloquentModelStub[newQueryWithoutScopes]');
         $query = m::mock('Illuminate\Database\Eloquent\Builder');
+        $query->shouldReceive('withoutTimestamps')->once();
         $query->shouldReceive('where')->once()->with('id', '=', 1);
         $query->shouldReceive('update')->once()->with(['name' => 'taylor'])->andReturn(1);
         $model->shouldReceive('newQueryWithoutScopes')->once()->andReturn($query);


### PR DESCRIPTION
This fixes https://github.com/laravel/framework/issues/10028 where timestamps are updated even if `['timestamps' => false]` is passed to the `save()` method.

The easiest solution would be to simply pass the `$options` array to the update method on the  `Builder` but since that would be a breaking change (someone may be extending the Builder) I added a new flag `$shouldUpdateTimestamps` that is set to `false` if timestamps were disabled.
