### PR TITLE
[5.2] Make use of Arr::exists in Arr::has/get

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -264,7 +264,7 @@ class Arr
             return $array;
         }
 
-        if (isset($array[$key])) {
+        if (static::exists($array, $key)) {
             return $array[$key];
         }
 
@@ -292,7 +292,7 @@ class Arr
             return false;
         }
 
-        if (array_key_exists($key, $array)) {
+        if (static::exists($array, $key)) {
             return true;
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -136,11 +136,11 @@ class Arr
      */
     public static function exists($array, $key)
     {
-        if (is_array($array)) {
-            return array_key_exists($key, $array);
+        if ($array instanceof ArrayAccess) {
+            return $array->offsetExists($key);
         }
 
-        return $array->offsetExists($key);
+        return array_key_exists($key, $array);
     }
 
     /**

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -288,7 +288,7 @@ class Arr
      */
     public static function has($array, $key)
     {
-        if (empty($array) || is_null($key)) {
+        if (is_null($key)) {
             return false;
         }
 


### PR DESCRIPTION
Consolidate the codebase, and fixes a very few edge cases, hence targetting 5.2 as it shouldn't be breaking (as more `ArrayAccess` support is very recent):

``` php
$array = ['foo.bar' => null];

array_has($array, 'foo.bar'); // true
array_get($array, 'foo.bar', 'default'); // expected null, returns 'default'

$collection = collect($array);

array_has($collection, 'foo.bar'); // expected true, returns false
array_get($collection, 'foo.bar', 'default'); // null
```

As a reminder, objects extending `ArrayAccess` (for instance Collection) have a few discrepancies about null values, whereas `ArrayObject` actually behaves "correctly" (and can even be passed to array_key_exists).

See JosephSilber's comments and mine at bottom of #6571.
