### PR TITLE
[5.2] Unloop calls to path bindings in Application

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -276,10 +276,12 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected function bindPathsInContainer()
     {
         $this->instance('path', $this->path());
-
-        foreach (['base', 'config', 'database', 'lang', 'public', 'storage'] as $path) {
-            $this->instance('path.'.$path, $this->{$path.'Path'}());
-        }
+        $this->instance('path.base', $this->basePath());
+        $this->instance('path.config', $this->configPath());
+        $this->instance('path.database', $this->databasePath());
+        $this->instance('path.lang', $this->langPath());
+        $this->instance('path.public', $this->publicPath());
+        $this->instance('path.storage', $this->storagePath());
     }
 
     /**


### PR DESCRIPTION
While searching in the codebase I missed `path.lang` because of this loop, and the same goes for the other paths. Not the first time I fall on this. :trollface:

Hence this PR to ease searching in codebase. Also, though a tiny bit longer, I think it's much more readable this way.
