### PR TITLE
[5.2] Flash input when unable to match email (or other error) during password reset

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -118,7 +118,7 @@ trait ResetsPasswords
      */
     protected function getSendResetLinkEmailFailureResponse($response)
     {
-        return redirect()->back()->withErrors(['email' => trans($response)]);
+        return redirect()->back()->withErrors(['email' => trans($response)])->withInput();
     }
 
     /**


### PR DESCRIPTION
Flash the input into session when responding with an error during the reset password process.

Allows population of the `email` field using the `old()` helper.
