### PR TITLE
[5.2] Added dispatchNow to DispatchesJobs trait

### DIFF
--- a/src/Illuminate/Foundation/Bus/DispatchesJobs.php
+++ b/src/Illuminate/Foundation/Bus/DispatchesJobs.php
@@ -16,4 +16,15 @@ trait DispatchesJobs
     {
         return app(Dispatcher::class)->dispatch($job);
     }
+
+    /**
+     * Dispatch a command to its appropriate handler in the current process.
+     *
+     * @param  mixed  $job
+     * @return mixed
+     */
+    public function dispatchNow($job)
+    {
+        return app(Dispatcher::class)->dispatchNow($job);
+    }
 }


### PR DESCRIPTION
I have an use case where I dispatch a job to the queue while over http and want to dispatch it synchronously while in CLI (in an artisan command). Another use case: in a client's website I have the opposite, the thumb for an image should be generated synchronously over http, but the batch process that runs daily should add the thumb generation to a queue.

It would be convenient to have the `dispatchNow` method added to the `DispatchesJob` trait. I'm only afraid of increasing confusion adding more options to it.
