### PR TITLE
[5.3] Add forceSchemaless method to UrlGenerator

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -287,6 +287,18 @@ class UrlGenerator implements UrlGeneratorContract
 
         $this->forceSchema = $schema.'://';
     }
+    
+    /**
+     * Force schemaless URLs.
+     *
+     * @return void
+     */
+    public function forceSchemaless()
+    {
+        $this->cachedSchema = null;
+
+        $this->forceSchema = '//';
+    }
 
     /**
      * Get the URL to a named route.


### PR DESCRIPTION
This would allow the url generator to generate "protocol relative" asset urls such as: `//mywebsite.com/logo.svg`.

Use case:

I'm using Cloudflare as a CDN which does plain `http` requests to my webserver. Laravel will return `http` assets because of this. I could do `forceSchema('https')`, but that currently breaks my development environment unless I set up self signed certificates.

This method would give me the flexibility for the browser to request `https` assets if needed without breaking non-https development (or production) environments.

This is open for discussion of course.
