### PR TITLE
Revert "[5.2] Use the proper application namespace in HomeController when "make:auth""

### DIFF
--- a/src/Illuminate/Auth/Console/MakeAuthCommand.php
+++ b/src/Illuminate/Auth/Console/MakeAuthCommand.php
@@ -58,15 +58,6 @@ class MakeAuthCommand extends Command
                 $this->compileControllerStub()
             );
 
-            file_put_contents(
-                app_path('Http/Controllers/HomeController.php'),
-                str_replace(
-                    'App\\',
-                    $this->laravel->getNamespace(),
-                    file_get_contents(app_path('Http/Controllers/HomeController.php'))
-                )
-            );
-
             $this->info('Updated Routes File.');
 
             file_put_contents(


### PR DESCRIPTION
Reverts #12307 

This PR (#12307) was probably merged without realizing that this was already merged: https://github.com/laravel/framework/pull/12245
which accomplishes the same functionality and makes this one actually doing nothing.
