### PR TITLE
[5.2] Raise exception occurred job event before releasing the job

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -213,22 +213,29 @@ class Worker
 
             return ['job' => $job, 'failed' => false];
         } catch (Exception $e) {
-            // If we catch an exception, we will attempt to release the job back onto
-            // the queue so it is not lost. This will let is be retried at a later
-            // time by another listener (or the same one). We will do that here.
-            if (! $job->isDeleted()) {
-                $job->release($delay);
+            try {
+                $this->raiseExceptionOccurredJobEvent($connection, $job, $e);
+            } finally {
+                // If we catch an exception, we will attempt to release the job back onto
+                // the queue so it is not lost. This will let is be retried at a later
+                // time by another listener (or the same one). We will do that here.
+                if (! $job->isDeleted()) {
+                    $job->release($delay);
+                }
             }
-
-            $this->raiseExceptionOccurredJobEvent($connection, $job, $e);
 
             throw $e;
         } catch (Throwable $e) {
-            if (! $job->isDeleted()) {
-                $job->release($delay);
+            try {
+                $this->raiseExceptionOccurredJobEvent($connection, $job, $e);
+            } finally {
+                // If we catch an exception, we will attempt to release the job back onto
+                // the queue so it is not lost. This will let is be retried at a later
+                // time by another listener (or the same one). We will do that here.
+                if (! $job->isDeleted()) {
+                    $job->release($delay);
+                }
             }
-
-            $this->raiseExceptionOccurredJobEvent($connection, $job, $e);
 
             throw $e;
         }


### PR DESCRIPTION
My pull request for the JobExceptionOccurred event got merged about 6 days ago (#12659) the only problem is that the event should be fired before releasing the job so people can append data to the job or could potentially release the job manually in an event listener (by listening to the JobExceptionOccurred event) based on certain conditions as an example.

Releasing the job in an event listener wouldn't cause any problem because of the following part of code that checks if the job is deleted before releasing it.

``` php
if (! $job->isDeleted()) {
    $job->release($delay);
}
```
