### PR TITLE
[5.3] Reset password abstraction

### DIFF
--- a/src/Illuminate/Auth/Passwords/CanResetPassword.php
+++ b/src/Illuminate/Auth/Passwords/CanResetPassword.php
@@ -13,4 +13,12 @@ trait CanResetPassword
     {
         return $this->email;
     }
+
+    /**
+     * Reset the user's password.
+     */
+    public function resetPassword($password)
+    {
+        $this->password = bcrypt($password);
+    }
 }

--- a/src/Illuminate/Contracts/Auth/CanResetPassword.php
+++ b/src/Illuminate/Contracts/Auth/CanResetPassword.php
@@ -10,4 +10,10 @@ interface CanResetPassword
      * @return string
      */
     public function getEmailForPasswordReset();
+
+
+    /**
+     * Reset the user's password.
+     */
+    public function resetPassword($password);
 }

--- a/src/Illuminate/Contracts/Auth/CanResetPassword.php
+++ b/src/Illuminate/Contracts/Auth/CanResetPassword.php
@@ -11,7 +11,6 @@ interface CanResetPassword
      */
     public function getEmailForPasswordReset();
 
-
     /**
      * Reset the user's password.
      */

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -213,7 +213,7 @@ trait ResetsPasswords
      */
     protected function resetPassword($user, $password)
     {
-        $user->password = bcrypt($password);
+        $user->resetPassword($password);
 
         $user->save();
 


### PR DESCRIPTION
In my app, I'm using a custom user table for authentication (wordpress wp_users table) ... I made a custom Auth provider in my laravel app, and everything's working perfectly except for the `reset password` functionality.

So I had to move the `bcrypt()` password encryption function to the `CanResetPassword` trait. This way, I can override the `resetPassword` function in my user model, and use whatever encryption I want.
