### PR TITLE
[5.2] Avoid compile route twice

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -414,7 +414,9 @@ class Route
      */
     public function bind(Request $request)
     {
-        $this->compileRoute();
+        if (! isset($this->compiled)) {
+            $this->compileRoute();
+        }
 
         $this->bindParameters($request);
 


### PR DESCRIPTION
In the Route.php, routes are compiled at "matches", and then a matched route compiled again at "bind" to the request.

Add a check to skip compiling
