### PR TITLE
[5.2] Fixed terminable middlewares assigned to the controller

### DIFF
--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -103,7 +103,7 @@ class ControllerDispatcher
      * @param  string  $method
      * @return array
      */
-    protected function getMiddleware($instance, $method)
+    public function getMiddleware($instance, $method)
     {
         $results = new Collection;
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -235,7 +235,18 @@ class Route
     public function middleware($middleware = null)
     {
         if (is_null($middleware)) {
-            return (array) Arr::get($this->action, 'middleware', []);
+            $middlewares = (array) Arr::get($this->action, 'middleware', []);
+
+            if (is_string($this->action['uses'])) {
+                list($class, $method) = explode('@', $this->action['uses']);
+                $controller = $this->container->make($class);
+
+                $controllerMiddlewares = (new ControllerDispatcher($this->router, $this->container))
+                    ->getMiddleware($controller, $method);
+                $middlewares = array_merge($middlewares, $controllerMiddlewares);
+            }
+
+            return $middlewares;
         }
 
         if (is_string($middleware)) {


### PR DESCRIPTION
Middlewares with `terminate` method (such as `StartSession`, default middleware in `web` group) that assigned to the controller doesn't work  for now due to bug in `Route@middleware` method.
