### PR TITLE
[5.2] Escape blade statement compilation with @

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -266,7 +266,9 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         $callback = function ($match) {
-            if (isset($this->customDirectives[$match[1]])) {
+            if (Str::contains($match[1], '@')) {
+                $match[0] = isset($match[3]) ? $match[1].$match[3] : $match[1];
+            } elseif (isset($this->customDirectives[$match[1]])) {
                 $match[0] = call_user_func($this->customDirectives[$match[1]], Arr::get($match, 3));
             } elseif (method_exists($this, $method = 'compile'.ucfirst($match[1]))) {
                 $match[0] = $this->$method(Arr::get($match, 3));
@@ -275,7 +277,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
             return isset($match[3]) ? $match[0] : $match[0].$match[2];
         };
 
-        return preg_replace_callback('/\B@(\w+)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', $callback, $value);
+        return preg_replace_callback('/\B@(@?\w+)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', $callback, $value);
     }
 
     /**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -159,6 +159,19 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
             '));
     }
 
+    public function testEscapedWithAtDirectivesAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $this->assertEquals('@foreach', $compiler->compileString('@@foreach'));
+        $this->assertEquals('@foreach($i as $x)', $compiler->compileString('@@foreach($i as $x)'));
+        $this->assertEquals('@continue @break', $compiler->compileString('@@continue @@break'));
+        $this->assertEquals('@foreach(
+            $i as $x
+        )', $compiler->compileString('@@foreach(
+            $i as $x
+        )'));
+    }
+
     public function testExtendsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);


### PR DESCRIPTION
Same as escaping echos:

```
@{{ something }}    =>    {{ something }}
```

This PR allows escaping statements:

```
@@foreach($Ys as $y)    =>    @foreach($Ys as $y)
```
