### PR TITLE
[5.2] Add isLocale method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1021,6 +1021,17 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Determine if application locale equals the given locale.
+     *
+     * @param  string  $locale
+     * @return bool
+     */
+    public function isLocale($locale)
+    {
+        return $this->getLocale() == $locale;
+    }
+
+    /**
      * Register the core class aliases in the container.
      *
      * @return void


### PR DESCRIPTION
I find myself doing `if('en' === app()->getLocale()){}` a lot and therefore I've written a helper myself.

```
/**
 * @return bool
 */
function is_locale($locale)
{
    return app()->getLocale() === $locale;
}
```

Why still send a PR?
- There are similar checks for the environment (`app()->environment('staging')` and `app()->isLocal()`)
- I think more users would like this helper
- `app()->isLocale('en')` looks cleaner and is more Laravelish

Perhaps making it work more like app()->environment()' would be a good idea, so you can pass an array and check in multiple languages. But I'm not sure how often artisans would do that.
