### PR TITLE
[5.2] Fix isset($container[$key]) behavior for instances and aliases

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1164,7 +1164,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function offsetExists($key)
     {
-        return isset($this->bindings[$this->normalize($key)]);
+        return $this->bound($key);
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -268,6 +268,16 @@ return $obj; });
         $this->assertFalse($container->bound('object'));
     }
 
+    public function testBoundInstanceAndAliasCheckViaArrayAccess()
+    {
+        $container = new Container;
+        $container->instance('object', new StdClass);
+        $container->alias('object', 'alias');
+
+        $this->assertTrue(isset($container['object']));
+        $this->assertTrue(isset($container['alias']));
+    }
+
     public function testReboundListeners()
     {
         unset($_SERVER['__test.rebind']);


### PR DESCRIPTION
Previously, this would only check the bindings, but not the instances and aliases. This way, we centralize the logic in the `bound()` method.

Fixes #11167
