### PR TITLE
[5.3] Preserve numeric keys in callback for Arr::last

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -158,7 +158,7 @@ class Arr
             return empty($array) ? value($default) : end($array);
         }
 
-        return static::first(array_reverse($array), $callback, $default);
+        return static::first(array_reverse($array, true), $callback, $default);
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -83,6 +83,9 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $last = Arr::last($array, function ($key, $value) { return $value < 250; });
         $this->assertEquals(200, $last);
 
+        $last = Arr::last($array, function ($key, $value) { return $key < 2; });
+        $this->assertEquals(200, $last);
+
         $this->assertEquals(300, Arr::last($array));
     }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -79,8 +79,10 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
     public function testLast()
     {
         $array = [100, 200, 300];
-        $last = Arr::last($array, function () { return true; });
-        $this->assertEquals(300, $last);
+
+        $last = Arr::last($array, function ($key, $value) { return $value < 250; });
+        $this->assertEquals(200, $last);
+
         $this->assertEquals(300, Arr::last($array));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -25,6 +25,8 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $data = new Collection([100, 200, 300]);
         $result = $data->last(function ($key, $value) { return $value < 250; });
         $this->assertEquals(200, $result);
+        $result = $data->last(function ($key, $value) { return $key < 2; });
+        $this->assertEquals(200, $result);
     }
 
     public function testLastWithCallbackAndDefault()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -22,9 +22,9 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
     public function testLastWithCallback()
     {
-        $data = new Collection([2, 4, 3, 2]);
-        $result = $data->last(function ($key, $value) { return $value > 2; });
-        $this->assertEquals(3, $result);
+        $data = new Collection([100, 200, 300]);
+        $result = $data->last(function ($key, $value) { return $value < 250; });
+        $this->assertEquals(200, $result);
     }
 
     public function testLastWithCallbackAndDefault()


### PR DESCRIPTION
[`array_reverse`](http://php.net/manual/en/function.array-reverse.php) doesn't preserve numeric keys by default.

Demonstration of the issue:

``` php
$array = ['foo', 'bar', 'baz', 'qux'];
Arr::last($array, function ($key, $value) {
    return $key > 1;
});
// expected: qux
// returned: baz
```

Targetting 5.3, because maybe some people were using `$key` to look for iteration count.
