### PR TITLE
[5.2] Fix testSharedGet test failing on Windows.

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -290,6 +290,9 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
         @rmdir(__DIR__.'/foo');
     }
 
+    /**
+     * @requires extension pcntl
+     */
     public function testSharedGet()
     {
         if (defined('HHVM_VERSION')) {


### PR DESCRIPTION
This test cannot pass on Windows based systems because the pcntl extension is not available there. So before running it, we make sure the extension is present.
