### PR TITLE
[5.2] Consider implicit attributes while guessing column names in exists & unique

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1256,7 +1256,7 @@ class Validator implements ValidatorContract
         // The second parameter position holds the name of the column that needs to
         // be verified as unique. If this parameter isn't specified we will just
         // assume that this column to be verified shares the attribute's name.
-        $column = isset($parameters[1]) ? $parameters[1] : $attribute;
+        $column = $this->guessColumnIfNotGiven($attribute, isset($parameters[1]) ? $parameters[1] : null);
 
         list($idColumn, $id) = [null, null];
 
@@ -1344,7 +1344,7 @@ class Validator implements ValidatorContract
         // The second parameter position holds the name of the column that should be
         // verified as existing. If this parameter is not specified we will guess
         // that the columns being "verified" shares the given attribute's name.
-        $column = isset($parameters[1]) ? $parameters[1] : $attribute;
+        $column = $this->guessColumnIfNotGiven($attribute, isset($parameters[1]) ? $parameters[1] : null);
 
         $expected = (is_array($value)) ? count($value) : 1;
 
@@ -1404,6 +1404,24 @@ class Validator implements ValidatorContract
         }
 
         return $extra;
+    }
+
+    /**
+     * Guess the database column from the given attribute name if not given already.
+     *
+     * @param  string  $attribute
+     * @param  string  $column
+     * @return string
+     */
+    public function guessColumnIfNotGiven($attribute, $column = null)
+    {
+        if ($column) {
+            return $column;
+        }
+
+        return in_array($attribute, array_collapse($this->implicitAttributes))
+               && ! is_numeric($last = last(explode('.', $attribute)))
+               ? $last : $attribute;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1217,6 +1217,18 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateUniqueAndExistsSendsCorrectFieldNameToDBWithArrays()
+    {
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, [['email' => 'foo', 'type' => 'bar']], ['*.email' => 'unique:users', '*.type' => 'exists:user_types']);
+        $mock = m::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $mock->shouldReceive('setConnection')->twice()->with(null);
+        $mock->shouldReceive('getCount')->with('users', 'email', 'foo', null, null, [])->andReturn(0);
+        $mock->shouldReceive('getCount')->with('user_types', 'type', 'bar', null, null, [])->andReturn(1);
+        $v->setPresenceVerifier($mock);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidationExists()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
As mentioned here https://github.com/laravel/framework/issues/12947.

This PR handles implicit attributes to guess the column name for the `unique` and `exists` validation rules, the result will be like:
- `users.1.email` => `email`
- `1.username` => `username`
- `emails.1` => `emails.1` (unable to guess the name)
- `email` => `email` (as usual)
