### PR TITLE
[5.1] Refresh remember_token if reset password

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -113,6 +113,7 @@ trait ResetsPasswords
     protected function resetPassword($user, $password)
     {
         $user->password = bcrypt($password);
+        $user->remember_token = str_random(60);
 
         $user->save();
 


### PR DESCRIPTION
For security reasons, if the user to reset the password, refresh remember_token.

because:

In this case the user may have been hacking account

All the old password generated `remember cookie` should not be trusted
