### PR TITLE
[5.2] Add @verbatim to Blade

### DIFF
--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -508,6 +508,42 @@ empty
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
+    public function testVerbatimBlocksAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@verbatim {{ $a }} @if($b) {{ $b }} @endif @endverbatim';
+        $expected = ' {{ $a }} @if($b) {{ $b }} @endif ';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testVerbatimBlocksWithMultipleLinesAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = 'Some text
+@verbatim
+    {{ $a }}
+    @if($b)
+        {{ $b }}
+    @endif
+@endverbatim';
+        $expected = 'Some text
+
+    {{ $a }}
+    @if($b)
+        {{ $b }}
+    @endif
+';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testMultipleVerbatimBlocksAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@verbatim {{ $a }} @endverbatim {{ $b }} @verbatim {{ $c }} @endverbatim';
+        $expected = ' {{ $a }}  <?php echo e($b); ?>  {{ $c }} ';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
     public function testStatementThatContainsNonConsecutiveParanthesisAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
# This prevents Blade for compile certain sections of a template

Useful when parts of the templates need to include VueJS tags, JavaScript or documentation about Blade.

Example:

```
@verbatim
    @if {{ $var }} @endif
@endverbatim
```

Will show `@if {{ $var }} @endif` instead of compiling
