### PR TITLE
[5.2] use new 'MaintenanceModeException'

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
@@ -4,7 +4,7 @@ namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
 use Illuminate\Contracts\Foundation\Application;
-use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Http\Exception\MaintenanceModeException;
 
 class CheckForMaintenanceMode
 {
@@ -33,12 +33,12 @@ class CheckForMaintenanceMode
      * @param  \Closure  $next
      * @return mixed
      *
-     * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+     * @throws \Illuminate\Http\Exception\MaintenanceModeException
      */
     public function handle($request, Closure $next)
     {
         if ($this->app->isDownForMaintenance()) {
-            throw new HttpException(503);
+            throw new MaintenanceModeException();
         }
 
         return $next($request);

--- a/src/Illuminate/Http/Exception/MaintenanceModeException.php
+++ b/src/Illuminate/Http/Exception/MaintenanceModeException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Http\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class MaintenanceModeException extends HttpException
+{
+    /**
+     * Constructor.
+     *
+     * @param string     $message  The internal exception message
+     * @param \Exception $previous The previous exception
+     * @param int        $code     The internal exception code
+     */
+    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    {
+        parent::__construct(503, $message, $previous, array(), $code);
+    }
+}

--- a/src/Illuminate/Http/Exception/MaintenanceModeException.php
+++ b/src/Illuminate/Http/Exception/MaintenanceModeException.php
@@ -15,6 +15,6 @@ class MaintenanceModeException extends HttpException
      */
     public function __construct($message = null, \Exception $previous = null, $code = 0)
     {
-        parent::__construct(503, $message, $previous, array(), $code);
+        parent::__construct(503, $message, $previous, [], $code);
     }
 }


### PR DESCRIPTION
currently the middleware throws an HTTP Exception. while we can ignore reporting these in our handler, sometimes I prefer to actually report my http exception. it can help pick up on bad links or other strange errors.  however, reporting an exception when the app is in maintenance mode is not important to me. currently, there is no way to distinguish between these two.  this gives us the ability to ignore reporting maintenance mode exceptions, but to report other http exceptions.
