### PR TITLE
[5.2] Adding dynamic where operators

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1105,7 +1105,24 @@ class Builder
         // clause on the query. Then we'll increment the parameter index values.
         $bool = strtolower($connector);
 
-        $this->where(Str::snake($segment), '=', $parameters[$index], $bool);
+        $operator = '=';
+
+        // Determine if the operator should be anything other than equals
+        if (Str::endsWith($segment, 'Gt')) {
+            $operator = '>';
+            $segment = substr($segment, 0, -2);
+        } elseif (Str::endsWith($segment, 'Lt')) {
+            $operator = '<';
+            $segment = substr($segment, 0, -2);
+        } elseif (Str::endsWith($segment, 'Gte')) {
+            $operator = '>=';
+            $segment = substr($segment, 0, -3);
+        } elseif (Str::endsWith($segment, 'Lte')) {
+            $operator = '<=';
+            $segment = substr($segment, 0, -3);
+        }
+
+        $this->where(Str::snake($segment), $operator, $parameters[$index], $bool);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1263,13 +1263,28 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($builder, $builder->dynamicWhere($method, $parameters));
     }
 
+    public function testDynamicWhereOperators()
+    {
+        $method = 'whereFooBarAndBazGtAndQuxLtAndFubarGteAndNorfLte';
+        $parameters = ['corge', 'waldo', 'fred', 'linus', 'mike'];
+        $builder = m::mock('Illuminate\Database\Query\Builder')->makePartial();
+
+        $builder->shouldReceive('where')->with('foo_bar', '=', $parameters[0], 'and')->once()->andReturn($builder);
+        $builder->shouldReceive('where')->with('baz', '>', $parameters[1], 'and')->once()->andReturn($builder);
+        $builder->shouldReceive('where')->with('qux', '<', $parameters[2], 'and')->once()->andReturn($builder);
+        $builder->shouldReceive('where')->with('fubar', '>=', $parameters[3], 'and')->once()->andReturn($builder);
+        $builder->shouldReceive('where')->with('norf', '<=', $parameters[4], 'and')->once()->andReturn($builder);
+
+        $this->assertEquals($builder, $builder->dynamicWhere($method, $parameters));
+    }
+
     public function testDynamicWhereIsNotGreedy()
     {
-        $method = 'whereIosVersionAndAndroidVersionOrOrientation';
+        $method = 'whereIosVersionGteAndAndroidVersionOrOrientation';
         $parameters = ['6.1', '4.2', 'Vertical'];
         $builder = m::mock('Illuminate\Database\Query\Builder')->makePartial();
 
-        $builder->shouldReceive('where')->with('ios_version', '=', '6.1', 'and')->once()->andReturn($builder);
+        $builder->shouldReceive('where')->with('ios_version', '>=', '6.1', 'and')->once()->andReturn($builder);
         $builder->shouldReceive('where')->with('android_version', '=', '4.2', 'and')->once()->andReturn($builder);
         $builder->shouldReceive('where')->with('orientation', '=', 'Vertical', 'or')->once()->andReturn($builder);
 


### PR DESCRIPTION
Adding "Greater Than", "Less Than", "Greater Than or Equal to" and "Less Than or Equal to" options to the dynamic where clauses. E.g. `whereBarGte(37)`
