### PR TITLE
[5.2] Adding a method to disable model observers in tests.

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -221,7 +221,7 @@ trait MocksApplicationServices
     }
 
     /**
-     * Specify a list of observers that will not run for the given operation
+     * Specify a list of observers that will not run for the given operation.
      *
      * These observers will be mocked, so that they will not actually be executed.
      *

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -226,6 +226,7 @@ trait MocksApplicationServices
      * These observers will be mocked, so that they will not actually be executed.
      *
      * @param array|string $observers
+     * @return $this
      */
     public function withoutObservers($observers)
     {
@@ -236,5 +237,7 @@ trait MocksApplicationServices
                 return $this->getMockBuilder($observer)->disableOriginalConstructor()->getMock();
             });
         }, $observers);
+
+        return $this;
     }
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -219,4 +219,22 @@ trait MocksApplicationServices
 
         return false;
     }
+
+    /**
+     * Specify a list of observers that will not run for the given operation
+     *
+     * These observers will be mocked, so that they will not actually be executed.
+     *
+     * @param array|string $observers
+     */
+    public function withoutObservers($observers)
+    {
+        $observers = is_array($observers) ? $observers : [$observers];
+
+        array_map(function ($observer) {
+            $this->app->bind($observer, function () use ($observer) {
+                return $this->getMockBuilder($observer)->disableOriginalConstructor()->getMock();
+            });
+        }, $observers);
+    }
 }


### PR DESCRIPTION
I often find myself having to disable model observers in my tests. As this method functions very similarly to withoutEvents or withoutJobs it seemed like it would be a natural fit for the framework. The expected usage would be:

`$this->withoutObservers(JobObserver::class);`

or 

`$this->withoutObservers([JobObserver::class, PostObserver::class]);`
