### PR TITLE
[5.2] Fix group prefix

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -482,13 +482,13 @@ class Router implements RegistrarContract
      */
     protected static function formatGroupPrefix($new, $old)
     {
-        $oldPrefix = isset($old['prefix']) ? $old['prefix'] : null;
-
-        if (isset($new['prefix'])) {
-            return trim($oldPrefix, '/').'/'.trim($new['prefix'], '/');
+        if (isset($old['prefix'])) {
+            return isset($new['prefix'])
+                    ? trim($old['prefix'], '/').'/'.trim($new['prefix'], '/')
+                    : $old['prefix'];
         }
 
-        return $oldPrefix;
+        return isset($new['prefix']) ? trim($new['prefix'], '/') : null;
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -490,6 +490,9 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $old = ['prefix' => 'foo/bar/'];
         $this->assertEquals(['prefix' => 'foo/bar/baz', 'namespace' => null, 'where' => []], Router::mergeGroup(['prefix' => 'baz'], $old));
 
+        $old = [];
+        $this->assertEquals(['prefix' => 'baz', 'namespace' => null, 'where' => []], Router::mergeGroup(['prefix' => 'baz'], $old));
+
         $old = ['domain' => 'foo'];
         $this->assertEquals(['domain' => 'baz', 'prefix' => null, 'namespace' => null, 'where' => []], Router::mergeGroup(['domain' => 'baz'], $old));
 


### PR DESCRIPTION
This PR fix 

```
Router::mergeGroup(['prefix' => 'baz'], []) // original: '/baz', fixed: 'baz'
```
