### PR TITLE
[5.1] Fix detection of view file extension

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -308,7 +308,7 @@ class Factory implements FactoryContract
         $extensions = array_keys($this->extensions);
 
         return Arr::first($extensions, function ($key, $value) use ($path) {
-            return Str::endsWith($path, $value);
+            return Str::endsWith($path, '.'.$value);
         });
     }
 


### PR DESCRIPTION
Backport of #12830 for Laravel 5.1 _Long Term Support_.
