### PR TITLE
[5.2] Use isEmpty to check for empty message bag in the passes function of the Validator

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -431,7 +431,7 @@ class Validator implements ValidatorContract
             call_user_func($after);
         }
 
-        return count($this->messages->all()) === 0;
+        return $this->messages->isEmpty();
     }
 
     /**


### PR DESCRIPTION
Use isEmpty to check for empty message bag in the passes function of the Validator.
