### PR TITLE
[5.3] Make Collection@where use loose comparison by default

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -267,7 +267,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * @param  bool  $strict
      * @return static
      */
-    public function whereIn($key, array $values, $strict = true)
+    public function whereIn($key, array $values, $strict = false)
     {
         return $this->filter(function ($item) use ($key, $values, $strict) {
             return in_array(data_get($item, $key), $values, $strict);
@@ -275,15 +275,15 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Filter items by the given key value pair using loose comparison.
+     * Filter items by the given key value pair using strict comparison.
      *
      * @param  string  $key
      * @param  array  $values
      * @return static
      */
-    public function whereInLoose($key, array $values)
+    public function whereInStrict($key, array $values)
     {
-        return $this->whereIn($key, $values, false);
+        return $this->whereIn($key, $values, true);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -247,13 +247,13 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 default:
                 case '=':
                 case '==':  return $retrieved == $value;
-                case '===': return $retrieved === $value;
-                case '<=':  return $retrieved <= $value;
-                case '>=':  return $retrieved >= $value;
+                case '!=':
+                case '<>':  return $retrieved != $value;
                 case '<':   return $retrieved < $value;
                 case '>':   return $retrieved > $value;
-                case '<>':
-                case '!=':  return $retrieved != $value;
+                case '<=':  return $retrieved <= $value;
+                case '>=':  return $retrieved >= $value;
+                case '===': return $retrieved === $value;
                 case '!==': return $retrieved !== $value;
             }
         };

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -224,22 +224,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         if (func_num_args() == 2) {
             $value = $operator;
 
-            $operator = '===';
+            $operator = '=';
         }
 
         return $this->filter($this->operatorForWhere($key, $operator, $value));
-    }
-
-    /**
-     * Filter items by the given key value pair using loose comparison.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return static
-     */
-    public function whereLoose($key, $value)
-    {
-        return $this->where($key, '=', $value);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -277,7 +277,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
 
         $this->assertEquals(
-            [['v' => 3]],
+            [['v' => 3], ['v' => '3']],
             $c->where('v', 3)->values()->all()
         );
         $this->assertEquals(
@@ -325,12 +325,6 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             [['v' => 4]],
             $c->where('v', '>', 3)->values()->all()
         );
-    }
-
-    public function testWhereLoose()
-    {
-        $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
-        $this->assertEquals([['v' => 3], ['v' => '3']], $c->whereLoose('v', 3)->values()->all());
     }
 
     public function testWhereIn()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -330,13 +330,13 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
     public function testWhereIn()
     {
         $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
-        $this->assertEquals([['v' => 1], ['v' => 3]], $c->whereIn('v', [1, 3])->values()->all());
+        $this->assertEquals([['v' => 1], ['v' => 3], ['v' => '3']], $c->whereIn('v', [1, 3])->values()->all());
     }
 
-    public function testWhereInLoose()
+    public function testWhereInStrict()
     {
         $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
-        $this->assertEquals([['v' => 1], ['v' => 3], ['v' => '3']], $c->whereInLoose('v', [1, 3])->values()->all());
+        $this->assertEquals([['v' => 1], ['v' => 3]], $c->whereInStrict('v', [1, 3])->values()->all());
     }
 
     public function testValues()


### PR DESCRIPTION
Make `$collection->where($key, $value)` use loose comparison.
1. Everything else in PHP uses loose comparison by default.
2. SQL's `where` also obviously uses loose comparison.

This is a breaking change that will have to be called out in the upgrade docs.

---

Also, the order of operation in `operatorForWhere`'s `switch` statement is now reorganized according to most-used, for better performance.
