### PR TITLE
[5.2] Add custom query for join table

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -324,7 +324,7 @@ class Builder
 
     /**
      * Creates a join clause with given table. Checks if the table is a closure
-     * to enable custom query instead of the table name
+     * to enable custom query instead of the table name.
      *
      * @param  string                                                   $type
      * @param  string|\Closure|\Illuminate\Database\Query\Expression    $table
@@ -338,7 +338,7 @@ class Builder
         // we need to prepare the statement before compiling the query
         if ($joinClause->table instanceof \Closure) {
 
-            /** @var Builder $query */
+            /* @var Builder $query */
             $joinQuery = $this->newQuery();
 
             // Similar to the sub-select clause, we will create a new query instance so
@@ -348,14 +348,14 @@ class Builder
 
             // merge the bindings for the statements to pass values
             // used in the query
-            $this->addBinding($joinQuery->getBindings(), "join");
+            $this->addBinding($joinQuery->getBindings(), 'join');
 
             // compile the query and wrap it in brackets
-            $table = "(" . $joinQuery->getGrammar()->compileSelect($joinQuery) . ")";
+            $table = '('.$joinQuery->getGrammar()->compileSelect($joinQuery).')';
 
             // build the sql statement with a raw expression to enable compile
             // also add a alias for sql query. Uses the table
-            $joinClause->table =  $this->raw($table . " AS " . $joinQuery->from);
+            $joinClause->table = $this->raw($table.' AS '.$joinQuery->from);
         }
 
         return $joinClause;
@@ -381,7 +381,6 @@ class Builder
         // is trying to build a join with a complex "on" clause containing more than
         // one condition, so we'll add the join and call a Closure with the query.
         if ($one instanceof Closure) {
-
             call_user_func($one, $join);
 
             $this->joins[] = $join;
@@ -393,7 +392,6 @@ class Builder
         // "on" clause with a single condition. So we will just build the join with
         // this simple join clauses attached to it. There is not a join callback.
         else {
-
             $this->joins[] = $join->on(
                 $one, $operator, $two, 'and', $where
             );

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -323,6 +323,45 @@ class Builder
     }
 
     /**
+     * Creates a join clause with given table. Checks if the table is a closure
+     * to enable custom query instead of the table name
+     *
+     * @param  string                                                   $type
+     * @param  string|\Closure|\Illuminate\Database\Query\Expression    $table
+     * @return JoinClause
+     */
+    protected function createJoinClause($type, $table)
+    {
+        $joinClause = new JoinClause($type, $table);
+
+        // enable the sub query for the join instead of the table
+        // we need to prepare the statement before compiling the query
+        if ($joinClause->table instanceof \Closure) {
+
+            /** @var Builder $query */
+            $joinQuery = $this->newQuery();
+
+            // Similar to the sub-select clause, we will create a new query instance so
+            // the developer may cleanly specify the entire exists query and we will
+            // compile the whole thing in the grammar and insert it into the SQL.
+            call_user_func($joinClause->table, $joinQuery);
+
+            // merge the bindings for the statements to pass values
+            // used in the query
+            $this->addBinding($joinQuery->getBindings(), "join");
+
+            // compile the query and wrap it in brackets
+            $table = "(" . $joinQuery->getGrammar()->compileSelect($joinQuery) . ")";
+
+            // build the sql statement with a raw expression to enable compile
+            // also add a alias for sql query. Uses the table
+            $joinClause->table =  $this->raw($table . " AS " . $joinQuery->from);
+        }
+
+        return $joinClause;
+    }
+
+    /**
      * Add a join clause to the query.
      *
      * @param  string  $table
@@ -335,11 +374,13 @@ class Builder
      */
     public function join($table, $one, $operator = null, $two = null, $type = 'inner', $where = false)
     {
+        // create the join closure instance
+        $join = $this->createJoinClause($type, $table);
+
         // If the first "column" of the join is really a Closure instance the developer
         // is trying to build a join with a complex "on" clause containing more than
         // one condition, so we'll add the join and call a Closure with the query.
         if ($one instanceof Closure) {
-            $join = new JoinClause($type, $table);
 
             call_user_func($one, $join);
 
@@ -352,7 +393,6 @@ class Builder
         // "on" clause with a single condition. So we will just build the join with
         // this simple join clauses attached to it. There is not a join callback.
         else {
-            $join = new JoinClause($type, $table);
 
             $this->joins[] = $join->on(
                 $one, $operator, $two, 'and', $where

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -800,13 +800,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
     /**
      * Test the closure in the join that supports custom select query
      * on the table name. Creates alias for the table you are setting in the
-     * inner closure
+     * inner closure.
      */
-    public function testJoinsClosureQueryBuilder() {
+    public function testJoinsClosureQueryBuilder()
+    {
         $builder = $this->getBuilder();
 
         // enable the raw on connection
-        $innerSql ='(select * from "contacts" where "is_active" = ?) AS contacts';
+        $innerSql = '(select * from "contacts" where "is_active" = ?) AS contacts';
         $builder->getConnection()->shouldReceive('raw')->once()
             ->with($innerSql)
             ->andReturn(new \Illuminate\Database\Query\Expression($innerSql));
@@ -814,16 +815,16 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $joinRunned = false;
 
         // check if the bindings work before adding join
-        $builder->where("id", "<", 10);
-        $builder->join(function($builder) use(&$joinRunned) {
+        $builder->where('id', '<', 10);
+        $builder->join(function ($builder) use (&$joinRunned) {
             $joinRunned = true;
-            $builder->from("contacts")->where("is_active", 1);
-        }, "users", "users.id", "contacts.user_id");
+            $builder->from('contacts')->where('is_active', 1);
+        }, 'users', 'users.id', 'contacts.user_id');
 
         // check if the bindings work after adding join
-        $builder->where("id", ">", 2);
+        $builder->where('id', '>', 2);
 
-        $this->assertTrue($joinRunned, "the closure should be runned");
+        $this->assertTrue($joinRunned, 'the closure should be runned');
 
         $this->assertEquals(
             'select * inner join (select * from "contacts" where "is_active" = ?) AS contacts on "users" users.id "contacts"."user_id" where "id" < ? and "id" > ?',
@@ -831,7 +832,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         );
         // check bindings
         $this->assertEquals([
-            1, 10, 2
+            1, 10, 2,
         ], $builder->getBindings());
     }
 
@@ -1132,7 +1133,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = m::mock('Illuminate\Database\Query\Builder[where,exists,insert]', [
             m::mock('Illuminate\Database\ConnectionInterface'),
-            new Illuminate\Database\Query\Grammars\Grammar,
+            new Illuminate\Database\Query\Grammars\Grammar(),
             m::mock('Illuminate\Database\Query\Processors\Processor'),
         ]);
 
@@ -1144,7 +1145,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
         $builder = m::mock('Illuminate\Database\Query\Builder[where,exists,update]', [
             m::mock('Illuminate\Database\ConnectionInterface'),
-            new Illuminate\Database\Query\Grammars\Grammar,
+            new Illuminate\Database\Query\Grammars\Grammar(),
             m::mock('Illuminate\Database\Query\Processors\Processor'),
         ]);
 
@@ -1188,7 +1189,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->getConnection()->shouldReceive('statement')->once()->with('truncate "users"', []);
         $builder->from('users')->truncate();
 
-        $sqlite = new Illuminate\Database\Query\Grammars\SQLiteGrammar;
+        $sqlite = new Illuminate\Database\Query\Grammars\SQLiteGrammar();
         $builder = $this->getBuilder();
         $builder->from('users');
         $this->assertEquals([
@@ -1495,7 +1496,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
     protected function getBuilder()
     {
-        $grammar = new Illuminate\Database\Query\Grammars\Grammar;
+        $grammar = new Illuminate\Database\Query\Grammars\Grammar();
         $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
 
         return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
@@ -1503,7 +1504,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
     protected function getPostgresBuilder()
     {
-        $grammar = new Illuminate\Database\Query\Grammars\PostgresGrammar;
+        $grammar = new Illuminate\Database\Query\Grammars\PostgresGrammar();
         $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
 
         return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
@@ -1511,7 +1512,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
     protected function getMySqlBuilder()
     {
-        $grammar = new Illuminate\Database\Query\Grammars\MySqlGrammar;
+        $grammar = new Illuminate\Database\Query\Grammars\MySqlGrammar();
         $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
 
         return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
@@ -1519,7 +1520,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
     protected function getSQLiteBuilder()
     {
-        $grammar = new Illuminate\Database\Query\Grammars\SQLiteGrammar;
+        $grammar = new Illuminate\Database\Query\Grammars\SQLiteGrammar();
         $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
 
         return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
@@ -1527,7 +1528,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
     protected function getSqlServerBuilder()
     {
-        $grammar = new Illuminate\Database\Query\Grammars\SqlServerGrammar;
+        $grammar = new Illuminate\Database\Query\Grammars\SqlServerGrammar();
         $processor = m::mock('Illuminate\Database\Query\Processors\Processor');
 
         return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
@@ -1535,8 +1536,8 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
     protected function getMySqlBuilderWithProcessor()
     {
-        $grammar = new Illuminate\Database\Query\Grammars\MySqlGrammar;
-        $processor = new Illuminate\Database\Query\Processors\MySqlProcessor;
+        $grammar = new Illuminate\Database\Query\Grammars\MySqlGrammar();
+        $processor = new Illuminate\Database\Query\Processors\MySqlProcessor();
 
         return new Builder(m::mock('Illuminate\Database\ConnectionInterface'), $grammar, $processor);
     }


### PR DESCRIPTION
Hi All,
Ads support to custom sql query for a join instead of regular table name. Needed for some fast queries.
Added unit test with example usage.

Example of the query:

> select \* inner join (select \* from "contacts" where "is_active" = '1') AS contacts on "users" users.id "contacts"."user_id" where "id" < '2' and "id" > '3'

Usage (similar to whereExists):

```
    $builder->where("id", "<", 10);
    $builder->join(function($builder) {
        // create a custom query
        $builder->from("contacts")->where("is_active", 1);
    }, "users", "users.id", "contacts.user_id"); // alias will be same as the from table in the builder

    // check if the bindings work after adding join
    $builder->where("id", ">", 2);
```

Improvments and advices are welcomed.
Martin.
