### PR TITLE
[5.2] Update SessionGuard.php

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -534,7 +534,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // listening for anytime a user signs out of this application manually.
         $this->clearUserDataFromStorage();
 
-        if (! is_null($this->user)) {
+        if (! is_null($this->user) && ! is_null($this->user->remember_token)) {
             $this->refreshRememberToken($user);
         }
 


### PR DESCRIPTION
Stumpled to this while creating a custom authentication model (inherit from Illuminate\Foundation\Auth\User as Authenticatable intead of Illuminate\Database\Eloquent\Model) and then loggend in without remember_token (Auth::login($model, false)). This little modification seems to complete the given behaviour related to the remember_token and ensures to not be refreshed if it doesn't exists.
