### PR TITLE
[5.2] Test chainability of $query->when()

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -125,12 +125,12 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         };
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(true, $callback);
-        $this->assertEquals('select * from "users" where "id" = ?', $builder->toSql());
+        $builder->select('*')->from('users')->when(true, $callback)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(false, $callback);
-        $this->assertEquals('select * from "users"', $builder->toSql());
+        $builder->select('*')->from('users')->when(false, $callback)->where('email', 'foo');
+        $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
     }
 
     public function testBasicWheres()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -120,16 +120,16 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
     public function testWhenCallback()
     {
+        $callback = function ($query) {
+            return $query->where('id', '=', 1);
+        };
+
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(true, function ($callback) {
-            return $callback->where('id', '=', 1);
-        });
+        $builder->select('*')->from('users')->when(true, $callback);
         $this->assertEquals('select * from "users" where "id" = ?', $builder->toSql());
 
         $builder = $this->getBuilder();
-        $builder->select('*')->from('users')->when(false, function ($callback) {
-            return $callback->where('id', '=', 1);
-        });
+        $builder->select('*')->from('users')->when(false, $callback);
         $this->assertEquals('select * from "users"', $builder->toSql());
     }
 


### PR DESCRIPTION
Follow-up to #13091.

I (sadly) discarded the change to `$query->when()`, yet I'm submitting hardened tests for the current implementation.

This ensures `$query->when()` returns either:
- `$query` if callback not applied
- callback return value if callback applied
