### PR TITLE
[5.2] Overwrite URL parameter if already exists in fullUrlWithQuery

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -120,7 +120,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function fullUrlWithQuery(array $query)
     {
         return count($this->query()) > 0
-                        ? $this->fullUrl().'&'.http_build_query($query)
+                        ? $this->url().'/?'.http_build_query(array_merge($this->query(), $query))
                         : $this->fullUrl().'?'.http_build_query($query);
     }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -105,6 +105,9 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
         $request = Request::create('https://foo.com?a=b', 'GET');
         $this->assertEquals('https://foo.com/?a=b&coupon=foo', $request->fullUrlWithQuery(['coupon' => 'foo']));
+
+        $request = Request::create('https://foo.com?a=b', 'GET');
+        $this->assertEquals('https://foo.com/?a=c', $request->fullUrlWithQuery(['a' => 'c']));
     }
 
     public function testIsMethod()


### PR DESCRIPTION
In `Request@fullUrlWithQuery($query)` if any of the `$query` parameters already exist it'll be overwritten with the new value and produce `?key=new` instead of `?key=old&key=new`.
