### PR TITLE
[4.2] Ensure openssl's vulnerable random generation is not used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "jeremeamia/superclosure": "~1.0.1",
         "monolog/monolog": "~1.6",
         "nesbot/carbon": "~1.0",
+        "paragonie/random_compat": "~1.3",
         "patchwork/utf8": "~1.1",
         "phpseclib/phpseclib": "0.3.*",
         "predis/predis": "0.8.*",

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -1,7 +1,7 @@
 <?php namespace Illuminate\Encryption;
 
+use Illuminate\Support\Str;
 use Symfony\Component\Security\Core\Util\StringUtils;
-use Symfony\Component\Security\Core\Util\SecureRandom;
 
 class Encrypter {
 
@@ -157,12 +157,7 @@ class Encrypter {
 	 */
 	protected function validMac(array $payload)
 	{
-		if ( ! function_exists('openssl_random_pseudo_bytes'))
-		{
-			throw new \RuntimeException('OpenSSL extension is required.');
-		}
-
-		$bytes = (new SecureRandom)->nextBytes(16);
+		$bytes = Str::randomBytes(16);
 
 		$calcMac = hash_hmac('sha256', $this->hash($payload['iv'], $payload['value']), $bytes, true);
 

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -10,6 +10,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "4.2.*",
+        "paragonie/random_compat": "~1.3",
         "symfony/security-core": "2.5.*"
     },
     "autoload": {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -207,24 +207,30 @@ class Str {
 	 *
 	 * @param  int  $length
 	 * @return string
-	 *
-	 * @throws \RuntimeException
 	 */
 	public static function random($length = 16)
 	{
-		if (function_exists('openssl_random_pseudo_bytes'))
+		$string = '';
+
+		while (($len = strlen($string)) < $length)
 		{
-			$bytes = openssl_random_pseudo_bytes($length * 2);
-
-			if ($bytes === false)
-			{
-				throw new \RuntimeException('Unable to generate random string.');
-			}
-
-			return substr(str_replace(array('/', '+', '='), '', base64_encode($bytes)), 0, $length);
+			$size = $length - $len;
+			$bytes = static::randomBytes($size);
+			$string .= substr(str_replace(['/', '+', '='], '', base64_encode($bytes)), 0, $size);
 		}
 
-		return static::quickRandom($length);
+		return $string;
+	}
+
+	/**
+	 * Generate a more truly "random" bytes.
+	 *
+	 * @param  int  $length
+	 * @return string
+	 */
+	public static function randomBytes($length = 16)
+	{
+		return random_bytes($length);
 	}
 
 	/**

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -8,7 +8,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "paragonie/random_compat": "~1.3"
     },
     "require-dev": {
         "jeremeamia/superclosure": "~1.0.1",

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -28,7 +28,8 @@ class DatabaseConnectorTest extends PHPUnit_Framework_TestCase {
 		$connector->expects($this->once())->method('getOptions')->with($this->equalTo($config))->will($this->returnValue(array('options')));
 		$connector->expects($this->once())->method('createConnection')->with($this->equalTo($dsn), $this->equalTo($config), $this->equalTo(array('options')))->will($this->returnValue($connection));
 		$connection->shouldReceive('prepare')->once()->with('set names \'utf8\' collate \'utf8_unicode_ci\'')->andReturn($connection);
-		$connection->shouldReceive('execute')->once();
+		$connection->shouldReceive('prepare')->once()->with('set session sql_mode=\'\'')->andReturn($connection);
+		$connection->shouldReceive('execute')->times(2);
 		$connection->shouldReceive('exec')->zeroOrMoreTimes();
 		$result = $connector->connect($config);
 


### PR DESCRIPTION
This basically just direct copies the functions from 5.0 (after my PR to it).
