### PR TITLE
[5.2] Cache based sessions don't need to take part in the GC lottery

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -147,7 +147,7 @@ class StartSession
         // Cache based sessions use their own mechanism to invalidate entries
         // once their lifetime expires so there's no need to perform the garbage
         // collection for them.
-        if (! $this->usingCacheBasedSessions()) {
+        if (! $this->sessionUsesCacheBasedHandler($session)) {
             $config = $this->manager->getSessionConfig();
 
             // Here we will see if this request hits the garbage collection lottery by hitting
@@ -251,16 +251,13 @@ class StartSession
     }
 
     /**
-     * Determine if the session is using cache based sessions.
+     * Determine if the session is using a cache based session handler instance.
      *
+     * @param  \Illuminate\Session\SessionInterface  $session
      * @return bool
      */
-    protected function usingCacheBasedSessions()
+    protected function sessionUsesCacheBasedHandler(SessionInterface $session)
     {
-        if (! $this->sessionConfigured()) {
-            return false;
-        }
-
-        return $this->manager->driver()->getHandler() instanceof CacheBasedSessionHandler;
+        return $session->getHandler() instanceof CacheBasedSessionHandler;
     }
 }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -9,9 +9,9 @@ use Illuminate\Http\Request;
 use Illuminate\Session\SessionManager;
 use Illuminate\Session\SessionInterface;
 use Illuminate\Session\CookieSessionHandler;
-use Illuminate\Session\CacheBasedSessionHandler;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Session\CacheBasedSessionHandler;
 
 class StartSession
 {


### PR DESCRIPTION
Cache based session handlers, `CacheBasedSessionHandler` in particular, don't support the garbage collection used by the `StartSession` middleware.
So there's actually no need for them to take part in the GC lottery or to call the the `gc` method which doesn't have any effect.
