### PR TITLE
[5.2] Forget key when key exists

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -233,6 +233,11 @@ class Arr
         }
 
         foreach ($keys as $key) {
+            if (static::exists($array, $key)) {
+                unset($array[$key]);
+                continue;
+            }
+
             $parts = explode('.', $key);
 
             // clean up before each pass

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -305,6 +305,18 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $name = Arr::pull($array, 'name');
         $this->assertEquals('Desk', $name);
         $this->assertEquals(['price' => 100], $array);
+
+        // Only works on first level keys
+        $array = ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane'];
+        $name = Arr::pull($array, 'joe@example.com');
+        $this->assertEquals('Joe', $name);
+        $this->assertEquals(['jane@localhost' => 'Jane'], $array);
+
+        // Does not work for nested keys
+        $array = ['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']];
+        $name = Arr::pull($array, 'emails.joe@example.com');
+        $this->assertEquals(null, $name);
+        $this->assertEquals(['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']], $array);
     }
 
     public function testSet()
@@ -438,5 +450,15 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
         $array = ['products' => ['desk' => ['price' => 50], null => 'something']];
         Arr::forget($array, ['products.amount.all', 'products.desk.price']);
         $this->assertEquals(['products' => ['desk' => [], null => 'something']], $array);
+
+        // Only works on first level keys
+        $array = ['joe@example.com' => 'Joe', 'jane@example.com' => 'Jane'];
+        Arr::forget($array, 'joe@example.com');
+        $this->assertEquals(['jane@example.com' => 'Jane'], $array);
+
+        // Does not work for nested keys
+        $array = ['emails' => ['joe@example.com' => ['name' => 'Joe'], 'jane@localhost' => ['name' => 'Jane']]];
+        Arr::forget($array, ['emails.joe@example.com','emails.jane@localhost']);
+        $this->assertEquals(['emails' => ['joe@example.com' => ['name' => 'Joe']]], $array);
     }
 }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -458,7 +458,7 @@ class SupportArrTest extends PHPUnit_Framework_TestCase
 
         // Does not work for nested keys
         $array = ['emails' => ['joe@example.com' => ['name' => 'Joe'], 'jane@localhost' => ['name' => 'Jane']]];
-        Arr::forget($array, ['emails.joe@example.com','emails.jane@localhost']);
+        Arr::forget($array, ['emails.joe@example.com', 'emails.jane@localhost']);
         $this->assertEquals(['emails' => ['joe@example.com' => ['name' => 'Joe']]], $array);
     }
 }


### PR DESCRIPTION
When using for example ip addresses as keys for an array and try to use `array_forget()` or `Arr::forget()` it wil not check if the key exists in the array before exploding the key.

This wil, like `Arr::get()` or `Arr::has()`, first check if the key exists.
