### PR TITLE
[5.2] Use DIRECTORY_SEPARATOR to create migrations path

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/BaseCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/BaseCommand.php
@@ -13,6 +13,6 @@ class BaseCommand extends Command
      */
     protected function getMigrationPath()
     {
-        return $this->laravel->databasePath().'/migrations';
+        return $this->laravel->databasePath().DIRECTORY_SEPARATOR.'migrations';
     }
 }


### PR DESCRIPTION
I believe it should be changed also in many other places but I've changed it only in this place for now.

The problem:

``` php
$path = $this->getMigrationPath() 

if ($path == database_path('migrations'))
```

On Windows this could will evaluate to false, because `getMigrationPath()` function is using now `/` as separator but on Windows `database_path` method will use DIRECTORY_SEPARATOR what is `\` for Windows and it might cause unexpected behaviour for users launching code on Windows.

I've found this issue today when my colleagues tried to launch code on Windows whereas other developer run it in native Linux or use Homestead so this problem was not experienced by others.
