### PR TITLE
[5.2] Fix an issue with data_set affecting the Validator

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -484,6 +484,14 @@ if (! function_exists('data_set')) {
             } elseif ($overwrite || ! isset($target->{$segment})) {
                 $target->{$segment} = $value;
             }
+        } else {
+            $target = [];
+
+            if ($segments) {
+                data_set($target[$segment], $segments, $value, $overwrite);
+            } elseif ($overwrite) {
+                $target[$segment] = $value;
+            }
         }
 
         return $target;

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -332,7 +332,7 @@ class Validator implements ValidatorContract
             return $data;
         }
 
-        return data_fill($data, $attribute, null);
+        return data_set($data, $attribute, null, true);
     }
 
     /**

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -502,6 +502,16 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
             ['foo' => ['bar' => 'boom'], 'baz' => 'kaboom'],
             data_set($data, 'foo.bar', 'boom')
         );
+
+        $this->assertEquals(
+            ['foo' => ['bar' => 'boom'], 'baz' => ['bar' => 'boom']],
+            data_set($data, 'baz.bar', 'boom')
+        );
+
+        $this->assertEquals(
+            ['foo' => ['bar' => 'boom'], 'baz' => ['bar' => ['boom' => ['kaboom' => 'boom']]]],
+            data_set($data, 'baz.bar.boom.kaboom', 'boom')
+        );
     }
 
     public function testDataSetWithStar()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2112,6 +2112,10 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     {
         $trans = $this->getRealTranslator();
 
+        $data = ['companies' => ['spark']];
+        $v = new Validator($trans, $data, ['companies.*.name' => 'required']);
+        $this->assertFalse($v->passes());
+
         $data = ['names' => [['second' => 'I have no first']]];
         $v = new Validator($trans, $data, ['names.*.first' => 'required']);
         $this->assertFalse($v->passes());


### PR DESCRIPTION
``` php
$data = ['companies' => 'acme'];

data_set($data, 'companies.name', 'acme');
```

The result is:

```
['companies' => 'acme']
```

While it should be:

```
['companies' => ['name' => 'acme']]
```

This was affecting a case with the Validator as described here https://github.com/laravel/framework/issues/13212

For the validator's `initializeAttributeOnData()` to work properly it needs to overwrite the data values, so we need to use `data_set()` instead of `data_fill()`.
