### PR TITLE
[5.2] Remove duplicate "[y/N]" from confirmable console commands

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -29,7 +29,7 @@ trait ConfirmableTrait
             $this->comment(str_repeat('*', strlen($warning) + 12));
             $this->output->writeln('');
 
-            $confirmed = $this->confirm('Do you really wish to run this command? [y/N]');
+            $confirmed = $this->confirm('Do you really wish to run this command?');
 
             if (! $confirmed) {
                 $this->comment('Command Cancelled!');


### PR DESCRIPTION
Currently, the console asks:

```
Do you really wish to run this command? [y/N] (yes/no) [no]:
```

This PR changes it to:

```
Do you really wish to run this command? (yes/no) [no]:
```
