### PR TITLE
[5.2] Adding proper alias for FailedJobProviderInterface

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1084,6 +1084,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'auth.password.broker' => ['Illuminate\Auth\Passwords\PasswordBroker', 'Illuminate\Contracts\Auth\PasswordBroker'],
             'queue'                => ['Illuminate\Queue\QueueManager', 'Illuminate\Contracts\Queue\Factory', 'Illuminate\Contracts\Queue\Monitor'],
             'queue.connection'     => ['Illuminate\Contracts\Queue\Queue'],
+            'queue.failer'         => ['Illuminate\Queue\Failed\FailedJobProviderInterface'],
             'redirect'             => ['Illuminate\Routing\Redirector'],
             'redis'                => ['Illuminate\Redis\Database', 'Illuminate\Contracts\Redis\Database'],
             'request'              => ['Illuminate\Http\Request', 'Symfony\Component\HttpFoundation\Request'],


### PR DESCRIPTION
Failed Job feature isn't working when using command:

```
php artisan queue:work --daemon --tries=3
```

It fails because the command gets a new instance of `Worker` and it fails to find the `FailedJobProviderInterface` dependency.

With this fix i think we also can get rid of this if: https://github.com/laravel/framework/blob/5.2/src/Illuminate/Queue/Worker.php#L302

As now it will always have a failer object, this was probably a bad fix for this issue.

**PS: This issue might also be happening on older versions.**
