### PR TITLE
[5.2] Allows developers to traverse their query result via a cursor

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -362,6 +362,8 @@ class Connection implements ConnectionInterface
             // row from the database table, and will either be an array or objects.
             $statement = $this->getPdoForSelect($useReadPdo)->prepare($query);
 
+            $statement->setFetchMode($me->getFetchMode());
+
             $statement->execute($me->prepareBindings($bindings));
 
             return $statement;

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -343,14 +343,14 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Run a select statement against the database and returns a 'cursor'.
+     * Run a select statement against the database and returns a cursor.
      *
      * @param  string  $query
      * @param  array  $bindings
      * @param  bool  $useReadPdo
      * @return mixed
      */
-    public function fetch($query, $bindings = [], $useReadPdo = true)
+    public function cursor($query, $bindings = [], $useReadPdo = true)
     {
         return $this->run($query, $bindings, function ($me, $query, $bindings) use ($useReadPdo) {
             if ($me->pretending()) {

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -343,7 +343,7 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Run a select statement against the database and return 'cursor'
+     * Run a select statement against the database and returns a 'cursor'.
      *
      * @param  string  $query
      * @param  array  $bindings
@@ -366,7 +366,7 @@ class Connection implements ConnectionInterface
 
             return $statement;
         });
-    }    
+    }
 
     /**
      * Get the PDO connection to use for a select query.

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -371,34 +371,6 @@ class Connection implements ConnectionInterface
     }
 
     /**
-     * Run a select statement against the database and returns a 'cursor'.
-     *
-     * @param  string  $query
-     * @param  array  $bindings
-     * @param  bool  $useReadPdo
-     * @return mixed
-     */
-    public function fetch($query, $bindings = [], $useReadPdo = true)
-    {
-        return $this->run($query, $bindings, function ($me, $query, $bindings) use ($useReadPdo) {
-            if ($me->pretending()) {
-                return [];
-            }
-
-            // For select statements, we'll simply execute the query and return an array
-            // of the database result set. Each element in the array will be a single
-            // row from the database table, and will either be an array or objects.
-            $statement = $this->getPdoForSelect($useReadPdo)->prepare($query);
-
-            $statement->setFetchMode($me->getFetchMode());
-
-            $statement->execute($me->prepareBindings($bindings));
-
-            return $statement;
-        });
-    }
-
-    /**
      * Get the PDO connection to use for a select query.
      *
      * @param  bool  $useReadPdo

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -371,6 +371,34 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Run a select statement against the database and returns a 'cursor'.
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  bool  $useReadPdo
+     * @return mixed
+     */
+    public function fetch($query, $bindings = [], $useReadPdo = true)
+    {
+        return $this->run($query, $bindings, function ($me, $query, $bindings) use ($useReadPdo) {
+            if ($me->pretending()) {
+                return [];
+            }
+
+            // For select statements, we'll simply execute the query and return an array
+            // of the database result set. Each element in the array will be a single
+            // row from the database table, and will either be an array or objects.
+            $statement = $this->getPdoForSelect($useReadPdo)->prepare($query);
+
+            $statement->setFetchMode($me->getFetchMode());
+
+            $statement->execute($me->prepareBindings($bindings));
+
+            return $statement;
+        });
+    }
+
+    /**
      * Get the PDO connection to use for a select query.
      *
      * @param  bool  $useReadPdo

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -343,6 +343,32 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Run a select statement against the database and return 'cursor'
+     *
+     * @param  string  $query
+     * @param  array  $bindings
+     * @param  bool  $useReadPdo
+     * @return mixed
+     */
+    public function fetch($query, $bindings = [], $useReadPdo = true)
+    {
+        return $this->run($query, $bindings, function ($me, $query, $bindings) use ($useReadPdo) {
+            if ($me->pretending()) {
+                return [];
+            }
+
+            // For select statements, we'll simply execute the query and return an array
+            // of the database result set. Each element in the array will be a single
+            // row from the database table, and will either be an array or objects.
+            $statement = $this->getPdoForSelect($useReadPdo)->prepare($query);
+
+            $statement->execute($me->prepareBindings($bindings));
+
+            return $statement;
+        });
+    }    
+
+    /**
      * Get the PDO connection to use for a select query.
      *
      * @param  bool  $useReadPdo

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -291,7 +291,7 @@ class Builder
     }
 
     /**
-     * Fetch the row from the result set
+     * Fetch the row from the result set.
      *
      * @param  callable  $callback
      * @return bool
@@ -314,7 +314,7 @@ class Builder
         }
 
         return true;
-    }    
+    }
 
     /**
      * Execute the query as a "select" statement.

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -302,7 +302,6 @@ class Builder
 
         $statement = $this->query->fetch();
 
-
         while ($row = $statement->fetch()) {
             // On each result set, we will pass them to the callback and then let the
             // developer take care of everything within the callback, which allows us to
@@ -310,7 +309,6 @@ class Builder
             if (call_user_func($callback, $row) === false) {
                 return false;
             }
-
         }
 
         return true;

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -291,6 +291,32 @@ class Builder
     }
 
     /**
+     * Fetch the row from the result set
+     *
+     * @param  callable  $callback
+     * @return bool
+     */
+    public function fetch(callable $callback)
+    {
+        $builder = $this->applyScopes();
+
+        $statement = $this->query->fetch();
+
+
+        while ($row = $statement->fetch()) {
+            // On each result set, we will pass them to the callback and then let the
+            // developer take care of everything within the callback, which allows us to
+            // keep the memory low for spinning through large result sets for working.
+            if (call_user_func($callback, $row) === false) {
+                return false;
+            }
+
+        }
+
+        return true;
+    }    
+
+    /**
      * Execute the query as a "select" statement.
      *
      * @param  array  $columns

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -306,30 +306,6 @@ class Builder
             // developer take care of everything within the callback, which allows us to
             // keep the memory low for spinning through large result sets for working.
 
-            $continue = (yield $row);
-
-            if ($continue === false) {
-                return;
-            }
-        }
-    }
-
-    /**
-     * Traverses through a result set using a cursor.
-     *
-     * @return void
-     */
-    public function traverse()
-    {
-        $builder = $this->applyScopes();
-
-        $statement = $builder->query->fetch();
-
-        while ($row = $statement->fetch()) {
-            // On each result set, we will pass them to the callback and then let the
-            // developer take care of everything within the callback, which allows us to
-            // keep the memory low for spinning through large result sets for working.
-
             if ($row === false) {
                 return;
             }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -307,7 +307,7 @@ class Builder
             // keep the memory low for spinning through large result sets for working.
 
             $continue = (yield $row);
-            
+
             if ($continue === false) {
                 return;
             }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -291,27 +291,30 @@ class Builder
     }
 
     /**
-     * Fetch the row from the result set.
-     *
-     * @param  callable  $callback
-     * @return bool
+     * Traverses through a result set using a cursor.
+     *     
+     * @return void     
      */
-    public function fetch(callable $callback)
+    public function traverse()
     {
         $builder = $this->applyScopes();
 
-        $statement = $this->query->fetch();
+        $statement = $builder->query->fetch();
+
 
         while ($row = $statement->fetch()) {
             // On each result set, we will pass them to the callback and then let the
             // developer take care of everything within the callback, which allows us to
             // keep the memory low for spinning through large result sets for working.
-            if (call_user_func($callback, $row) === false) {
-                return false;
+
+            $continue = (yield $row);
+            
+            if ($continue === false) {
+                return;
             }
+
         }
 
-        return true;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -292,15 +292,14 @@ class Builder
 
     /**
      * Traverses through a result set using a cursor.
-     *     
-     * @return void     
+     *
+     * @return void
      */
     public function traverse()
     {
         $builder = $this->applyScopes();
 
         $statement = $builder->query->fetch();
-
 
         while ($row = $statement->fetch()) {
             // On each result set, we will pass them to the callback and then let the
@@ -312,9 +311,7 @@ class Builder
             if ($continue === false) {
                 return;
             }
-
         }
-
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -315,6 +315,30 @@ class Builder
     }
 
     /**
+     * Traverses through a result set using a cursor.
+     *
+     * @return void
+     */
+    public function traverse()
+    {
+        $builder = $this->applyScopes();
+
+        $statement = $builder->query->fetch();
+
+        while ($row = $statement->fetch()) {
+            // On each result set, we will pass them to the callback and then let the
+            // developer take care of everything within the callback, which allows us to
+            // keep the memory low for spinning through large result sets for working.
+
+            if ($row === false) {
+                return;
+            }
+
+            yield $row;
+        }
+    }
+
+    /**
      * Execute the query as a "select" statement.
      *
      * @param  array  $columns

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -295,11 +295,11 @@ class Builder
      *
      * @return void
      */
-    public function traverse()
+    public function cursor()
     {
         $builder = $this->applyScopes();
 
-        $statement = $builder->query->fetch();
+        $statement = $builder->query->cursor();
 
         while ($row = $statement->fetch()) {
             // On each result set, we will pass them to the callback and then let the
@@ -310,7 +310,10 @@ class Builder
                 return;
             }
 
-            yield $row;
+            //Hydrate and yield an Eloquent Model
+            $model = $this->model->newFromBuilder($row);
+
+            yield $model;
         }
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1638,7 +1638,7 @@ class Builder
      */
     public function fetch()
     {
-        $results =  $this->connection->fetch($this->toSql(), $this->getBindings(), ! $this->useWritePdo);
+        $results = $this->connection->fetch($this->toSql(), $this->getBindings(), ! $this->useWritePdo);
 
         return $results;
     }    

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1641,7 +1641,7 @@ class Builder
         $results = $this->connection->fetch($this->toSql(), $this->getBindings(), ! $this->useWritePdo);
 
         return $results;
-    }    
+    }
 
     /**
      * Chunk the results of the query.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1644,6 +1644,18 @@ class Builder
     }
 
     /**
+     * Execute the query as a "select" statement.
+     *
+     * @return mixed
+     */
+    public function fetch()
+    {
+        $results = $this->connection->fetch($this->toSql(), $this->getBindings(), ! $this->useWritePdo);
+
+        return $results;
+    }
+
+    /**
      * Chunk the results of the query.
      *
      * @param  int  $count

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1632,6 +1632,18 @@ class Builder
     }
 
     /**
+     * Execute the query as a "select" statement.
+     *
+     * @return mixed
+     */
+    public function fetch()
+    {
+        $results =  $this->connection->fetch($this->toSql(), $this->getBindings(), ! $this->useWritePdo);
+
+        return $results;
+    }    
+
+    /**
      * Chunk the results of the query.
      *
      * @param  int  $count

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1644,18 +1644,6 @@ class Builder
     }
 
     /**
-     * Execute the query as a "select" statement.
-     *
-     * @return mixed
-     */
-    public function fetch()
-    {
-        $results = $this->connection->fetch($this->toSql(), $this->getBindings(), ! $this->useWritePdo);
-
-        return $results;
-    }
-
-    /**
      * Chunk the results of the query.
      *
      * @param  int  $count

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1636,9 +1636,9 @@ class Builder
      *
      * @return mixed
      */
-    public function fetch()
+    public function cursor()
     {
-        $results = $this->connection->fetch($this->toSql(), $this->getBindings(), ! $this->useWritePdo);
+        $results = $this->connection->cursor($this->toSql(), $this->getBindings(), ! $this->useWritePdo);
 
         return $results;
     }


### PR DESCRIPTION
Ran into an issue with attempting to use chunk wherein the underlining database would change and therefore the data would no longer be as initially requested. It is also generated a query for every chuck it returns.

Traditionally in php we would do something like below, but I found no Eloquent equivalent.

```
    while ($row = $stmt->fetch(PDO::FETCH_NUM)) {
      $data = $row[0] . "\t" . $row[1] . "\t" . $row[2] . "\n";
      print $data;
    }

```
- Efficiently process thousands of records, uses memory efficiently.
- Hits the database once with single query with local and global scopes.
- Allows you to use a cursor to process the result set.

Usage:

```
foreach(Flight::where('foo', 'bar')->cursor() as $model) {

    //Do something complex with each $model

};
```

Update: Using generator instead of callback
Update: Using Eloquent model and changed name to cursor
