### PR TITLE
[5.2] Display the attribute name as it is if found to be implicit

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1940,9 +1940,16 @@ class Validator implements ValidatorContract
             return $line;
         }
 
-        // If no language line has been specified for the attribute all of the
-        // underscores are removed from the attribute name and that will be
-        // used as default versions of the attribute's displayable names.
+        // If no language line has been specified for the attribute and
+        // the attribute is found to be an implicit attribute we will
+        // display the raw attribute as a default displayable name.
+        if (isset($this->implicitAttributes[$attributeName])) {
+            return $attribute;
+        }
+
+        // If the attribute is not found to be implicit all of the underscores
+        // are removed from the attribute name and that will be used as
+        // default versions of the attribute's displayable names.
         return str_replace('_', ' ', Str::snake($attribute));
     }
 
@@ -1952,7 +1959,7 @@ class Validator implements ValidatorContract
      * For example, if "name.0" is given, "name.*" will be returned.
      *
      * @param  string  $attribute
-     * @return string|null
+     * @return string
      */
     protected function getPrimaryAttribute($attribute)
     {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -183,6 +183,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     public function testAttributeNamesAreReplacedInArrays()
     {
         $trans = $this->getRealTranslator();
+        $trans->addResource('array', ['validation.required' => ':attribute is required!'], 'en', 'messages');
+        $v = new Validator($trans, ['users' => [['country_code' => 'US'], ['country_code' => null]]], ['users.*.country_code' => 'Required']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('users.1.country_code is required!', $v->messages()->first('users.1.country_code'));
+
+        $trans = $this->getRealTranslator();
         $trans->addResource('array', [
             'validation.string' => ':attribute must be a string!',
             'validation.attributes.name.*' => 'Any name',


### PR DESCRIPTION
For the following array:

```
[
    'users' => [['country_code' => 'US'], ['country_code' => null]]
]
```

An error message will look like:

```
users.1.country code is required.
```

This PR will display the raw attribute name, without replacing _ with space, if the attribute was found to be implicit:

```
users.1.country_code is required.
```
