### PR TITLE
Using isset() in offsetExists() for performance advantage

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1081,7 +1081,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function offsetExists($key)
     {
-        return array_key_exists($key, $this->items);
+        return isset($this->items[$key]) || array_key_exists($key, $this->items);
     }
 
     /**


### PR DESCRIPTION
isset() is significantly faster than array_key_exists() but does not return TRUE for array keys that correspond to a NULL value, while array_key_exists() does. To keep the NULL element correctly detected we use isset() || array_key_exists()
