### PR TITLE
Add PHPDocs that properly describe Mailer send & sendSwiftMessage return types

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -144,7 +144,7 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  string|array  $view
      * @param  array  $data
      * @param  \Closure|string  $callback
-     * @return void
+     * @return int The number of successful recipients. Can be 0 which indicates failure
      */
     public function send($view, array $data, $callback)
     {
@@ -375,7 +375,7 @@ class Mailer implements MailerContract, MailQueueContract
      * Send a Swift Message instance.
      *
      * @param  \Swift_Message  $message
-     * @return void
+     * @return int The number of successful recipients. Can be 0 which indicates failure
      */
     protected function sendSwiftMessage($message)
     {


### PR DESCRIPTION
It currently says that those both methods return void. This is not true, as the underlying library SwiftMailer that Illuminate\Mail uses returns a number of successful recipients. 
Without this being documented (let alone confusion) IDEs like PHPStorm complain that void method result is used.
