### PR TITLE
[5.2] Store unicode more compact

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3008,7 +3008,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function asJson($value)
     {
-        return json_encode($value);
+        return json_encode($value, JSON_UNESCAPED_UNICODE);
     }
 
     /**


### PR DESCRIPTION
Now casted arrays are saved with escaped unicode in database what makes them huge when some languages are used. Fix it please.
