### PR TITLE
Add array support to required_if validation rule.

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -678,7 +678,11 @@ class Validator implements ValidatorContract
 
         $values = array_slice($parameters, 1);
 
-        if (in_array($data, $values)) {
+        if (is_array($data)) {
+            if (count(array_intersect($data, $values)) > 0) {
+                return $this->validateRequired($attribute, $value);
+            }
+        } elseif (in_array($data, $values)) {
             return $this->validateRequired($attribute, $value);
         }
 
@@ -1963,7 +1967,15 @@ class Validator implements ValidatorContract
      */
     protected function replaceRequiredIf($message, $attribute, $rule, $parameters)
     {
-        $parameters[1] = $this->getDisplayableValue($parameters[0], Arr::get($this->data, $parameters[0]));
+        if ($this->hasRule($parameters[0], 'Array')) {
+            $values = [];
+            foreach (array_slice($parameters, 1) as $value) {
+                array_push($values, $this->getDisplayableValue($parameters[0], $value));
+            }
+            $parameters[1] = implode(', ', $values);
+        } else {
+            $parameters[1] = $this->getDisplayableValue($parameters[0], Arr::get($this->data, $parameters[0]));
+        }
 
         $parameters[0] = $this->getAttribute($parameters[0]);
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -452,9 +452,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testRequiredIf()
     {
+// other field is a non array
         $trans = $this->getRealTranslator();
+        $trans->addResource('array', ['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en', 'messages');
         $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'required_if:first,taylor']);
         $this->assertTrue($v->fails());
+        $this->assertEquals('The last field is required when first is taylor.', $v->messages()->first('last'));
 
         $trans = $this->getRealTranslator();
         $v = new Validator($trans, ['first' => 'taylor', 'last' => 'otwell'], ['last' => 'required_if:first,taylor']);
@@ -471,9 +474,36 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         // error message when passed multiple values (required_if:foo,bar,baz)
         $trans = $this->getRealTranslator();
         $trans->addResource('array', ['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en', 'messages');
-        $v = new Validator($trans, ['first' => 'dayle', 'last' => ''], ['last' => 'RequiredIf:first,taylor,dayle']);
+        $v = new Validator($trans, ['first' => 'dayle', 'last' => ''], ['last' => 'required_if:first,taylor,dayle']);
         $this->assertFalse($v->passes());
         $this->assertEquals('The last field is required when first is dayle.', $v->messages()->first('last'));
+
+        // other field is an array
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['speaker' => ['other'], 'other' => ''], ['speaker' => 'array', 'other' => 'required_if:speaker,other']);
+        $this->assertTrue($v->fails());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['speaker' => ['other'], 'other' => 'dayle'], ['speaker' => 'array', 'other' => 'required_if:speaker,other']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['speaker' => ['taylor', 'dayle'], 'other' => 'abigail'], ['speaker' => 'array', 'other' => 'required_if:speaker,taylor,other']);
+        $this->assertTrue($v->passes());
+
+        // error message when passed single value (required_if:foo,bar)
+        $trans = $this->getRealTranslator();
+        $trans->addResource('array', ['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en', 'messages');
+        $v = new Validator($trans, ['speaker' => ['other'], 'other' => ''], ['speaker' => 'array', 'other' => 'required_if:speaker,other']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals('The other field is required when speaker is other.', $v->messages()->first('other'));
+
+        // error message when passed multiple values (required_if:foo,bar,baz)
+        $trans = $this->getRealTranslator();
+        $trans->addResource('array', ['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en', 'messages');
+        $v = new Validator($trans, ['speaker' => ['other'], 'other' => ''], ['speaker' => 'array', 'other' => 'required_if:speaker,taylor,other']);
+        $this->assertFalse($v->passes());
+        $this->assertEquals('The other field is required when speaker is taylor, other.', $v->messages()->first('other'));
     }
 
     public function testRequiredUnless()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -452,7 +452,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
     public function testRequiredIf()
     {
-// other field is a non array
+        // other field is a non array
         $trans = $this->getRealTranslator();
         $trans->addResource('array', ['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en', 'messages');
         $v = new Validator($trans, ['first' => 'taylor'], ['last' => 'required_if:first,taylor']);


### PR DESCRIPTION
In a nutshell required_if only worked when the other field is a non-array value. This allows for arrays to also be the subject of a required_if check. A common example is when an array of options is available and one such option is an "other" value. When the "other" value is present on a field it should require the "other" field to be filled. Something like:

``` php
$rules = [
    'selected_options' => ['array', 'in:foo,bar,other'],
    'other_option' => ['required_if:selected_options,other'],
];
```

This new validator would require the `other_option` field when the `selected_options` field contains the value of `other`. Additional arguments to the `required_if` rule would allow for any partial match. It's backwards compatible to 5.1 at least so that's why I've targeted it to this branch. If it fits the bill it should be available to 5.1 installations.

This works but the language starts to break down because an error message for the above might read like: "The other option field is required when selected options is other." This is not too bad but the obvious grammar of "options is" when it should be "options are" but then that also makes it not make sense as there aren't multiple options present. If the rules had additional arguments then it would read like "The other option field is required when selected options is foo, bar." and that's not grammatically correct either and fluently should be "options are either foo, bar, or baz." Translation support for this would be rather weak and something like "options include – foo, bar, baz." would be better but would require rethinking language lines in `validation.php`.

I thought I'd put this up and then see if a new rule is needed such as `required_if_array` or `required_if_contains`. Or perhaps we just need a way to start separating rule messages as array and non-array such that we could have singular language for non-arrays and a more plural language option for arrays for most all rules. Then language lines would always be `validation.required_if.string` and `validation.required_if.array` much like `validation.between.array`, etc. If a new method is best then I guess it should target 5.2 instead.
