### PR TITLE
[5.2] Add helper to check decoded json response

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
@@ -337,6 +338,19 @@ trait MakesHttpRequests
     protected function seeJsonSubset(array $data)
     {
         $this->assertArraySubset($data, $this->decodeResponseJson());
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response can pass the test of closure.
+     *
+     * @param  \Closure  $closure
+     * @return $this
+     */
+    public function seeDecodedJson(Closure $closure)
+    {
+        call_user_func($closure, $this->decodeResponseJson());
 
         return $this;
     }

--- a/tests/Foundation/FoundationCrawlerTraitJsonTest.php
+++ b/tests/Foundation/FoundationCrawlerTraitJsonTest.php
@@ -26,6 +26,17 @@ class FoundationCrawlerTraitJsonTest extends PHPUnit_Framework_TestCase
         $this->response = new Illuminate\Http\Response(new JsonSerializableSingleResourceStub);
         $this->seeJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
     }
+
+    public function testSeeDecodedJson()
+    {
+        $this->response = new Illuminate\Http\Response(new JsonSerializableMixedResourcesStub);
+
+        $this->seeDecodedJson(function ($json) {
+            $this->assertEquals((new JsonSerializableMixedResourcesStub)->jsonSerialize(), $json);
+
+            $this->assertCount(3, $json['bars']);
+        });
+    }
 }
 
 class JsonSerializableMixedResourcesStub implements JsonSerializable


### PR DESCRIPTION
I call an api and return a json response.
But sometimes I just want to test whether its count matches, or just want to check some relationship between fields.

It could be better if we can manipulate test directly on the response json.

And actually, one could add such helper to their `tests/TestCase.php`, I think it can be generalized here.
