### PR TITLE
[5.2] Make validation rule "Filled" work with arrays

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -147,7 +147,7 @@ class Validator implements ValidatorContract
      * @var array
      */
     protected $implicitRules = [
-        'Required', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
+        'Required', 'Filled', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
         'RequiredIf', 'RequiredUnless', 'Accepted',
         // 'Array', 'Boolean', 'Integer', 'Numeric', 'String',
     ];
@@ -625,7 +625,7 @@ class Validator implements ValidatorContract
      */
     protected function validateFilled($attribute, $value)
     {
-        if (array_key_exists($attribute, $this->data) || array_key_exists($attribute, $this->files)) {
+        if (Arr::get(array_merge($this->data, $this->files), $attribute, '__NOT_PRESENT__') != '__NOT_PRESENT__') {
             return $this->validateRequired($attribute, $value);
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -314,17 +314,17 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['name' => ''], ['name' => 'filled']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => [['id'=>1],[]]], ['foo.*.id' => 'filled']);
+        $v = new Validator($trans, ['foo' => [['id' => 1], []]], ['foo.*.id' => 'filled']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['foo' => [['id'=>'']]], ['foo.*.id' => 'filled']);
+        $v = new Validator($trans, ['foo' => [['id' => '']]], ['foo.*.id' => 'filled']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['foo' => [['id'=>null]]], ['foo.*.id' => 'filled']);
+        $v = new Validator($trans, ['foo' => [['id' => null]]], ['foo.*.id' => 'filled']);
         $this->assertFalse($v->passes());
     }
 
-        public function testValidateRequired()
+    public function testValidateRequired()
     {
         $trans = $this->getRealTranslator();
         $v = new Validator($trans, [], ['name' => 'Required']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -305,7 +305,26 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateRequired()
+    public function testValidateFilled()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, [], ['name' => 'filled']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ''], ['name' => 'filled']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['id'=>1],[]]], ['foo.*.id' => 'filled']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['id'=>'']]], ['foo.*.id' => 'filled']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['id'=>null]]], ['foo.*.id' => 'filled']);
+        $this->assertFalse($v->passes());
+    }
+
+        public function testValidateRequired()
     {
         $trans = $this->getRealTranslator();
         $v = new Validator($trans, [], ['name' => 'Required']);


### PR DESCRIPTION
Currently the `filled` validation rule uses `array_key_exists()` to check for the existence of the attribute, this won't work well when dealing with arrays.

The fix uses `Arr::get()` to check for existence instead of `array_key_exists()`.
