### PR TITLE
[5.3] Consistent mail sending return values

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -19,7 +19,7 @@ interface Mailer
      * @param  string|array  $view
      * @param  array  $data
      * @param  \Closure|string  $callback
-     * @return void
+     * @return int
      */
     public function send($view, array $data, $callback);
 

--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -19,7 +19,7 @@ interface Mailer
      * @param  string|array  $view
      * @param  array  $data
      * @param  \Closure|string  $callback
-     * @return int
+     * @return void
      */
     public function send($view, array $data, $callback);
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -170,7 +170,7 @@ class Mailer implements MailerContract, MailQueueContract
 
         $message = $message->getSwiftMessage();
 
-        return $this->sendSwiftMessage($message);
+        $this->sendSwiftMessage($message);
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -34,6 +34,8 @@ class LogTransport extends Transport
         $this->beforeSendPerformed($message);
 
         $this->logger->debug($this->getMimeEntityString($message));
+
+        return $this->getCount($message);
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -76,7 +76,9 @@ class MailgunTransport extends Transport
             ];
         }
 
-        return $this->client->post($this->url, $options);
+        $this->client->post($this->url, $options);
+
+        return $this->getCount($message);
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/MandrillTransport.php
+++ b/src/Illuminate/Mail/Transport/MandrillTransport.php
@@ -45,7 +45,7 @@ class MandrillTransport extends Transport
             'key' => $this->key,
             'to' => $this->getToAddresses($message),
             'raw_message' => $message->toString(),
-            'async' => false,
+            'async' => true,
         ];
 
         if (version_compare(ClientInterface::VERSION, '6') === 1) {
@@ -54,7 +54,9 @@ class MandrillTransport extends Transport
             $options = ['body' => $data];
         }
 
-        return $this->client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', $options);
+        $this->client->post('https://mandrillapp.com/api/1.0/messages/send-raw.json', $options);
+
+        return $this->getCount($message);
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -32,11 +32,13 @@ class SesTransport extends Transport
     {
         $this->beforeSendPerformed($message);
 
-        return $this->ses->sendRawEmail([
+        $this->ses->sendRawEmail([
             'Source' => key($message->getSender() ?: $message->getFrom()),
             'RawMessage' => [
                 'Data' => $message->toString(),
             ],
         ]);
+
+        return $this->getCount($message);
     }
 }

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -57,7 +57,9 @@ class SparkPostTransport extends Transport
             ],
         ];
 
-        return $this->client->post('https://api.sparkpost.com/api/v1/transmissions', $options);
+        $this->client->post('https://api.sparkpost.com/api/v1/transmissions', $options);
+
+        return $this->getCount($message);
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/Transport.php
+++ b/src/Illuminate/Mail/Transport/Transport.php
@@ -71,13 +71,13 @@ abstract class Transport implements Swift_Transport
     /**
      * Get the number of recipients.
      *
-     * @param  \Swift_Mime_MimeEntity $entity
+     * @param  \Swift_Mime_Message  $message
      * @return int
      */
-    protected function getCount(Swift_Mime_MimeEntity $entity)
+    protected function getCount(Swift_Mime_Message $message)
     {
         $contacts = array_merge(
-            (array) $entity->getTo(), (array) $entity->getCc(), (array) $entity->getBcc()
+            (array) $message->getTo(), (array) $message->getCc(), (array) $message->getBcc()
         );
 
         return count($contacts);

--- a/src/Illuminate/Mail/Transport/Transport.php
+++ b/src/Illuminate/Mail/Transport/Transport.php
@@ -67,4 +67,19 @@ abstract class Transport implements Swift_Transport
             }
         }
     }
+
+    /**
+     * Get the number of recipients.
+     *
+     * @param  \Swift_Mime_MimeEntity $entity
+     * @return int
+     */
+    protected function getCount(Swift_Mime_MimeEntity $entity)
+    {
+        $contacts = array_merge(
+            (array) $entity->getTo(), (array) $entity->getCc(), (array) $entity->getBcc()
+        );
+
+        return count($contacts);
+    }
 }


### PR DESCRIPTION
As pointed out by @Mevrael, and many others, the current situation is pretty crap.

We are literally not allowed to return anything but an integer here if we want to correctly work with swiftmailer. All but our smtp driver send mail asynchronously, so I'm just going to plug the number of recipients sent to, in order to correctly implement the interface.
