### PR TITLE
[5.2] Use the method() wrapper method instead of getMethod().

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -643,7 +643,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             return $this->json();
         }
 
-        return $this->getMethod() == 'GET' ? $this->query : $this->request;
+        return $this->method() == 'GET' ? $this->query : $this->request;
     }
 
     /**


### PR DESCRIPTION
Use the wrapper method of method() instead of getMethod() for retrieving HTTP method.
