### PR TITLE
[5.2] Decode app key if it is encoded with base64

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -4,6 +4,7 @@ namespace Illuminate\Auth\Passwords;
 
 use InvalidArgumentException;
 use Illuminate\Contracts\Auth\PasswordBrokerFactory as FactoryContract;
+use Illuminate\Support\Str;
 
 class PasswordBrokerManager implements FactoryContract
 {
@@ -82,10 +83,15 @@ class PasswordBrokerManager implements FactoryContract
      */
     protected function createTokenRepository(array $config)
     {
+        $hashKey = $this->app['config']['app.key'];
+        if (Str::startsWith($hashKey, 'base64:')) {
+            $hashKey = base64_decode(substr($hashKey, 7));
+        }
+
         return new DatabaseTokenRepository(
             $this->app['db']->connection(),
             $config['table'],
-            $this->app['config']['app.key'],
+            $hashKey,
             $config['expire']
         );
     }


### PR DESCRIPTION
App key can be encoded in base64 in that case it should be decoded
before using it as hash key to create password reset token.

Fix #13269
