### PR TITLE
[5.2] Make use of static::class

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -734,7 +734,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function getName()
     {
-        return 'login_'.$this->name.'_'.sha1(get_class($this));
+        return 'login_'.$this->name.'_'.sha1(static::class);
     }
 
     /**
@@ -744,7 +744,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function getRecallerName()
     {
-        return 'remember_'.$this->name.'_'.sha1(get_class($this));
+        return 'remember_'.$this->name.'_'.sha1(static::class);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -288,7 +288,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function bootIfNotBooted()
     {
-        $class = get_class($this);
+        $class = static::class;
 
         if (! isset(static::$booted[$class])) {
             static::$booted[$class] = true;
@@ -318,9 +318,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected static function bootTraits()
     {
-        foreach (class_uses_recursive(get_called_class()) as $trait) {
-            if (method_exists(get_called_class(), $method = 'boot'.class_basename($trait))) {
-                forward_static_call([get_called_class(), $method]);
+        foreach (class_uses_recursive(static::class) as $trait) {
+            if (method_exists(static::class, $method = 'boot'.class_basename($trait))) {
+                forward_static_call([static::class, $method]);
             }
         }
     }
@@ -348,15 +348,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public static function addGlobalScope($scope, Closure $implementation = null)
     {
         if (is_string($scope) && $implementation !== null) {
-            return static::$globalScopes[get_called_class()][$scope] = $implementation;
+            return static::$globalScopes[static::class][$scope] = $implementation;
         }
 
         if ($scope instanceof Closure) {
-            return static::$globalScopes[get_called_class()][spl_object_hash($scope)] = $scope;
+            return static::$globalScopes[static::class][spl_object_hash($scope)] = $scope;
         }
 
         if ($scope instanceof Scope) {
-            return static::$globalScopes[get_called_class()][get_class($scope)] = $scope;
+            return static::$globalScopes[static::class][get_class($scope)] = $scope;
         }
 
         throw new InvalidArgumentException('Global scope must be an instance of Closure or Scope.');
@@ -381,7 +381,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public static function getGlobalScope($scope)
     {
-        $modelScopes = Arr::get(static::$globalScopes, get_called_class(), []);
+        $modelScopes = Arr::get(static::$globalScopes, static::class, []);
 
         if (is_string($scope)) {
             return isset($modelScopes[$scope]) ? $modelScopes[$scope] : null;
@@ -399,7 +399,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getGlobalScopes()
     {
-        return Arr::get(static::$globalScopes, get_class($this), []);
+        return Arr::get(static::$globalScopes, static::class, []);
     }
 
     /**
@@ -1266,7 +1266,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $instance = new static;
 
         foreach ($instance->getObservableEvents() as $event) {
-            static::$dispatcher->forget("eloquent.{$event}: ".get_called_class());
+            static::$dispatcher->forget("eloquent.{$event}: ".static::class);
         }
     }
 
@@ -1281,7 +1281,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected static function registerModelEvent($event, $callback, $priority = 0)
     {
         if (isset(static::$dispatcher)) {
-            $name = get_called_class();
+            $name = static::class;
 
             static::$dispatcher->listen("eloquent.{$event}: {$name}", $callback, $priority);
         }
@@ -1672,7 +1672,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // We will append the names of the class to the event to distinguish it from
         // other model events that are fired, allowing us to listen on each model
         // event set individually instead of catching event for all the models.
-        $event = "eloquent.{$event}: ".get_class($this);
+        $event = "eloquent.{$event}: ".static::class;
 
         $method = $halt ? 'until' : 'fire';
 
@@ -2038,7 +2038,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $morphMap = Relation::morphMap();
 
-        $class = get_class($this);
+        $class = static::class;
 
         if (! empty($morphMap) && in_array($class, $morphMap)) {
             return array_search($class, $morphMap, true);
@@ -3349,7 +3349,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getMutatedAttributes()
     {
-        $class = get_class($this);
+        $class = static::class;
 
         if (! isset(static::$mutatorCache[$class])) {
             static::cacheMutatedAttributes($class);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -288,10 +288,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function bootIfNotBooted()
     {
-        $class = static::class;
-
-        if (! isset(static::$booted[$class])) {
-            static::$booted[$class] = true;
+        if (! isset(static::$booted[static::class])) {
+            static::$booted[static::class] = true;
 
             $this->fireModelEvent('booting', false);
 
@@ -318,9 +316,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected static function bootTraits()
     {
-        foreach (class_uses_recursive(static::class) as $trait) {
-            if (method_exists(static::class, $method = 'boot'.class_basename($trait))) {
-                forward_static_call([static::class, $method]);
+        $class = static::class;
+
+        foreach (class_uses_recursive($class) as $trait) {
+            if (method_exists($class, $method = 'boot'.class_basename($trait))) {
+                forward_static_call([$class, $method]);
             }
         }
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2156,7 +2156,7 @@ class Builder
             return $this->dynamicWhere($method, $parameters);
         }
 
-        $className = get_class($this);
+        $className = static::class;
 
         throw new BadMethodCallException("Call to undefined method {$className}::{$method}()");
     }

--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -206,7 +206,7 @@ trait AuthenticatesUsers
     protected function isUsingThrottlesLoginsTrait()
     {
         return in_array(
-            ThrottlesLogins::class, class_uses_recursive(get_class($this))
+            ThrottlesLogins::class, class_uses_recursive(static::class)
         );
     }
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -92,7 +92,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
      */
     protected function setUpTraits()
     {
-        $uses = array_flip(class_uses_recursive(get_class($this)));
+        $uses = array_flip(class_uses_recursive(static::class));
 
         if (isset($uses[DatabaseTransactions::class])) {
             $this->beginDatabaseTransaction();

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -104,7 +104,7 @@ abstract class ServiceProvider
      */
     protected function publishes(array $paths, $group = null)
     {
-        $class = get_class($this);
+        $class = static::class;
 
         if (! array_key_exists($class, static::$publishes)) {
             static::$publishes[$class] = [];

--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -50,7 +50,7 @@ trait Macroable
     {
         if (static::hasMacro($method)) {
             if (static::$macros[$method] instanceof Closure) {
-                return call_user_func_array(Closure::bind(static::$macros[$method], null, get_called_class()), $parameters);
+                return call_user_func_array(Closure::bind(static::$macros[$method], null, static::class), $parameters);
             } else {
                 return call_user_func_array(static::$macros[$method], $parameters);
             }
@@ -72,7 +72,7 @@ trait Macroable
     {
         if (static::hasMacro($method)) {
             if (static::$macros[$method] instanceof Closure) {
-                return call_user_func_array(static::$macros[$method]->bindTo($this, get_class($this)), $parameters);
+                return call_user_func_array(static::$macros[$method]->bindTo($this, static::class), $parameters);
             } else {
                 return call_user_func_array(static::$macros[$method], $parameters);
             }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1467,12 +1467,12 @@ class EloquentModelBootingTestStub extends Model
 {
     public static function unboot()
     {
-        unset(static::$booted[get_called_class()]);
+        unset(static::$booted[static::class]);
     }
 
     public static function isBooted()
     {
-        return array_key_exists(get_called_class(), static::$booted);
+        return array_key_exists(static::class, static::$booted);
     }
 }
 


### PR DESCRIPTION
Since PHP 5.5 we can use `static::class` instead of `get_called_class()` and `get_class($this)`.
