### PR TITLE
[5.2] @php and @endphp

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -714,7 +714,18 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compilePhp($expression)
     {
-        return "<?php {$expression}; ?>";
+        return $expression ? "<?php {$expression}; ?>" : '<?php ';
+    }
+
+    /**
+     * Compile end-php statement into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileEndphp($expression)
+    {
+        return ' ?>';
     }
 
     /**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -476,11 +476,27 @@ empty
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
-    public function testPhpStatementsAreCompiled()
+    public function testPhpStatementsWithExpressionAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $string = '@php($set = true)';
         $expected = '<?php ($set = true); ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testPhpStatementsWithoutExpressionAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@php';
+        $expected = '<?php ';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testEndphpStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@endphp';
+        $expected = ' ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 


### PR DESCRIPTION
Follows #12545
With the appearance of `@php($foo = 'bar')`, it makes sense to allow using this tag as a block too.

This works very similar to the Envoy's `@setup` tag

```
@php
    $now = new DateTime();

    $environment = isset($env) ? $env : "testing";
@endphp
```

After this change you can litterally get rid of php tags in any view.
