### PR TITLE
[5.2] Prefix table name on `getColumnType` call

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -98,6 +98,8 @@ class Builder
      */
     public function getColumnType($table, $column)
     {
+        $table = $this->connection->getTablePrefix().$table;
+
         return $this->connection->getDoctrineColumn($table, $column)->getType()->getName();
     }
 

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -34,4 +34,20 @@ class DatabaseSchemaBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($builder->hasColumns('users', ['id', 'firstname']));
         $this->assertFalse($builder->hasColumns('users', ['id', 'address']));
     }
+
+    public function testGetColumnTypeAddsPrefix()
+    {
+        $connection = m::mock('Illuminate\Database\Connection');
+        $column = m::mock('StdClass');
+        $type = m::mock('StdClass');
+        $grammar = m::mock('StdClass');
+        $connection->shouldReceive('getSchemaGrammar')->once()->andReturn($grammar);
+        $builder = new Builder($connection);
+        $connection->shouldReceive('getTablePrefix')->once()->andReturn('prefix_');
+        $connection->shouldReceive('getDoctrineColumn')->once()->with('prefix_users', 'id')->andReturn($column);
+        $column->shouldReceive('getType')->once()->andReturn($type);
+        $type->shouldReceive('getName')->once()->andReturn('integer');
+
+        $this->assertEquals($builder->getColumnType('users', 'id'), 'integer');
+    }
 }


### PR DESCRIPTION
This adds the correct table prefix when querying the type of a column just like the `getColumnListing` method does. Test included.
