### PR TITLE
added optional $namespace param for auth route registration

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -362,23 +362,24 @@ class Router implements RegistrarContract
     /**
      * Register the typical authentication routes for an application.
      *
+     * @param  string  $namespace
      * @return void
      */
-    public function auth()
+    public function auth($namespace = 'Auth')
     {
         // Authentication Routes...
-        $this->get('login', 'Auth\AuthController@showLoginForm');
-        $this->post('login', 'Auth\AuthController@login');
-        $this->get('logout', 'Auth\AuthController@logout');
+        $this->get('login', $namespace.'\AuthController@showLoginForm');
+        $this->post('login', $namespace.'\AuthController@login');
+        $this->get('logout', $namespace.'\AuthController@logout');
 
         // Registration Routes...
-        $this->get('register', 'Auth\AuthController@showRegistrationForm');
-        $this->post('register', 'Auth\AuthController@register');
+        $this->get('register', $namespace.'\AuthController@showRegistrationForm');
+        $this->post('register', $namespace.'\AuthController@register');
 
         // Password Reset Routes...
-        $this->get('password/reset/{token?}', 'Auth\PasswordController@showResetForm');
-        $this->post('password/email', 'Auth\PasswordController@sendResetLinkEmail');
-        $this->post('password/reset', 'Auth\PasswordController@reset');
+        $this->get('password/reset/{token?}', $namespace.'\PasswordController@showResetForm');
+        $this->post('password/email', $namespace.'\PasswordController@sendResetLinkEmail');
+        $this->post('password/reset', $namespace.'\PasswordController@reset');
     }
 
     /**


### PR DESCRIPTION
Useful for anyone wishing to store their Auth Controllers under a different namespace such as /Auth/Frontend. Can be used in routes.php by calling Route::auth('Namespace\To\Controllers');
