### PR TITLE
[5.2] Optional query builder calls via a when() method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -436,10 +436,10 @@ class Builder
     }
 
     /**
-     * Apply the callback's query changes if the value is trueish.
+     * Apply the callback's query changes if the value is truthy.
      *
-     * @param $value
-     * @param $callback
+     * @param bool     $value
+     * @param \Closure $callback
      *
      * @return \Illuminate\Database\Query\Builder
      */

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -434,7 +434,7 @@ class Builder
     {
         return $this->joinWhere($table, $one, $operator, $two, 'right');
     }
-    
+
     /**
      * Apply the callback's query changes if the value is trueish.
      *

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -434,6 +434,25 @@ class Builder
     {
         return $this->joinWhere($table, $one, $operator, $two, 'right');
     }
+    
+    /**
+     * Apply the callback's query changes if the value is trueish.
+     *
+     * @param $value
+     * @param $callback
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function when($value, $callback)
+    {
+        $builder = $this;
+
+        if ($value) {
+            $builder = call_user_func($callback, $builder);
+        }
+
+        return $builder;
+    }
 
     /**
      * Add a basic where clause to the query.

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -117,6 +117,21 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('public.users');
         $this->assertEquals('select * from "public"."users"', $builder->toSql());
     }
+    
+    public function testWhenCallback()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(true, function($callback) {
+            return $callback->where('id', '=', 1);  
+        });
+        $this->assertEquals('select * from "users" where "id" = ?', $builder->toSql());
+        
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(false, function($callback) {
+            return $callback->where('id', '=', 1);  
+        });
+        $this->assertEquals('select * from "users"', $builder->toSql());
+    }
 
     public function testBasicWheres()
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -117,18 +117,18 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder->select('*')->from('public.users');
         $this->assertEquals('select * from "public"."users"', $builder->toSql());
     }
-    
+
     public function testWhenCallback()
     {
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(true, function($callback) {
-            return $callback->where('id', '=', 1);  
+        $builder->select('*')->from('users')->when(true, function ($callback) {
+            return $callback->where('id', '=', 1);
         });
         $this->assertEquals('select * from "users" where "id" = ?', $builder->toSql());
-        
+
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(false, function($callback) {
-            return $callback->where('id', '=', 1);  
+        $builder->select('*')->from('users')->when(false, function ($callback) {
+            return $callback->where('id', '=', 1);
         });
         $this->assertEquals('select * from "users"', $builder->toSql());
     }


### PR DESCRIPTION
I keep finding myself in situations where I need to break a chained query builder to add in optional calls. For instance, recently when working on an api, I needed to add optional sorting / filtering for the query. If the sort parameters existed in the url, then they should be added but if not it should follow its default sort.

To do this in the current QB you have to break the chain...

``` php
$query = $model->where('customer_id', 1234)
    ->where('created_at', '>=' '2016-01-04 20:34:56');

if (! empty($sortParams)) {
    $query->orderBy($sortParams);
}

return $query->get();
```

with this new `when()` method, we apply the new commands via a closure if the first parameter evaluates as true...

``` php
return $model->where('customer_id', 1234)
    ->where('created_at', '>=' '2016-01-04 20:34:56')
    ->when(! empty($sortParams), function($builder) use($sortParams) {
        return $builder->orderBy($sortParams);
    })
    ->get():
```

This is a simple example but if you were trying to add many things based on conditional arguments you could see how the top would get unruly pretty quickly. The lower example alleviates that a bit, at least in my mind.
