### PR TITLE
[5.2] reset the attempts on lockout to avoid race condition re-lockout

### DIFF
--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -40,6 +40,8 @@ class RateLimiter
 
         if ($this->attempts($key) > $maxAttempts) {
             $this->cache->add($key.':lockout', time() + ($decayMinutes * 60), $decayMinutes);
+            
+            $this->resetAttempts($key);
 
             return true;
         }
@@ -71,6 +73,17 @@ class RateLimiter
     {
         return $this->cache->get($key, 0);
     }
+    
+    /**
+     * Reset the number of attempts for the given key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function resetAttempts($key)
+    {
+        return $this->cache->forget($key;
+    }
 
     /**
      * Get the number of retries left for the given key.
@@ -94,7 +107,7 @@ class RateLimiter
      */
     public function clear($key)
     {
-        $this->cache->forget($key);
+        $this->resetAttempts($key);
 
         $this->cache->forget($key.':lockout');
     }

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -82,7 +82,7 @@ class RateLimiter
      */
     public function resetAttempts($key)
     {
-        return $this->cache->forget($key;
+        return $this->cache->forget($key);
     }
 
     /**

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -40,7 +40,7 @@ class RateLimiter
 
         if ($this->attempts($key) > $maxAttempts) {
             $this->cache->add($key.':lockout', time() + ($decayMinutes * 60), $decayMinutes);
-            
+
             $this->resetAttempts($key);
 
             return true;
@@ -73,7 +73,7 @@ class RateLimiter
     {
         return $this->cache->get($key, 0);
     }
-    
+
     /**
      * Reset the number of attempts for the given key.
      *

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -27,6 +27,7 @@ class CacheRateLimiterTest extends PHPUnit_Framework_TestCase
         $cache->shouldReceive('get')->once()->with('key', 0)->andReturn(10);
         $cache->shouldReceive('has')->once()->with('key:lockout')->andReturn(false);
         $cache->shouldReceive('add')->once()->with('key:lockout', m::type('int'), 1);
+        $cache->shouldReceive('forget')->once()->with('key');
         $rateLimiter = new RateLimiter($cache);
 
         $this->assertTrue($rateLimiter->tooManyAttempts('key', 1, 1));


### PR DESCRIPTION
As described in [this comment](https://github.com/laravel/framework/pull/12037#issuecomment-213852015) on the previous #12037 PR... There can be a race condition where the `:lockout` key expires before the attempts are reset causing the user to be instantly locked out again. This PR clears the attempts on lockout as they aren't needed anymore and should solve the race condition.
