### PR TITLE
[5.2] Implement success and error callbacks to Database Connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -479,11 +479,13 @@ class Connection implements ConnectionInterface
      * Execute a Closure within a transaction.
      *
      * @param  \Closure  $callback
+     * @param  callable|null  $success
+     * @param  callable|null  $error
      * @return mixed
      *
      * @throws \Exception|\Throwable
      */
-    public function transaction(Closure $callback)
+    public function transaction(Closure $callback, callable $success = null, callable $error = null)
     {
         $this->beginTransaction();
 
@@ -502,11 +504,23 @@ class Connection implements ConnectionInterface
         catch (Exception $e) {
             $this->rollBack();
 
+            if ($error) {
+                return call_user_func($error, $e, $this);
+            }
+
             throw $e;
         } catch (Throwable $e) {
             $this->rollBack();
 
+            if ($error) {
+                return call_user_func($error, $e, $this);
+            }
+
             throw $e;
+        }
+
+        if ($success) {
+            return call_user_func($success, $result, $this);
         }
 
         return $result;

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -151,6 +151,23 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($mock, $result);
     }
 
+    public function testTransactionMethodSuccessCallback()
+    {
+        $pdo = $this->getMock('DatabaseConnectionTestMockPDO', ['beginTransaction', 'commit']);
+        $mock = $this->getMockConnection([], $pdo);
+        $pdo->expects($this->once())->method('beginTransaction');
+        $pdo->expects($this->once())->method('commit');
+        $result = $mock->transaction(
+            function () {
+                return 'foo';
+            },
+            function ($result) {
+                return $result.'bar';
+            }
+        );
+        $this->assertEquals('foobar', $result);
+    }
+
     public function testTransactionMethodRollsbackAndThrows()
     {
         $pdo = $this->getMock('DatabaseConnectionTestMockPDO', ['beginTransaction', 'commit', 'rollBack']);
@@ -163,6 +180,48 @@ class DatabaseConnectionTest extends PHPUnit_Framework_TestCase
         } catch (Exception $e) {
             $this->assertEquals('foo', $e->getMessage());
         }
+    }
+
+    public function testTransactionMethodErrorCallback()
+    {
+        $pdo = $this->getMock('DatabaseConnectionTestMockPDO', ['beginTransaction', 'commit', 'rollBack']);
+        $mock = $this->getMockConnection([], $pdo);
+        $pdo->expects($this->once())->method('beginTransaction');
+        $pdo->expects($this->once())->method('rollBack');
+        $pdo->expects($this->never())->method('commit');
+
+        $result = $mock->transaction(
+            function () {
+                throw new Exception('foo');
+            },
+            null,
+            function (Exception $e) {
+                return $e;
+            }
+        );
+
+        $this->assertInstanceOf('Exception', $result);
+        $this->assertEquals('foo', $result->getMessage());
+    }
+
+    public function testTransactionMethodErrorExternalCallback()
+    {
+        $pdo = $this->getMock('DatabaseConnectionTestMockPDO', ['beginTransaction', 'commit', 'rollBack']);
+        $mock = $this->getMockConnection([], $pdo);
+        $pdo->expects($this->once())->method('beginTransaction');
+        $pdo->expects($this->once())->method('rollBack');
+        $pdo->expects($this->never())->method('commit');
+
+        $result = $mock->transaction(
+            function () {
+                throw new Exception('foo');
+            },
+            null,
+            DatabaseConnectionExceptionHandler::class.'::handle'
+        );
+
+        $this->assertInstanceOf('Exception', $result);
+        $this->assertEquals('foo', $result->getMessage());
     }
 
     /**
@@ -297,5 +356,13 @@ class DatabaseConnectionTestMockPDO extends PDO
 {
     public function __construct()
     {
+    }
+}
+
+class DatabaseConnectionExceptionHandler
+{
+    public static function handle($e)
+    {
+        return $e;
     }
 }


### PR DESCRIPTION
Allows to pass callbacks to transactions on success and error events.

```
$model->getConnection()->transaction(
    function () { ... },
    function () { doSomeSuccessAction(); },
    static::class.'::handleTransactionError',
);
```
