### PR TITLE
[5.2] Work on closure serialization in Mailer

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -289,7 +289,7 @@ class Mailer implements MailerContract, MailQueueContract
     protected function getQueuedCallable(array $data)
     {
         if (Str::contains($data['callback'], 'SerializableClosure')) {
-            return unserialize($data['callback'])->getClosure();
+            return (new Serializer)->unserialize($data['callback']);
         }
 
         return $data['callback'];

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -254,8 +254,8 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Build the callable for a queued e-mail job.
      *
-     * @param  mixed  $callback
-     * @return mixed
+     * @param  \Closure|string  $callback
+     * @return string
      */
     protected function buildQueueCallable($callback)
     {
@@ -284,7 +284,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Get the true callable for a queued e-mail message.
      *
      * @param  array  $data
-     * @return mixed
+     * @return \Closure|string
      */
     protected function getQueuedCallable(array $data)
     {

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -263,7 +263,18 @@ class Mailer implements MailerContract, MailQueueContract
             return $callback;
         }
 
-        return (new Serializer)->serialize($callback);
+        return $this->serialize($callback);
+    }
+
+    /**
+     * Serialize a closure for storage in queue.
+     *
+     * @param  \Closure  $closure
+     * @return string
+     */
+    protected function serialize(Closure $closure)
+    {
+        return (new Serializer)->serialize($closure);
     }
 
     /**
@@ -288,11 +299,22 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function getQueuedCallable(array $data)
     {
-        if (Str::contains($data['callback'], 'SerializableClosure')) {
-            return (new Serializer)->unserialize($data['callback']);
+        return $this->unserializeIfApplicable($data['callback']);
+    }
+
+    /**
+     * Unserialize the string if is a serialized closure.
+     *
+     * @param  string  $callback
+     * @return \Closure|string
+     */
+    protected function unserializeIfApplicable($callback)
+    {
+        if (Str::contains($callback, 'SerializableClosure')) {
+            return (new Serializer)->unserialize($callback);
         }
 
-        return $data['callback'];
+        return $callback;
     }
 
     /**


### PR DESCRIPTION
I analyzed execution speed of the phpunit test suite and noted some bottlenecks. The biggest one is the closure serialization using the AstAnalyzer, which is very slow even on a very simple closure.

Hence the work here, which of course has room for improvement.
It would be great to be able to easily switch closure serialization mechanism. Maybe someone would want to use the much faster TokenAnalyzer, or try Opis Closure (note it doesn't have the same syntax as SuperClosure).

There is also closure serialization code in the Queue class, maybe there is some DRY possible.
