### PR TITLE
[5.2] Output how to quit local webserver when using php artisan serve

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -44,7 +44,7 @@ class ServeCommand extends Command
         $binary = ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false));
 
         $this->info("Laravel development server started on http://{$host}:{$port}/");
-        $this->info("Press Ctrl-C to quit.");
+        $this->info('Press Ctrl-C to quit.');
 
         if (defined('HHVM_VERSION')) {
             if (version_compare(HHVM_VERSION, '3.8.0') >= 0) {

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -44,6 +44,7 @@ class ServeCommand extends Command
         $binary = ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false));
 
         $this->info("Laravel development server started on http://{$host}:{$port}/");
+        $this->info("Press Ctrl-C to quit.");
 
         if (defined('HHVM_VERSION')) {
             if (version_compare(HHVM_VERSION, '3.8.0') >= 0) {


### PR DESCRIPTION
New users may not know how to stop the PHP development server so printed the keyboard shortcut. This shortcut is used on windows, mac and unix command lines.
