### PR TITLE
[5.2] Fix implicit model binding bugs

### DIFF
--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -940,6 +940,21 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('hello/taylor/2015/otwell', 'GET'))->getContent());
     }
 
+    public function testImplicitBindingsMultipleModelsAndParametersWithOptinal()
+    {
+        $phpunit = $this;
+        $router = $this->getRouter();
+        $router->get('hello/{foo}/{year?}/{bar?}', function (RoutingTestUserModel $foo, $year = null, RoutingTestTeamModel $bar = null) use ($phpunit) {
+            $phpunit->assertEquals('taylor', $foo->value);
+            $phpunit->assertNull($year);
+
+            return 'hello';
+        });
+
+        // this makes sure the callback is called
+        $this->assertEquals('hello', $router->dispatch(Request::create('hello/taylor', 'GET'))->getContent());
+    }
+
     protected function getRouter()
     {
         return new Router(new Illuminate\Events\Dispatcher);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -944,9 +944,57 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
     {
         $phpunit = $this;
         $router = $this->getRouter();
-        $router->get('hello/{foo}/{year?}/{bar?}', function (RoutingTestUserModel $foo, $year = null, RoutingTestTeamModel $bar = null) use ($phpunit) {
+        $router->get('hello/{foo}/{year?}/{bar?}', function (RoutingTestUserModel $foo, $year = null, RoutingTestUserModel $bar = null) use ($phpunit) {
+            $phpunit->assertInstanceOf(RoutingTestUserModel::class, $foo);
             $phpunit->assertEquals('taylor', $foo->value);
             $phpunit->assertNull($year);
+            $phpunit->assertInstanceOf(RoutingTestUserModel::class, $bar);
+            $phpunit->assertNull($bar->value);
+
+            return 'hello';
+        });
+
+        // this makes sure the callback is called
+        $this->assertEquals('hello', $router->dispatch(Request::create('hello/taylor', 'GET'))->getContent());
+
+        $router = $this->getRouter();
+        $router->get('hello/{foo}/{year?}/{bar?}', function (RoutingTestUserModel $foo, $year = null, RoutingTestTeamModel $bar = null) use ($phpunit) {
+            $phpunit->assertInstanceOf(RoutingTestUserModel::class, $foo);
+            $phpunit->assertEquals('taylor', $foo->value);
+            $phpunit->assertNull($year);
+            $phpunit->assertInstanceOf(RoutingTestTeamModel::class, $bar);
+
+            return 'hello';
+        });
+
+        // this makes sure the callback is called
+        $this->assertEquals('hello', $router->dispatch(Request::create('hello/taylor', 'GET'))->getContent());
+
+        $router = $this->getRouter();
+        $router->get('hello/{foo}/{year?}/{bar?}', function (RoutingTestUserModel $foo, $year = 2015, RoutingTestTeamModel $bar = null) use ($phpunit) {
+            $phpunit->assertInstanceOf(RoutingTestUserModel::class, $foo);
+            $phpunit->assertEquals('taylor', $foo->value);
+            $phpunit->assertEquals(2015, $year);
+            $phpunit->assertInstanceOf(RoutingTestTeamModel::class, $bar);
+
+            return 'hello';
+        });
+
+        // this makes sure the callback is called
+        $this->assertEquals('hello', $router->dispatch(Request::create('hello/taylor', 'GET'))->getContent());
+    }
+
+    public function testImplicitBindingsMixAll()
+    {
+        $phpunit = $this;
+        $router = $this->getRouter();
+        $router->get('hello/{foo}/{year?}/{bar?}', function (Request $request, RoutingTestUserModel $foo, $year = null, RoutingTestUserModel $bar = null) use ($phpunit) {
+
+            $phpunit->assertInstanceOf(Request::class, $request);
+            $phpunit->assertInstanceOf(RoutingTestUserModel::class, $foo);
+            $phpunit->assertEquals('taylor', $foo->value);
+            $phpunit->assertNull($year);
+            $phpunit->assertInstanceOf(RoutingTestUserModel::class, $bar);
 
             return 'hello';
         });


### PR DESCRIPTION
As you may notice, commit 143ba0e and then doesn't pass the test, the one of the results are

```
$router->get('hello/{foo}/{year?}/{bar?}', function (User $foo, $year = null, Team $bar = null) {
  // $foo is instance of User
  // $year should be null, but instance of Team
  // $bar should be instance of Team, but null
  return 'hello';
});
$router->dispatch(Request::create('hello/taylor', 'GET'))->getContent();
```

It seems comes to do with `Routing\RouteDependencyResolverTrait@resolveClassMethodDependencies`, which will mess up the $parameter to call action.

Ref: you may see #12887 and #12886 how test works
Ref2: issue #12630

// Updated
