### PR TITLE
[5.2] Removed unused code from the encrypter

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Encryption;
 
 use RuntimeException;
-use Illuminate\Support\Str;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Contracts\Encryption\EncryptException;
 use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
@@ -29,10 +28,6 @@ class Encrypter extends BaseEncrypter implements EncrypterContract
     public function __construct($key, $cipher = 'AES-128-CBC')
     {
         $key = (string) $key;
-
-        if (Str::startsWith($key, 'base64:')) {
-            $key = base64_decode(substr($key, 7));
-        }
 
         if (static::supported($key, $cipher)) {
             $this->key = $key;

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Str;
 use Illuminate\Encryption\Encrypter;
+use Illuminate\Encryption\McryptEncrypter;
 
 class EncrypterTest extends PHPUnit_Framework_TestCase
 {
@@ -15,7 +16,7 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
 
     public function testEncryptionUsingBase64EncodedKey()
     {
-        $e = new Encrypter('base64:'.base64_encode(random_bytes(16)));
+        $e = new Encrypter(random_bytes(16));
         $encrypted = $e->encrypt('foo');
         $this->assertNotEquals('foo', $encrypted);
         $this->assertEquals('foo', $e->decrypt($encrypted));
@@ -28,7 +29,7 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
         $this->assertNotEquals('bar', $encrypted);
         $this->assertEquals('bar', $e->decrypt($encrypted));
 
-        $e = new Encrypter('base64:'.base64_encode(random_bytes(32)), 'AES-256-CBC');
+        $e = new Encrypter(random_bytes(32), 'AES-256-CBC');
         $encrypted = $e->encrypt('foo');
         $this->assertNotEquals('foo', $encrypted);
         $this->assertEquals('foo', $e->decrypt($encrypted));
@@ -100,9 +101,9 @@ class EncrypterTest extends PHPUnit_Framework_TestCase
         }
 
         $key = Str::random(32);
-        $encrypter = new Illuminate\Encryption\McryptEncrypter($key);
+        $encrypter = new McryptEncrypter($key);
         $encrypted = $encrypter->encrypt('foo');
-        $openSslEncrypter = new Illuminate\Encryption\Encrypter($key, 'AES-256-CBC');
+        $openSslEncrypter = new Encrypter($key, 'AES-256-CBC');
 
         $this->assertEquals('foo', $openSslEncrypter->decrypt($encrypted));
     }


### PR DESCRIPTION
This is already handled by the service provider, and this code is also forgotten from the mcrypt encrypter anyways.
