### PR TITLE
[5.2] Adding symfony/debug as a dependency for illuminate components

### DIFF
--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -20,7 +20,8 @@
         "illuminate/contracts": "5.2.*",
         "illuminate/support": "5.2.*",
         "nesbot/carbon": "~1.20",
-        "symfony/process": "2.8.*|3.0.*"
+        "symfony/process": "2.8.*|3.0.*",
+        "symfony/debug": "2.8.*|3.0.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -19,7 +19,8 @@
         "illuminate/contracts": "5.2.*",
         "illuminate/events": "5.2.*",
         "illuminate/filesystem": "5.2.*",
-        "illuminate/support": "5.2.*"
+        "illuminate/support": "5.2.*",
+        "symfony/debug": "2.8.*|3.0.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Both `Illuminate/Queue` and `Illuminate/View` contains code that throws:

```
Symfony\Component\Debug\Exception\FatalThrowableError
```

This PR updates `composer.json` for both components to require `symfony/debug`
