### PR TITLE
[5.2] Don't query relationship when the parent key is null for HasOne & HasMany

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -13,7 +13,7 @@ class HasMany extends HasOneOrMany
      */
     public function getResults()
     {
-        if ($key = $this->getParentKey()) {
+        if ($this->getParentKey()) {
             return $this->query->get();
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -13,7 +13,9 @@ class HasMany extends HasOneOrMany
      */
     public function getResults()
     {
-        return $this->query->get();
+        if ($key = $this->getParentKey()) {
+            return $this->query->get();
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -9,13 +9,14 @@ class HasMany extends HasOneOrMany
     /**
      * Get the results of the relationship.
      *
-     * @return mixed
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getResults()
     {
         if ($key = $this->getParentKey()) {
             return $this->query->get();
         }
+        return new Collection;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -16,6 +16,7 @@ class HasMany extends HasOneOrMany
         if ($key = $this->getParentKey()) {
             return $this->query->get();
         }
+
         return new Collection;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -13,7 +13,9 @@ class HasOne extends HasOneOrMany
      */
     public function getResults()
     {
-        return $this->query->first();
+        if ($key = $this->getParentKey()) {
+            return $this->query->get();
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -13,8 +13,8 @@ class HasOne extends HasOneOrMany
      */
     public function getResults()
     {
-        if ($key = $this->getParentKey()) {
-            return $this->query->get();
+        if ($this->getParentKey()) {
+            return $this->query->first();
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -47,8 +47,8 @@ abstract class HasOneOrMany extends Relation
      */
     public function addConstraints()
     {
-        if (static::$constraints) {
-            $this->query->where($this->foreignKey, '=', $this->getParentKey());
+        if (static::$constraints && $key = $this->getParentKey()) {
+            $this->query->where($this->foreignKey, '=', $key);
 
             $this->query->whereNotNull($this->foreignKey);
         }


### PR DESCRIPTION
We have users that have an optional organisation. When the organisation is empty the query is still run. The query looks for an organisation with id=0 where is not null, so the query is useless.

I added checks for the parentKey before the query is executed.
