### PR TITLE
[5.3] Add length check when using Bcrypt to hash a password

### DIFF
--- a/tests/Hashing/BcryptHasherTest.php
+++ b/tests/Hashing/BcryptHasherTest.php
@@ -11,4 +11,21 @@ class BcryptHasherTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($hasher->needsRehash($value));
         $this->assertTrue($hasher->needsRehash($value, ['rounds' => 1]));
     }
+
+    /**
+     * @expectedException LengthException
+     * @expectedExceptionMessageRegExp /Passwords longer than \d+ characters are truncated when using Bcrypt\./
+     */
+    public function testLongPasswords()
+    {
+        $hasher = new Illuminate\Hashing\BcryptHasher;
+        $hasher->make('ThisIsAReallyLongPasswordStringThatWillTriggerALengthExceptionWhenItIsUsed');
+    }
+
+    public function testLongPasswordsAcceptedWhenIgnoringLengthCheck()
+    {
+        $hasher = new Illuminate\Hashing\BcryptHasher;
+        $value = $hasher->make('ThisIsAReallyLongPasswordStringThatWouldOtherwiseTriggerALengthExceptionWhenItIsUsed', ['ignore_password_length' => true]);
+        $this->assertTrue($hasher->check('ThisIsAReallyLongPasswordStringThatWouldOtherwiseTriggerALengthExceptionWhenItIsUsed', $value));
+    }
 }


### PR DESCRIPTION
This PR addresses an issue where [Bcrypt uses only the first 72 characters](https://en.wikipedia.org/wiki/Bcrypt#User_input) of a string when computing a hash.

This pull request adds a check for the length of the passed in `$value` and throws a `LengthException` if it exceeds 72 character, unless the developer chooses to ignore the check, by passing the `ignore_password_length` option to the `Hash::make()` method.

A PHP [RFC](https://wiki.php.net/rfc/password_hash_spec) was also opened quite some time ago to address this behaviour, but doesn't seem to have moved at all. I think, in that case, that the framework is a good place to check for this behaviour. That seems to be the [thinking](https://marc.info/?l=php-internals&m=140577067811277&w=2) by on of the contributors.

My initial thought was to amend the validation of passwords (in the `AuthController`), adding a `max:72` rule but that wouldn't address any users calling the `Hash` service directly, such as when implementing peppering. Given that the framework currently only implements the `BcryptHasher` out of the box, it may make sense that the default validation includes a `max:72` rule for the `password` field. I'll submit a PR for this to the main Laravel application repo.

``` php
// This test would fail, because $hasher->check() will compare
// the computed hash of the truncated strings, which match.
public function testLongPasswordHashingIsTruncatedWithBcrypt()
{
    $hasher = new Illuminate\Hashing\BcryptHasher;
    $hash = $hasher->make('ThisIsAReallyLongPasswordStringThatWillTriggerALengthExceptionWhenItIsUse|**********************************');
    $pass = 'ThisIsAReallyLongPasswordStringThatWillTriggerALengthExceptionWhenItIsUse|###############################';
    $this->assertFalse($hasher->check($pass, $hash));
}
```

This is the resulting verification when using the `Hash::make()` and `Hash::check()` methods. The `|` character is used as a marker for 72 characters to show that the rest of the string is ignored when computing the hash.

```
>>> Hash::make('ThisIsAReallyLongPasswordStringThatWillTriggerALengthExceptionWhenItIsUse|**********************************');
=> "$2y$10$BDD6vdzyXZTPNTuRb3H4iuuysXuKeZySgp0pklXtkXa4X60H5iPLS"
>>> Hash::check('ThisIsAReallyLongPasswordStringThatWillTriggerALengthExceptionWhenItIsUse|###############################', '$2y$10$au/r5waHW9q.U0Ba3RecHuQlLAXoA7gw80FlXD2n2W1y2ipn8D13S');
=> true
```

I've targeted this PR for the next release, as it will be a (minor?) BC break for any current implementations of the framework, given that a `LengthException` will now be thrown for long strings.

Note that there is no length check in the `check` function, which means that any users who already have a long password will be unaffected, although they will not be able to create a password that exceeds 72 characters.
