### PR TITLE
[5.2] Added "in_array" validation rule

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -830,7 +830,7 @@ class Validator implements ValidatorContract
      */
     protected function validateInArray($attribute, $value, $parameters)
     {
-        $this->requireParameterCount(1, $parameters, 'same');
+        $this->requireParameterCount(1, $parameters, 'in_array');
 
         $otherValues = Arr::where(Arr::dot($this->data), function ($key) use ($parameters) {
             return Str::is($parameters[0], $key);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -821,6 +821,25 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * Validate that the values of an attribute is in another attribute.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @param  array   $parameters
+     * @return bool
+     */
+    protected function validateInArray($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'same');
+
+        $otherValues = Arr::where(Arr::dot($this->data), function ($key) use ($parameters) {
+            return Str::is($parameters[0], $key);
+        });
+
+        return in_array($value, $otherValues);
+    }
+
+    /**
      * Validate that an attribute has a matching confirmation.
      *
      * @param  string  $attribute
@@ -1157,13 +1176,9 @@ class Validator implements ValidatorContract
             }
         }
 
-        $data = [];
-
-        foreach (Arr::dot($this->data) as $key => $val) {
-            if ($key != $attribute && Str::is($rawAttribute, $key)) {
-                $data[$key] = $val;
-            }
-        }
+        $data = Arr::where(Arr::dot($this->data), function ($key) use ($attribute, $rawAttribute) {
+            return $key != $attribute &&  Str::is($rawAttribute, $key);
+        });
 
         return ! in_array($value, array_values($data));
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -590,6 +590,25 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('The last field is required unless first is in taylor, sven.', $v->messages()->first('last'));
     }
 
+    public function testValidateInArray()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => [1, 2, 3], 'bar' => [1, 2]], ['foo.*' => 'in_array:bar.*']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => [1, 2], 'bar' => [1, 2, 3]], ['foo.*' => 'in_array:bar.*']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => [['bar_id' => 5], ['bar_id' => 2]], 'bar' => [['id' => 1, ['id' => 2]]]], ['foo.*.bar_id' => 'in_array:bar.*.id']);
+        $this->assertFalse($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => [['bar_id' => 1], ['bar_id' => 2]], 'bar' => [['id' => 1, ['id' => 2]]]], ['foo.*.bar_id' => 'in_array:bar.*.id']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateConfirmed()
     {
         $trans = $this->getRealTranslator();
@@ -1052,7 +1071,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
     }
 
-    public function testValidateNoDuplicates()
+    public function testValidateDistinct()
     {
         $trans = $this->getRealTranslator();
 


### PR DESCRIPTION
This is how the rule works:

``` php
Validator::make(
    [
        'users' => [['id' => 1], ['id' => 2]],
        'devices' => [['user_id' => 1], ['user_id' => 2]]
    ],
    ['devices.*.user_id' => 'in_array:users.*.id']
);
```

I also applied some refactoring to the `Validator::validateDistinct()` method.
