### PR TITLE
[5.3] Enable/disable foreign key checks

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -179,6 +179,24 @@ class Builder
     }
 
     /**
+     * Enable or disable foreign key checks.
+     *
+     * @param $enable
+     * @return bool
+     * @throws \Exception
+     */
+    public function foreignKeyChecks($enable)
+    {
+        if (! is_bool($enable)) {
+            throw new \Exception("The parameter should either be 'true' or 'false'");
+        }
+
+        return $this->connection->statement(
+            $this->grammar->compileForeignKeyChecks($enable)
+        );
+    }
+
+    /**
      * Rename a table on the schema.
      *
      * @param  string  $from

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -287,6 +287,21 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Enable or disable foreign key checks.
+     *
+     * @param $enable
+     * @return string
+     */
+    public function compileForeignKeyChecks($enable)
+    {
+        if ($enable) {
+            return 'SET FOREIGN_KEY_CHECKS=1;';
+        }
+
+        return 'SET FOREIGN_KEY_CHECKS=0;';
+    }
+
+    /**
      * Create the column definition for a char type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -243,6 +243,21 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Enable or disable foreign key checks.
+     *
+     * @param $enable
+     * @return string
+     */
+    public function compileForeignKeyChecks($enable)
+    {
+        if ($enable) {
+            return 'SET CONSTRAINTS ALL IMMEDIATE;';
+        }
+
+        return 'SET CONSTRAINTS ALL DEFERRED;';
+    }
+
+    /**
      * Create the column definition for a char type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -295,6 +295,21 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Enable or disable foreign key checks.
+     *
+     * @param $enable
+     * @return string
+     */
+    public function compileForeignKeyChecks($enable)
+    {
+        if ($enable) {
+            return 'PRAGMA foreign_keys = ON;';
+        }
+
+        return 'PRAGMA foreign_keys = OFF;';
+    }
+
+    /**
      * Create the column definition for a char type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -247,6 +247,21 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Enable or disable foreign key checks.
+     *
+     * @param $enable
+     * @return string
+     */
+    public function compileForeignKeyChecks($enable)
+    {
+        if ($enable) {
+            return 'EXEC sp_msforeachtable @command1="print \'?\'", @command2="ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all";';
+        }
+
+        return 'EXEC sp_msforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all";';
+    }
+
+    /**
      * Create the column definition for a char type.
      *
      * @param  \Illuminate\Support\Fluent  $column


### PR DESCRIPTION
This PR allows user to enable/disable foreign key checks dynamically. As mentioned in this issue #2502, we need to utilize the DB facade to write queries in this regard. This PR removes that constraint. 

To enable/disable foreign key checks while creating migrations:

```
// Disable foreign key checks
Schema::foreignKeyChecks(false);

// Enable foreign key checks
Schema::foreignKeyChecks(true);
```

Since this is a breaking change, i thought its better that i send for inclusion directly into master branch for inclusion in 5.3. @GrahamCampbell kindly advise if it is the correct way.
