### PR TITLE
[5.2] originalIsNumericallyEquivalent float bug fix

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3174,7 +3174,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         $original = $this->original[$key];
 
-        return is_numeric($current) && is_numeric($original) && strcmp((string) $current, (string) $original) === 0;
+        return is_numeric($current) && is_numeric($original) && strcmp((string)(float) $current, (string)(float) $original) === 0;
     }
 
     /**


### PR DESCRIPTION
not working for floats because of
(string)'1.00' === '1.00'
(string)1.00  === '1'
