### PR TITLE
Mailer: fix phpdoc @return void to mixed and add @throws

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -118,7 +118,8 @@ class Mailer implements MailerContract, MailQueueContract
      *
      * @param  string  $text
      * @param  mixed  $callback
-     * @return void
+     * @throws \Exception  when tried to send an email, usually Swift_RfcComplianceException or RequestException
+     * @return mixed  result from Mail driver, usually a Response or int
      */
     public function raw($text, $callback)
     {
@@ -131,7 +132,8 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  string  $view
      * @param  array  $data
      * @param  mixed  $callback
-     * @return void
+     * @throws \Exception  when tried to send an email, usually Swift_RfcComplianceException or RequestException
+     * @return mixed  result from Mail driver, usually a Response or int
      */
     public function plain($view, array $data, $callback)
     {
@@ -144,7 +146,8 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  string|array  $view
      * @param  array  $data
      * @param  \Closure|string  $callback
-     * @return void
+     * @throws \Exception  when tried to send an email, usually Swift_RfcComplianceException or RequestException
+     * @return mixed  result from Mail driver, usually a Response or int
      */
     public function send($view, array $data, $callback)
     {
@@ -375,7 +378,8 @@ class Mailer implements MailerContract, MailQueueContract
      * Send a Swift Message instance.
      *
      * @param  \Swift_Message  $message
-     * @return void
+     * @throws \Exception  when tried to send an email, usually Swift_RfcComplianceException or RequestException
+     * @return mixed  result from Mail driver, usually a Response or int
      */
     protected function sendSwiftMessage($message)
     {


### PR DESCRIPTION
Tested with mailgun, it returns Request.

Since you know only phpdoc and think that void was invented by the phpdoc I will quote a more specific type that shoud be used in this case from your phpBible https://phpdoc.org/docs/latest/guides/types.html

> **mixed**
> A value with this type can be literally anything; the author of the documentation is **unable to predict which type it will be**.

But since Request or any other value === null in GrahamCampbell's head and PHP community don't know anything except PHP, you can close this "another shitty PR". Anyway thank you for making my weekend. I also would recommend you to learn some basics of C.

P.S. never say "we", but use "I" instead.
