### PR TITLE
[5.2] JsonResponse : encoding options

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -13,13 +13,6 @@ class JsonResponse extends BaseJsonResponse
     use ResponseTrait;
 
     /**
-     * The json encoding options.
-     *
-     * @var int
-     */
-    protected $jsonOptions;
-
-    /**
      * Constructor.
      *
      * @param  mixed  $data
@@ -29,7 +22,7 @@ class JsonResponse extends BaseJsonResponse
      */
     public function __construct($data = null, $status = 200, $headers = [], $options = 0)
     {
-        $this->jsonOptions = $options;
+        $this->encodingOptions = $options;
 
         parent::__construct($data, $status, $headers);
     }
@@ -52,13 +45,13 @@ class JsonResponse extends BaseJsonResponse
     public function setData($data = [])
     {
         if ($data instanceof Arrayable) {
-            $this->data = json_encode($data->toArray(), $this->jsonOptions);
+            $this->data = json_encode($data->toArray(), $this->encodingOptions);
         } elseif ($data instanceof Jsonable) {
-            $this->data = $data->toJson($this->jsonOptions);
+            $this->data = $data->toJson($this->encodingOptions);
         } elseif ($data instanceof JsonSerializable) {
-            $this->data = json_encode($data->jsonSerialize(), $this->jsonOptions);
+            $this->data = json_encode($data->jsonSerialize(), $this->encodingOptions);
         } else {
-            $this->data = json_encode($data, $this->jsonOptions);
+            $this->data = json_encode($data, $this->encodingOptions);
         }
 
         if (JSON_ERROR_NONE !== json_last_error()) {
@@ -75,7 +68,15 @@ class JsonResponse extends BaseJsonResponse
      */
     public function getJsonOptions()
     {
-        return $this->jsonOptions;
+        return $this->getEncodingOptions();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setEncodingOptions($encodingOptions)
+    {
+        return $this->setJsonOptions($encodingOptions);
     }
 
     /**
@@ -86,7 +87,7 @@ class JsonResponse extends BaseJsonResponse
      */
     public function setJsonOptions($options)
     {
-        $this->jsonOptions = $options;
+        $this->encodingOptions = (int) $options;
 
         return $this->setData($this->getData());
     }

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -44,6 +44,12 @@ class HttpJsonResponseTest extends PHPUnit_Framework_TestCase
         $this->assertSame(JSON_PRETTY_PRINT, $response->getJsonOptions());
     }
 
+    public function testSetAndRetrieveDefaultOptions()
+    {
+        $response = new Illuminate\Http\JsonResponse(['foo' => 'bar']);
+        $this->assertSame(0, $response->getJsonOptions());
+    }
+
     public function testSetAndRetrieveStatusCode()
     {
         $response = new Illuminate\Http\JsonResponse(['foo' => 'bar'], 404);


### PR DESCRIPTION
There's no need to use `$jsonOptions`. Furthermore, it's easy to mix `setEncodingOptions()` and `setJsonOptions()`.
- Make `setEncodingOptions()` and `setJsonOptions()` behave the same way
- Directly use `\Symfony\Component\HttpFoundation\JsonResponse::$encodingOptions`
