### PR TITLE
[5.2] Add monthlyOn convenience method to scheduled event

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -486,6 +486,20 @@ class Event
     }
 
     /**
+     * Schedule the event to run monthly on a given day and time.
+     *
+     * @param int $day
+     * @param string $time
+     * @return $this
+     */
+    public function monthlyOn($day = 1, $time = '0:0')
+    {
+        $this->dailyAt($time);
+
+        return $this->spliceIntoPosition(3, $day);
+    }
+
+    /**
      * Schedule the event to run quarterly.
      *
      * @return $this

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -60,6 +60,9 @@ class ConsoleScheduledEventTest extends PHPUnit_Framework_TestCase
 
         $event = new Event('php foo');
         $this->assertEquals('0 * * * * *', $event->everyFiveMinutes()->hourly()->getExpression());
+
+        $event = new Event('php foo');
+        $this->assertEquals('0 15 4 * * *', $event->monthlyOn(4, '15:00')->getExpression());
     }
 
     public function testEventIsDueCheck()


### PR DESCRIPTION
With the existing monthly() method, it's not particularly easy to
specify on which day of the month a scheduled task should be executed.
