### PR TITLE
[5.2] Adds a transpose() and passes() methods to the Collection object, and transpose() to Arr.

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -500,6 +500,19 @@ class Arr
     }
 
     /**
+     * Transpose each item in the array, interchanging the row and column indexes.
+     *
+     * @param  array $arrayOfArrays
+     * @return mixed
+     */
+    public static function transpose(array $arrayOfArrays)
+    {
+        array_unshift($arrayOfArrays, null);
+
+        return call_user_func_array('array_map', $arrayOfArrays);
+    }
+
+    /**
      * Filter the array using the given callback.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -427,4 +427,33 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         Arr::forget($array, ['products.amount.all', 'products.desk.price']);
         $this->assertEquals(['products' => ['desk' => [], null => 'something']], $array);
     }
+
+    public function testTranspose()
+    {
+        $this->assertEquals([[1, 4, 7], [2, 5, 8], [3, 6, 9]], Arr::transpose([[1, 2, 3], [4, 5, 6], [7, 8, 9]]));
+
+        // with a single array
+        $this->assertEquals([1, 2, 3], Arr::transpose([[1, 2, 3]]));
+
+        // with an associative array
+        $array = [
+            'names' =>  ['adam', 'ben', 'claire'],
+            'ages' => [24, 32, 52],
+            'emails' => ['adam@example.com', 'ben@example.com', 'claire@example.com'],
+        ];
+
+        $expected = [
+            ['adam', 24, 'adam@example.com'],
+            ['ben', 32, 'ben@example.com'],
+            ['claire', 52, 'claire@example.com'],
+        ];
+
+        $this->assertEquals($expected, Arr::transpose($array));
+
+        // with arrays of different lengths
+        $array = [['a', 'b', 'c', 'd'], ['apple', 'box', 'car']];
+        $expected = [['a', 'apple'], ['b', 'box'], ['c', 'car'], ['d', null]];
+
+        $this->assertEquals($expected, Arr::transpose($array));
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1216,6 +1216,121 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $actual);
     }
+
+    public function testTransposeWithMultiDimensionalArray()
+    {
+        $collection = new Collection([
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+        ]);
+
+        $expected = new Collection([
+            [1, 4, 7],
+            [2, 5, 8],
+            [3, 6, 9],
+        ]);
+
+        $this->assertEquals($expected, $collection->transpose());
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testTransposeWithSingleArray()
+    {
+        $collection = new Collection([1, 2, 3]);
+
+        $collection->transpose();
+    }
+
+    public function testTransposeWithAssociativeArray()
+    {
+        $collection = new Collection([
+            'names' =>  ['adam', 'ben', 'claire'],
+            'ages' => [24, 32, 52],
+            'emails' => ['adam@example.com', 'ben@example.com', 'claire@example.com'],
+        ]);
+
+        $expected = new Collection([
+            ['adam', 24, 'adam@example.com'],
+            ['ben', 32, 'ben@example.com'],
+            ['claire', 52, 'claire@example.com'],
+        ]);
+
+        $this->assertEquals($expected, $collection->transpose());
+    }
+
+    public function testTransposeWithCollectionOfCollections()
+    {
+        $collection = new Collection([
+            new Collection([1, 2, 3]),
+            new Collection([4, 5, new Collection(['foo', 'bar'])]),
+            new Collection([7, 8, 9]),
+        ]);
+
+        $expected = new Collection([
+            new Collection([1, 4, 7]),
+            new Collection([2, 5, 8]),
+            new Collection([3, new Collection(['foo', 'bar']), 9]),
+        ]);
+
+        $this->assertEquals($expected, $collection->transpose());
+    }
+
+    public function testTransposeWithMixedCollection()
+    {
+        $collection = new Collection([
+            new Collection([1, 2, 3]),
+            [4, 5, 6],
+        ]);
+
+        $expected = new Collection([
+            new Collection([1, 4]),
+            new Collection([2, 5]),
+            new Collection([3, 6]),
+        ]);
+
+        $this->assertEquals($expected, $collection->transpose());
+    }
+
+    public function testPassesWithEvenNumbers()
+    {
+        $evenCollection = new Collection([2, 4, 6, 8, 10]);
+        $oddCollection = new Collection([1, 3, 5, 7, 9]);
+        $mixedCollection = new Collection([1, 2, 3, 4, 5]);
+        $emptyCollection = new Collection();
+
+        $isEven = function ($n) {
+            return $n % 2 == 0;
+        };
+
+        $this->assertTrue($evenCollection->passes($isEven));
+        $this->assertFalse($oddCollection->passes($isEven));
+        $this->assertFalse($mixedCollection->passes($isEven));
+        $this->assertTrue($emptyCollection->passes($isEven));
+    }
+
+    public function testPassesMultiDimensionalArrays()
+    {
+        $collectionOfArrays = new Collection([
+            [1, 2, 3],
+            [4, 5, 6],
+        ]);
+
+        $collectionOfInts = new Collection([1, 2, 3]);
+
+        $collectionOfMixedTypes = new Collection([
+            ['foo' => 'bar'],
+            1,
+            'string',
+            new \stdClass(),
+        ]);
+
+        $this->assertTrue($collectionOfArrays->passes('is_array'));
+        $this->assertFalse($collectionOfInts->passes('is_array'));
+        $this->assertFalse($collectionOfMixedTypes->passes('is_array'));
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
Takes some ideas from this blog post by Adam Wathan to add a `transpose()` method to the collection object. 
http://adamwathan.me/2016/04/06/cleaning-up-form-input-with-transpose/

Also added a `passes($c)` method which returns true/false if a given callable $c holds true for every item in the collection (and used by the transpose method to make sure every item is an array or collection.)
