### PR TITLE
[5.2] Allow pipe parameters to be passed as array

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -112,26 +112,33 @@ class Pipeline implements PipelineContract
     {
         return function ($stack, $pipe) {
             return function ($passable) use ($stack, $pipe) {
+                $parameters = [$passable, $stack];
+
+                if (is_array($pipe)) {
+                    $pipe = array_values($pipe);
+                    $parameters = array_merge($parameters, array_splice($pipe, 1));
+                    list($pipe) = $pipe;
+                }
+
                 if ($pipe instanceof Closure) {
                     // If the pipe is an instance of a Closure, we will just call it directly but
                     // otherwise we'll resolve the pipes out of the container and call it with
                     // the appropriate method and arguments, returning the results back out.
-                    return call_user_func($pipe, $passable, $stack);
+                    return call_user_func_array($pipe, $parameters);
                 } elseif (! is_object($pipe)) {
-                    list($name, $parameters) = $this->parsePipeString($pipe);
+                    list($name, $additional) = $this->parsePipeString($pipe);
 
                     // If the pipe is a string we will parse the string and resolve the class out
                     // of the dependency injection container. We can then build a callable and
                     // execute the pipe function giving in the parameters that are required.
                     $pipe = $this->container->make($name);
 
-                    $parameters = array_merge([$passable, $stack], $parameters);
-                } else {
-                    // If the pipe is already an object we'll just make a callable and pass it to
-                    // the pipe as-is. There is no need to do any extra parsing and formatting
-                    // since the object we're given was already a fully instantiated object.
-                    $parameters = [$passable, $stack];
+                    $parameters = array_merge($parameters, $additional);
                 }
+
+                // If the pipe is already an object we'll just make a callable and pass it to
+                // the pipe as-is. There is no need to do any extra parsing and formatting
+                // since the object we're given was already a fully instantiated object.
 
                 return call_user_func_array([$pipe, $this->method], $parameters);
             };

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -59,6 +59,25 @@ class PipelineTest extends PHPUnit_Framework_TestCase
         unset($_SERVER['__test.pipe.parameters']);
     }
 
+    public function testPipelineUsageWithArrayParameters()
+    {
+        $parameters = ['one', 'two'];
+
+        $result = (new Pipeline(new Illuminate\Container\Container))
+            ->send('foo')
+            ->through([
+                [new PipelineTestParameterPipe, 'one', 'two'],
+            ])
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertEquals('foo', $result);
+        $this->assertEquals($parameters, $_SERVER['__test.pipe.parameters']);
+
+        unset($_SERVER['__test.pipe.parameters']);
+    }
+
     public function testPipelineViaChangesTheMethodBeingCalledOnThePipes()
     {
         $pipelineInstance = new Pipeline(new Illuminate\Container\Container);


### PR DESCRIPTION
An extended way to define pipe with array.
Useful if you need to pass objects as parameters.

``` php
(new Pipeline)->send($post)
->through([
    [new Formatter, $request],
    [new Sender, 'json'],
    [new ResponseHandler, $log],
])
->then(...);
```

And, of course, middlewares can now be defined this way:

``` php
'api' => [
    [ThrottleRequests::class, config('security.throttle.period', 60), 1],
],
```
