### PR TITLE
[5.2] Sometimes Validation Fix & "JIT Compile" of Rules

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1908,6 +1908,13 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['x' => 'foo'], ['x' => 'Required']);
         $v->sometimes('x', ['Foo', 'Bar:Baz'], function ($i) { return $i->x == 'foo'; });
         $this->assertEquals(['x' => ['Required', 'Foo', 'Bar:Baz']], $v->getRules());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans,
+            ['foo' => [['name' => 'first', 'title' => null]]],
+            []);
+        $v->sometimes('foo.*.name', 'Required|String', function ($i) { return $i['foo'][0]['title'] === null; });
+        $this->assertEquals(['foo.0.name' => ['Required', 'String']], $v->getRules());
     }
 
     public function testCustomValidators()


### PR DESCRIPTION
This adds to #12738 and fixes a similar bug of #12717. The `sometimes` call would not work on array validators. 

This also compiles the rules when they are needed mainly when `getRules()` is called or `passes()`. 
