### PR TITLE
[5.2] Fix Arr::get($array, null) when $array is empty

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -262,7 +262,7 @@ class Arr
      */
     public static function get($array, $key, $default = null)
     {
-        if (! $array) {
+        if (! static::accessible($array)) {
             return value($default);
         }
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -182,8 +182,13 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $this->assertNull(Arr::get($array, 'bar.baz', 'default'));
 
         // Test $array not an array
-        $this->assertEquals('default', Arr::get(null, 'foo', 'default'));
-        $this->assertEquals('default', Arr::get(false, 'foo', 'default'));
+        $this->assertSame('default', Arr::get(null, 'foo', 'default'));
+        $this->assertSame('default', Arr::get(false, 'foo', 'default'));
+        $this->assertSame('default', Arr::get(null, null, 'default'));
+
+        // Test $array is empty and key is null
+        $this->assertSame([], Arr::get([], null));
+        $this->assertSame([], Arr::get([], null, 'default'));
     }
 
     public function testHas()


### PR DESCRIPTION
Following https://github.com/laravel/framework/pull/12958, https://github.com/laravel/framework/pull/12946 and https://github.com/laravel/framework/pull/12945.

Basically, in that particular use case, when the model is created, `attributes` and `original` are both set to empty arrays. In `Arr::get`, we have `if (! $array) { return $default; }`. However, in PHP, when an array is empty, `(! $array) === true`.
This PR just adds to the condition the `&& ! is_array($array)` to fix the problem.
