### PR TITLE
Change the order of the `trans` method arguments

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -691,7 +691,7 @@ if (! function_exists('trans')) {
      * @param  string  $locale
      * @return \Symfony\Component\Translation\TranslatorInterface|string
      */
-    function trans($id = null, $parameters = [], $domain = 'messages', $locale = null)
+    function trans($id = null, $locale = null, $parameters = [], $domain = 'messages')
     {
         if (is_null($id)) {
             return app('translator');


### PR DESCRIPTION
Currently if we want to get the localized string in a particular language we need to do it like this:
`trans(‘messages.welcome’,  [], 'messages', $theTargetLocale);`

after this changes we’ll do it like this:

`trans(‘messages.welcome’, $theTargetLocale);`
