### PR TITLE
[5.2] Fix engine issueing

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -308,7 +308,7 @@ class Factory implements FactoryContract
         $extensions = array_keys($this->extensions);
 
         return Arr::first($extensions, function ($key, $value) use ($path) {
-            return Str::endsWith($path, $value);
+            return Str::endsWith($path, '.'.$value);
         });
     }
 


### PR DESCRIPTION
Fix that a view (`welcomeblade.php`) would run the `BladeEngine` instead of the `PhpEngine`.
