### PR TITLE
[5.2] Fix typo

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -99,7 +99,7 @@ class Container implements ArrayAccess, ContainerContract
     protected $globalAfterResolvingCallbacks = [];
 
     /**
-     * All of the after resolving callbacks by class type.
+     * All of the resolving callbacks by class type.
      *
      * @var array
      */


### PR DESCRIPTION
the comment describes the property `protected $resolvingCallbacks = [];` (L106)

it should be "resolving callbacks" not "after resolving callbacks"
