### PR TITLE
[5.2] Fix a case with parameters of explicit depending rules

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -460,10 +460,10 @@ class Validator implements ValidatorContract
             return;
         }
 
-        // First we will get the numeric keys for the given attribute in case the field is nested in
+        // First we will get the correct keys for the given attribute in case the field is nested in
         // an array. Then we determine if the given rule accepts other field names as parameters.
-        // If so, we will replace any asterisks found in the parameters with the numeric keys.
-        if (($keys = $this->getNumericKeys($attribute)) &&
+        // If so, we will replace any asterisks found in the parameters with the correct keys.
+        if (($keys = $this->getExplicitKeys($attribute)) &&
             $this->dependsOnOtherFields($rule)) {
             $parameters = $this->replaceAsterisksInParameters($parameters, $keys);
         }
@@ -2576,17 +2576,21 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Get the numeric keys from an attribute flattened with dot notation.
+     * Get the explicit keys from an attribute flattened with dot notation.
      *
-     * E.g. 'foo.1.bar.2.baz' -> [1, 2]
+     * E.g. 'foo.1.bar.spark.baz' -> [1, 'spark'] for 'foo.*.bar.*.baz'
      *
      * @param  string  $attribute
      * @return array
      */
-    protected function getNumericKeys($attribute)
+    protected function getExplicitKeys($attribute)
     {
-        if (preg_match_all('/\.(\d+)\./', $attribute, $keys)) {
-            return $keys[1];
+        $pattern = str_replace('\*', '([^\.]+)', preg_quote($this->getPrimaryAttribute($attribute)));
+
+        if (preg_match('/^'.$pattern.'/', $attribute, $keys)) {
+            array_shift($keys);
+
+            return $keys;
         }
 
         return [];
@@ -2629,7 +2633,7 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Replace each field parameter which has asterisks with the given numeric keys.
+     * Replace each field parameter which has asterisks with the given keys.
      *
      * @param  array  $parameters
      * @param  array  $keys
@@ -2643,9 +2647,9 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Replace asterisks with numeric keys.
+     * Replace asterisks with explicit keys.
      *
-     * E.g. 'foo.*.bar.*.baz', [1, 2] -> foo.1.bar.2.baz
+     * E.g. 'foo.*.bar.*.baz', [1, 'spark'] -> foo.1.bar.spark.baz
      *
      * @param  string  $field
      * @param  array  $keys
@@ -2653,7 +2657,7 @@ class Validator implements ValidatorContract
      */
     protected function replaceAsterisksWithKeys($field, array $keys)
     {
-        return vsprintf(str_replace('*', '%d', $field), $keys);
+        return vsprintf(str_replace('*', '%s', $field), $keys);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2516,6 +2516,12 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->messages()->has('foo.0.name'));
         $this->assertTrue($v->messages()->has('foo.1.name'));
 
+        $v = new Validator($trans, ['fields' => [
+            'fr' => ['name' => '', 'content' => 'ragnar'],
+            'es' => ['name' => '', 'content' => 'lagertha'],
+        ]], ['fields.*.name' => 'required_with:fields.*.content']);
+        $this->assertFalse($v->passes());
+
         // nested required_with fails
         $v = new Validator($trans, ['foo' => [
             ['bar' => [


### PR DESCRIPTION
As noted in https://github.com/laravel/framework/issues/13047

This PR handles explicit depending rules when the explicit keys are non-numeric:

``` php
Validator::make(
    [
        'fields' => [
            'fr' => ['name' => '', 'content' => 'ragnar'],
            'es' => ['name' => '', 'content' => 'lagertha'],
        ]
    ],
    ['fields.*.name' => 'required_with:fields.*.content']
);
```

Before, it was only working with numeric keys [0, 1] rather than string keys ['fr', 'es'].
