### PR TITLE
[5.1] Ensure ModelIdentifier use write PDO connection.

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -64,7 +64,8 @@ trait SerializesModels
     protected function getRestoredPropertyValue($value)
     {
         return $value instanceof ModelIdentifier
-                        ? (new $value->class)->findOrFail($value->id) : $value;
+                        ? (new $value->class)->newQuery()->useWritePdo()->findOrFail($value->id)
+                        : $value;
     }
 
     /**


### PR DESCRIPTION
When working with `SerializesModels`, it is possible that when Queue attempts to work on the job
the model is yet to be available on the read PDO connection, therefore `findOrFail()` would just fail.

On heavy server load, it also possible that the latency is long enough to max out the number of attempts
configured for queue.

Signed-off-by: crynobone crynobone@gmail.com
