### PR TITLE
[5.2] Add support for a condition for blade's @continue and @break

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -534,7 +534,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileBreak($expression)
     {
-        return '<?php break; ?>';
+        return $expression ? "<?php if{$expression} break; ?>" : '<?php break; ?>';
     }
 
     /**
@@ -545,7 +545,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileContinue($expression)
     {
-        return '<?php continue; ?>';
+        return $expression ? "<?php if{$expression} continue; ?>" : '<?php continue; ?>';
     }
 
     /**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -343,6 +343,20 @@ test
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testBreakStatementsWithExpressionAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@for ($i = 0; $i < 10; $i++)
+test
+@break(TRUE)
+@endfor';
+        $expected = '<?php for($i = 0; $i < 10; $i++): ?>
+test
+<?php if(TRUE) break; ?>
+<?php endfor; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     public function testContinueStatementsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
@@ -353,6 +367,20 @@ test
         $expected = '<?php for($i = 0; $i < 10; $i++): ?>
 test
 <?php continue; ?>
+<?php endfor; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testContinueStatementsWithExpressionAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@for ($i = 0; $i < 10; $i++)
+test
+@continue(TRUE)
+@endfor';
+        $expected = '<?php for($i = 0; $i < 10; $i++): ?>
+test
+<?php if(TRUE) continue; ?>
 <?php endfor; ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
     }


### PR DESCRIPTION
Instead of this:

```
@if($user->id == 1)
    @continue
@endif
```

We'll be able to do:

```
@continue($user->id == 1)
```

And same for break, however `@continue` and `@break` can still be used with no expression.
