### PR TITLE
[5.2] csrf_meta_tag() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -265,6 +265,18 @@ if (! function_exists('csrf_field')) {
     }
 }
 
+if (! function_exists('csrf_meta_tag')) {
+    /**
+     * Generate a CSRF token meta tag.
+     *
+     * @return string
+     */
+    function csrf_meta_tag()
+    {
+        return new HtmlString('<meta name="csrf-token" content="'.csrf_token().'">');
+    }
+}
+
 if (! function_exists('csrf_token')) {
     /**
      * Get the CSRF token value.


### PR DESCRIPTION
`csrf_field()` helper has been warmly welcommed by the community.

What about going one step further?

If you are curious, those crazy Rails folks have a similar one https://github.com/rails/rails/blob/7f18ea14c893cb5c9f04d4fda9661126758332b5/railties/lib/rails/generators/rails/plugin/templates/app/views/layouts/%25namespaced_name%25/application.html.erb.tt#L7

Not sure between `csrf_meta_tag()` and `csrf_meta()`
