### PR TITLE
[5.2] Skip confirmation on non-interactive mode

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -15,6 +15,10 @@ trait ConfirmableTrait
      */
     public function confirmToProceed($warning = 'Application In Production!', $callback = null)
     {
+        if (! $this->input->isInteractive()) {
+            return true;
+        }
+
         $callback = is_null($callback) ? $this->getDefaultConfirmCallback() : $callback;
 
         $shouldConfirm = $callback instanceof Closure ? call_user_func($callback) : $callback;


### PR DESCRIPTION
The Symfony Input interface supports `isInteractive()`, which is the true by default, unless running in non-interactive mode (`--no-interaction` or `-n`). 
While in this case, the effect is the same as `--force`, it can be expected behaviour (eg. for deployments, scripts etc) to continue without asking questions.
Current behaviour is that the command is cancelled. After this PR, non-interactive mode will always continue.
