### PR TITLE
[5.2] Add a rule to validate an attribute exists even if not filled

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -148,7 +148,7 @@ class Validator implements ValidatorContract
      */
     protected $implicitRules = [
         'Required', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
-        'RequiredIf', 'RequiredUnless', 'Accepted',
+        'RequiredIf', 'RequiredUnless', 'Accepted', 'Present',
         // 'Array', 'Boolean', 'Integer', 'Numeric', 'String',
     ];
 
@@ -614,6 +614,18 @@ class Validator implements ValidatorContract
         }
 
         return true;
+    }
+
+    /**
+     * Validate that an attribute exists even if not filled.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    protected function validatePresent($attribute, $value)
+    {
+        return Arr::get($this->data, $attribute, '__NO_KEY__') != '__NO_KEY__';
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -305,6 +305,28 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidatePresent()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, [], ['name' => 'present']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => ''], ['name' => 'present']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['id' => 1], ['name' => 'a']]], ['foo.*.id' => 'present']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['id' => 1], []]], ['foo.*.id' => 'present']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['id' => 1], ['id' => '']]], ['foo.*.id' => 'present']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['id' => 1], ['id' => null]]], ['foo.*.id' => 'present']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateRequired()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
This validation rule will check if a specific key is present in the input data, it'll succeed if they key is present even if the value is null or empty string.

A sample use case for this rule is validating a complex JSON object in an API request, the rule will insure certain keys are present even if their values are `''` or `null`.
