### PR TITLE
[5.2] Register console commands from Kernel

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -215,6 +215,17 @@ class Kernel implements KernelContract
     }
 
     /**
+     * Register the given command to the console application.
+     *
+     * @param  \Symfony\Component\Console\Command\Command  $command
+     * @return void
+     */
+    public function registerCommand($command)
+    {
+        $this->getArtisan()->add($command);
+    }
+
+    /**
      * Get the Artisan application instance.
      *
      * @return \Illuminate\Console\Application


### PR DESCRIPTION
This PR introduces a method to register console commands:

``` php
$this->app['Illuminate\Contracts\Console\Kernel']->registerCommand( Command::class );
```

One useful use case for this is the ability to register a partial mock of a command to test interactivity:

``` php
$command = m::mock('\...\TransCommand[ask]');
$command->shouldReceive('ask')->once()->with('..."')->andReturn('First Name');

$this->app[Kernel::class]->register($command);
$this->artisan('langman:trans', ['key' => 'users.name.first']);
```
