### PR TITLE
[5.2] Add shared locks to Filesystem and Cache/FileStore

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -63,7 +63,7 @@ class FileStore implements Store
         // just return null. Otherwise, we'll get the contents of the file and get
         // the expiration UNIX timestamps from the start of the file's contents.
         try {
-            $expire = substr($contents = $this->files->get($path), 0, 10);
+            $expire = substr($contents = $this->files->get($path, true), 0, 10);
         } catch (Exception $e) {
             return ['data' => null, 'time' => null];
         }
@@ -101,7 +101,7 @@ class FileStore implements Store
 
         $this->createCacheDirectory($path = $this->path($key));
 
-        $this->files->put($path, $value);
+        $this->files->put($path, $value, true);
     }
 
     /**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -45,7 +45,7 @@ class Filesystem
     }
 
     /**
-     * Get contents of a file with shared access
+     * Get contents of a file with shared access.
      *
      * @param  string  $path
      * @return string
@@ -56,7 +56,7 @@ class Filesystem
         $handle = fopen($path, 'r');
         if ($handle) {
             if (flock($handle, LOCK_SH)) {
-                while (!feof($handle)) {
+                while (! feof($handle)) {
                     $contents .= fread($handle, 1048576);
                 }
             }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -56,12 +56,15 @@ class Filesystem
         $contents = '';
         $handle = fopen($path, 'r');
         if ($handle) {
-            if (flock($handle, LOCK_SH)) {
-                while (! feof($handle)) {
-                    $contents .= fread($handle, 1048576);
+            try {
+                if (flock($handle, LOCK_SH)) {
+                    while (! feof($handle)) {
+                        $contents .= fread($handle, 1048576);
+                    }
                 }
+            } finally {
+                fclose($handle);
             }
-            fclose($handle);
         }
 
         return $contents;

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -38,6 +38,7 @@ class Filesystem
             if ($lock) {
                 return $this->sharedGet($path, $lock);
             }
+
             return file_get_contents($path);
         }
 
@@ -62,6 +63,7 @@ class Filesystem
             }
             fclose($handle);
         }
+
         return $contents;
     }
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -27,17 +27,42 @@ class Filesystem
      * Get the contents of a file.
      *
      * @param  string  $path
+     * @param  bool  $lock
      * @return string
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    public function get($path)
+    public function get($path, $lock = false)
     {
         if ($this->isFile($path)) {
+            if ($lock) {
+                return $this->sharedGet($path, $lock);
+            }
             return file_get_contents($path);
         }
 
         throw new FileNotFoundException("File does not exist at path {$path}");
+    }
+
+    /**
+     * Get contents of a file with shared access
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function sharedGet($path)
+    {
+        $contents = '';
+        $handle = fopen($path, 'r');
+        if ($handle) {
+            if (flock($handle, LOCK_SH)) {
+                while (!feof($handle)) {
+                    $contents .= fread($handle, 1048576);
+                }
+            }
+            fclose($handle);
+        }
+        return $contents;
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -292,6 +292,11 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
 
     public function testSharedGet()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('Skip HHVM test due to bug: https://github.com/facebook/hhvm/issues/5657');
+            return;
+        }
+
         $content = '';
         for ($i = 0; $i < 1000000; ++$i) {
             $content .= $i;

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -301,7 +301,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
         for ($i = 1; $i <= 20; ++$i) {
             $pid = pcntl_fork();
 
-            if (!$pid) {
+            if (! $pid) {
                 $files = new Filesystem;
                 $files->put(__DIR__.'/file.txt', $content, true);
                 $read = $files->get(__DIR__.'/file.txt', true);

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -294,6 +294,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
     {
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped('Skip HHVM test due to bug: https://github.com/facebook/hhvm/issues/5657');
+
             return;
         }
 

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -289,4 +289,33 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
         $this->assertFileExists(__DIR__.'/foo');
         @rmdir(__DIR__.'/foo');
     }
+
+    public function testSharedGet()
+    {
+        $content = '';
+        for ($i = 0; $i < 1000000; ++$i) {
+            $content .= $i;
+        }
+        $result = 1;
+
+        for ($i = 1; $i <= 20; ++$i) {
+            $pid = pcntl_fork();
+
+            if (!$pid) {
+                $files = new Filesystem;
+                $files->put(__DIR__.'/file.txt', $content, true);
+                $read = $files->get(__DIR__.'/file.txt', true);
+
+                exit(($read === $content) ? 1 : 0);
+            }
+        }
+
+        while (pcntl_waitpid(0, $status) != -1) {
+            $status = pcntl_wexitstatus($status);
+            $result *= $status;
+        }
+
+        $this->assertTrue($result === 1);
+        @unlink(__DIR__.'/file.txt');
+    }
 }


### PR DESCRIPTION
Have a problem with Cache/FileStore on a production server. It periodically fails with unserialize error:

```
exception 'ErrorException' with message 'unserialize(): Error at offset 282612 of 282614 bytes' in /home/user/xxx/vendor/laravel/framework/src/Illuminate/Cache/FileStore.php:80
Stack trace:
#0 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(8, 'unserialize(): ...', '/home/user/xxx...', 80, Array)
#1 /home/user/xxx/vendor/laravel/framework/src/Illuminate/Cache/FileStore.php(80): unserialize('O:39:"Illuminat...')
#2 /home/user/xxx/vendor/laravel/framework/src/Illuminate/Cache/FileStore.php(49): Illuminate\Cache\FileStore->getPayload('todayEvents')
#3 /home/user/xxx/vendor/laravel/framework/src/Illuminate/Cache/Repository.php(129): Illuminate\Cache\FileStore->get('todayEvents')
#4 /home/user/xxx/vendor/laravel/framework/src/Illuminate/Cache/Repository.php(288): Illuminate\Cache\Repository->get('todayEvents')
#5 [internal function]: Illuminate\Cache\Repository->remember('todayEvents', 1, Object(Closure))
#6 /home/user/xxx/vendor/laravel/framework/src/Illuminate/Cache/CacheManager.php(296): call_user_func_array(Array, Array)
#7 /home/user/xxx/bootstrap/cache/compiled.php(6222): Illuminate\Cache\CacheManager->__call('remember', Array)
#8 /home/user/xxx/bootstrap/cache/compiled.php(6222): Illuminate\Cache\CacheManager->remember('todayEvents', 1, Object(Closure))
#9 /home/user/xxx/app/Http/Controllers/Controller.php(101): Illuminate\Support\Facades\Facade::__callStatic('remember', Array)
#10 /home/user/xxx/app/Http/Controllers/Controller.php(101): Illuminate\Support\Facades\Cache::remember('todayEvents', 1, Object(Closure))
```

Cache/FileStore read file from cache when another instance of php script write same file into cache. I've added some locks to read/write from cache.
