### PR TITLE
[5.0] Back-port ability to use vendor:publish --provider and --tag together

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -111,9 +111,11 @@ abstract class ServiceProvider {
 
 		static::$publishes[$class] = array_merge(static::$publishes[$class], $paths);
 
-		if ($group)
-		{
-			static::$publishGroups[$group] = $paths;
+		if ($group) {
+			if (! array_key_exists($group, static::$publishGroups)) {
+				static::$publishGroups[$group] = [];
+			}
+			static::$publishGroups[$group] = array_merge(static::$publishGroups[$group], $paths);
 		}
 	}
 
@@ -126,6 +128,13 @@ abstract class ServiceProvider {
 	 */
 	public static function pathsToPublish($provider = null, $group = null)
 	{
+		if ($provider && $group) {
+			if (empty(static::$publishes[$provider]) || empty(static::$publishGroups[$group])) {
+				return [];
+			}
+			return array_intersect_key(static::$publishes[$provider], static::$publishGroups[$group]);
+		}
+
 		if ($group && array_key_exists($group, static::$publishGroups))
 		{
 			return static::$publishGroups[$group];


### PR DESCRIPTION
It was getting a little frustrating when trying to publish specific assets via `vendor:publish` for a particular `--provider` and `--tag` combination so I simply back-ported the changes from 5.1.

Having a quick look I can't see any tests around this feature but happy to collaborate on this.
