### PR TITLE
[5.2] VerifyPostSize: Early return for VerifyPostSize::getPostMaxSize

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyPostSize.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyPostSize.php
@@ -32,7 +32,9 @@ class VerifyPostSize
      */
     protected function getPostMaxSize()
     {
-        $postMaxSize = ini_get('post_max_size');
+        if (is_numeric($postMaxSize = ini_get('post_max_size'))) {
+            return (int) $postMaxSize;
+        }
 
         $metric = strtoupper(substr($postMaxSize, -1));
 


### PR DESCRIPTION
No need to need to determine the metric when `post_max_size` is numeric
