### PR TITLE
[5.2] Added ability to use custom classes for pivot models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1900,7 +1900,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function newPivot(Model $parent, array $attributes, $table, $exists, $using = null)
     {
-        if($using){
+        if ($using) {
             return new $using($parent, $attributes, $table, $exists);
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1895,10 +1895,15 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  array  $attributes
      * @param  string  $table
      * @param  bool  $exists
+     * @param  string  $using
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
-    public function newPivot(Model $parent, array $attributes, $table, $exists)
+    public function newPivot(Model $parent, array $attributes, $table, $exists, $using = null)
     {
+        if($using){
+            return new $using($parent, $attributes, $table, $exists);
+        }
+
         return new Pivot($parent, $attributes, $table, $exists);
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1895,7 +1895,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  array  $attributes
      * @param  string  $table
      * @param  bool  $exists
-     * @param  string  $using
+     * @param  string|null  $using
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
     public function newPivot(Model $parent, array $attributes, $table, $exists, $using = null)

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -443,12 +443,12 @@ class BelongsToMany extends Relation
     protected function getPivotModelColumns()
     {
         $columns = [];
- 
+
         if ($this->using) {
             $custom_pivot_class = $this->using;
             $columns = $custom_pivot_class::getPivotColumns();
         }
- 
+
         return $columns;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -444,7 +444,7 @@ class BelongsToMany extends Relation
     {
         $columns = [];
  
-        if($this->using){
+        if ($this->using) {
             $custom_pivot_class = $this->using;
             $columns = $custom_pivot_class::getPivotColumns();
         }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -445,8 +445,8 @@ class BelongsToMany extends Relation
         $columns = [];
 
         if ($this->using) {
-            $custom_pivot_class = $this->using;
-            $columns = $custom_pivot_class::getPivotColumns();
+            $customPivotClass = $this->using;
+            $columns = $customPivotClass::getPivotColumns();
         }
 
         return $columns;

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -226,12 +226,12 @@ class BelongsToMany extends Relation
     /**
      * Set a custom pivot model to use.
      *
-     * @param  string  $pivot_model_name
+     * @param  string  $pivotModelName
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
      */
-    public function using($pivot_model_name)
+    public function using($pivotModelName)
     {
-        $this->using = $pivot_model_name;
+        $this->using = $pivotModelName;
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -107,7 +107,7 @@ class Pivot extends Model
     /**
      * Retrieve columns required by custom pivot model.
      *
-     * @return null
+     * @return array
      */
     public static function getPivotColumns(){
         return (new ReflectionClass(static::class))->getDefaultProperties()['include'];

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -109,7 +109,8 @@ class Pivot extends Model
      *
      * @return array
      */
-    public static function getPivotColumns(){
+    public static function getPivotColumns()
+    {
         return (new ReflectionClass(static::class))->getDefaultProperties()['include'];
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -105,6 +105,15 @@ class Pivot extends Model
     }
 
     /**
+     * Retrieve columns required by custom pivot model.
+     *
+     * @return null
+     */
+    public static function getPivotColumns(){
+        return (new ReflectionClass(static::class))->getDefaultProperties()['include'];
+    }
+
+    /**
      * Delete the pivot model record from the database.
      *
      * @return int

--- a/src/Illuminate/Database/Eloquent/Relations/Pivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Pivot.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
+use ReflectionClass;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -36,6 +37,13 @@ class Pivot extends Model
     protected $guarded = [];
 
     /**
+     * The attributes that should be loaded into the pivot model.
+     *
+     * @var array
+     */
+    protected $include = [];
+
+    /**
      * Create a new pivot model instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $parent
@@ -59,6 +67,8 @@ class Pivot extends Model
 
         $this->syncOriginal();
 
+        $this->eagerLoadRelations();
+
         // We store off the parent instance so we will access the timestamp column names
         // for the model, since the pivot model timestamps aren't easily configurable
         // from the developer's point of view. We can use the parents to get these.
@@ -80,6 +90,18 @@ class Pivot extends Model
         $query->where($this->foreignKey, $this->getAttribute($this->foreignKey));
 
         return $query->where($this->otherKey, $this->getAttribute($this->otherKey));
+    }
+
+    /**
+     * Eager load any defined relations.
+     *
+     * @return null
+     */
+    protected function eagerLoadRelations()
+    {
+        foreach ($this->with as $relation) {
+            $this->relations[$relation] = $this->$relation()->getResults();
+        }
     }
 
     /**


### PR DESCRIPTION
There are currently 2 missing features that I think Eloquent's Many-To-Many relationships could benefit from:
1. Custom functionality on the pivot model
2. The ability to define unlimited "Many"s to the relationship (i.e. Site-User-Role would be a Many-To-Many-To-Many)

This PR resolves both issues. You can define custom classes to use for your pivot models. Within the classes you can define the fields to load into your pivot table, you can eager load additional relationships, you can added mutators and accessors, etc, etc.
## Example:

Assuming we have an app that serves up multiple websites. Each site can have multiple users each with their own role. There is a 'sites' table, a 'roles' table, and an 'users' table. These would be connected together with a 'role_site_user' table that contains `id, site_id, user_id, role_id`. You could establish a 3 way Many-To-Many relationship this way:

Sites Model:

``` php
public function users()
{
    return $this->belongsToMany(\App\User::class, 'role_site_user')->using(\App\RoleSiteUser::class);
}
```

app/RoleSiteUser.php

``` php
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;
use Illuminate\Database\Eloquent\Relations\Pivot;

class RoleSiteUser extends Pivot
{
    protected $table = "role_site_user";
    protected $include = [
        'role_id',
        'site_id',
        'user_id'
    ];
    protected $with = [
        'role',
        'site',
        'user',
    ];

    public function role()
    {
        return $this->belongsTo(\App\Role::class);
    }

    public function site()
    {
        return $this->belongsTo(\App\Site::class);
    }

    public function user()
    {
        return $this->belongsTo(\App\User::class);
    }
}
```

Then you can query the role that is assigned to the user for a particular site like so:

``` php
$role = Site::find(1)->users[0]->pivot->role;
```
