### PR TITLE
[5.2] Proposal for using mysql json fields with query builder

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -136,6 +136,12 @@ class MySqlGrammar extends Grammar
             return $value;
         }
 
+        if (str_contains($value, '->')) {
+            $valuePath = explode('->', $value);
+
+            return array_shift($valuePath).'->'.'"$.'.implode('.', $valuePath).'"';
+        }
+
         return '`'.str_replace('`', '``', $value).'`';
     }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1146,6 +1146,25 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('select * from `users`', $builder->toSql());
     }
 
+    public function testMySqlWrappingJson()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereRaw('items->"$.price" = 1');
+        $this->assertEquals('select * from `users` where items->"$.price" = 1', $builder->toSql());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('items->price')->from('users')->where('items->price', '=', 1)->orderBy('items->price');
+        $this->assertEquals('select items->"$.price" from `users` where items->"$.price" = ? order by items->"$.price" asc', $builder->toSql());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
+        $this->assertEquals('select * from `users` where items->"$.price.in_usd" = ?', $builder->toSql());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1)->where('items->age', '=', 2);
+        $this->assertEquals('select * from `users` where items->"$.price.in_usd" = ? and items->"$.age" = ?', $builder->toSql());
+    }
+
     public function testSQLiteOrderBy()
     {
         $builder = $this->getSQLiteBuilder();


### PR DESCRIPTION
With mysql 5.7 introducing a json field type we can currently do the following:

``` php
User::selectRaw('name->"$.en"')
    ->whereRaw('contacts->"$.phone.home" = 123')
    ->orWhere(DB::raw('contacts->"$.phone.mobile"'), 123)
    ->get();
```

This PR is a suggestion that'll allow us to use the fluent query builder with this type of fields:

``` php
User::select('name->en')
    ->where('contacts->phone->home', 123)
    ->orWhere('contacts->phone->mobile', 123)
    ->whereBetween('specs->height', [100, 120])
    ->orderBy('specs->weight')
    ->get();
```
