### PR TITLE
[5.2] getOriginal will return null for newly created models

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -45,6 +45,17 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($model->isDirty(['foo', 'bar']));
     }
 
+    public function testGetOriginalShouldAlwaysReturnArray()
+    {
+        $model = new EloquentModelStub;
+        $this->assertEquals([], $model->getOriginal());
+
+        $model->fill($attrs = ['foo' => '1', 'bar' => 2, 'baz' => 3]);
+        $model->syncOriginal();
+
+        $this->assertEquals($attrs, $model->getOriginal());
+    }
+
     public function testCalculatedAttributes()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
_This is a failing test to verify unexpected behavior._

This is a test which fails as `getOriginal` will return `null` for newly created models. This is undocumented and new behavior from 5.1.

I am creating a PR for the test and fix separately, for the curious to verify the failing case.

The reason for the change in behavior is found in `Arr::get`, where an additional clause has been added in commit 2f4fc2e4fc4dd07c6d44419935c2a49f6fd3f034.
