### PR TITLE
[5.2] HasManyThrough over a polymorphic relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -883,7 +883,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string|null  $localKey
      * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
-    public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null)
+    public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $morphColumn = null, $morphType = null, $localKey = null)
     {
         $through = new $through;
 
@@ -893,7 +893,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $localKey = $localKey ?: $this->getKeyName();
 
-        return new HasManyThrough((new $related)->newQuery(), $this, $through, $firstKey, $secondKey, $localKey);
+        return new HasManyThrough((new $related)->newQuery(), $this, $through, $firstKey, $secondKey, $morphColumn, $morphType, $localKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -883,7 +883,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string|null  $localKey
      * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
-    public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $morphColumn = null, $morphType = null, $localKey = null)
+    public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null, $morphTypeColumn = null, $morphTypeValue = null)
     {
         $through = new $through;
 
@@ -893,7 +893,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $localKey = $localKey ?: $this->getKeyName();
 
-        return new HasManyThrough((new $related)->newQuery(), $this, $through, $firstKey, $secondKey, $morphColumn, $morphType, $localKey);
+        return new HasManyThrough((new $related)->newQuery(), $this, $through, $firstKey, $secondKey, $localKey, $morphTypeColumn, $morphTypeValue);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -883,7 +883,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  string|null  $localKey
      * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
      */
-    public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null, $morphTypeColumn = null, $morphTypeValue = null)
+    public function hasManyThrough($related, $through, $firstKey = null, $secondKey = null, $localKey = null, $morphTypeColumn = null)
     {
         $through = new $through;
 
@@ -893,6 +893,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $localKey = $localKey ?: $this->getKeyName();
 
+        $morphTypeValue = $related;
+        
         return new HasManyThrough((new $related)->newQuery(), $this, $through, $firstKey, $secondKey, $localKey, $morphTypeColumn, $morphTypeValue);
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -894,7 +894,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $localKey = $localKey ?: $this->getKeyName();
 
         $morphTypeValue = $related;
-        
+
         return new HasManyThrough((new $related)->newQuery(), $this, $through, $firstKey, $secondKey, $localKey, $morphTypeColumn, $morphTypeValue);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -38,6 +38,20 @@ class HasManyThrough extends Relation
      * @var string
      */
     protected $localKey;
+    
+    /**
+     * The `type` column's name of a polymorphic relation.
+     *
+     * @var string
+     */
+    protected $morphTypeColumn;
+    
+    /**
+     * The `type` column's value of a polymorphic relation.
+     *
+     * @var string
+     */
+    protected $morphTypeValue;
 
     /**
      * Create a new has many through relationship instance.
@@ -50,12 +64,14 @@ class HasManyThrough extends Relation
      * @param  string  $localKey
      * @return void
      */
-    public function __construct(Builder $query, Model $farParent, Model $parent, $firstKey, $secondKey, $localKey)
+    public function __construct(Builder $query, Model $farParent, Model $parent, $firstKey, $secondKey, $localKey, $morphTypeColumn, $morphTypeValue)
     {
         $this->localKey = $localKey;
         $this->firstKey = $firstKey;
         $this->secondKey = $secondKey;
         $this->farParent = $farParent;
+        $this->morphTypeColumn = $morphTypeColumn;
+        $this->morphTypeValue = $morphTypeValue;
 
         parent::__construct($query, $parent);
     }
@@ -113,6 +129,10 @@ class HasManyThrough extends Relation
 
         $query->join($this->parent->getTable(), $this->getQualifiedParentKeyName(), '=', $foreignKey);
 
+        if (!is_null($this->morphTypeColumn)) {
+            $query->where($this->morphTypeColumn, $this->morphTypeValue);
+        }
+        
         if ($this->parentSoftDeletes()) {
             $query->whereNull($this->parent->getQualifiedDeletedAtColumn());
         }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -38,14 +38,14 @@ class HasManyThrough extends Relation
      * @var string
      */
     protected $localKey;
-    
+
     /**
      * The `type` column's name of a polymorphic relation.
      *
      * @var string
      */
     protected $morphTypeColumn;
-    
+
     /**
      * The `type` column's value of a polymorphic relation.
      *
@@ -129,7 +129,7 @@ class HasManyThrough extends Relation
 
         $query->join($this->parent->getTable(), $this->getQualifiedParentKeyName(), '=', $foreignKey);
 
-        if (!is_null($this->morphTypeColumn)) {
+        if (! is_null($this->morphTypeColumn)) {
             $query->where($this->morphTypeColumn, $this->morphTypeValue);
         }
         

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -132,7 +132,7 @@ class HasManyThrough extends Relation
         if (! is_null($this->morphTypeColumn)) {
             $query->where($this->morphTypeColumn, $this->morphTypeValue);
         }
-        
+
         if ($this->parentSoftDeletes()) {
             $query->whereNull($this->parent->getQualifiedDeletedAtColumn());
         }


### PR DESCRIPTION
`HasManyThrough` couldn't fetch right rows over a polymorphic relation. This PR will handle this issue correctly. 

Table 1: `Users`

```
id
name
```

Table 2: `Invoices`

```
id
user_id
invoiceable_id
invoiceable_type
```

Table 3: `Commissions`

```
id
invoice_id
amount
```

Models:

`Invoice`'s Model:

```
<?php
.
.
.
class Invoice extends Model
{
    public function invoiceable()
    {
        return $this->morphTo();
    }

    public function commission()
    {
        return $this->hasOne('\App\Commission');
    }
}
```

`Commission`'s Model:

```
<?php
.
.
.
class Commission extends Model
{
    public function invoice()
    {
        return $this->morphOne('\App\Invoice');
    }
}
```

`User`'s Model:

```
<?php
.
.
.
class User extends Model
{
    public function invoices()
    {
        return $this->hasMany('\App\Invoice');
    }

    public function commissions()
    {
        return $this->hasManyThrough('\App\Commission', '\App\Invoice', 'invoiceable_id', 'invoice_id', null, 'invoiceable_type');
    }
}
```
