### PR TITLE
[5.2] Apply a middleware only once

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -242,9 +242,9 @@ class Route
             $middleware = [$middleware];
         }
 
-        $this->action['middleware'] = array_merge(
+        $this->action['middleware'] = array_unique(array_merge(
             (array) Arr::get($this->action, 'middleware', []), $middleware
-        );
+        ));
 
         return $this;
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -575,6 +575,20 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testRouteMiddlewareAppliedOnlyOnce()
+    {
+        $router = $this->getRouter();
+        $router->group(['middleware' => 'foo'], function () use ($router) {
+            $router->get('bar', function () { return 'hello'; })->middleware(['foo', 'foo']);
+        });
+        $routes = $router->getRoutes()->getRoutes();
+        $route = $routes[0];
+        $this->assertEquals(
+            ['foo'],
+            $route->middleware()
+        );
+    }
+
     public function testRoutePrefixing()
     {
         /*


### PR DESCRIPTION
As discussed in: https://github.com/laravel/framework/issues/12877, https://github.com/laravel/framework/pull/12879, and https://github.com/laravel/framework/pull/12903.

This PR makes a single middleware applied only once on a single route, I can't think of a scenario where applying a middleware multiple times on the same route is useful.
