### PR TITLE
[5.2] Add ability to set reset_link_email_subject via lang dictionary

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -85,9 +85,9 @@ trait ResetsPasswords
     protected function getEmailSubject()
     {
         $mailSubject = Lang::has('passwords.reset_link_email_subject')
-                        ? Lang::get('passwords.reset_link_email_subject')
-                        : 'Your Password Reset Link';
-                        
+            ? Lang::get('passwords.reset_link_email_subject')
+            : 'Your Password Reset Link';
+
         return property_exists($this, 'subject') ? $this->subject : $mailSubject;
     }
 

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -87,6 +87,7 @@ trait ResetsPasswords
         $mailSubject = Lang::has('passwords.reset_link_email_subject')
                         ? Lang::get('passwords.reset_link_email_subject')
                         : 'Your Password Reset Link';
+                        
         return property_exists($this, 'subject') ? $this->subject : $mailSubject;
     }
 

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Auth;
 use Illuminate\Http\Request;
 use Illuminate\Mail\Message;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Password;
 
 trait ResetsPasswords
@@ -83,7 +84,10 @@ trait ResetsPasswords
      */
     protected function getEmailSubject()
     {
-        return property_exists($this, 'subject') ? $this->subject : 'Your Password Reset Link';
+        $mailSubject = Lang::has('passwords.reset_link_email_subject')
+                        ? Lang::get('passwords.reset_link_email_subject')
+                        : 'Your Password Reset Link';
+        return property_exists($this, 'subject') ? $this->subject : $mailSubject;
     }
 
     /**


### PR DESCRIPTION
Hi, Im Kamil from Poland - this will be very handy to defnie 'reset link' email title in lang/en/passwords.php or lang/pl/passwords.php :)
