### PR TITLE
[5.2] Type declaration makes developers can't overide it

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2975,7 +2975,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  \DateTime  $date
      * @return string
      */
-    protected function serializeDate(DateTime $date)
+    protected function serializeDate($date)
     {
         return $date->format($this->getDateFormat());
     }


### PR DESCRIPTION
we cant overide this function while trying to use timestamp.

``` php
<?php
use Illuminate\Database\Eloquent\Model as Eloquent;

abstract class Model extends Eloquent {

    // using timestamp instead of Datetime Object
    protected function serializeDate($value)
    {
        return $value;
    }
}
```
