### PR TITLE
[5.2] Query Builder - Allow “on” clauses on cross joins

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -439,10 +439,17 @@ class Builder
      * Add a "cross join" clause to the query.
      *
      * @param  string  $table
+     * @param  string  $first
+     * @param  string  $operator
+     * @param  string  $second
      * @return \Illuminate\Database\Query\Builder|static
      */
-    public function crossJoin($table)
+    public function crossJoin($table, $first = null, $operator = null, $second = null)
     {
+        if ($first) {
+            return $this->join($table, $first, $operator, $second, 'cross');
+        }
+
         $this->joins[] = new JoinClause('cross', $table);
 
         return $this;

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -143,9 +143,9 @@ class Grammar extends BaseGrammar
             $type = $join->type;
 
             // Cross joins generate a cartesian product between the first table and the
-            // joined table. Since they don't expect any "on" clauses to perform the
+            // joined table. In case the user didn't specify any "on" clauses on the
             // join, we append the SQL and jump to the next iteration of the loop.
-            if ($type === 'cross') {
+            if ($type === 'cross' &&  ! $join->clauses) {
                 $sql[] = "cross join $table";
 
                 continue;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -708,6 +708,14 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('sizes')->crossJoin('colors');
         $this->assertEquals('select * from "sizes" cross join "colors"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('tableB')->join('tableA', 'tableA.column1', '=', 'tableB.column2', 'cross');
+        $this->assertEquals('select * from "tableB" cross join "tableA" on "tableA"."column1" = "tableB"."column2"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('tableB')->crossJoin('tableA', 'tableA.column1', '=', 'tableB.column2');
+        $this->assertEquals('select * from "tableB" cross join "tableA" on "tableA"."column1" = "tableB"."column2"', $builder->toSql());
     }
 
     public function testComplexJoin()


### PR DESCRIPTION
See: https://github.com/laravel/framework/pull/12950#issuecomment-209860105

In that PR, I mistakenly assumed that cross joins never accepted “on” clauses, but it turns out that they are supported, and that some people do use them.

This PR includes a fix as well as two tests to cover this use case.
