### PR TITLE
[5.2] Make $callback optional for Arr:first and Arr::last

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -154,7 +154,7 @@ class Arr
     public static function first($array, callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
-            return !empty($array) ? reset($array) : value($default);
+            return empty($array) ? value($default) : reset($array);
         }
 
         foreach ($array as $key => $value) {
@@ -177,7 +177,7 @@ class Arr
     public static function last($array, callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
-            return !empty($array) ? end($array) : value($default);
+            return empty($array) ? value($default) : end($array);
         }
 
         return static::first(array_reverse($array), $callback, $default);

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -151,10 +151,10 @@ class Arr
      * @param  mixed  $default
      * @return mixed
      */
-    public static function first($array, callable $callback, $default = null)
+    public static function first($array, callable $callback = null, $default = null)
     {
         foreach ($array as $key => $value) {
-            if (call_user_func($callback, $key, $value)) {
+            if (is_null($callback) || call_user_func($callback, $key, $value)) {
                 return $value;
             }
         }
@@ -170,7 +170,7 @@ class Arr
      * @param  mixed  $default
      * @return mixed
      */
-    public static function last($array, callable $callback, $default = null)
+    public static function last($array, callable $callback = null, $default = null)
     {
         return static::first(array_reverse($array), $callback, $default);
     }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -153,8 +153,12 @@ class Arr
      */
     public static function first($array, callable $callback = null, $default = null)
     {
+        if (is_null($callback)) {
+            return !empty($array) ? reset($array) : value($default);
+        }
+
         foreach ($array as $key => $value) {
-            if (is_null($callback) || call_user_func($callback, $key, $value)) {
+            if (call_user_func($callback, $key, $value)) {
                 return $value;
             }
         }
@@ -172,6 +176,10 @@ class Arr
      */
     public static function last($array, callable $callback = null, $default = null)
     {
+        if (is_null($callback)) {
+            return !empty($array) ? end($array) : value($default);
+        }
+
         return static::first(array_reverse($array), $callback, $default);
     }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -147,7 +147,7 @@ class Arr
      * Return the first element in an array passing a given truth test.
      *
      * @param  array  $array
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  mixed  $default
      * @return mixed
      */
@@ -166,7 +166,7 @@ class Arr
      * Return the last element in an array passing a given truth test.
      *
      * @param  array  $array
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  mixed  $default
      * @return mixed
      */

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -123,7 +123,7 @@ if (! function_exists('array_first')) {
      * @param  mixed  $default
      * @return mixed
      */
-    function array_first($array, callable $callback, $default = null)
+    function array_first($array, callable $callback = null, $default = null)
     {
         return Arr::first($array, $callback, $default);
     }
@@ -195,7 +195,7 @@ if (! function_exists('array_last')) {
      * @param  mixed  $default
      * @return mixed
      */
-    function array_last($array, $callback, $default = null)
+    function array_last($array, $callback = null, $default = null)
     {
         return Arr::last($array, $callback, $default);
     }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -119,7 +119,7 @@ if (! function_exists('array_first')) {
      * Return the first element in an array passing a given truth test.
      *
      * @param  array  $array
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  mixed  $default
      * @return mixed
      */
@@ -191,7 +191,7 @@ if (! function_exists('array_last')) {
      * Return the last element in an array passing a given truth test.
      *
      * @param  array  $array
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  mixed  $default
      * @return mixed
      */

--- a/tests/Support/SupportArrayTest.php
+++ b/tests/Support/SupportArrayTest.php
@@ -60,6 +60,7 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         });
 
         $this->assertEquals(200, $value);
+        $this->assertEquals(100, Arr::first($array));
     }
 
     public function testIs()
@@ -80,6 +81,7 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $array = [100, 200, 300];
         $last = Arr::last($array, function () { return true; });
         $this->assertEquals(300, $last);
+        $this->assertEquals(300, Arr::last($array));
     }
 
     public function testFlatten()


### PR DESCRIPTION
Hi,

I think it would beneficial if we could use `Arr::first()` and `Arr::last()` without passing the callback. This may not be the speediest way to get the first or last element from an array but it's probably simplest (and most obvious) to be able to just type `array_first($arr)` and `array_last($arr)`(in particular for associative arrays). Therefore in most cases this would do the job and fits the purpose of these methods.

Additionally other methods of grabbing the first item in an associative array, such as using `reset()`, require a variable to be passed by reference. This means we can't do something like `$first = reset(config('some.item'));` but `$first = array_first(config('some.item'));` works fine.

Thanks for your consideration.
