### PR TITLE
[5.3] Queued session garbage collection

### DIFF
--- a/src/Illuminate/Session/CollectGarbageJob.php
+++ b/src/Illuminate/Session/CollectGarbageJob.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Session;
+
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Bus\Queueable;
+use SessionHandlerInterface;
+
+class CollectGarbageJob implements ShouldQueue
+{
+    use Queueable,
+        SerializesModels;
+
+    /**
+     * The session handler instance for which the garbage collection should run.
+     *
+     * @var \SessionHandlerInterface
+     */
+    protected $sessionHandler;
+
+    /**
+     * Session lifetime in seconds.
+     *
+     * @var int
+     */
+    protected $sessionLifetime;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param \SessionHandlerInterface $sessionHandler
+     */
+    public function __construct(SessionHandlerInterface $sessionHandler, $sessionLifetime)
+    {
+        $this->sessionHandler = $sessionHandler;
+        $this->sessionLifetime = $sessionLifetime;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->sessionHandler->gc($this->sessionLifetime);
+    }
+}

--- a/src/Illuminate/Session/CollectGarbageJob.php
+++ b/src/Illuminate/Session/CollectGarbageJob.php
@@ -24,7 +24,9 @@ class CollectGarbageJob implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param \SessionHandlerInterface $sessionHandler
+     * @param  \SessionHandlerInterface  $sessionHandler
+     * @param  int  $sessionLifetime
+     * @return void
      */
     public function __construct(SessionHandlerInterface $sessionHandler, $sessionLifetime)
     {

--- a/src/Illuminate/Session/CollectGarbageJob.php
+++ b/src/Illuminate/Session/CollectGarbageJob.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Session;
 
-use Illuminate\Contracts\Queue\ShouldQueue;
 use SessionHandlerInterface;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 class CollectGarbageJob implements ShouldQueue
 {
@@ -12,26 +12,26 @@ class CollectGarbageJob implements ShouldQueue
      *
      * @var \SessionHandlerInterface
      */
-    protected $sessionHandler;
+    protected $handler;
 
     /**
      * Session lifetime in seconds.
      *
      * @var int
      */
-    protected $sessionLifetime;
+    protected $lifetime;
 
     /**
      * Create a new job instance.
      *
-     * @param  \SessionHandlerInterface  $sessionHandler
-     * @param  int  $sessionLifetime
+     * @param  \SessionHandlerInterface  $handler
+     * @param  int  $lifetime
      * @return void
      */
-    public function __construct(SessionHandlerInterface $sessionHandler, $sessionLifetime)
+    public function __construct(SessionHandlerInterface $handler, $lifetime)
     {
-        $this->sessionHandler = $sessionHandler;
-        $this->sessionLifetime = $sessionLifetime;
+        $this->handler = $handler;
+        $this->lifetime = $lifetime;
     }
 
     /**
@@ -41,6 +41,6 @@ class CollectGarbageJob implements ShouldQueue
      */
     public function handle()
     {
-        $this->sessionHandler->gc($this->sessionLifetime);
+        $this->handler->gc($this->lifetime);
     }
 }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -8,12 +8,16 @@ use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use Illuminate\Session\SessionManager;
 use Illuminate\Session\SessionInterface;
-use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Session\CookieSessionHandler;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Session\CollectGarbageJob;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
 
 class StartSession
 {
+    use DispatchesJobs;
+
     /**
      * The session manager.
      *
@@ -149,7 +153,7 @@ class StartSession
         // the odds needed to perform garbage collection on any given request. If we do
         // hit it, we'll call this handler to let it delete all the expired sessions.
         if ($this->configHitsLottery($config)) {
-            $session->getHandler()->gc($this->getSessionLifetimeInSeconds());
+            $this->dispatch(new CollectGarbageJob($session->getHandler(), $this->getSessionLifetimeInSeconds()));
         }
     }
 

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -26,7 +26,7 @@ class StartSession
     /**
      * The bus dispatcher implementation.
      *
-     * @var \Illuminate\Contracts\Bus\Dispatcher
+     * @var \Illuminate\Contracts\Bus\Dispatcher|null
      */
     protected $dispatcher;
 
@@ -41,10 +41,10 @@ class StartSession
      * Create a new session middleware.
      *
      * @param  \Illuminate\Session\SessionManager  $manager
-     * @param  \Illuminate\Contracts\Bus\Dispatcher  $dispatcher
+     * @param  \Illuminate\Contracts\Bus\Dispatcher|null  $dispatcher
      * @return void
      */
-    public function __construct(SessionManager $manager, DispatcherContract $dispatcher)
+    public function __construct(SessionManager $manager, DispatcherContract $dispatcher = null)
     {
         $this->manager = $manager;
         $this->dispatcher = $dispatcher;
@@ -160,7 +160,11 @@ class StartSession
         // the odds needed to perform garbage collection on any given request. If we do
         // hit it, we'll call this handler to let it delete all the expired sessions.
         if ($this->configHitsLottery($config)) {
-            $this->dispatcher->dispatch(new CollectGarbageJob($session->getHandler(), $this->getSessionLifetimeInSeconds()));
+            if ($this->dispatcher) {
+                $this->dispatcher->dispatch(new CollectGarbageJob($session->getHandler(), $this->getSessionLifetimeInSeconds()));
+            } else {
+                $session->getHandler()->gc($this->getSessionLifetimeInSeconds());
+            }
         }
     }
 


### PR DESCRIPTION
See #13096

Session garbage collections are currently executed as part of the standard request cycle. This may have negative impacts on requests.

If a garbage collection takes a long time then the request of a user is unnecessarily delayed for no obvious reason (at least from a user's perspective). This might even lead to a request timeout.
Furthermore if a gc throws an exception the whole request will fail even though the gc doesn't have anything to do with the request the user made. If the same request is made again by the user it will most likely not fail which would be very confusing.

Queueing gc operations and processing them outside of a request cycle makes more sense and does make the whole system more robust.
