### PR TITLE
[5.2] Prevent dd() calls from crashing production apps

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -507,6 +507,12 @@ if (! function_exists('dd')) {
      */
     function dd()
     {
+        if (app()->environment('production')) {
+            logger('dd() found', debug_backtrace()[1]);
+
+            return;
+        }
+
         array_map(function ($x) {
             (new Dumper)->dump($x);
         }, func_get_args());


### PR DESCRIPTION
Stop `dd()` calls taking affect in production environment applications. Instead, a log message is raised with the calling stack trace frame passed as context.
