### PR TITLE
[5.2] Fix postgres Schema::hasTable();

### DIFF
--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database;
 
+use Illuminate\Database\Schema\PostgresBuilder;
 use Doctrine\DBAL\Driver\PDOPgSql\Driver as DoctrineDriver;
 use Illuminate\Database\Query\Processors\PostgresProcessor;
 use Illuminate\Database\Query\Grammars\PostgresGrammar as QueryGrammar;
@@ -9,6 +10,20 @@ use Illuminate\Database\Schema\Grammars\PostgresGrammar as SchemaGrammar;
 
 class PostgresConnection extends Connection
 {
+    /**
+     * Get a schema builder instance for the connection.
+     *
+     * @return \Illuminate\Database\Schema\PostgresBuilder
+     */
+    public function getSchemaBuilder()
+    {
+        if (is_null($this->schemaGrammar)) {
+            $this->useDefaultSchemaGrammar();
+        }
+
+        return new PostgresBuilder($this);
+    }
+
     /**
      * Get the default query grammar instance.
      *

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -28,7 +28,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileTableExists()
     {
-        return 'select * from information_schema.tables where table_name = ?';
+        return 'select * from information_schema.tables where table_schema = ? and table_name = ?';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Database\Schema;
+
+class PostgresBuilder extends Builder
+{
+    /**
+     * Determine if the given table exists.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function hasTable($table)
+    {
+        $sql = $this->grammar->compileTableExists();
+
+        $schema = $this->connection->getConfig('schema');
+
+        $table = $this->connection->getTablePrefix().$table;
+
+        return count($this->connection->select($sql, [$schema, $table])) > 0;
+    }
+}


### PR DESCRIPTION
As reported in https://github.com/laravel/framework/issues/12856, the current query looks for tables in the `information_schema` regardless of the `TABLE_SCHEMA`.
