### PR TITLE
[5.2] Fix an issue with explicit custom validator attributes

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1931,28 +1931,32 @@ class Validator implements ValidatorContract
      */
     protected function getAttribute($attribute)
     {
-        $attributeName = $this->getPrimaryAttribute($attribute);
+        $primaryAttribute = $this->getPrimaryAttribute($attribute);
 
-        // The developer may dynamically specify the array of custom attributes
-        // on this Validator instance. If the attribute exists in this array
-        // it takes precedence over all other ways we can pull attributes.
-        if (isset($this->customAttributes[$attributeName])) {
-            return $this->customAttributes[$attributeName];
-        }
+        $expectedAttributes = $attribute != $primaryAttribute ? [$attribute, $primaryAttribute] : [$attribute];
 
-        $key = "validation.attributes.{$attributeName}";
+        foreach ($expectedAttributes as $expectedAttributeName) {
+            // The developer may dynamically specify the array of custom attributes
+            // on this Validator instance. If the attribute exists in this array
+            // it takes precedence over all other ways we can pull attributes.
+            if (isset($this->customAttributes[$expectedAttributeName])) {
+                return $this->customAttributes[$expectedAttributeName];
+            }
 
-        // We allow for the developer to specify language lines for each of the
-        // attributes allowing for more displayable counterparts of each of
-        // the attributes. This provides the ability for simple formats.
-        if (($line = $this->translator->trans($key)) !== $key) {
-            return $line;
+            $key = "validation.attributes.{$expectedAttributeName}";
+
+            // We allow for the developer to specify language lines for each of the
+            // attributes allowing for more displayable counterparts of each of
+            // the attributes. This provides the ability for simple formats.
+            if (($line = $this->translator->trans($key)) !== $key) {
+                return $line;
+            }
         }
 
         // When no language line has been specified for the attribute and it is
         // also an implicit attribute we will display the raw attribute name
         // and not modify it with any replacements before we display this.
-        if (isset($this->implicitAttributes[$attributeName])) {
+        if (isset($this->implicitAttributes[$primaryAttribute])) {
             return $attribute;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -212,6 +212,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
         $this->assertEquals('Any name must be a string!', $v->messages()->first('users.1.name'));
+
+        $trans->addResource('array', ['validation.required' => ':attribute is required!'], 'en', 'messages');
+        $v = new Validator($trans, ['title' => ['nl' => '', 'en' => 'Hello']], ['title.*' => 'required'], [], ['title.nl' => 'Titel', 'title.en' => 'Title']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('Titel is required!', $v->messages()->first('title.nl'));
     }
 
     public function testDisplayableValuesAreReplaced()


### PR DESCRIPTION
In a previous PR https://github.com/laravel/framework/pull/12578, we introduced replacing attributes with asterisks in array validation as mentioned in https://github.com/laravel/framework/issues/12548:

```
'attributes' => [
    'users.*.name' => ' User name'
],
```

That way an error would appear `User name is required`, instead of `users.6.name is required`.

However this change broke the ability to define a custom attribute using an explicit key as reported here https://github.com/laravel/framework/issues/12819:

```
$customAttributes = [
    'title.nl' => 'Titel (Nederlands)',
    'title.en' => 'Title (English)'
]
```

This PR fixes the matter by checking if an exact key exists first `title.nl` before checking for a key with an asterisk `title.*`.
