### PR TITLE
[5.2] It is redundant to pass grammar and processor to Builder constructor

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -212,12 +212,12 @@ class Builder
      * @return void
      */
     public function __construct(ConnectionInterface $connection,
-                                Grammar $grammar,
-                                Processor $processor)
+                                Grammar $grammar = null,
+                                Processor $processor = null)
     {
-        $this->grammar = $grammar;
-        $this->processor = $processor;
         $this->connection = $connection;
+        $this->grammar = $grammar ?: $connection->getQueryGrammar();
+        $this->processor = $processor ?: $connection->getPostProcessor();
     }
 
     /**


### PR DESCRIPTION
They can just be inferred from the connection.

This change is fully backward compatible, and still allows to pass grammar/processor to the Builder constructor (maybe someone has developed some esoteric connection class which doesn't have grammar/processor properties, who knows?).

This change would allow to do:

```
$connection = DB::connection();
$qb = new ExtendedQueryBuilder($connection);
```

Instead of:

```
$connection = DB::connection();
$qb = new ExtendedQueryBuilder($connection, $connection->getQueryGrammar(), $connection->getPostProcessor());
```
