### PR TITLE
[5.2] Register console application via container

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -6,7 +6,6 @@ use Exception;
 use Throwable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Console\Scheduling\Schedule;
-use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Console\Kernel as KernelContract;
 use Symfony\Component\Debug\Exception\FatalThrowableError;

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -222,8 +222,7 @@ class Kernel implements KernelContract
     protected function getArtisan()
     {
         if (is_null($this->artisan)) {
-            return $this->artisan = (new Artisan($this->app, $this->events, $this->app->version()))
-                                ->resolveCommands($this->commands);
+            return $this->artisan = $this->app['artisan']->resolveCommands($this->commands);
         }
 
         return $this->artisan;

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -106,6 +106,10 @@ class ArtisanServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->app->singleton('artisan', function ($app) {
+            return new \Illuminate\Console\Application($app, $app['events'], $app->version());
+        });
+
         $this->registerCommands($this->commands);
 
         //if (! $this->app->environment('production')) {


### PR DESCRIPTION
This PR registers and resolves `Illuminate\Console\Application` via the container.

Not sure if `Illuminate\Foundation\Providers\ArtisanServiceProvider` is the right place for this though.
