### PR TITLE
[5.2] Let use custom Application in Composer scripts

### DIFF
--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -54,7 +54,7 @@ class ComposerScripts
      * Creates a Laravel application instance.
      *
      * @param  string  $basePath
-     * @return \Illuminate\Foundation\Application
+     * @return \Illuminate\Contracts\Foundation\Application
      */
     protected static function createApplication($basePath)
     {

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -39,7 +39,7 @@ class ComposerScripts
      */
     protected static function clearCompiled()
     {
-        $laravel = static::createApplication();
+        $laravel = static::createApplication(getcwd());
 
         if (file_exists($compiledPath = $laravel->getCachedCompilePath())) {
             @unlink($compiledPath);
@@ -53,10 +53,11 @@ class ComposerScripts
     /**
      * Creates a Laravel application instance.
      *
+     * @param  string  $basePath
      * @return \Illuminate\Foundation\Application
      */
-    protected static function createApplication()
+    protected static function createApplication($basePath)
     {
-        return new Application(getcwd());
+        return new Application($basePath);
     }
 }

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -37,9 +37,9 @@ class ComposerScripts
      *
      * @return void
      */
-    private static function clearCompiled()
+    protected static function clearCompiled()
     {
-        $laravel = new Application(getcwd());
+        $laravel = static::createApplication();
 
         if (file_exists($compiledPath = $laravel->getCachedCompilePath())) {
             @unlink($compiledPath);
@@ -48,5 +48,15 @@ class ComposerScripts
         if (file_exists($servicesPath = $laravel->getCachedServicesPath())) {
             @unlink($servicesPath);
         }
+    }
+
+    /**
+     * Creates a Laravel application instance.
+     *
+     * @return \Illuminate\Foundation\Application
+     */
+    protected static function createApplication()
+    {
+        return new Application(getcwd());
     }
 }


### PR DESCRIPTION
Allow to use custom Application by extending `ComposerScripts::createApplication` and using the extended `ComposerScripts` class in `composer.json`.
