### PR TITLE
[5.2] Seeder Dependencies

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -23,14 +23,14 @@ abstract class Seeder
 
     /**
      * What seeders must be run before this seeder.
-     * 
+     *
      * @var array
      */
     protected $dependencies = [];
 
     /**
      * What seeders have been run already.
-     * 
+     *
      * @var array
      */
     protected $seedersRun = [];

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -22,6 +22,20 @@ abstract class Seeder
     protected $command;
 
     /**
+     * What seeders must be run before this seeder.
+     * 
+     * @var array
+     */
+    protected $dependencies = [];
+
+    /**
+     * What seeders have been run already.
+     * 
+     * @var array
+     */
+    protected $seedersRun = [];
+
+    /**
      * Run the database seeds.
      *
      * @return void
@@ -36,7 +50,18 @@ abstract class Seeder
      */
     public function call($class)
     {
-        $this->resolve($class)->run();
+        if (array_key_exists($class, $this->seedersRun)) {
+            return;
+        }
+
+        $seeder = $this->resolve($class);
+
+        foreach ($seeder->dependencies as $dependency) {
+            $this->call($dependency);
+        }
+
+        $seeder->run();
+        $this->seedersRun[$class] = true;
 
         if (isset($this->command)) {
             $this->command->getOutput()->writeln("<info>Seeded:</info> $class");

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -27,10 +27,46 @@ class DatabaseSeederTest extends PHPUnit_Framework_TestCase
         $command = m::mock('Illuminate\Console\Command');
         $command->shouldReceive('getOutput')->once()->andReturn($output);
         $seeder->setCommand($command);
-        $container->shouldReceive('make')->once()->with('ClassName')->andReturn($child = m::mock('StdClass'));
+        $child = m::mock('StdClass');
+        $child->dependencies = [];
+        $container->shouldReceive('make')->once()->with('ClassName')->andReturn($child);
         $child->shouldReceive('setContainer')->once()->with($container)->andReturn($child);
         $child->shouldReceive('setCommand')->once()->with($command)->andReturn($child);
         $child->shouldReceive('run')->once();
+
+        $seeder->call('ClassName');
+    }
+
+    public function testCallResolveDependencies()
+    {
+        $container = m::mock('Illuminate\Container\Container');
+
+        $seeder = new TestSeeder;
+        $seeder->setContainer($container);
+
+        $output = m::mock('Symfony\Component\Console\Output\OutputInterface');
+        $output->shouldReceive('writeln')->twice()->andReturn('foo');
+
+        $command = m::mock('Illuminate\Console\Command');
+        $command->shouldReceive('getOutput')->twice()->andReturn($output);
+        $seeder->setCommand($command);
+
+        $child = m::mock('StdClass');
+        $child->dependencies = ['ClassTwo'];
+
+        $dependant = m::mock('StdClass');
+        $dependant->dependencies = [];
+
+        $container->shouldReceive('make')->once()->with('ClassName')->andReturn($child);
+        $container->shouldReceive('make')->once()->with('ClassTwo')->andReturn($dependant);
+
+        $child->shouldReceive('setContainer')->once()->with($container)->andReturn($child);
+        $child->shouldReceive('setCommand')->once()->with($command)->andReturn($child);
+        $child->shouldReceive('run')->once();
+
+        $dependant->shouldReceive('setContainer')->once()->with($container)->andReturn($dependant);
+        $dependant->shouldReceive('setCommand')->once()->with($command)->andReturn($dependant);
+        $dependant->shouldReceive('run')->once();
 
         $seeder->call('ClassName');
     }


### PR DESCRIPTION
Some seeders depend on other seeders having run first. Rather than having to manually determine the seeder order, this pull creates an opt-in method of declaring that one seeder depends upon another. When run, all dependencies of a seeder get run, which in turn run all of their dependencies. Seeders which are depended upon through multiple paths will run only the first time that they are needed. Seeders that have no dependencies still need to be explicitly called.

Suppose that SeedB depends on SeedA. If only SeedB is called, then both will run. If SeedB is called first and then SeedA is called, SeedA will run as a dependency of SeedB and then not run when explicitly called. If SeedA is called first and then SeedB, SeedA will run from the explicit call and then not run as a dependency of SeedB. Thus, any potential ordering of the seeders will still result in each one running once and in a dependency-first order.

This should lead to greater code clarity with inter-seeder dependencies and simplify complex seeder hierarchies by explicitly declaring dependencies between seeders rather than simply having a linear list with dependencies embedded.

The project from which this sprang also scans the seeder directory for seed classes and automatically runs them. While out of scope for this pull request, it is an interesting and useful piece of functionality that this pull should enable.
