### PR TITLE
[5.2] Make use of the stripParentheses method and fix test

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -833,9 +833,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileIncludeIf($expression)
     {
-        if (Str::startsWith($expression, '(')) {
-            $expression = substr($expression, 1, -1);
-        }
+        $expression = $this->stripParentheses($expression);
 
         return "<?php if (\$__env->exists($expression)) echo \$__env->make($expression, array_except(get_defined_vars(), array('__data', '__path')))->render(); ?>";
     }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -577,7 +577,7 @@ empty
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $this->assertEquals('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeIf(\'foo\')'));
-        $this->assertEquals('<?php if ($__env->exists(name(foo)) echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeIf(name(foo))'));
+        $this->assertEquals('<?php if ($__env->exists(name(foo))) echo $__env->make(name(foo), array_except(get_defined_vars(), array(\'__data\', \'__path\')))->render(); ?>', $compiler->compileString('@includeIf(name(foo))'));
     }
 
     public function testShowEachAreCompiled()


### PR DESCRIPTION
This PR strips the parentheses around the given expression in the `compileIncludeIf()` method using the `stripParentheses()` method instead of rewriting the stripping code inside the method.

Also the written test had a minor typo that was fixed in this PR, the typo caused travis CI build to fail: https://travis-ci.org/laravel/framework/builds/117480799
