### PR TITLE
[5.2] Merges server variables instead of replacing them

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -500,7 +500,7 @@ trait MakesHttpRequests
 
         $request = Request::create(
             $this->currentUri, $method, $parameters,
-            $cookies, $files, array_replace($this->serverVariables, $server), $content
+            $cookies, $files, array_merge($this->serverVariables, $server), $content
         );
 
         $response = $kernel->handle($request);


### PR DESCRIPTION
### Overview

This change allows users to add new `$server` values during a `$this->call()` request. Current behavior uses `array_replace()`, which only allows you to modify existing keys, but does not allow you to insert new keys. 

For example, I want to test that if `$_SERVER['HTTP_X_FORWARDED_FOR']` is set, then I should return a certain result. Under the current code, since the local test request is not being forwarded, `$_SERVER['HTTP_X_FORWARDED_FOR']` is not set. This is undesirable behavior (at least for me).

See the following examples:
#### Current

``` php
$params = [];
$cookies = [];
$files = [];
$server = ['HTTP_X_FORWARDED_FOR' => '127.0.0.1'];
$this->call('GET', '/test', $params, $cookies, $files, $server);

...

class TestController extends Controller {
    function test() {
        dd($_SERVER['HTTP_X_FORWARDED_FOR']); // returns error, no key exists
    }
}
```

This call will fail to set `HTTP_X_FORWARDED_FOR` into the `$_SERVER` array, since it doesn't already exists.
#### With My PR change

``` php
$params = [];
$cookies = [];
$files = [];
$server = ['HTTP_X_FORWARDED_FOR' => '127.0.0.1'];
$this->call('GET', '/test', $params, $cookies, $files, $server);

...

class TestController extends Controller {
    function test() {
        dd($_SERVER['HTTP_X_FORWARDED_FOR']); // returns 127.0.0.1
    }
}
```

As you can see, when `MakesHttpRequest::call()` uses `array_merge`, then this works as expected. Since the signature doesn't change, and this does not remove any keys, this change _should_ be backwards compatible, so I submitted it to the `5.2` branch. If I need to re-submit on a different branch, please let me know.

Thanks for reading. Let me know if there's anything I need to change.
