### PR TITLE
[5.2] Replace attributes for array keys in validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1943,7 +1943,7 @@ class Validator implements ValidatorContract
         // If no language line has been specified for the attribute all of the
         // underscores are removed from the attribute name and that will be
         // used as default versions of the attribute's displayable names.
-        return str_replace('_', ' ', Str::snake($rawAttribute));
+        return str_replace('_', ' ', Str::snake($attribute));
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1932,8 +1932,8 @@ class Validator implements ValidatorContract
         // The developer may dynamically specify the array of custom attributes
         // on this Validator instance. If the attribute exists in this array
         // it takes precedence over all other ways we can pull attributes.
-        if (isset($this->customAttributes[$attribute])) {
-            return $this->customAttributes[$attribute];
+        if ($customAttribute = $this->getCustomAttribute($attribute)) {
+            return $customAttribute;
         }
 
         $key = "validation.attributes.{$attribute}";
@@ -1949,6 +1949,19 @@ class Validator implements ValidatorContract
         // underscores are removed from the attribute name and that will be
         // used as default versions of the attribute's displayable names.
         return str_replace('_', ' ', Str::snake($attribute));
+    }
+
+    /**
+     * Get the value of a custom attribute.
+     *
+     * @param  string  $attribute
+     * @return string|null
+     */
+    protected function getCustomAttribute($attribute)
+    {
+        return array_first($this->customAttributes, function ($custom) use ($attribute) {
+            return Str::is($custom, $attribute);
+        });
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1167,14 +1167,7 @@ class Validator implements ValidatorContract
      */
     protected function validateDistinct($attribute, $value, $parameters)
     {
-        $rawAttribute = '';
-
-        foreach ($this->implicitAttributes as $raw => $dataAttributes) {
-            if (in_array($attribute, $dataAttributes)) {
-                $rawAttribute = $raw;
-                break;
-            }
-        }
+        $rawAttribute = $this->getRawAttribute($attribute);
 
         $data = Arr::where(Arr::dot($this->data), function ($key) use ($attribute, $rawAttribute) {
             return $key != $attribute &&  Str::is($rawAttribute, $key);
@@ -1929,14 +1922,16 @@ class Validator implements ValidatorContract
      */
     protected function getAttribute($attribute)
     {
+        $rawAttribute = $this->getRawAttribute($attribute);
+
         // The developer may dynamically specify the array of custom attributes
         // on this Validator instance. If the attribute exists in this array
         // it takes precedence over all other ways we can pull attributes.
-        if ($customAttribute = $this->getCustomAttribute($attribute)) {
-            return $customAttribute;
+        if (isset($this->customAttributes[$rawAttribute])) {
+            return $this->customAttributes[$rawAttribute];
         }
 
-        $key = "validation.attributes.{$attribute}";
+        $key = "validation.attributes.{$rawAttribute}";
 
         // We allow for the developer to specify language lines for each of the
         // attributes allowing for more displayable counterparts of each of
@@ -1948,20 +1943,27 @@ class Validator implements ValidatorContract
         // If no language line has been specified for the attribute all of the
         // underscores are removed from the attribute name and that will be
         // used as default versions of the attribute's displayable names.
-        return str_replace('_', ' ', Str::snake($attribute));
+        return str_replace('_', ' ', Str::snake($rawAttribute));
     }
 
     /**
-     * Get the value of a custom attribute.
+     * Get the raw attribute name.
      *
      * @param  string  $attribute
      * @return string|null
      */
-    protected function getCustomAttribute($attribute)
+    protected function getRawAttribute($attribute)
     {
-        return array_first($this->customAttributes, function ($custom) use ($attribute) {
-            return Str::is($custom, $attribute);
-        });
+        $rawAttribute = $attribute;
+
+        foreach ($this->implicitAttributes as $raw => $dataAttributes) {
+            if (in_array($attribute, $dataAttributes)) {
+                $rawAttribute = $raw;
+                break;
+            }
+        }
+
+        return $rawAttribute;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -183,6 +183,16 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testAttributeNamesAreReplacedInArrays()
     {
         $trans = $this->getRealTranslator();
+        $trans->addResource('array', [
+            'validation.string' => ':attribute must be a string!',
+            'validation.attributes.name.*' => 'Any name',
+        ], 'en', 'messages');
+        $v = new Validator($trans, ['name' => ['Jon', 2]], ['name.*' => 'string']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('Any name must be a string!', $v->messages()->first('name.1'));
+
+        $trans = $this->getRealTranslator();
         $trans->addResource('array', ['validation.string' => ':attribute must be a string!'], 'en', 'messages');
         $v = new Validator($trans, ['name' => ['Jon', 2]], ['name.*' => 'string']);
         $v->setAttributeNames(['name.*' => 'Any name']);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -180,6 +180,23 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('NAME is required!', $v->messages()->first('name'));
     }
 
+    public function testAttributeNamesAreReplacedInArrays()
+    {
+        $trans = $this->getRealTranslator();
+        $trans->addResource('array', ['validation.string' => ':attribute must be a string!'], 'en', 'messages');
+        $v = new Validator($trans, ['name' => ['Jon', 2]], ['name.*' => 'string']);
+        $v->setAttributeNames(['name.*' => 'Any name']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('Any name must be a string!', $v->messages()->first('name.1'));
+
+        $v = new Validator($trans, ['users' => [['name' => 'Jon'], ['name' => 2]]], ['users.*.name' => 'string']);
+        $v->setAttributeNames(['users.*.name' => 'Any name']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('Any name must be a string!', $v->messages()->first('users.1.name'));
+    }
+
     public function testDisplayableValuesAreReplaced()
     {
         //required_if:foo,bar


### PR DESCRIPTION
As reported in this issue https://github.com/laravel/framework/issues/12548

On array validation setting a custom attribute for `users.*.name` wasn't working, this PR will allow setting an attribute name like this:

```
'attributes' => [
    'users.*.name' => ' User name'
],
```

To get a message like that:

```
The User name must be a string.
```
