### PR TITLE
[5.1] Fix Str::studly method for UTF-8 strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -412,7 +412,7 @@ class Str
             return static::$studlyCache[$key];
         }
 
-        $value = ucwords(str_replace(['-', '_'], ' ', $value));
+        $value = static::ucwords(str_replace(['-', '_'], ' ', $value));
 
         return static::$studlyCache[$key] = str_replace(' ', '', $value);
     }
@@ -439,5 +439,16 @@ class Str
     public static function ucfirst($string)
     {
         return static::upper(static::substr($string, 0, 1)).static::substr($string, 1);
+    }
+
+    /**
+     * Make uppercase the first character of each word in a string.
+     *
+     * @param  string $string
+     * @return string
+     */
+    public static function ucwords($string)
+    {
+        return mb_convert_case($string, MB_CASE_TITLE, 'UTF-8');
     }
 }


### PR DESCRIPTION
Similar issue at #12923. Because of this bug, some of migrations file can't convert correctly. I fix it with adding a `Str::ucwords` method that can convert correctly utf-8 strings.

For example, `2016_03_13_134252_create_food_ingredients_table.php` migration file is converted to `CreateFoodingredientsTable` instead of `CreateFoodIngredientsTable`. So when i run migration, this error throws:

```
[Symfony\Component\Debug\Exception\FatalThrowableError]
Fatal error: Class 'CreateFoodingredientsTable' not found
```

This issue occurs on PHP 7 setup when PHP locale is `tr_TR.UTF-8`
