### PR TITLE
[5.4] Extending Blade's looping functionality

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -579,7 +579,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileForeach($expression)
     {
-        return "<?php foreach{$expression}: ?>";
+        preg_match('/\( *(.*) *as *([^\)]*)/', $expression, $matches);
+
+        $iteratee = trim($matches[1]);
+
+        $iteration = trim($matches[2]);
+
+        $initLoop = "\$__currentLoopData = {$iteratee}; \$__env->addLoop(\$__currentLoopData);";
+
+        $iterateLoop = '$__env->incrementLoopIndices(); $loop = $__env->getFirstLoop();';
+
+        return "<?php {$initLoop} foreach(\$__currentLoopData as {$iteration}): {$iterateLoop} ?>";
     }
 
     /**
@@ -715,7 +725,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileEndforeach($expression)
     {
-        return '<?php endforeach; ?>';
+        return '<?php endforeach; $__env->popLoop(); $loop = $__env->getFirstLoop(); ?>';
     }
 
     /**

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -92,6 +92,13 @@ class Factory implements FactoryContract
     protected $sectionStack = [];
 
     /**
+     * The stack of in-progress loops.
+     *
+     * @var array
+     */
+    protected $loopsStack = [];
+
+    /**
      * The number of active rendering operations.
      *
      * @var int
@@ -690,6 +697,81 @@ class Factory implements FactoryContract
     public function doneRendering()
     {
         return $this->renderCount == 0;
+    }
+
+    /**
+     * Add new loop to the stack.
+     *
+     * @param  array|\Countable  $data
+     * @return void
+     */
+    public function addLoop($data)
+    {
+        $length = is_array($data) || $data instanceof \Countable ? count($data) : null;
+
+        $parent = Arr::last($this->loopsStack);
+
+        $this->loopsStack[] = $added = [
+            'index' => 0,
+            'reverseIndex' => isset($length) ? $length + 1 : null,
+            'size' => $length,
+            'isFirst' => true,
+            'isLast' => isset($length) ? $length == 1 : null,
+            'depth' => count($this->loopsStack) + 1,
+            'parent' => $parent ? (object) $parent : null,
+        ];
+    }
+
+    /**
+     * Pop the a loop from the top of the stack.
+     *
+     * @return void
+     */
+    public function popLoop()
+    {
+        array_pop($this->loopsStack);
+    }
+
+    /**
+     * Increment the top loop's indices.
+     *
+     * @return void
+     */
+    public function incrementLoopIndices()
+    {
+        $loop = &$this->loopsStack[count($this->loopsStack) - 1];
+
+        $loop['index'] += 1;
+
+        $loop['isFirst'] = $loop['index'] == 1;
+
+        if (isset($loop['size'])) {
+            $loop['reverseIndex'] -= 1;
+
+            $loop['isLast'] = $loop['index'] == $loop['size'];
+        }
+    }
+
+    /**
+     * Get the entire loops stack.
+     *
+     * @return array
+     */
+    public function getLoopsStack()
+    {
+        return $this->loopsStack;
+    }
+
+    /**
+     * Get an instance of the first loop in the stack.
+     *
+     * @return array
+     */
+    public function getFirstLoop()
+    {
+        $last = Arr::last($this->loopsStack);
+
+        return $last ? (object) $last : null;
     }
 
     /**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -426,9 +426,9 @@ test
         $string = '@foreach ($this->getUsers() as $user)
 test
 @endforeach';
-        $expected = '<?php foreach($this->getUsers() as $user): ?>
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); ?>
 test
-<?php endforeach; ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getFirstLoop(); ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 
@@ -441,12 +441,33 @@ user info
 tag info
 @endforeach
 @endforeach';
-        $expected = '<?php foreach($this->getUsers() as $user): ?>
+        $expected = '<?php $__currentLoopData = $this->getUsers(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); ?>
 user info
-<?php foreach($user->tags as $tag): ?>
+<?php $__currentLoopData = $user->tags; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $tag): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); ?>
 tag info
-<?php endforeach; ?>
-<?php endforeach; ?>';
+<?php endforeach; $__env->popLoop(); $loop = $__env->getFirstLoop(); ?>
+<?php endforeach; $__env->popLoop(); $loop = $__env->getFirstLoop(); ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+    }
+
+    public function testLoopContentHolderIsExtractedFromForeachStatements()
+    {
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+
+        $string = '@foreach ($some_uSers1 as $user)';
+        $expected = '<?php $__currentLoopData = $some_uSers1; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+
+        $string = '@foreach ($users->get() as $user)';
+        $expected = '<?php $__currentLoopData = $users->get(); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+
+        $string = '@foreach (range(1, 4) as $user)';
+        $expected = '<?php $__currentLoopData = range(1, 4); $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); ?>';
+        $this->assertEquals($expected, $compiler->compileString($string));
+
+        $string = '@foreach (   $users as $user)';
+        $expected = '<?php $__currentLoopData = $users; $__env->addLoop($__currentLoopData); foreach($__currentLoopData as $user): $__env->incrementLoopIndices(); $loop = $__env->getFirstLoop(); ?>';
         $this->assertEquals($expected, $compiler->compileString($string));
     }
 


### PR DESCRIPTION
As noted in this issue https://github.com/laravel/framework/issues/12601, this PR adds extra functionality for Blade's loops:

``` php
@foreach($items as $item)
     {{ $loop->index }} // The current iteration starting 1.
     {{ $loop->reverseIndex }} // The number of iterations left till the end. Ends with 1.
     {{ $loop->size }} // The size of the iteratee.
     {{ $loop->isFirst }} // If the current iteration is the first. (boolean)
     {{ $loop->isLast }} // If the current iteration is the last. (boolean)
     {{ $loop->depth }} // The depth inside a nested loop.
     {{ $loop->parent }} // The direct parent loop information.

    {{ $loop->parent->isFirst }} // This checks if the parent loop is at the first iteration.
@endforeach
```

`$loop` carries information about the current iteration of the loop it was called inside, outside loops `$loop` will be `null`.

---

**Note:** This proposal is applied only on `@foreach` for now but I'm willing to apply it on `@for` & `@forelse` as well if approved and after iterations.
