### PR TITLE
[5.2] Make secure_url() $path param optional to compatible with url()

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -636,7 +636,7 @@ if (! function_exists('secure_url')) {
      *
      * @param  string  $path
      * @param  mixed   $parameters
-     * @return string
+     * @return Illuminate\Contracts\Routing\UrlGenerator|string
      */
     function secure_url($path = null, $parameters = [])
     {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -638,7 +638,7 @@ if (! function_exists('secure_url')) {
      * @param  mixed   $parameters
      * @return string
      */
-    function secure_url($path, $parameters = [])
+    function secure_url($path = null, $parameters = [])
     {
         return url($path, $parameters, true);
     }


### PR DESCRIPTION
$path is optional, the same as url() method.
