### PR TITLE
[5.2] Remove return on nullableTimestamps

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -779,7 +779,7 @@ class Blueprint
      */
     public function nullableTimestamps()
     {
-        return $this->timestamps();
+        $this->timestamps();
     }
 
     /**


### PR DESCRIPTION
Remove return on nullableTimestamps since this is a void method.
