### PR TITLE
[5.3] 2 way route model binding with custom getRouteKey

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -17,4 +17,12 @@ interface UrlRoutable
      * @return string
      */
     public function getRouteKeyName();
+
+    /**
+     * Mutate route param back to the model's key value.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function mutateRouteKey($key);
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1991,6 +1991,17 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Mutate route param back to the model's key value.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function mutateRouteKey($key)
+    {
+        return $key;
+    }
+
+    /**
      * Determine if the model uses timestamps.
      *
      * @return bool

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -756,7 +756,7 @@ class Router implements RegistrarContract
 
                 $route->setParameter(
                     $parameter->name, $model->where(
-                        $model->getRouteKeyName(), $parameters[$parameter->name]
+                        $model->getRouteKeyName(), $model->mutateRouteKey($parameters[$parameter->name])
                     )->{$method}()
                 );
             }
@@ -881,10 +881,10 @@ class Router implements RegistrarContract
             // For model binders, we will attempt to retrieve the models using the first
             // method on the model instance. If we cannot retrieve the models we'll
             // throw a not found exception otherwise we will return the instance.
-            $instance = $this->container->make($class);
+            $model = $this->container->make($class);
 
-            if ($model = $instance->where($instance->getRouteKeyName(), $value)->first()) {
-                return $model;
+            if ($instance = $model->where($model->getRouteKeyName(), $model->mutateRouteKey($value))->first()) {
+                return $instance;
             }
 
             // If a callback was supplied to the method we will call that to determine

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -956,6 +956,18 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('id', $model->getRouteKeyName());
     }
 
+    public function testRouteKeyParamCanBeMutated()
+    {
+        $model = new EloquentModelRoutableStub;
+        $this->assertEquals('foo', $model->mutateRouteKey('hashed_foo'));
+    }
+
+    public function testRouteKeyParamPassedOnByDefault()
+    {
+        $model = new EloquentModelStub;
+        $this->assertEquals('foo', $model->mutateRouteKey('foo'));
+    }
+
     public function testCloneModelMakesAFreshCopyOfTheModel()
     {
         $class = new EloquentModelStub;
@@ -1565,4 +1577,12 @@ class EloquentModelNonIncrementingStub extends Illuminate\Database\Eloquent\Mode
     protected $table = 'stub';
     protected $guarded = [];
     public $incrementing = false;
+}
+
+class EloquentModelRoutableStub extends Model
+{
+    public function mutateRouteKey($key)
+    {
+        return str_replace('hashed_', '', $key);
+    }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -978,6 +978,11 @@ class RouteModelBindingStub
         return 'id';
     }
 
+    public function mutateRouteKey($key)
+    {
+        return $key;
+    }
+
     public function where($key, $value)
     {
         $this->value = $value;
@@ -996,6 +1001,11 @@ class RouteModelBindingNullStub
     public function getRouteKeyName()
     {
         return 'id';
+    }
+
+    public function mutateRouteKey($key)
+    {
+        return $key;
     }
 
     public function where($key, $value)

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -384,4 +384,9 @@ class RoutableInterfaceStub implements UrlRoutable
     {
         return 'key';
     }
+
+    public function mutateRouteKey($key)
+    {
+        return $key;
+    }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1640,7 +1640,7 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $uploadedFile = [__FILE__, '', null, null, null, true];
 
         $file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', ['guessExtension'], $uploadedFile);
-        $file->expects($this->any())->method('validateMimetypes')->will($this->returnValue('php'));
+        $file->expects($this->any())->method('guessExtension')->will($this->returnValue('php'));
         $v = new Validator($trans, [], ['x' => 'mimetypes:text/x-php']);
         $v->setFiles(['x' => $file]);
         $this->assertTrue($v->passes());


### PR DESCRIPTION
**BC breaking (interface) -> master**

Currently we are able to customize the way our model is represented in the url, when the latter is generated:

``` php
// App\User
public function getRouteKey()
{
    return Hashids::encode($this->getKey());
}

>>> $user = App\User::first()
=> App\User {#664 ... }
>>> route('users.show', $user)
=> "http://localhost/users/WE21K9jmvV"
```

**but it is impossible to easily get the model back from a customized route param:**

``` php
// implicit binding:
Route::get('users/{user}', function (App\User $user) { ... });
GET /users/WE21K9jmvV   --> 404 Not Found

// model binding:
Route::model('user', App\User::class);
GET /users/WE21K9jmvV   --> 404 Not Found
```

in this case the only way is custom binder:

``` php
Route::bind('user', function ($hash) {
    return App\User::findOrFail(Hashids::decode($hash));
});
```

---

This PR introduces a new method for making implicit and model binding easier, thus the the easiest implicit binding consistent:

``` php
// App\User
public function mutateRouteKey($key)
{
    return Hashids::decode($key);
}

// both implicit and model binding:
Route::get('users/{user}', function (App\User $user) { ... });
GET /users/WE21K9jmvV  --> model found
```
