### PR TITLE
[5.2] Fix seeAuthenticatedAs

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -50,8 +50,15 @@ trait InteractsWithAuthentication
      */
     public function seeIsAuthenticatedAs($user, $guard = null)
     {
+        $expected = $this->app->make('auth')->guard($guard)->user();
+
+        $this->assertInstanceOf(
+            get_class($expected), $user,
+            'The logged in user is not the same'
+        );
+
         $this->assertSame(
-            $this->app->make('auth')->guard($guard)->user(), $user,
+            $expected->getAuthIdentifier(), $user->getAuthIdentifier(),
             'The logged in user is not the same'
         );
 

--- a/tests/Foundation/FoundationAuthenticationTest.php
+++ b/tests/Foundation/FoundationAuthenticationTest.php
@@ -73,12 +73,20 @@ class FoundationAuthenticationTest extends PHPUnit_Framework_TestCase
 
     public function testSeeIsAuthenticatedAs()
     {
+        $expected = m::mock(Authenticatable::class);
+        $expected->shouldReceive('getAuthIdentifier')
+            ->andReturn('1');
+
         $this->mockGuard()
             ->shouldReceive('user')
             ->once()
-            ->andReturn('Someone');
+            ->andReturn($expected);
 
-        $this->seeIsAuthenticatedAs('Someone');
+        $user = m::mock(Authenticatable::class);
+        $user->shouldReceive('getAuthIdentifier')
+            ->andReturn('1');
+
+        $this->seeIsAuthenticatedAs($user);
     }
 
     protected function setupProvider(array $credentials)


### PR DESCRIPTION
Fix bug when seeAuthenticatedAs is called with a different user object than the user returned by Auth::user() even when they both represent the same user. I attempt to solve this problem comparing through `getAuthIdentifier()` instead of the objects directly.
