### PR TITLE
[5.2] Fix double json_encode on pivot model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2867,7 +2867,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $value = $this->fromDateTime($value);
         }
 
-        if ($this->isJsonCastable($key) && ! is_null($value)) {
+        if ($this->isJsonCastable($key) && ! is_null($value) && ! isset($this->parent)) {
             $value = $this->asJson($value);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -48,6 +48,11 @@ class Pivot extends Model
     {
         parent::__construct();
 
+        // We store off the parent instance so we will access the timestamp column names
+        // for the model, since the pivot model timestamps aren't easily configurable
+        // from the developer's point of view. We can use the parents to get these.
+        $this->parent = $parent;
+
         // The pivot model is a "dynamic" model since we will set the tables dynamically
         // for the instance. This allows it work for any intermediate tables for the
         // many to many relationship that are defined by this developer's classes.
@@ -58,11 +63,6 @@ class Pivot extends Model
         $this->forceFill($attributes);
 
         $this->syncOriginal();
-
-        // We store off the parent instance so we will access the timestamp column names
-        // for the model, since the pivot model timestamps aren't easily configurable
-        // from the developer's point of view. We can use the parents to get these.
-        $this->parent = $parent;
 
         $this->exists = $exists;
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -93,6 +93,21 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($pivot->delete());
     }
+
+    public function testJsonIsCastCorrectly()
+    {
+        $parent = m::mock('Illuminate\Database\Eloquent\Model[getConnectionName]');
+        $parent->shouldReceive('getConnectionName')->once()->andReturn('connection');
+
+        $pivot = new DatabaseEloquentPivotTestJsonCastStub($parent, ['data' => '{"foo":"bar"}'], 'table', true);
+
+        $this->assertEquals($pivot->data, ['foo' => 'bar']);
+    }
+}
+
+class DatabaseEloquentPivotTestJsonCastStub  extends Illuminate\Database\Eloquent\Relations\Pivot
+{
+    protected $casts = ['data' => 'array'];
 }
 
 class DatabaseEloquentPivotTestDateStub extends Illuminate\Database\Eloquent\Relations\Pivot

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -105,7 +105,7 @@ class DatabaseEloquentPivotTest extends PHPUnit_Framework_TestCase
     }
 }
 
-class DatabaseEloquentPivotTestJsonCastStub  extends Illuminate\Database\Eloquent\Relations\Pivot
+class DatabaseEloquentPivotTestJsonCastStub extends Illuminate\Database\Eloquent\Relations\Pivot
 {
     protected $casts = ['data' => 'array'];
 }


### PR DESCRIPTION
I'm not 100% sure if this is the best way to fix https://github.com/laravel/framework/issues/10533 but this works and no failing tests.
