### PR TITLE
[5.2] Allow for @has in blade

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -660,7 +660,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         return "<?php elseif{$expression}: ?>";
     }
-    
+
     /**
      * Compile the has statements into valid PHP.
      *

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -662,8 +662,8 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
     
     /**
-     * Compile the has statements into valid PHP
-     * 
+     * Compile the has statements into valid PHP.
+     *
      * @param  string  $expression
      * @return string
      */

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -667,10 +667,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
      * @param  string  $expression
      * @return string
      */
-     protected function compileHas($expression)
-     {
+    protected function compileHas($expression)
+    {
         return "<?php if(!empty(trim(\$__env->yieldContent{$expression}))): ?>";
-     }
+    }
 
     /**
      * Compile the forelse statements into valid PHP.

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -660,6 +660,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         return "<?php elseif{$expression}: ?>";
     }
+    
+    /**
+     * Compile the has statements into valid PHP
+     * 
+     * @param  string  $expression
+     * @return string
+     */
+     protected function compileHas($expression)
+     {
+        return "<?php if(!empty(trim(\$__env->yieldContent{$expression}))): ?>";
+     }
 
     /**
      * Compile the forelse statements into valid PHP.

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -239,7 +239,7 @@ breeze
 <?php endif; ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
     }
-    
+
     public function testHasStatementsAreCompiled()
     {
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -239,6 +239,18 @@ breeze
 <?php endif; ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
     }
+    
+    public function testHasStatementsAreCompiled()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $string = '@has ("section")
+breeze
+@endif';
+        $expected = '<?php if(!empty(trim(\$__env->yieldContent("section")))): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
 
     public function testCanStatementsAreCompiled()
     {

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -246,7 +246,7 @@ breeze
         $string = '@has ("section")
 breeze
 @endif';
-        $expected = '<?php if(!empty(trim(\$__env->yieldContent("section")))): ?>
+        $expected = '<?php if(!empty(trim($__env->yieldContent("section")))): ?>
 breeze
 <?php endif; ?>';
         $this->assertEquals($expected, $compiler->compileString($string));


### PR DESCRIPTION
Currently, it is difficult to determine whether something can be @yield'd

Code usage is the same as @if.

Example usage:

![image](https://cloud.githubusercontent.com/assets/842974/14053307/307d49de-f2c8-11e5-8104-d27843eddf73.png)
