### PR TITLE
[5.2] Fix numeric array index causing valid validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2428,7 +2428,7 @@ class Validator implements ValidatorContract
      */
     public function attributes()
     {
-        return array_merge($this->data, $this->files);
+        return $this->data + $this->files;
     }
 
     /**
@@ -2816,7 +2816,7 @@ class Validator implements ValidatorContract
 
         $rules = $this->explodeRules($this->initialRules);
 
-        $this->rules = array_merge($this->rules, $rules);
+        $this->rules = $this->rules + $rules;
 
         return $this;
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -892,6 +892,9 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
 
         $v = new Validator($trans, ['foo' => '1'], ['foo' => 'Integer']);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['1234' => 'asdad'], ['1234' => 'Integer']);
+        $this->assertFalse($v->passes());
     }
 
     public function testValidateInt()


### PR DESCRIPTION
When validating data when using an ID number for the array key in a post request, for example. The use of `array_merge` would cause the numbers to start from `0` rather than the ID number for the item.
