### PR TITLE
[5.2] update httponly flags

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -135,7 +135,7 @@ class VerifyCsrfToken
         $response->headers->setCookie(
             new Cookie(
                 'XSRF-TOKEN', $request->session()->token(), time() + 60 * 120,
-                $config['path'], $config['domain'], $config['secure'], false
+                $config['path'], $config['domain'], $config['secure'], $config['http_only']
             )
         );
 

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -135,7 +135,7 @@ class VerifyCsrfToken
         $response->headers->setCookie(
             new Cookie(
                 'XSRF-TOKEN', $request->session()->token(), time() + 60 * 120,
-                $config['path'], $config['domain'], Arr::get($config, 'secure', false), Arr::get($config, 'http_only', true)
+                $config['path'], $config['domain'], Arr::get($config, 'secure', false), Arr::get($config, 'http_only', false)
             )
         );
 

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -135,7 +135,7 @@ class VerifyCsrfToken
         $response->headers->setCookie(
             new Cookie(
                 'XSRF-TOKEN', $request->session()->token(), time() + 60 * 120,
-                $config['path'], $config['domain'], $config['secure'], $config['http_only']
+                $config['path'], $config['domain'], Arr::get($config, 'secure', false), Arr::get($config, 'http_only', true)
             )
         );
 

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -180,7 +180,7 @@ class StartSession
         if ($this->sessionIsPersistent($config = $this->manager->getSessionConfig())) {
             $response->headers->setCookie(new Cookie(
                 $session->getName(), $session->getId(), $this->getCookieExpirationDate(),
-                $config['path'], $config['domain'], Arr::get($config, 'secure', false), Arr::get($config, 'http_only', true)
+                $config['path'], $config['domain'], Arr::get($config, 'secure', false), Arr::get($config, 'http_only', false)
             ));
         }
     }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -180,7 +180,7 @@ class StartSession
         if ($this->sessionIsPersistent($config = $this->manager->getSessionConfig())) {
             $response->headers->setCookie(new Cookie(
                 $session->getName(), $session->getId(), $this->getCookieExpirationDate(),
-                $config['path'], $config['domain'], $config['secure'], $config['http_only']
+                $config['path'], $config['domain'], Arr::get($config, 'secure', false), Arr::get($config, 'http_only', true)
             ));
         }
     }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -180,7 +180,7 @@ class StartSession
         if ($this->sessionIsPersistent($config = $this->manager->getSessionConfig())) {
             $response->headers->setCookie(new Cookie(
                 $session->getName(), $session->getId(), $this->getCookieExpirationDate(),
-                $config['path'], $config['domain'], Arr::get($config, 'secure', false)
+                $config['path'], $config['domain'], $config['secure'], $config['http_only']
             ));
         }
     }


### PR DESCRIPTION
this is a updated version of https://github.com/laravel/framework/pull/12809

in StartSession I also changed this:

```
Arr::get($config, 'secure', false)
```

to

```
$config['secure']
```

Is this correct?
