### PR TITLE
[5.2] Fixed a phpdoc typo

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1164,7 +1164,7 @@ class Router implements RegistrarContract
     }
 
     /**
-     * Alias for the "currentRouteNamed" method.
+     * Alias for the "currentRouteName" method.
      *
      * @param  mixed  string
      * @return bool


### PR DESCRIPTION
is() calls currentRouteName() not currentRouteNamed()
