### PR TITLE
[5.3] Make logging out a POST request

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -161,16 +161,6 @@ trait AuthenticatesUsers
      *
      * @return \Illuminate\Http\Response
      */
-    public function getLogout()
-    {
-        return $this->logout();
-    }
-
-    /**
-     * Log the user out of the application.
-     *
-     * @return \Illuminate\Http\Response
-     */
     public function logout()
     {
         Auth::guard($this->getGuard())->logout();

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -279,7 +279,7 @@ class Router implements RegistrarContract
         // Authentication Routes...
         $this->get('login', 'Auth\AuthController@showLoginForm');
         $this->post('login', 'Auth\AuthController@login');
-        $this->get('logout', 'Auth\AuthController@logout');
+        $this->post('logout', 'Auth\AuthController@logout');
 
         // Registration Routes...
         $this->get('register', 'Auth\AuthController@showRegistrationForm');


### PR DESCRIPTION
Register logout as POST in Router auth method.
Remove getLogout method from AuthenticatesUsers trait.

Continuation of #13204.

> Logging out should be a POST request, not GET.
> http://stackoverflow.com/questions/3521290/logout-get-or-post
