### PR TITLE
[5.2] In the Unique validation rule, allow ignoring an id using an array key

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -166,7 +166,7 @@ class Validator implements ValidatorContract
      */
     protected $dependentRules = [
         'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
-        'RequiredIf', 'RequiredUnless', 'Confirmed', 'Same', 'Different',
+        'RequiredIf', 'RequiredUnless', 'Confirmed', 'Same', 'Different', 'Unique',
     ];
 
     /**
@@ -1201,6 +1201,10 @@ class Validator implements ValidatorContract
 
         if (isset($parameters[2])) {
             list($idColumn, $id) = $this->getUniqueIds($parameters);
+
+            if (preg_match('/\[(.*)\]/', $id, $matches)) {
+                $id = $this->getValue($matches[1]);
+            }
 
             if (strtolower($id) == 'null') {
                 $id = null;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1154,7 +1154,6 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v->setPresenceVerifier($mock);
         $this->assertTrue($v->passes());
 
-        $trans = $this->getRealTranslator();
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:connection.users']);
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with('connection');
@@ -1173,6 +1172,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
         $mock->shouldReceive('setConnection')->once()->with(null);
         $mock->shouldReceive('getCount')->once()->with('users', 'email_addr', 'foo', '1', 'id_col', [])->andReturn(2);
+        $v->setPresenceVerifier($mock);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['users' => [['id' => 1, 'email' => 'foo']]], ['users.*.email' => 'Unique:users,email,[users.*.id]']);
+        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('setConnection')->once()->with(null);
+        $mock->shouldReceive('getCount')->once()->with('users', 'email', 'foo', '1', 'id', [])->andReturn(1);
         $v->setPresenceVerifier($mock);
         $this->assertFalse($v->passes());
 


### PR DESCRIPTION
As mentioned in this issue https://github.com/laravel/framework/issues/12607.

While validating a value is unique inside an array of values there's currently no way to ignore a specific id for every record in the array.

```
$validator = Validator::make($request->all(), [
    'person.*.email' => 'email|unique:users,email,???,id',
]);
```

This PR will allow the following:

```
'person.*.email' => 'email|unique:users,email,[person.*.id],id'
```

**Notes**
1. I introduced the syntax `[array_key]` to be able to separate between a value and a key.
2. I understand that this approach will make the application hit the database for every single array record but I'm not sure what's the best way to hit the database only once and pass the result to the rule checker for every iteration. I didn't want to make changes in `PresenceVerifier` for now. 
