### PR TITLE
[5.2] Allow key:generate to work on explicity set environment

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -29,7 +29,9 @@ class KeyGenerateCommand extends Command
      */
     public function fire()
     {
-        $key = $this->getRandomKey($this->laravel['config']['app.cipher']);
+        $app = $this->laravel;
+
+        $key = $this->getRandomKey($app['config']['app.cipher']);
 
         if ($this->option('show')) {
             return $this->line('<comment>'.$key.'</comment>');
@@ -38,7 +40,7 @@ class KeyGenerateCommand extends Command
         $path = base_path('.env');
 
         if (file_exists($path)) {
-            $content = str_replace('APP_KEY='.$this->laravel['config']['app.key'], 'APP_KEY='.$key, file_get_contents($path));
+            $content = str_replace('APP_KEY='.$app['config']['app.key'], 'APP_KEY='.$key, file_get_contents($path));
 
             if (! Str::contains($content, 'APP_KEY')) {
                 $content = sprintf("%s\nAPP_KEY=%s\n", $content, $key);
@@ -47,7 +49,7 @@ class KeyGenerateCommand extends Command
             file_put_contents($path, $content);
         }
 
-        $this->laravel['config']['app.key'] = $key;
+        $app['config']['app.key'] = $key;
 
         $this->info("Application key [$key] set successfully.");
     }

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -37,7 +37,7 @@ class KeyGenerateCommand extends Command
             return $this->line('<comment>'.$key.'</comment>');
         }
 
-        $path = base_path('.env');
+        $path = $app->environmentPath().'/'.$app->environmentFile();
 
         if (file_exists($path)) {
             $content = str_replace('APP_KEY='.$app['config']['app.key'], 'APP_KEY='.$key, file_get_contents($path));


### PR DESCRIPTION
With this PR, use cases such as `artisan key:generate --env=testing` work on the correct .env file.
Fixes #12657.

See [`DetectEnvironment`](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php) for main part of the environment logic.
