### PR TITLE
Redis cache: transactional mode in putMany()

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -107,7 +107,7 @@ class RedisStore extends TaggableStore implements Store
      */
     public function putMany(array $values, $minutes)
     {
-        $this->connection()->multi();
+        $this->connection()->multi(\Redis::PIPELINE);
 
         foreach ($values as $key => $value) {
             $this->put($key, $value, $minutes);


### PR DESCRIPTION
The `Redis::PIPELINE` mode of transaction is transmitted faster to the server.

https://github.com/phpredis/phpredis#multi-exec-discard
