### PR TITLE
[5.2] Make sure joins in query scopes are carried over when nested

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -724,6 +724,14 @@ class Builder
             $this->addBinding($query->getBindings(), 'where');
         }
 
+        if (count($query->joins)) {
+            foreach ($query->joins as $join) {
+                $this->joins[] = $join;
+
+                $this->addBinding($join->bindings, 'join');
+            }
+        }
+
         return $this;
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -724,7 +724,7 @@ class Builder
             $this->addBinding($query->getBindings(), 'where');
         }
 
-        if (count($query->joins)) {
+        if (! empty($query->joins)) {
             foreach ($query->joins as $join) {
                 $this->joins[] = $join;
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -395,6 +395,24 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($builder, $result);
     }
 
+    public function testQueryScopeWithJoin()
+    {
+        $model = new EloquentBuilderTestScopeJoinStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->where('foo', '=', 'bar')->popular();
+        $this->assertEquals('select * from "users" inner join "popular_users" on "popular_users"."user_id" = "users"."id" where "foo" = ? and "popular_users"."popularity" > ?', $query->toSql());
+        $this->assertEquals(['bar', 100], $query->getBindings());
+    }
+
+    public function testNestedQueryScopeWithJoin()
+    {
+        $model = new EloquentBuilderTestScopeJoinStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->where('foo', '=', 'bar')->where(function ($query) { $query->popular(); });
+        $this->assertEquals('select * from "users" inner join "popular_users" on "popular_users"."user_id" = "users"."id" where "foo" = ? and ("popular_users"."popularity" > ?)', $query->toSql());
+        $this->assertEquals(['bar', 100], $query->getBindings());
+    }
+
     public function testNestedWhere()
     {
         $nestedQuery = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -601,6 +619,17 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $query->shouldReceive('from')->with('foo_table');
 
         return $query;
+    }
+}
+
+class EloquentBuilderTestScopeJoinStub extends Illuminate\Database\Eloquent\Model
+{
+    protected $table = 'users';
+
+    public function scopePopular($query)
+    {
+        $query->join('popular_users', 'popular_users.user_id', '=', 'users.id')
+            ->where('popular_users.popularity', '>', 100);
     }
 }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -653,6 +653,17 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([0 => 'foo', 1 => 'bar', 2 => 25], $builder->getBindings());
     }
 
+    public function testNestedWheresWithJoins()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('email', '=', 'foo')->orWhere(function ($q) {
+            $q->join('contacts', 'users.id', '=', 'contacts.user_id')
+                ->where('contacts.email', '=', 'bar');
+        });
+        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."user_id" where "email" = ? or ("contacts"."email" = ?)', $builder->toSql());
+        $this->assertEquals([0 => 'foo', 1 => 'bar'], $builder->getBindings());
+    }
+
     public function testFullSubSelects()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This is intended to fix the behavior seen in #12925.

Eloquent query scopes that contain joins currently work fine unless that query scope is being called within a nested query, in which case only the where clauses are merged in `addNestedWhereQuery` and not the joins resulting in invalid SQL.
