### PR TITLE
[5.2] Reverse a breaking addition in Route.php

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -235,15 +235,7 @@ class Route
     public function middleware($middleware = null)
     {
         if (is_null($middleware)) {
-            $middlewares = (array) Arr::get($this->action, 'middleware', []);
-
-            if (is_string($this->action['uses'])) {
-                $middlewares = array_merge(
-                    $middlewares, $this->controllerMiddleware()
-                );
-            }
-
-            return $middlewares;
+            return (array) Arr::get($this->action, 'middleware', []);
         }
 
         if (is_string($middleware)) {


### PR DESCRIPTION
In an earlier PR https://github.com/laravel/framework/pull/12899, controller routes were included in the `Route:middleware()` method output by calling `ControllerDispatcher`, this had two effects:
1. All middlewares registered inside the controller's constructor will be executed twice, once from `ControllerDispatcher::callWithinStack()` when the controller is actually being dispatched and another in `Router::runRouteWithinStack()` while the Router is dispatching the request to the route.
2. All code inside the controller constructor will be executed while the `ControllerDispatcher` is instantiating the controller, some of this code is considered protected by a middleware registered in `routes.php`.

For example a code inside the controller constructor that logs a user's presence inside the dashboard area, this code will be executed although the controller is protected under the `auth` controller for example, or `auth.type.admin`

Also calls to `Request::user()` && `Auth::user()` will return null if the user is not logged in, although the developer added the `auth` middleware to this controller inside the routes file, this will call a PHP error when Controller dispatches is called instead of executing the `auth` middleware and redirect the user to the log in screen.

---

Terminable middlewares are useful, however I say we keep the old behaviour of firing them only when registered otherwhere than the controller for 5.2 in order not to break things.

And I suggest in 5.3 we remove the `Controller::middleware()` method and make people use a static method for example that we can run from outside to collect the middlewares without executing the constructor code.

And since we will be already collecting controller middlewares data before firing the controller actions, we won't need to read the controller routes from inside the controller itself.
