### PR TITLE
[5.2] Allow objects to be passed as pipes

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -117,12 +117,15 @@ class Pipeline implements PipelineContract
                 // the appropriate method and arguments, returning the results back out.
                 if ($pipe instanceof Closure) {
                     return call_user_func($pipe, $passable, $stack);
-                } else {
+                } elseif (! is_object($pipe)) {
                     list($name, $parameters) = $this->parsePipeString($pipe);
-
-                    return call_user_func_array([$this->container->make($name), $this->method],
-                            array_merge([$passable, $stack], $parameters));
+                    $pipe = $this->container->make($name);
+                    $parameters = array_merge([$passable, $stack], $parameters);
+                } else {
+                    $parameters = [$passable, $stack];
                 }
+
+                return call_user_func_array([$pipe, $this->method], $parameters);
             };
         };
     }

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -27,6 +27,21 @@ class PipelineTest extends PHPUnit_Framework_TestCase
         unset($_SERVER['__test.pipe.two']);
     }
 
+    public function testPipelineUsageWithObjects()
+    {
+        $result = (new Pipeline(new Illuminate\Container\Container))
+            ->send('foo')
+            ->through([new PipelineTestPipeOne])
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertEquals('foo', $result);
+        $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
+
+        unset($_SERVER['__test.pipe.one']);
+    }
+
     public function testPipelineUsageWithParameters()
     {
         $parameters = ['one', 'two'];


### PR DESCRIPTION
Allows following code to be executed, very useful in case pipes require some complex constructing or already exist.

``` php
(new Pipeline($app))->send($subject)->through([new A, new B])->via('pipe_method')->then(...);
```
