### PR TITLE
[5.2] Make $query->when() return instance if callback return null

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -457,13 +457,13 @@ class Builder
      */
     public function when($value, $callback)
     {
-        $builder = $this;
-
         if ($value) {
-            $builder = call_user_func($callback, $builder);
+            $builder = call_user_func($callback, $this);
+
+            return is_null($builder) ? $this : $builder;
         }
 
-        return $builder;
+        return $this;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -125,12 +125,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         };
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(true, $callback);
-        $this->assertEquals('select * from "users" where "id" = ?', $builder->toSql());
+        $builder->select('*')->from('users')->when(true, $callback)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(false, $callback);
-        $this->assertEquals('select * from "users"', $builder->toSql());
+        $builder->select('*')->from('users')->when(false, $callback)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
     }
 
     public function testBasicWheres()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -120,16 +120,29 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
     public function testWhenCallback()
     {
-        $callback = function ($query) {
+        $callbackQuery = function ($query) {
             return $query->where('id', '=', 1);
         };
 
+        $callbackNull = function ($query) {
+            $query->where('id', '=', 1);
+        };
+
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(true, $callback)->where('email', 'foo');
+        $builder->select('*')->from('users')->when(true, $callbackQuery)->where('email', 'foo');
         $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(false, $callback)->where('email', 'foo');
+        $builder->select('*')->from('users')->when(false, $callbackQuery)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
+
+        // Return builder if callback return null.
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(true, $callbackNull)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(false, $callbackNull)->where('email', 'foo');
         $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -120,16 +120,16 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
     public function testWhenCallback()
     {
+        $callback = function ($query) {
+            return $query->where('id', '=', 1);
+        };
+
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(true, function ($callback) {
-            return $callback->where('id', '=', 1);
-        });
+        $builder->select('*')->from('users')->when(true, $callback);
         $this->assertEquals('select * from "users" where "id" = ?', $builder->toSql());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(false, function ($callback) {
-            return $callback->where('id', '=', 1);
-        });
+        $builder->select('*')->from('users')->when(false, $callback);
         $this->assertEquals('select * from "users"', $builder->toSql());
     }
 


### PR DESCRIPTION
Follow-up to #12878.

When breaking the chain, we aren't using return value of `orderBy`:

```
$query = $model->where('customer_id', 1234)
    ->where('created_at', '>=' '2016-01-04 20:34:56');

if (! empty($sortParams)) {
    $query->orderBy($sortParams);
}

return $query->get();
```

Likewise, when using `when` this PR allows to omit the return in the callback:

```
return $model->where('customer_id', 1234)
    ->where('created_at', '>=' '2016-01-04 20:34:56')
    ->when(! empty($sortParams), function ($builder) use ($sortParams) {
        $builder->orderBy($sortParams); // <-- now you can omit the "return" here
    })
    ->get();
```

TL;DR: If callback returns null, `when` returns builder instance instead of null. This improves chainability.

Added tests for all this goodness. :information_desk_person:

Ping @tomschlick
