### PR TITLE
[5.2] Add updateOrInsert() method for query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1905,6 +1905,22 @@ class Builder
     }
 
     /**
+     * Insert or update a record matching the attributes, and fill it with values.
+     *
+     * @param  array  $attributes
+     * @param  array  $values
+     * @return bool
+     */
+    public function updateOrInsert(array $attributes, array $values = [])
+    {
+        if (! $this->where($attributes)->first()) {
+            return $this->insert(array_merge($attributes, $values));
+        }
+
+        return (bool) $this->where($attributes)->take(1)->update($values);
+    }
+
+    /**
      * Increment a column's value by a given amount.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1913,7 +1913,7 @@ class Builder
      */
     public function updateOrInsert(array $attributes, array $values = [])
     {
-        if (! $this->where($attributes)->first()) {
+        if (! $this->where($attributes)->exists()) {
             return $this->insert(array_merge($attributes, $values));
         }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1092,26 +1092,26 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
     public function testUpdateOrInsertMethod()
     {
-        $builder = m::mock('Illuminate\Database\Query\Builder[where,first,insert]', [
+        $builder = m::mock('Illuminate\Database\Query\Builder[where,exists,insert]', [
             m::mock('Illuminate\Database\ConnectionInterface'),
             new Illuminate\Database\Query\Grammars\Grammar,
             m::mock('Illuminate\Database\Query\Processors\Processor'),
         ]);
 
         $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
-        $builder->shouldReceive('first')->once()->andReturn(null);
+        $builder->shouldReceive('exists')->once()->andReturn(false);
         $builder->shouldReceive('insert')->once()->with(['email' => 'foo', 'name' => 'bar'])->andReturn(true);
 
         $this->assertEquals(true, $builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
 
-        $builder = m::mock('Illuminate\Database\Query\Builder[where,first,update]', [
+        $builder = m::mock('Illuminate\Database\Query\Builder[where,exists,update]', [
             m::mock('Illuminate\Database\ConnectionInterface'),
             new Illuminate\Database\Query\Grammars\Grammar,
             m::mock('Illuminate\Database\Query\Processors\Processor'),
         ]);
 
         $builder->shouldReceive('where')->twice()->with(['email' => 'foo'])->andReturn(m::self());
-        $builder->shouldReceive('first')->once()->andReturn(m\Matcher\Any::class);
+        $builder->shouldReceive('exists')->once()->andReturn(true);
         $builder->shouldReceive('take')->andReturnSelf();
         $builder->shouldReceive('update')->once()->with(['name' => 'bar'])->andReturn(1);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1090,6 +1090,34 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testUpdateOrInsertMethod()
+    {
+        $builder = m::mock('Illuminate\Database\Query\Builder[where,first,insert]', [
+            m::mock('Illuminate\Database\ConnectionInterface'),
+            new Illuminate\Database\Query\Grammars\Grammar,
+            m::mock('Illuminate\Database\Query\Processors\Processor'),
+        ]);
+
+        $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
+        $builder->shouldReceive('first')->once()->andReturn(null);
+        $builder->shouldReceive('insert')->once()->with(['email' => 'foo', 'name' => 'bar'])->andReturn(true);
+
+        $this->assertEquals(true, $builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
+
+        $builder = m::mock('Illuminate\Database\Query\Builder[where,first,update]', [
+            m::mock('Illuminate\Database\ConnectionInterface'),
+            new Illuminate\Database\Query\Grammars\Grammar,
+            m::mock('Illuminate\Database\Query\Processors\Processor'),
+        ]);
+
+        $builder->shouldReceive('where')->twice()->with(['email' => 'foo'])->andReturn(m::self());
+        $builder->shouldReceive('first')->once()->andReturn(m\Matcher\Any::class);
+        $builder->shouldReceive('take')->andReturnSelf();
+        $builder->shouldReceive('update')->once()->with(['name' => 'bar'])->andReturn(1);
+
+        $this->assertEquals(true, $builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
+    }
+
     public function testDeleteMethod()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Similar to `Eloquent/Builder::updateOrCreate($attributes, $values)`.
