### PR TITLE
[5.2] Added a check for a valid key before update

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1702,8 +1702,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if (isset($this->original[$this->getKeyName()])) {
             return $this->original[$this->getKeyName()];
         }
+        
+        $keyAttribute = $this->getAttribute($this->getKeyName());
+        
+        if (is_null($keyAttribute)) {
+            throw new Exception('Invalid primary key defined on model.');
+        }
 
-        return $this->getAttribute($this->getKeyName());
+        return $keyAttribute;
+
+Sorry my
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1710,8 +1710,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
 
         return $keyAttribute;
-
-Sorry my
     }
 
     /**


### PR DESCRIPTION
Suppose you had set a `protected $primaryKey = "Id";` in your User model ( attention for the capitalized "I" ).

When you do a `User::find(1)`. The generated query will be "select \* from `users` where `users`.`Id` = ? limit 1"

in MySQL its a valid query. But, if you update the model: 

``` php
$user->email = "changed@email.com";
$user->save();
```

No errors will be displayed, but the query executed will be: "update `users` set `name` = ?, `updated_at` = ? where `Id` is null"

This occurs because in that specific scenario there's no check key and the method `GetKeyForSaveQuery` will return `null`.

This code tells the user what happened and prevent a mistaken massive update.
