### PR TITLE
[5.2] Add new method for utf8mb4 string in Blueprint

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -454,6 +454,18 @@ class Blueprint
     }
 
     /**
+     * Create a new utf8mb4 string column on the table.
+     *
+     * @param  string  $column
+     * @param  int $length
+     * @return \Illuminate\Support\Fluent
+     */
+    public function mb4String($column, $length = 191)
+    {
+        return $this->addColumn('string', $column, compact('length'));
+    }
+
+    /**
      * Create a new text column on the table.
      *
      * @param  string  $column


### PR DESCRIPTION
New method called mb4String() on Blueprint Class. For creating a new string column on the table.

Reason: if use string() method for indexes instead when the charset is set to utf8mb4, this error will be thrown after running the migration: #1071 - Specified key was too long; max key length is 767 bytes. Because the maximum for VARCHAR should be 191, not 255.
