### PR TITLE
[5.3] Add withQueryString to RedirectResponse

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -82,6 +82,30 @@ class RedirectResponse extends BaseRedirectResponse
 
         return $this;
     }
+    
+    /**
+     * Append the query string parameters from the last request
+     *
+     * @param  bool  $overwriteOld
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    function withQueryString($overwriteOld = true)
+    {
+        parse_str($_SERVER['QUERY_STRING'], $oldParams);
+        parse_str(parse_url($this->getTargetUrl(), PHP_URL_QUERY), $newParams);
+        
+        if ($overwriteOld)
+        {
+            $queryString = '?' . http_build_query(array_merge($oldParams, $newParams));
+        }
+        else {
+            $queryString = '?' . http_build_query(array_merge($newParams, $oldParams));
+        }
+        
+        $this->setTargetUrl(parse_url($this->getTargetUrl(), PHP_URL_PATH) . $queryString);
+
+        return $this;
+    }
 
     /**
      * Flash an array of input to the session.


### PR DESCRIPTION
Useful for forwarding the query string on landing pages that always redirect.

For example, if a password reminder email sends a user to www.sportsite.com?modal=password_reset and the landing route redirects to www.sportsite.com/round/5, the query string parameters are preserved (making it redirect to www.sportsite.com/round/5?modal=password_reset)
