### PR TITLE
[5.2] A case with Arr:dot()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -105,7 +105,7 @@ class Arr
         $results = [];
 
         foreach ($array as $key => $value) {
-            if (is_array($value)) {
+            if (is_array($value) && ! empty($value)) {
                 $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
             } else {
                 $results[$prepend.$key] = $value;

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -41,6 +41,15 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
     {
         $array = Arr::dot(['foo' => ['bar' => 'baz']]);
         $this->assertEquals(['foo.bar' => 'baz'], $array);
+
+        $array = Arr::dot([]);
+        $this->assertEquals([], $array);
+
+        $array = Arr::dot(['foo' => []]);
+        $this->assertEquals(['foo' => []], $array);
+
+        $array = Arr::dot(['foo' => ['bar' => []]]);
+        $this->assertEquals(['foo.bar' => []], $array);
     }
 
     public function testExcept()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2099,6 +2099,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testSometimesFailOnEmptyArrayInImplicitRules()
+    {
+        $trans = $this->getRealTranslator();
+
+        $data = ['names' => [['second' => []]]];
+        $v = new Validator($trans, $data, ['names.*.second' => 'sometimes|required']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateImplicitEachWithAsterisksForRequiredNonExistingKey()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
Currently: 

``` php
$output = Arr::dot(['emails' => []]);
// Returns an empty array $output == []
```

It skips the key if the value is an empty array, this has some effect on array validation as reported in: https://github.com/laravel/framework/issues/13007.

This PR checks if a key inside `Arr::dot` has an empty value, and if so it just returns the key as is.

``` php
Arr::dot(['emails' => []]);
// Returns ['emails' => []]
```

I'm not sure if returning `[]` is breaking as it's not expected that `Arr::dot()` to have array values, thought of returning null or empty string.

If this is breaking, I believe `Arr::dot()` shouldn't be used in the validator and the validator to have its own method in 5.2 and fix `Arr::dot()` in 5.3.

What do you think?
