### PR TITLE
[5.2] Fix elixir manifest caching to detect if different build paths are used

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -336,10 +336,12 @@ if (! function_exists('elixir')) {
      */
     function elixir($file, $buildDirectory = 'build')
     {
-        static $manifest = null;
-
-        if (is_null($manifest)) {
+        static $manifest;
+        static $manifestPath;
+        
+        if (is_null($manifest) || $manifestPath !== $buildDirectory) {
             $manifest = json_decode(file_get_contents(public_path($buildDirectory.'/rev-manifest.json')), true);
+            $manifestPath = $buildDirectory;
         }
 
         if (isset($manifest[$file])) {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -338,7 +338,7 @@ if (! function_exists('elixir')) {
     {
         static $manifest;
         static $manifestPath;
-        
+
         if (is_null($manifest) || $manifestPath !== $buildDirectory) {
             $manifest = json_decode(file_get_contents(public_path($buildDirectory.'/rev-manifest.json')), true);
             $manifestPath = $buildDirectory;


### PR DESCRIPTION
With the previous functionality it was not possible to use multiple manifest files in different locations (for example from vendor packages), as the first manifest file would be cached, not reading subsequent manifest files.

This change will retain caching as long as the manifest files remain the same, and otherwise load the new manifest file.
