### PR TITLE
[5.3] Make method Application::getKernel public

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1109,7 +1109,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @return \Illuminate\Contracts\Console\Kernel|\Illuminate\Contracts\Http\Kernel
      */
-    protected function getKernel()
+    public function getKernel()
     {
         $kernelContract = $this->runningInConsole()
                     ? 'Illuminate\Contracts\Console\Kernel'


### PR DESCRIPTION
This method has been introduced in #8098 but isn't used by laravel itself since #9100.
As I think it's an useful one, maybe we should promote it to public.

ping @arrilot
