### PR TITLE
[5.2] Make sure unguarded() does not change unguarded state on exception

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2282,9 +2282,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 
         static::unguard();
 
-        $result = $callback();
-
-        static::reguard();
+        try {
+            $result = $callback();
+        } finally {
+            static::reguard();
+        }
 
         return $result;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -812,6 +812,18 @@ class DatabaseEloquentModelTest extends PHPUnit_Framework_TestCase
         Model::reguard();
     }
 
+    public function testUnguardedCallDoesNotChangeUnguardedStateOnException()
+    {
+        try {
+            Model::unguarded(function () {
+                throw new Exception;
+            });
+        } catch (Exception $e) {
+            // ignore the exception
+        }
+        $this->assertFalse(Model::isUnguarded());
+    }
+
     public function testHasOneCreatesProperRelation()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
This makes sure that when an exception is thrown in the callback passed to `Model::unguarded()`, the Model is still guarded afterwards. It uses the `try .. finally` construct. I also added a unit test.

A use case when this can happen is in `FactoryBuilder::makeInstance`, which throws an exception when it cannot find the model factory. In tests, this can result in strange errors in other tests, because all models are unguarded afterwards (also in other test cases) when this exception is thrown. So then tests will fail when they shouldn't. This PR prevents this kind of situations.
