### PR TITLE
[5.3] Make Arr::only work with multidimensional arrays

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -311,7 +311,7 @@ class Arr
     }
 
     /**
-     * Get a subset of the items from the given array.
+     * Get a subset of the items from the given array using "dot" notation.
      *
      * @param  array  $array
      * @param  array|string  $keys
@@ -319,7 +319,19 @@ class Arr
      */
     public static function only($array, $keys)
     {
-        return array_intersect_key($array, array_flip((array) $keys));
+        $results = [];
+
+        foreach ((array) $keys as $key) {
+            $keyValue = static::get($array, $key, '__missing__');
+
+            if ($keyValue == '__missing__') {
+                continue;
+            }
+
+            static::set($results, $key, $keyValue);
+        }
+
+        return $results;
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -187,7 +187,7 @@ if (! function_exists('array_last')) {
 
 if (! function_exists('array_only')) {
     /**
-     * Get a subset of the items from the given array.
+     * Get a subset of the items from the given array using "dot" notation.
      *
      * @param  array  $array
      * @param  array|string  $keys

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -234,6 +234,22 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];
         $array = Arr::only($array, ['name', 'price']);
         $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
+
+        $array = ['cat' => ['cat1' => ['name']], ['cat2' => ['name2']]];
+        $array = Arr::only($array, 'cat.cat1');
+        $this->assertEquals(['cat' => ['cat1' => ['name']]], $array);
+
+        $array = ['cat' => ['cat1' => ['name' => '1', 'price' => 1], 'cat2' => ['name' => 2]]];
+        $array = Arr::only($array, 'cat.cat1.name');
+        $this->assertEquals(['cat' => ['cat1' => ['name' => '1']]], $array);
+
+        $array = ['cat' => ['cat1' => ['name' => '1', 'price' => 1, 'other'], 'cat2' => ['name' => '2']]];
+        $array = Arr::only($array, ['cat.cat1.name', 'cat.cat1.price']);
+        $this->assertEquals(['cat' => ['cat1' => ['name' => '1', 'price' => 1]]], $array);
+
+        $array = ['cat' => ['cat1' => ['name' => '1', 'price' => 1, 'other'], 'cat2' => ['name' => '2']]];
+        $array = Arr::only($array, ['cat.cat1.name', 'cat.cat2.name']);
+        $this->assertEquals(['cat' => ['cat1' => ['name' => '1'], 'cat2' => ['name' => '2']]], $array);
     }
 
     public function testPluck()


### PR DESCRIPTION
Currently `Arr::only` works "only" with flat arrays:

``` php
Arr::only(['name' => 'jon', 'age' => 18], ['name']); // returns ['name' => 'jon']
```

This PR makes it work with multidimensional arrays as well:

``` php
$array = [
        'characters' => [
            'jon' => ['name' => 'Jon Snow', 'house' => 'Stark'], 
            'daenerys' => ['name' => 'Khaleesi', 'house' => 'Targaryen'], 
        ]
    ];

Arr::only(
    $array,
    ['characters.jon.name', 'characters.jon.house', 'characters.daenerys.name']
)

// Returned array

 [
        'characters' => [
            'jon' => ['name' => 'Jon Snow', 'house' => 'Stark'], 
            'daenerys' => ['name' => 'Khaleesi'], 
        ]
];
```
