### PR TITLE
[5.2] TokenGuard: make `inputKey` and `storageKey` configurable

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -150,7 +150,8 @@ class AuthManager implements FactoryContract
         // user in the database or another persistence layer where users are.
         $guard = new TokenGuard(
             $this->createUserProvider($config['provider']),
-            $this->app['request']
+            $this->app['request'],
+            $config
         );
 
         $this->app->refresh('request', $guard, 'setRequest');

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -38,12 +38,12 @@ class TokenGuard implements Guard
      * @param  \Illuminate\Http\Request  $request
      * @return void
      */
-    public function __construct(UserProvider $provider, Request $request)
+    public function __construct(UserProvider $provider, Request $request, array $config)
     {
         $this->request = $request;
         $this->provider = $provider;
-        $this->inputKey = 'api_token';
-        $this->storageKey = 'api_token';
+        $this->inputKey = $config['inputKey'];
+        $this->storageKey = $config['storageKey'];
     }
 
     /**

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -38,12 +38,12 @@ class TokenGuard implements Guard
      * @param  \Illuminate\Http\Request  $request
      * @return void
      */
-    public function __construct(UserProvider $provider, Request $request, array $config)
+    public function __construct(UserProvider $provider, Request $request, array $config = [])
     {
         $this->request = $request;
         $this->provider = $provider;
-        $this->inputKey = $config['inputKey'];
-        $this->storageKey = $config['storageKey'];
+        $this->inputKey = isset($config['inputKey']) ? $config['inputKey'] : 'api_token';
+        $this->storageKey = isset($config['storageKey']) ? $config['storageKey'] : 'api_token';
     }
 
     /**

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -11,6 +11,25 @@ class AuthTokenGuardTest extends PHPUnit_Framework_TestCase
         Mockery::close();
     }
 
+    public function testQueryStringVariableNameIsConfigurable()
+    {
+        $provider = Mockery::mock(UserProvider::class);
+        $request = Request::create('/', 'GET', ['foo' => 'bar']);
+        $guard = Mockery::mock(new TokenGuard($provider, $request, ['inputKey' => 'foo']))->shouldAllowMockingProtectedMethods();
+
+        $this->assertEquals('bar', $guard->getTokenForRequest());
+    }
+
+    public function testStorageKeyVariableNameIsConfigurable()
+    {
+        $provider = Mockery::mock(UserProvider::class);
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['foo' => 'bar']);
+        $request = Request::create('/', 'GET', ['api_token' => 'bar']);
+        $guard = Mockery::mock(new TokenGuard($provider, $request, ['storageKey' => 'foo']));
+
+        $guard->validate(['api_token' => 'bar']);
+    }
+
     public function testUserCanBeRetrievedByQueryStringVariable()
     {
         $provider = Mockery::mock(UserProvider::class);


### PR DESCRIPTION
Make these params configurable. Useful in situations where replacing 3rd party solutions with built-in.
