### PR TITLE
[5.2] Add @set and @unset to Blade

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -707,6 +707,28 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Compile the set statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileSet($expression)
+    {
+        return "<?php {$expression}; ?>";
+    }
+
+    /**
+     * Compile the unset statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileUnset($expression)
+    {
+        return "<?php unset{$expression}; ?>";
+    }
+
+    /**
      * Compile the extends statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -476,6 +476,22 @@ empty
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testSetStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@set ($set = true)';
+        $expected = '<?php ($set = true); ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testUnsetStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@unset ($unset)';
+        $expected = '<?php unset($unset); ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     public function testStatementThatContainsNonConsecutiveParanthesisAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
Since you added `@continue` and `@break` I think these ones could be useful as well. 

Adding variables to the view can be useful at a _presentation level_

For example in `welcome.blade.php` I want to add a custom title without using `@yield` / `@section` so I can do:

// welcome.blade.php
`@set ($title = "Welcome to website!")`

// layout.blade.php
And then `{{ $title or "Website" }}`

Or I could set a flag to show / hide some sections, add custom CSS classes, etc. 
