### PR TITLE
[5.2] Remove unnecessary use statement in generated controllers

### DIFF
--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -64,4 +64,17 @@ class ControllerMakeCommand extends GeneratorCommand
             ['resource', null, InputOption::VALUE_NONE, 'Generate a resource controller class.'],
         ];
     }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $namespace = $this->getNamespace($name);
+
+        return str_replace("use $namespace\Controller;\n", '', parent::buildClass($name));
+    }
 }


### PR DESCRIPTION
`use App\Http\Controllers\Controller;` is not necessary if the generated controller has the same namespace, this is a small fix for that. 
