### PR TITLE
[5.2] Allow the application to register custom exception handlers

### DIFF
--- a/src/Illuminate/Contracts/Debug/ExceptionHandler.php
+++ b/src/Illuminate/Contracts/Debug/ExceptionHandler.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Contracts\Debug;
 
+use Closure;
 use Exception;
 
 interface ExceptionHandler
@@ -31,4 +32,12 @@ interface ExceptionHandler
      * @return void
      */
     public function renderForConsole($output, Exception $e);
+
+    /**
+     * Register a custom exception handler.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function register(Closure $callback);
 }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -896,6 +896,17 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Register a custom exception handler.
+     *
+     * @param  \Closure   $callback
+     * @return void
+     */
+    public function catch(Closure $callback)
+    {
+        $this['Illuminate\Contracts\Debug\ExceptionHandler']->register($callback);
+    }
+
+    /**
      * Register a terminating callback with the application.
      *
      * @param  \Closure  $callback

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -901,7 +901,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      * @param  \Closure   $callback
      * @return void
      */
-    public function catch(Closure $callback)
+    public function handleException(Closure $callback)
     {
         $this['Illuminate\Contracts\Debug\ExceptionHandler']->register($callback);
     }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -111,19 +111,23 @@ class Handler implements ExceptionHandlerContract
 
         if ($e instanceof HttpResponseException) {
             return $e->getResponse();
-        } elseif ($e instanceof ModelNotFoundException) {
+        }
+
+        if ($e instanceof ValidationException && $e->getResponse()) {
+            return $e->getResponse();
+        }
+
+        if ($e instanceof ModelNotFoundException) {
             $e = new NotFoundHttpException($e->getMessage(), $e);
         } elseif ($e instanceof AuthorizationException) {
             $e = new HttpException(403, $e->getMessage());
-        } elseif ($e instanceof ValidationException && $e->getResponse()) {
-            return $e->getResponse();
         }
 
         if ($this->isHttpException($e)) {
             return $this->toIlluminateResponse($this->renderHttpException($e), $e);
-        } else {
-            return $this->toIlluminateResponse($this->convertExceptionToResponse($e), $e);
         }
+
+        return $this->toIlluminateResponse($this->convertExceptionToResponse($e), $e);
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Exceptions;
 
+use Closure;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Illuminate\Http\Response;
@@ -32,6 +33,13 @@ class Handler implements ExceptionHandlerContract
      * @var array
      */
     protected $dontReport = [];
+
+    /**
+     * A list of the custom exception handlers.
+     *
+     * @var array
+     */
+    protected $handlers = [];
 
     /**
      * Create a new exception handler instance.
@@ -214,5 +222,16 @@ EOF;
     protected function isHttpException(Exception $e)
     {
         return $e instanceof HttpException;
+    }
+
+    /**
+     * Register a custom exception handler.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function register(Closure $callback)
+    {
+        array_unshift($this->handlers, $callback);
     }
 }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -158,7 +158,7 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase
         $app['Illuminate\Contracts\Debug\ExceptionHandler'] = $handler = m::mock('Illuminate\Contracts\Debug\ExceptionHandler');
         $handler->shouldReceive('register')->once()->with($closure);
 
-        $app->catch($closure);
+        $app->handleException($closure);
     }
 }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -150,6 +150,16 @@ class FoundationApplicationTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey(0, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\RegisterFacades'));
         $this->assertSame($closure, $app['events']->getListeners('bootstrapped: Illuminate\Foundation\Bootstrap\RegisterFacades')[0]);
     }
+
+    public function testExceptionHandlerCanRegisterCustomHandlers()
+    {
+        $app = new Application;
+        $closure = function () {};
+        $app['Illuminate\Contracts\Debug\ExceptionHandler'] = $handler = m::mock('Illuminate\Contracts\Debug\ExceptionHandler');
+        $handler->shouldReceive('register')->once()->with($closure);
+
+        $app->catch($closure);
+    }
 }
 
 class ApplicationDeferredSharedServiceProviderStub extends Illuminate\Support\ServiceProvider


### PR DESCRIPTION
This PR allows the Laravel exception handler to register custom handlers defined by the user.

The custom exception handlers can now be registered by the application via the `handleException()` method:

```
app()->handleException(function (CustomException $e) {
    return $e->getMessage();
});
```

If the argument passed through the Closure is not type-hinted or it's missing, the defined handler will be able to handle any exception.

An exception can also be handled by several handlers until one of them returns a response.

Thanks to this feature we can
- avoid cluttering the `render()` method of the default exception handler
- create a tailored ServiceProvider to register the exception handlers
- let external Laravel packages register their own handlers automatically.
