### PR TITLE
[5.2] Fix sortRecursive method

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -495,6 +495,9 @@ class Arr
             if (is_array($value)) {
                 $value = static::sortRecursive($value);
             }
+            if (is_object($value)) {
+                $value = static::sortRecursive((array) $value);
+            }
         }
 
         if (static::isAssoc($array)) {


### PR DESCRIPTION
I had notice that `sortRecursive` method does not sort `Carbon` objects.
There was a fail when i use `seeJson` phpUnit method to compare `Carbon` fields.
I have added a cast test objects on array elements.
