### PR TITLE
Method Model::removeGlobalScope()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -363,6 +363,33 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Remove a global scope from the model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Scope|\Closure|string  $scope
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function removeGlobalScope($scope)
+    {
+        if (is_string($scope)) {
+            unset(static::$globalScopes[static::class][$scope]);
+            return;
+        }
+
+        if ($scope instanceof Closure) {
+            unset(static::$globalScopes[static::class][spl_object_hash($scope)]);
+            return;
+        }
+
+        if ($scope instanceof Scope) {
+            unset(static::$globalScopes[static::class][get_class($scope)]);
+            return;
+        }
+
+        throw new InvalidArgumentException('Global scope must be an instance of Closure or Scope.');
+    }
+
+    /**
      * Determine if a model has a global scope.
      *
      * @param  \Illuminate\Database\Eloquent\Scope|string  $scope


### PR DESCRIPTION
I have a model where I apply a scope on boot. Basically this model will always need this scope, excepted a few exceptions. On these exceptions I want to disable this scope. As I couldnt find an acceptable way to do so, I thought about this `removeGlobalScope()` method.

For the record, I used to disable my scope by calling the scope's remove() method:

```
$model = new MyModel();
$builder = $model->newQuery();
$model->getGlobalScopes()['Path\To\My\Scope']->remove($builder, $model);
$results = $builder->get();
```

which was no longer possible after updating illuminate/database from `v5.1.25` to `v5.2.28`. I believe this commit https://github.com/laravel/framework/commit/9cce184103e6ef40d90dd601224efa11e30884b2 is the cause.
Since this commit there is no way to disable one scope before calling `get()` as the scopes arent applied until you call this function.
