### PR TITLE
[5.3] Numerical keys are preserved during validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2679,7 +2679,7 @@ class Validator implements ValidatorContract
 
         $rules = $this->explodeRules($this->initialRules);
 
-        $this->rules = array_merge($this->rules, $rules);
+        $this->rules = $this->rules + $rules;
 
         return $this;
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -432,6 +432,10 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['name' => 'foo'], ['name' => 'Required']);
         $this->assertTrue($v->passes());
 
+        // numerical keys are preserved
+        $v = new Validator($trans, ['1' => 'foo'], ['1' => 'Required']);
+        $this->assertTrue($v->passes());
+
         $file = new File('', false);
         $v = new Validator($trans, ['name' => $file], ['name' => 'Required']);
         $this->assertFalse($v->passes());


### PR DESCRIPTION
My controller has the following method which is accessible via `/foo`

```
public function foo(Request $request)
{
    $this->validate($request, [
        '1' => 'required'
    ]);

    return "success!";
}
```

If I call `/foo?1=enter` the requests fails. While `/foo?0=enter` works fine.

The problem only occurs if the field name can be converted to a numerical value:
PHP silently converts array keys to the corresponding integer if possible, e.g. `['123' => 'bar']` is converted to `[123 => 'bar']`. And the `array_merge()` function does not preserve numerical keys: `array_merge([], [123 => 'bar'])` is converted to `[0 => 'bar']`.
