### PR TITLE
[5.2] A FormRequest can now include a hash when redirecting due to errors

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -53,6 +53,23 @@ class FormRequest extends Request implements ValidatesWhenResolved
     protected $redirectAction;
 
     /**
+     * The hash to append to the auto-generated redirect URL.
+     *
+     * This is useful when a form is not on top of the page to which the user is
+     * being redirected, so that the browser will automatically scroll down to
+     * the correct location in the page and the user can see the form and its
+     * error messages.
+     *
+     * Do not prefix this value with the actual hash symbol "#", e.g. if you
+     * want to redirect the user to "http://example.com/foo#bar", just set this
+     * value to "bar", and handle the actual URL with one of the other redirect
+     * attributes.
+     *
+     * @var string|null
+     */
+    protected $redirectHash;
+
+    /**
      * The key to be used for the view error bag.
      *
      * @var string
@@ -173,14 +190,23 @@ class FormRequest extends Request implements ValidatesWhenResolved
         $url = $this->redirector->getUrlGenerator();
 
         if ($this->redirect) {
-            return $url->to($this->redirect);
+            $redirectUrl = $url->to($this->redirect);
         } elseif ($this->redirectRoute) {
-            return $url->route($this->redirectRoute);
+            $redirectUrl = $url->route($this->redirectRoute);
         } elseif ($this->redirectAction) {
-            return $url->action($this->redirectAction);
+            $redirectUrl = $url->action($this->redirectAction);
+        } else {
+            $redirectUrl = $url->previous();
         }
 
-        return $url->previous();
+        // Append the hash only if it's defined and if it isn't already included
+        // in the generated URL, for example if the user has included it via the
+        // `$redirect` attribute.
+        if ($this->redirectHash && strpos($redirectUrl, '#') === false) {
+            $redirectUrl .= "#{$this->redirectHash}";
+        }
+
+        return $redirectUrl;
     }
 
     /**
@@ -227,5 +253,19 @@ class FormRequest extends Request implements ValidatesWhenResolved
     public function attributes()
     {
         return [];
+    }
+
+    /**
+     * Returns the configured redirect hash.
+     *
+     * Useful to keep things DRY in case of, for example, a controller using
+     * this request needs to redirect to the same hash in the case of successful
+     * form submission.
+     *
+     * @return string|null
+     */
+    public function getRedirectHash()
+    {
+        return $this->redirectHash;
     }
 }


### PR DESCRIPTION
As described in the docblock - this is useful when a form is not on top of the page to which the user is being redirected, so that the browser will automatically scroll down to the correct location in the page and the user can see the form and its error messages immediately.

The feature should be fully backwards-compatible.

I'm not sure if the docblocks are okay, as they are more descriptive than the rest of the docblocks in the class, but having them could only help someone inspecting the class, so I don't think they do any harm. Let me know if the tests are okay too, I'm aware that they might be a bit over-engineered for such a trivial feature. Better safe than sorry though.

Supersedes #12870
