### PR TITLE
[5.1] Remove redundant function call

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -484,8 +484,6 @@ class Guard implements GuardContract
      */
     public function loginUsingId($id, $remember = false)
     {
-        $this->session->set($this->getName(), $id);
-
         $this->login($user = $this->provider->retrieveById($id), $remember);
 
         return $user;


### PR DESCRIPTION
The `login` function will call `updateSession` function which will excute

``` php
$this->session->set($this->getName(), $id);
```

https://github.com/laravel/framework/blob/5.1/src/Illuminate/Auth/Guard.php#L432
