### PR TITLE
[5.2] Let the MySqlGrammar use the right JSON types instead of just strings

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -127,7 +127,7 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Check for a JSON selector
+     * Check for a JSON selector.
      *
      * @param  string  $value
      * @return bool
@@ -161,13 +161,14 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Removes one where binding from the query
+     * Removes one where binding from the query.
      *
      * @param  Builder $query
      * @param  array   $where
      * @return void
      */
-    protected function removeWhereBindingFromQuery(Builder $query, $where){
+    protected function removeWhereBindingFromQuery(Builder $query, $where)
+    {
         $wheres = $query->wheres;
         $offset = array_search($where, $wheres);
 

--- a/src/Illuminate/Database/Query/JsonExpression.php
+++ b/src/Illuminate/Database/Query/JsonExpression.php
@@ -40,7 +40,7 @@ class JsonExpression extends Expression
                 return '?';
         }
 
-        throw new \IllegalArgumentException('JSON value is of illegal type: '.$type);
+        throw new \InvalidArgumentException('JSON value is of illegal type: '.$type);
     }
 
     /**

--- a/src/Illuminate/Database/Query/JsonExpression.php
+++ b/src/Illuminate/Database/Query/JsonExpression.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+class JsonExpression extends Expression
+{
+    /**
+     * The value of the expression.
+     *
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * Create a new raw query expression.
+     *
+     * @param  mixed  $value
+     * @return void
+     */
+    public function __construct($value)
+    {
+        $this->value = $this->getJsonValue($value);
+    }
+
+    /**
+     * Get the value of a JSON using the correct type
+     *
+     * @param  mixed  $value
+     * @return string
+     */
+    protected function getJsonValue($value)
+    {
+        switch ($type = gettype($value)) {
+            case 'boolean':
+                return $value ? 'true' : 'false';
+            case 'integer':
+            case 'double':
+                return $value;
+            case 'string':
+                return '?';
+        }
+
+        throw new \IllegalArgumentException('JSON value is of illegal type: ' . $type);
+    }
+
+    /**
+     * Get the value of the expression.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Get the value of the expression.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->getValue();
+    }
+}

--- a/src/Illuminate/Database/Query/JsonExpression.php
+++ b/src/Illuminate/Database/Query/JsonExpression.php
@@ -23,7 +23,7 @@ class JsonExpression extends Expression
     }
 
     /**
-     * Get the value of a JSON using the correct type
+     * Get the value of a JSON using the correct type.
      *
      * @param  mixed  $value
      * @return string
@@ -40,7 +40,7 @@ class JsonExpression extends Expression
                 return '?';
         }
 
-        throw new \IllegalArgumentException('JSON value is of illegal type: ' . $type);
+        throw new \IllegalArgumentException('JSON value is of illegal type: '.$type);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1212,15 +1212,21 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
 
         $builder = $this->getMySqlBuilder();
         $builder->select('items->price')->from('users')->where('items->price', '=', 1)->orderBy('items->price');
-        $this->assertEquals('select `items`->"$.price" from `users` where `items`->"$.price" = ? order by `items`->"$.price" asc', $builder->toSql());
+        $this->assertEquals('select `items`->"$.price" from `users` where `items`->"$.price" = 1 order by `items`->"$.price" asc', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
-        $this->assertEquals('select * from `users` where `items`->"$.price.in_usd" = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where `items`->"$.price.in_usd" = 1', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1)->where('items->age', '=', 2);
-        $this->assertEquals('select * from `users` where `items`->"$.price.in_usd" = ? and `items`->"$.age" = ?', $builder->toSql());
+        $this->assertEquals('select * from `users` where `items`->"$.price.in_usd" = 1 and `items`->"$.age" = 2', $builder->toSql());
+
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->where('items->sku', '=', 'foo-bar')->where('items->pi', '=', 3.141592653);
+        $this->assertEquals('select * from `users` where `items`->"$.sku" = ? and `items`->"$.pi" = 3.141592653', $builder->toSql());
+        $this->assertCount(1, $builder->getRawBindings()['where']);
+        $this->assertEquals('foo-bar', $builder->getRawBindings()['where'][0]);
     }
 
     public function testPostgresWrappingJson()


### PR DESCRIPTION
Supposed you have a column `attr` in your table. Supposed your table has these entries:

```
+------+--------------------------------------+
| name | attr                                 |
+------+--------------------------------------+
| a    | {"a": 1, "b": 3.1415926, "c": "foo"} |
| b    | {"a": 2, "b": 1.7182818, "c": "bar"} |
+------+--------------------------------------+
```

Now using Eloquent to get the row where the value of `a` is 1, you would have `DB::raw(1)` as the value in the call to `where` like this:

```
/* case #1 */ $model->where('attr->a', 1); // Does not work!
/* case #2 */ $model->where('attr->a', DB::raw(1));
```

With this fix, you can easily use it as you would expect (like in case 1).
