### PR TITLE
[5.2] Fix for wrong return value from getOriginal

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3084,7 +3084,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  mixed  $default
      * @return array
      */
-    public function getOriginal($key = null, $default = null)
+    public function getOriginal($key = null, $default = [])
     {
         return Arr::get($this->original, $key, $default);
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -45,6 +45,17 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($model->isDirty(['foo', 'bar']));
     }
 
+    public function testGetOriginalShouldAlwaysReturnArray()
+    {
+        $model = new EloquentModelStub;
+        $this->assertEquals([], $model->getOriginal());
+
+        $model->fill($attrs = ['foo' => '1', 'bar' => 2, 'baz' => 3]);
+        $model->syncOriginal();
+
+        $this->assertEquals($attrs, $model->getOriginal());
+    }
+
     public function testCalculatedAttributes()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
This is the fix for the issue mentioned in #12945.
