### PR TITLE
[5.2] Validator : no need to merge an empty array

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2424,9 +2424,9 @@ class Validator implements ValidatorContract
             $keys = array_map('\Illuminate\Support\Str::snake', array_keys($extensions));
 
             $extensions = array_combine($keys, array_values($extensions));
-        }
 
-        $this->extensions = array_merge($this->extensions, $extensions);
+            $this->extensions = array_merge($this->extensions, $extensions);
+        }
     }
 
     /**
@@ -2492,9 +2492,9 @@ class Validator implements ValidatorContract
             $keys = array_map('\Illuminate\Support\Str::snake', array_keys($replacers));
 
             $replacers = array_combine($keys, array_values($replacers));
-        }
 
-        $this->replacers = array_merge($this->replacers, $replacers);
+            $this->replacers = array_merge($this->replacers, $replacers);
+        }
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2426,23 +2426,6 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Format an array of custom extensions or replacers.
-     *
-     * @param  array  $array
-     * @return array
-     */
-    protected function formatArray(array $array)
-    {
-        if (empty($array)) {
-            return [];
-        }
-
-        $keys = array_map('\Illuminate\Support\Str::snake', array_keys($array));
-
-        return array_combine($keys, array_values($array));
-    }
-
-    /**
      * Register an array of custom implicit validator extensions.
      *
      * @param  array  $extensions
@@ -2504,6 +2487,23 @@ class Validator implements ValidatorContract
         if ($replacers = $this->formatArray($replacers)) {
             $this->replacers = array_merge($this->replacers, $replacers);
         }
+    }
+
+    /**
+     * Format an array of custom extensions or replacers.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    protected function formatArray(array $array)
+    {
+        if (empty($array)) {
+            return [];
+        }
+
+        $keys = array_map('\Illuminate\Support\Str::snake', array_keys($array));
+
+        return array_combine($keys, array_values($array));
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2420,13 +2420,26 @@ class Validator implements ValidatorContract
      */
     public function addExtensions(array $extensions)
     {
-        if ($extensions) {
-            $keys = array_map('\Illuminate\Support\Str::snake', array_keys($extensions));
-
-            $extensions = array_combine($keys, array_values($extensions));
-
+        if ($extensions = $this->formatArray($extensions)) {
             $this->extensions = array_merge($this->extensions, $extensions);
         }
+    }
+
+    /**
+     * Format an array of custom extensions or replacers.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    protected function formatArray(array $array)
+    {
+        if (empty($array)) {
+            return [];
+        }
+
+        $keys = array_map('\Illuminate\Support\Str::snake', array_keys($array));
+
+        return array_combine($keys, array_values($array));
     }
 
     /**
@@ -2488,11 +2501,7 @@ class Validator implements ValidatorContract
      */
     public function addReplacers(array $replacers)
     {
-        if ($replacers) {
-            $keys = array_map('\Illuminate\Support\Str::snake', array_keys($replacers));
-
-            $replacers = array_combine($keys, array_values($replacers));
-
+        if ($replacers = $this->formatArray($replacers)) {
             $this->replacers = array_merge($this->replacers, $replacers);
         }
     }


### PR DESCRIPTION
- https://github.com/lucasmichot/framework/commit/c7af46f914db84d38bb0491ba605aef6ddcadc30 : No need to merge an empty array
- https://github.com/lucasmichot/framework/commit/e99ff132fbc29b8152d58070cb47c811165833b8 : Extract logic to `\Illuminate\Validation\Validator::formatArray` (`\Illuminate\Validation\Validator::addExtensions` and `\Illuminate\Validation\Validator::addReplacers` are doing exactly the same thing)
