### PR TITLE
[5.3] Consider integer values while binding pdo params

### DIFF
--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -39,8 +39,9 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $pdo = $this->getMock('DatabaseConnectionTestMockPDO', ['prepare']);
         $writePdo = $this->getMock('DatabaseConnectionTestMockPDO', ['prepare']);
         $writePdo->expects($this->never())->method('prepare');
-        $statement = $this->getMock('PDOStatement', ['execute', 'fetchAll']);
-        $statement->expects($this->once())->method('execute')->with($this->equalTo(['foo' => 'bar']));
+        $statement = $this->getMock('PDOStatement', ['execute', 'fetchAll', 'bindValue']);
+        $statement->expects($this->once())->method('bindValue')->with('foo', 'bar', 2);
+        $statement->expects($this->once())->method('execute');
         $statement->expects($this->once())->method('fetchAll')->will($this->returnValue(['boom']));
         $pdo->expects($this->once())->method('prepare')->with('foo')->will($this->returnValue($statement));
         $mock = $this->getMockConnection(['prepareBindings'], $writePdo);
@@ -81,8 +82,9 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
     public function testStatementProperlyCallsPDO()
     {
         $pdo = $this->getMock('DatabaseConnectionTestMockPDO', ['prepare']);
-        $statement = $this->getMock('PDOStatement', ['execute']);
-        $statement->expects($this->once())->method('execute')->with($this->equalTo(['bar']))->will($this->returnValue('foo'));
+        $statement = $this->getMock('PDOStatement', ['execute', 'bindValue']);
+        $statement->expects($this->once())->method('bindValue')->with(1, 'bar', 2);
+        $statement->expects($this->once())->method('execute')->will($this->returnValue('foo'));
         $pdo->expects($this->once())->method('prepare')->with($this->equalTo('foo'))->will($this->returnValue($statement));
         $mock = $this->getMockConnection(['prepareBindings'], $pdo);
         $mock->expects($this->once())->method('prepareBindings')->with($this->equalTo(['bar']))->will($this->returnValue(['bar']));
@@ -97,8 +99,9 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
     public function testAffectingStatementProperlyCallsPDO()
     {
         $pdo = $this->getMock('DatabaseConnectionTestMockPDO', ['prepare']);
-        $statement = $this->getMock('PDOStatement', ['execute', 'rowCount']);
-        $statement->expects($this->once())->method('execute')->with($this->equalTo(['foo' => 'bar']));
+        $statement = $this->getMock('PDOStatement', ['execute', 'rowCount', 'bindValue']);
+        $statement->expects($this->once())->method('bindValue')->with('foo', 'bar', 2);
+        $statement->expects($this->once())->method('execute');
         $statement->expects($this->once())->method('rowCount')->will($this->returnValue(['boom']));
         $pdo->expects($this->once())->method('prepare')->with('foo')->will($this->returnValue($statement));
         $mock = $this->getMockConnection(['prepareBindings'], $pdo);


### PR DESCRIPTION
The framework currently binds all sql parameters as `PDO::PARAM_STR`, and it's probably fine for most of the cases, however as noted here https://github.com/laravel/framework/issues/12728#issuecomment-200299283 there are some cases where separating between string and integer values is required.

This PR is a proposal for binding numerical values as `PDO::PARAM_INT`.
