### PR TITLE
[5.2] String After and Before

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -469,6 +469,42 @@ class Str
     }
 
     /**
+     * Return part of the string before occurrence
+     *
+     * @param string $haystack
+     * @param string $needles
+     * @return string
+    */
+    function strAfter($haystack, $needles) {
+
+        $pos = strpos($haystack, $needles);
+        
+        if ($pos === false){
+            return $haystack;
+        }
+
+        return(substr($haystack, $pos+strlen($needles)));
+    }
+
+    /**
+     * Return part of the string after occurrence
+     *
+     * @param string $haystack
+     * @param string $needles
+     * @return string
+    */
+    function strBefore($haystack, $needles) {
+        
+        $pos = strpos($haystack, $needles);
+        
+        if ($pos === false){
+            return $haystack;
+        }
+
+         return(substr($haystack, 0, $pos));
+    }
+
+    /**
      * Make a string's first character uppercase.
      *
      * @param  string  $string

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -639,6 +639,36 @@ if (! function_exists('starts_with')) {
     }
 }
 
+if (! function_exists('str_after')) {
+
+    /**
+     * Return part of the string before occurrence
+    *
+     * @param string $haystack
+     * @param string $needles
+     * @return string
+    */
+    function str_after($haystack, $needles)
+    {
+        return Str::strAfter($haystack, $needles);
+    }
+}
+
+if (! function_exists('str_before')) {
+
+    /**
+     * Return part of the string after occurrence
+     *
+     * @param string $haystack
+     * @param string $needles
+     * @return string
+    */
+    function str_before($haystack, $needles)
+    {
+        return Str::strBefore($haystack, $needles);
+    }
+}
+
 if (! function_exists('str_contains')) {
     /**
      * Determine if a given string contains a given substring.


### PR DESCRIPTION
- Get specific part of the string after or before occurrence

Example:

$dag = ‘a funny person, nerd, goof’;

echo str_before($dag, ‘person’)
//result: a funny

echo str_after($dag,’person’)
//result: , nerd, goof
