### PR TITLE
[5.2] Add test for Arr::collapse, and Arr::add

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -30,7 +30,7 @@ class Arr
      */
     public static function add($array, $key, $value)
     {
-        if (is_null(static::get($array, $key))) {
+        if (! static::has($array, $key)) {
             static::set($array, $key, $value);
         }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -22,11 +22,18 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
     {
         $array = Arr::add(['name' => 'Desk'], 'price', 100);
         $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
+
+        // do not add even null value
+        $array = Arr::add(['name' => null], 'name', 100);
+        $this->assertEquals(['name' => null], $array);
     }
 
     public function testCollapse()
     {
         $data = [['foo', 'bar'], ['baz']];
+        $this->assertEquals(['foo', 'bar', 'baz'], Arr::collapse($data));
+
+        $data = [new Collection(['foo', 'bar']), ['baz']];
         $this->assertEquals(['foo', 'bar', 'baz'], Arr::collapse($data));
     }
 


### PR DESCRIPTION
Add some test.

For `Arr::add`, if an element is null, it considers existing, should not be replaced.
