### PR TITLE
[5.2] Queued session garbage collection 

### DIFF
--- a/src/Illuminate/Session/CollectGarbageJob.php
+++ b/src/Illuminate/Session/CollectGarbageJob.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Session;
+
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Bus\Queueable;
+use SessionHandlerInterface;
+
+class CollectGarbageJob implements ShouldQueue
+{
+    use Queueable,
+        SerializesModels;
+
+    /**
+     * The session handler instance for which the garbage collection should run.
+     *
+     * @var \SessionHandlerInterface
+     */
+    protected $sessionHandler;
+
+    /**
+     * Session lifetime in seconds.
+     *
+     * @var int
+     */
+    protected $sessionLifetime;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param \SessionHandlerInterface $sessionHandler
+     */
+    public function __construct(SessionHandlerInterface $sessionHandler, $sessionLifetime)
+    {
+        $this->sessionHandler = $sessionHandler;
+        $this->sessionLifetime = $sessionLifetime;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->sessionHandler->gc($this->sessionLifetime);
+    }
+}

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -8,12 +8,16 @@ use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Session\SessionManager;
 use Illuminate\Session\SessionInterface;
-use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Session\CookieSessionHandler;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Session\CollectGarbageJob;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
 
 class StartSession
 {
+    use DispatchesJobs;
+
     /**
      * The session manager.
      *
@@ -149,7 +153,7 @@ class StartSession
         // the odds needed to perform garbage collection on any given request. If we do
         // hit it, we'll call this handler to let it delete all the expired sessions.
         if ($this->configHitsLottery($config)) {
-            $session->getHandler()->gc($this->getSessionLifetimeInSeconds());
+            $this->dispatch(new CollectGarbageJob($session->getHandler(), $this->getSessionLifetimeInSeconds()));
         }
     }
 


### PR DESCRIPTION
Session garbage collections are currently executed as part of the standard request cycle. This may have negative impacts on requests.

If a garbage collection takes a long time then the request of a user is unnecessarily delayed for no obvious reason (at least from a user's perspective). This might even lead to a request timeout.
Furthermore if a gc throws an exception the whole request will fail even though the gc doesn't have anything to do with the request the user made. If the same request is made again by the user it will most likely not fail which would be very confusing.

Queueing gc operations and processing them outside of a request cycle makes more sense and does make the whole system more robust.
