### PR TITLE
[5.2] Validate array size of implicit attributes

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -293,6 +293,8 @@ class Validator implements ValidatorContract
 
         $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute));
 
+        $data = array_merge($data, $this->getExactAttributeValues($data, $attribute));
+
         foreach ($data as $key => $value) {
             if (Str::startsWith($key, $attribute) || (bool) preg_match('/^'.$pattern.'\z/', $key)) {
                 foreach ((array) $rules as $ruleKey => $ruleValue) {
@@ -304,6 +306,37 @@ class Validator implements ValidatorContract
                 }
             }
         }
+    }
+
+    /**
+     * Get the exact attribute values in different iterations.
+     *
+     * @param  array $data
+     * @param  string $attribute
+     *
+     * @return array
+     */
+    public function getExactAttributeValues($data, $attribute)
+    {
+        $allKeys = [];
+
+        $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute));
+
+        foreach ($data as $key => $value) {
+            if ((bool) preg_match('/^'.$pattern.'/', $key, $matches)) {
+                $allKeys[] = $matches[0];
+            }
+        }
+
+        $allKeys = array_unique($allKeys);
+
+        $exactData = [];
+
+        foreach ($allKeys as $key) {
+            $exactData[$key] = array_get($this->data, $key);
+        }
+
+        return $exactData;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1956,32 +1956,6 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v->passes();
     }
 
-    public function testValidateEach()
-    {
-        $trans = $this->getRealTranslator();
-        $data = ['foo' => [5, 10, 15]];
-
-        $v = new Validator($trans, $data, ['foo' => 'Array']);
-        $v->each('foo', ['numeric|min:6|max:14']);
-        $this->assertFalse($v->passes());
-
-        $v = new Validator($trans, $data, ['foo' => 'Array']);
-        $v->each('foo', ['numeric|min:4|max:16']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, $data, ['foo' => 'Array']);
-        $v->each('foo', 'numeric|min:4|max:16');
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($trans, $data, ['foo' => 'Array']);
-        $v->each('foo', ['numeric', 'min:6', 'max:14']);
-        $this->assertFalse($v->passes());
-
-        $v = new Validator($trans, $data, ['foo' => 'Array']);
-        $v->each('foo', ['numeric', 'min:4', 'max:16']);
-        $this->assertTrue($v->passes());
-    }
-
     public function testValidateImplicitEachWithAsterisks()
     {
         $trans = $this->getRealTranslator();
@@ -2114,6 +2088,38 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
             ],
         ];
         $v = new Validator($trans, $data, ['people.*.cars.*.model' => 'required']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testImplicitEachWithAsterisksWithArrayValues()
+    {
+        $trans = $this->getRealTranslator();
+
+        $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'size:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [1, 2, 3, 4]], ['foo' => 'size:4']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]], ['foo.*.bar' => 'size:4']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans,
+            ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]], ['foo.*.bar' => 'min:3']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans,
+            ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]], ['foo.*.bar' => 'between:3,6']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans,
+            ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
+            ['foo.*.votes' => ['Required', 'Size:2']]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans,
+            ['foo' => [['name' => 'first', 'votes' => [1, 2, 3]], ['name' => 'second', 'votes' => ['something', 2]]]],
+            ['foo.*.votes' => ['Required', 'Size:2']]);
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
Currently there's no way to validate the size of an array in an implicit attribute:

``` php
Validator::make(
    ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]], 
    ['foo.*.bar' => 'size:4']
);
```

The case is the same with `size`, `between`, `min`, and `max`. 

The reason is that inside the `each` method all arrays are flattened, so no key will ever has an array value for these rules to work.

``` php
$data = Arr::dot($this->initializeAttributeOnData($attribute));
```

This PR appends exact values for the `attribute` for each iteration at the end of the `$data` variable.

**NOTE** 

For these changes to pass the unit tests I had to remove the `ValidationValidatorTest::testValidateEach()` tests, they hit the `each()` method directly with invalid validation rules that won't work if applied to the `Validator::make()` method, and since exact values are now appended to the `$data` variable these tests will no longer succeed.
