### PR TITLE
Returns empty for UUID keys: 5.1

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -165,7 +165,7 @@ class BelongsTo extends Relation
         // it so the query doesn't fail, but will not return any results, which should
         // be what this developer is expecting in a case where this happens to them.
         if (count($keys) == 0) {
-            return [0];
+            return [];
         }
 
         return array_values(array_unique($keys));


### PR DESCRIPTION
This is identical to this https://github.com/laravel/framework/pull/12052 but onto 5.1.

The issue appears when eager loading a BelongsTo relationship where the foreign key is null. 
