### PR TITLE
[5.1] fixed empty clauses usage for join

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -134,28 +134,35 @@ class Grammar extends BaseGrammar
         foreach ($joins as $join) {
             $table = $this->wrapTable($join->table);
 
-            // First we need to build all of the "on" clauses for the join. There may be many
-            // of these clauses so we will need to iterate through each one and build them
-            // separately, then we'll join them up into a single string when we're done.
-            $clauses = [];
-
-            foreach ($join->clauses as $clause) {
-                $clauses[] = $this->compileJoinConstraint($clause);
-            }
-
-            // Once we have constructed the clauses, we'll need to take the boolean connector
-            // off of the first clause as it obviously will not be required on that clause
-            // because it leads the rest of the clauses, thus not requiring any boolean.
-            $clauses[0] = $this->removeLeadingBoolean($clauses[0]);
-
-            $clauses = implode(' ', $clauses);
-
             $type = $join->type;
 
-            // Once we have everything ready to go, we will just concatenate all the parts to
-            // build the final join statement SQL for the query and we can then return the
-            // final clause back to the callers as a single, stringified join statement.
-            $sql[] = "$type join $table on $clauses";
+            // First build the JOIN
+            $sql[] = $type.' join '.$table;
+
+            // build the ON clauses only if provided. In custom closure for $join->one it's not
+            // necessary to provide on clause
+            if (!empty($join->clauses)) {
+                // First we need to build all of the "on" clauses for the join. There may be many
+                // of these clauses so we will need to iterate through each one and build them
+                // separately, then we'll join them up into a single string when we're done.
+                $clauses = [];
+
+                foreach ($join->clauses as $clause) {
+                    $clauses[] = $this->compileJoinConstraint($clause);
+                }
+
+                // Once we have constructed the clauses, we'll need to take the boolean connector
+                // off of the first clause as it obviously will not be required on that clause
+                // because it leads the rest of the clauses, thus not requiring any boolean.
+                $clauses[0] = $this->removeLeadingBoolean($clauses[0]);
+
+                $clauses = implode(' ', $clauses);
+
+                // Once we have everything ready to go, we will just concatenate all the parts to
+                // build the final join statement SQL for the query and we can then return the
+                // final clause back to the callers as a single, stringified join statement.
+                $sql[] = 'on '.$clauses;
+            }
         }
 
         return implode(' ', $sql);


### PR DESCRIPTION
When using closure on $one with no on usage of any function for a closure, the grammar compile creates and empty ON closure with `` as columns (because one and second is null). 

Sometimes the query needs a custom AS command with function and etc

```
   $query->join(\DB::raw("CUSTOM SELECT AS search_objects3 USING(object_id)"),
        function ($joinClause) {
            // no on clause
        });
```

Example of the join

```
  JOIN
    (SELECT
        object_id
    FROM
        `index_search_objects`
    WHERE
        option_id IN (66,257)
    GROUP BY object_id
    ) AS search_objects3 USING(object_id)
```

Probably would be neat to enable null on $one = null and skip creating the on closure with empty one/second.
