### PR TITLE
Return only entered items in Request::only()

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -352,7 +352,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $input = $this->all();
 
         foreach ($keys as $key) {
-            if (array_key_exists($key, $input)) {
+            if (Arr::has($input, $key)) {
                 Arr::set($results, $key, data_get($input, $key));
             }
         }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -352,7 +352,9 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         $input = $this->all();
 
         foreach ($keys as $key) {
-            Arr::set($results, $key, data_get($input, $key));
+            if (array_key_exists($key, $input)) {
+                Arr::set($results, $key, data_get($input, $key));
+            }
         }
 
         return $results;


### PR DESCRIPTION
Before setting selected item in result array, check if the items exist in inputs.

Consider a situation that you want to update a model, and you do something like this:

``` php
// ...

class PostController extend Controller {

    // ...

    public function update(Request $request, $postId) {
        $post = Post::find($postId);
        $post->update($request->only(['title', 'content']));

        return $post;
    }

    // ...

}

// ...
```

In this situation if I only want to update post `content` and send only `content` value (with PATCH/PUT method), `$request->only(['title', 'content'])` will return  `title` as `null`. And if title column is nullable it would be updated to `null`.

**_Sample request:**_

``` json
{
    "content": "lorem ipsum ..."
}
```
