### PR TITLE
[5.2] In the Unique validation rule, when parameter contains space, ignore space

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1062,6 +1062,10 @@ class Validator implements ValidatorContract
     protected function validateUnique($attribute, $value, $parameters)
     {
         $this->requireParameterCount(1, $parameters, 'unique');
+        //remove all space in parameters
+        array_walk($parameters, function(&$value){
+            $value = str_replace(' ', '', $value);
+        });
 
         list($connection, $table) = $this->parseTable($parameters[0]);
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1064,7 +1064,7 @@ class Validator implements ValidatorContract
         $this->requireParameterCount(1, $parameters, 'unique');
         //remove all space in parameters
         array_walk($parameters, function(&$value){
-            $value = str_replace(' ', '', $value);
+            $value = trim($value);
         });
 
         list($connection, $table) = $this->parseTable($parameters[0]);


### PR DESCRIPTION
When use unique validation like this:

```
$v = \Validator::make($attributes, [
            'name' => 'required|min:1|max:20',
            'keyword' => 'required|min:3|unique:directories,   keyword',
        ]);

        if ($v->fails()){
            throw new \Exception($v->errors()->first(), 500);
        }
```

You will get a Exception: 

```
Column not found: 1054 Unknown column ' id' in 'where clause' (SQL: select count(*) as aggregate from `target_table` where `   keyword` = "some_keyword")
```

This pull request will remove all space in validate parameters like '   keyword'. 

This issue not only exist in version 5.2, but also exist in versions 5.1 .
