### PR TITLE
[5.3] In PDO, bind float and integer as PDO::PARAM_INT

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -356,7 +356,7 @@ class Connection implements ConnectionInterface
         foreach ($bindings as $key => $value) {
             $statement->bindValue(
                 is_string($key) ? $key : $key + 1, $value,
-                filter_var($value, FILTER_VALIDATE_INT) !== false ? PDO::PARAM_INT : PDO::PARAM_STR
+                filter_var($value, FILTER_VALIDATE_FLOAT) !== false ? PDO::PARAM_INT : PDO::PARAM_STR
             );
         }
     }


### PR DESCRIPTION
Following up on https://github.com/laravel/framework/pull/13066

This PR binds a float type as `PDO::PARAM_INT` so that the following query would work.

```
DB::table('products')->where('price->regular', 1.2)->get();
```
