### PR TITLE
Fix mailer contract

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -19,7 +19,7 @@ interface Mailer
      * @param  string|array  $view
      * @param  array  $data
      * @param  \Closure|string  $callback
-     * @return void
+     * @return int
      */
     public function send($view, array $data, $callback);
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -144,7 +144,7 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  string|array  $view
      * @param  array  $data
      * @param  \Closure|string  $callback
-     * @return void
+     * @return int
      */
     public function send($view, array $data, $callback)
     {
@@ -375,7 +375,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Send a Swift Message instance.
      *
      * @param  \Swift_Message  $message
-     * @return void
+     * @return int
      */
     protected function sendSwiftMessage($message)
     {

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -34,6 +34,8 @@ class LogTransport extends Transport
         $this->beforeSendPerformed($message);
 
         $this->logger->debug($this->getMimeEntityString($message));
+
+        return count($message->getTo());
     }
 
     /**


### PR DESCRIPTION
The mailer contract didn't reflect the fact that the transport returns
the number of recipients accepted by the mail endpoint.
