### PR TITLE
[5.3] Auth - Some changes for consistency

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -25,7 +25,7 @@ trait AuthenticatesUsers
      *
      * @return \Illuminate\Http\Response
      */
-    public function showLoginForm()
+    protected function showLoginForm()
     {
         $view = property_exists($this, 'loginView')
                     ? $this->loginView : 'auth.authenticate';
@@ -54,7 +54,7 @@ trait AuthenticatesUsers
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function login(Request $request)
+    protected function login(Request $request)
     {
         $this->validateLogin($request);
 
@@ -171,7 +171,7 @@ trait AuthenticatesUsers
      *
      * @return \Illuminate\Http\Response
      */
-    public function logout()
+    protected function logout()
     {
         Auth::guard($this->getGuard())->logout();
 

--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -24,7 +24,7 @@ trait RegistersUsers
      *
      * @return \Illuminate\Http\Response
      */
-    public function showRegistrationForm()
+    protected function showRegistrationForm()
     {
         if (property_exists($this, 'registerView')) {
             return view($this->registerView);
@@ -50,7 +50,7 @@ trait RegistersUsers
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function register(Request $request)
+    protected function register(Request $request)
     {
         $validator = $this->validator($request->all());
 

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -56,7 +56,7 @@ trait ResetsPasswords
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function sendResetLinkEmail(Request $request)
+    protected function sendResetLinkEmail(Request $request)
     {
         $this->validate($request, ['email' => 'required|email']);
 
@@ -131,7 +131,7 @@ trait ResetsPasswords
      * @param  string|null  $token
      * @return \Illuminate\Http\Response
      */
-    public function showResetForm(Request $request, $token = null)
+    protected function showResetForm(Request $request, $token = null)
     {
         if (is_null($token)) {
             return $this->getEmail();
@@ -167,7 +167,7 @@ trait ResetsPasswords
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function reset(Request $request)
+    protected function reset(Request $request)
     {
         $this->validate($request, $this->getResetValidationRules());
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -277,18 +277,18 @@ class Router implements RegistrarContract
     public function auth()
     {
         // Authentication Routes...
-        $this->get('login', 'Auth\AuthController@showLoginForm');
-        $this->post('login', 'Auth\AuthController@login');
-        $this->get('logout', 'Auth\AuthController@logout');
+        $this->get('login', 'Auth\AuthController@getLogin');
+        $this->post('login', 'Auth\AuthController@postLogin');
+        $this->get('logout', 'Auth\AuthController@getLogout');
 
         // Registration Routes...
-        $this->get('register', 'Auth\AuthController@showRegistrationForm');
-        $this->post('register', 'Auth\AuthController@register');
+        $this->get('register', 'Auth\AuthController@getRegister');
+        $this->post('register', 'Auth\AuthController@postRegister');
 
         // Password Reset Routes...
-        $this->get('password/reset/{token?}', 'Auth\PasswordController@showResetForm');
-        $this->post('password/email', 'Auth\PasswordController@sendResetLinkEmail');
-        $this->post('password/reset', 'Auth\PasswordController@reset');
+        $this->get('password/reset/{token?}', 'Auth\PasswordController@getReset');
+        $this->post('password/email', 'Auth\PasswordController@postEmail');
+        $this->post('password/reset', 'Auth\PasswordController@postReset');
     }
 
     /**


### PR DESCRIPTION
These changes makes possible to easily extend the Auth methods on controller. Also this was the intended behaviour from the start (I guess).

Example:

**Auth\AuthController.php**

```
public function getLogout()
{
    // ...
    // Custom user logic
    // ...

    return $this->logout();
}
```

It's possible we're facing a breaking change, that's the reason i've tagged the 5.3 version.
