### PR TITLE
[5.3] New Artisan command: "config:view"

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigViewCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigViewCommand.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+
+class ConfigViewCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'config:view
+        {section? : Section of your config that you want to view (e.g. "app" or "database.connections.mysql")}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'View the full configuration for this environment.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $section = $this->argument('section');
+        if (! empty($section)) {
+            if (! array_key_exists($section, $this->laravel['config'])) {
+                $this->error($section.' does not exist in your configuration.');
+
+                return;
+            }
+
+            // If the requested string is a string, and not something that can be displayed in a table, then just print
+            // it out in the console.
+            $config = $this->laravel['config'][$section];
+            if (! is_array($config)) {
+                $this->line('<comment>'.$config.'</comment>');
+
+                return;
+            }
+
+            $configs = [
+                $section => $config,
+            ];
+        } else {
+            $configs = $this->laravel['config'];
+            ksort($configs);
+        }
+
+        foreach ($configs as $section => $config) {
+            $depth = $this->getConfigDepth($config);
+            $tree = $this->generateTree($config, $depth);
+            $this->line('<info>Configuration:</info> <comment>'.$section.'</comment>');
+            $this->table([/* don't display any headers */], $tree, 'default');
+        }
+    }
+
+    /**
+     * Take a configuration array, recursively traverse and create a padded tree array to output as a table.
+     *
+     * @param  array  $data
+     * @param  int  $total_depth
+     * @param  int  $current_depth
+     * @return array
+     */
+    private function generateTree($data, $total_depth, $current_depth = 1)
+    {
+        ksort($data);
+        $table = [];
+        foreach ($data as $key => $value) {
+            $row = [];
+            if ($current_depth > 1) {
+                $row = array_merge($row, array_fill(0, ($current_depth - 1), ''));
+            }
+
+            $row[] = '<comment>'.$key.'</comment>';
+            if (! is_array($value)) {
+                $row[] = (is_bool($value)) ? (($value) ? 'true' : 'false') : $value;
+            }
+
+            // Pad the row out with empty columns equal to the total subtracting the current recursive depth.
+            $empty_columns = ($total_depth - $current_depth);
+            $empty_columns = array_fill(count($row) - 1, $empty_columns, '');
+            $row = array_merge($row, $empty_columns);
+            $table[] = $row;
+            if (is_array($value)) {
+                $table = array_merge($table, $this->generateTree($value, $total_depth, $current_depth + 1));
+            }
+        }
+
+        return $table;
+    }
+
+    /**
+     * Determine the depth of this configuration so we know how to pad the outputted table of data.
+     *
+     * @param  array  $config
+     * @return int
+     */
+    private function getConfigDepth($config)
+    {
+        $total_depth = 1;
+        foreach ($config as $data) {
+            if (is_array($data)) {
+                $depth = $this->getConfigDepth($data) + 1;
+                if ($depth > $total_depth) {
+                    $total_depth = $depth;
+                }
+            }
+        }
+
+        return $total_depth;
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -28,6 +28,7 @@ use Illuminate\Routing\Console\ControllerMakeCommand;
 use Illuminate\Routing\Console\MiddlewareMakeCommand;
 use Illuminate\Foundation\Console\ConfigCacheCommand;
 use Illuminate\Foundation\Console\ConfigClearCommand;
+use Illuminate\Foundation\Console\ConfigViewCommand;
 use Illuminate\Foundation\Console\ConsoleMakeCommand;
 use Illuminate\Foundation\Console\EnvironmentCommand;
 use Illuminate\Foundation\Console\KeyGenerateCommand;
@@ -58,6 +59,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'ClearResets' => 'command.auth.resets.clear',
         'ConfigCache' => 'command.config.cache',
         'ConfigClear' => 'command.config.clear',
+        'ConfigView' => 'command.config.view',
         'Down' => 'command.down',
         'Environment' => 'command.environment',
         'KeyGenerate' => 'command.key.generate',
@@ -211,6 +213,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.config.clear', function ($app) {
             return new ConfigClearCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerConfigViewCommand()
+    {
+        $this->app->singleton('command.config.view', function ($app) {
+            return new ConfigViewCommand;
         });
     }
 


### PR DESCRIPTION
This adds a new Artisan command, `config:view` that lets you inspect the compiled config that's running in your environment. This is helpful to quickly determine settings that are being used without having to switch between your `.env` or `config/<section>.php` files.

It lets you do cool things like:
1. View your entire config

```
$ php artisan config:view
Configuration: app
+----------+----------+-------------------------------------+
| aliases  |          |                                     |
|          | App      | Illuminate\Support\Facades\App      |
|          | Artisan  | Illuminate\Support\Facades\Artisan  |
…
+----------+----------+-------------------------------------+
Configuration: auth
+----------+----------+-----------------+
| driver   | eloquent |                 |
| model    | App\User |                 |
| password |          |                 |
|          | email    | emails.password |
|          | expire   | 60              |
|          | table    | password_resets |
| table    | users    |                 |
+----------+----------+-----------------+
…
Configuration: view
+----------+----------------------------------------+--------------------------------+
| compiled | /home/site/web/storage/framework/views |                                |
| paths    |                                        |                                |
|          | 0                                      | /home/site/web/resources/views |
+----------+----------------------------------------+--------------------------------+
```
1. Your `app` config

```
$ php artisan config:view app
Configuration: app
+----------------------+------------------------------------+---------------------------------------------------------------+
| aliases              |                                    |                                                               |
|                      | App                                | Illuminate\Support\Facades\App                                |
|                      | Artisan                            | Illuminate\Support\Facades\Artisan                            |
|                      | Auth                               | Illuminate\Support\Facades\Auth                               |
|                      | Blade                              | Illuminate\Support\Facades\Blade                              |
…
|                      | Schema                             | Illuminate\Support\Facades\Schema                             |
|                      | Session                            | Illuminate\Support\Facades\Session                            |
|                      | Storage                            | Illuminate\Support\Facades\Storage                            |
|                      | URL                                | Illuminate\Support\Facades\URL                                |
|                      | Validator                          | Illuminate\Support\Facades\Validator                          |
|                      | View                               | Illuminate\Support\Facades\View                               |
| cipher               | rijndael-128                       |                                                               |
| cookie_domain        | localhost                          |                                                               |
| debug                | true                               |                                                               |
| fallback_locale      | en                                 |                                                               |
| key                  | W4ZQxqTlGycvzKYZFyGi8WJa4ki1bhNO   |                                                               |
| locale               | en                                 |                                                               |
| log                  | daily                              |                                                               |
| name                 | My Site!                           |                                                               |
| providers            |                                    |                                                               |
|                      | 0                                  | Illuminate\Foundation\Providers\ArtisanServiceProvider        |
|                      | 1                                  | Illuminate\Auth\AuthServiceProvider                           |
…
|                      | 16                                 | Illuminate\Translation\TranslationServiceProvider             |
|                      | 17                                 | Illuminate\Validation\ValidationServiceProvider               |
|                      | 18                                 | Illuminate\View\ViewServiceProvider                           |
| timezone             | America/New_York                   |                                                               |
| url                  | http://localhost                   |                                                               |
+----------------------+------------------------------------+---------------------------------------------------------------+
```
1. Or a single config like `app.timezone`:

```
$ php artisan config:view app.timezone
America/New_York
```
