### PR TITLE
[5.1] Add missing symfony/debug dependency for illuminate/view

### DIFF
--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -19,7 +19,8 @@
         "illuminate/contracts": "5.1.*",
         "illuminate/events": "5.1.*",
         "illuminate/filesystem": "5.1.*",
-        "illuminate/support": "5.1.*"
+        "illuminate/support": "5.1.*",
+        "symfony/debug": "2.7.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
When using `illuminate/view` as a standalone component, any exceptions that are thrown from the view template are not displayed, as the illuminate code that catches them depends on `symfony/debug` which is not required by its `composer.json`
