### PR TITLE
[5.3] Fix broken travis-ci test

### DIFF
--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -42,7 +42,7 @@ class JsonResponse extends BaseJsonResponse
     /**
      * {@inheritdoc}
      */
-    public function setData($data = [])
+    public function setData($data = [], $preEncoded = false)
     {
         if ($data instanceof Arrayable) {
             $this->data = json_encode($data->toArray(), $this->encodingOptions);


### PR DESCRIPTION
The symfony http-foundation update their `Symfony\Component\HttpFoundation\JsonResponse@setData`.

The original is `public function setData($data = array())`
, and after 2/2 they update to `public function setData($data = array(), $preEncoded = false)`

So, the travis-cy can't not pass. I add `$preEncoded` to PR, however the preEncoded is useless in laravel framework case.

If Symfony change their class back, the PR can be ignored.
