### PR TITLE
[5.2] Add chunkById query builder tests

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -330,9 +330,9 @@ class Builder
     /**
      * Chunk the results of the query.
      *
-     * @param  int      $count
-     * @param  callable $callback
-     * @return bool
+     * @param  int  $count
+     * @param  callable  $callback
+     * @return  bool
      */
     public function chunk($count, callable $callback)
     {
@@ -357,10 +357,10 @@ class Builder
     /**
      * Chunk the results of a query by comparing numeric IDs.
      *
-     * @param int      $count
-     * @param callable $callback
-     * @param string   $column
-     * @return bool
+     * @param  int  $count
+     * @param  callable  $callback
+     * @param  string  $column
+     * @return  bool
      */
     public function chunkById($count, callable $callback, $column = 'id')
     {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -330,8 +330,8 @@ class Builder
     /**
      * Chunk the results of the query.
      *
-     * @param  int  $count
-     * @param  callable  $callback
+     * @param  int      $count
+     * @param  callable $callback
      * @return bool
      */
     public function chunk($count, callable $callback)
@@ -357,9 +357,9 @@ class Builder
     /**
      * Chunk the results of a query by comparing numeric IDs.
      *
-     * @param int  $count
-     * @param callable  $callback
-     * @param string  $column
+     * @param int      $count
+     * @param callable $callback
+     * @param string   $column
      * @return bool
      */
     public function chunkById($count, callable $callback, $column = 'id')

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -373,9 +373,7 @@ class Builder
                 return false;
             }
 
-            if ($column) {
-                $lastId = $results->last()->{$column};
-            }
+            $lastId = $results->last()->{$column};
 
             $results = $this->pageAfterId($count, $lastId, $column)->get();
         }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1621,8 +1621,8 @@ class Builder
     /**
      * Chunk the results of the query.
      *
-     * @param  int  $count
-     * @param  callable  $callback
+     * @param  int      $count
+     * @param  callable $callback
      * @return bool
      */
     public function chunk($count, callable $callback)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1653,22 +1653,20 @@ class Builder
      * @param string   $idColumn
      * @return bool
      */
-    public function chunkById($count, callable $callback, $column = 'id')
+    public function chunkById($count, callable $callback, $idColumn = 'id')
     {
         $lastId = null;
 
-        $results = $this->pageAfterId($count, 0, $column)->get();
+        $results = $this->pageAfterId($count, 0, $idColumn)->get();
 
         while (! empty($results)) {
             if (call_user_func($callback, $results) === false) {
                 return false;
             }
 
-            if ($column) {
-                $lastId = last($results)->{$column};
-            }
+            $lastId = last($results)->{$idColumn};
 
-            $results = $this->pageAfterId($count, $lastId, $column)->get();
+            $results = $this->pageAfterId($count, $lastId, $idColumn)->get();
         }
 
         return true;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1335,10 +1335,10 @@ class Builder
     /**
      * Constrain the query to the next "page" of results after a given ID.
      *
-     * @param int  $perPage
-     * @param int  $column
-     * @param string  $column
-     * @return Builder|static
+     * @param  int    $perPage
+     * @param  int    $lastId
+     * @param  string $column
+     * @return \Illuminate\Database\Query\Builder|static
      */
     public function pageAfterId($perPage = 15, $lastId = 0, $column = 'id')
     {
@@ -1648,9 +1648,9 @@ class Builder
     /**
      * Chunk the results of a query by comparing numeric IDs.
      *
-     * @param int  $count
-     * @param callable  $callback
-     * @param string  $column
+     * @param int      $count
+     * @param callable $callback
+     * @param string   $idColumn
      * @return bool
      */
     public function chunkById($count, callable $callback, $column = 'id')

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1650,23 +1650,23 @@ class Builder
      *
      * @param int      $count
      * @param callable $callback
-     * @param string   $idColumn
+     * @param string   $column
      * @return bool
      */
-    public function chunkById($count, callable $callback, $idColumn = 'id')
+    public function chunkById($count, callable $callback, $column = 'id')
     {
         $lastId = null;
 
-        $results = $this->pageAfterId($count, 0, $idColumn)->get();
+        $results = $this->pageAfterId($count, 0, $column)->get();
 
         while (! empty($results)) {
             if (call_user_func($callback, $results) === false) {
                 return false;
             }
 
-            $lastId = last($results)->{$idColumn};
+            $lastId = last($results)->{$column};
 
-            $results = $this->pageAfterId($count, $lastId, $idColumn)->get();
+            $results = $this->pageAfterId($count, $lastId, $column)->get();
         }
 
         return true;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1335,10 +1335,10 @@ class Builder
     /**
      * Constrain the query to the next "page" of results after a given ID.
      *
-     * @param  int    $perPage
-     * @param  int    $lastId
-     * @param  string $column
-     * @return \Illuminate\Database\Query\Builder|static
+     * @param  int  $perPage
+     * @param  int  $lastId
+     * @param  string  $column
+     * @return  \Illuminate\Database\Query\Builder|static
      */
     public function pageAfterId($perPage = 15, $lastId = 0, $column = 'id')
     {
@@ -1621,9 +1621,9 @@ class Builder
     /**
      * Chunk the results of the query.
      *
-     * @param  int      $count
-     * @param  callable $callback
-     * @return bool
+     * @param  int  $count
+     * @param  callable  $callback
+     * @return  bool
      */
     public function chunk($count, callable $callback)
     {
@@ -1648,10 +1648,10 @@ class Builder
     /**
      * Chunk the results of a query by comparing numeric IDs.
      *
-     * @param int      $count
-     * @param callable $callback
-     * @param string   $column
-     * @return bool
+     * @param  int  $count
+     * @param  callable  $callback
+     * @param  string  $column
+     * @return  bool
      */
     public function chunkById($count, callable $callback, $column = 'id')
     {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -194,7 +194,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         });
     }
 
-    public function testChunkPaginatesUsingWhereBetweenIds()
+    public function testChunkPaginatesUsingId()
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder[pageAfterId,get]', [$this->getMockQueryBuilder()]);
         $builder->shouldReceive('pageAfterId')->once()->with(2, 0, 'someIdField')->andReturn($builder);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1540,7 +1540,6 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
      */
     protected function getMockQueryBuilder()
     {
-
         $builder = m::mock('Illuminate\Database\Query\Builder[pageAfterId,get]', [
             m::mock('Illuminate\Database\ConnectionInterface'),
             new Illuminate\Database\Query\Grammars\Grammar,


### PR DESCRIPTION
This just adds a test for query builder chunkById, and fixes up some crappy docblocks from my last pr.

There were no existing tests for the query builder chunk method -- possibly because the method is essentially duped from the eloquent builder file. Seems nice to have both sides tested.

Happy to add a couple more tests if they bring any value.
