### PR TITLE
[5.2] Blade push with layouts weird ordering

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -844,7 +844,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compilePush($expression)
     {
-        return "<?php \$__env->startSection{$expression}; ?>";
+        return "<?php \$__env->startSectionPush{$expression}; ?>";
     }
 
     /**

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -528,6 +528,14 @@ class Factory implements FactoryContract
             $this->extendSection($section, $content);
         }
     }
+
+    /**
+     * Start injecting content into a push section.
+     *
+     * @param  string  $section
+     * @param  string  $content
+     * @return void
+     */
     public function startSectionPush($section, $content = '')
     {
         if (! isset($this->sections[$section])) {
@@ -891,6 +899,7 @@ class Factory implements FactoryContract
 
     /**
      * Get the section from the last element.
+     *
      * @param  string  $section
      * @return string|null
      */
@@ -901,6 +910,7 @@ class Factory implements FactoryContract
 
     /**
      * Set the section to the last element.
+     *
      * @param  string  $section
      * @param  string  $content
      * @param  bool  $append

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -192,7 +192,7 @@ test';
         $string = '@push(\'foo\')
 test
 @endpush';
-        $expected = '<?php $__env->startSection(\'foo\'); ?>
+        $expected = '<?php $__env->startSectionPush(\'foo\'); ?>
 test
 <?php $__env->appendSection(); ?>';
         $this->assertEquals($expected, $compiler->compileString($string));


### PR DESCRIPTION
Original issue #12753

In this PR, fix the weird results in #12753.
After the fix, the results below is much more like what the "push" do

```
b0  c1  c2
```

Template: 

```
>> a.blade.php
@stack('me')
>> b.blade.php
@extends('a')
@push('me') b0 @endpush('me')
>> c.blade.php
@extends('b')
@push('me') c1 @endpush('me')
@push('me') c2 @endpush('me')
```

This PR try to modify the `$sections` array, let the `@push` to save its state according to the `renderNumber`

There some drawbacks:
1. People may manually modify their template, but this PR brokes their view
2. They must clean their compiled view
3. I have no idea how the test codes should be, at least I test on a runnig server
