### PR TITLE
[5.2] Update some docblocks

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithPages.php
@@ -230,7 +230,7 @@ trait InteractsWithPages
     /**
      * Assert the given constraint.
      *
-     * @param  string  $constraint
+     * @param  \Illuminate\Foundation\Testing\Constraints\PageConstraint  $constraint
      * @param  bool  $reverse
      * @param  string  $message
      * @return $this

--- a/src/Illuminate/Foundation/Testing/Constraints/FormFieldConstraint.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/FormFieldConstraint.php
@@ -45,7 +45,7 @@ abstract class FormFieldConstraint extends PageConstraint
     /**
      * Get the form field.
      *
-     * @param  \Symfony\Component\DomCrawler\Crawler  $name
+     * @param  \Symfony\Component\DomCrawler\Crawler  $crawler
      * @return \Symfony\Component\DomCrawler\Crawler
      *
      * @throws \PHPUnit_Framework_ExpectationFailedException

--- a/src/Illuminate/Foundation/Testing/Constraints/HasLink.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasLink.php
@@ -71,7 +71,6 @@ class HasLink extends PageConstraint
     /**
      * Add a root if the URL is relative (helper method of the hasLink function).
      *
-     * @param  string  $url
      * @return string
      */
     protected function absoluteUrl()

--- a/src/Illuminate/Foundation/Testing/Constraints/IsSelected.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/IsSelected.php
@@ -32,7 +32,6 @@ class IsSelected extends FormFieldConstraint
     /**
      * Get the selected value of a select field or radio group.
      *
-     * @param  string  $selector
      * @param  \Symfony\Component\DomCrawler\Crawler  $crawler
      * @return array
      *

--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -4,6 +4,11 @@ namespace Illuminate\Foundation\Testing;
 
 trait DatabaseMigrations
 {
+    /**
+     * Run the database migrations for the application.
+     *
+     * @return void
+     */
     public function runDatabaseMigrations()
     {
         $this->artisan('migrate');

--- a/src/Illuminate/Foundation/Testing/WithoutEvents.php
+++ b/src/Illuminate/Foundation/Testing/WithoutEvents.php
@@ -7,6 +7,8 @@ use Exception;
 trait WithoutEvents
 {
     /**
+     * Prevent all event handlers from running.
+     * 
      * @throws \Exception
      */
     public function disableEventsForAllTests()

--- a/src/Illuminate/Foundation/Testing/WithoutMiddleware.php
+++ b/src/Illuminate/Foundation/Testing/WithoutMiddleware.php
@@ -7,6 +7,8 @@ use Exception;
 trait WithoutMiddleware
 {
     /**
+     * Disable all middleware for the test class.
+     * 
      * @throws \Exception
      */
     public function disableMiddlewareForAllTests()


### PR DESCRIPTION
Fixed the dockblocks on the Illuminate/Foundation/Testing namespace
- Removed unused parameters
- Added some missing descriptions
- Updated some type hints
