### PR TITLE
Add environment to config:cache

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -17,13 +17,7 @@ class DetectEnvironment
     public function bootstrap(Application $app)
     {
         if (! $app->configurationIsCached()) {
-            $this->checkForSpecificEnvironmentFile($app);
-
-            try {
-                (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
-            } catch (InvalidPathException $e) {
-                //
-            }
+            $this->loadEnvironment($app);
         }
     }
 
@@ -44,5 +38,24 @@ class DetectEnvironment
         if (file_exists($app->environmentPath().'/'.$file)) {
             $app->loadEnvironmentFrom($file);
         }
+    }
+
+    /**
+     * Load the environment.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @return mixed
+     */
+    public function loadEnvironment(Application $app)
+    {
+        $this->checkForSpecificEnvironmentFile($app);
+
+        try {
+            (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
+        } catch (InvalidPathException $e) {
+            //
+        }
+
+        return $_ENV;
     }
 }


### PR DESCRIPTION
Environment is curently not being loaded if you cache your config. If you do a `artisan cache:config` and 

```
{{ env('APP_KEY') }}
```

You'll get zero, zilch, zip, nada, nothing! I tested it on a clean Laravel app. And I wonder why this was not seen before, people must be forgetting to cache config on their production servers, wich may save 100ms or more, because DotDenv is a nice and slow guy.

This PR adds some lines to the bootstrap/config.php file to reload the cached environment:

```
<?php 
putenv("APP_ENV=local"); $_ENV["APP_ENV"] = "local"; $_SERVER["APP_ENV"] = "local";
putenv("APP_DEBUG=true"); $_ENV["APP_DEBUG"] = "true"; $_SERVER["APP_DEBUG"] = "true";
putenv("APP_KEY=whateverkeyyouhavehere"); $_ENV["APP_KEY"] = "dTJjzDoQPkai6Cchy7YIXzBQM3fqtdzc"; $_SERVER["APP_KEY"] = "dTJjzDoQPkai6Cchy7YIXzBQM3fqtdzc";
putenv("DB_CONNECTION=pgsql"); $_ENV["DB_CONNECTION"] = "pgsql"; $_SERVER["DB_CONNECTION"] = "pgsql";
putenv("DB_HOST=localhost"); $_ENV["DB_HOST"] = "localhost"; $_SERVER["DB_HOST"] = "localhost";

...

return array (
  'app' => 
  array (
    'name' => 'Kall Zenter',
    'debug' => true,
    'upload_root' => 'public',
    'upload_relative_path' => 'files/uploaded',
    'url' => 'http://localhost',
    'timezone' => 'America/Sao_Paulo',
    'locale' => 'pt_BR',
    'fallback_locale' => 'en',
    'key' => 'SomeRandomString',
...
```
