### PR TITLE
[5.2] Add Bootstrap Composer scripts

### DIFF
--- a/src/Illuminate/Bootstrap/Composer.php
+++ b/src/Illuminate/Bootstrap/Composer.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Bootstrap;
+
+use Composer\Script\Event;
+use Illuminate\Foundation\Application;
+
+class Composer
+{
+    public static function postInstall(Event $event)
+    {
+        $vendorDir = $event->getComposer()->getConfig()->get('vendor-dir');
+        require $vendorDir . '/autoload.php';
+
+        static::clearCompiled();
+    }
+
+    public static function postUpdate(Event $event)
+    {
+        $vendorDir = $event->getComposer()->getConfig()->get('vendor-dir');
+        require $vendorDir . '/autoload.php';
+
+        static::clearCompiled();
+    }
+
+    private static function clearCompiled()
+    {
+        $baseDir = getcwd();
+        $laravel = new Application($baseDir);
+
+        $compiledPath = $laravel->getCachedCompilePath();
+        $servicesPath = $laravel->getCachedServicesPath();
+
+        if (file_exists($compiledPath)) {
+            @unlink($compiledPath);
+        }
+
+        if (file_exists($servicesPath)) {
+            @unlink($servicesPath);
+        }
+    }
+}


### PR DESCRIPTION
Alternative to https://github.com/laravel/laravel/pull/3695 and the manual scripts

Instead of running a `php artisan` command, you can run it like this:

``` js
"scripts": {
        "post-install-cmd": [
            "Illuminate\\Bootstrap\\Composer::postInstall"
        ],
        "post-update-cmd": [
            "Illuminate\\Bootstrap\\Composer::postUpdate"
        ]       
    }
```

This avoids loading the compiled path or needing any bootstrap configuration.
Also adds more flexibility when upgrading, instead of a laravel/laravel command.

I now used `postInstall` and `postUpdate` to call `clearCompiled()`. We could also call `clearCompiled` directly, but this way you could perhaps add different functions later on when needed.
