### PR TITLE
[5.3] Allow scopes starting with or boolean

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1141,12 +1141,13 @@ class Builder
         $whereSlice = array_slice($wheres, $sliceFrom, $sliceTo - $sliceFrom);
 
         $whereBooleans = collect($whereSlice)->pluck('boolean');
+        $firstBoolean = $whereBooleans->first();
 
         // Here we'll check if the given subset of where clauses contains any "or"
         // booleans and in this case create a nested where expression. That way
         // we don't add any unnecessary nesting thus keeping the query clean.
         if ($whereBooleans->contains('or')) {
-            $query->wheres[] = $this->nestWhereSlice($whereSlice);
+            $query->wheres[] = $this->nestWhereSlice($whereSlice, $firstBoolean);
         } else {
             $query->wheres = array_merge($query->wheres, $whereSlice);
         }
@@ -1156,15 +1157,16 @@ class Builder
      * Create a where array with nested where conditions.
      *
      * @param  array  $whereSlice
+     * @param  string  $boolean
      * @return array
      */
-    protected function nestWhereSlice($whereSlice)
+    protected function nestWhereSlice($whereSlice, $boolean = 'and')
     {
         $whereGroup = $this->getQuery()->forNestedWhere();
 
         $whereGroup->wheres = $whereSlice;
 
-        return ['type' => 'Nested', 'query' => $whereGroup, 'boolean' => 'and'];
+        return ['type' => 'Nested', 'query' => $whereGroup, 'boolean' => $boolean];
     }
 
     /**

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -82,6 +82,14 @@ class DatabaseEloquentGlobalScopesTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo', 'bar', 1, 0], $query->getBindings());
     }
 
+    public function testScopesStartingWithOrBooleanArePreserved()
+    {
+        $query = EloquentClosureGlobalScopesTestModel::withoutGlobalScopes()->where('foo', 'foo')->orWhere('bar', 'bar')->orApproved();
+
+        $this->assertEquals('select * from "table" where ("foo" = ? or "bar" = ?) or ("approved" = ? or "should_approve" = ?)', $query->toSql());
+        $this->assertEquals(['foo', 'bar', 1, 0], $query->getBindings());
+    }
+
     public function testHasQueryWhereBothModelsHaveGlobalScopes()
     {
         $query = EloquentGlobalScopesWithRelationModel::has('related')->where('bar', 'baz');
@@ -114,6 +122,11 @@ class EloquentClosureGlobalScopesTestModel extends Illuminate\Database\Eloquent\
     public function scopeApproved($query)
     {
         return $query->where('approved', 1)->orWhere('should_approve', 0);
+    }
+
+    public function scopeOrApproved($query)
+    {
+        return $query->orWhere('approved', 1)->orWhere('should_approve', 0);
     }
 }
 


### PR DESCRIPTION
Based on the feedback I am proposing a minor change in query scopes:

``` php
// Lets say we have the following scope:
public function scopeOrActive($query)
{
    $query->orWhere('active', 1);
}

// And we execute the following query:
User::where('foo', 'bar')->orActive();
```

Since in 5.2 scopes are automatically nested to avoid any confusion in logical order of the operators, we would get the following sql:

``` sql
/* Note that the "or" boolean was replaced with "and" */
select * from "users" where ("foo"="bar") and ("active"="1")
```

However, it seems that some people would prefer the leading boolean to be respected:

``` sql
select * from "users" where ("foo"="bar") or ("active"="1")
```

I am targeting this PR to 5.3, since it's a minor BC  break.
