### PR TITLE
[5.2] Sparkpost bcc

### DIFF
--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -102,7 +102,7 @@ class SparkPostTransport extends Transport
     protected function getFrom(Swift_Mime_Message $message)
     {
         $from = array_map(function ($email, $name) {
-            return ['name' => $name, 'email' => $email];
+            return compact('name', 'email');
         }, array_keys($message->getFrom()), $message->getFrom());
 
         return $from[0];

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -87,7 +87,7 @@ class SparkPostTransport extends Transport
         }
 
         $recipients = array_map(function ($address) {
-            return ['address' => [ 'email' => $address ,'header_to' => $address]];
+            return ['address' => ['email' => $address, 'header_to' => $address]];
         }, $to);
 
         return $recipients;
@@ -102,7 +102,7 @@ class SparkPostTransport extends Transport
     protected function getFrom(Swift_Mime_Message $message)
     {
         $from = array_map(function ($email, $name) {
-            return [ 'name' => $name, 'email' => $email ];
+            return ['name' => $name, 'email' => $email];
         }, array_keys($message->getFrom()), $message->getFrom());
 
         return $from[0];

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -42,7 +42,7 @@ class SparkPostTransport extends Transport
         $this->beforeSendPerformed($message);
 
         $recipients = $this->getRecipients($message);
-        //dd($recipients);
+
         $message->setBcc([]);
 
         $options = [
@@ -83,18 +83,14 @@ class SparkPostTransport extends Transport
         }
 
         if ($message->getBcc()) {
-            $bcc = array_merge($bcc, array_keys($message->getBcc()));
-            $recipients_bcc = array_map(function ($address) {
-                return ['address' => [ 'email' => $address ,'header_to' => $address] ];
-            }, $bcc);
+            $to = array_merge($bcc, array_keys($message->getBcc()));
         }
 
-        $recipients_to = array_map(function ($address) {
-            return ['address' => [ 'email' => $address] ];
-//            return compact('address');
+        $recipients = array_map(function ($address) {
+            return ['address' => [ 'email' => $address ,'header_to' => $address] ];
         }, $to);
 
-        return (isset($recipients_bcc)) ? $recipients_to + $recipients_bcc : $recipients_to;
+        return $recipients;
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -54,7 +54,7 @@ class SparkPostTransport extends Transport
                 'content' => [
                     'html' => $message->getBody(),
                     'from' => $this->getFrom($message),
-                    'subject' => $message->getSubject()
+                    'subject' => $message->getSubject(),
                 ],
             ],
         ];
@@ -87,24 +87,23 @@ class SparkPostTransport extends Transport
         }
 
         $recipients = array_map(function ($address) {
-            return ['address' => [ 'email' => $address ,'header_to' => $address] ];
+            return ['address' => [ 'email' => $address ,'header_to' => $address]];
         }, $to);
 
         return $recipients;
     }
 
     /**
-     * Get From in a format needed by SparkPost
+     * Get From in a format needed by SparkPost.
      *
      * @param Swift_Mime_Message $message
      * @return array
      */
     protected function getFrom(Swift_Mime_Message $message)
     {
-
         $from = array_map(function ($email, $name) {
             return [ 'name' => $name, 'email' => $email ];
-        }, array_keys($message->getFrom()), $message->getFrom() );
+        }, array_keys($message->getFrom()), $message->getFrom());
 
         return $from[0];
     }

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -42,7 +42,7 @@ class SparkPostTransport extends Transport
         $this->beforeSendPerformed($message);
 
         $recipients = $this->getRecipients($message);
-
+        //dd($recipients);
         $message->setBcc([]);
 
         $options = [
@@ -52,7 +52,9 @@ class SparkPostTransport extends Transport
             'json' => [
                 'recipients' => $recipients,
                 'content' => [
-                    'email_rfc822' => $message->toString(),
+                    'html' => $message->getBody(),
+                    'from' => $this->getFrom($message),
+                    'subject' => $message->getSubject()
                 ],
             ],
         ];
@@ -70,7 +72,7 @@ class SparkPostTransport extends Transport
      */
     protected function getRecipients(Swift_Mime_Message $message)
     {
-        $to = [];
+        $to = $bcc = [];
 
         if ($message->getTo()) {
             $to = array_merge($to, array_keys($message->getTo()));
@@ -81,14 +83,34 @@ class SparkPostTransport extends Transport
         }
 
         if ($message->getBcc()) {
-            $to = array_merge($to, array_keys($message->getBcc()));
+            $bcc = array_merge($bcc, array_keys($message->getBcc()));
+            $recipients_bcc = array_map(function ($address) {
+                return ['address' => [ 'email' => $address ,'header_to' => $address] ];
+            }, $bcc);
         }
 
-        $recipients = array_map(function ($address) {
-            return compact('address');
+        $recipients_to = array_map(function ($address) {
+            return ['address' => [ 'email' => $address] ];
+//            return compact('address');
         }, $to);
 
-        return $recipients;
+        return (isset($recipients_bcc)) ? $recipients_to + $recipients_bcc : $recipients_to;
+    }
+
+    /**
+     * Get From in a format needed by SparkPost
+     *
+     * @param Swift_Mime_Message $message
+     * @return array
+     */
+    protected function getFrom(Swift_Mime_Message $message)
+    {
+
+        $from = array_map(function ($email, $name) {
+            return [ 'name' => $name, 'email' => $email ];
+        }, array_keys($message->getFrom()), $message->getFrom() );
+
+        return $from[0];
     }
 
     /**


### PR DESCRIPTION
I found that when sending to multiple email addresses would result to all addresses displaying in the "to" field of the email. This did not happen with Mandrill. After reading the SparkPost Docs, the use of the BCC field is the only way to hide email addresses, but the current implementation would not allow to set the "header_to" option on the recipients because of the usage of the "email_rfc822" for the content.  This is my first contribution so I understand my code might not be the best so bear with me, any suggestions/comments appreciated.
