### PR TITLE
[5.2] Fixes #12821

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -89,7 +89,14 @@ class AuthManager implements FactoryContract
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($name, $config);
         } else {
-            return $this->{'create'.ucfirst($config['driver']).'Driver'}($name, $config);
+            $driver = ucfirst($config['driver']);
+            $driverCreatorMethod = "create{$driver}Driver";
+
+            if (method_exists($this, $driverCreatorMethod)) {
+                return $this->$driverCreatorMethod($name, $config);
+            } else {
+                throw new InvalidArgumentException("Auth guard driver [{$driver}] is not defined.");
+            }
         }
     }
 


### PR DESCRIPTION
As explained on #12821, this fixes a bug where a infinite loop occurs when trying to call any `Auth` facade method when the Guard Driver defined on `auth.php` config is set to a invalid driver.

I didn't created any test since there are no test files for this class, but the bug is obvious.
