### PR TITLE
[5.2] Fix Str::snake method for UTF-8 strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -395,7 +395,7 @@ class Str
         if (! ctype_lower($value)) {
             $value = preg_replace('/\s+/', '', $value);
 
-            $value = strtolower(preg_replace('/(.)(?=[A-Z])/', '$1'.$delimiter, $value));
+            $value = static::lower(preg_replace('/(.)(?=[A-Z])/', '$1'.$delimiter, $value));
         }
 
         return static::$snakeCache[$key] = $value;


### PR DESCRIPTION
When i set locale to `tr_TR.UTF-8`, Str::snake() method can't convert an utf-8 string to snake case correctly because of `strtolower`. So in SQL queries, it causes query exceptions:

```
 Next Illuminate\Database\QueryException: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'dbname.Invites' doesn't exist (SQL: select * from `Invites` where ...
```

In this example, it is trying to get Laravel Eloquent model called `Invite`'s data but it's table name converted to `Invites` instead of `invites`. When i set table name manually to model (`$table` property), it works.

_NOTE: This issue occurs on PHP 7 setup._
