### PR TITLE
[5.2] Correct logic in the returned numeric casted "id".

### DIFF
--- a/src/Illuminate/Database/Query/Processors/Processor.php
+++ b/src/Illuminate/Database/Query/Processors/Processor.php
@@ -33,7 +33,7 @@ class Processor
 
         $id = $query->getConnection()->getPdo()->lastInsertId($sequence);
 
-        return is_numeric($id) ? (int) $id : $id;
+        return !is_numeric($id) ? (int) $id : $id;
     }
 
     /**


### PR DESCRIPTION
The query processor attempts to cast any non-numeric inserted `id` to an integer. However, the existing logic (shown below) is inverted. Basically missing the `!`. This pull request corrects the logic.

Current:

```
        return is_numeric($id) ? (int) $id : $id;
```

New

```
        return !is_numeric($id) ? (int) $id : $id;
```
