### PR TITLE
[5.2] Model: let asTimeStamp return \DateTime::getTimestamp

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2970,7 +2970,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function asTimeStamp($value)
     {
-        return (int) $this->asDateTime($value)->timestamp;
+        return $this->asDateTime($value)->getTimestamp();
     }
 
     /**


### PR DESCRIPTION
No need to go through `\Carbon\Carbon::__get`
(No need to cast either)
