### PR TITLE
Redis cache: transactional mode in putMany()

### DIFF
--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -149,7 +149,7 @@ class MemcachedStore extends TaggableStore implements Store
      */
     public function forever($key, $value)
     {
-        $this->put($key, $value, 0);
+        $this->memcached->set($this->prefix.$key, $value);
     }
 
     /**

--- a/src/Illuminate/Cache/MemcachedStore.php
+++ b/src/Illuminate/Cache/MemcachedStore.php
@@ -82,6 +82,7 @@ class MemcachedStore extends TaggableStore implements Store
      */
     public function put($key, $value, $minutes)
     {
+        $minutes = max(1, $minutes);
         $this->memcached->set($this->prefix.$key, $value, $minutes * 60);
     }
 
@@ -99,6 +100,8 @@ class MemcachedStore extends TaggableStore implements Store
         foreach ($values as $key => $value) {
             $prefixedValues[$this->prefix.$key] = $value;
         }
+
+        $minutes = max(1, $minutes);
 
         $this->memcached->setMulti($prefixedValues, $minutes * 60);
     }

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -107,7 +107,7 @@ class RedisStore extends TaggableStore implements Store
      */
     public function putMany(array $values, $minutes)
     {
-        $this->connection()->multi();
+        $this->connection()->multi(\Redis::PIPELINE);
 
         foreach ($values as $key => $value) {
             $this->put($key, $value, $minutes);


### PR DESCRIPTION
The `Redis::PIPELINE` mode of transaction is transmitted faster to the server.

https://github.com/phpredis/phpredis#multi-exec-discard
