### PR TITLE
[5.2] Fixed path prefix for LocalAdapter

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -237,7 +237,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
 
             return $adapter->getClient()->getObjectUrl($adapter->getBucket(), $path);
         } elseif ($adapter instanceof LocalAdapter) {
-            return '/storage/'.$path;
+            return $adapter->getPathPrefix().$path;
         } else {
             throw new RuntimeException('This driver does not support retrieving URLs.');
         }


### PR DESCRIPTION
If you change root for local filesystem disk - Storage::url() is not working.
