### PR TITLE
[5.2] Sorting of masked routes. Added Router::processRoutes method.

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -851,6 +851,10 @@ class Route
      */
     public function getCompiled()
     {
+        if (! isset($this->compiled)) {
+            $this->compileRoute();
+        }
+
         return $this->compiled;
     }
 

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -129,6 +129,19 @@ class RouteCollection implements Countable, IteratorAggregate
     }
 
     /**
+     * Process the route arrays with a Callable.
+     *
+     * @param callable $processor
+     */
+    public function processRoutes(callable $processor)
+    {
+        foreach ($this->routes as $method => $methodRoutes) {
+            $this->routes[$method] = $processor($methodRoutes);
+        }
+        $this->allRoutes = $processor($this->allRoutes);
+    }
+
+    /**
      * Find the first route matching a given request.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -401,6 +401,16 @@ class Router implements RegistrarContract
     }
 
     /**
+     * Proxy to RouteCollection::processRoutes.
+     *
+     * @param callable $callable
+     */
+    public function processRoutes(callable $callable)
+    {
+        $this->routes->processRoutes($callable);
+    }
+
+    /**
      * Update the group stack with the given attributes.
      *
      * @param  array  $attributes

--- a/src/Illuminate/Routing/Sorting/RoutesSorter.php
+++ b/src/Illuminate/Routing/Sorting/RoutesSorter.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Illuminate\Routing\Sorting;
+
+use Illuminate\Routing\Route;
+use Symfony\Component\Routing\CompiledRoute;
+
+/**
+ * Processes routes order promoting routes that are masked by some other route.
+ *
+ * Class RoutesSorter
+ */
+class RoutesSorter
+{
+    /**
+     * @param  Route[]  $routes
+     *
+     * @return Route[]
+     */
+    public function __invoke(array $routes)
+    {
+        $order = [];
+        $n = 1;
+        foreach ($routes as $key => $route) {
+            $order[$key] = $n++;
+        }
+
+        uksort($routes, function ($key1, $key2) use ($routes, $order) {
+            $route1 = $routes[$key1];
+            $route2 = $routes[$key2];
+
+            if (! array_intersect($route1->getMethods(), $route2->getMethods())) {
+                return $order[$key1] - $order[$key2];
+            }
+
+            if (($route1->httpOnly() && $route2->secure()) || ($route2->httpOnly() && $route1->secure())) {
+                return $order[$key1] - $order[$key2];
+            }
+
+            if ($route1->domain() != $route2->domain()) {
+                return $order[$key1] - $order[$key2];
+            }
+
+            $isRoute1Shadowed = $this->isRouteMasked($route1, $route2);
+            $isRoute2Shadowed = $this->isRouteMasked($route2, $route1);
+
+            if ($isRoute1Shadowed && $isRoute2Shadowed) {
+                return $order[$key1] - $order[$key2];
+            }
+            if ($isRoute1Shadowed) {
+                return -1;
+            }
+            if ($isRoute2Shadowed) {
+                return 1;
+            }
+
+            return $order[$key1] - $order[$key2];
+        });
+
+        return $routes;
+    }
+
+    /**
+     * Checks if first route is masked by second.
+     *
+     * @param  Route  $route1
+     * @param  Route  $route2
+     *
+     * @return bool
+     */
+    private function isRouteMasked(Route $route1, Route $route2)
+    {
+        $compiledRoute2 = $route2->getCompiled();
+        if (! $compiledRoute2->getVariables()) {
+            return false;
+        }
+
+        $compiledRoute1 = $route1->getCompiled();
+        if (preg_match($compiledRoute2->getRegex(), $compiledRoute1->getStaticPrefix())) {
+            return true;
+        }
+
+        return $this->compareTokens($compiledRoute1, $compiledRoute2);
+    }
+
+    /**
+     * Checks if the routes have the same variables until the first optional parameter of the second route.
+     *
+     * @param  CompiledRoute  $route1
+     * @param  CompiledRoute  $route2
+     *
+     * @return bool
+     */
+    private function compareTokens(CompiledRoute $route1, CompiledRoute $route2)
+    {
+        $route2FirstOptionalParameterIndex = $this->getFirstOptionalParameterIndex($route2);
+        if (null === $route2FirstOptionalParameterIndex) {
+            return false;
+        }
+
+        $route1Tokens = $route1->getTokens();
+        $route2Tokens = $route2->getTokens();
+
+        $key1 = count($route1Tokens) - 1;
+        $key2 = count($route2Tokens) - 1;
+        $variablesFound2 = 0;
+        do {
+            $token2 = $route2Tokens[$key2];
+            if ($route1Tokens[$key1] != $token2) {
+                return false;
+            }
+            if ('variable' == $token2[0]) {
+                ++$variablesFound2;
+            }
+            --$key1;
+            --$key2;
+        } while ($key1 >= 0 && $key2 >= 0);
+
+        return $variablesFound2 == $route2FirstOptionalParameterIndex;
+    }
+
+    /**
+     * @param  CompiledRoute  $route
+     *
+     * @return int|null|string
+     */
+    private function getFirstOptionalParameterIndex(CompiledRoute $route)
+    {
+        if (preg_match_all('/(\(.+?\))/', $route->getRegex(), $matches)) {
+            foreach ($matches[1] as $param_index => $match) {
+                if (strpos($match, '(?:/') === 0) {
+                    return $param_index;
+                }
+            }
+        }
+
+        return;
+    }
+}

--- a/tests/Routing/RoutingRoutesSortingTest.php
+++ b/tests/Routing/RoutingRoutesSortingTest.php
@@ -1,0 +1,211 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
+use Illuminate\Routing\Sorting\RoutesSorter;
+
+class RoutingRoutesSortingTest extends PHPUnit_Framework_TestCase
+{
+    public function testSortRoutesWithMandatoryParams()
+    {
+        $router = $this->getRouter();
+        $router->any('foo/{param}', function ($param) { return 'foo/'.$param; });
+        $router->any('foo/bar', function () { return 'foobarconstant'; });
+
+        // foo/bar route is masked
+        $this->assertEquals('foo/bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertEquals('foo/111', $router->dispatch(Request::create('foo/111', 'GET'))->getContent());
+
+        $router->processRoutes(new RoutesSorter());
+
+        // foo/bar route matches
+        $this->assertEquals('foobarconstant', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertEquals('foo/111', $router->dispatch(Request::create('foo/111', 'GET'))->getContent());
+    }
+
+    public function testSortRoutesWithOptionalParams()
+    {
+        $router = $this->getRouter();
+        $router->any('foo/{param?}', function ($param = 'void') { return 'foo/'.$param; });
+        $router->any('foo/bar', function () { return 'foobarconstant'; });
+        $router->any('foo', function () { return 'fooconstant'; });
+
+        // foo and foo/bar routes are masked
+        $this->assertEquals('foo/void', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+        $this->assertEquals('foo/bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertEquals('foo/111', $router->dispatch(Request::create('foo/111', 'GET'))->getContent());
+
+        $router->processRoutes(new RoutesSorter());
+
+        // foo and foo/bar route match
+        $this->assertEquals('fooconstant', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+        $this->assertEquals('foobarconstant', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertEquals('foo/111', $router->dispatch(Request::create('foo/111', 'GET'))->getContent());
+    }
+
+    public function testSortRoutesWithMandatoryAndOptionalParams()
+    {
+        $router = $this->getRouter();
+        $router->any('foo/{param1}/{param2?}', function ($param1, $param2 = 'void') { return 'foo/'.$param1.'/'.$param2; });
+        $router->any('foo/bar/baz', function () { return 'foobarbazconstant'; });
+        $router->any('foo/bar', function () { return 'foobarconstant'; });
+
+        // foo/bar and foo/bar/baz route are masked
+        $this->assertEquals('foo/bar/void', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertEquals('foo/bar/baz', $router->dispatch(Request::create('foo/bar/baz', 'GET'))->getContent());
+        $this->assertEquals('foo/111/222', $router->dispatch(Request::create('foo/111/222', 'GET'))->getContent());
+
+        $router->processRoutes(new RoutesSorter());
+
+        // foo and foo/bar/baz route match
+        $this->assertEquals('foobarconstant', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertEquals('foobarbazconstant', $router->dispatch(Request::create('foo/bar/baz', 'GET'))->getContent());
+        $this->assertEquals('foo/111/222', $router->dispatch(Request::create('foo/111/222', 'GET'))->getContent());
+    }
+
+    public function testSortRoutesWithPrefixes()
+    {
+        $router = $this->getRouter();
+        $router->group(['prefix' => 'prefix'], function (Router $router) {
+            $router->any('foo/{param}', function ($param) { return 'foo/'.$param; });
+            $router->any('foo/bar', function () { return 'foobarconstant'; });
+        });
+
+        // foo/bar route is masked
+        $this->assertEquals('foo/bar', $router->dispatch(Request::create('prefix/foo/bar', 'GET'))->getContent());
+        $this->assertEquals('foo/111', $router->dispatch(Request::create('prefix/foo/111', 'GET'))->getContent());
+
+        $router->processRoutes(new RoutesSorter());
+
+        // foo/bar route matches
+        $this->assertEquals('foobarconstant', $router->dispatch(Request::create('prefix/foo/bar', 'GET'))->getContent());
+        $this->assertEquals('foo/111', $router->dispatch(Request::create('prefix/foo/111', 'GET'))->getContent());
+    }
+
+    /**
+     * @dataProvider isRouteMaskedTestCases
+     */
+    public function testIsRouteMasked(Route $route1, Route $route2, $expectedResult)
+    {
+        $this->assertEquals($expectedResult, $this->checkIfRouteIsMasked($route1, $route2));
+    }
+
+    private function checkIfRouteIsMasked(Route $route1, Route $route2)
+    {
+        $method = new ReflectionMethod(RoutesSorter::class, 'isRouteMasked');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->getRoutesSorter(), $route1, $route2);
+    }
+
+    public function isRouteMaskedTestCases()
+    {
+        $ret = [];
+
+        // uris without the same prefix are not shadowed
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo/{param}', function () {});
+        $route2 = $router->any('bar/{param}', function () {});
+        $ret[0] = [$route1, $route2, false];
+
+        // mandatory params do not shadow when segment not present
+
+        $router = $this->getRouter();
+        $routes[] = $router->any('foo/{param}', function () {});
+        $routes[] = $router->any('foo', function () {});
+        $ret[1] = [$route1, $route2, false];
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo', function () {});
+        $route2 = $router->any('foo/{param}', function () {});
+        $ret[2] = [$route1, $route2, false];
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo/{param1}/{param2}', function () {});
+        $route2 = $router->any('foo/bar', function () {});
+        $ret[3] = [$route1, $route2, false];
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo/bar', function () {});
+        $route2 = $router->any('foo/{param1}/{param2}', function () {});
+        $ret[4] = [$route1, $route2, false];
+
+        // mandatory params shadow constant segments
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo/bar', function () {});
+        $route2 = $router->any('foo/{param}', function () {});
+        $ret[5] = [$route1, $route2, true];
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo/{param}', function () {});
+        $route2 = $router->any('foo/bar', function () {});
+        $ret[6] = [$route1, $route2, false];
+
+        // optional params shadow constant segments
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo/bar', function () {});
+        $route2 = $router->any('foo/{param?}', function () {});
+        $ret[7] = [$route1, $route2, true];
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo/{param?}', function () {});
+        $route2 = $router->any('foo/bar', function () {});
+        $ret[8] = [$route1, $route2, false];
+
+        // check shadowing when mandatory and optional params present
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo/bar/baz', function () {});
+        $route2 = $router->any('foo/{param1}/{param2?}', function () {});
+        $ret[9] = [$route1, $route2, true];
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo/{param1}/{param2?}', function () {});
+        $route2 = $router->any('foo/bar/baz', function () {});
+        $ret[10] = [$route1, $route2, false];
+
+        // optional params shadow not present segments
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo', function () {});
+        $route2 = $router->any('foo/{param?}', function () {});
+        $ret[11] = [$route1, $route2, true];
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo/{param?}', function () {});
+        $route2 = $router->any('foo', function () {});
+        $ret[12] = [$route1, $route2, false];
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo/{param1}', function () {});
+        $route2 = $router->any('foo/{param1}/{param2?}', function () {});
+        $ret[13] = [$route1, $route2, true];
+
+        $router = $this->getRouter();
+        $route1 = $router->any('foo/{param1}/{param2?}', function () {});
+        $route2 = $router->any('foo/{param1}', function () {});
+        $ret[14] = [$route1, $route2, false];
+
+        return $ret;
+    }
+
+    /**
+     * @return RoutesSorter
+     */
+    private function getRoutesSorter()
+    {
+        return new RoutesSorter();
+    }
+
+    /**
+     * @return Router
+     */
+    private function getRouter()
+    {
+        return new Router(new Illuminate\Events\Dispatcher());
+    }
+}


### PR DESCRIPTION
This change adds a `Illuminate\Routing\Sorting\RoutesSorter` class. When applied to a routes array, it promotes those that are masked by other routes added before. Related to #12253 .

The `RoutesSorter` compares each pair of `Route` objects, and checks if one `Route` path is _less specific_ than the other:

`foo/bar` path is more specific than `foo/{param}` and it should be matched against first. 

The sorter process should be applied after adding all the routes.

The `RouteCollection` object is not accesible from outside the `Router`. In order to apply the sorter class, I have added a `processRoutes` method to both the `Router` and `RouteCollection` classes. It receives a `Callable` and executes it passing the array of routes. This method could be used for other purposes: 

``` php

use Illuminate\Routing\Sorting\RoutesSorter;

// add routes
Route::get('/', function () {
    return view('welcome');
});
Route::get('/foo', function () {
    return view('bar');
});

// sort the routes
Route::processRoutes(new RoutesSorter());

```

Another approach for applying the sorter would be making the `RouteCollection` class aware of processors and having the `RoutesSorter` processor attached somehow. Not sure about which option is best. Any ideas on any other way of applying the sort process?

I also changed `Route` to make ir cache the `CompiledRoute` instance computed in `Route::getCompiled` method. The `RoutesSorter` class needs to check the compiled route, but there is no need to compile it again. I haven't noticed any problem with this.
