### PR TITLE
[5.2] Allow escaping Blade's "@verbatim" using "@"

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -184,7 +184,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function storeVerbatimBlocks($value)
     {
-        return preg_replace_callback('/@verbatim(.*?)@endverbatim/s', function ($matches) {
+        return preg_replace_callback('/(?<!@)@verbatim(.*?)@endverbatim/s', function ($matches) {
             $this->verbatimBlocks[] = $matches[1];
 
             return $this->verbatimPlaceholder;

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -163,6 +163,7 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $this->assertEquals('@foreach', $compiler->compileString('@@foreach'));
+        $this->assertEquals('@verbatim @continue @endverbatim', $compiler->compileString('@@verbatim @@continue @@endverbatim'));
         $this->assertEquals('@foreach($i as $x)', $compiler->compileString('@@foreach($i as $x)'));
         $this->assertEquals('@continue @break', $compiler->compileString('@@continue @@break'));
         $this->assertEquals('@foreach(


### PR DESCRIPTION
This PR allows escaping the "@verbatim" directive using "@".

``` markup
@@verbatim @@continue @@endverbatim

// Output before PR
 @@continue @

// Output after PR
@verbatim @continue @endverbatim
```

The fix was made by updating the regex that looks for the directive and include a negative look behind `(?<!@)` so that it only matches `@verbatim`s that don't come after a `@`.
