### PR TITLE
[5.2] Rename and reposition unit test

### DIFF
--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -5,6 +5,19 @@ use Illuminate\Support\Collection;
 
 class SupportArrTest extends PHPUnit_Framework_TestCase
 {
+    public function testAccessible()
+    {
+        $this->assertTrue(Arr::accessible([]));
+        $this->assertTrue(Arr::accessible([1, 2]));
+        $this->assertTrue(Arr::accessible(['a' => 1, 'b' => 2]));
+        $this->assertTrue(Arr::accessible(new Collection));
+
+        $this->assertFalse(Arr::accessible(null));
+        $this->assertFalse(Arr::accessible('abc'));
+        $this->assertFalse(Arr::accessible(new stdClass));
+        $this->assertFalse(Arr::accessible((object) ['a' => 1, 'b' => 2]));
+    }
+
     public function testAdd()
     {
         $array = Arr::add(['name' => 'Desk'], 'price', 100);
@@ -61,19 +74,6 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(200, $value);
         $this->assertEquals(100, Arr::first($array));
-    }
-
-    public function testIs()
-    {
-        $this->assertTrue(Arr::accessible([]));
-        $this->assertTrue(Arr::accessible([1, 2]));
-        $this->assertTrue(Arr::accessible(['a' => 1, 'b' => 2]));
-        $this->assertTrue(Arr::accessible(new Collection));
-
-        $this->assertFalse(Arr::accessible(null));
-        $this->assertFalse(Arr::accessible('abc'));
-        $this->assertFalse(Arr::accessible(new stdClass));
-        $this->assertFalse(Arr::accessible((object) ['a' => 1, 'b' => 2]));
     }
 
     public function testLast()


### PR DESCRIPTION
A very trivial one, I'm submitting it because I had started writing unit tests for this `Arr::accessible` method, before noticing they were already present. :trollface:

Refs https://github.com/laravel/framework/commit/6fe531c2f62872a99fb3a982eee6cb0aa2a3fe6a
