### PR TITLE
[5.1] Removed two useless return statements

### DIFF
--- a/src/Illuminate/Foundation/Testing/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/InteractsWithPages.php
@@ -533,8 +533,6 @@ trait InteractsWithPages
                 return $option->getAttribute('value');
             }
         }
-
-        return;
     }
 
     /**
@@ -556,8 +554,6 @@ trait InteractsWithPages
                 return $radio->getAttribute('value');
             }
         }
-
-        return;
     }
 
     /**


### PR DESCRIPTION
I was just regression testing some upcoming changes in StyleCI that will be deployed this weekend, and came across this.
