### PR TITLE
[5.2] Fix AppNameCommand when setting composer namespace

### DIFF
--- a/src/Illuminate/Foundation/Console/AppNameCommand.php
+++ b/src/Illuminate/Foundation/Console/AppNameCommand.php
@@ -153,7 +153,7 @@ class AppNameCommand extends Command
     protected function setComposerNamespace()
     {
         $this->replaceIn(
-            $this->getComposerPath(), $this->currentRoot.'\\\\', str_replace('\\', '\\\\', $this->argument('name')).'\\\\'
+            $this->getComposerPath(), str_replace('\\', '\\\\', $this->currentRoot).'\\\\', str_replace('\\', '\\\\', $this->argument('name')).'\\\\'
         );
     }
 


### PR DESCRIPTION
Fix AppNameCommand when setting composer namespace for namespaces with more than one section.

If the namespace is changed using the artisan app:name command to Hello\World it changes fine since the original namespace has only a single section. Then if the namespace is changed again it was failing because it couldn't match the original namespace on the replacement sentence.

Escaping the slashes solves the problem.
