### PR TITLE
[5.3] php artisan queue:work --daemon --timeout[=TIMEOUT]

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -100,7 +100,7 @@ class WorkCommand extends Command
 
             return $this->worker->daemon(
                 $connection, $queue, $delay, $memory,
-                $this->option('sleep'), $this->option('tries')
+                $this->option('sleep'), $this->option('tries'), $this->option('timeout')
             );
         }
 
@@ -171,6 +171,8 @@ class WorkCommand extends Command
             ['memory', null, InputOption::VALUE_OPTIONAL, 'The memory limit in megabytes', 128],
 
             ['sleep', null, InputOption::VALUE_OPTIONAL, 'Number of seconds to sleep when no job is available', 3],
+
+            ['timeout', null, InputOption::VALUE_OPTIONAL, 'Maximum number of seconds the daemon is allowed to pop jobs', 0],
 
             ['tries', null, InputOption::VALUE_OPTIONAL, 'Number of times to attempt a job before logging it failed', 0],
         ];


### PR DESCRIPTION
Daemon workers are efficient in term of eliminating the Laravel boot time. But they increase the probability of connections to database and other servers being closed, because of being idle for a long time or other reasons. The `--timeout` option lets the developers reach a trade-off.
