### PR TITLE
[5.2] When running tests return exceptions directly

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -96,7 +96,9 @@ class Handler implements ExceptionHandlerContract
      */
     public function render($request, Exception $e)
     {
-        if ($e instanceof HttpResponseException) {
+        if (app('env') == 'testing') {
+            return $e;
+        } elseif ($e instanceof HttpResponseException) {
             return $e->getResponse();
         } elseif ($e instanceof ModelNotFoundException) {
             $e = new NotFoundHttpException($e->getMessage(), $e);


### PR DESCRIPTION
The current exception handler throws exceptions including the HTML for testing which is really hard to read in the console or in IDE.
I am proposing to return the exception object directly for testing environment and it will be casted to string.
It will display the plain exception and the stack trace. Even in the IDEs like PhpStorm the user can click on the links which the IDE produces from the file names and line numbers to go to the caller method.
