### PR TITLE
[5.3] Make use of argument unpacking

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -118,7 +118,7 @@ class Gate implements GateContract
         return function () use ($callback) {
             list($class, $method) = explode('@', $callback);
 
-            return call_user_func_array([$this->resolvePolicy($class), $method], func_get_args());
+            return $this->resolvePolicy($class)->$method(...func_get_args());
         };
     }
 
@@ -365,9 +365,7 @@ class Gate implements GateContract
                 // into the policy before methods with the arguments and get the result.
                 $beforeArguments = array_merge([$user, $ability], $arguments);
 
-                $result = call_user_func_array(
-                    [$instance, 'before'], $beforeArguments
-                );
+                $result = $instance->before(...$beforeArguments);
 
                 // If we received a non-null result from the before method, we will return it
                 // as the result of a check. This allows developers to override the checks
@@ -385,9 +383,7 @@ class Gate implements GateContract
                 return false;
             }
 
-            return call_user_func_array(
-                [$instance, $ability], array_merge([$user], $arguments)
-            );
+            return $instance->$ability($user, ...$arguments);
         };
     }
 

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -279,6 +279,6 @@ class AuthManager implements FactoryContract
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->guard(), $method], $parameters);
+        return $this->guard()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -131,6 +131,6 @@ class PasswordBrokerManager implements FactoryContract
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->broker(), $method], $parameters);
+        return $this->broker()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -214,6 +214,6 @@ class BroadcastManager implements FactoryContract
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->driver(), $method], $parameters);
+        return $this->driver()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -293,6 +293,6 @@ class CacheManager implements FactoryContract
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->store(), $method], $parameters);
+        return $this->store()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -146,7 +146,7 @@ class RedisTaggedCache extends TaggedCache
         $values = array_unique($this->store->connection()->lrange($referenceKey, 0, -1));
 
         if (count($values) > 0) {
-            call_user_func_array([$this->store->connection(), 'del'], $values);
+            $this->store->connection()->del(...$values);
         }
     }
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -508,7 +508,7 @@ class Repository implements CacheContract, ArrayAccess
             return $this->macroCall($method, $parameters);
         }
 
-        return call_user_func_array([$this->store, $method], $parameters);
+        return $this->store->$method(...$parameters);
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -131,11 +131,11 @@ class Command extends SymfonyCommand
         // set them all on the base command instance. This specifies what can get
         // passed into these commands as "parameters" to control the execution.
         foreach ($this->getArguments() as $arguments) {
-            call_user_func_array([$this, 'addArgument'], $arguments);
+            $this->addArgument(...$arguments);
         }
 
         foreach ($this->getOptions() as $options) {
-            call_user_func_array([$this, 'addOption'], $options);
+            $this->addOption(...$options);
         }
     }
 

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -120,7 +120,7 @@ class CookieJar implements JarContract
         if (head(func_get_args()) instanceof Cookie) {
             $cookie = head(func_get_args());
         } else {
-            $cookie = call_user_func_array([$this, 'make'], func_get_args());
+            $cookie = $this->make(...func_get_args());
         }
 
         $this->queued[$cookie->getName()] = $cookie;

--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -196,6 +196,6 @@ class Manager
      */
     public static function __callStatic($method, $parameters)
     {
-        return call_user_func_array([static::connection(), $method], $parameters);
+        return static::connection()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -314,6 +314,6 @@ class DatabaseManager implements ConnectionResolverInterface
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->connection(), $method], $parameters);
+        return $this->connection()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -687,7 +687,7 @@ class Builder
 
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
         } else {
-            call_user_func_array([$this->query, 'where'], func_get_args());
+            $this->query->where(...func_get_args());
         }
 
         return $this;
@@ -1019,7 +1019,7 @@ class Builder
         // query as their own isolated nested where statement and avoid issues.
         $originalWhereCount = count($query->wheres);
 
-        $result = call_user_func_array([$this->model, $scope], $parameters) ?: $this;
+        $result = $this->model->$scope(...$parameters) ?: $this;
 
         if ($this->shouldNestWheresForScope($query, $originalWhereCount)) {
             $this->nestWheresForScope($query, $originalWhereCount);
@@ -1291,10 +1291,10 @@ class Builder
         }
 
         if (in_array($method, $this->passthru)) {
-            return call_user_func_array([$this->toBase(), $method], $parameters);
+            return $this->toBase()->$method(...$parameters);
         }
 
-        call_user_func_array([$this->query, $method], $parameters);
+        $this->query->$method(...$parameters);
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -264,7 +264,7 @@ class Collection extends BaseCollection
      */
     public function zip($items)
     {
-        return call_user_func_array([$this->toBase(), 'zip'], func_get_args());
+        return $this->toBase()->zip(...func_get_args());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3460,12 +3460,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     public function __call($method, $parameters)
     {
         if (in_array($method, ['increment', 'decrement'])) {
-            return call_user_func_array([$this, $method], $parameters);
+            return $this->$method(...$parameters);
         }
 
-        $query = $this->newQuery();
-
-        return call_user_func_array([$query, $method], $parameters);
+        return $this->newQuery()->$method(...$parameters);
     }
 
     /**
@@ -3477,9 +3475,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public static function __callStatic($method, $parameters)
     {
-        $instance = new static;
-
-        return call_user_func_array([$instance, $method], $parameters);
+        return (new static)->$method(...$parameters);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -1098,7 +1098,7 @@ class BelongsToMany extends Relation
         $query = $this->newPivotStatement();
 
         foreach ($this->pivotWheres as $whereArgs) {
-            call_user_func_array([$query, 'where'], $whereArgs);
+            $query->where(...$whereArgs);
         }
 
         return $query->where($this->foreignKey, $this->parent->getKey());

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -341,7 +341,7 @@ abstract class Relation
      */
     public function __call($method, $parameters)
     {
-        $result = call_user_func_array([$this->query, $method], $parameters);
+        $result = $this->query->$method(...$parameters);
 
         if ($result === $this->query) {
             return $this;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -518,7 +518,7 @@ class Builder
         return $this->whereNested(function ($query) use ($column) {
             foreach ($column as $key => $value) {
                 if (is_numeric($key) && is_array($value)) {
-                    call_user_func_array([$query, 'where'], $value);
+                    $query->where(...$value);
                 } else {
                     $query->where($key, '=', $value);
                 }

--- a/src/Illuminate/Events/CallQueuedHandler.php
+++ b/src/Illuminate/Events/CallQueuedHandler.php
@@ -38,9 +38,7 @@ class CallQueuedHandler
             $job, $this->container->make($data['class'])
         );
 
-        call_user_func_array(
-            [$handler, $data['method']], unserialize($data['data'])
-        );
+        $handler->{$data['method']}(...unserialize($data['data']));
 
         if (! $job->isDeletedOrReleased()) {
             $job->delete();
@@ -74,7 +72,7 @@ class CallQueuedHandler
         $handler = $this->container->make($data['class']);
 
         if (method_exists($handler, 'failed')) {
-            call_user_func_array([$handler, 'failed'], unserialize($data['data']));
+            $handler->failed(...unserialize($data['data']));
         }
     }
 }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -315,9 +315,7 @@ class Dispatcher implements DispatcherContract
         if (isset($this->listeners[$eventName])) {
             krsort($this->listeners[$eventName]);
 
-            $this->sorted[$eventName] = call_user_func_array(
-                'array_merge', $this->listeners[$eventName]
-            );
+            $this->sorted[$eventName] = array_merge(...$this->listeners[$eventName]);
         }
     }
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -373,6 +373,6 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      */
     public function __call($method, array $parameters)
     {
-        return call_user_func_array([$this->driver, $method], $parameters);
+        return $this->driver->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -323,6 +323,6 @@ class FilesystemManager implements FactoryContract
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->disk(), $method], $parameters);
+        return $this->disk()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Foundation/Console/QueuedJob.php
+++ b/src/Illuminate/Foundation/Console/QueuedJob.php
@@ -33,7 +33,7 @@ class QueuedJob
      */
     public function fire($job, $data)
     {
-        call_user_func_array([$this->kernel, 'call'], $data);
+        $this->kernel->call(...$data);
 
         $job->delete();
     }

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -122,9 +122,7 @@ class ArtisanServiceProvider extends ServiceProvider
     protected function registerCommands(array $commands)
     {
         foreach (array_keys($commands) as $command) {
-            $method = "register{$command}Command";
-
-            call_user_func_array([$this, $method], []);
+            $this->{"register{$command}Command"}();
         }
 
         $this->commands(array_values($commands));

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -110,6 +110,6 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->app->make(Router::class), $method], $parameters);
+        return $this->app->make(Router::class)->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -62,7 +62,7 @@ trait ResponseTrait
      */
     public function cookie($cookie)
     {
-        return call_user_func_array([$this, 'withCookie'], func_get_args());
+        return $this->withCookie(...func_get_args());
     }
 
     /**
@@ -74,7 +74,7 @@ trait ResponseTrait
     public function withCookie($cookie)
     {
         if (is_string($cookie) && function_exists('cookie')) {
-            $cookie = call_user_func_array('cookie', func_get_args());
+            $cookie = cookie(...func_get_args());
         }
 
         $this->headers->setCookie($cookie);

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -291,8 +291,6 @@ class Message
      */
     public function __call($method, $parameters)
     {
-        $callable = [$this->swift, $method];
-
-        return call_user_func_array($callable, $parameters);
+        return $this->swift->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -506,7 +506,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->getCollection(), $method], $parameters);
+        return $this->getCollection()->$method(...$parameters);
     }
 
     /**

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -120,8 +120,7 @@ class Pipeline implements PipelineContract
                 } else {
                     list($name, $parameters) = $this->parsePipeString($pipe);
 
-                    return call_user_func_array([$this->container->make($name), $this->method],
-                            array_merge([$passable, $stack], $parameters));
+                    return $this->container->make($name)->{$this->method}($passable, $stack, ...$parameters);
                 }
             };
         };

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -166,7 +166,7 @@ class Manager
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->manager, $method], $parameters);
+        return $this->manager->$method(...$parameters);
     }
 
     /**
@@ -178,6 +178,6 @@ class Manager
      */
     public static function __callStatic($method, $parameters)
     {
-        return call_user_func_array([static::connection(), $method], $parameters);
+        return static::connection()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -262,8 +262,6 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     public function __call($method, $parameters)
     {
-        $callable = [$this->connection(), $method];
-
-        return call_user_func_array($callable, $parameters);
+        return $this->connection()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -235,7 +235,7 @@ class RedisQueue extends Queue implements QueueContract
      */
     protected function pushExpiredJobsOntoNewQueue($transaction, $to, $jobs)
     {
-        call_user_func_array([$transaction, 'rpush'], array_merge([$to], $jobs));
+        $transaction->rpush($to, ...$jobs);
     }
 
     /**

--- a/src/Illuminate/Redis/Database.php
+++ b/src/Illuminate/Redis/Database.php
@@ -85,7 +85,7 @@ class Database implements DatabaseContract
      */
     public function command($method, array $parameters = [])
     {
-        return call_user_func_array([$this->clients['default'], $method], $parameters);
+        return $this->clients['default']->$method(...$parameters);
     }
 
     /**
@@ -101,7 +101,7 @@ class Database implements DatabaseContract
     {
         $loop = $this->connection($connection)->pubSubLoop();
 
-        call_user_func_array([$loop, $method], (array) $channels);
+        $loop->$method(...(array) $channels);
 
         foreach ($loop as $message) {
             if ($message->kind === 'message' || $message->kind === 'pmessage') {

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -77,7 +77,7 @@ abstract class Controller
      */
     public function callAction($method, $parameters)
     {
-        return call_user_func_array([$this, $method], $parameters);
+        return $this->$method(...$parameters);
     }
 
     /**

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -18,9 +18,7 @@ trait RouteDependencyResolverTrait
      */
     protected function callWithDependencies($instance, $method)
     {
-        return call_user_func_array(
-            [$instance, $method], $this->resolveClassMethodDependencies([], $instance, $method)
-        );
+        return $instance->$method(...$this->resolveClassMethodDependencies([], $instance, $method));
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -989,11 +989,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             return $this->getArrayableItems($items);
         }, func_get_args());
 
-        $params = array_merge([function () {
+        $result = array_map(function () {
             return new static(func_get_args());
-        }, $this->items], $arrayableItems);
+        }, $this->items, ...$arrayableItems);
 
-        return new static(call_user_func_array('array_map', $params));
+        return new static($result);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -51,7 +51,7 @@ abstract class Facade
             $mock = static::createFreshMockInstance($name);
         }
 
-        return call_user_func_array([$mock, 'shouldReceive'], func_get_args());
+        return $mock->shouldReceive(...func_get_args());
     }
 
     /**

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -134,6 +134,6 @@ abstract class Manager
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->driver(), $method], $parameters);
+        return $this->driver()->$method(...$parameters);
     }
 }

--- a/src/Illuminate/Support/ViewErrorBag.php
+++ b/src/Illuminate/Support/ViewErrorBag.php
@@ -79,7 +79,7 @@ class ViewErrorBag implements Countable
      */
     public function __call($method, $parameters)
     {
-        return call_user_func_array([$this->default, $method], $parameters);
+        return $this->default->$method(...$parameters);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2938,7 +2938,7 @@ class Validator implements ValidatorContract
     {
         list($class, $method) = explode('@', $callback);
 
-        return call_user_func_array([$this->container->make($class), $method], $parameters);
+        return $this->container->make($class)->$method(...$parameters);
     }
 
     /**
@@ -2975,7 +2975,7 @@ class Validator implements ValidatorContract
     {
         list($class, $method) = explode('@', $callback);
 
-        return call_user_func_array([$this->container->make($class), $method], array_slice(func_get_args(), 1));
+        return $this->container->make($class)->$method(...array_slice(func_get_args(), 1));
     }
 
     /**

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -461,9 +461,7 @@ class Factory implements FactoryContract
         // the instance out of the IoC container and call the method on it with the
         // given arguments that are passed to the Closure as the composer's data.
         return function () use ($class, $method) {
-            $callable = [$this->container->make($class), $method];
-
-            return call_user_func_array($callable, func_get_args());
+            return $this->container->make($class)->$method(...func_get_args());
         };
     }
 


### PR DESCRIPTION
Make use of PHP 5.6 [argument unpacking](https://wiki.php.net/rfc/argument_unpacking).

Important note: PHP versions prior to 7 don't support string `ClassName::methodName` as [variable function](http://php.net/manual/en/functions.variable-functions.php):

```
$f = "Foo::bar";
$func(); // prints "bar" as of PHP 7.0.0; prior, it raised a fatal error
```

Therefore, I only made replacements for instance methods and global functions.

Also, there are a few uses of braces, see for instance `CallQueuedHandler.php`, `Pipeline.php` files, and the [parsing changes in PHP 7](http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect).
