### PR TITLE
[5.2] Apply middleware once even in nested groups

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -435,6 +435,10 @@ class Router implements RegistrarContract
      */
     public static function mergeGroup($new, $old)
     {
+        if (isset($new['middleware'], $old['middleware'])) {
+            $new['middleware'] = array_diff((array) $new['middleware'], (array) $old['middleware']);
+        }
+
         $new['namespace'] = static::formatUsesPrefix($new, $old);
 
         $new['prefix'] = static::formatGroupPrefix($new, $old);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -587,6 +587,34 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
             ['foo'],
             $route->middleware()
         );
+
+        $router = $this->getRouter();
+        $router->group(['middleware' => 'web'], function () use ($router) {
+            $router->group(['middleware' => 'web'], function () use ($router) {
+                $router->get('bar', function () { return 'hello'; });
+            });
+        });
+        $routes = $router->getRoutes()->getRoutes();
+        $route = $routes[0];
+        $this->assertEquals(
+            ['web'],
+            $route->middleware()
+        );
+
+        $router = $this->getRouter();
+        $router->group(['middleware' => ['web', 'foo']], function () use ($router) {
+            $router->group(['middleware' => 'web'], function () use ($router) {
+                $router->group(['middleware' => ['web', 'foo', 'baz']], function () use ($router) {
+                    $router->get('bar', function () { return 'hello'; });
+                });
+            });
+        });
+        $routes = $router->getRoutes()->getRoutes();
+        $route = $routes[0];
+        $this->assertEquals(
+            array_values(['web', 'foo', 'baz']),
+            array_values($route->middleware())
+        );
     }
 
     public function testRoutePrefixing()


### PR DESCRIPTION
In a previous PR we handled the case of applying a middleware more than once using `Route::middleware()` however the case of nested groups wasn't handled.

Here's the case:

```
$router->group(['middleware' => ['web', 'foo']], function () use ($router) {
    $router->group(['middleware' => 'web'], function () use ($router) {
        $router->group(['middleware' => ['web', 'foo', 'baz']], function () use ($router) {
            $router->get('bar', function () { return 'hello'; });
        });
    });
});
```

The middlewares extracted from this case are:

```
'web', 'foo', 'baz'
```

Before this PR:

```
'web', 'foo', 'web', 'web', 'foo', 'baz'
```
