### PR TITLE
[5.2] Add IDE auto-complete support for find() result

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -141,7 +141,7 @@ class Builder
      *
      * @param  mixed  $id
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|null
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]|null
      */
     public function find($id, $columns = ['*'])
     {


### PR DESCRIPTION
After adding this, when I type code as below, the ·created_at· property can has auto-complete support by IDE, much more convenient.

``` php
echo SomeModel::find(123)->created_at;

echo SomeModel::find([1,2])[0]->created_at;
```
