### PR TITLE
[WIP] [5.2] Do not throw PostTooLargeException with post_max_size = 0

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyPostSize.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyPostSize.php
@@ -18,7 +18,9 @@ class VerifyPostSize
      */
     public function handle($request, Closure $next)
     {
-        if ($request->server('CONTENT_LENGTH') > $this->getPostMaxSize()) {
+        $postMaxSize = $this->getPostMaxSize();
+
+        if ($postMaxSize > 0 && $request->server('CONTENT_LENGTH') > $postMaxSize) {
             throw new PostTooLargeException;
         }
 


### PR DESCRIPTION
As `post_max_size` implies and unlimited size.
