### PR TITLE
[5.2] Add USING command

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -161,7 +161,10 @@ class Grammar extends BaseGrammar
             // Once we have everything ready to go, we will just concatenate all the parts to
             // build the final join statement SQL for the query and we can then return the
             // final clause back to the callers as a single, stringified join statement.
-            $sql[] = "$type join $table on $clauses";
+            if (starts_with($clauses, 'using('))
+                $sql[] = "$type join $table $clauses";
+            else
+                $sql[] = "$type join $table on $clauses";
         }
 
         return implode(' ', $sql);
@@ -191,7 +194,10 @@ class Grammar extends BaseGrammar
             $second = $this->wrap($clause['second']);
         }
 
-        return "{$clause['boolean']} $first {$clause['operator']} $second";
+        if (strtolower($clause['operator']) == 'using')
+            return "using({$first})";
+        else
+            return "{$clause['boolean']} $first {$clause['operator']} $second";
     }
 
     /**


### PR DESCRIPTION
Usage:
$query->leftJoin('brands', 'brand_id', 'using')
or
$query->leftJoin('brands', \DB::Raw('`brand_id`, `brand_name`'), 'using')

The issue that now it's impossible to use USING mysql command. So, the point is add any function for support this command.

And of course it's possible to write some scope, like:
    public function scopeJoinUsing($query, $table, $field) {
        return $query->join( 'brands', 'brand_id', 'using' );
    }

Conversation here: http://stackoverflow.com/questions/36076108/laravel-5-using-the-using-operator
