### PR TITLE
[5.1] Make addColumn() method public

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -934,7 +934,7 @@ class Blueprint
      * @param  array   $parameters
      * @return \Illuminate\Support\Fluent
      */
-    protected function addColumn($type, $name, array $parameters = [])
+    public function addColumn($type, $name, array $parameters = [])
     {
         $attributes = array_merge(compact('type', 'name'), $parameters);
 


### PR DESCRIPTION
I'm currently building some migration helpers for Flarum.

They will significantly reduce the work of writing migrations for mundane tasks like adding columns, creating a table, renaming columns and so on. (Essentially extension authors won't have to do the boring stuff of writing the logic for reversing the migration, as that's straightforward.)

For the `addColumns` helper, I need an easy way to define columns, though - I'll simply create an array mapping from column name to type and options, as expected by the `addColumn()` method. That's private, unfortunately. Can we have it public? :)
