### PR TITLE
[5.2] Add support for testing Eloquent model events

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Mockery;
 use Exception;
+use Illuminate\Database\Eloquent\Model;
 
 trait MocksApplicationServices
 {
@@ -88,7 +89,14 @@ trait MocksApplicationServices
             $this->firedEvents[] = $called;
         });
 
+        $mock->shouldReceive('until')->andReturnUsing(function ($called) {
+            $this->firedEvents[] = $called;
+
+            return true;
+        });
+
         $this->app->instance('events', $mock);
+        Model::setEventDispatcher($mock);
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -84,7 +84,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         putenv('APP_ENV=testing');
 
         $this->app = $this->createApplication();
-        Model::setEventDispatcher($this->app["events"]);
+        Model::setEventDispatcher($this->app['events']);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing;
 
 use Mockery;
 use PHPUnit_Framework_TestCase;
+use Illuminate\Database\Eloquent\Model;
 
 abstract class TestCase extends PHPUnit_Framework_TestCase
 {
@@ -83,6 +84,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         putenv('APP_ENV=testing');
 
         $this->app = $this->createApplication();
+        Model::setEventDispatcher($this->app["events"]);
     }
 
     /**


### PR DESCRIPTION
Currently, when testing one's application, you cannot check for eloquent events. The reasons for this are two-fold:
1. The mock used by `expectsEvents` / `withoutEvents` doesn't record `until` calls.
2. The event dispatcher is stored statically on the eloquent model and therefore doesn't update when the instance updates on the container.

Others have had issues with testing against model events as well (#12711) and this should fix those issues too.
