### PR TITLE
[5.2] Fix dot property access problem in Arr

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -258,7 +258,7 @@ class Arr
      * Get an item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string  $key
+     * @param  string|array  $key
      * @param  mixed   $default
      * @return mixed
      */
@@ -268,11 +268,9 @@ class Arr
             return $array;
         }
 
-        if (static::exists($array, $key)) {
-            return $array[$key];
-        }
+        $key = is_array($key) ? $key : explode('.', $key);
 
-        foreach (explode('.', $key) as $segment) {
+        foreach ($key as $segment) {
             if (static::accessible($array) && static::exists($array, $segment)) {
                 $array = $array[$segment];
             } else {
@@ -287,7 +285,7 @@ class Arr
      * Check if an item exists in an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string  $key
+     * @param  string|array  $key
      * @return bool
      */
     public static function has($array, $key)
@@ -296,11 +294,9 @@ class Arr
             return false;
         }
 
-        if (static::exists($array, $key)) {
-            return true;
-        }
+        $key = is_array($key) ? $key : explode('.', $key);
 
-        foreach (explode('.', $key) as $segment) {
+        foreach ($key as $segment) {
             if (static::accessible($array) && static::exists($array, $segment)) {
                 $array = $array[$segment];
             } else {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -180,6 +180,11 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $array = new ArrayObject(['foo' => null, 'bar' => new ArrayObject(['baz' => null])]);
         $this->assertNull(Arr::get($array, 'foo', 'default'));
         $this->assertNull(Arr::get($array, 'bar.baz', 'default'));
+
+        // Test dotted key
+        $dottedArray = ['first.name' => 'Taylor', 'first' => ['name' => 'taylor']];
+        $this->assertEquals('taylor', Arr::get($dottedArray, 'first.name'));
+        $this->assertEquals('Taylor', Arr::get($dottedArray, ['first.name']));
     }
 
     public function testHas()


### PR DESCRIPTION
The proposed PR is due to the inconsistency of Arr::get and data_get

```
$array = [
        'first.name' => 'Taylor',
        'first' => ['name' => 'Bob'],
];

Arr::get($array, 'first.name') // Taylor
data_get($array, 'first.name') // Bob
```

I fix Arr::get and Arr::has because the Arr::set do

```
$array = [];
Arr::set($array, 'first.name', 'Taylor'); // ['first' => ['name' => 'Taylor']]
```
