### PR TITLE
[5.2] Fix required_if with bools

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -839,6 +839,13 @@ class Validator implements ValidatorContract
 
         $values = array_slice($parameters, 1);
 
+        if (is_bool($data)) {
+            array_walk($values, function (&$value) {
+                $value = $value == 'true' ?
+                    true : ($value == 'false' ? false : $value);
+            });
+        }
+
         if (in_array($data, $values)) {
             return $this->validateRequired($attribute, $value);
         }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -613,6 +613,14 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['first' => 'dayle', 'last' => 'rees'], ['last' => 'required_if:first,taylor,dayle']);
         $this->assertTrue($v->passes());
 
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => true], ['bar' => 'required_if:foo,false']);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getRealTranslator();
+        $v = new Validator($trans, ['foo' => true], ['bar' => 'required_if:foo,true']);
+        $this->assertTrue($v->fails());
+
         // error message when passed multiple values (required_if:foo,bar,baz)
         $trans = $this->getRealTranslator();
         $trans->addResource('array', ['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en', 'messages');


### PR DESCRIPTION
``` php
Validator::make(['foo' => true], ['bar' => 'required_if:foo,false']); // currently fails
```

That's because:

``` php
in_array(true, ['anythingString']); // true
in_array(false, ['anythingString']); // false
```
