### PR TITLE
[5.2] Remove route group from make:auth stub

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/routes.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/routes.stub
@@ -1,6 +1,4 @@
 
-Route::group(['middleware' => 'web'], function () {
-    Route::auth();
+Route::auth();
 
-    Route::get('/home', 'HomeController@index');
-});
+Route::get('/home', 'HomeController@index');


### PR DESCRIPTION
It looks like the routes stub for the `make:auth` command needs to be updated to reflect the fact that the 'web' middleware group is applied elsewhere now.
