### PR TITLE
[5.3] Inject migration dependencies from container

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -333,7 +333,7 @@ class Migrator
 
         $class = Str::studly($file);
 
-        return new $class;
+        return app($class);
     }
 
     /**


### PR DESCRIPTION
Sometimes database migrations have dependencies. Currently migration classes are assumed to have no constructor dependencies at all and are instantiated with `new $class`. This change instead resolves the migration with the global `app($class)`. Dependencies are therefore auto-injected by the DI-container.

``` php
interface FooInterface
{
}

class Migration extends \Illuminate\Database\Migrations\Migration
{

    function __construct(FooInterface $foo)
    {
        // code
    }

    public function up() {}
    public function down() {}

}
```

Ideally the container itself would be injected into the migrator so we don't need to use `app()`, but I guess that's a little too ambitious.

Feedback is appreciated.
