### PR TITLE
[5.2] Wrap field name in MySQL JSON path expressions

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -154,6 +154,8 @@ class MySqlGrammar extends Grammar
     {
         $path = explode('->', $value);
 
-        return array_shift($path).'->'.'"$.'.implode('.', $path).'"';
+        $field = $this->wrapValue(array_shift($path));
+
+        return $field.'->'.'"$.'.implode('.', $path).'"';
     }
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1193,19 +1193,19 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereRaw('items->"$.price" = 1');
-        $this->assertEquals('select * from `users` where items->"$.price" = 1', $builder->toSql());
+        $this->assertEquals('select * from `users` where `items`->"$.price" = 1', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('items->price')->from('users')->where('items->price', '=', 1)->orderBy('items->price');
-        $this->assertEquals('select items->"$.price" from `users` where items->"$.price" = ? order by items->"$.price" asc', $builder->toSql());
+        $this->assertEquals('select `items`->"$.price" from `users` where `items`->"$.price" = ? order by `items`->"$.price" asc', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
-        $this->assertEquals('select * from `users` where items->"$.price.in_usd" = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where `items`->"$.price.in_usd" = ?', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1)->where('items->age', '=', 2);
-        $this->assertEquals('select * from `users` where items->"$.price.in_usd" = ? and items->"$.age" = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where `items`->"$.price.in_usd" = ? and `items`->"$.age" = ?', $builder->toSql());
     }
 
     public function testPostgresWrappingJson()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1193,7 +1193,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereRaw('items->"$.price" = 1');
-        $this->assertEquals('select * from `users` where `items`->"$.price" = 1', $builder->toSql());
+        $this->assertEquals('select * from `users` where items->"$.price" = 1', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('items->price')->from('users')->where('items->price', '=', 1)->orderBy('items->price');


### PR DESCRIPTION
Without this, MySQL throws an error e.g. when using reserved names as field names.

At least in theory, this should also reduce attack surface for SQL injection! _This weakness may apply to other database grammars (Postgres?), not tested._

Example behavior without this fix:

```
~/Code/backend$ php artisan tinker

Psy Shell v0.7.2 (PHP 7.0.3-13+deb.sury.org~trusty+1 — cli) by Justin Hileman

>>> App\User::where('values->test', "1")->get()

Illuminate\Database\QueryException with message 'SQLSTATE[42000]: Syntax
error or access violation: 1064 You have an error in your SQL syntax; check the
manual that corresponds to your MySQL server version for the right syntax to
use near '->"$.test" = ?' at line 1 (SQL: select * from `users` where
values->"$.test" = 1)'
```
