### PR TITLE
[5.3] Type strict validation and adding a "Nullable" modifier

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -163,7 +163,6 @@ class Validator implements ValidatorContract
     protected $implicitRules = [
         'Required', 'Filled', 'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
         'RequiredIf', 'RequiredUnless', 'Accepted', 'Present',
-        // 'Array', 'Boolean', 'Integer', 'Numeric', 'String',
     ];
 
     /**
@@ -551,6 +550,7 @@ class Validator implements ValidatorContract
     {
         return $this->presentOrRuleIsImplicit($rule, $attribute, $value) &&
                $this->passesOptionalCheck($attribute) &&
+               $this->failsNullableCheck($attribute, $value) &&
                $this->hasNotFailedPreviousRuleIfPresenceRule($rule, $attribute);
     }
 
@@ -564,7 +564,7 @@ class Validator implements ValidatorContract
      */
     protected function presentOrRuleIsImplicit($rule, $attribute, $value)
     {
-        return $this->validateRequired($attribute, $value) || $this->isImplicit($rule);
+        return $this->validatePresent($attribute, $value) || $this->isImplicit($rule);
     }
 
     /**
@@ -579,6 +579,22 @@ class Validator implements ValidatorContract
             return array_key_exists($attribute, Arr::dot($this->data))
                 || in_array($attribute, array_keys($this->data))
                 || array_key_exists($attribute, $this->files);
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if the attribute fails the nullable check.
+     *
+     * @param  string  $rule
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function failsNullableCheck($attribute, $value)
+    {
+        if ($this->hasRule($attribute, ['Nullable'])) {
+            return ! is_null($value);
         }
 
         return true;
@@ -655,6 +671,18 @@ class Validator implements ValidatorContract
     }
 
     /**
+     * "Indicate" validation should pass if value is null.
+     *
+     * Always returns true, just lets us put "nullable" in rules.
+     *
+     * @return bool
+     */
+    protected function validateNullable()
+    {
+        return true;
+    }
+
+    /**
      * "Break" on first validation fail.
      *
      * Always returns true, just lets us put "bail" in rules.
@@ -712,7 +740,7 @@ class Validator implements ValidatorContract
      */
     protected function validatePresent($attribute, $value)
     {
-        return Arr::has($this->data, $attribute);
+        return Arr::has(array_merge($this->data, $this->files), $attribute);
     }
 
     /**
@@ -992,11 +1020,7 @@ class Validator implements ValidatorContract
      */
     protected function validateArray($attribute, $value)
     {
-        if (! $this->hasAttribute($attribute)) {
-            return true;
-        }
-
-        return is_null($value) || is_array($value);
+        return is_array($value);
     }
 
     /**
@@ -1008,13 +1032,9 @@ class Validator implements ValidatorContract
      */
     protected function validateBoolean($attribute, $value)
     {
-        if (! $this->hasAttribute($attribute)) {
-            return true;
-        }
-
         $acceptable = [true, false, 0, 1, '0', '1'];
 
-        return is_null($value) || in_array($value, $acceptable, true);
+        return in_array($value, $acceptable, true);
     }
 
     /**
@@ -1026,11 +1046,7 @@ class Validator implements ValidatorContract
      */
     protected function validateInteger($attribute, $value)
     {
-        if (! $this->hasAttribute($attribute)) {
-            return true;
-        }
-
-        return is_null($value) || filter_var($value, FILTER_VALIDATE_INT) !== false;
+        return filter_var($value, FILTER_VALIDATE_INT) !== false;
     }
 
     /**
@@ -1042,11 +1058,7 @@ class Validator implements ValidatorContract
      */
     protected function validateNumeric($attribute, $value)
     {
-        if (! $this->hasAttribute($attribute)) {
-            return true;
-        }
-
-        return is_null($value) || is_numeric($value);
+        return is_numeric($value);
     }
 
     /**
@@ -1058,11 +1070,7 @@ class Validator implements ValidatorContract
      */
     protected function validateString($attribute, $value)
     {
-        if (! $this->hasAttribute($attribute)) {
-            return true;
-        }
-
-        return is_null($value) || is_string($value);
+        return is_string($value);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -115,6 +115,54 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testEmptyExistingAttributesAreValidated()
+    {
+        $trans = $this->getRealTranslator();
+
+        $v = new Validator($trans, ['x' => ''], ['x' => 'array']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => ''], ['x' => 'boolean']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => ''], ['x' => 'numeric']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => ''], ['x' => 'integer']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => ''], ['x' => 'string']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => null], ['x' => 'string']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, [], ['x' => 'string', 'y' => 'numeric', 'z' => 'integer', 'a' => 'boolean', 'b' => 'array']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => []], ['x' => 'string']);
+        $this->assertTrue($v->fails());
+    }
+
+    public function testNullable()
+    {
+        $trans = $this->getRealTranslator();
+
+        $v = new Validator($trans, [
+            'x' => null, 'y' => null, 'z' => null, 'a' => null, 'b' => null,
+        ], [
+            'x' => 'string|nullable', 'y' => 'integer|nullable', 'z' => 'numeric|nullable', 'a' => 'array|nullable', 'b' => 'bool|nullable',
+        ]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, [
+            'x' => null, 'y' => null, 'z' => null, 'a' => null, 'b' => null,
+        ], [
+            'x' => 'string', 'y' => 'integer', 'z' => 'numeric', 'a' => 'array', 'b' => 'bool',
+        ]);
+        $this->assertTrue($v->fails());
+    }
+
     public function testProperLanguageLineIsSet()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
Currently these cases will pass the validation:

``` php
Validator::make(['roles' => ''], ['roles' => 'array']); // same for numeric, integer, boolean

Validator::make(['price' => ''], ['price' => 'numeric|min:2']);

Validator::make(['price' => []], ['price' => 'numeric']);

Validator::make(['name' => null], ['name' => 'string']);
```

I understand that there's a debate going on around this matter as in here https://github.com/laravel/framework/issues/11452#, while `null` and empty string is not an integer for example, some people believe that validation should pass in such case.

In this PR I made type validation strict, so that an integer only accepts an integer, not `null` and not an empty string (same for numeric, boolean, array, and string in case of `null`), however I also introduced a `nullable` modifier.

``` php
Validator::make(['middle_name' => null], ['middle_name' => 'string']); //fails

Validator::make(['middle_name' => null], ['middle_name' => 'string|nullable']); //passes
```

So for those who use nullable/string, nullable/integer, nullable/\* fields and expect a type check to pass on null they may use the `nullable` modifier.

For those expecting an empty string to pass validation I think they need to `array_filter` or we shall add a modifier for that, but I believe it makes sense to fail when validating an empty string is an integer.
