### PR TITLE
[5.2] Make custom blade directive overwrites a core directive

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -266,10 +266,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         $callback = function ($match) {
-            if (method_exists($this, $method = 'compile'.ucfirst($match[1]))) {
-                $match[0] = $this->$method(Arr::get($match, 3));
-            } elseif (isset($this->customDirectives[$match[1]])) {
+            if (isset($this->customDirectives[$match[1]])) {
                 $match[0] = call_user_func($this->customDirectives[$match[1]], Arr::get($match, 3));
+            } elseif (method_exists($this, $method = 'compile'.ucfirst($match[1]))) {
+                $match[0] = $this->$method(Arr::get($match, 3));
             }
 
             return isset($match[3]) ? $match[0] : $match[0].$match[2];

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -615,6 +615,18 @@ empty
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testCustomExtensionOverwritesCore()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $compiler->directive('foreach', function ($expression) {
+            return '<?php custom(); ?>';
+        });
+
+        $string = '@foreach';
+        $expected = '<?php custom(); ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     public function testRawTagsCanBeSetToLegacyValues()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
Currently there's no way to overwrite a core blade directive compilation, so if a developer did register a custom directive `@php()` and then the core team decided to add a new directive to the framework with the same name, the core directive compilation will overwrite the custom one.

This might break the developer's app, in this PR I propose using the custom directive compilation if found and overwrite the core compilation.
