### PR TITLE
[5.2] Add makeHidden method to the Eloquent collection class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -197,6 +197,19 @@ class Collection extends BaseCollection
     }
 
     /**
+     * Make the given, typically visible, attributes hidden across the entire collection.
+     *
+     * @param  array|string  $attributes
+     * @return $this
+     */
+    public function makeHidden($attributes)
+    {
+        return $this->each(function ($model) use ($attributes) {
+            $model->addHidden($attributes);
+        });
+    }
+
+    /**
      * Make the given, typically hidden, attributes visible across the entire collection.
      *
      * @param  array|string  $attributes
@@ -204,11 +217,9 @@ class Collection extends BaseCollection
      */
     public function makeVisible($attributes)
     {
-        $this->each(function ($model) use ($attributes) {
+        return $this->each(function ($model) use ($attributes) {
             $model->makeVisible($attributes);
         });
-
-        return $this;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -223,7 +223,15 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(new Collection([$one]), $c->except([2, 3]));
     }
 
-    public function testWithHiddenSetsHiddenOnEntireCollection()
+    public function testMakeHiddenAddsHiddenOnEntireCollection()
+    {
+        $c = new Collection([new TestEloquentCollectionModel]);
+        $c = $c->makeHidden(['visible']);
+
+        $this->assertEquals(['hidden', 'visible'], $c[0]->getHidden());
+    }
+
+    public function testMakeVisibleRemovesHiddenFromEntireCollection()
     {
         $c = new Collection([new TestEloquentCollectionModel]);
         $c = $c->makeVisible(['hidden']);


### PR DESCRIPTION
To complement the `makeVisible` method:

``` php
$user = User::all()->makeHidden('age');
```
