### PR TITLE
[5.2] Cross join support for query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -436,6 +436,19 @@ class Builder
     }
 
     /**
+     * Add a "cross join" clause to the query.
+     *
+     * @param  string  $table
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function crossJoin($table)
+    {
+        $this->joins[] = new JoinClause('cross', $table);
+
+        return $this;
+    }
+
+    /**
      * Apply the callback's query changes if the given "value" is true.
      *
      * @param  bool  $value

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -140,6 +140,16 @@ class Grammar extends BaseGrammar
         foreach ($joins as $join) {
             $table = $this->wrapTable($join->table);
 
+            $type = $join->type;
+
+            // Cross joins generate a cartesian product between the first table and the joined
+            // table. Since they don't expect any "on" clauses to perform the join, we just
+            // just append the SQL statement and jump to the next iteration of the loop.
+            if ($type === 'cross') {
+                $sql[] = "cross join $table";
+                continue;
+            }
+
             // First we need to build all of the "on" clauses for the join. There may be many
             // of these clauses so we will need to iterate through each one and build them
             // separately, then we'll join them up into a single string when we're done.
@@ -155,8 +165,6 @@ class Grammar extends BaseGrammar
             $clauses[0] = $this->removeLeadingBoolean($clauses[0]);
 
             $clauses = implode(' ', $clauses);
-
-            $type = $join->type;
 
             // Once we have everything ready to go, we will just concatenate all the parts to
             // build the final join statement SQL for the query and we can then return the

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -703,6 +703,13 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['bar', 'foo'], $builder->getBindings());
     }
 
+    public function testCrossJoins()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('sizes')->crossJoin('colors');
+        $this->assertEquals('select * from "sizes" cross join "colors"', $builder->toSql());
+    }
+
     public function testComplexJoin()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This PR adds a `crossJoin($table)` method to Laravel's query builder to support [SQL cross joins](https://en.wikipedia.org/wiki/Join_%28SQL%29#Cross_join).

Cross joins are useful in [a variety of situations](http://stackoverflow.com/a/219758) and they are supported by MySQL, PostgreSQL and SQLite so I think it makes sense to add them to the query builder. 
