### PR TITLE
[5.2] Support Traversable in Arr::collapse and pluck, as a result also in data_get()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -72,9 +72,7 @@ class Arr
         foreach ($array as $values) {
             if ($values instanceof Collection) {
                 $values = $values->all();
-            }
-
-            if (! is_array($values)) {
+            } elseif (! is_array($values)) {
                 continue;
             }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use ArrayAccess;
+use Traversable;
 use Illuminate\Support\Traits\Macroable;
 
 class Arr
@@ -62,7 +63,7 @@ class Arr
     /**
      * Collapse an array of arrays into a single array.
      *
-     * @param  array  $array
+     * @param  \Traversable|array  $array
      * @return array
      */
     public static function collapse($array)
@@ -72,6 +73,8 @@ class Arr
         foreach ($array as $values) {
             if ($values instanceof Collection) {
                 $values = $values->all();
+            } elseif ($values instanceof Traversable) {
+                $values = iterator_to_array($values);
             } elseif (! is_array($values)) {
                 continue;
             }
@@ -339,7 +342,7 @@ class Arr
     /**
      * Pluck an array of values from an array.
      *
-     * @param  \ArrayAccess|array  $array
+     * @param  \Traversable|array  $array
      * @param  string|array  $value
      * @param  string|array|null  $key
      * @return array
@@ -489,6 +492,17 @@ class Arr
         }
 
         return $array;
+    }
+
+    /**
+     * Determine whether the given value is traversable using foreach.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    public static function traversable($value)
+    {
+        return is_array($value) || $value instanceof Traversable;
     }
 
     /**

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -68,6 +68,11 @@ class Arr
      */
     public static function collapse($array)
     {
+        // Iterate on the array for performance.
+        if ($array instanceof Collection) {
+            $array = $array->all();
+        }
+
         $results = [];
 
         foreach ($array as $values) {
@@ -349,6 +354,11 @@ class Arr
      */
     public static function pluck($array, $value, $key = null)
     {
+        // Iterate on the array for performance.
+        if ($array instanceof Collection) {
+            $array = $array->all();
+        }
+
         $results = [];
 
         list($value, $key) = static::explodePluckParameters($value, $key);

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -64,7 +64,7 @@ if (! function_exists('array_collapse')) {
     /**
      * Collapse an array of arrays into a single array.
      *
-     * @param  array  $array
+     * @param  \Traversable|array  $array
      * @return array
      */
     function array_collapse($array)
@@ -219,7 +219,7 @@ if (! function_exists('array_pluck')) {
     /**
      * Pluck an array of values from an array.
      *
-     * @param  array   $array
+     * @param  \Traversable|array  $array
      * @param  string|array  $value
      * @param  string|array|null  $key
      * @return array
@@ -412,7 +412,7 @@ if (! function_exists('data_get')) {
 
         while (($segment = array_shift($key)) !== null) {
             if ($segment === '*') {
-                if (! Arr::accessible($target)) {
+                if (! Arr::traversable($target)) {
                     return value($default);
                 }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -357,6 +357,19 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expect, Arr::sortRecursive($array));
     }
 
+    public function testTraversable()
+    {
+        $this->assertTrue(Arr::traversable([]));
+        $this->assertTrue(Arr::traversable([1, 2]));
+        $this->assertTrue(Arr::traversable(['a' => 1, 'b' => 2]));
+        $this->assertTrue(Arr::traversable(new Collection));
+
+        $this->assertFalse(Arr::traversable(null));
+        $this->assertFalse(Arr::traversable('abc'));
+        $this->assertFalse(Arr::traversable(new stdClass));
+        $this->assertFalse(Arr::traversable((object) ['a' => 1, 'b' => 2]));
+    }
+
     public function testWhere()
     {
         $array = [100, '200', 300, '400', 500];

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -356,8 +356,8 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['taylor', 'abigail', 'dayle'], data_get($array, '*.name'));
         $this->assertEquals(['taylorotwell@gmail.com', null, null], data_get($array, '*.email', 'irrelevant'));
 
-        $arrayAccess = new SupportTestArrayAccess($array);
-        $this->assertEquals([], data_get($arrayAccess, '*.name'));
+        $iterable = new SupportTestIterable($array);
+        $this->assertEquals(['taylor', 'abigail', 'dayle'], data_get($iterable, '*.name'));
 
         $array = [
             'users' => [
@@ -711,5 +711,20 @@ class SupportTestArrayAccess implements ArrayAccess
     public function offsetUnset($offset)
     {
         unset($this->attributes[$offset]);
+    }
+}
+
+class SupportTestIterable implements IteratorAggregate
+{
+    public $items;
+
+    public function __construct($items)
+    {
+        $this->items = $items;
+    }
+
+    public function getIterator()
+    {
+        return new ArrayIterator($this->items);
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -80,6 +80,15 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['taylor', 'dayle'], array_pluck($array, ['user', 0]));
         $this->assertEquals(['taylor' => 'otwell', 'dayle' => 'rees'], array_pluck($array, 'user.1', 'user.0'));
         $this->assertEquals(['taylor' => 'otwell', 'dayle' => 'rees'], array_pluck($array, ['user', 1], ['user', 0]));
+
+        $array = new SupportTestIterable([
+            new SupportTestArrayAccess(['user' => new SupportTestArrayAccess(['taylor', 'otwell'])]),
+            collect(['user' => collect(['dayle', 'rees'])]),
+        ]);
+        $this->assertEquals(['taylor', 'dayle'], array_pluck($array, 'user.0'));
+        $this->assertEquals(['taylor', 'dayle'], array_pluck($array, ['user', 0]));
+        $this->assertEquals(['taylor' => 'otwell', 'dayle' => 'rees'], array_pluck($array, 'user.1', 'user.0'));
+        $this->assertEquals(['taylor' => 'otwell', 'dayle' => 'rees'], array_pluck($array, ['user', 1], ['user', 0]));
     }
 
     public function testArrayPluckWithNestedArrays()
@@ -99,6 +108,26 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
                 ],
             ],
         ];
+
+        $this->assertEquals([['taylor'], ['abigail', 'dayle']], array_pluck($array, 'users.*.first'));
+        $this->assertEquals(['a' => ['taylor'], 'b' => ['abigail', 'dayle']], array_pluck($array, 'users.*.first', 'account'));
+        $this->assertEquals([['taylorotwell@gmail.com'], [null, null]], array_pluck($array, 'users.*.email'));
+
+        $array = new SupportTestIterable([
+            new SupportTestArrayAccess([
+                'account' => 'a',
+                'users' => new SupportTestIterable([
+                    new SupportTestArrayAccess(['first' => 'taylor', 'last' => 'otwell', 'email' => 'taylorotwell@gmail.com']),
+                ]),
+            ]),
+            collect([
+                'account' => 'b',
+                'users' => collect([
+                    collect(['first' => 'abigail', 'last' => 'otwell']),
+                    collect(['first' => 'dayle', 'last' => 'rees']),
+                ]),
+            ]),
+        ]);
 
         $this->assertEquals([['taylor'], ['abigail', 'dayle']], array_pluck($array, 'users.*.first'));
         $this->assertEquals(['a' => ['taylor'], 'b' => ['abigail', 'dayle']], array_pluck($array, 'users.*.first', 'account'));
@@ -126,7 +155,7 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
 
     public function testArrayCollapse()
     {
-        $array = [[1], [2], [3], ['foo', 'bar'], collect(['baz', 'boom'])];
+        $array = [[1], [2], [3], new SupportTestIterable(['foo', 'bar']), collect(['baz', 'boom'])];
         $this->assertEquals([1, 2, 3, 'foo', 'bar', 'baz', 'boom'], array_collapse($array));
     }
 
@@ -401,6 +430,34 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
                 ],
             ],
         ];
+
+        $this->assertEquals(['taylor', 'abigail', 'abigail', 'dayle', 'dayle', 'taylor'], data_get($array, 'posts.*.comments.*.author'));
+        $this->assertEquals([4, 3, 2, null, null, 1], data_get($array, 'posts.*.comments.*.likes'));
+        $this->assertEquals([], data_get($array, 'posts.*.users.*.name', 'irrelevant'));
+        $this->assertEquals([], data_get($array, 'posts.*.users.*.name'));
+
+        $array = new SupportTestArrayAccess([
+            'posts' => new SupportTestIterable([
+                new SupportTestArrayAccess([
+                    'comments' => new SupportTestIterable([
+                        new SupportTestArrayAccess(['author' => 'taylor', 'likes' => 4]),
+                        new SupportTestArrayAccess(['author' => 'abigail', 'likes' => 3]),
+                    ]),
+                ]),
+                new SupportTestArrayAccess([
+                    'comments' => new SupportTestIterable([
+                        new SupportTestArrayAccess(['author' => 'abigail', 'likes' => 2]),
+                        new SupportTestArrayAccess(['author' => 'dayle']),
+                    ]),
+                ]),
+                collect([
+                    'comments' => collect([
+                        collect(['author' => 'dayle']),
+                        collect(['author' => 'taylor', 'likes' => 1]),
+                    ]),
+                ]),
+            ]),
+        ]);
 
         $this->assertEquals(['taylor', 'abigail', 'abigail', 'dayle', 'dayle', 'taylor'], data_get($array, 'posts.*.comments.*.author'));
         $this->assertEquals([4, 3, 2, null, null, 1], data_get($array, 'posts.*.comments.*.likes'));


### PR DESCRIPTION
<br>**edit: see instead #12638.**
<br>

Follow-up to support of wildcards in `data_get()` and to confusions between [`ArrayAccess`](http://php.net/manual/en/class.arrayaccess.php) and [`Traversable`](http://php.net/manual/en/class.traversable.php) in `data_get()` and some `Arr` methods.

Refs: #10709, #12287, #12621

Ping: @JosephSilber :sunglasses:
