### PR TITLE
[5.2] [WIP] Add ability to combine two validators into a single instance

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -421,11 +421,19 @@ class Validator implements ValidatorContract
      * Combine a validator instance into the current instance.
      *
      * @param \Illuminate\Contracts\Validation\Validator $validator
-     * @return void
+     * @return \Illuminate\Contracts\Validation\Validator
      */
     public function combine(ValidatorContract $validator)
     {
         $newRules = $this->initialRules;
+
+        $newData = $this->parseData(
+            array_merge_recursive($this->getData(), $validator->getData())
+        );
+
+        $newCustomMessages = array_merge($this->getCustomMessages(), $validator->getCustomMessages());
+
+        $newCustomAttributes = array_merge($this->getCustomAttributes(), $validator->getCustomAttributes());
 
         foreach ($validator->initialRules as $attribute => $rule) {
             if (Str::contains($attribute, '*')) {
@@ -449,11 +457,7 @@ class Validator implements ValidatorContract
             }
         }
 
-        $this->data = $this->parseData(
-            array_merge_recursive($this->getData(), $validator->getData())
-        );
-
-        $this->setRules($newRules);
+        return new Validator($this->getTranslator(), $newData, $newRules, $newCustomMessages, $newCustomAttributes);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2685,33 +2685,35 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     {
         $trans = $this->getRealTranslator();
 
-        $v = new Validator($trans, ['foo' => '1'], ['foo' => 'required|string']);
-        $v2 = new Validator($trans, ['bar' => 1], ['bar' => 'required|integer']);
-        $v->combine($v2);
+        $v = new Validator($trans, ['foo' => '1'], ['foo' => 'required|string'], ['required' => 'hey you!'], ['foo' => 'the foo']);
+        $v2 = new Validator($trans, ['bar' => 1], ['bar' => 'required|integer'], ['integer' => 'integer please.'], ['bar' => 'the bar']);
+        $v3 = $v->combine($v2);
 
-        $this->assertEquals(['foo' => '1', 'bar' => '1'], $v->getData());
-        $this->assertEquals(['foo' => ['required', 'string'], 'bar' => ['required', 'integer']], $v->getRules());
+        $this->assertEquals(['foo' => '1', 'bar' => 1], $v3->getData());
+        $this->assertEquals(['foo' => ['required', 'string'], 'bar' => ['required', 'integer']], $v3->getRules());
+        $this->assertEquals(['required' => 'hey you!', 'integer' => 'integer please.'], $v3->getCustomMessages());
+        $this->assertEquals(['foo' => 'the foo', 'bar' => 'the bar'], $v3->getCustomAttributes());
 
         $v = new Validator($trans, ['foo' => '1'], ['foo' => 'required']);
         $v2 = new Validator($trans, ['foo' => 2], ['foo' => 'integer']);
-        $v->combine($v2);
+        $v3 = $v->combine($v2);
 
-        $this->assertEquals(['foo' => ['1', 2]], $v->getData());
-        $this->assertEquals(['foo.0' => ['required'], 'foo.1' => ['integer']], $v->getRules());
+        $this->assertEquals(['foo' => ['1', 2]], $v3->getData());
+        $this->assertEquals(['foo.0' => ['required'], 'foo.1' => ['integer']], $v3->getRules());
 
         $v = new Validator($trans, ['foo' => [1, 2]], ['foo' => 'array']);
         $v2 = new Validator($trans, ['foo' => [3, 4]], ['foo' => 'array']);
-        $v->combine($v2);
+        $v3 = $v->combine($v2);
 
-        $this->assertEquals(['foo' => [1, 2, 3, 4]], $v->getData());
-        $this->assertEquals(['foo' => ['array']], $v->getRules());
+        $this->assertEquals(['foo' => [1, 2, 3, 4]], $v3->getData());
+        $this->assertEquals(['foo' => ['array']], $v3->getRules());
 
         $v = new Validator($trans, ['users' => [['name' => 'a']]], ['users.*.name' => 'required']);
         $v2 = new Validator($trans, ['users' => [['name' => 'b']]], ['users.*.name' => 'string']);
-        $v->combine($v2);
+        $v3 = $v->combine($v2);
 
-        $this->assertEquals(['users' => [['name' => 'a'], ['name' => 'b']]], $v->getData());
-        $this->assertEquals(['users.0.name' => ['required', 'string'], 'users.1.name' => ['required', 'string']], $v->getRules());
+        $this->assertEquals(['users' => [['name' => 'a'], ['name' => 'b']]], $v3->getData());
+        $this->assertEquals(['users.0.name' => ['required', 'string'], 'users.1.name' => ['required', 'string']], $v3->getRules());
     }
 
     public function testGetLeadingExplicitAttributePath()


### PR DESCRIPTION
This PR adds the ability to do the following:

``` php
$validator = Validator::make(['name' => 'Ragnar'], ['name' => 'required']);
$validator2 = Validator::make(['preferred_weapon' => 'axe'], ['preferred_weapon' => 'string'])

$validator->combine($validator2);
```

The result is a validator instance with the rules and data of the two validators combined. 

``` php
$data1 = ['foo' => [1, 2]];
$rules1 = ['foo.*' => 'integer'];

$data2 = ['foo' => [3, 4]];
$rules2 = ['foo.*' => 'max:10'];

// combined data = ['foo' => [1, 2, 3, 4]]
// combined rules = ['foo.*' => ['integer', 'max:10']]
```

``` php
$data1 = ['foo' => 'a'];
$rules1 = ['foo' => 'string'];

$data2 = ['foo' => 'b'];
$rules2 = ['foo' => 'required'];

// combined data = ['foo' => ['a', 'b']]
// combines rules = ['foo.0' => 'string', 'foo.1' => 'required']
```
