### PR TITLE
[5.2] Fix indentation in `Route::controllerMiddleware`

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -269,7 +269,7 @@ class Route
         $controller = $this->container->make($class);
 
         return (new ControllerDispatcher($this->router, $this->container))
-                    ->getMiddleware($controller, $method);
+            ->getMiddleware($controller, $method);
     }
 
     /**


### PR DESCRIPTION
Weird indentation introduced in https://github.com/laravel/framework/commit/74b0636e6fae73109cb8256640b21f57b44908a5.
