### PR TITLE
[5.2] ResourceRegistrar where patterns

### DIFF
--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -83,8 +83,35 @@ class ResourceRegistrar
         $defaults = $this->resourceDefaults;
 
         foreach ($this->getResourceMethods($defaults, $options) as $m) {
-            $this->{'addResource'.ucfirst($m)}($name, $base, $controller, $options);
+            $this->addWheres(
+                $this->{'addResource'.ucfirst($m)}($name, $base, $controller, $options),
+                $options
+            );
         }
+    }
+
+    /**
+     * Add any parameter patterns to the route.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  array  $options
+     * @return \Illuminate\Routing\Route
+     */
+    protected function addWheres($route, array $options = [])
+    {
+        if (empty($options['where'])) {
+            return $route;
+        }
+
+        if (! isset($this->wheres)) {
+            array_walk($options['where'], function ($item, $key) use (&$wheres) {
+                $wheres[$this->getResourceWildcard($key)] = $item;
+            });
+
+            $this->wheres = $wheres;
+        }
+
+        return $route->where($this->wheres);
     }
 
     /**


### PR DESCRIPTION
Add ability to define where patterns on resource parameters.

``` php
Route::resource('test', 'TestController', ['where' => ['test' => '[0-9]+']]);
```

In reference to Issue #11945
