### PR TITLE
[5.2] Simplify code in data_get()

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -421,17 +421,9 @@ if (! function_exists('data_get')) {
                 return in_array('*', $key) ? Arr::collapse($result) : $result;
             }
 
-            if (Arr::accessible($target)) {
-                if (! Arr::exists($target, $segment)) {
-                    return value($default);
-                }
-
+            if (Arr::accessible($target) && Arr::exists($target, $segment)) {
                 $target = $target[$segment];
-            } elseif (is_object($target)) {
-                if (! isset($target->{$segment})) {
-                    return value($default);
-                }
-
+            } elseif (is_object($target) && isset($target->{$segment})) {
                 $target = $target->{$segment};
             } else {
                 return value($default);


### PR DESCRIPTION
Exact same behavior, just more straightforward.

By the way, `property_exists()` would be better than `isset()` so null values would be supported, but that's another story (backward compatibility, but maybe it could be considered as non-breaking).
