### PR TITLE
[5.2] Don't register schedule on every application command

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -15,6 +15,13 @@ class Schedule
     protected $events = [];
 
     /**
+     * Indicates if the schedule has been registered.
+     *
+     * @var bool
+     */
+    protected $eventsRegistered = false;
+
+    /**
      * Add a new callback event to the schedule.
      *
      * @param  string  $callback
@@ -101,6 +108,11 @@ class Schedule
      */
     public function dueEvents($app)
     {
+        if (! $this->eventsRegistered) {
+            $app->make('Illuminate\Contracts\Console\Kernel')->schedule($this);
+            $this->eventsRegistered = true;
+        }
+
         return array_filter($this->events, function ($event) use ($app) {
             return $event->isDue($app);
         });

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -88,8 +88,6 @@ class Kernel implements KernelContract
         $this->app->instance(
             'Illuminate\Console\Scheduling\Schedule', $schedule = new Schedule
         );
-
-        $this->schedule($schedule);
     }
 
     /**


### PR DESCRIPTION
As @sergey-rud pointed out in #12798, schedule is registered when executing every application command. So, on every command we are executing code which is unrelated and may be heavy if the app does a lot of tasks. Instead, process the schedule registration when it is actually used.
