### PR TITLE
[5.1] Quote user-supplied content for use in preg_match

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -587,7 +587,7 @@ class Request extends SymfonyRequest implements ArrayAccess
             $split[0] = preg_quote($split[0], '/');
             $split[1] = preg_quote($split[1], '/');
 
-            return @preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type);
+            return preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type);
         }
 
         return false;

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -583,8 +583,11 @@ class Request extends SymfonyRequest implements ArrayAccess
 
         $split = explode('/', $actual);
 
-        if (isset($split[1]) && @preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type)) {
-            return true;
+        if (isset($split[1])) {
+            $split[0] = preg_quote($split[0], '/');
+            $split[1] = preg_quote($split[1], '/');
+
+            return @preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type);
         }
 
         return false;

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -584,10 +584,10 @@ class Request extends SymfonyRequest implements ArrayAccess
         $split = explode('/', $actual);
 
         if (isset($split[1])) {
-            $split[0] = preg_quote($split[0], '/');
-            $split[1] = preg_quote($split[1], '/');
+            $split[0] = preg_quote($split[0], '#');
+            $split[1] = preg_quote($split[1], '#');
 
-            return preg_match('/'.$split[0].'\/.+\+'.$split[1].'/', $type);
+            return preg_match('#'.$split[0].'/.+\+'.$split[1].'#', $type);
         }
 
         return false;

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -517,6 +517,15 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($request->accepts('application/baz+json'));
         $this->assertFalse($request->acceptsHtml());
         $this->assertFalse($request->acceptsJson());
+
+        // Should not be handled as regex.
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => '.+/.+']);
+        $this->assertFalse($request->accepts('application/json'));
+        $this->assertFalse($request->accepts('application/baz+json'));
+
+        // Should not produce compilation error on invalid regex.
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => '(/(']);
+        $this->assertFalse($request->accepts('text/html'));
     }
 
     /**


### PR DESCRIPTION
Follow-up to #13039.

Escaping for use in regex as it should be.

Removed the error suppression as it shouldn't be needed now.
It was just a "poor man fix", and there is no `@preg_*` elsewhere in the code.
