### PR TITLE
[5.2] Add missing typehint for consistency

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -195,7 +195,7 @@ if (! function_exists('array_last')) {
      * @param  mixed  $default
      * @return mixed
      */
-    function array_last($array, $callback = null, $default = null)
+    function array_last($array, callable $callback = null, $default = null)
     {
         return Arr::last($array, $callback, $default);
     }


### PR DESCRIPTION
`array_first()`, `Arr::first()` and `Arr::last()` are already typehinted, seems like it was missing here.
