### PR TITLE
[5.2] Mysql json generated migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -923,7 +923,7 @@ class Blueprint
     {
         $index = strtolower($this->table.'_'.implode('_', $columns).'_'.$type);
 
-        return str_replace(['-', '.'], '_', $index);
+        return str_replace(['->', '-', '.'], '_', $index);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -708,7 +708,7 @@ class MySqlGrammar extends Grammar
 
     /**
      * Get the SQL for a "generated" column modifier.
-     * 
+     *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $column
      * @return string|null

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -13,7 +13,7 @@ class MySqlGrammar extends Grammar
      *
      * @var array
      */
-    protected $modifiers = ['Unsigned', 'Charset', 'Collate', 'Generated','Nullable', 'Default', 'Increment', 'Comment', 'After', 'First'];
+    protected $modifiers = ['Unsigned', 'Charset', 'Collate', 'Generated', 'Nullable', 'Default', 'Increment', 'Comment', 'After', 'First'];
 
     /**
      * The possible column serials.

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -13,7 +13,7 @@ class MySqlGrammar extends Grammar
      *
      * @var array
      */
-    protected $modifiers = ['Unsigned', 'Charset', 'Collate', 'Nullable', 'Default', 'Increment', 'Comment', 'After', 'First'];
+    protected $modifiers = ['Unsigned', 'Charset', 'Collate', 'Generated','Nullable', 'Default', 'Increment', 'Comment', 'After', 'First'];
 
     /**
      * The possible column serials.
@@ -707,6 +707,20 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Get the SQL for a "generated" column modifier.
+     * 
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyGenerated(Blueprint $blueprint, Fluent $column)
+    {
+        if (! is_null($column->generated)) {
+            return ' generated always as (json_unquote('.$this->wrapJsonSelector($column->name).'))';
+        }
+    }
+
+    /**
      * Wrap a single string in keyword identifiers.
      *
      * @param  string  $value
@@ -718,6 +732,19 @@ class MySqlGrammar extends Grammar
             return $value;
         }
 
-        return '`'.str_replace('`', '``', $value).'`';
+        return '`'.str_replace(['`', '->'], ['``', '_'], $value).'`';
+    }
+
+    /**
+     * Wrap the given JSON selector.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    protected function wrapJsonSelector($value)
+    {
+        $path = explode('->', $value);
+
+        return array_shift($path).'->'.'"$.'.implode('.', $path).'"';
     }
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -266,6 +266,12 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
+
+        $blueprint->index('foo->bar->baz');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(2, count($statements));
+        $this->assertEquals('alter table `users` add index `users_foo_bar_baz_index`(`foo_bar_baz`)', $statements[1]);
     }
 
     public function testAddingForeignKey()
@@ -672,6 +678,16 @@ class DatabaseMySqlSchemaGrammarTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, count($statements));
         $this->assertEquals('alter table `users` add `foo` char(36) not null', $statements[0]);
+    }
+
+    public function testGeneratedColumn()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->string('foo->bar->baz')->generated();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertEquals('alter table `users` add `foo_bar_baz` varchar(255) generated always as (json_unquote(foo->"$.bar.baz")) not null', $statements[0]);
     }
 
     protected function getConnection()


### PR DESCRIPTION
#12685 added the ability to query on the new mysql json fields.  In a similar fashion, this pull request allows you to index json queries you frequently query (mysql only).

`$table->string('foo->bar->baz')->generated();
$table->index('foor->bar->baz);`
