### PR TITLE
[5.2] Remove unused method postLogin

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -43,17 +43,6 @@ trait AuthenticatesUsers
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function postLogin(Request $request)
-    {
-        return $this->login($request);
-    }
-
-    /**
-     * Handle a login request to the application.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
     public function login(Request $request)
     {
         $this->validateLogin($request);


### PR DESCRIPTION
The postLogin method is not used. On **Illuminate/Routing/Router.php** the post login route is registered as 
`$this->post('login',` `'Auth\AuthController@login');`

If there is no logic of postLogin method, I suggest to remove it. (it's confusing).
