### PR TITLE
Mail::to(): Fix doc comment @return void to int

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -144,7 +144,7 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  string|array  $view
      * @param  array  $data
      * @param  \Closure|string  $callback
-     * @return void
+     * @return int
      */
     public function send($view, array $data, $callback)
     {
@@ -375,7 +375,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Send a Swift Message instance.
      *
      * @param  \Swift_Message  $message
-     * @return void
+     * @return int
      */
     protected function sendSwiftMessage($message)
     {


### PR DESCRIPTION
Fix doc comment @return void to int

Original Swift\Mailer::send() returns int
