### PR TITLE
[5.2] Add filtered() method on Request for casting empty strings as null.

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -330,7 +330,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function filtered()
     {
-        return array_map(function($value) {
+        return array_map(function ($value) {
             return $value === '' ? null : $value;
         }, $this->all());
     }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -324,6 +324,18 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Get all of the input and files for the request, with empty strings mapped as nullable.
+     *
+     * @return array
+     */
+    public function filtered()
+    {
+        return array_map(function($value) {
+            return $value === '' ? null : $value;
+        }, $this->all());
+    }
+
+    /**
      * Retrieve an input item from the request.
      *
      * @param  string  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -394,6 +394,13 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([1 => 'A', 2 => 'B', 3 => 'C'], $request2->all());
     }
 
+    public function testFilteredInputReturnsInputAndFilesWithEmptyStringsAsNull()
+    {
+        $file = $this->getMock('Illuminate\Http\UploadedFile', null, [__FILE__, 'photo.jpg']);
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'bool' => 0, 'nullable' => '', 'baz' => $file]);
+        $this->assertSame(['name' => 'Taylor', 'bool' => 0, 'nullable' => null, 'baz' => $file], $request->filtered());
+    }
+
     public function testInputWithEmptyFilename()
     {
         $invalidFiles = [


### PR DESCRIPTION
If your migration schema has `nullable()` string fields, Eloquent mutators need to be set on every nullable field if you want `Model::create($request->all())` to actually store `null` values from incoming text inputs.

This proposition would give the user the to run `Model::create($request->filtered())`.  A strict check is made against the array so that all empty strings are mapped to null, and thus null values would be sent to database.

Note: User would have to understand that using `create($request->filtered())` would require nullable fields on their schema to allow for these null values.  In cases where this might be a problem, the user can still use `create($request->all())` and mutate to null values on a field-by-field basis.

Also, maybe a better method name could be suggested?  Something like `$request->nullable()`, idk.  Technically I'm not 'filtering' out values, but mapping/casting empty strings to null.
