### PR TITLE
[5.2] Migration tags

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -100,7 +100,7 @@ class MigrateCommand extends BaseCommand
             // so that migrations may be run for any path within the applications.
             if (! is_null($path = $this->input->getOption('path'))) {
                 $path = $this->laravel->basePath().'/'.$path;
-            } elseif (! is_null($tag)) {
+            } elseif (! empty($tag)) {
                 $path = $this->laravel->basePath().'/'.$this->migrator->getTagPath($tag);
             } else {
                 $path = $this->getMigrationPath();

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -100,7 +100,7 @@ class MigrateCommand extends BaseCommand
             // so that migrations may be run for any path within the applications.
             if (! is_null($path = $this->input->getOption('path'))) {
                 $path = $this->laravel->basePath().'/'.$path;
-            } elseif (! empty($tag)) {
+            } elseif (! is_null($tag)) {
                 $path = $this->laravel->basePath().'/'.$this->migrator->getTagPath($tag);
             } else {
                 $path = $this->getMigrationPath();

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -63,8 +63,7 @@ class MigrateCommand extends BaseCommand
             $tags = $this->migrator->getAllTags();
 
             foreach ($tags as $tag => $path) {
-
-                $this->output->writeln("Running Migrations for tag: " . $tag);
+                $this->output->writeln('Running Migrations for tag: '.$tag);
 
                 $this->call('migrate', [
                     '--pretend' => $this->input->getOption('pretend'),
@@ -74,10 +73,9 @@ class MigrateCommand extends BaseCommand
                     '--step' => $this->input->getOption('step'),
                     '--tag' => $tag,
                 ]);
-
             }
 
-            $this->output->writeln("Running Core Migrations");
+            $this->output->writeln('Running Core Migrations');
 
             // Then call the default tag
             $this->call('migrate', [
@@ -87,7 +85,6 @@ class MigrateCommand extends BaseCommand
                 '--path' => $this->input->getOption('path'),
                 '--step' => $this->input->getOption('step'),
             ]);
-
         } else {
             // The pretend option can be used for "simulating" the migration and grabbing
             // the SQL queries that would fire if the migration were to be run against
@@ -112,7 +109,7 @@ class MigrateCommand extends BaseCommand
             $this->migrator->run($path, [
                 'pretend' => $pretend,
                 'step' => $this->input->getOption('step'),
-                'tag' => $tag
+                'tag' => $tag,
             ]);
 
             // Once the migrator has run we will grab the note output and send it out to

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -41,8 +41,17 @@ class RefreshCommand extends Command
 
         $path = $this->input->getOption('path');
 
+        // Fetch the tag/tags this command is run against, can be empty thats not an issue
+        // its by design meaning "core" migrations are run with an empty tag
+        $tag = $this->input->getOption('tag');
+
+        $tags = $this->input->getOption('tag');
+
         $this->call('migrate:reset', [
-            '--database' => $database, '--force' => $force,
+            '--database' => $database,
+            '--force' => $force,
+            '--tag' => $tag,
+            '--tags' => $tags
         ]);
 
         // The refresh command is essentially just a brief aggregate of a few other of
@@ -52,6 +61,8 @@ class RefreshCommand extends Command
             '--database' => $database,
             '--force' => $force,
             '--path' => $path,
+            '--tag' => $tag,
+            '--tags' => $tags
         ]);
 
         if ($this->needsSeeding()) {
@@ -103,6 +114,10 @@ class RefreshCommand extends Command
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run.'],
 
             ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder.'],
+
+            ['tag', null, InputOption::VALUE_OPTIONAL, 'Rollback migrations for a specific tag.'],
+
+            ['tags', null, InputOption::VALUE_NONE, 'Rollback migrations for all tags.'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -51,7 +51,7 @@ class RefreshCommand extends Command
             '--database' => $database,
             '--force' => $force,
             '--tag' => $tag,
-            '--tags' => $tags
+            '--tags' => $tags,
         ]);
 
         // The refresh command is essentially just a brief aggregate of a few other of
@@ -62,7 +62,7 @@ class RefreshCommand extends Command
             '--force' => $force,
             '--path' => $path,
             '--tag' => $tag,
-            '--tags' => $tags
+            '--tags' => $tags,
         ]);
 
         if ($this->needsSeeding()) {

--- a/src/Illuminate/Database/Console/Migrations/ResetCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/ResetCommand.php
@@ -69,8 +69,7 @@ class ResetCommand extends Command
             $tags = $this->migrator->getAllTags();
 
             foreach ($tags as $tag => $path) {
-
-                $this->output->writeln("Resetting Migrations for tag: " . $tag);
+                $this->output->writeln('Resetting Migrations for tag: '.$tag);
 
                 $this->call('migrate:reset', [
                     '--pretend' => $this->input->getOption('pretend'),
@@ -78,10 +77,9 @@ class ResetCommand extends Command
                     '--force' => $this->input->getOption('force'),
                     '--tag' => $tag,
                 ]);
-
             }
 
-            $this->output->writeln("Resetting Core Migrations");
+            $this->output->writeln('Resetting Core Migrations');
 
             // Then call the default tag
             $this->call('migrate:reset', [

--- a/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RollbackCommand.php
@@ -60,7 +60,11 @@ class RollbackCommand extends Command
 
         $pretend = $this->input->getOption('pretend');
 
-        $this->migrator->rollback($pretend);
+        // Fetch the tag this command is run against, can be empty thats not an issue
+        // its by design meaning "core" migrations are run with an empty tag
+        $tag = $this->input->getOption('tag');
+
+        $this->migrator->rollback($pretend, $tag);
 
         // Once the migrator has run we will grab the note output and send it out to
         // the console screen, since the migrator itself functions without having
@@ -83,6 +87,8 @@ class RollbackCommand extends Command
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
 
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run.'],
+
+            ['tag', null, InputOption::VALUE_OPTIONAL, 'Rollback last migrations batch for a specific tag.'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -54,13 +54,19 @@ class StatusCommand extends BaseCommand
 
         $this->migrator->setConnection($this->input->getOption('database'));
 
+        // Fetch the tag this command is run against, can be empty thats not an issue
+        // its by design meaning "core" migrations are run with an empty tag
+        $tag = $this->input->getOption('tag');
+
         if (! is_null($path = $this->input->getOption('path'))) {
             $path = $this->laravel->basePath().'/'.$path;
+        } elseif (! empty($tag)) {
+            $path = $this->laravel->basePath().'/'.$this->migrator->getTagPath($tag);
         } else {
             $path = $this->getMigrationPath();
         }
 
-        $ran = $this->migrator->getRepository()->getRan();
+        $ran = $this->migrator->getRepository()->getRan($tag);
 
         $migrations = [];
 
@@ -97,6 +103,8 @@ class StatusCommand extends BaseCommand
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use.'],
 
             ['path', null, InputOption::VALUE_OPTIONAL, 'The path of migrations files to use.'],
+
+            ['tag', null, InputOption::VALUE_OPTIONAL, 'Run migrations for a specific tag.'],
         ];
     }
 }

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -132,9 +132,9 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
             // table to hold the migration file's path as well as the tag and batch ID.
             $table->string('migration');
 
-            $table->string('tag');
-
             $table->integer('batch');
+
+            $table->string('tag')->nullable();
         });
     }
 
@@ -151,19 +151,29 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
+     * Add the tags column if needed
+     *
+     * @return void
+     */
+    public function addTagColumn()
+    {
+        $schema = $this->getConnection()->getSchemaBuilder();
+
+        $schema->table($this->table, function ($table) {
+            $table->string('tag')->nullable();
+        });
+    }
+
+    /**
      * Determine if the migration repository has the tag column
      *
      * @return bool
      */
     public function repositoryTagColumnExists()
     {
-        if($this->repositoryExists())
-        {
-            $schema = $this->getConnection()->getSchemaBuilder();
-            return $schema->hasColumn($this->table, 'tag');
-        }
+        $schema = $this->getConnection()->getSchemaBuilder();
 
-        return false;
+        return $schema->hasColumn($this->table, 'tag');
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -43,11 +43,13 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     /**
      * Get the ran migrations.
      *
+     * @param string $tag
      * @return array
      */
-    public function getRan()
+    public function getRan($tag = '')
     {
         return $this->table()
+                ->where('tag', $tag)
                 ->orderBy('batch', 'asc')
                 ->orderBy('migration', 'asc')
                 ->pluck('migration');
@@ -56,11 +58,12 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     /**
      * Get the last migration batch.
      *
+     * @param  string $tag
      * @return array
      */
-    public function getLast()
+    public function getLast($tag = '')
     {
-        $query = $this->table()->where('batch', $this->getLastBatchNumber());
+        $query = $this->table()->where('tag', $tag)->where('batch', $this->getLastBatchNumber());
 
         return $query->orderBy('migration', 'desc')->get();
     }
@@ -70,11 +73,12 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      *
      * @param  string  $file
      * @param  int     $batch
+     * @param  string  $tag
      * @return void
      */
-    public function log($file, $batch)
+    public function log($file, $batch, $tag = '')
     {
-        $record = ['migration' => $file, 'batch' => $batch];
+        $record = ['migration' => $file, 'batch' => $batch, 'tag' => $tag];
 
         $this->table()->insert($record);
     }
@@ -83,31 +87,34 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      * Remove a migration from the log.
      *
      * @param  object  $migration
+     * @param  string  $tag
      * @return void
      */
-    public function delete($migration)
+    public function delete($migration, $tag = '')
     {
-        $this->table()->where('migration', $migration->migration)->delete();
+        $this->table()->where('migration', $migration->migration)->where('tag', $tag)->delete();
     }
 
     /**
      * Get the next migration batch number.
      *
+     * @param  string  $tag
      * @return int
      */
-    public function getNextBatchNumber()
+    public function getNextBatchNumber($tag = '')
     {
-        return $this->getLastBatchNumber() + 1;
+        return $this->getLastBatchNumber($tag) + 1;
     }
 
     /**
      * Get the last migration batch number.
      *
+     * @param  string  $tag
      * @return int
      */
-    public function getLastBatchNumber()
+    public function getLastBatchNumber($tag = '')
     {
-        return $this->table()->max('batch');
+        return $this->table()->where('tag', $tag)->max('batch');
     }
 
     /**
@@ -122,8 +129,10 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
         $schema->create($this->table, function ($table) {
             // The migrations table is responsible for keeping track of which of the
             // migrations have actually run for the application. We'll create the
-            // table to hold the migration file's path as well as the batch ID.
+            // table to hold the migration file's path as well as the tag and batch ID.
             $table->string('migration');
+
+            $table->string('tag');
 
             $table->integer('batch');
         });
@@ -139,6 +148,22 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
         $schema = $this->getConnection()->getSchemaBuilder();
 
         return $schema->hasTable($this->table);
+    }
+
+    /**
+     * Determine if the migration repository has the tag column
+     *
+     * @return bool
+     */
+    public function repositoryTagColumnExists()
+    {
+        if($this->repositoryExists())
+        {
+            $schema = $this->getConnection()->getSchemaBuilder();
+            return $schema->hasColumn($this->table, 'tag');
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -151,7 +151,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * Add the tags column if needed
+     * Add the tags column if needed.
      *
      * @return void
      */
@@ -165,7 +165,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     }
 
     /**
-     * Determine if the migration repository has the tag column
+     * Determine if the migration repository has the tag column.
      *
      * @return bool
      */

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -7,40 +7,45 @@ interface MigrationRepositoryInterface
     /**
      * Get the ran migrations for a given package.
      *
+     * @param  string $tag
      * @return array
      */
-    public function getRan();
+    public function getRan($tag = '');
 
     /**
      * Get the last migration batch.
      *
+     * @param  string $tag
      * @return array
      */
-    public function getLast();
+    public function getLast($tag = '');
 
     /**
      * Log that a migration was run.
      *
      * @param  string  $file
      * @param  int     $batch
+     * @param  string $tag
      * @return void
      */
-    public function log($file, $batch);
+    public function log($file, $batch, $tag = '');
 
     /**
      * Remove a migration from the log.
      *
      * @param  object  $migration
+     * @param  string $tag
      * @return void
      */
-    public function delete($migration);
+    public function delete($migration, $tag = '');
 
     /**
      * Get the next migration batch number.
      *
+     * @param  string $tag
      * @return int
      */
-    public function getNextBatchNumber();
+    public function getNextBatchNumber($tag = '');
 
     /**
      * Create the migration repository data store.
@@ -55,6 +60,13 @@ interface MigrationRepositoryInterface
      * @return bool
      */
     public function repositoryExists();
+
+    /**
+     * Determine if the migration repository has the tag column
+     *
+     * @return bool
+     */
+    public function repositoryTagColumnExists();
 
     /**
      * Set the information source to gather data.

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -62,14 +62,14 @@ interface MigrationRepositoryInterface
     public function repositoryExists();
 
     /**
-     * Determine if the migration repository has the tag column
+     * Determine if the migration repository has the tag column.
      *
      * @return bool
      */
     public function repositoryTagColumnExists();
 
     /**
-     * Add the tags column if needed
+     * Add the tags column if needed.
      *
      * @return void
      */

--- a/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
+++ b/src/Illuminate/Database/Migrations/MigrationRepositoryInterface.php
@@ -69,6 +69,13 @@ interface MigrationRepositoryInterface
     public function repositoryTagColumnExists();
 
     /**
+     * Add the tags column if needed
+     *
+     * @return void
+     */
+    public function addTagColumn();
+
+    /**
      * Set the information source to gather data.
      *
      * @param  string  $name

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -45,7 +45,7 @@ class Migrator
     protected $notes = [];
 
     /**
-     * Map of tag names to paths
+     * Map of tag names to paths.
      */
     protected $tags = [];
 
@@ -67,7 +67,7 @@ class Migrator
     }
 
     /**
-     * Register a tag path on the migrator instance
+     * Register a tag path on the migrator instance.
      *
      * @param  string $tag
      * @param  string $path
@@ -81,7 +81,7 @@ class Migrator
     }
 
     /**
-     * Fetch a path by tag
+     * Fetch a path by tag.
      *
      * @param  string $tag
      * @return string $path
@@ -92,7 +92,7 @@ class Migrator
     }
 
     /**
-     * Fetch all registered tags
+     * Fetch all registered tags.
      *
      * @return array $tags
      */
@@ -461,7 +461,7 @@ class Migrator
     }
 
     /**
-     * Add the tags column if needed
+     * Add the tags column if needed.
      *
      * @return void
      */

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -18,9 +18,10 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => false, 'tag' => '']);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $migrator->shouldReceive('repositoryTagColumnExists')->once()->andReturn(true);
 
         $this->runCommand($command);
     }
@@ -33,10 +34,27 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => false, 'tag' => '']);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
         $command->expects($this->once())->method('call')->with($this->equalTo('migrate:install'), $this->equalTo(['--database' => null]));
+
+        $this->runCommand($command);
+    }
+
+    public function testMigrationRepositoryTagColumnAddedWhenNecessary()
+    {
+        $params = [$migrator = m::mock('Illuminate\Database\Migrations\Migrator'), __DIR__.'/vendor'];
+        $command = $this->getMock('Illuminate\Database\Console\Migrations\MigrateCommand', ['call'], $params);
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => false, 'tag' => '']);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $migrator->shouldReceive('repositoryTagColumnExists')->once()->andReturn(false);
+        $migrator->shouldReceive('addTagColumn')->once()->andReturn(false);
 
         $this->runCommand($command);
     }
@@ -48,9 +66,10 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => true, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => true, 'step' => false, 'tag' => '']);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $migrator->shouldReceive('repositoryTagColumnExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--pretend' => true]);
     }
@@ -62,9 +81,10 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with('foo');
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => false, 'tag' => '']);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $migrator->shouldReceive('repositoryTagColumnExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--database' => 'foo']);
     }
@@ -76,9 +96,10 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => true]);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => true, 'tag' => '']);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $migrator->shouldReceive('repositoryTagColumnExists')->once()->andReturn(true);
 
         $this->runCommand($command, ['--step' => true]);
     }

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -17,6 +17,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase
         $connectionMock = m::mock('Illuminate\Database\Connection');
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+        $query->shouldReceive('where')->once()->with('tag', '')->andReturn($query);
         $query->shouldReceive('orderBy')->once()->with('batch', 'asc')->andReturn($query);
         $query->shouldReceive('orderBy')->once()->with('migration', 'asc')->andReturn($query);
         $query->shouldReceive('pluck')->once()->with('migration')->andReturn('bar');
@@ -34,6 +35,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase
         $connectionMock = m::mock('Illuminate\Database\Connection');
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+        $query->shouldReceive('where')->once()->with('tag', '')->andReturn($query);
         $query->shouldReceive('where')->once()->with('batch', 1)->andReturn($query);
         $query->shouldReceive('orderBy')->once()->with('migration', 'desc')->andReturn($query);
         $query->shouldReceive('get')->once()->andReturn('foo');
@@ -48,7 +50,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase
         $connectionMock = m::mock('Illuminate\Database\Connection');
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
-        $query->shouldReceive('insert')->once()->with(['migration' => 'bar', 'batch' => 1]);
+        $query->shouldReceive('insert')->once()->with(['migration' => 'bar', 'batch' => 1, 'tag' => '']);
 
         $repo->log('bar', 1);
     }
@@ -60,6 +62,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase
         $connectionMock = m::mock('Illuminate\Database\Connection');
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+        $query->shouldReceive('where')->once()->with('tag', '')->andReturn($query);
         $query->shouldReceive('where')->once()->with('migration', 'foo')->andReturn($query);
         $query->shouldReceive('delete')->once();
         $migration = (object) ['migration' => 'foo'];
@@ -84,6 +87,7 @@ class DatabaseMigrationRepositoryTest extends PHPUnit_Framework_TestCase
         $connectionMock = m::mock('Illuminate\Database\Connection');
         $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
         $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+        $query->shouldReceive('where')->once()->with('tag', '')->andReturn($query);
         $query->shouldReceive('max')->once()->andReturn(1);
 
         $this->assertEquals(1, $repo->getLastBatchNumber());

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -16,7 +16,7 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase
         $command->setLaravel(new AppDatabaseMigrationStub());
         $migrator->shouldReceive('setConnection')->once()->with(null);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
-        $migrator->shouldReceive('reset')->once()->with(false);
+        $migrator->shouldReceive('reset')->once()->with(false, '');
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command);
@@ -28,7 +28,7 @@ class DatabaseMigrationResetCommandTest extends PHPUnit_Framework_TestCase
         $command->setLaravel(new AppDatabaseMigrationStub());
         $migrator->shouldReceive('setConnection')->once()->with('foo');
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
-        $migrator->shouldReceive('reset')->once()->with(true);
+        $migrator->shouldReceive('reset')->once()->with(true, '');
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -16,7 +16,7 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase
         $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $command->setLaravel(new AppDatabaseMigrationRollbackStub());
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('rollback')->once()->with(false);
+        $migrator->shouldReceive('rollback')->once()->with(false, '');
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command);
@@ -27,7 +27,7 @@ class DatabaseMigrationRollbackCommandTest extends PHPUnit_Framework_TestCase
         $command = new RollbackCommand($migrator = m::mock('Illuminate\Database\Migrations\Migrator'));
         $command->setLaravel(new AppDatabaseMigrationRollbackStub());
         $migrator->shouldReceive('setConnection')->once()->with('foo');
-        $migrator->shouldReceive('rollback')->once()->with(true);
+        $migrator->shouldReceive('rollback')->once()->with(true, '');
         $migrator->shouldReceive('getNotes')->andReturn([]);
 
         $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -29,9 +29,9 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase
         $migrator->getRepository()->shouldReceive('getRan')->once()->andReturn([
             '1_foo',
         ]);
-        $migrator->getRepository()->shouldReceive('getNextBatchNumber')->once()->andReturn(1);
-        $migrator->getRepository()->shouldReceive('log')->once()->with('2_bar', 1);
-        $migrator->getRepository()->shouldReceive('log')->once()->with('3_baz', 1);
+        $migrator->getRepository()->shouldReceive('getNextBatchNumber')->once()->with('')->andReturn(1);
+        $migrator->getRepository()->shouldReceive('log')->once()->with('2_bar', 1, '');
+        $migrator->getRepository()->shouldReceive('log')->once()->with('3_baz', 1, '');
         $barMock = m::mock('stdClass');
         $barMock->shouldReceive('up')->once();
         $bazMock = m::mock('stdClass');


### PR DESCRIPTION
as discussed in https://github.com/laravel/framework/issues/12558 this adds the ability to "tag" locations for migrations.

By no means the finished product, but i think theres enough here to get feedback.

In its current state all existing migration tests pass, which is key to BC. Ive modified the test mock objects slightly, only to expect and return the right values, not the functionality of the tests.

usage without "tagging" is exactly the same, usage with "tags" is like this:

**Register a "tagged" migration location (probably called in package service providers)**

```
Migrator::tag('tagname', __DIR__ . '../migrations');
```

Links "mytag" to that location

**Migrate Command**

```
php artisan migrate // same as before

php artisan migrate --tag=mytag // runs all migrations registered for "mytag"

php artisan migrate --tags //runs all migrations for all registered tags by internally calling the migrate command with --tag=xx
```

**Migrate Rollback**

Doesnt have `--tags` option as would be confusing, can use --tag=xxx to rollback specific tag

**Migrate Reset**

Has both `--tag=xx` and `--tags` options, and works just like the migrate command

**Migrate Refresh**

Calls reset and migrate internally so wasnt much work, has both `--tag=xx` and `--tags` options.

As i said above all current tests work as expected, admittedly i havent created new test methods to test the new functionality *yet but wanted to gather a little feedback before proceeding any further.
