### PR TITLE
HasManyThrough intermediate table foreign key fix

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Encryption;
 
 use RuntimeException;
+use Illuminate\Support\Str;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\EncryptException;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
@@ -28,6 +29,10 @@ class Encrypter extends BaseEncrypter implements EncrypterContract
     public function __construct($key, $cipher = 'AES-128-CBC')
     {
         $key = (string) $key;
+
+        if (Str::startsWith($key, 'base64:')) {
+            $key = base64_decode(substr($key, 7));
+        }
 
         if (static::supported($key, $cipher)) {
             $this->key = $key;

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -442,6 +442,16 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Get the fully qualified path to the environment file.
+     *
+     * @return string
+     */
+    public function environmentFilePath()
+    {
+        return $this->environmentPath().'/'.$this->environmentFile();
+    }
+
+    /**
      * Get or check the current application environment.
      *
      * @param  mixed

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Console;
 
-use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 
 class KeyGenerateCommand extends Command

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -4,16 +4,15 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
-use Symfony\Component\Console\Input\InputOption;
 
 class KeyGenerateCommand extends Command
 {
     /**
-     * The console command name.
+     * The name and signature of the console command.
      *
      * @var string
      */
-    protected $name = 'key:generate';
+    protected $signature = 'key:generate {--show : Display the key instead of modifying files}';
 
     /**
      * The console command description.
@@ -29,55 +28,46 @@ class KeyGenerateCommand extends Command
      */
     public function fire()
     {
-        $app = $this->laravel;
-
-        $key = $this->getRandomKey($app['config']['app.cipher']);
+        $key = $this->generateRandomKey();
 
         if ($this->option('show')) {
             return $this->line('<comment>'.$key.'</comment>');
         }
 
-        $path = $app->environmentPath().'/'.$app->environmentFile();
+        // Next, we will replace the application key in the environment file so it is
+        // automatically setup for this developer. This key gets generated using a
+        // secure random byte generator and is later base64 encoded for storage.
+        $this->setKeyInEnvironmentFile($key);
 
-        if (file_exists($path)) {
-            $content = str_replace('APP_KEY='.$app['config']['app.key'], 'APP_KEY='.$key, file_get_contents($path));
-
-            if (! Str::contains($content, 'APP_KEY')) {
-                $content = sprintf("%s\nAPP_KEY=%s\n", $content, $key);
-            }
-
-            file_put_contents($path, $content);
-        }
-
-        $app['config']['app.key'] = $key;
+        $this->laravel['config']['app.key'] = $key;
 
         $this->info("Application key [$key] set successfully.");
     }
 
     /**
-     * Generate a random key for the application.
+     * Set the environmeny key in the environment file.
      *
-     * @param  string  $cipher
-     * @return string
+     * @param  string  $key
+     * @return void
      */
-    protected function getRandomKey($cipher)
+    protected function setKeyInEnvironmentFile($key)
     {
-        if ($cipher === 'AES-128-CBC') {
-            return Str::random(16);
-        }
-
-        return Str::random(32);
+        file_put_contents($this->laravel->environmentFilePath(), str_replace(
+            'APP_KEY='.$this->laravel['config']['app.key'],
+            'APP_KEY='.$key,
+            file_get_contents($this->laravel->environmentFilePath())
+        ));
     }
 
     /**
-     * Get the console command options.
+     * Generate a random key for the application.
      *
-     * @return array
+     * @return string
      */
-    protected function getOptions()
+    protected function generateRandomKey()
     {
-        return [
-            ['show', null, InputOption::VALUE_NONE, 'Simply display the key instead of modifying files.'],
-        ];
+        return 'base64:'.base64_encode(random_bytes(
+            $this->laravel['config']['app.cipher'] == 'AES-128-CBC' ? 16 : 32
+        ));
     }
 }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -118,7 +118,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      *
      * @return mixed
      *
-     * @throws \\Illuminate\Http\Exception\HttpResponseExceptio
+     * @throws \\Illuminate\Http\Exception\HttpResponseException
      */
     protected function failedAuthorization()
     {

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -88,7 +88,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Handle a failed validation attempt.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
-     * @return mixed
+     * @return void
      *
      * @throws \Illuminate\Http\Exception\HttpResponseException
      */
@@ -116,9 +116,9 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Handle a failed authorization attempt.
      *
-     * @return mixed
+     * @return void
      *
-     * @throws \\Illuminate\Http\Exception\HttpResponseException
+     * @throws \Illuminate\Http\Exception\HttpResponseException
      */
     protected function failedAuthorization()
     {

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -13,12 +13,25 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $e->decrypt($encrypted));
     }
 
+    public function testEncryptionUsingBase64EncodedKey()
+    {
+        $e = new Encrypter('base64:'.base64_encode(random_bytes(16)));
+        $encrypted = $e->encrypt('foo');
+        $this->assertNotEquals('foo', $encrypted);
+        $this->assertEquals('foo', $e->decrypt($encrypted));
+    }
+
     public function testWithCustomCipher()
     {
         $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
         $encrypted = $e->encrypt('bar');
         $this->assertNotEquals('bar', $encrypted);
         $this->assertEquals('bar', $e->decrypt($encrypted));
+
+        $e = new Encrypter('base64:'.base64_encode(random_bytes(32)), 'AES-256-CBC');
+        $encrypted = $e->encrypt('foo');
+        $this->assertNotEquals('foo', $encrypted);
+        $this->assertEquals('foo', $e->decrypt($encrypted));
     }
 
     /**


### PR DESCRIPTION
Wrong foreign key generated in setJoin() method of hasManyThrough relation class. When both models and foreign keys specified, $this->getQualifiedParentKeyName() always results in `id` key instead of using specified key.

```
tables:
`task`
  id: task id (primary)
  title: task title
  ...
`task_user`
  task_id: task ID foreign key
  user_id: user ID foreign key
  ...
$this->hasManyThrough('Model\Task', 'Model\UserTask', 'user_id', 'id')
```

resolves to following query upon relation data request, which results in exception

```
select `tasks`.*, `task_user`.`user_id` from `tasks`
inner join `task_user` on `task_user`.`id` = `tasks`.`id`
where `task_user`.`user_id` = 1
```
