### PR TITLE
[5.2] Wrap all database indexes and constraints

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -82,6 +82,8 @@ abstract class Grammar extends BaseGrammar
     {
         $table = $this->wrapTable($blueprint);
 
+        $index = $this->wrap($command->index);
+
         $on = $this->wrapTable($command->on);
 
         // We need to prepare several of the elements of the foreign key definition
@@ -91,7 +93,7 @@ abstract class Grammar extends BaseGrammar
 
         $onColumns = $this->columnize((array) $command->references);
 
-        $sql = "alter table {$table} add constraint {$command->index} ";
+        $sql = "alter table {$table} add constraint {$index} ";
 
         $sql .= "foreign key ({$columns}) references {$on} ({$onColumns})";
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -165,7 +165,9 @@ class MySqlGrammar extends Grammar
 
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} add {$type} `{$command->index}`($columns)";
+        $index = $this->wrap($command->index);
+
+        return "alter table {$table} add {$type} {$index}($columns)";
     }
 
     /**
@@ -231,7 +233,9 @@ class MySqlGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} drop index `{$command->index}`";
+        $index = $this->wrap($command->index);
+
+        return "alter table {$table} drop index {$index}";
     }
 
     /**
@@ -245,7 +249,9 @@ class MySqlGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} drop index `{$command->index}`";
+        $index = $this->wrap($command->index);
+
+        return "alter table {$table} drop index {$index}";
     }
 
     /**
@@ -259,7 +265,9 @@ class MySqlGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} drop foreign key `{$command->index}`";
+        $index = $this->wrap($command->index);
+
+        return "alter table {$table} drop foreign key {$index}";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -101,9 +101,11 @@ class PostgresGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
+        $index = $this->wrap($command->index);
+
         $columns = $this->columnize($command->columns);
 
-        return "alter table $table add constraint {$command->index} unique ($columns)";
+        return "alter table $table add constraint {$index} unique ($columns)";
     }
 
     /**
@@ -117,7 +119,9 @@ class PostgresGrammar extends Grammar
     {
         $columns = $this->columnize($command->columns);
 
-        return "create index {$command->index} on ".$this->wrapTable($blueprint)." ({$columns})";
+        $index = $this->wrap($command->index);
+
+        return "create index {$index} on ".$this->wrapTable($blueprint)." ({$columns})";
     }
 
     /**
@@ -171,7 +175,9 @@ class PostgresGrammar extends Grammar
     {
         $table = $blueprint->getTable();
 
-        return 'alter table '.$this->wrapTable($blueprint)." drop constraint {$table}_pkey";
+        $index = $this->wrap("{$table}_pkey");
+
+        return 'alter table '.$this->wrapTable($blueprint)." drop constraint {$index}";
     }
 
     /**
@@ -185,7 +191,9 @@ class PostgresGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} drop constraint {$command->index}";
+        $index = $this->wrap($command->index);
+
+        return "alter table {$table} drop constraint {$index}";
     }
 
     /**
@@ -197,7 +205,9 @@ class PostgresGrammar extends Grammar
      */
     public function compileDropIndex(Blueprint $blueprint, Fluent $command)
     {
-        return "drop index {$command->index}";
+        $index = $this->wrap($command->index);
+
+        return "drop index {$index}";
     }
 
     /**
@@ -211,7 +221,9 @@ class PostgresGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} drop constraint {$command->index}";
+        $index = $this->wrap($command->index);
+
+        return "alter table {$table} drop constraint {$index}";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -170,7 +170,9 @@ class SQLiteGrammar extends Grammar
 
         $table = $this->wrapTable($blueprint);
 
-        return "create unique index {$command->index} on {$table} ({$columns})";
+        $index = $this->wrap($command->index);
+
+        return "create unique index {$index} on {$table} ({$columns})";
     }
 
     /**
@@ -186,7 +188,9 @@ class SQLiteGrammar extends Grammar
 
         $table = $this->wrapTable($blueprint);
 
-        return "create index {$command->index} on {$table} ({$columns})";
+        $index = $this->wrap($command->index);
+
+        return "create index {$index} on {$table} ({$columns})";
     }
 
     /**
@@ -257,7 +261,9 @@ class SQLiteGrammar extends Grammar
      */
     public function compileDropUnique(Blueprint $blueprint, Fluent $command)
     {
-        return "drop index {$command->index}";
+        $index = $this->wrap($command->index);
+
+        return "drop index {$index}";
     }
 
     /**
@@ -269,7 +275,9 @@ class SQLiteGrammar extends Grammar
      */
     public function compileDropIndex(Blueprint $blueprint, Fluent $command)
     {
-        return "drop index {$command->index}";
+        $index = $this->wrap($command->index);
+
+        return "drop index {$index}";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -87,7 +87,9 @@ class SqlServerGrammar extends Grammar
 
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} add constraint {$command->index} primary key ({$columns})";
+        $index = $this->wrap($command->index);
+
+        return "alter table {$table} add constraint {$index} primary key ({$columns})";
     }
 
     /**
@@ -103,7 +105,9 @@ class SqlServerGrammar extends Grammar
 
         $table = $this->wrapTable($blueprint);
 
-        return "create unique index {$command->index} on {$table} ({$columns})";
+        $index = $this->wrap($command->index);
+
+        return "create unique index {$index} on {$table} ({$columns})";
     }
 
     /**
@@ -119,7 +123,9 @@ class SqlServerGrammar extends Grammar
 
         $table = $this->wrapTable($blueprint);
 
-        return "create index {$command->index} on {$table} ({$columns})";
+        $index = $this->wrap($command->index);
+
+        return "create index {$index} on {$table} ({$columns})";
     }
 
     /**
@@ -173,7 +179,9 @@ class SqlServerGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} drop constraint {$command->index}";
+        $index = $this->wrap($command->index);
+
+        return "alter table {$table} drop constraint {$index}";
     }
 
     /**
@@ -187,7 +195,9 @@ class SqlServerGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        return "drop index {$command->index} on {$table}";
+        $index = $this->wrap($command->index);
+
+        return "drop index {$index} on {$table}";
     }
 
     /**
@@ -201,7 +211,9 @@ class SqlServerGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        return "drop index {$command->index} on {$table}";
+        $index = $this->wrap($command->index);
+
+        return "drop index {$index} on {$table}";
     }
 
     /**
@@ -215,7 +227,9 @@ class SqlServerGrammar extends Grammar
     {
         $table = $this->wrapTable($blueprint);
 
-        return "alter table {$table} drop constraint {$command->index}";
+        $index = $this->wrap($command->index);
+
+        return "alter table {$table} drop constraint {$index}";
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -275,7 +275,7 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table `users` add constraint users_foo_id_foreign foreign key (`foo_id`) references `orders` (`id`)', $statements[0]);
+        $this->assertEquals('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`)', $statements[0]);
     }
 
     public function testAddingIncrementingID()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -81,7 +81,7 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" drop constraint users_pkey', $statements[0]);
+        $this->assertEquals('alter table "users" drop constraint "users_pkey"', $statements[0]);
     }
 
     public function testDropUnique()
@@ -91,7 +91,7 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" drop constraint foo', $statements[0]);
+        $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
     }
 
     public function testDropIndex()
@@ -101,7 +101,7 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('drop index foo', $statements[0]);
+        $this->assertEquals('drop index "foo"', $statements[0]);
     }
 
     public function testDropForeign()
@@ -111,7 +111,7 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" drop constraint foo', $statements[0]);
+        $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
     }
 
     public function testDropTimestamps()
@@ -161,7 +161,7 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" add constraint bar unique ("foo")', $statements[0]);
+        $this->assertEquals('alter table "users" add constraint "bar" unique ("foo")', $statements[0]);
     }
 
     public function testAddingIndex()
@@ -171,7 +171,7 @@ class DatabasePostgresSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create index baz on "users" ("foo", "bar")', $statements[0]);
+        $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
     public function testAddingIncrementingID()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -61,7 +61,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('drop index foo', $statements[0]);
+        $this->assertEquals('drop index "foo"', $statements[0]);
     }
 
     public function testDropIndex()
@@ -71,7 +71,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('drop index foo', $statements[0]);
+        $this->assertEquals('drop index "foo"', $statements[0]);
     }
 
     public function testRenameTable()
@@ -115,7 +115,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create unique index bar on "users" ("foo")', $statements[0]);
+        $this->assertEquals('create unique index "bar" on "users" ("foo")', $statements[0]);
     }
 
     public function testAddingIndex()
@@ -125,7 +125,7 @@ class DatabaseSQLiteSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create index baz on "users" ("foo", "bar")', $statements[0]);
+        $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
     public function testAddingIncrementingID()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -71,7 +71,7 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" drop constraint foo', $statements[0]);
+        $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
     }
 
     public function testDropUnique()
@@ -81,7 +81,7 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('drop index foo on "users"', $statements[0]);
+        $this->assertEquals('drop index "foo" on "users"', $statements[0]);
     }
 
     public function testDropIndex()
@@ -91,7 +91,7 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('drop index foo on "users"', $statements[0]);
+        $this->assertEquals('drop index "foo" on "users"', $statements[0]);
     }
 
     public function testDropForeign()
@@ -101,7 +101,7 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" drop constraint foo', $statements[0]);
+        $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
     }
 
     public function testDropTimestamps()
@@ -141,7 +141,7 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('alter table "users" add constraint bar primary key ("foo")', $statements[0]);
+        $this->assertEquals('alter table "users" add constraint "bar" primary key ("foo")', $statements[0]);
     }
 
     public function testAddingUniqueKey()
@@ -151,7 +151,7 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create unique index bar on "users" ("foo")', $statements[0]);
+        $this->assertEquals('create unique index "bar" on "users" ("foo")', $statements[0]);
     }
 
     public function testAddingIndex()
@@ -161,7 +161,7 @@ class DatabaseSqlServerSchemaGrammarTest extends PHPUnit_Framework_TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertEquals(1, count($statements));
-        $this->assertEquals('create index baz on "users" ("foo", "bar")', $statements[0]);
+        $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
     public function testAddingIncrementingID()


### PR DESCRIPTION
This pull request updates the database grammars to wrap all constraints and indexes by default. 

See issue #12503
