### PR TITLE
[5.2] Add property overloading to the Base Collection.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -331,6 +331,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Dynamically retrieve attributes on the collection.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->get($key);
+    }
+
+    /**
      * Group an associative array by a field or using a callback.
      *
      * @param  callable|string  $groupBy
@@ -1099,6 +1110,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Determine if an item exists at an offset.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        return $this->offsetExists($key);
+    }
+
+    /**
      * Get an item at a given offset.
      *
      * @param  mixed  $key
@@ -1126,6 +1148,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Set the item at a given offset.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function __set($key, $value)
+    {
+        $this->put($key, $value);
+    }
+
+    /**
      * Unset the item at a given offset.
      *
      * @param  string  $key
@@ -1134,6 +1168,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function offsetUnset($key)
     {
         unset($this->items[$key]);
+    }
+
+    /**
+     * Unset the item at a given offset.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function __unset($key)
+    {
+        $this->offsetUnset($key);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1216,6 +1216,23 @@ class SupportCollectionTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $actual);
     }
+
+    public function testPropertyOverloading()
+    {
+        $collection = new Collection([
+            'foo' => 1,
+            'bar' => 2,
+        ]);
+
+        $this->assertEquals($collection->foo, 1);
+
+        $collection->put('baz', 3);
+        $this->assertTrue(isset($collection->baz));
+        $this->assertEquals($collection->baz, 3);
+
+        unset($collection->baz);
+        $this->assertFalse(isset($collection->baz));
+    }
 }
 
 class TestAccessorEloquentTestStub


### PR DESCRIPTION
Eloquent models implement property overloading, which can be reviewed at
the following link:

[PHP Overloading](http://php.net/manual/en/language.oop5.overloading.php)

This is a feature that should be implemented into Laravel Collections,
as it makes accessing items in the collection much cleaner. It also
requires no extra functionality or logic, the magic methods are simply
calls to existing Collection methods.
