### PR TITLE
[5.3] Allow additional values to be passed to firstOrCreate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -231,15 +231,16 @@ class Builder
      * Get the first record matching the attributes or create it.
      *
      * @param  array  $attributes
+     * @param  array  $values
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrCreate(array $attributes)
+    public function firstOrCreate(array $attributes, array $values = [])
     {
         if (! is_null($instance = $this->where($attributes)->first())) {
             return $instance;
         }
 
-        $instance = $this->model->newInstance($attributes);
+        $instance = $this->model->newInstance($attributes + $values);
 
         $instance->save();
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -38,6 +38,7 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         foreach (['default', 'second_connection'] as $connection) {
             $this->schema($connection)->create('users', function ($table) {
                 $table->increments('id');
+                $table->string('name')->nullable();
                 $table->string('email');
                 $table->timestamps();
             });
@@ -162,6 +163,32 @@ class DatabaseEloquentIntegrationTest extends PHPUnit_Framework_TestCase
         $query = EloquentTestUser::groupBy('email')->getQuery();
 
         $this->assertEquals(3, $query->getCountForPagination());
+    }
+
+    public function testFirstOrCreate()
+    {
+        $user1 = EloquentTestUser::firstOrCreate(['email' => 'taylorotwell@gmail.com']);
+
+        $this->assertEquals('taylorotwell@gmail.com', $user1->email);
+        $this->assertNull($user1->name);
+
+        $user2 = EloquentTestUser::firstOrCreate(
+            ['email' => 'taylorotwell@gmail.com'],
+            ['name' => 'Taylor Otwell']
+        );
+
+        $this->assertEquals($user1->id, $user2->id);
+        $this->assertEquals('taylorotwell@gmail.com', $user2->email);
+        $this->assertNull($user2->name);
+
+        $user3 = EloquentTestUser::firstOrCreate(
+            ['email' => 'abigailotwell@gmail.com'],
+            ['name' => 'Abigail Otwell']
+        );
+
+        $this->assertNotEquals($user3->id, $user1->id);
+        $this->assertEquals('abigailotwell@gmail.com', $user3->email);
+        $this->assertEquals('Abigail Otwell', $user3->name);
     }
 
     public function testPluck()


### PR DESCRIPTION
Many times you want to use some attributes to query, but if you're creating it now you want additional attributes to be saved.

---

For example, imagine you're using Github OAuth for sign-in. You'd want to use the Github ID to check if the user exists, but if you're creating that user now you'd also want to save their avatar.

Before, you'd do this:

``` php
$user = User::firstOrNew(['github_id', $githubUser->id]);

if (! $user->exists) {
    $user->fill(['avatar' => $githubUser->avatar])->save();
}

return $user;
```

After this change, you can do it all with the `firstOrCreate` method:

``` php
return User::firstOrCreate(['github_id', $githubUser->id], ['avatar' => $githubUser->avatar]);
```

---

This PR also adds integration tests for `firstOrCreate`, which were missing before.
