### PR TITLE
[5.2] Allow multiply relations on the same level in with()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -664,7 +664,17 @@ class Builder
         // that start with the given top relations and adds them to our arrays.
         foreach ($this->eagerLoad as $name => $constraints) {
             if ($this->isNested($name, $relation)) {
-                $nested[substr($name, strlen($relation.'.'))] = $constraints;
+                $nestedRelation = substr($name, strlen($relation.'.'));
+
+                if (Str::contains($name, '|')) {
+                    foreach (explode('|', $nestedRelation) as $nestededRelation) {
+                        $nested[$nestededRelation] = $constraints;
+                    }
+
+                    continue;
+                }
+
+                $nested[$nestedRelation] = $constraints;
             }
         }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -294,6 +294,19 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $relation = $builder->getRelation('orders');
     }
 
+    public function testGetRelationProperlySetsPipedNestedRelationships()
+    {
+        $builder = $this->getBuilder();
+        $builder->setModel($this->getMockModel());
+        $builder->getModel()->shouldReceive('orders')->once()->andReturn($relation = m::mock('stdClass'));
+        $relationQuery = m::mock('stdClass');
+        $relation->shouldReceive('getQuery')->andReturn($relationQuery);
+        $relationQuery->shouldReceive('with')->once()->with(['groups' => null, 'lines.details' => null]);
+        $builder->setEagerLoads(['orders.groups|lines.details' => null]);
+
+        $relation = $builder->getRelation('orders');
+    }
+
     public function testGetRelationProperlySetsNestedRelationshipsWithSimilarNames()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
I've changed the `with()` method, so now you can write:
`Model::with('foo.bar|poo|test')`
instead of:
`Model::with('foo.bar', 'foo.poo', 'foo.test')`
