### PR TITLE
[5.2] Register swiftmailer before mailer

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -21,9 +21,9 @@ class MailServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('mailer', function ($app) {
-            $this->registerSwiftMailer();
+        $this->registerSwiftMailer();
 
+        $this->app->singleton('mailer', function ($app) {
             // Once we have create the mailer instance, we will set a container instance
             // on the mailer. This allows us to resolve mailer classes via containers
             // for maximum testability on said classes instead of passing Closures.


### PR DESCRIPTION
This change allows users to extend the `swift.transport` manager from their own service providers:

``` php
    public function register()
    {
        $this->app['swift.transport']->extend('postmark', function () {
            return new PostmarkTransport($this->app['config']->get('services.postmark.token'));
        });
    }
```

Without this it is not possible to add mail drivers before the `mailer` is constructed with the current mail driver, because `swift.transport` is not registered on the container yet.

This applies to all 5.x versions.
