### PR TITLE
[5.2] Fix an issue with fluent routes with uses()

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -824,7 +824,20 @@ class Route
      */
     public function uses($action)
     {
-        return $this->setAction(array_merge($this->action, $this->parseAction($action)));
+        if (is_string($action)) {
+            $groupStack = last($this->router->getGroupStack());
+
+            if (isset($groupStack['namespace']) && strpos($action, '\\') !== 0) {
+                $action = $groupStack['namespace'].'\\'.$action;
+            }
+        }
+
+        $action = $this->parseAction([
+            'uses' => $action,
+            'controller' => $action,
+        ]);
+
+        return $this->setAction(array_merge($this->action, $action));
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -122,6 +122,20 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $router->dispatch(Request::create('foo/bar', 'GET'));
     }
 
+    public function testFluentRoutingWithControllerAction()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/bar')->uses('RouteTestControllerStub@index');
+        $this->assertEquals('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+
+        $router = $this->getRouter();
+        $router->group(['namespace' => 'App'], function ($router) {
+            $router->get('foo/bar')->uses('RouteTestControllerStub@index');
+        });
+        $action = $router->getRoutes()->getRoutes()[0]->getAction();
+        $this->assertEquals('App\\RouteTestControllerStub@index', $action['controller']);
+    }
+
     public function testMiddlewareGroups()
     {
         unset($_SERVER['__middleware.group']);


### PR DESCRIPTION
As reported in https://github.com/laravel/framework/issues/13074.

This PR fixes the issue with routing using `->uses('Controller@method')`.
