### PR TITLE
[5.2] Add an event listener for the exception occurred job event

### DIFF
--- a/src/Illuminate/Queue/Events/JobExceptionOccurred.php
+++ b/src/Illuminate/Queue/Events/JobExceptionOccurred.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobExceptionOccurred
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The job instance.
+     *
+     * @var \Illuminate\Contracts\Jobs\Job
+     */
+    public $job;
+
+    /**
+     * The data given to the job.
+     *
+     * @var array
+     */
+    public $data;
+
+    /**
+     * The exception instance.
+     *
+     * @var \Throwable
+     */
+    public $exception;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Jobs\Job  $job
+     * @param  array  $data
+     * @param  \Throwable  $exception
+     * @return void
+     */
+    public function __construct($connectionName, $job, $data, $exception)
+    {
+        $this->job = $job;
+        $this->data = $data;
+        $this->connectionName = $connectionName;
+        $this->exception = $exception;
+    }
+}

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -64,6 +64,17 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
+     * Register an event listener for the exception occurred job event.
+     *
+     * @param  mixed  $callback
+     * @return void
+     */
+    public function exceptionOccurred($callback)
+    {
+        $this->app['events']->listen(Events\JobExceptionOccurred::class, $callback);
+    }
+
+    /**
      * Register an event listener for the daemon queue loop.
      *
      * @param  mixed  $callback

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -31,10 +31,14 @@ class SyncQueue extends Queue implements QueueContract
 
             $this->raiseAfterJobEvent($queueJob);
         } catch (Exception $e) {
+            $this->raiseExceptionOccurredJobEvent($queueJob, $e);
+
             $this->handleFailedJob($queueJob);
 
             throw $e;
         } catch (Throwable $e) {
+            $this->raiseExceptionOccurredJobEvent($queueJob, $e);
+
             $this->handleFailedJob($queueJob);
 
             throw $e;
@@ -119,6 +123,22 @@ class SyncQueue extends Queue implements QueueContract
 
         if ($this->container->bound('events')) {
             $this->container['events']->fire(new Events\JobProcessed('sync', $job, $data));
+        }
+    }
+
+    /**
+     * Raise the exception occurred queue job event.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  \Throwable  $exception
+     * @return void
+     */
+    protected function raiseExceptionOccurredJobEvent(Job $job, $exception)
+    {
+        $data = json_decode($job->getRawBody(), true);
+
+        if ($this->container->bound('events')) {
+            $this->container['events']->fire(new Events\JobExceptionOccurred('sync', $job, $data, $exception));
         }
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -220,11 +220,15 @@ class Worker
                 $job->release($delay);
             }
 
+            $this->raiseExceptionOccurredJobEvent($connection, $job, $e);
+
             throw $e;
         } catch (Throwable $e) {
             if (! $job->isDeleted()) {
                 $job->release($delay);
             }
+
+            $this->raiseExceptionOccurredJobEvent($connection, $job, $e);
 
             throw $e;
         }
@@ -259,6 +263,23 @@ class Worker
             $data = json_decode($job->getRawBody(), true);
 
             $this->events->fire(new Events\JobProcessed($connection, $job, $data));
+        }
+    }
+
+    /**
+     * Raise the exception occurred queue job event.
+     *
+     * @param  string  $connection
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  \Throwable  $exception
+     * @return void
+     */
+    protected function raiseExceptionOccurredJobEvent($connection, Job $job, $exception)
+    {
+        if ($this->events) {
+            $data = json_decode($job->getRawBody(), true);
+
+            $this->events->fire(new Events\JobExceptionOccurred($connection, $job, $data, $exception));
         }
     }
 

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -69,7 +69,7 @@ class QueueSyncQueueTest extends PHPUnit_Framework_TestCase
         $encrypter = new Illuminate\Encryption\Encrypter(str_repeat('c', 16));
         $container->instance('Illuminate\Contracts\Encryption\Encrypter', $encrypter);
         $events = m::mock('Illuminate\Contracts\Events\Dispatcher');
-        $events->shouldReceive('fire')->twice();
+        $events->shouldReceive('fire')->times(3);
         $container->instance('events', $events);
         $sync->setContainer($container);
         $sync->setEncrypter($encrypter);


### PR DESCRIPTION
I'm currently using this event to attach backtrace to a job when an exception is thrown. There's already an event for whenever a job fails (called 'failing') but a job is only considered 'failed' when the number of attempts is higher than the maximum number of tries.

``` php
if ($maxTries > 0 && $job->attempts() > $maxTries) {
    return $this->logFailedJob($connection, $job);
}
```

Being able to warn devs in HipChat, as an example, when a job is released back into the queue, because of an exception, could be really helpful I guess. There's probably a lot of other scenarios where this event could be used.
