### PR TITLE
[5.3] Allow pipeline to be instantiated without container

### DIFF
--- a/src/Illuminate/Pipeline/Hub.php
+++ b/src/Illuminate/Pipeline/Hub.php
@@ -11,7 +11,7 @@ class Hub implements HubContract
     /**
      * The container implementation.
      *
-     * @var \Illuminate\Contracts\Container\Container
+     * @var \Illuminate\Contracts\Container\Container|null
      */
     protected $container;
 
@@ -25,10 +25,10 @@ class Hub implements HubContract
     /**
      * Create a new Hub instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container)
+    public function __construct(Container $container = null)
     {
         $this->container = $container;
     }

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Pipeline;
 
 use Closure;
+use RuntimeException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
 
@@ -39,10 +40,10 @@ class Pipeline implements PipelineContract
     /**
      * Create a new class instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container)
+    public function __construct(Container $container = null)
     {
         $this->container = $container;
     }
@@ -104,6 +105,21 @@ class Pipeline implements PipelineContract
     }
 
     /**
+     * Get internal container instance.
+     *
+     * @return \Illuminate\Contracts\Container\Container
+     * @throws \RuntimeException
+     */
+    protected function getContainer()
+    {
+        if (! $this->container) {
+            throw new RuntimeException('Container is not set up in pipe.');
+        }
+
+        return $this->container;
+    }
+
+    /**
      * Get a Closure that represents a slice of the application onion.
      *
      * @return \Closure
@@ -123,7 +139,7 @@ class Pipeline implements PipelineContract
                     // If the pipe is a string we will parse the string and resolve the class out
                     // of the dependency injection container. We can then build a callable and
                     // execute the pipe function giving in the parameters that are required.
-                    $pipe = $this->container->make($name);
+                    $pipe = $this->getContainer()->make($name);
 
                     $parameters = array_merge([$passable, $stack], $parameters);
                 } else {

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -70,6 +70,18 @@ class PipelineTest extends PHPUnit_Framework_TestCase
             });
         $this->assertEquals('data', $result);
     }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testPipelineThrowsExceptionOnResolveWithoutContainer()
+    {
+        (new Pipeline)->send('data')
+            ->through('PipelineTestPipeOne')
+            ->then(function ($piped) {
+                return $piped;
+            });
+    }
 }
 
 class PipelineTestPipeOne


### PR DESCRIPTION
If we don't use container resolving, it can be omitted. Pipeline can be now used outside framework freely.
