### PR TITLE
[5.2] Add `failed()` on InteractsWithQueue

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -14,6 +14,16 @@ trait InteractsWithQueue
     protected $job;
 
     /**
+     * Get the number of times the job has been attempted.
+     *
+     * @return int
+     */
+    public function attempts()
+    {
+        return $this->job ? $this->job->attempts() : 1;
+    }
+
+    /**
      * Delete the job from the queue.
      *
      * @return void
@@ -22,6 +32,18 @@ trait InteractsWithQueue
     {
         if ($this->job) {
             return $this->job->delete();
+        }
+    }
+
+    /**
+     * Fail the job from the queue.
+     *
+     * @return void
+     */
+    public function failed()
+    {
+        if ($this->job) {
+            return $this->job->failed();
         }
     }
 
@@ -36,16 +58,6 @@ trait InteractsWithQueue
         if ($this->job) {
             return $this->job->release($delay);
         }
-    }
-
-    /**
-     * Get the number of times the job has been attempted.
-     *
-     * @return int
-     */
-    public function attempts()
-    {
-        return $this->job ? $this->job->attempts() : 1;
     }
 
     /**


### PR DESCRIPTION
Allow to failed a job when using InteractsWithQueue instead of just
deleting the job.

Signed-off-by: crynobone crynobone@gmail.com
