### PR TITLE
[5.1] Added a Postgres lost connection error message string

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -24,6 +24,7 @@ trait DetectsLostConnections
             'is dead or not enabled',
             'Error while sending',
             'decryption failed or bad record mac',
+            'server closed the connection unexpectedly',
             'SSL connection has been closed unexpectedly',
             'Deadlock found when trying to get lock',
             'Error writing data to the connection',


### PR DESCRIPTION
In Postgres 9.4.*, if the connection to the database is killed and I trigger a queued job, the DB Connection class throws an error and doesn't retry. This is the error that occurs:

```
SomeQueuedJob error: SQLSTATE[HY000]: General error: 7 server closed the connection unexpectedly
    This probably means the server terminated abnormally
    before or while processing the request. (SQL: select * from "table" where "id" = 1 limit 1)
[/var/www/html/vendor/illuminate/database/Connection.php:651]
```

I've added an additional string to the DetectsLostConnections class to catch this error so the application will retry the connection.
