### PR TITLE
[5.3] [WIP] Custom Type Casting

### DIFF
--- a/src/Illuminate/Contracts/Database/TypeCaster/Factory.php
+++ b/src/Illuminate/Contracts/Database/TypeCaster/Factory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Contracts\Database\TypeCaster;
+
+interface TypeCaster
+{
+    /**
+     * Register a custom Type Caster extension.
+     *
+     * @param  string  $rule
+     * @param  \Closure|string  $fromDatabase
+     * @param  \Closure|string|null  $toDatabase
+     * @return void
+     */
+    public function extend($rule, $fromDatabase, $toDatabase = null);
+}

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Database\Eloquent\QueueEntityResolver;
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Database\Eloquent\Factory as EloquentFactory;
+use Illuminate\Database\Eloquent\TypeCaster as TypeCasterFactory;
 
 class DatabaseServiceProvider extends ServiceProvider
 {
@@ -36,6 +37,8 @@ class DatabaseServiceProvider extends ServiceProvider
         $this->registerEloquentFactory();
 
         $this->registerQueueableEntityResolver();
+
+        $this->registerTypeCasterFactory();
 
         // The connection factory is used to create the actual connection instances on
         // the database. We will inject the factory into the manager so that it may
@@ -85,4 +88,29 @@ class DatabaseServiceProvider extends ServiceProvider
             return new QueueEntityResolver;
         });
     }
+
+    /**
+     * Register the Type Caster factory.
+     *
+     * @return void
+     */
+    protected function registerTypeCasterFactory()
+    {
+        $this->app->singleton('typecaster', function ($app) {
+            return new TypeCasterFactory($app);
+        });
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [
+            'typecaster',
+        ];
+    }
 }
+

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2965,18 +2965,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         }
 
         $reflectionClass = new \ReflectionClass($cast);
+
         return $reflectionClass->newInstanceArgs([$value] + $this->castParameters($key));
     }
 
     /**
      * Has a custom cast type been defined for a model attribute and does it exist.
      *
-     * @param  string  $key
-     * @return boolean
+     * @param  string $key
+     * @return bool
      */
     protected function castExists($key)
     {
-        if (!$this->castClass($key)) {
+        if (! $this->castClass($key)) {
             return false;
         }
 
@@ -2984,8 +2985,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Return the fully qualified custom class
-     * 
+     * Return the fully qualified custom class.
+     *
      * @param  string $key
      * @return string
      */
@@ -3003,9 +3004,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Return an array of custom cast parameters
-     * 
-     * @param  string $key 
+     * Return an array of custom cast parameters.
+     *
+     * @param  string $key
      * @return array
      */
     protected function castParameters($key)

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3020,7 +3020,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         return [];
     }
 
-
     /**
      * Prepare a date for array / JSON serialization.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2817,7 +2817,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if ($this->castExists($key)) {
             return $this->asCustom($key, $value);
         }
-        
+
         return $value;
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2771,10 +2771,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function getCastType($key)
     {
-        if ($this->castExists($key)) {
-            return 'custom';
-        }
-
         return trim(strtolower($this->getCasts()[$key]));
     }
 
@@ -2816,11 +2812,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimeStamp($value);
-            case 'custom':
-                return $this->asCustom($key, $value);
-            default:
-                return $value;
         }
+
+        if ($this->castExists($key)) {
+            return $this->asCustom($key, $value);
+        }
+        
+        return $value;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/TypeCaster/Factory.php
+++ b/src/Illuminate/Database/Eloquent/TypeCaster/Factory.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\TypeCaster;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Database\TypeCaster\Factory as FactoryContract;
+
+class Factory implements FactoryContract
+{
+    /**
+     * The IoC container instance.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    protected $container;
+
+    /**
+     * All of the custom Type Caster extensions.
+     *
+     * @var array
+     */
+    protected $extensions = [];
+
+    /**
+     * Create a new Type Caster factory instance.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return void
+     */
+    public function __construct(Container $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Create a new Type Caster instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model $model
+     * @return \Illuminate\Database\Eloquent\TypeCaster\TypeCaster
+     */
+    public function make(Model $model)
+    {
+        $typecaster = new TypeCaster($model);
+
+        // Next we'll set the IoC container instance of the type caster, which is used 
+        // to resolve out class based type casting extensions. If it is not set then 
+        // these extension types wont be possible on these type caster instances.
+        if (! is_null($this->container)) {
+            $typecaster->setContainer($this->container);
+        }
+
+        $typecaster->addExtensions($this->extensions);
+
+        return $typecaster;
+    }
+
+    /**
+     * Register a custom Type Caster extension.
+     *
+     * @param  string  $rule
+     * @param  \Closure|string  $fromDatabase
+     * @param  \Closure|string|null  $toDatabase
+     * @return void
+     */
+    public function extend($rule, $fromDatabase, $toDatabase = null)
+    {
+        $this->extensions[$rule] = [
+            'from' => $fromDatabase,
+            'to' => $toDatabase,
+        ];
+    }
+}

--- a/src/Illuminate/Database/Eloquent/TypeCaster/TypeCaster.php
+++ b/src/Illuminate/Database/Eloquent/TypeCaster/TypeCaster.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\TypeCaster;
+
+use Str;
+use Closure;
+use BadMethodCallException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Container\Container;
+
+class TypeCaster
+{
+    /**
+     * The container instance.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    protected $container;
+
+    /**
+     * The Model to perform Type Casting on.
+     *
+     * @var array
+     */
+    protected $model;
+
+    /**
+     * All of the custom Type Casting extensions.
+     *
+     * @var array
+     */
+    protected $extensions = [];
+
+    /**
+     * Create a new Type Caster instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function __construct(Model $data)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Run the Type Caster's rule against an attribute.
+     *
+     * @return void
+     */
+    public function cast()
+    {
+        
+    }
+
+    /**
+     * Determine if an cast has been set on an attribute.
+     *
+     * @param  string  $attribute
+     * @return bool
+     */
+    public function hasCast($attribute)
+    {
+        return ! is_null($this->getCast($attribute));
+    }
+
+    /**
+     * Get a cast type and its parameters for a given attribute.
+     *
+     * @param  string  $attribute
+     * @return array|null
+     */
+    protected function getCast($attribute)
+    {
+        
+    }
+
+    /**
+     * Get the array of the custom Type Caster extensions.
+     *
+     * @return array
+     */
+    public function getExtensions()
+    {
+        return $this->extensions;
+    }
+
+    /**
+     * Register an array of custom Type Caster extensions.
+     *
+     * @param  array  $extensions
+     * @return void
+     */
+    public function addExtensions(array $extensions)
+    {
+        if ($extensions) {
+            $keys = array_map('\Illuminate\Support\Str::snake', array_keys($extensions));
+
+            $extensions = array_combine($keys, array_values($extensions));
+        }
+
+        $this->extensions = array_merge($this->extensions, $extensions);
+    }
+
+    /**
+     * Register a custom Type Caster extension.
+     *
+     * @param  string  $rule
+     * @param  \Closure|string  $extension
+     * @return void
+     */
+    public function addExtension($rule, $extension)
+    {
+        $this->extensions[Str::snake($rule)] = $extension;
+    }
+
+    /**
+     * Set the IoC container instance.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return void
+     */
+    public function setContainer(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Call a custom validator extension.
+     *
+     * @param  string  $rule
+     * @param  array   $parameters
+     * @return bool|null
+     */
+    protected function callExtension($rule, $parameters)
+    {
+        $callback = $this->extensions[$rule];
+
+        if ($callback instanceof Closure) {
+            return call_user_func_array($callback, $parameters);
+        } elseif (is_string($callback)) {
+            return $this->callClassBasedExtension($callback, $parameters);
+        }
+    }
+
+    /**
+     * Call a class based validator extension.
+     *
+     * @param  string  $callback
+     * @param  array   $parameters
+     * @return bool
+     */
+    protected function callClassBasedExtension($callback, $parameters)
+    {
+        list($class, $method) = explode('@', $callback);
+
+        return call_user_func_array([$this->container->make($class), $method], $parameters);
+    }
+
+    /**
+     * Handle dynamic calls to class methods.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($method, $parameters)
+    {
+        $rule = Str::snake(substr($method, 8));
+
+        if (isset($this->extensions[$rule])) {
+            return $this->callExtension($rule, $parameters);
+        }
+
+        throw new BadMethodCallException("Method [$method] does not exist.");
+    }
+}

--- a/src/Illuminate/Support/Facades/TypeCaster.php
+++ b/src/Illuminate/Support/Facades/TypeCaster.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+/**
+ * @see \Illuminate\Database\Eloquent\TypeCaster\Factory
+ */
+class TypeCaster extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'typecaster';
+    }
+}


### PR DESCRIPTION
This is an early draft of some custom type casting functionality, discussed here: 
https://github.com/laravel/internals/issues/9

The proposed implementation would allow Model Attributes to be cast to custom classes, with optional parameters.

For instance:

``` php
    /**
     * The attributes that should be cast to native types.
     *
     * @var array
     */
    protected $casts = [
        'html_content' => HtmlString::class,
        'money' => '\App\Money,£',
    ];
```

Where the cast class is instantiated with the attribute value as the first parameter, followed by any additional parameters provided.

Assuming a casting class has a __toString() method, this will be used when inserting the attribute back into the database.

A simple custom class example could be automatic casting to HtmlString (useful for WYSIWYG stored content). Creating additional cast classes for Value Objects, such as Money, Currency, Url etc would be as straightforward as creating a class with a __construct and __toString().

``` php
class Money 
{
    protected $value;

    public function __construct($value, $symbol)
    {
        $this->value = $value;
        $this->symbol = $symbol;
    }

    public function withSymbol()
    {
          return $this->symbol.$this->value;
    }

    public function add($value)
    {
          $this->value  = $this->value + $value;

          return $this;
    }

    public function __toString()
    {
         return $this->value;
    }
}
```

This could certainly be made stricter, perhaps with a Castable interface to be implemented on castable objects but it works nicely as above.

**This is an early draft to gather some feedback, thoughts?**

:)
