### PR TITLE
[5.1] Drastically reduce overhead in Blade comment matching

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -196,7 +196,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileComments($value)
     {
-        $pattern = sprintf('/%s--((.|\s)*?)--%s/', $this->contentTags[0], $this->contentTags[1]);
+        $pattern = sprintf('/%s--(.*?)--%s/s', $this->contentTags[0], $this->contentTags[1]);
 
         return preg_replace($pattern, '<?php /*$1*/ ?>', $value);
     }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -208,8 +208,8 @@ this is a comment
 */ ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
 
-        $string = '{{-- this is an ' . str_repeat('extremely ', 100) . 'long comment --}}';
-        $expected = '<?php /* this is an ' . str_repeat('extremely ', 100) . 'long comment */ ?>';
+        $string = sprintf('{{-- this is an %s long comment --}}', str_repeat('extremely ', 1000));
+        $expected = sprintf('<?php /* this is an %s long comment */ ?>', str_repeat('extremely ', 1000));
 
         $this->assertEquals($expected, $compiler->compileString($string));
     }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -207,6 +207,30 @@ this is a comment
 this is a comment
 */ ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
+
+        $string = '{{--
+this is an extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely long comment
+--}}';
+        $expected = '<?php /*
+this is an extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
+extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely long comment
+*/ ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
     }
 
     public function testIfStatementsAreCompiled()

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -208,28 +208,9 @@ this is a comment
 */ ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
 
-        $string = '{{--
-this is an extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely long comment
---}}';
-        $expected = '<?php /*
-this is an extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely
-extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely extremely long comment
-*/ ?>';
+        $string = '{{-- this is an ' . str_repeat('extremely ', 100) . 'long comment --}}';
+        $expected = '<?php /* this is an ' . str_repeat('extremely ', 100) . 'long comment */ ?>';
+
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 


### PR DESCRIPTION
See #12505 

Prior to this change, a capture group was being created for every single character in the comment.

For any comments over 1024 characters (not uncommon when commenting out a chunk of markup), PHP 7 would fail to match the regex due to hitting a JIT stack limit, causing the entire template to render as an empty string.

Adding the `s` modifier tells the regex engine to include newline characters when matching the dot character and allows us to remove the inner capture group. This drastically reduces the amount of memory the regex uses and keeps it well within the JIT stack limit for typical uses.

This increases the limit for comment length up to approximately 1 million characters, instead 1024.
