### PR TITLE
[5.2] Don't limit column selection while chunking by id

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1355,8 +1355,7 @@ class Builder
      */
     public function forPageAfterId($perPage = 15, $lastId = 0, $column = 'id')
     {
-        return $this->select($column)
-                    ->where($column, '>', $lastId)
+        return $this->where($column, '>', $lastId)
                     ->orderBy($column, 'asc')
                     ->take($perPage);
     }


### PR DESCRIPTION
This PR https://github.com/laravel/framework/pull/12861 speed up chunking significantly, however it limits the results of the query to only the given id column and sometimes the rest of the columns are required.
