### PR TITLE
[5.2] fix validateAfter()

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1733,10 +1733,6 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(1, $parameters, 'after');
 
-        if (! is_string($value)) {
-            return false;
-        }
-
         if ($format = $this->getDateFormat($attribute)) {
             return $this->validateAfterWithFormat($format, $value, $parameters);
         }


### PR DESCRIPTION
$value is an instance of Carbon\Carbon so checking is_string() will always return false, breaking any 'after:some_date' validation.
