### PR TITLE
[5.2] Added private $tableName to migrations' up()/down()

### DIFF
--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -6,13 +6,20 @@ use Illuminate\Database\Migrations\Migration;
 class CreateCacheTable extends Migration
 {
     /**
+     * Table name
+     *
+     * @var string
+     */
+    private $tableName = 'cache';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('cache', function (Blueprint $table) {
+        Schema::create($this->tableName, function (Blueprint $table) {
             $table->string('key')->unique();
             $table->text('value');
             $table->integer('expiration');
@@ -26,6 +33,6 @@ class CreateCacheTable extends Migration
      */
     public function down()
     {
-        Schema::drop('cache');
+        Schema::drop($this->tableName);
     }
 }

--- a/src/Illuminate/Database/Migrations/stubs/create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/create.stub
@@ -6,13 +6,20 @@ use Illuminate\Database\Migrations\Migration;
 class DummyClass extends Migration
 {
     /**
+     * Table name
+     *
+     * @var string
+     */
+    private $tableName = 'DummyTable';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('DummyTable', function (Blueprint $table) {
+        Schema::create($this->tableName, function (Blueprint $table) {
             $table->increments('id');
             $table->timestamps();
         });
@@ -25,6 +32,6 @@ class DummyClass extends Migration
      */
     public function down()
     {
-        Schema::drop('DummyTable');
+        Schema::drop($this->tableName);
     }
 }

--- a/src/Illuminate/Database/Migrations/stubs/update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/update.stub
@@ -6,13 +6,20 @@ use Illuminate\Database\Migrations\Migration;
 class DummyClass extends Migration
 {
     /**
+     * Table name
+     *
+     * @var string
+     */
+    private $tableName = 'DummyTable';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::table('DummyTable', function (Blueprint $table) {
+        Schema::table($this->tableName, function (Blueprint $table) {
             //
         });
     }
@@ -24,7 +31,7 @@ class DummyClass extends Migration
      */
     public function down()
     {
-        Schema::table('DummyTable', function (Blueprint $table) {
+        Schema::table($this->tableName, function (Blueprint $table) {
             //
         });
     }

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -6,13 +6,20 @@ use Illuminate\Database\Migrations\Migration;
 class Create{{tableClassName}}Table extends Migration
 {
     /**
+     * Table name
+     *
+     * @var string
+     */
+    private $tableName = '{{table}}';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('{{table}}', function (Blueprint $table) {
+        Schema::create($this->tableName, function (Blueprint $table) {
             $table->increments('id');
             $table->text('connection');
             $table->text('queue');
@@ -28,6 +35,6 @@ class Create{{tableClassName}}Table extends Migration
      */
     public function down()
     {
-        Schema::drop('{{table}}');
+        Schema::drop($this->tableName);
     }
 }

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -6,13 +6,20 @@ use Illuminate\Database\Migrations\Migration;
 class Create{{tableClassName}}Table extends Migration
 {
     /**
+     * Table name
+     *
+     * @var string
+     */
+    private $tableName = '{{table}}';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('{{table}}', function (Blueprint $table) {
+        Schema::create($this->tableName, function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('queue');
             $table->longText('payload');
@@ -32,6 +39,6 @@ class Create{{tableClassName}}Table extends Migration
      */
     public function down()
     {
-        Schema::drop('{{table}}');
+        Schema::drop($this->tableName);
     }
 }

--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -6,13 +6,20 @@ use Illuminate\Database\Migrations\Migration;
 class CreateSessionsTable extends Migration
 {
     /**
+     * Table name
+     *
+     * @var string
+     */
+    private $tableName = 'sessions';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('sessions', function (Blueprint $table) {
+        Schema::create($this->tableName, function (Blueprint $table) {
             $table->string('id')->unique();
             $table->integer('user_id')->nullable();
             $table->string('ip_address', 45)->nullable();
@@ -29,6 +36,6 @@ class CreateSessionsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('sessions');
+        Schema::drop($this->tableName);
     }
 }


### PR DESCRIPTION
The table name duplication is avoided in migrations stubs.
Useful when you copy a migration to another but forget to change the table name to both up/down methods.
