### PR TITLE
[5.2] Fix confusion between ArrayAccess and iterability in data_get()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -339,7 +339,7 @@ class Arr
     /**
      * Pluck an array of values from an array.
      *
-     * @param  \ArrayAccess|array  $array
+     * @param  array  $array
      * @param  string|array  $value
      * @param  string|array|null  $key
      * @return array

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -72,9 +72,7 @@ class Arr
         foreach ($array as $values) {
             if ($values instanceof Collection) {
                 $values = $values->all();
-            }
-
-            if (! is_array($values)) {
+            } elseif (! is_array($values)) {
                 continue;
             }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -412,7 +412,9 @@ if (! function_exists('data_get')) {
 
         while (($segment = array_shift($key)) !== null) {
             if ($segment === '*') {
-                if (! Arr::accessible($target)) {
+                if ($target instanceof Collection) {
+                    $target = $target->all();
+                } elseif (! is_array($target)) {
                     return value($default);
                 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -356,9 +356,6 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['taylor', 'abigail', 'dayle'], data_get($array, '*.name'));
         $this->assertEquals(['taylorotwell@gmail.com', null, null], data_get($array, '*.email', 'irrelevant'));
 
-        $arrayAccess = new SupportTestArrayAccess($array);
-        $this->assertEquals([], data_get($arrayAccess, '*.name'));
-
         $array = [
             'users' => [
                 ['first' => 'taylor', 'last' => 'otwell', 'email' => 'taylorotwell@gmail.com'],
@@ -372,9 +369,6 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['taylorotwell@gmail.com', null, null], data_get($array, 'users.*.email', 'irrelevant'));
         $this->assertEquals('not found', data_get($array, 'posts.*.date', 'not found'));
         $this->assertNull(data_get($array, 'posts.*.date'));
-
-        $arrayAccess = new SupportTestArrayAccess($array);
-        $this->assertEquals(['taylor', 'abigail', 'dayle'], data_get($arrayAccess, 'users.*.first'));
     }
 
     public function testDataGetWithDoubleNestedArraysCollapsesResult()


### PR DESCRIPTION
A different attempt at #12629.
Much simpler, only fixes `data_get()`, still fully supporting Collection. And most important, doesn't break the "`Arr` takes arrays" rule.

Do I have green light for this one?
