### PR TITLE
[5.2] Fix adding implicit rules via sometimes() method

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -278,7 +278,11 @@ class Validator implements ValidatorContract
 
         if (call_user_func($callback, $payload)) {
             foreach ((array) $attribute as $key) {
-                $this->mergeRules($key, $rules);
+                if (Str::contains($key, '*')) {
+                    $this->explodeRules([$key => $rules]);
+                } else {
+                    $this->mergeRules($key, $rules);
+                }
             }
         }
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1962,6 +1962,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['x' => 'foo'], ['x' => 'Required']);
         $v->sometimes('x', ['Foo', 'Bar:Baz'], function ($i) { return $i->x == 'foo'; });
         $this->assertEquals(['x' => ['Required', 'Foo', 'Bar:Baz']], $v->getRules());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => [['name' => 'first', 'title' => null]]], []);
+        $v->sometimes('foo.*.name', 'Required|String', function ($i) { return $i['foo'][0]['title'] === null; });
+        $this->assertEquals(['foo.0.name' => ['Required', 'String']], $v->getRules());
     }
 
     public function testCustomValidators()


### PR DESCRIPTION
Originally submitted here https://github.com/laravel/framework/pull/12755

This PR correctly merges validation rules added via `sometimes()` when the keys are implicit.
