### PR TITLE
[5.3] Cast bindings to array to ease singlular whereRaw bindings

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -557,13 +557,15 @@ class Builder
      * Add a raw where clause to the query.
      *
      * @param  string  $sql
-     * @param  array   $bindings
+     * @param  mixed   $bindings
      * @param  string  $boolean
      * @return $this
      */
-    public function whereRaw($sql, array $bindings = [], $boolean = 'and')
+    public function whereRaw($sql, $bindings = [], $boolean = 'and')
     {
         $type = 'raw';
+
+        $bindings = (array) $bindings;
 
         $this->wheres[] = compact('type', 'sql', 'boolean');
 


### PR DESCRIPTION
This change just makes it a little easier when writing raw where statements which only have a single binding. For example, this code...

``` php
DB::table('users')->whereRaw('YEAR(created_at) = ?', [2016])->get();
```

Could be replaced with...

``` php
DB::table('users')->whereRaw('YEAR(created_at) = ?', 2016)->get();
```

By simply casting the parameter to an array if it is not already.
