### PR TITLE
[5.2] Restore working behavior if inaccessible input passed to Arr::get

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -262,6 +262,10 @@ class Arr
      */
     public static function get($array, $key, $default = null)
     {
+        if (! $array) {
+            return value($default);
+        }
+
         if (is_null($key)) {
             return $array;
         }
@@ -290,6 +294,10 @@ class Arr
      */
     public static function has($array, $key)
     {
+        if (! $array) {
+            return false;
+        }
+
         if (is_null($key)) {
             return false;
         }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -180,6 +180,10 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $array = new ArrayObject(['foo' => null, 'bar' => new ArrayObject(['baz' => null])]);
         $this->assertNull(Arr::get($array, 'foo', 'default'));
         $this->assertNull(Arr::get($array, 'bar.baz', 'default'));
+
+        // Test $array not an array
+        $this->assertEquals('default', Arr::get(null, 'foo', 'default'));
+        $this->assertEquals('default', Arr::get(false, 'foo', 'default'));
     }
 
     public function testHas()
@@ -206,6 +210,9 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $array = new ArrayObject(['foo' => null, 'bar' => new ArrayObject(['baz' => null])]);
         $this->assertTrue(Arr::has($array, 'foo'));
         $this->assertTrue(Arr::has($array, 'bar.baz'));
+
+        $this->assertFalse(Arr::has(null, 'foo'));
+        $this->assertFalse(Arr::has(false, 'foo'));
     }
 
     public function testIsAssoc()


### PR DESCRIPTION
After the nice comments I've received, fixes the following use cases, though they weren't supposed to be supported:

```
Arr::get(null, 'foo');
Arr::get('chicken', 'foo');
```

Though it was "working" only with `Arr::get` but not `Arr::has`, I'm doing the change to the latter too for consistency.
