### PR TITLE
[5.2] Add after and before to dependent rules array

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -174,6 +174,7 @@ class Validator implements ValidatorContract
     protected $dependentRules = [
         'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
         'RequiredIf', 'RequiredUnless', 'Confirmed', 'Same', 'Different', 'Unique',
+        'Before', 'After',
     ];
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2647,6 +2647,31 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->messages()->has('foo.0.bar.1.name'));
     }
 
+    public function testValidateImplicitEachWithAsterisksBeforeAndAfter()
+    {
+        $trans = $this->getRealTranslator();
+
+        $v = new Validator($trans, ['foo' => [
+            ['start' => '2016-04-19', 'end' => '2046-04-19'],
+        ]], ['foo.*.start' => ['before:foo.*.end']]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => [
+            ['start' => '2016-04-19', 'end' => '2046-04-19'],
+        ]], ['foo.*.end' => ['before:foo.*.start']]);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['foo' => [
+            ['start' => '2016-04-19', 'end' => '2046-04-19'],
+        ]], ['foo.*.end' => ['after:foo.*.start']]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => [
+            ['start' => '2016-04-19', 'end' => '2046-04-19'],
+        ]], ['foo.*.start' => ['after:foo.*.end']]);
+        $this->assertTrue($v->fails());
+    }
+
     public function testValidateEachWithNonIndexedArray()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/11648#issuecomment-205878088
