### PR TITLE
@set() allows for arbitrary code to run

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -686,6 +686,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Compile the set statement into valid PHP.
+     * 
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileSet($expression)
+    {
+        return "<?php {$expression}; ?>"
+    }
+
+    /**
      * Compile the while statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -693,7 +693,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileSet($expression)
     {
-        return "<?php {$expression}; ?>"
+        return "<?php {$expression}; ?>";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -687,7 +687,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
 
     /**
      * Compile the set statement into valid PHP.
-     * 
+     *
      * @param  string  $expression
      * @return string
      */


### PR DESCRIPTION
Usage example:

`@set($var = 'string')`

Would produce:

`<?php $var = 'string'; ?>`

Cases where this may be useful is for local renaming of variables to allow them to make more sense. For example, often when iterating over several nested loops, expecially if they are arrays, you could easily end up with `$outer_array[$i][$j]` being used, and it isn't always necessarily easy to read or name these variables in a structure that is usable in  the code, instead renaming them within the local scope can be useful.
