### PR TITLE
[5.2] Last executed query helper function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Debug\Dumper;
 use Illuminate\Contracts\Support\Htmlable;
 
@@ -504,6 +505,45 @@ if (! function_exists('dd')) {
         }, func_get_args());
 
         die(1);
+    }
+}
+
+if (! function_exists('dddb')) {
+    /**
+     * Dump last query and exit.
+     *
+     * Needs query logging to be enabled.
+     *
+     * @return void
+     */
+    function dddb()
+    {
+        if (DB::logging()) {
+            $queries = DB::getQueryLog();
+
+            if ($queries) {
+                $query_parts = end($queries);
+
+                $query = $query_parts['query'];
+                $bindings = $query_parts['bindings'];
+
+                foreach ($bindings as $binding) {
+                    if (is_numeric($binding)) {
+                        $query = preg_replace('/\?/', $binding, $query, 1);
+                    } else {
+                        $query = preg_replace('/\?/', "'".$binding."'", $query, 1);
+                    }
+                }
+
+                dd($query);
+            } else {
+                echo 'No Queries.'.PHP_EOL;
+                die(1);
+            }
+        } else {
+            echo 'Query logging is currently disabled.'.PHP_EOL;
+            die(1);
+        }
     }
 }
 


### PR DESCRIPTION
Little helper function to dump the last executed query and exit. Name comes from the action Dump & Die with the last DB query.
Needs query logging to be enabled (DB::enableQueryLog()) for it to work, but I didn't think it wise to force that here.
