### PR TITLE
[5.1] Quoting the string given to Schema default() modifier

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -249,7 +249,7 @@ abstract class Grammar extends BaseGrammar
             return "'".(int) $value."'";
         }
 
-        return "'".strval($value)."'";
+        return "'".addslashes(strval($value))."'";
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/13282
