### PR TITLE
[5.2] Add seeCredentials to InteractsWithAuthentication

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -57,4 +57,54 @@ trait InteractsWithAuthentication
 
         return $this;
     }
+
+    /**
+     * Return true is the credentials are valid, false otherwise.
+     *
+     * @param  array $credentials
+     * @param  string|null  $guard
+     * @return bool
+     */
+    protected function hasCredentials(array $credentials, $guard = null)
+    {
+        $provider = $this->app->make('auth')->guard($guard)->getProvider();
+
+        $user = $provider->retrieveByCredentials($credentials);
+
+        return $user && $provider->validateCredentials($user, $credentials);
+    }
+
+    /**
+     * Assert that the given credentials are valid.
+     *
+     * @param  array  $credentials
+     * @param  string|null  $guard
+     * @return $this
+     */
+    public function seeCredentials(array $credentials, $guard = null)
+    {
+        $this->assertTrue(
+            $this->hasCredentials($credentials, $guard),
+            'The given credentials are invalid.'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the given credentials are invalid.
+     *
+     * @param  array  $credentials
+     * @param  string|null  $guard
+     * @return $this
+     */
+    public function dontSeeCredentials(array $credentials, $guard = null)
+    {
+        $this->assertFalse(
+            $this->hasCredentials($credentials, $guard),
+            'The given credentials are valid.'
+        );
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Useful for checking that the user data was saved correctly after a user registers or change its password. 

Since the code below won't work:

```
$this->seeInDatabase([
    'email' => 'someone@laravel.com',
    'password' => bcrypt('secret_password'),
]);
```

`seeCredentials` will check that the password was encrypted properly relying on the methods provided in the UserProvider implementation.

```
$this->seeCredentials([
    'email' => 'someone@laravel.com',
    'password' => 'secret_password',
]);
```
