### PR TITLE
[5.2] Fixed Request::route() incompatibility with lumen

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -8,6 +8,7 @@ use SplFileInfo;
 use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Routing\Route;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -867,7 +868,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         if (is_null($route) || is_null($param)) {
             return $route;
         } else {
-            return $route->parameter($param);
+            return $route instanceof Route ? $route->parameter($param) : array_get($route[2], $param);
         }
     }
 


### PR DESCRIPTION
When using _laravel/lumen_, calling `$request->router($param)` causes error _Call to a member function parameter() on array_ as the lumen routes are simple arrays instead of _Illuminate\Routing\Route_ objects.
