### PR TITLE
[5.2] Strengthen closures unserialization in Mailer

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -289,7 +289,7 @@ class Mailer implements MailerContract, MailQueueContract
     protected function getQueuedCallable(array $data)
     {
         if (Str::contains($data['callback'], 'SerializableClosure')) {
-            return unserialize($data['callback'])->getClosure();
+            return (new Serializer)->unserialize($data['callback']);
         }
 
         return $data['callback'];

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -254,8 +254,8 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Build the callable for a queued e-mail job.
      *
-     * @param  mixed  $callback
-     * @return mixed
+     * @param  \Closure|string  $callback
+     * @return string
      */
     protected function buildQueueCallable($callback)
     {
@@ -284,7 +284,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Get the true callable for a queued e-mail message.
      *
      * @param  array  $data
-     * @return mixed
+     * @return \Closure|string
      */
     protected function getQueuedCallable(array $data)
     {


### PR DESCRIPTION
Took the good parts from my laboratory at #12535.

Currently with a malformed string, [`unserialize`](http://php.net/manual/en/function.unserialize.php) would return false (and throw a notice), then a "call method on non-object" error would happen.
With this PR we get proper exceptions instead. See [`Serializer::unserialize`](https://github.com/jeremeamia/super_closure/blob/master/src/Serializer.php).

As a reminder, unserialization isn't tested currently.
