### PR TITLE
[5.2] update docblock for mailer 

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -724,7 +724,7 @@ if (! function_exists('view')) {
      * @param  string  $view
      * @param  array   $data
      * @param  array   $mergeData
-     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\View\Factory
+     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
      */
     function view($view = null, $data = [], $mergeData = [])
     {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -724,7 +724,7 @@ if (! function_exists('view')) {
      * @param  string  $view
      * @param  array   $data
      * @param  array   $mergeData
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\View\Factory
      */
     function view($view = null, $data = [], $mergeData = [])
     {

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -144,7 +144,7 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  string|array  $view
      * @param  array  $data
      * @param  \Closure|string  $callback
-     * @return void
+     * @return mixed
      */
     public function send($view, array $data, $callback)
     {
@@ -375,7 +375,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Send a Swift Message instance.
      *
      * @param  \Swift_Message  $message
-     * @return void
+     * @return mixed
      */
     protected function sendSwiftMessage($message)
     {

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -52,7 +52,9 @@ class MailgunTransport extends Transport
     }
 
     /**
-     * {@inheritdoc}
+     * @param \Swift_Mime_Message $message
+     * @param array $failedRecipients An array of failures by-reference
+     * @return mixed
      */
     public function send(Swift_Mime_Message $message, &$failedRecipients = null)
     {

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -35,7 +35,9 @@ class MandrillTransport extends Transport
     }
 
     /**
-     * {@inheritdoc}
+     * @param \Swift_Mime_Message $message
+     * @param array $failedRecipients An array of failures by-reference
+     * @return mixed
      */
     public function send(Swift_Mime_Message $message, &$failedRecipients = null)
     {


### PR DESCRIPTION
guzzle client should return `mixed` instead of return `void`
