### PR TITLE
Update TokenGuard to allow api_token in HTTP header

### DIFF
--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -83,6 +83,10 @@ class TokenGuard implements Guard
         $token = $this->request->input($this->inputKey);
 
         if (empty($token)) {
+            $token = $this->request->header($this->inputKey);
+        }
+
+        if (empty($token)) {
             $token = $this->request->bearerToken();
         }
 


### PR DESCRIPTION
The TokenGuard currently doesn't look for  in the request headers. This change allows a HTTP request to send the  header as part of the request.
