### PR TITLE
[5.2] Implement the ability to run SQL_CALC_FOUND_ROWS for MySQL

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use DB;
 use Closure;
+use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Pagination\Paginator;
@@ -440,6 +442,29 @@ class Builder
     public function lists($column, $key = null)
     {
         return $this->pluck($column, $key);
+    }
+
+    /**
+     * Get the last total row count calculated by MySQL.
+     *
+     * This only works when the `SQL_CALC_FOUND_ROWS` option is enabled on the
+     * underlying base query builder.
+     *
+     * @return integer
+     */
+    public function foundRows()
+    {
+        $results = DB::select(
+            'SELECT FOUND_ROWS() AS `total`;'
+        );
+
+        if (count($results) !== 1) {
+            throw new Exception('foundRows() got an unexpected result from the database');
+        }
+
+        $result = reset($results);
+
+        return (int) $result->total;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -450,7 +450,7 @@ class Builder
      * This only works when the `SQL_CALC_FOUND_ROWS` option is enabled on the
      * underlying base query builder.
      *
-     * @return integer
+     * @return int
      */
     public function foundRows()
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -79,6 +79,15 @@ class Builder
     public $distinct = false;
 
     /**
+     * Whether to include `SQL_CALC_FOUND_ROWS` in the query.
+     *
+     * Only applicable when using MySQL.
+     *
+     * @var bool
+     */
+    public $sqlCalcFoundRows = false;
+
+    /**
      * The table which the query is targeting.
      *
      * @var string
@@ -305,6 +314,18 @@ class Builder
     public function distinct()
     {
         $this->distinct = true;
+
+        return $this;
+    }
+
+    /**
+     * Enables `SQL_CALC_FOUND_ROWS` for this query.
+     *
+     * @return $this
+     */
+    public function sqlCalcFoundRows()
+    {
+        $this->sqlCalcFoundRows = true;
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -44,6 +44,35 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile the "select *" portion of the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $columns
+     * @return string|null
+     */
+    protected function compileColumns(Builder $query, $columns)
+    {
+        // If the query is actually performing an aggregating select, we will let that
+        // compiler handle the building of the select clauses, as it will need some
+        // more syntax that is best handled by that function to keep things neat.
+        if (! is_null($query->aggregate)) {
+            return;
+        }
+
+        $select = 'select ';
+
+        if ($query->sqlCalcFoundRows) {
+            $select .= 'SQL_CALC_FOUND_ROWS ';
+        }
+
+        if ($query->distinct) {
+            $select .= 'distinct ';
+        }
+
+        return $select.$this->columnize($columns);
+    }
+
+    /**
      * Compile a single union statement.
      *
      * @param  array  $union

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -88,6 +88,13 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('select distinct "foo", "bar" from "users"', $builder->toSql());
     }
 
+    public function testBasicSelectSqlCalcFoundRows()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->sqlCalcFoundRows()->select('foo', 'bar')->from('users');
+        $this->assertEquals('select SQL_CALC_FOUND_ROWS `foo`, `bar` from `users`', $builder->toSql());
+    }
+
     public function testBasicAlias()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Usage:

``` php
$model->sqlCalcFoundRows()->whereFoo('bar')->forPage($page, $perPage)->get();

// on the instance
$model->foundRows();

// on the model class
App\Models\Model::foundRows();
```

This enables much more efficient pagination for MySQL, as opposed to performing double queries via `count()`, especially when doing more complicated filtering (e.g. what you would implement in an average e-commerce solution).

Not sure if this is in the spirit of Eloquent, as it only works for MySQL (obviously), but we use it in our projects and it's pretty useful for performance.

Having this in user-land via a service provider and overriden classes is okay, though it causes some problems with Artisan - since the service provider needs to access the database to configure our custom `MySqlGrammar`, and this can obviously cause issues when there is no database configured. Thus, it would be awesome if it was included in the framework (and it seems to have been requested multiple times).

If you feel this belongs in the core, and it needs more work, I'd be happy to contribute.
