### PR TITLE
[5.2] Added Collection::combine()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1115,6 +1115,20 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Combines the collection as keys together with items as values
+     *
+     * e.g. new Collection([1, 2, 3])->combine([4, 5, 6]);
+     *      => [1=>4, 2=>5, 3->6]
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function combine($items)
+    {
+        return new static(array_combine($this->all(), $this->getArrayableItems($items)));
+    }
+
+    /**
      * Convert the collection to its string representation.
      *
      * @return string

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1115,7 +1115,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Combines the collection as keys together with items as values
+     * Combines the collection as keys together with items as values.
      *
      * e.g. new Collection([1, 2, 3])->combine([4, 5, 6]);
      *      => [1=>4, 2=>5, 3=>6]

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1118,7 +1118,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Combines the collection as keys together with items as values
      *
      * e.g. new Collection([1, 2, 3])->combine([4, 5, 6]);
-     *      => [1=>4, 2=>5, 3->6]
+     *      => [1=>4, 2=>5, 3=>6]
      *
      * @param  mixed  $items
      * @return static

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1169,6 +1169,35 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
             'baz',
         ], $c->jsonSerialize());
     }
+
+    public function testCombineWithArray()
+    {
+        $expected = [
+            1 => 4,
+            2 => 5,
+            3 => 6
+        ];
+
+        $c = new Collection(array_keys($expected));
+        $actual = $c->combine(array_values($expected))->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testCombineWithCollection()
+    {
+        $expected = [
+            1 => 4,
+            2 => 5,
+            3 => 6
+        ];
+
+        $keyCollection = new Collection(array_keys($expected));
+        $valueCollection = new Collection(array_values($expected));
+        $actual = $keyCollection->combine($valueCollection)->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
 }
 
 class TestAccessorEloquentTestStub

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1175,7 +1175,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $expected = [
             1 => 4,
             2 => 5,
-            3 => 6
+            3 => 6,
         ];
 
         $c = new Collection(array_keys($expected));
@@ -1189,7 +1189,7 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
         $expected = [
             1 => 4,
             2 => 5,
-            3 => 6
+            3 => 6,
         ];
 
         $keyCollection = new Collection(array_keys($expected));


### PR DESCRIPTION
I added a function combine() to the Collections class to mimic the php array_combine() functionality, but still returns a new Collection.
