### PR TITLE
[5.1] Fix for bad accept headers

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -583,7 +583,7 @@ class Request extends SymfonyRequest implements ArrayAccess
 
         $split = explode('/', $actual);
 
-        if (isset($split[1]) && preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type)) {
+        if (isset($split[1]) && @preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type)) {
             return true;
         }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -507,6 +507,18 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($request->accepts('application/baz+json'));
     }
 
+    public function testBadAcceptHeader()
+    {
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'Mozilla/5.0 (Windows; U; Windows NT 5.1; pt-PT; rv:1.9.1.2) Gecko/20090729 Firefox/3.5.2 (.NET CLR 3.5.30729)']);
+        $this->assertFalse($request->accepts(['text/html', 'application/json']));
+        $this->assertFalse($request->accepts('text/html'));
+        $this->assertFalse($request->accepts('text/foo'));
+        $this->assertFalse($request->accepts('application/json'));
+        $this->assertFalse($request->accepts('application/baz+json'));
+        $this->assertFalse($request->acceptsHtml());
+        $this->assertFalse($request->acceptsJson());
+    }
+
     /**
      * @expectedException RuntimeException
      */


### PR DESCRIPTION
For some reason someone passed:

```
Mozilla/5.0 (Windows; U; Windows NT 5.1; pt-PT; rv:1.9.1.2) Gecko/20090729 Firefox/3.5.2 (.NET CLR 3.5.30729)
```

as an `Accept` header to my server (either by mistake, or as an attempt to attack it), and successfully crashed it with:

```
preg_match(): Compilation failed: missing ) at offset 25`
```

and since `preg_match` returns false when an error occurs, simply suppressing errors is the desired behaviour here.
