### PR TITLE
[5.3] Fixes for RedisQueue 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
 
 sudo: false
 
+services:
+  - redis-server
+
 before_install:
   - travis_retry composer self-update
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -177,7 +177,7 @@ class RedisQueue extends Queue implements QueueContract
     public function migrateExpiredJobs($from, $to)
     {
         $redis = $this->getConnection();
-        $script = <<<LUA
+        $script = <<<'LUA'
 local val = redis.call('zrangebyscore', KEYS[1], '-inf', KEYS[3])
 if(next(val) ~= nil) then
     redis.call('zremrangebyrank', KEYS[1], 0, #val - 1)

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -129,8 +129,10 @@ class RedisQueue extends Queue implements QueueContract
 
         $queue = $this->getQueue($queue);
 
+        $this->migrateExpiredJobs($queue.':delayed', $queue);
+
         if (! is_null($this->expire)) {
-            $this->migrateAllExpiredJobs($queue);
+            $this->migrateExpiredJobs($queue.':reserved', $queue);
         }
 
         $script = <<<'LUA'
@@ -157,19 +159,6 @@ LUA;
     public function deleteReserved($queue, $job)
     {
         $this->getConnection()->zrem($this->getQueue($queue).':reserved', $job);
-    }
-
-    /**
-     * Migrate all of the waiting jobs in the queue.
-     *
-     * @param  string  $queue
-     * @return void
-     */
-    protected function migrateAllExpiredJobs($queue)
-    {
-        $this->migrateExpiredJobs($queue.':delayed', $queue);
-
-        $this->migrateExpiredJobs($queue.':reserved', $queue);
     }
 
     /**

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -21,7 +21,8 @@ class QueueRedisJobTest extends PHPUnit_Framework_TestCase
     public function testDeleteRemovesTheJobFromRedis()
     {
         $job = $this->getJob();
-        $job->getRedisQueue()->shouldReceive('deleteReserved')->once()->with('default', $job->getRedisJob());
+        $job->getRedisQueue()->shouldReceive('deleteReserved')->once()
+            ->with('default', json_encode(['job' => 'foo', 'data' => ['data'], 'attempts' => 2]));
 
         $job->delete();
     }
@@ -29,8 +30,8 @@ class QueueRedisJobTest extends PHPUnit_Framework_TestCase
     public function testReleaseProperlyReleasesJobOntoRedis()
     {
         $job = $this->getJob();
-        $job->getRedisQueue()->shouldReceive('deleteReserved')->once()->with('default', $job->getRedisJob());
-        $job->getRedisQueue()->shouldReceive('release')->once()->with('default', $job->getRedisJob(), 1, 2);
+        $job->getRedisQueue()->shouldReceive('deleteAndRelease')->once()
+            ->with('default', json_encode(['job' => 'foo', 'data' => ['data'], 'attempts' => 2]), 1);
 
         $job->release(1);
     }
@@ -38,9 +39,10 @@ class QueueRedisJobTest extends PHPUnit_Framework_TestCase
     protected function getJob()
     {
         return new Illuminate\Queue\Jobs\RedisJob(
-            m::mock('Illuminate\Container\Container'),
-            m::mock('Illuminate\Queue\RedisQueue'),
+            m::mock(Illuminate\Container\Container::class),
+            m::mock(Illuminate\Queue\RedisQueue::class),
             json_encode(['job' => 'foo', 'data' => ['data'], 'attempts' => 1]),
+            json_encode(['job' => 'foo', 'data' => ['data'], 'attempts' => 2]),
             'default'
         );
     }

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -55,14 +55,4 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase
 
         $queue->later($date, 'foo', ['data']);
     }
-
-    public function testReleaseMethod()
-    {
-        $queue = $this->getMock('Illuminate\Queue\RedisQueue', ['getTime'], [$redis = m::mock('Illuminate\Redis\Database'), 'default']);
-        $queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
-        $redis->shouldReceive('connection')->once()->andReturn($redis);
-        $redis->shouldReceive('zadd')->once()->with('queues:default:delayed', 2, json_encode(['attempts' => 2]));
-
-        $queue->release('default', json_encode(['attempts' => 1]), 1, 2);
-    }
 }

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -56,22 +56,6 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase
         $queue->later($date, 'foo', ['data']);
     }
 
-    public function testPopProperlyPopsJobOffOfRedis()
-    {
-        $queue = $this->getMock('Illuminate\Queue\RedisQueue', ['getTime', 'migrateAllExpiredJobs'], [$redis = m::mock('Illuminate\Redis\Database'), 'default']);
-        $queue->setContainer(m::mock('Illuminate\Container\Container'));
-        $queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
-        $queue->expects($this->once())->method('migrateAllExpiredJobs')->with($this->equalTo('queues:default'));
-
-        $redis->shouldReceive('connection')->andReturn($redis);
-        $redis->shouldReceive('lpop')->once()->with('queues:default')->andReturn('foo');
-        $redis->shouldReceive('zadd')->once()->with('queues:default:reserved', 61, 'foo');
-
-        $result = $queue->pop();
-
-        $this->assertInstanceOf('Illuminate\Queue\Jobs\RedisJob', $result);
-    }
-
     public function testReleaseMethod()
     {
         $queue = $this->getMock('Illuminate\Queue\RedisQueue', ['getTime'], [$redis = m::mock('Illuminate\Redis\Database'), 'default']);
@@ -80,33 +64,5 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase
         $redis->shouldReceive('zadd')->once()->with('queues:default:delayed', 2, json_encode(['attempts' => 2]));
 
         $queue->release('default', json_encode(['attempts' => 1]), 1, 2);
-    }
-
-    public function testNotExpireJobsWhenExpireNull()
-    {
-        $queue = $this->getMock('Illuminate\Queue\RedisQueue', ['getTime', 'migrateAllExpiredJobs'], [$redis = m::mock('Illuminate\Redis\Database'), 'default', null]);
-        $redis->shouldReceive('connection')->andReturn($predis = m::mock('Predis\Client'));
-        $queue->setContainer(m::mock('Illuminate\Container\Container'));
-        $queue->setExpire(null);
-        $queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
-        $queue->expects($this->never())->method('migrateAllExpiredJobs');
-        $predis->shouldReceive('lpop')->once()->with('queues:default')->andReturn('foo');
-        $predis->shouldReceive('zadd')->once()->with('queues:default:reserved', 1, 'foo');
-
-        $result = $queue->pop();
-    }
-
-    public function testExpireJobsWhenExpireSet()
-    {
-        $queue = $this->getMock('Illuminate\Queue\RedisQueue', ['getTime', 'migrateAllExpiredJobs'], [$redis = m::mock('Illuminate\Redis\Database'), 'default', null]);
-        $redis->shouldReceive('connection')->andReturn($predis = m::mock('Predis\Client'));
-        $queue->setContainer(m::mock('Illuminate\Container\Container'));
-        $queue->setExpire(30);
-        $queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
-        $queue->expects($this->once())->method('migrateAllExpiredJobs')->with($this->equalTo('queues:default'));
-        $predis->shouldReceive('lpop')->once()->with('queues:default')->andReturn('foo');
-        $predis->shouldReceive('zadd')->once()->with('queues:default:reserved', 31, 'foo');
-
-        $result = $queue->pop();
     }
 }

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -82,23 +82,6 @@ class QueueRedisQueueTest extends PHPUnit_Framework_TestCase
         $queue->release('default', json_encode(['attempts' => 1]), 1, 2);
     }
 
-    public function testMigrateExpiredJobs()
-    {
-        $queue = $this->getMock('Illuminate\Queue\RedisQueue', ['getTime'], [$redis = m::mock('Illuminate\Redis\Database'), 'default']);
-        $queue->expects($this->once())->method('getTime')->will($this->returnValue(1));
-        $transaction = m::mock('StdClass');
-        $redis->shouldReceive('connection')->once()->andReturn($redis);
-        $redis->shouldReceive('transaction')->with(m::any(), m::type('Closure'))->andReturnUsing(function ($options, $callback) use ($transaction) {
-            $callback($transaction);
-        });
-        $transaction->shouldReceive('zrangebyscore')->once()->with('from', '-inf', 1)->andReturn(['foo', 'bar']);
-        $transaction->shouldReceive('multi')->once();
-        $transaction->shouldReceive('zremrangebyscore')->once()->with('from', '-inf', 1);
-        $transaction->shouldReceive('rpush')->once()->with('to', 'foo', 'bar');
-
-        $queue->migrateExpiredJobs('from', 'to');
-    }
-
     public function testNotExpireJobsWhenExpireNull()
     {
         $queue = $this->getMock('Illuminate\Queue\RedisQueue', ['getTime', 'migrateAllExpiredJobs'], [$redis = m::mock('Illuminate\Redis\Database'), 'default', null]);

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Container\Container;
+use Illuminate\Redis\Database;
+use Mockery as m;
+
+class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Database
+     */
+    private $redis;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->redis = new Database([
+            'cluster' => false,
+            'default' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'database' => 5,
+            ]]);
+        $this->redis->connection()->flushdb();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->redis->connection()->flushdb();
+    }
+
+    public function testExpiredJobsArePopped()
+    {
+        $queue = new \Illuminate\Queue\RedisQueue($this->redis);
+        $queue->setContainer(m::mock(Container::class));
+
+        $jobs = [
+            new RedisQueueIntegrationTestJob(0),
+            new RedisQueueIntegrationTestJob(1),
+            new RedisQueueIntegrationTestJob(2),
+            new RedisQueueIntegrationTestJob(3),
+        ];
+
+        $queue->later(1000, $jobs[0]);
+        $queue->later(-200, $jobs[1]);
+        $queue->later(-300, $jobs[2]);
+        $queue->later(-100, $jobs[3]);
+
+        $this->assertEquals($jobs[2], unserialize(json_decode($queue->pop()->getRawBody())->data->command));
+        $this->assertEquals($jobs[1], unserialize(json_decode($queue->pop()->getRawBody())->data->command));
+        $this->assertEquals($jobs[3], unserialize(json_decode($queue->pop()->getRawBody())->data->command));
+        $this->assertNull($queue->pop());
+
+        $this->assertEquals(1, $this->redis->connection()->zcard('queues:default:delayed'));
+        $this->assertEquals(3, $this->redis->connection()->zcard('queues:default:reserved'));
+        $this->redis->connection()->flushdb();
+    }
+}
+
+class RedisQueueIntegrationTestJob
+{
+    public $i;
+
+    public function __construct($i)
+    {
+        $this->i = $i;
+    }
+
+    public function handle()
+    {
+        var_dump($this->i . ' handled');
+    }
+}

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Container\Container;
+use Illuminate\Queue\RedisQueue;
 use Illuminate\Redis\Database;
 use Mockery as m;
 
@@ -10,6 +11,11 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
      * @var Database
      */
     private $redis;
+
+    /**
+     * @var RedisQueue
+     */
+    private $queue;
 
     public function setUp()
     {
@@ -23,19 +29,20 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
             ],
         ]);
         $this->redis->connection()->flushdb();
+
+        $this->queue = new RedisQueue($this->redis);
+        $this->queue->setContainer(m::mock(Container::class));
     }
 
     public function tearDown()
     {
         parent::tearDown();
+        m::close();
         $this->redis->connection()->flushdb();
     }
 
     public function testExpiredJobsArePopped()
     {
-        $queue = new \Illuminate\Queue\RedisQueue($this->redis);
-        $queue->setContainer(m::mock(Container::class));
-
         $jobs = [
             new RedisQueueIntegrationTestJob(0),
             new RedisQueueIntegrationTestJob(1),
@@ -43,19 +50,98 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
             new RedisQueueIntegrationTestJob(3),
         ];
 
-        $queue->later(1000, $jobs[0]);
-        $queue->later(-200, $jobs[1]);
-        $queue->later(-300, $jobs[2]);
-        $queue->later(-100, $jobs[3]);
+        $this->queue->later(1000, $jobs[0]);
+        $this->queue->later(-200, $jobs[1]);
+        $this->queue->later(-300, $jobs[2]);
+        $this->queue->later(-100, $jobs[3]);
 
-        $this->assertEquals($jobs[2], unserialize(json_decode($queue->pop()->getRawBody())->data->command));
-        $this->assertEquals($jobs[1], unserialize(json_decode($queue->pop()->getRawBody())->data->command));
-        $this->assertEquals($jobs[3], unserialize(json_decode($queue->pop()->getRawBody())->data->command));
-        $this->assertNull($queue->pop());
+        $this->assertEquals($jobs[2], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
+        $this->assertEquals($jobs[1], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
+        $this->assertEquals($jobs[3], unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
+        $this->assertNull($this->queue->pop());
 
         $this->assertEquals(1, $this->redis->connection()->zcard('queues:default:delayed'));
         $this->assertEquals(3, $this->redis->connection()->zcard('queues:default:reserved'));
-        $this->redis->connection()->flushdb();
+    }
+
+    public function testPopProperlyPopsJobOffOfRedis()
+    {
+        // Push an item into queue
+        $job = new RedisQueueIntegrationTestJob(10);
+        $this->queue->push($job);
+
+        // Pop and check it is popped correctly
+        $before = time();
+        $this->assertEquals($job, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
+        $after = time();
+
+        // Check reserved queue
+        $this->assertEquals(1, $this->redis->connection()->zcard('queues:default:reserved'));
+        $result = $this->redis->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+        $reservedJob = array_keys($result)[0];
+        $score = $result[$reservedJob];
+        $this->assertGreaterThanOrEqual($score, $before + 60);
+        $this->assertLessThanOrEqual($score, $after + 60);
+        $this->assertEquals($job, unserialize(json_decode($reservedJob)->data->command));
+    }
+
+    public function testNotExpireJobsWhenExpireNull()
+    {
+        $this->queue->setExpire(null);
+
+        // Make an expired reserved job
+        $failed = new RedisQueueIntegrationTestJob(-20);
+        $this->queue->push($failed);
+        $beforeFailPop = time();
+        $this->queue->pop();
+        $afterFailPop = time();
+
+        // Push an item into queue
+        $job = new RedisQueueIntegrationTestJob(10);
+        $this->queue->push($job);
+
+        // Pop and check it is popped correctly
+        $before = time();
+        $this->assertEquals($job, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
+        $after = time();
+
+        // Check reserved queue
+        $this->assertEquals(2, $this->redis->connection()->zcard('queues:default:reserved'));
+        $result = $this->redis->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+
+        $reservedJob = array_keys($result)[1];
+        $score = $result[$reservedJob];
+        $this->assertGreaterThanOrEqual($score, $before);
+        $this->assertLessThanOrEqual($score, $after);
+        $this->assertEquals($job, unserialize(json_decode($reservedJob)->data->command));
+
+        $reservedFailedJob = array_keys($result)[0];
+        $failedScore = $result[$reservedFailedJob];
+        $this->assertGreaterThanOrEqual($failedScore, $beforeFailPop);
+        $this->assertLessThanOrEqual($failedScore, $afterFailPop);
+        $this->assertEquals($failed, unserialize(json_decode($reservedFailedJob)->data->command));
+    }
+
+    public function testExpireJobsWhenExpireSet()
+    {
+        $this->queue->setExpire(30);
+        // Push an item into queue
+        $job = new RedisQueueIntegrationTestJob(10);
+        $this->queue->push($job);
+
+        // Pop and check it is popped correctly
+        $before = time();
+        $this->assertEquals($job, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command));
+        $after = time();
+
+        // Check reserved queue
+        $this->assertEquals(1, $this->redis->connection()->zcard('queues:default:reserved'));
+        $result = $this->redis->connection()->zrangebyscore('queues:default:reserved', -INF, INF, ['WITHSCORES' => true]);
+        $reservedJob = array_keys($result)[0];
+        $score = $result[$reservedJob];
+        $this->assertGreaterThanOrEqual($score, $before + 30);
+        $this->assertLessThanOrEqual($score, $after + 30);
+        $this->assertEquals($job, unserialize(json_decode($reservedJob)->data->command));
     }
 }
 

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -20,7 +20,8 @@ class RedisQueueIntegrationTest extends PHPUnit_Framework_TestCase
                 'host' => '127.0.0.1',
                 'port' => 6379,
                 'database' => 5,
-            ]]);
+            ],
+        ]);
         $this->redis->connection()->flushdb();
     }
 
@@ -69,6 +70,5 @@ class RedisQueueIntegrationTestJob
 
     public function handle()
     {
-        var_dump($this->i . ' handled');
     }
 }


### PR DESCRIPTION
Reopening of #12655
#### Changes
- Implement `migrateExpiredJobs()` using `eval` instead of watch-multi-exec (check and set) transactions to prevent issue #12653.
- Increment `attempts` counter when reserving job, instead of when releasing it, so that fatal errors be considered as tries.
- Migrate expired delayed jobs but not expired release ones when expire is null. Issue #12595 
- A few transaction guards for the times we moving jobs between main/reserved and delayed queues, so that the jobs are not lost in Redis server in the case of network/client failures.
#### Upgrade guides required

The changes require Redis >= 2.6.0. I don't think it will be an issue, since 2.6.0 itself is too old! Also, Redis eval command should not be disabled in the Redis configuration file, which I don't think is a big deal - why should somebody do that.
