### PR TITLE
[5.2] migrate expired delayed jobs but not expired reserved jobs when expire is null

### DIFF
--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -129,8 +129,9 @@ class RedisQueue extends Queue implements QueueContract
 
         $queue = $this->getQueue($queue);
 
+        $this->migrateExpiredJobs($queue.':delayed', $queue);
         if (! is_null($this->expire)) {
-            $this->migrateAllExpiredJobs($queue);
+            $this->migrateExpiredJobs($queue.':reserved', $queue);
         }
 
         $job = $this->getConnection()->lpop($queue);


### PR DESCRIPTION
`migrateAllExpiredJobs()` can get deprecated. 
