### PR TITLE
[5.2] Arr::collapse doesn't support ArrayAccess objects

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -62,7 +62,7 @@ class Arr
     /**
      * Collapse an array of arrays into a single array.
      *
-     * @param  \Illuminate\Support\Collection|array  $array
+     * @param  array  $array
      * @return array
      */
     public static function collapse($array)

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -62,7 +62,7 @@ class Arr
     /**
      * Collapse an array of arrays into a single array.
      *
-     * @param  \ArrayAccess|array  $array
+     * @param  \Illuminate\Support\Collection|array  $array
      * @return array
      */
     public static function collapse($array)
@@ -70,11 +70,15 @@ class Arr
         $results = [];
 
         foreach ($array as $values) {
-            if (! static::accessible($values)) {
+            if ($values instanceof Collection) {
+                $values = $values->all();
+            }
+
+            if (! is_array($values)) {
                 continue;
             }
 
-            $results = array_merge($results, $values instanceof Collection ? $values->all() : $values);
+            $results = array_merge($results, $values);
         }
 
         return $results;

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -64,7 +64,7 @@ if (! function_exists('array_collapse')) {
     /**
      * Collapse an array of arrays into a single array.
      *
-     * @param  \Illuminate\Support\Collection|array  $array
+     * @param  array  $array
      * @return array
      */
     function array_collapse($array)

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -64,7 +64,7 @@ if (! function_exists('array_collapse')) {
     /**
      * Collapse an array of arrays into a single array.
      *
-     * @param  \ArrayAccess|array  $array
+     * @param  \Illuminate\Support\Collection|array  $array
      * @return array
      */
     function array_collapse($array)


### PR DESCRIPTION
That is because the underlying `array_merge()` doesn't support `ArrayAccess` objects. Basically this PR undoes #12287.

Also, as I stated in #10709, `data_get()` makes use of `Arr::collapse` in some cases and thus might not support `ArrayAccess` objects in those. Though, if the key doesn't contain at least 2 wildcards (e.g. `orders.*.items.*.product.colors`) the `Arr::collapse` isn't even called.
