### PR TITLE
[5.2] Use Carbon for everything time related in DatabaseTokenRepository

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -123,19 +123,9 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      */
     protected function tokenExpired($token)
     {
-        $expirationTime = strtotime($token['created_at']) + $this->expires;
+        $expiresAt = Carbon::parse($token['created_at'])->addSeconds($this->expires);
 
-        return $expirationTime < $this->getCurrentTime();
-    }
-
-    /**
-     * Get the current UNIX timestamp.
-     *
-     * @return int
-     */
-    protected function getCurrentTime()
-    {
-        return time();
+        return $expiresAt->lt(new Carbon);
     }
 
     /**

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -125,7 +125,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     {
         $expiresAt = Carbon::parse($token['created_at'])->addSeconds($this->expires);
 
-        return $expiresAt->lt(new Carbon);
+        return $expiresAt->isPast();
     }
 
     /**


### PR DESCRIPTION
Fixes timezone issues where my tokens had been expired for an hour already as soon as they were issued.
App timezone was CET and token expiry set to 60 minutes.
