### PR TITLE
[5.2] Prevent registering the web middleware twice on make:auth command

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/controllers/HomeController.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/controllers/HomeController.stub
@@ -14,7 +14,6 @@ class HomeController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
     }
 
     /**

--- a/src/Illuminate/Auth/Console/stubs/make/routes.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/routes.stub
@@ -1,6 +1,4 @@
 
-Route::group(['middleware' => 'web'], function () {
-    Route::auth();
+Route::auth();
 
-    Route::get('/home', 'HomeController@index');
-});
+Route::get('/home', 'HomeController@index');


### PR DESCRIPTION
As noted in https://github.com/laravel/framework/issues/12877, on `make:auth` command the generated routes in `routes.php` & `HomeController` both have the `web` middleware registered, while it's by default registered on all routes in `RouteServiceProvider.php` no need to register it again.
