### PR TITLE
[5.2] Adding proper alias for FailedJobProviderInterface

### DIFF
--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -15,6 +15,7 @@ use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Queue\Connectors\DatabaseConnector;
 use Illuminate\Queue\Connectors\BeanstalkdConnector;
 use Illuminate\Queue\Failed\DatabaseFailedJobProvider;
+use Illuminate\Queue\Failed\FailedJobProviderInterface;
 
 class QueueServiceProvider extends ServiceProvider
 {
@@ -247,6 +248,8 @@ class QueueServiceProvider extends ServiceProvider
                 return new NullFailedJobProvider;
             }
         });
+
+        $this->app->alias('queue.failer', FailedJobProviderInterface::class);
     }
 
     /**


### PR DESCRIPTION
Failed Job feature isn't working when using command:

```
php artisan queue:work --daemon --tries=3
```

It fails because the command gets a new instance of `Worker` and it fails to find the `FailedJobProviderInterface` dependency.

With this fix i think we also can get rid of this if: https://github.com/laravel/framework/blob/5.2/src/Illuminate/Queue/Worker.php#L302

As now it will always have a failer object, this was probably a bad fix for this issue.

**PS: This issue might also be happening on older versions.**
