### PR TITLE
[5.1] Add tests for Str::is with stringable objects

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -93,6 +93,12 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(Str::is('/', '/a'));
         $this->assertTrue(Str::is('foo/*', 'foo/bar/baz'));
         $this->assertTrue(Str::is('*/foo', 'blah/baz/foo'));
+
+        $valueObject = new StringableObjectStub('foo/bar/baz');
+        $patternObject = new StringableObjectStub('foo/*');
+
+        $this->assertTrue(Str::is('foo/bar/baz', $valueObject));
+        $this->assertTrue(Str::is($patternObject, $valueObject));
     }
 
     public function testLower()
@@ -180,5 +186,20 @@ class SupportStrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Laravel framework', Str::ucfirst('laravel framework'));
         $this->assertEquals('Мама', Str::ucfirst('мама'));
         $this->assertEquals('Мама мыла раму', Str::ucfirst('мама мыла раму'));
+    }
+}
+
+class StringableObjectStub
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return $this->value;
     }
 }


### PR DESCRIPTION
- First test to demonstrate the `if ($pattern == $value)` at beginning of `Str::is` (loose comparison).
- Second test to ensure the implementation supports stringable objects in place of string literals.
