### PR TITLE
[5.2] expose token methods to user in password broker

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -250,4 +250,37 @@ class PasswordBroker implements PasswordBrokerContract
     {
         return $this->tokens;
     }
+
+    /**
+     * Generate a password reset token.
+     *
+     * @param CanResetPasswordContract $user
+     * @return string
+     */
+    public function generateToken(CanResetPasswordContract $user)
+    {
+        return $this->tokens->create($user);
+    }
+
+    /**
+     * Delete password reset token.
+     *
+     * @param string $token
+     */
+    public function deleteToken($token)
+    {
+        $this->tokens->delete($token);
+    }
+
+    /**
+     * Validate password reset token.
+     *
+     * @param CanResetPasswordContract $user
+     * @param string $token
+     * @return bool
+     */
+    public function validateToken(CanResetPasswordContract $user, $token)
+    {
+        return $this->tokens->exists($user, $token);
+    }
 }


### PR DESCRIPTION
this PR references internals issue [12](https://github.com/laravel/internals/issues/12). please read my initial comment on that page for my reason behind submitting this PR.

by giving the user access to the token repository, they now have full control over resetting passwords. the user is given free reign over validating the input, sending emails, and other things they would like to do.

here is how i would use it in a controller or service class.

``` php
class PasswordService
{
    public function __construct(\Illuminate\Contracts\Auth\PasswordBroker $broker)
    {
        $this->broker = $broker;
    }

    public function request(array $input)
    {
            //retrieve user
            $user = $this->broker->getUser($input);

            //no user found with email
            if (is_null($user)) {
                throw new Exception('User not found.');
            }

            //get token
            $token = $this->broker->generateToken($user);

            //send email
        }
    }

    public function reset(array $input)
    {
            //retrieve user
            $user = $this->broker->getUser($input);

            //no user found with email
            if (is_null($user)) {
                throw new Exception('User not found.');
            }

            //reset password
            if($this->broker->validateToken($user, $input['token'])){

                $user->password = bcrypt($password);
                $user->save();

                $this->broker->deleteToken($input['token'];
            } 

            throw new Exception('token was invalid');
    }
}
```
