### PR TITLE
[5.2] Make MessageBag constructor consistent with add method

### DIFF
--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -147,4 +147,11 @@ class SupportMessageBagTest extends PHPUnit_Framework_TestCase
         $messageBag = new MessageBag(['country' => 'Azerbaijan', 'capital' => 'Baku']);
         $this->assertEquals(['country' => ['Azerbaijan'], 'capital' => ['Baku']], $messageBag->getMessages());
     }
+
+    public function testConstructorUniqueness()
+    {
+        $messageBag = new MessageBag(['messages' => ['first', 'second', 'third', 'third']]);
+        $messages = $messageBag->getMessages();
+        $this->assertEquals(['first', 'second', 'third'], $messages['messages']);
+    }
 }


### PR DESCRIPTION
Currently, the behaviour between initialising a new `MessageBag` and using the `add` method is inconsistent.

The `add` method tests for uniqueness (of the key, and the message in the keyed bag), whereas the constructor will accept duplicate messages.

``` php
$messageBag = new MessageBag(['messages' => ['first', 'second', 'third', 'third']]);

// $messageBag->getMessages()
// ['messages' => ['first', 'second', 'third', 'third']]

$messageBag = new MessageBag;
$messageBag->add('messages', 'first');
$messageBag->add('messages', 'second');
$messageBag->add('messages', 'third');
$messageBag->add('messages', 'third');

// $messageBag->getMessages()
// ['messages' => ['first', 'second', 'third']
```

I'm not certain if this is on purpose, so I have opened a PR with a failing test to demonstrate the proposed behaviour, which will amend should the desire exist to match the behaviour between the constructor and public API of the MessageBag class.

It appears this has been around since [January, 2013](https://github.com/laravel/framework/issues/84#issuecomment-12636821), so this would likely be targeted to next release due to backwards compatibility breakage.
