### PR TITLE
[5.2] Blade push with layouts weird ordering

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -833,7 +833,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileStack($expression)
     {
-        return "<?php echo \$__env->yieldContent{$expression}; ?>";
+        return "<?php echo \$__env->yieldPushContent{$expression}; ?>";
     }
 
     /**
@@ -844,7 +844,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compilePush($expression)
     {
-        return "<?php \$__env->startSection{$expression}; ?>";
+        return "<?php \$__env->startPush{$expression}; ?>";
     }
 
     /**
@@ -855,7 +855,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileEndpush($expression)
     {
-        return '<?php $__env->appendSection(); ?>';
+        return '<?php $__env->stopPush(); ?>';
     }
 
     /**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -193,9 +193,9 @@ test';
         $string = '@push(\'foo\')
 test
 @endpush';
-        $expected = '<?php $__env->startSection(\'foo\'); ?>
+        $expected = '<?php $__env->startPush(\'foo\'); ?>
 test
-<?php $__env->appendSection(); ?>';
+<?php $__env->stopPush(); ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
@@ -203,7 +203,7 @@ test
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $string = '@stack(\'foo\')';
-        $expected = '<?php echo $__env->yieldContent(\'foo\'); ?>';
+        $expected = '<?php echo $__env->yieldPushContent(\'foo\'); ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -264,22 +264,34 @@ class ViewFactoryTest extends PHPUnit_Framework_TestCase
     public function testSingleStackPush()
     {
         $factory = $this->getFactory();
-        $factory->startSection('foo');
+        $factory->startPush('foo');
         echo 'hi';
-        $factory->appendSection();
-        $this->assertEquals('hi', $factory->yieldContent('foo'));
+        $factory->stopPush();
+        $this->assertEquals('hi', $factory->yieldPushContent('foo'));
     }
 
     public function testMultipleStackPush()
     {
         $factory = $this->getFactory();
-        $factory->startSection('foo');
+        $factory->startPush('foo');
         echo 'hi';
-        $factory->appendSection();
-        $factory->startSection('foo');
+        $factory->stopPush();
+        $factory->startPush('foo');
         echo ', Hello!';
-        $factory->appendSection();
-        $this->assertEquals('hi, Hello!', $factory->yieldContent('foo'));
+        $factory->stopPush();
+        $this->assertEquals('hi, Hello!', $factory->yieldPushContent('foo'));
+
+        // mimic a parent view is rendering
+        $factory->incrementRender();
+        $factory->startPush('foo');
+        echo 'Dear ';
+        $factory->stopPush();
+        $factory->startPush('foo');
+        echo 'friend';
+        $factory->stopPush();
+        $factory->decrementRender();
+
+        $this->assertEquals('Dear friendhi, Hello!', $factory->yieldPushContent('foo'));
     }
 
     public function testSessionAppending()


### PR DESCRIPTION
Modified version of #12769, this time, I separate the logic of `@push` and `@section`. So, only the push and stack part are modified.

Reason to separate push and section:
1. In original method, they share the same compiling result `startSection`. If I keep it, I have to break the structure of internal `$sections` or break the behavior of `appendSection`
2. There is no reason to use `@push` and `@section` with same name together. i.e. 

```
@push('me') @endpush
@section('me') @endsection
```

is undefined. So, we can separate them.
