### PR TITLE
[5.2] Add method Application::bootstrapPath()

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -92,7 +92,7 @@ interface Application extends Container
     public function getCachedCompilePath();
 
     /**
-     * Get the path to the cached services.json file.
+     * Get the path to the cached services.php file.
      *
      * @return string
      */

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -282,6 +282,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->instance('path.public', $this->publicPath());
         $this->instance('path.storage', $this->storagePath());
         $this->instance('path.database', $this->databasePath());
+        $this->instance('path.bootstrap', $this->bootstrapPath());
     }
 
     /**
@@ -382,6 +383,16 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->instance('path.storage', $path);
 
         return $this;
+    }
+
+    /**
+     * Get the path to the bootstrap directory.
+     *
+     * @return string
+     */
+    public function bootstrapPath()
+    {
+        return $this->basePath.DIRECTORY_SEPARATOR.'bootstrap';
     }
 
     /**
@@ -812,7 +823,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedConfigPath()
     {
-        return $this->basePath().'/bootstrap/cache/config.php';
+        return $this->bootstrapPath().'/cache/config.php';
     }
 
     /**
@@ -832,7 +843,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedRoutesPath()
     {
-        return $this->basePath().'/bootstrap/cache/routes.php';
+        return $this->bootstrapPath().'/cache/routes.php';
     }
 
     /**
@@ -842,7 +853,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedCompilePath()
     {
-        return $this->basePath().'/bootstrap/cache/compiled.php';
+        return $this->bootstrapPath().'/cache/compiled.php';
     }
 
     /**
@@ -852,7 +863,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedServicesPath()
     {
-        return $this->basePath().'/bootstrap/cache/services.php';
+        return $this->bootstrapPath().'/cache/services.php';
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -247,7 +247,7 @@ class AppNameCommand extends Command
      */
     protected function getBootstrapPath()
     {
-        return $this->laravel->basePath().'/bootstrap/app.php';
+        return $this->laravel->bootstrapPath().'/app.php';
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -66,7 +66,7 @@ class ConfigCacheCommand extends Command
      */
     protected function getFreshConfiguration()
     {
-        $app = require $this->laravel->basePath().'/bootstrap/app.php';
+        $app = require $this->laravel->bootstrapPath().'/app.php';
 
         $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
 

--- a/src/Illuminate/Foundation/Console/IlluminateCaster.php
+++ b/src/Illuminate/Foundation/Console/IlluminateCaster.php
@@ -30,6 +30,7 @@ class IlluminateCaster
         'langPath',
         'publicPath',
         'storagePath',
+        'bootstrapPath',
     ];
 
     /**

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -75,7 +75,7 @@ class RouteCacheCommand extends Command
      */
     protected function getFreshApplicationRoutes()
     {
-        $app = require $this->laravel->basePath().'/bootstrap/app.php';
+        $app = require $this->laravel->bootstrapPath().'/app.php';
 
         $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
 


### PR DESCRIPTION
Bootstrap directory is currently hardcoded, hence this PR allowing to relocate it just like others paths.
