### PR TITLE
Use composer cache + dist installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,13 @@ matrix:
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 install:
-  - if [[ $setup = 'basic' ]]; then travis_retry composer install --no-interaction --prefer-source; fi
-  - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-source --no-interaction --prefer-stable; fi
-  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-source --no-interaction --prefer-lowest --prefer-stable; fi
+  - if [[ $setup = 'basic' ]]; then travis_retry composer install --no-interaction; fi
+  - if [[ $setup = 'stable' ]]; then travis_retry composer update --no-interaction --prefer-stable; fi
+  - if [[ $setup = 'lowest' ]]; then travis_retry composer update --no-interaction --prefer-lowest --prefer-stable; fi
 
 script: vendor/bin/phpunit


### PR DESCRIPTION
Should speed up installs, especially since API limits on archives have been removed (see https://github.com/composer/composer/issues/4884#issuecomment-195229989 )
