### PR TITLE
[5.3] Proposal - Change the way controller middlewares are registered

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesResources.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Foundation\Auth\Access;
 
-use Illuminate\Routing\ControllerMiddlewareOptions;
+use Illuminate\Contracts\Auth\Access\Gate;
 
 trait AuthorizesResources
 {
@@ -11,11 +11,10 @@ trait AuthorizesResources
      *
      * @param  string  $model
      * @param  string|null  $name
-     * @param  array  $options
      * @param  \Illuminate\Http\Request|null  $request
      * @return \Illuminate\Routing\ControllerMiddlewareOptions
      */
-    public function authorizeResource($model, $name = null, array $options = [], $request = null)
+    public function authorizeResource($model, $name = null, $request = null)
     {
         $action = with($request ?: request())->route()->getActionName();
 
@@ -24,14 +23,12 @@ trait AuthorizesResources
             'edit' => 'update', 'update' => 'update', 'delete' => 'delete',
         ];
 
-        if (! in_array($method = array_last(explode('@', $action)), array_keys($map))) {
-            return new ControllerMiddlewareOptions($options);
-        }
+        $method = array_last(explode('@', $action));
 
         $name = $name ?: strtolower(class_basename($model));
 
         $model = in_array($method, ['index', 'create', 'store']) ? $model : $name;
 
-        return $this->middleware("can:{$map[$method]},{$model}", $options);
+        return app(Gate::class)->authorize($map[$method], [$model]);
     }
 }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Str;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Illuminate\Console\Command;
-use Illuminate\Routing\Controller;
 use Symfony\Component\Console\Input\InputOption;
 
 class RouteListCommand extends Command
@@ -138,54 +137,7 @@ class RouteListCommand extends Command
      */
     protected function getMiddleware($route)
     {
-        $middlewares = array_values($route->middleware());
-
-        $actionName = $route->getActionName();
-
-        if (! empty($actionName) && $actionName !== 'Closure') {
-            $middlewares = array_merge($middlewares, $this->getControllerMiddleware($actionName));
-        }
-
-        return implode(',', $middlewares);
-    }
-
-    /**
-     * Get the middleware for the given Controller@action name.
-     *
-     * @param  string  $actionName
-     * @return array
-     */
-    protected function getControllerMiddleware($actionName)
-    {
-        Controller::setRouter($this->laravel['router']);
-
-        $segments = explode('@', $actionName);
-
-        return $this->getControllerMiddlewareFromInstance(
-            $this->laravel->make($segments[0]), $segments[1]
-        );
-    }
-
-    /**
-     * Get the middlewares for the given controller instance and method.
-     *
-     * @param  \Illuminate\Routing\Controller  $controller
-     * @param  string  $method
-     * @return array
-     */
-    protected function getControllerMiddlewareFromInstance($controller, $method)
-    {
-        $middleware = $this->router->getMiddleware();
-
-        $results = [];
-
-        foreach ($controller->getMiddleware() as $name => $options) {
-            if (! $this->methodExcludedByOptions($method, $options)) {
-                $results[] = Arr::get($middleware, $name, $name);
-            }
-        }
-
-        return $results;
+        return implode(',', $route->middleware());
     }
 
     /**
@@ -198,7 +150,7 @@ class RouteListCommand extends Command
     protected function methodExcludedByOptions($method, array $options)
     {
         return (! empty($options['only']) && ! in_array($method, (array) $options['only'])) ||
-            (! empty($options['except']) && in_array($method, (array) $options['except']));
+        (! empty($options['except']) && in_array($method, (array) $options['except']));
     }
 
     /**
@@ -210,8 +162,8 @@ class RouteListCommand extends Command
     protected function filterRoute(array $route)
     {
         if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
-             $this->option('path') && ! Str::contains($route['uri'], $this->option('path')) ||
-             $this->option('method') && ! Str::contains($route['method'], $this->option('method'))) {
+            $this->option('path') && ! Str::contains($route['uri'], $this->option('path')) ||
+            $this->option('method') && ! Str::contains($route['method'], $this->option('method'))) {
             return;
         }
 

--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -8,44 +8,11 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 abstract class Controller
 {
     /**
-     * The middleware registered on the controller.
-     *
-     * @var array
-     */
-    protected $middleware = [];
-
-    /**
      * The router instance.
      *
      * @var \Illuminate\Routing\Router
      */
     protected static $router;
-
-    /**
-     * Register middleware on the controller.
-     *
-     * @param  array|string  $middleware
-     * @param  array   $options
-     * @return \Illuminate\Routing\ControllerMiddlewareOptions
-     */
-    public function middleware($middleware, array $options = [])
-    {
-        foreach ((array) $middleware as $middlewareName) {
-            $this->middleware[$middlewareName] = &$options;
-        }
-
-        return new ControllerMiddlewareOptions($options);
-    }
-
-    /**
-     * Get the middleware assigned to the controller.
-     *
-     * @return array
-     */
-    public function getMiddleware()
-    {
-        return $this->middleware;
-    }
 
     /**
      * Get the router instance.
@@ -78,6 +45,16 @@ abstract class Controller
     public function callAction($method, $parameters)
     {
         return call_user_func_array([$this, $method], $parameters);
+    }
+
+    /**
+     * The middleware registered on the controller.
+     *
+     * @return array
+     */
+    public static function middleware()
+    {
+        return [];
     }
 
     /**

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 
 class ControllerDispatcher
@@ -81,7 +80,7 @@ class ControllerDispatcher
         $shouldSkipMiddleware = $this->container->bound('middleware.disable') &&
                                 $this->container->make('middleware.disable') === true;
 
-        $middleware = $shouldSkipMiddleware ? [] : $this->getMiddleware($instance, $method);
+        $middleware = $shouldSkipMiddleware ? [] : $route->controllerMiddleware();
 
         // Here we will make a stack onion instance to execute this request in, which gives
         // us the ability to define middlewares on controllers. We will return the given
@@ -94,39 +93,6 @@ class ControllerDispatcher
                             $request, $this->call($instance, $route, $method)
                         );
                     });
-    }
-
-    /**
-     * Get the middleware for the controller instance.
-     *
-     * @param  \Illuminate\Routing\Controller  $instance
-     * @param  string  $method
-     * @return array
-     */
-    public function getMiddleware($instance, $method)
-    {
-        $results = new Collection;
-
-        foreach ($instance->getMiddleware() as $name => $options) {
-            if (! $this->methodExcludedByOptions($method, $options)) {
-                $results[] = $this->router->resolveMiddlewareClassName($name);
-            }
-        }
-
-        return $results->flatten()->all();
-    }
-
-    /**
-     * Determine if the given options exclude a particular method.
-     *
-     * @param  string  $method
-     * @param  array  $options
-     * @return bool
-     */
-    public function methodExcludedByOptions($method, array $options)
-    {
-        return (isset($options['only']) && ! in_array($method, (array) $options['only'])) ||
-            (! empty($options['except']) && in_array($method, (array) $options['except']));
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -589,6 +589,24 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testRouteMiddlewareCollection()
+    {
+        $router = $this->getRouter();
+        $router->group(['prefix' => 'foo', 'middleware' => 'boo:foo'], function () use ($router) {
+            $router->get('bar', 'RouteTestControllerStub@index')->middleware('baz:gaz');
+        });
+        $routes = $router->getRoutes()->getRoutes();
+        $route = $routes[0];
+        $this->assertEquals(
+            [
+                'boo:foo', 'baz:gaz', 'RouteTestControllerMiddleware',
+                'RouteTestControllerParameterizedMiddlewareOne:0',
+                'RouteTestControllerParameterizedMiddlewareTwo:foo,bar',
+            ],
+            $route->middleware()
+        );
+    }
+
     public function testRoutePrefixing()
     {
         /*
@@ -919,30 +937,34 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
 
 class RouteTestControllerStub extends Illuminate\Routing\Controller
 {
-    public function __construct()
-    {
-        $this->middleware('RouteTestControllerMiddleware');
-        $this->middleware('RouteTestControllerParameterizedMiddlewareOne:0');
-        $this->middleware('RouteTestControllerParameterizedMiddlewareTwo:foo,bar');
-        $this->middleware('RouteTestControllerExceptMiddleware', ['except' => 'index']);
-    }
-
     public function index()
     {
         return 'Hello World';
+    }
+
+    public static function middleware()
+    {
+        return [
+            'RouteTestControllerMiddleware',
+            'RouteTestControllerParameterizedMiddlewareOne:0',
+            'RouteTestControllerParameterizedMiddlewareTwo:foo,bar',
+            'RouteTestControllerExceptMiddleware' => ['except' => 'index'],
+        ];
     }
 }
 
 class RouteTestControllerMiddlewareGroupStub extends Illuminate\Routing\Controller
 {
-    public function __construct()
-    {
-        $this->middleware('web');
-    }
-
     public function index()
     {
         return 'Hello World';
+    }
+
+    public static function middleware()
+    {
+        return [
+            'web',
+        ];
     }
 }
 


### PR DESCRIPTION
**Currently:**

``` php
public function __construct()
{
     $this->middleware('auth', [/** options **/]);
}
```

**Problem:**

In order to collect the middleware of a specific routes, we currently check the routes registered in `routes.php` for the route and use `ControllerDispatcher` to collect the middleware registered within the controller constructor, this is done by creating an actual instance of the controller which means all the code in the constructor will be executed, some of this code assumes the requested route already passed the middleware registered in `routes.php`, but during collection the middlewares are not actually handled.

Currently there are two cases where you need to collect a route middleware:
1. `route:list` command.
2. The case with Terminable Middlewares as in here https://github.com/laravel/framework/pull/12899.

PR #12899 was reverted in https://github.com/laravel/framework/pull/12991 as it caused the Controller to be instantiated twice, once while the router is dispatching the request to the route, and another when the controller is being actually dispatched.

**Proposal:**

Instead of registering controller middleware through a method call, we do that using a static method inside the controller:

``` php
class HomeController extends Controller
{
    static function middleware()
    {
        return [
            'auth' => ['only' => 'show'],
            'web'
        ];
    }
}
```

That way we can collect controller middlewares without creating an instance.

---

**Note** I understand that this will make registering middlewares from the controller not dynamic, it's also less elegant than `$this->middleware()`, but I think discussing the matter is useful.
