### PR TITLE
[5.2] Use relation setter when setting relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2694,7 +2694,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 .'Illuminate\Database\Eloquent\Relations\Relation');
         }
 
-        return $this->relations[$method] = $relations->getResults();
+        $this->setRelation($method, $results = $relations->getResults());
+
+        return $results;
     }
 
     /**


### PR DESCRIPTION
I am currently working in a project which really need to have access to the moment when an Eloquent relation is loaded. Currently, Eloquent uses `setRelation` only when using eager loading. If a relationship is just lazy loaded by its property name, Eloquent just sets `$this->relations[$method]` manually (from `getRelationshipFromMethod`).

In order to make Eloquent easier to extend and overwrite, I suggest to use the Eloquent relation setter also in this case.
