### PR TITLE
Remove unnecessary else statement.

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -88,9 +88,9 @@ class AuthManager implements FactoryContract
 
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($name, $config);
-        } else {
-            return $this->{'create'.ucfirst($config['driver']).'Driver'}($name, $config);
         }
+
+        return $this->{'create'.ucfirst($config['driver']).'Driver'}($name, $config);
     }
 
     /**


### PR DESCRIPTION
Cleanup AuthManager::resolve() protected method by removing the else statement.
