### PR TITLE
[5.2] Refresh remember_token if reset password

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Http\Request;
 use Illuminate\Mail\Message;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Password;
 
@@ -226,6 +227,7 @@ trait ResetsPasswords
     protected function resetPassword($user, $password)
     {
         $user->password = bcrypt($password);
+        $user->remember_token = Str::random(60);
 
         $user->save();
 


### PR DESCRIPTION
For security reasons, if the user to reset the password, refresh remember_token.

because:

In this case the user may have been hacking account

All the old password generated `remember cookie` should not be trusted

https://github.com/laravel/framework/pull/13012
