### PR TITLE
[5.2] Fix assert in page default argument

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -235,7 +235,7 @@ trait InteractsWithPages
      * @param  string  $message
      * @return $this
      */
-    protected function assertInPage(PageConstraint $constraint, $reverse = false, $message = 'Something')
+    protected function assertInPage(PageConstraint $constraint, $reverse = false, $message = '')
     {
         if ($reverse) {
             $constraint = new ReversePageConstraint($constraint);


### PR DESCRIPTION
Sorry about this. I was doing some tests in local and committed this by mistake. 
