### PR TITLE
Type-hinting fix in PasswordBroker

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Auth\PasswordBroker as PasswordBrokerContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+use Illuminate\Mail\Message;
 
 class PasswordBroker implements PasswordBrokerContract
 {
@@ -110,11 +111,11 @@ class PasswordBroker implements PasswordBrokerContract
         // so that it may be displayed for an user to click for password reset.
         $view = $this->emailView;
 
-        return $this->mailer->send($view, compact('token', 'user'), function ($m) use ($user, $token, $callback) {
-            $m->to($user->getEmailForPasswordReset());
+        return $this->mailer->send($view, compact('token', 'user'), function (Message $message) use ($user, $token, $callback) {
+            $message->to($user->getEmailForPasswordReset());
 
             if (! is_null($callback)) {
-                call_user_func($callback, $m, $user, $token);
+                call_user_func($callback, $message, $user, $token);
             }
         });
     }

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -60,7 +60,7 @@ class AuthPasswordBrokerTest extends PHPUnit_Framework_TestCase
             return $callback;
         });
         $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
-        $message = m::mock('StdClass');
+        $message = m::mock('\Illuminate\Mail\Message');
         $message->shouldReceive('to')->once()->with('email');
         $result = $broker->emailResetLink($user, 'token', $callback);
         call_user_func($result, $message);


### PR DESCRIPTION
Just a small type-hinting related fix to make the code more readable.
