### PR TITLE
[5.2] Improved exception output for migrations and use DB Transactions

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -1206,4 +1206,16 @@ class Connection implements ConnectionInterface
 
         return $grammar;
     }
+
+    /**
+     * Some database such as MySQL do not "entirely" support transactions
+     * even though it has some support. For example, creating a table and
+     * rolling it back does not work in MySQL.
+     *
+     * @return bool
+     */
+    public function hasFullTransactionSupport()
+    {
+        return false;
+    }
 }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -109,7 +109,7 @@ class Migrator
         $batch = $this->repository->getNextBatchNumber();
 
         $pretend = Arr::get($options, 'pretend', false);
-        $step    = Arr::get($options, 'step', false);
+        $step = Arr::get($options, 'step', false);
 
         // Once we have the array of migrations, we will spin through them and run the
         // migrations "up" so the changes are made to the databases. We'll then log
@@ -120,11 +120,11 @@ class Migrator
             $success = $this->runUp($file, $batch, $pretend);
 
             if ($success) {
-              DB::commit();
+                DB::commit();
             } else {
-              // If the migration was not successful, back out
-              DB::rollback();
-              break;
+                // If the migration was not successful, back out
+                DB::rollback();
+                break;
             }
 
             // If we are stepping through the migrations, then we will increment the
@@ -156,56 +156,56 @@ class Migrator
         }
 
         try {
-          $migration->up();
+            $migration->up();
 
-          // Once we have run a migrations class, we will log that it was run in this
-          // repository so that we don't try to run it next time we do a migration
-          // in the application. A migration repository keeps the migrate order.
-          $this->repository->log($file, $batch);
+            // Once we have run a migrations class, we will log that it was run in this
+            // repository so that we don't try to run it next time we do a migration
+            // in the application. A migration repository keeps the migrate order.
+            $this->repository->log($file, $batch);
 
-          $this->note("<info>Migrated:</info> $file");
+            $this->note("<info>Migrated:</info> $file");
 
-          return true;
+            return true;
         } catch (Exception $e) {
-          $this->handleException($file, $e);
-          return false;
+            $this->handleException($file, $e);
+            return false;
         }
     }
 
     private function handleException($file, $exception)
     {
-      $trace      = $exception->getTrace();
-      $offsetFile = strlen(base_path()) + 1;
+        $trace      = $exception->getTrace();
+        $offsetFile = strlen(base_path()) + 1;
 
-      // We'll switch the order of the trace so we start with the migration
-      // file rather than end with it. After all, the migration file is where
-      // the error most likely occurred.
-      $ourTrace = [];
-      foreach($trace as $point) {
-        array_unshift($ourTrace, [
-          'file' => substr($point['file'], $offsetFile),
-          'line' => $point['line']
-        ]);
+        // We'll switch the order of the trace so we start with the migration
+        // file rather than end with it. After all, the migration file is where
+        // the error most likely occurred.
+        $ourTrace = [];
+        foreach($trace as $point) {
+            array_unshift($ourTrace, [
+                'file' => substr($point['file'], $offsetFile),
+                'line' => $point['line']
+            ]);
 
-        // We are not interested in the rest of the trace, only the migration
-        // and maybe the files that it dealt with
-        if (basename($point['file']) === "{$file}.php") {
-          break;
+            // We are not interested in the rest of the trace, only the migration
+            // and maybe the files that it dealt with
+            if (basename($point['file']) === "{$file}.php") {
+                break;
+            }
         }
-      }
 
-      // Pretty print
-      $message = "<info>An error occurred while running migrations:</info>\n\n";
-      $message .= "<error>" . $exception->getMessage() . "</error>\n\n";
+        // Pretty print
+        $message = "<info>An error occurred while running migrations:</info>\n\n";
+        $message .= "<error>" . $exception->getMessage() . "</error>\n\n";
 
-      foreach($ourTrace as $point) {
-        $line = str_pad($point['line'], 5);
-        $file = $point['file'];
+        foreach($ourTrace as $point) {
+            $line = str_pad($point['line'], 5);
+            $file = $point['file'];
 
-        $message .= "  <comment>Line:</comment> {$line} <comment>File:</comment> {$file}\n";
-      }
+            $message .= "  <comment>Line:</comment> {$line} <comment>File:</comment> {$file}\n";
+        }
 
-      $this->note($message);
+        $this->note($message);
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -352,6 +352,8 @@ class Migrator
 
             $this->note("<info>{$name}:</info> {$query['query']}");
         }
+
+        return true;
     }
 
     /**

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -48,4 +48,9 @@ class PostgresConnection extends Connection
     {
         return new DoctrineDriver;
     }
+
+    public function hasFullTransactionSupport()
+    {
+        return true;
+    }
 }

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -48,4 +48,9 @@ class SQLiteConnection extends Connection
     {
         return new DoctrineDriver;
     }
+
+    public function hasFullTransactionSupport()
+    {
+        return true;
+    }
 }

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -92,4 +92,9 @@ class SqlServerConnection extends Connection
     {
         return new DoctrineDriver;
     }
+
+    public function hasFullTransactionSupport()
+    {
+        return true;
+    }
 }

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -32,7 +32,11 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase
             '1_foo',
         ]);
 
+        $connectionMock = m::mock('stdClass');
+        $connectionMock->shouldReceive('hasFullTransactionSupport')->andReturn(true);
+
         // Each migration should be done within a transaction
+        DB::shouldReceive('connection')->andReturn($connectionMock);
         DB::shouldReceive('beginTransaction')->times(2);
         DB::shouldReceive('commit')->times(2);
 

--- a/tests/Database/DatabaseMigratorTest.php
+++ b/tests/Database/DatabaseMigratorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Support\Facades\DB;
 
 class DatabaseMigratorTest extends PHPUnit_Framework_TestCase
 {
@@ -16,6 +17,7 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase
             $resolver = m::mock('Illuminate\Database\ConnectionResolverInterface'),
             m::mock('Illuminate\Filesystem\Filesystem'),
         ]);
+
         $migrator->getFilesystem()->shouldReceive('glob')->once()->with(__DIR__.'/*_*.php')->andReturn([
             __DIR__.'/2_bar.php',
             __DIR__.'/1_foo.php',
@@ -29,6 +31,11 @@ class DatabaseMigratorTest extends PHPUnit_Framework_TestCase
         $migrator->getRepository()->shouldReceive('getRan')->once()->andReturn([
             '1_foo',
         ]);
+
+        // Each migration should be done within a transaction
+        DB::shouldReceive('beginTransaction')->times(2);
+        DB::shouldReceive('commit')->times(2);
+
         $migrator->getRepository()->shouldReceive('getNextBatchNumber')->once()->andReturn(1);
         $migrator->getRepository()->shouldReceive('log')->once()->with('2_bar', 1);
         $migrator->getRepository()->shouldReceive('log')->once()->with('3_baz', 1);


### PR DESCRIPTION
You would think migrations would always work, but sometimes developers do not use them properly. It becomes very difficult to track down where things went wrong when your migration folder is huge.

This PR does two things:
1) If a migration fails half way through, a DB transaction rolls it back
2) Shows a relevant error with a trace showing the migration that is messed up

![migrations](https://cloud.githubusercontent.com/assets/7494573/14765149/7325275c-09a2-11e6-8f1e-5ff2d0752923.png)
