### PR TITLE
[5.2] Add validatedOnly() method to FormRequest

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -210,6 +210,18 @@ class FormRequest extends Request implements ValidatesWhenResolved
     }
 
     /**
+     * Return only those items that were registered in rules method.
+     *
+     * @return array
+     */
+    public function validatedOnly()
+    {
+        $rules = $this->container->call([$this, 'rules']);
+
+        return $this->only(array_keys($rules));
+    }
+
+    /**
      * Set custom messages for validator errors.
      *
      * @return array

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -76,6 +76,22 @@ class FoundationFormRequestTest extends PHPUnit_Framework_TestCase
 
         $request->response(['errors']);
     }
+
+    public function testValidatedOnlyMethod()
+    {
+        $request = FoundationTestFormRequestStub::create('/', 'GET', ['name' => 'abigail', 'foo' => 'bar']);
+        $request->setContainer($container = new Container);
+        $factory = m::mock('Illuminate\Validation\Factory');
+        $factory->shouldReceive('make')->once()->with(['name' => 'abigail', 'foo' => 'bar'], ['name' => 'required'], [], [])->andReturn(
+            $validator = m::mock('Illuminate\Validation\Validator')
+        );
+        $container->instance('Illuminate\Contracts\Validation\Factory', $factory);
+        $validator->shouldReceive('passes')->once()->andReturn(true);
+
+        $request->validate($factory);
+
+        $this->assertEquals(['name' => 'abigail'], $request->validatedOnly());
+    }
 }
 
 class FoundationTestFormRequestStub extends Illuminate\Foundation\Http\FormRequest


### PR DESCRIPTION
Adds method to retrieve from `FormRequest` only those items that were registered in `rules()` method. It saves from duplications when using `$request->only()` method in your controller.
