### PR TITLE
[5.2] Alt remember_token to a fixed length of column

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -863,7 +863,7 @@ class Blueprint
      */
     public function rememberToken()
     {
-        return $this->string('remember_token', 100)->nullable();
+        return $this->char('remember_token', 100)->nullable();
     }
 
     /**


### PR DESCRIPTION
The remember_token is often a fixed length. This change improves performance of database.
