### PR TITLE
Add missing dependency (jeremeamia/superclosure)

### DIFF
--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -18,6 +18,7 @@
         "illuminate/container": "5.2.*",
         "illuminate/contracts": "5.2.*",
         "illuminate/support": "5.2.*",
+        "jeremeamia/superclosure": "~2.2",
         "psr/log": "~1.0",
         "swiftmailer/swiftmailer": "~5.1"
     },


### PR DESCRIPTION
'illuminate/mail' requires jeremeamia/superclosure to send queued emails. 

Eventhough this will not be a issue in laravel framework. This library cannot 
use independently (e.g with lumen) because it missinng 'jeremeamia/superclosure'.

Fix #13229
