### PR TITLE
[5.2] Store passed validation attributes

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -44,6 +44,13 @@ class Validator implements ValidatorContract
     protected $container;
 
     /**
+     * The passed validation rules.
+     *
+     * @var array
+     */
+    protected $passedRules = [];
+
+    /**
      * The failed validation rules.
      *
      * @var array
@@ -416,6 +423,9 @@ class Validator implements ValidatorContract
         if ($validatable && ! $this->$method($attribute, $value, $parameters, $this)) {
             $this->addFailure($attribute, $rule, $parameters);
         }
+        else if ($validatable) {
+          $this->addPass($attribute, $rule, $parameters);
+        }
     }
 
     /**
@@ -530,6 +540,19 @@ class Validator implements ValidatorContract
     {
         return in_array($rule, ['Unique', 'Exists'])
                         ? ! $this->messages->has($attribute) : true;
+    }
+
+    /**
+     * Add a passed rule to the collection.
+     *
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return void
+     */
+    protected function addPass($attribute, $rule, $parameters)
+    {
+        $this->passedRules[$attribute][$rule] = $parameters;
     }
 
     /**
@@ -2838,6 +2861,16 @@ class Validator implements ValidatorContract
     public function setFallbackMessages(array $messages)
     {
         $this->fallbackMessages = $messages;
+    }
+
+    /**
+     * Get the passed validation rules.
+     *
+     * @return array
+     */
+    public function passed()
+    {
+        return $this->passedRules;
     }
 
     /**


### PR DESCRIPTION
There is no way to grep the attributes that pass a validation routine. You can get attributes that fail with the `failed()` method. This commit adds a, similar, `passed()` method to grab attributes that pass.

Given the following,

```
$validator = Validator::make([
  'user' => [
    'email' => 'user@example.com',
  ],
  'repos' => [
    ['name' => 'repo-name', 'full_name' => 'org/repo-name'],
    ['name' => 'repo-name', 'full_name' => 'otherorg/repo-name'],
  ]
], [
  'repos.*.name' => 'regex:/repo-name/',
  'repos.*.full_name' => 'regex:/org\/repo-name/',
]);
```
