### PR TITLE
[5.1] Improvements to Redis cache tagging

### DIFF
--- a/src/Illuminate/Cache/RedisTaggedCache.php
+++ b/src/Illuminate/Cache/RedisTaggedCache.php
@@ -96,7 +96,7 @@ class RedisTaggedCache extends TaggedCache
         $fullKey = $this->getPrefix().sha1($namespace).':'.$key;
 
         foreach (explode('|', $namespace) as $segment) {
-            $this->store->connection()->lpush($this->referenceKey($segment, $reference), $fullKey);
+            $this->store->connection()->sadd($this->referenceKey($segment, $reference), $fullKey);
         }
     }
 
@@ -143,7 +143,7 @@ class RedisTaggedCache extends TaggedCache
      */
     protected function deleteValues($referenceKey)
     {
-        $values = array_unique($this->store->connection()->lrange($referenceKey, 0, -1));
+        $values = array_unique($this->store->connection()->smembers($referenceKey));
 
         if (count($values) > 0) {
             call_user_func_array([$this->store->connection(), 'del'], $values);

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -74,8 +74,8 @@ class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase
         $redis = new Illuminate\Cache\RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');
         $store->shouldReceive('connection')->andReturn($conn = m::mock('StdClass'));
-        $conn->shouldReceive('lpush')->once()->with('prefix:foo:forever', 'prefix:'.sha1('foo|bar').':key1');
-        $conn->shouldReceive('lpush')->once()->with('prefix:bar:forever', 'prefix:'.sha1('foo|bar').':key1');
+        $conn->shouldReceive('sadd')->once()->with('prefix:foo:forever', 'prefix:'.sha1('foo|bar').':key1');
+        $conn->shouldReceive('sadd')->once()->with('prefix:bar:forever', 'prefix:'.sha1('foo|bar').':key1');
         $store->shouldReceive('forever')->with(sha1('foo|bar').':key1', 'key1:value');
 
         $redis->forever('key1', 'key1:value');
@@ -90,8 +90,8 @@ class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase
         $redis = new Illuminate\Cache\RedisTaggedCache($store, $tagSet);
         $store->shouldReceive('getPrefix')->andReturn('prefix:');
         $store->shouldReceive('connection')->andReturn($conn = m::mock('StdClass'));
-        $conn->shouldReceive('lpush')->once()->with('prefix:foo:standard', 'prefix:'.sha1('foo|bar').':key1');
-        $conn->shouldReceive('lpush')->once()->with('prefix:bar:standard', 'prefix:'.sha1('foo|bar').':key1');
+        $conn->shouldReceive('sadd')->once()->with('prefix:foo:standard', 'prefix:'.sha1('foo|bar').':key1');
+        $conn->shouldReceive('sadd')->once()->with('prefix:bar:standard', 'prefix:'.sha1('foo|bar').':key1');
         $store->shouldReceive('push')->with(sha1('foo|bar').':key1', 'key1:value');
 
         $redis->put('key1', 'key1:value');
@@ -107,16 +107,16 @@ class CacheTaggedCacheTest extends PHPUnit_Framework_TestCase
         $store->shouldReceive('connection')->andReturn($conn = m::mock('StdClass'));
 
         // Forever tag keys
-        $conn->shouldReceive('lrange')->once()->with('prefix:foo:forever', 0, -1)->andReturn(['key1', 'key2']);
-        $conn->shouldReceive('lrange')->once()->with('prefix:bar:forever', 0, -1)->andReturn(['key3']);
+        $conn->shouldReceive('smembers')->once()->with('prefix:foo:forever')->andReturn(['key1', 'key2']);
+        $conn->shouldReceive('smembers')->once()->with('prefix:bar:forever')->andReturn(['key3']);
         $conn->shouldReceive('del')->once()->with('key1', 'key2');
         $conn->shouldReceive('del')->once()->with('key3');
         $conn->shouldReceive('del')->once()->with('prefix:foo:forever');
         $conn->shouldReceive('del')->once()->with('prefix:bar:forever');
 
         // Standard tag keys
-        $conn->shouldReceive('lrange')->once()->with('prefix:foo:standard', 0, -1)->andReturn(['key4', 'key5']);
-        $conn->shouldReceive('lrange')->once()->with('prefix:bar:standard', 0, -1)->andReturn(['key6']);
+        $conn->shouldReceive('smembers')->once()->with('prefix:foo:standard')->andReturn(['key4', 'key5']);
+        $conn->shouldReceive('smembers')->once()->with('prefix:bar:standard')->andReturn(['key6']);
         $conn->shouldReceive('del')->once()->with('key4', 'key5');
         $conn->shouldReceive('del')->once()->with('key6');
         $conn->shouldReceive('del')->once()->with('prefix:foo:standard');


### PR DESCRIPTION
Use SETs rather than LISTs for storing cache key references.
