### PR TITLE
[5.1] Never retry query if failed within transaction

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -610,6 +610,10 @@ class Connection implements ConnectionInterface
         try {
             $result = $this->runQueryCallback($query, $bindings, $callback);
         } catch (QueryException $e) {
+            if ($this->transactions >= 1) {
+                throw $e;
+            }
+
             $result = $this->tryAgainIfCausedByLostConnection(
                 $e, $query, $bindings, $callback
             );

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -193,7 +193,7 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);
         $mock->expects($this->once())->method('tryAgainIfCausedByLostConnection');
 
-        $method->invokeArgs($mock, ['', [], function () {throw new \Illuminate\Database\QueryException('', [], new \Exception);}]);
+        $method->invokeArgs($mock, ['', [], function () {throw new \Illuminate\Database\QueryException('', [], new \Exception); }]);
     }
 
     /**
@@ -210,7 +210,7 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $mock->expects($this->never())->method('tryAgainIfCausedByLostConnection');
         $mock->beginTransaction();
 
-        $method->invokeArgs($mock, ['', [], function () {throw new \Illuminate\Database\QueryException('', [], new \Exception);}]);
+        $method->invokeArgs($mock, ['', [], function () {throw new \Illuminate\Database\QueryException('', [], new \Exception); }]);
     }
 
     public function testFromCreatesNewQueryBuilder()

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -184,6 +184,35 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $mock->transaction(function ($connection) { $connection->reconnect(); });
     }
 
+    public function testRunMethodRetriesOnFailure()
+    {
+        $method = (new ReflectionClass('Illuminate\Database\Connection'))->getMethod('run');
+        $method->setAccessible(true);
+
+        $pdo = $this->getMock('DatabaseConnectionTestMockPDO');
+        $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);
+        $mock->expects($this->once())->method('tryAgainIfCausedByLostConnection');
+
+        $method->invokeArgs($mock, ['', [], function () {throw new \Illuminate\Database\QueryException('', [], new \Exception);}]);
+    }
+
+    /**
+     * @expectedException \Illuminate\Database\QueryException
+     */
+    public function testRunMethodNeverRetriesIfWithinTransaction()
+    {
+        $method = (new ReflectionClass('Illuminate\Database\Connection'))->getMethod('run');
+        $method->setAccessible(true);
+
+        $pdo = $this->getMock('DatabaseConnectionTestMockPDO', ['beginTransaction']);
+        $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);
+        $pdo->expects($this->once())->method('beginTransaction');
+        $mock->expects($this->never())->method('tryAgainIfCausedByLostConnection');
+        $mock->beginTransaction();
+
+        $method->invokeArgs($mock, ['', [], function () {throw new \Illuminate\Database\QueryException('', [], new \Exception);}]);
+    }
+
     public function testFromCreatesNewQueryBuilder()
     {
         $conn = $this->getMockConnection();


### PR DESCRIPTION
Here's the scenario:

``` php
DB::beginTransaction();
DB::insert(); // QueryException thrown
```

This causes the following to happen
1. `Connection::tryAgainIfCausedByLostConnection()` is called inside `Connection::run()`
2. `Connection::reconnect()` is called inside `tryAgainIfCausedByLostConnection()`
3. `DatabaseManager::reconnect()` is called
4. `DatabaseManager::disconnect()` is called inside `DatabaseManager::reconnect()`
5. `Connection::disconnect()` is called inside `DatabaseManager::disconnect()`
6. `Connection::setPdo(null)` is called inside `Connection::disconnect()`

Inside `setPDO()`:

``` php
if ($this->transactions >= 1) {
    throw new RuntimeException("Can't swap PDO instance while within transaction.");
}
```

So while there's a transaction open a retry can never happen, the result of this behaviour is that a `RuntimeException` is thrown hiding the `QueryException` which contains useful information about the problem.

This PR checks if there's a transaction open when a `QueryException` is thrown, if so it just throws the exception again for developers to handle it properly and never retries the query because it'll fail anyway.
