### PR TITLE
commit fix pagination total

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -430,7 +430,7 @@ class Builder
     {
         $query = $this->toBase();
 
-        $total = $query->getCountForPagination();
+        $total = $query->getCountForPagination($columns);
 
         $this->forPage(
             $page = $page ?: Paginator::resolveCurrentPage($pageName),


### PR DESCRIPTION
If a distinct column is used to retrieve the models (select distinct table.id ....) then the total does not take it into account because no information about columns is sent to getCountForPagination
