### PR TITLE
[5.2] Speed up chunk for large sets of data

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -368,7 +368,7 @@ class Builder
     public function chunkById($count, callable $callback, $idField)
     {
         $lastId = null;
-        $results = $this->forPageById($count, $idField)->get();
+        $results = $this->pageAfterId($count, $idField)->get();
 
         while (! $results->isEmpty()) {
             if (call_user_func($callback, $results) === false) {
@@ -379,7 +379,7 @@ class Builder
                 $lastId = last($results->all())->{$idField};
             }
 
-            $results = $this->forPageById($count, $idField, $lastId)->get();
+            $results = $this->pageAfterId($count, $idField, $lastId)->get();
         }
 
         return true;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1323,7 +1323,7 @@ class Builder
      * @param int $lastId
      * @return Builder|static
      */
-    public function forPageById($perPage = 15, $idField, $lastId = 0)
+    public function pageAfterId($perPage = 15, $idField = 'id', $lastId = 0)
     {
         return $this->select($idField)
             ->where($idField, '>', $lastId)
@@ -1642,7 +1642,7 @@ class Builder
     public function chunkById($count, callable $callback, $idField)
     {
         $lastId = null;
-        $results = $this->forPageById($count, $idField)->get();
+        $results = $this->pageAfterId($count, $idField)->get();
 
         while (! $results->isEmpty()) {
             if (call_user_func($callback, $results) === false) {
@@ -1653,7 +1653,7 @@ class Builder
                 $lastId = last($results->all())->{$idField};
             }
 
-            $results = $this->forPageById($count, $idField, $lastId)->get();
+            $results = $this->pageAfterId($count, $idField, $lastId)->get();
         }
 
         return true;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1315,6 +1315,23 @@ class Builder
     }
 
     /**
+     * Set the limit and query for the next set of results, given the
+     * last scene ID in a set.
+     *
+     * @param int $perPage
+     * @param $idField
+     * @param int $lastId
+     * @return Builder|static
+     */
+    public function forPageById($perPage = 15, $idField, $lastId = 0)
+    {
+        return $this->select($idField)
+            ->where($idField, '>', $lastId)
+            ->orderBy($idField, 'asc')
+            ->take($perPage);
+    }
+
+    /**
      * Add a union statement to the query.
      *
      * @param  \Illuminate\Database\Query\Builder|\Closure  $query
@@ -1606,6 +1623,37 @@ class Builder
             $page++;
 
             $results = $this->forPage($page, $count)->get();
+        }
+
+        return true;
+    }
+
+    /**
+     * Chunk the results of a query, when the ID to query by is known.
+     *
+     * Because if we know the ID to key by, then we can get through each page much faster,
+     * especially in larger sets of data.
+     *
+     * @param $count
+     * @param callable $callback
+     * @param $idField
+     * @return bool
+     */
+    public function chunkById($count, callable $callback, $idField)
+    {
+        $lastId = null;
+        $results = $this->forPageById($count, $idField)->get();
+
+        while (! $results->isEmpty()) {
+            if (call_user_func($callback, $results) === false) {
+                return false;
+            }
+
+            if ($idField) {
+                $lastId = last($results->all())->{$idField};
+            }
+
+            $results = $this->forPageById($count, $idField, $lastId)->get();
         }
 
         return true;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -196,10 +196,10 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
 
     public function testChunkPaginatesUsingWhereBetweenIds()
     {
-        $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPageById,get]', [$this->getMockQueryBuilder()]);
-        $builder->shouldReceive('forPageById')->once()->with(2, 'someIdField')->andReturn($builder);
-        $builder->shouldReceive('forPageById')->once()->with(2, 'someIdField', 2)->andReturn($builder);
-        $builder->shouldReceive('forPageById')->once()->with(2, 'someIdField', 10)->andReturn($builder);
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder[pageAfterId,get]', [$this->getMockQueryBuilder()]);
+        $builder->shouldReceive('pageAfterId')->once()->with(2, 'someIdField')->andReturn($builder);
+        $builder->shouldReceive('pageAfterId')->once()->with(2, 'someIdField', 2)->andReturn($builder);
+        $builder->shouldReceive('pageAfterId')->once()->with(2, 'someIdField', 10)->andReturn($builder);
 
         $builder->shouldReceive('get')->times(3)->andReturn(
             new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]),
@@ -207,7 +207,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
             new Collection([])
         );
 
-        $builder->chunkById(2, function($results){}, 'someIdField');
+        $builder->chunkById(2, function ($results) {}, 'someIdField');
     }
 
     public function testPluckReturnsTheMutatedAttributesOfAModel()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -194,6 +194,22 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         });
     }
 
+    public function testChunkPaginatesUsingWhereBetweenIds()
+    {
+        $builder = m::mock('Illuminate\Database\Eloquent\Builder[forPageById,get]', [$this->getMockQueryBuilder()]);
+        $builder->shouldReceive('forPageById')->once()->with(2, 'someIdField')->andReturn($builder);
+        $builder->shouldReceive('forPageById')->once()->with(2, 'someIdField', 2)->andReturn($builder);
+        $builder->shouldReceive('forPageById')->once()->with(2, 'someIdField', 10)->andReturn($builder);
+
+        $builder->shouldReceive('get')->times(3)->andReturn(
+            new Collection([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]),
+            new Collection([(object) ['someIdField' => 10]]),
+            new Collection([])
+        );
+
+        $builder->chunkById(2, function($results){}, 'someIdField');
+    }
+
     public function testPluckReturnsTheMutatedAttributesOfAModel()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
I've been working on a project that involves sifting through some pretty large databases, and the query builder's chunk method was not really doing it for me because it slowed down so much as it worked through the table. 

As chunk gets deeper and deeper into a table, it asks MySQL to count through more and more rows. When chunk says to MySQL, `select whatever from wherever limit 800000, 1000` MySQL counts through 800,000 rows without using an index or nuthin. Then, the next page, it again counts through all previous rows to find the next set. Poor MySQL... It gets really really slow (details below).

I realize this may be too much an edge case, so didn't want to spend too much time working on the code; just looking for feedback at this point.

If you're still reading, here are some scrappy benchmarks. :)

---

After 4 seconds, chunk is very optimistic:
`187500/862443 [▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░]  21% 4 secs/18 secs 10.0 MiB`

However, in the end the process has taken substantially longer:
`862443/862443 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100% 2 mins/2 mins 10.0 MiB`

As you can imagine, the problem gets progressively worse as the database gets larger.

If we instead query by `'id' > $theLastIdFromTheLastSet`, the chunking is much faster.

Again, after 4 seconds:
`387000/862443 [▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░]  44% 4 secs/9 secs 10.0 MiB`

And the same set takes only 21s in the end.
`862443/862443 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100% 21 secs/21 secs 10.0 MiB`
