### PR TITLE
Adds an environment variable to control the default number of bcrypt rounds

### DIFF
--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -13,6 +13,16 @@ class BcryptHasher implements HasherContract
      * @var int
      */
     protected $rounds = 10;
+    
+    /**
+     * Create a new BcryptHasher.
+     *
+     * @return  void
+     */
+    public function __construct()
+    {
+        $this->rounds = (int) env('HASHING_ROUNDS', 10);
+    }
 
     /**
      * Hash the given value.

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -13,7 +13,7 @@ class BcryptHasher implements HasherContract
      * @var int
      */
     protected $rounds = 10;
-    
+
     /**
      * Create a new BcryptHasher.
      *


### PR DESCRIPTION
This is primarily useful when using the out-of-the-box authentication controllers, as overriding their functions to change the cost function would be suboptimal. 

Wasn't sure whether or not to leave $rounds with a default value; feedback welcome.
