### PR TITLE
View Make Command

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -2,42 +2,43 @@
 
 namespace Illuminate\Foundation\Providers;
 
-use Illuminate\Support\ServiceProvider;
-use Illuminate\Queue\Console\TableCommand;
-use Illuminate\Auth\Console\MakeAuthCommand;
-use Illuminate\Foundation\Console\UpCommand;
-use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Auth\Console\ClearResetsCommand;
-use Illuminate\Foundation\Console\ServeCommand;
+use Illuminate\Auth\Console\MakeAuthCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
-use Illuminate\Queue\Console\FailedTableCommand;
-use Illuminate\Foundation\Console\TinkerCommand;
-use Illuminate\Foundation\Console\JobMakeCommand;
+use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Foundation\Console\AppNameCommand;
-use Illuminate\Foundation\Console\OptimizeCommand;
-use Illuminate\Foundation\Console\TestMakeCommand;
-use Illuminate\Foundation\Console\RouteListCommand;
-use Illuminate\Foundation\Console\EventMakeCommand;
-use Illuminate\Foundation\Console\ModelMakeCommand;
-use Illuminate\Foundation\Console\ViewClearCommand;
-use Illuminate\Session\Console\SessionTableCommand;
-use Illuminate\Foundation\Console\PolicyMakeCommand;
-use Illuminate\Foundation\Console\RouteCacheCommand;
-use Illuminate\Foundation\Console\RouteClearCommand;
-use Illuminate\Routing\Console\ControllerMakeCommand;
-use Illuminate\Routing\Console\MiddlewareMakeCommand;
+use Illuminate\Foundation\Console\ClearCompiledCommand;
 use Illuminate\Foundation\Console\ConfigCacheCommand;
 use Illuminate\Foundation\Console\ConfigClearCommand;
 use Illuminate\Foundation\Console\ConsoleMakeCommand;
+use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Foundation\Console\EnvironmentCommand;
-use Illuminate\Foundation\Console\KeyGenerateCommand;
-use Illuminate\Foundation\Console\RequestMakeCommand;
-use Illuminate\Foundation\Console\ListenerMakeCommand;
-use Illuminate\Foundation\Console\ProviderMakeCommand;
-use Illuminate\Foundation\Console\ClearCompiledCommand;
 use Illuminate\Foundation\Console\EventGenerateCommand;
+use Illuminate\Foundation\Console\EventMakeCommand;
+use Illuminate\Foundation\Console\JobMakeCommand;
+use Illuminate\Foundation\Console\KeyGenerateCommand;
+use Illuminate\Foundation\Console\ListenerMakeCommand;
+use Illuminate\Foundation\Console\ModelMakeCommand;
+use Illuminate\Foundation\Console\OptimizeCommand;
+use Illuminate\Foundation\Console\PolicyMakeCommand;
+use Illuminate\Foundation\Console\ProviderMakeCommand;
+use Illuminate\Foundation\Console\RequestMakeCommand;
+use Illuminate\Foundation\Console\RouteCacheCommand;
+use Illuminate\Foundation\Console\RouteClearCommand;
+use Illuminate\Foundation\Console\RouteListCommand;
+use Illuminate\Foundation\Console\ServeCommand;
+use Illuminate\Foundation\Console\TestMakeCommand;
+use Illuminate\Foundation\Console\TinkerCommand;
+use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Console\VendorPublishCommand;
-use Illuminate\Database\Console\Seeds\SeederMakeCommand;
+use Illuminate\Foundation\Console\ViewClearCommand;
+use Illuminate\Queue\Console\FailedTableCommand;
+use Illuminate\Queue\Console\TableCommand;
+use Illuminate\Routing\Console\ControllerMakeCommand;
+use Illuminate\Routing\Console\MiddlewareMakeCommand;
+use Illuminate\Session\Console\SessionTableCommand;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\View\Console\ViewMakeCommand;
 
 class ArtisanServiceProvider extends ServiceProvider
 {
@@ -55,19 +56,19 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     protected $commands = [
         'ClearCompiled' => 'command.clear-compiled',
-        'ClearResets' => 'command.auth.resets.clear',
-        'ConfigCache' => 'command.config.cache',
-        'ConfigClear' => 'command.config.clear',
-        'Down' => 'command.down',
-        'Environment' => 'command.environment',
-        'KeyGenerate' => 'command.key.generate',
-        'Optimize' => 'command.optimize',
-        'RouteCache' => 'command.route.cache',
-        'RouteClear' => 'command.route.clear',
-        'RouteList' => 'command.route.list',
-        'Tinker' => 'command.tinker',
-        'Up' => 'command.up',
-        'ViewClear' => 'command.view.clear',
+        'ClearResets'   => 'command.auth.resets.clear',
+        'ConfigCache'   => 'command.config.cache',
+        'ConfigClear'   => 'command.config.clear',
+        'Down'          => 'command.down',
+        'Environment'   => 'command.environment',
+        'KeyGenerate'   => 'command.key.generate',
+        'Optimize'      => 'command.optimize',
+        'RouteCache'    => 'command.route.cache',
+        'RouteClear'    => 'command.route.clear',
+        'RouteList'     => 'command.route.list',
+        'Tinker'        => 'command.tinker',
+        'Up'            => 'command.up',
+        'ViewClear'     => 'command.view.clear',
     ];
 
     /**
@@ -76,27 +77,28 @@ class ArtisanServiceProvider extends ServiceProvider
      * @var array
      */
     protected $devCommands = [
-        'AppName' => 'command.app.name',
-        'AuthMake' => 'command.auth.make',
-        'CacheTable' => 'command.cache.table',
-        'ConsoleMake' => 'command.console.make',
-        'ControllerMake' => 'command.controller.make',
-        'EventGenerate' => 'command.event.generate',
-        'EventMake' => 'command.event.make',
-        'JobMake' => 'command.job.make',
-        'ListenerMake' => 'command.listener.make',
-        'MiddlewareMake' => 'command.middleware.make',
-        'ModelMake' => 'command.model.make',
-        'PolicyMake' => 'command.policy.make',
-        'ProviderMake' => 'command.provider.make',
+        'AppName'          => 'command.app.name',
+        'AuthMake'         => 'command.auth.make',
+        'CacheTable'       => 'command.cache.table',
+        'ConsoleMake'      => 'command.console.make',
+        'ControllerMake'   => 'command.controller.make',
+        'ViewMake'         => 'command.view.make',
+        'EventGenerate'    => 'command.event.generate',
+        'EventMake'        => 'command.event.make',
+        'JobMake'          => 'command.job.make',
+        'ListenerMake'     => 'command.listener.make',
+        'MiddlewareMake'   => 'command.middleware.make',
+        'ModelMake'        => 'command.model.make',
+        'PolicyMake'       => 'command.policy.make',
+        'ProviderMake'     => 'command.provider.make',
         'QueueFailedTable' => 'command.queue.failed-table',
-        'QueueTable' => 'command.queue.table',
-        'RequestMake' => 'command.request.make',
-        'SeederMake' => 'command.seeder.make',
-        'SessionTable' => 'command.session.table',
-        'Serve' => 'command.serve',
-        'TestMake' => 'command.test.make',
-        'VendorPublish' => 'command.vendor.publish',
+        'QueueTable'       => 'command.queue.table',
+        'RequestMake'      => 'command.request.make',
+        'SeederMake'       => 'command.seeder.make',
+        'SessionTable'     => 'command.session.table',
+        'Serve'            => 'command.serve',
+        'TestMake'         => 'command.test.make',
+        'VendorPublish'    => 'command.vendor.publish',
     ];
 
     /**
@@ -109,7 +111,7 @@ class ArtisanServiceProvider extends ServiceProvider
         $this->registerCommands($this->commands);
 
         //if (! $this->app->environment('production')) {
-            $this->registerCommands($this->devCommands);
+        $this->registerCommands($this->devCommands);
         //}
     }
 
@@ -535,6 +537,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.view.clear', function ($app) {
             return new ViewClearCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerViewMakeCommand()
+    {
+        $this->app->singleton('command.view.make', function ($app) {
+            return new ViewMakeCommand($app['files']);
         });
     }
 

--- a/src/Illuminate/View/Console/ViewMakeCommand.php
+++ b/src/Illuminate/View/Console/ViewMakeCommand.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Illuminate\View\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ViewMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:view';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new view file';
+
+    /**
+     * The name of file being generated.
+     *
+     * @var string
+     */
+    protected $fileName = null;
+    
+    /**
+     * The type of file being generated.
+     *
+     * @var string
+     */
+    protected $type = 'View';
+
+
+    /**
+     * The full path of file.
+     *
+     * @var string
+     */
+    protected $viewDirectoryPath = null;
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        if ($this->option('section')) {
+            return __DIR__ . '/stubs/view.section.stub';
+        }
+
+        if ($this->option('extends')) {
+            return __DIR__ . '/stubs/view.extends.stub';
+        }
+
+        return __DIR__ . '/stubs/view.plain.stub';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['extends', null, InputOption::VALUE_OPTIONAL, 'Select extends file path.'],
+            ['section', null, InputOption::VALUE_OPTIONAL, 'Select section name.'],
+        ];
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $this->createDirectories();
+
+        if ($this->alreadyExists($this->viewDirectoryPath.$this->fileName.'.blade.php')) {
+            $this->error($this->type . ' already exists!');
+            return false;
+        }
+
+        $this->makeView();
+
+        if ($this->option('extends')) {
+            file_put_contents($this->viewDirectoryPath . $this->fileName . '.blade.php', str_replace('extend_name', $this->option('extends'), file_get_contents($this->viewDirectoryPath . $this->fileName . '.blade.php')));
+        }
+        if ($this->option('section')) {
+            file_put_contents($this->viewDirectoryPath . $this->fileName . '.blade.php', str_replace('section_name', $this->option('section'), file_get_contents($this->viewDirectoryPath . $this->fileName . '.blade.php')));
+        }
+
+        $this->info('View ' . $this->fileName . ' generated successfully!');
+    }
+
+    /**
+     * Create the directories for the files.
+     *
+     * @return void
+     */
+    protected function createDirectories()
+    {
+        if (strpos($this->getNameInput(), '.')) {
+            $paths = explode('.', $this->getNameInput());
+            // remove file name
+            $this->fileName = array_pop($paths);
+            // concatinate the path in loop
+            $last_path = '';
+
+            foreach ($paths as $path) {
+                if (!is_dir(base_path('resources/views/' . $last_path . $path))) {
+                    mkdir(base_path('resources/views/' . $last_path . $path), 0755, true);
+                }
+                $last_path .= $path . '/';
+            }
+            $this->viewDirectoryPath = base_path('resources/views/' . $last_path);
+        }
+    }
+
+    /**
+     * Generate the view file.
+     *
+     * @return void
+     */
+    protected function makeView()
+    {
+        $path = $this->viewDirectoryPath;
+        file_put_contents($path . $this->fileName . '.blade.php', file_get_contents($this->getStub()));
+    }
+
+     /**
+     * Determine if the view already exists.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    protected function alreadyExists($path)
+    {
+        return $this->files->exists($path);
+    }
+}

--- a/src/Illuminate/View/Console/stubs/view.extends.stub
+++ b/src/Illuminate/View/Console/stubs/view.extends.stub
@@ -1,0 +1,1 @@
+@extends('extend_name')

--- a/src/Illuminate/View/Console/stubs/view.section.stub
+++ b/src/Illuminate/View/Console/stubs/view.section.stub
@@ -1,0 +1,4 @@
+@extends('extend_name')
+@section('section_name')
+
+@endsection


### PR DESCRIPTION
artisan has a lot of generator commands for controller,model,events,jobs but i actually don't know why there is no make:view command . i didn't find any reason of why not implement it . so i made a small command that generate views with some options 

1 - create a plain view

`php artisan make:view dashboard.posts.create`

that's create a plain view file 

2 - create view with blade extends 

`php artisan make:view dashboard.posts.create --extends="dashboard.layout"` 

if we want to use section with extends 

3 - create view with blade extends with section

`php artisan make:view dashboard.posts.create --extends="dashboard.layout"  --section="content"`

it's just a suggestion . 

Regards :) 
