### PR TITLE
[5.2] Pagination links to use & or ? based on provided path

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -129,7 +129,8 @@ abstract class AbstractPaginator implements Htmlable
             $parameters = array_merge($this->query, $parameters);
         }
 
-        return $this->path.'?'
+        return $this->path
+                        .(str_contains($this->path, '?') ? '&' : '?')
                         .http_build_query($parameters, null, '&')
                         .$this->buildFragment();
     }

--- a/tests/Pagination/PaginationPaginatorTest.php
+++ b/tests/Pagination/PaginationPaginatorTest.php
@@ -44,6 +44,12 @@ class PaginationPaginatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('http://website.com?foo=1', $p->url($p->currentPage() - 2));
     }
 
+    public function testPaginatorCanGenerateUrlsWithQuery()
+    {
+        $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, ['path' => 'http://website.com?sort_by=date', 'pageName' => 'foo']);
+        $this->assertEquals('http://website.com?sort_by=date&foo=2', $p->url($p->currentPage()));
+    }
+
     public function testLengthAwarePaginatorCanGenerateUrlsWithoutTrailingSlashes()
     {
         $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, ['path' => 'http://website.com/test/', 'pageName' => 'foo']);


### PR DESCRIPTION
This PR will make `AbstractPaginator::url()` decide to append pagination parameters after a `?` or a `&` based on the presence of query parameters in the provided path.

If current path is `name.app` the page link will be `name.app?page=2`.

If current path is `name.app?sort_by=date` the page link will be `name.app?sort_by=date&page=2`.

This will allow using a custom `PaginationServiceProvider` that sets the current path as the `fullUrl()` instead of the `url`.

``` php
public function register()
{
    $query = array_except($this->app['request']->query(), ['page']);

    Paginator::currentPathResolver(function () use ($query) {
        return $this->app['request']->url()
                 .($query ? '?' : '')
                 .http_build_query($query);
    });
}
```
