### PR TITLE
[5.2] Correct Bootstrap Navbar Style

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -26,7 +26,7 @@
     </style>
 </head>
 <body id="app-layout">
-    <nav class="navbar navbar-default">
+    <nav class="navbar navbar-default navbar-static-top">
         <div class="container">
             <div class="navbar-header">
 


### PR DESCRIPTION
We use full page width bootstrap navbar in auth layout stub, this navbar requires `navbar-static-top` **to remove rounded corners**.

Style we currently use (we use navbar outside the grid, so our width is 100% the page width): 
http://getbootstrap.com/examples/navbar/

Style expected (navbar with rounded corners removed): 
http://getbootstrap.com/examples/navbar-static-top/
