### PR TITLE
[5.3] Always return a container instance from Container::getInstance()

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1142,6 +1142,10 @@ class Container implements ArrayAccess, ContainerContract
      */
     public static function getInstance()
     {
+        if (is_null(static::$instance)) {
+            static::$instance = new static;
+        }
+
         return static::$instance;
     }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1152,12 +1152,12 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Set the shared instance of the container.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
-     * @return void
+     * @param  \Illuminate\Contracts\Container\Container|null  $container
+     * @return static
      */
-    public static function setInstance(ContainerContract $container)
+    public static function setInstance(ContainerContract $container = null)
     {
-        static::$instance = $container;
+        return static::$instance = $container;
     }
 
     /**

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -187,18 +187,25 @@ class ContainerContainerTest extends PHPUnit_Framework_TestCase
     public function testExtendInstancesArePreserved()
     {
         $container = new Container;
-        $container->bind('foo', function () { $obj = new StdClass; $obj->foo = 'bar';
+        $container->bind('foo', function () {
+            $obj = new StdClass;
+            $obj->foo = 'bar';
 
-return $obj; });
+            return $obj;
+        });
         $obj = new StdClass;
         $obj->foo = 'foo';
         $container->instance('foo', $obj);
-        $container->extend('foo', function ($obj, $container) { $obj->bar = 'baz';
+        $container->extend('foo', function ($obj, $container) {
+            $obj->bar = 'baz';
 
-return $obj; });
-        $container->extend('foo', function ($obj, $container) { $obj->baz = 'foo';
+            return $obj;
+        });
+        $container->extend('foo', function ($obj, $container) {
+            $obj->baz = 'foo';
 
-return $obj; });
+            return $obj;
+        });
         $this->assertEquals('foo', $container->make('foo')->foo);
     }
 
@@ -206,9 +213,11 @@ return $obj; });
     {
         $container = new Container;
         $container->bind('ContainerLazyExtendStub');
-        $container->extend('ContainerLazyExtendStub', function ($obj, $container) { $obj->init();
+        $container->extend('ContainerLazyExtendStub', function ($obj, $container) {
+            $obj->init();
 
-return $obj; });
+            return $obj;
+        });
         $this->assertFalse(ContainerLazyExtendStub::$initialized);
         $container->make('ContainerLazyExtendStub');
         $this->assertTrue(ContainerLazyExtendStub::$initialized);

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -4,6 +4,20 @@ use Illuminate\Container\Container;
 
 class ContainerContainerTest extends PHPUnit_Framework_TestCase
 {
+    public function testContainerSingleton()
+    {
+        $container = Container::setInstance(new Container);
+
+        $this->assertSame($container, Container::getInstance());
+
+        Container::setInstance(null);
+
+        $container2 = Container::getInstance();
+
+        $this->assertInstanceOf(Container::class, $container2);
+        $this->assertNotSame($container, $container2);
+    }
+
     public function testClosureResolution()
     {
         $container = new Container;


### PR DESCRIPTION
Currently, if you haven't set a singleton manually, `Container::getInstance()` returns `null`, even though the docblock says it always returns `static`.

After this patch, `Container::getInstance()` always returns an instance of the container; if no singleton has been set, it's set now.
