### PR TITLE
[5.2] Disable view cache if the cache flag is falsy

### DIFF
--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -72,7 +72,9 @@ class ViewServiceProvider extends ServiceProvider
         // this case will be the Blade compiler, so we'll first create the compiler
         // instance to pass into the engine so it can compile the views properly.
         $app->singleton('blade.compiler', function ($app) {
-            $cache = $app['config']['view.compiled'];
+            $cache = $app['config']['view.cache']
+                ? $app['config']['view.compiled']
+                : null;
 
             return new BladeCompiler($app['files'], $cache);
         });


### PR DESCRIPTION
Disable view cache if the cache flag is falsy.
This is pretty useful in development environment, so that the view cache does not have to be flushed all the time.

---

Related to https://github.com/laravel/laravel/pull/3680
