### PR TITLE
[5.2] Introduce deleteIfExists($path) method

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -162,6 +162,25 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     }
 
     /**
+     * Delete the file if it exists at the given path.
+     *
+     * @param  string|array  $paths
+     * @return bool
+     */
+    public function deleteIfExists($paths)
+    {
+        $paths = is_array($paths) ? $paths : func_get_args();
+
+        foreach ($paths as $path) {
+            if ($this->exists($path)) {
+                $this->driver->delete($path);
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Copy a file to a new location.
      *
      * @param  string  $from


### PR DESCRIPTION
After failing hard in #12775, here's another try:

---

This adds `deleteIfExists($path)` to the `FilesystemAdapter` so it can be used by the `Storage` facade.

I often find myself writing something like this:

``` php
if (Storage::disk('my-disk')->exists('my-file.txt')) {
    Storage::disk('my-disk')->delete('my-file.txt');
}
```

This looks a lot cleaner to me though:

``` php
Storage::disk('my-disk')->deleteIfExists('my-file.txt');
```
