### PR TITLE
Correct foreign key for setJoin() in hasManyThrough relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -111,7 +111,7 @@ class HasManyThrough extends Relation
 
         $foreignKey = $this->related->getTable().'.'.$this->secondKey;
 
-        $query->join($this->parent->getTable(), $this->getQualifiedParentKeyName(), '=', $foreignKey);
+        $query->join($this->parent->getTable(), $this->getThroughKey(), '=', $foreignKey);
 
         if ($this->parentSoftDeletes()) {
             $query->whereNull($this->parent->getQualifiedDeletedAtColumn());


### PR DESCRIPTION
Replace getQualifiedParentKeyName() with getThroughKey() to provide correct foreign key for query.
Wrong foreign key generated in setJoin() method of hasManyThrough relation class. When both models and foreign keys specified, $this->getQualifiedParentKeyName() always results in `id` key instead of using specified key.

```
tables:
`task`
  id: task id (primary)
  title: task title
  ...
`task_user`
  task_id: task ID foreign key
  user_id: user ID foreign key
  ...
$this->hasManyThrough('Model\Task', 'Model\UserTask', 'user_id', 'id')
```

resolves to following query upon relation data request, which results in exception

```
select `tasks`.*, `task_user`.`user_id` from `tasks`
inner join `task_user` on `task_user`.`id` = `tasks`.`id`
where `task_user`.`user_id` = 1
```
