### PR TITLE
[5.2] Introduce deleteIfExists($path) method to filesystem

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -133,7 +133,7 @@ class Filesystem
 
         return $success;
     }
-    
+
     /**
      * Delete the file if it exists at the given path.
      *
@@ -145,7 +145,7 @@ class Filesystem
         if ($this->exists($path)) {
             return $this->delete($path);
         }
-        
+
         return false;
     }
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -133,6 +133,21 @@ class Filesystem
 
         return $success;
     }
+    
+    /**
+     * Delete the file if it exists at the given path.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    public function deleteIfExists($path)
+    {
+        if ($this->exists($path)) {
+            return $this->delete($path);
+        }
+        
+        return false;
+    }
 
     /**
      * Move a file to a new location.

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -28,6 +28,15 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
         $this->assertFileNotExists(__DIR__.'/file.txt');
         @unlink(__DIR__.'/file.txt');
     }
+    
+    public function testDeleteIfExistsRemovesFiles()
+    {
+        file_put_contents(__DIR__.'/file.txt', 'Hello World');
+        $files = new Filesystem;
+        $files->deleteIfExists(__DIR__.'/file.txt');
+        $this->assertFileNotExists(__DIR__.'/file.txt');
+        @unlink(__DIR__.'/file.txt');
+    }
 
     public function testPrependExistingFiles()
     {

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -28,7 +28,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
         $this->assertFileNotExists(__DIR__.'/file.txt');
         @unlink(__DIR__.'/file.txt');
     }
-    
+
     public function testDeleteIfExistsRemovesFiles()
     {
         file_put_contents(__DIR__.'/file.txt', 'Hello World');


### PR DESCRIPTION
This adds `deleteIfExists($path)` to the Filesystem.

I often find myself writing something like this:

``` php
if (Storage::disk('my-disk')->exists('my-file.txt')) {
    Storage::disk('my-disk')->delete('my-file.txt');
}
```

This looks a lot clearer to me though:

``` php
Storage::disk('my-disk')->deleteIfExists('my-file.txt');
```
