### PR TITLE
[5.2] Add the --tests option to make:auth

### DIFF
--- a/src/Illuminate/Auth/Console/MakeAuthCommand.php
+++ b/src/Illuminate/Auth/Console/MakeAuthCommand.php
@@ -14,7 +14,7 @@ class MakeAuthCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'make:auth {--views : Only scaffold the authentication views}';
+    protected $signature = 'make:auth {--views : Only scaffold the authentication views} {--tests}';
 
     /**
      * The console command description.
@@ -65,6 +65,17 @@ class MakeAuthCommand extends Command
                 file_get_contents(__DIR__.'/stubs/make/routes.stub'),
                 FILE_APPEND
             );
+
+            $this->fixExampleTest();
+        }
+
+        if ($this->option('tests')) {
+            file_put_contents(
+                base_path('tests/AuthTest.php'),
+                $this->compileTestStub()
+            );
+
+            $this->info('Created registration and authentication tests.');
         }
 
         $this->comment('Authentication scaffolding generated successfully!');
@@ -107,16 +118,55 @@ class MakeAuthCommand extends Command
     }
 
     /**
+     * Replace the App namespace.
+     *
+     * @param  string $stub
+     * @return string
+     */
+    protected function replaceAppNamespace($stub)
+    {
+        return str_replace('{{namespace}}', $this->getAppNamespace(), $stub);
+    }
+
+    /**
      * Compiles the HomeController stub.
      *
      * @return string
      */
     protected function compileControllerStub()
     {
-        return str_replace(
-            '{{namespace}}',
-            $this->getAppNamespace(),
+        return $this->replaceAppNamespace(
             file_get_contents(__DIR__.'/stubs/make/controllers/HomeController.stub')
         );
+    }
+
+    /**
+     * Compiles the AuthTest stub.
+     *
+     * @return string
+     */
+    protected function compileTestStub()
+    {
+        return $this->replaceAppNamespace(
+            file_get_contents(__DIR__.'/stubs/make/tests/AuthTest.stub')
+        );
+    }
+
+    /**
+     * Fix the example test.
+     */
+    protected function fixExampleTest()
+    {
+        $file = base_path('tests/ExampleTest.php');
+
+        if (file_exists($file)) {
+            $code = str_replace(
+                "->see('Laravel 5')",
+                "->see('Welcome')",
+                file_get_contents($file)
+            );
+
+            file_put_contents($file, $code);
+        }
     }
 }

--- a/src/Illuminate/Auth/Console/stubs/make/tests/AuthTest.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/tests/AuthTest.stub
@@ -1,0 +1,63 @@
+<?php
+
+use {{namespace}}User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class AuthTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    protected $name = 'Your name';
+    protected $email = 'a@valid.email';
+    protected $password = 'secret';
+
+    public function test_registration()
+    {
+        $this->visit('register')
+            ->type($this->name, 'name')
+            ->type($this->email, 'email')
+            ->type($this->password, 'password')
+            ->type($this->password, 'password_confirmation')
+            ->press('Register')
+            ->seeCredentials([
+                'name' => $this->name,
+                'email' => $this->email,
+                'password' => $this->password,
+            ])
+            ->see('Welcome')
+            ->seePageIs('/')
+            ->seeIsAuthenticated();
+    }
+
+    public function test_login()
+    {
+        $this->createUser();
+
+        $this->visit('login')
+            ->type($this->email, 'email')
+            ->type($this->password, 'password')
+            ->press('Login')
+            ->see('Welcome')
+            ->seePageIs('/')
+            ->seeIsAuthenticated();
+    }
+
+    public function test_logout()
+    {
+        $user = $this->createUser();
+
+        $this->actingAs($user)
+            ->visit('logout')
+            ->seePageIs('/')
+            ->dontSeeIsAuthenticated();
+    }
+
+    protected function createUser()
+    {
+        return factory(User::class)->create([
+            'email' => $this->email,
+            'password' => bcrypt($this->password)
+        ]);
+    }
+}


### PR DESCRIPTION
Using this option will generate some nice authentication and registration tests for the project in tests/AuthTest.php 

Also using "make:auth" now fixes the ExampleTest (which is broken since the generated home doesn't have the word "Laravel" so I am replacing see('Laravel') for see('Welcome') instead. 

If you like this commit (I do like it), I'll also find a way to add some password reset tests.
