### PR TITLE
[5.2] Revert broken changes

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Mockery;
 use Exception;
-use Illuminate\Database\Eloquent\Model;
 
 trait MocksApplicationServices
 {
@@ -89,15 +88,7 @@ trait MocksApplicationServices
             $this->firedEvents[] = $called;
         });
 
-        $mock->shouldReceive('until')->andReturnUsing(function ($called) {
-            $this->firedEvents[] = $called;
-
-            return true;
-        });
-
         $this->app->instance('events', $mock);
-
-        Model::setEventDispatcher($mock);
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -84,8 +84,6 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         putenv('APP_ENV=testing');
 
         $this->app = $this->createApplication();
-
-        Model::setEventDispatcher($this->app['events']);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Testing;
 
 use Mockery;
 use PHPUnit_Framework_TestCase;
-use Illuminate\Database\Eloquent\Model;
 
 abstract class TestCase extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This broke Cachet, among other things.

```
[2016-04-27 09:09:31] testing.ERROR: BadMethodCallException: Method Mockery_0_Illuminate_Contracts_Events_Dispatcher::listen() does not exist on this mock object in /media/sf_GitHub/Cachet/Cachet/vendor/mockery/mockery/library/Mockery/Loader/EvalLoader.php(16) : eval()'d code:709
Stack trace:
#0 /media/sf_GitHub/Cachet/Cachet/vendor/mockery/mockery/library/Mockery/Loader/EvalLoader.php(16) : eval()'d code(761): Mockery_0_Illuminate_Contracts_Events_Dispatcher->_mockery_handleMethodCall('listen', Array)
#1 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1286): Mockery_0_Illuminate_Contracts_Events_Dispatcher->listen('eloquent.saving...', 'AltThree\\Valida...', 0)
#2 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(423): Illuminate\Database\Eloquent\Model::registerModelEvent('saving', 'AltThree\\Valida...', 0)
#3 /media/sf_GitHub/Cachet/Cachet/vendor/alt-three/validator/src/ValidatingTrait.php(30): Illuminate\Database\Eloquent\Model::observe(Object(AltThree\Validator\ValidatingObserver))
#4 [internal function]: CachetHQ\Cachet\Models\Subscriber::bootValidatingTrait()
#5 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(323): forward_static_call(Array)
#6 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(309): Illuminate\Database\Eloquent\Model::bootTraits()
#7 /media/sf_GitHub/Cachet/Cachet/app/Models/Subscriber.php(63): Illuminate\Database\Eloquent\Model::boot()
#8 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(296): CachetHQ\Cachet\Models\Subscriber::boot()
#9 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(277): Illuminate\Database\Eloquent\Model->bootIfNotBooted()
#10 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(3505): Illuminate\Database\Eloquent\Model->__construct()
#11 /media/sf_GitHub/Cachet/Cachet/app/Bus/Handlers/Commands/Subscriber/SubscribeSubscriberCommandHandler.php(40): Illuminate\Database\Eloquent\Model::__callStatic('where', Array)
#12 [internal function]: CachetHQ\Cachet\Bus\Handlers\Commands\Subscriber\SubscribeSubscriberCommandHandler->handle(Object(CachetHQ\Cachet\Bus\Commands\Subscriber\SubscribeSubscriberCommand))
#13 /media/sf_GitHub/Cachet/Cachet/vendor/alt-three/bus/src/Dispatcher.php(225): call_user_func(Array, Object(CachetHQ\Cachet\Bus\Commands\Subscriber\SubscribeSubscriberCommand))
#14 [internal function]: AltThree\Bus\Dispatcher->AltThree\Bus\{closure}(Object(CachetHQ\Cachet\Bus\Commands\Subscriber\SubscribeSubscriberCommand))
#15 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(150): call_user_func(Object(Closure), Object(CachetHQ\Cachet\Bus\Commands\Subscriber\SubscribeSubscriberCommand))
#16 [internal function]: Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(CachetHQ\Cachet\Bus\Commands\Subscriber\SubscribeSubscriberCommand))
#17 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(102): call_user_func(Object(Closure), Object(CachetHQ\Cachet\Bus\Commands\Subscriber\SubscribeSubscriberCommand))
#18 /media/sf_GitHub/Cachet/Cachet/vendor/alt-three/bus/src/Dispatcher.php(226): Illuminate\Pipeline\Pipeline->then(Object(Closure))
#19 /media/sf_GitHub/Cachet/Cachet/vendor/alt-three/bus/src/Dispatcher.php(201): AltThree\Bus\Dispatcher->dispatchNow(Object(CachetHQ\Cachet\Bus\Commands\Subscriber\SubscribeSubscriberCommand), NULL)
#20 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Foundation/helpers.php(323): AltThree\Bus\Dispatcher->dispatch(Object(CachetHQ\Cachet\Bus\Commands\Subscriber\SubscribeSubscriberCommand))
#21 /media/sf_GitHub/Cachet/Cachet/app/Http/Controllers/Api/SubscriberController.php(46): dispatch(Object(CachetHQ\Cachet\Bus\Commands\Subscriber\SubscribeSubscriberCommand))
#22 [internal function]: CachetHQ\Cachet\Http\Controllers\Api\SubscriberController->postSubscribers()
#23 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Controller.php(80): call_user_func_array(Array, Array)
#24 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php(146): Illuminate\Routing\Controller->callAction('postSubscribers', Array)
#25 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php(94): Illuminate\Routing\ControllerDispatcher->call(Object(CachetHQ\Cachet\Http\Controllers\Api\SubscriberController), Object(Illuminate\Routing\Route), 'postSubscribers')
#26 [internal function]: Illuminate\Routing\ControllerDispatcher->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
#27 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(52): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#28 [internal function]: Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
#29 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(102): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#30 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php(96): Illuminate\Pipeline\Pipeline->then(Object(Closure))
#31 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php(54): Illuminate\Routing\ControllerDispatcher->callWithinStack(Object(CachetHQ\Cachet\Http\Controllers\Api\SubscriberController), Object(Illuminate\Routing\Route), Object(Illuminate\Http\Request), 'postSubscribers')
#32 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Route.php(174): Illuminate\Routing\ControllerDispatcher->dispatch(Object(Illuminate\Routing\Route), Object(Illuminate\Http\Request), 'CachetHQ\\Cachet...', 'postSubscribers')
#33 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Route.php(140): Illuminate\Routing\Route->runController(Object(Illuminate\Http\Request))
#34 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Router.php(724): Illuminate\Routing\Route->run(Object(Illuminate\Http\Request))
#35 [internal function]: Illuminate\Routing\Router->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
#36 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(52): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#37 /media/sf_GitHub/Cachet/Cachet/app/Http/Middleware/ApiAuthentication.php(67): Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
#38 [internal function]: CachetHQ\Cachet\Http\Middleware\ApiAuthentication->handle(Object(Illuminate\Http\Request), Object(Closure), 'true')
#39 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(136): call_user_func_array(Array, Array)
#40 [internal function]: Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
#41 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(32): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#42 /media/sf_GitHub/Cachet/Cachet/app/Http/Middleware/Timezone.php(53): Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
#43 [internal function]: CachetHQ\Cachet\Http\Middleware\Timezone->handle(Object(Illuminate\Http\Request), Object(Closure))
#44 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(136): call_user_func_array(Array, Array)
#45 [internal function]: Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
#46 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(32): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#47 /media/sf_GitHub/Cachet/Cachet/app/Http/Middleware/Acceptable.php(35): Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
#48 [internal function]: CachetHQ\Cachet\Http\Middleware\Acceptable->handle(Object(Illuminate\Http\Request), Object(Closure))
#49 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(136): call_user_func_array(Array, Array)
#50 [internal function]: Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
#51 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(32): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#52 /media/sf_GitHub/Cachet/Cachet/vendor/barryvdh/laravel-cors/src/HandleCors.php(34): Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
#53 [internal function]: Barryvdh\Cors\HandleCors->handle(Object(Illuminate\Http\Request), Object(Closure))
#54 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(136): call_user_func_array(Array, Array)
#55 [internal function]: Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
#56 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(32): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#57 [internal function]: Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
#58 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(102): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#59 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Router.php(726): Illuminate\Pipeline\Pipeline->then(Object(Closure))
#60 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Router.php(699): Illuminate\Routing\Router->runRouteWithinStack(Object(Illuminate\Routing\Route), Object(Illuminate\Http\Request))
#61 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Router.php(675): Illuminate\Routing\Router->dispatchToRoute(Object(Illuminate\Http\Request))
#62 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(246): Illuminate\Routing\Router->dispatch(Object(Illuminate\Http\Request))
#63 [internal function]: Illuminate\Foundation\Http\Kernel->Illuminate\Foundation\Http\{closure}(Object(Illuminate\Http\Request))
#64 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(52): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#65 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php(44): Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
#66 [internal function]: Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode->handle(Object(Illuminate\Http\Request), Object(Closure))
#67 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(136): call_user_func_array(Array, Array)
#68 [internal function]: Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
#69 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(32): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#70 /media/sf_GitHub/Cachet/Cachet/vendor/fideloper/proxy/src/TrustProxies.php(46): Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
#71 [internal function]: Fideloper\Proxy\TrustProxies->handle(Object(Illuminate\Http\Request), Object(Closure))
#72 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(136): call_user_func_array(Array, Array)
#73 [internal function]: Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}(Object(Illuminate\Http\Request))
#74 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php(32): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#75 [internal function]: Illuminate\Routing\Pipeline->Illuminate\Routing\{closure}(Object(Illuminate\Http\Request))
#76 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(102): call_user_func(Object(Closure), Object(Illuminate\Http\Request))
#77 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(132): Illuminate\Pipeline\Pipeline->then(Object(Closure))
#78 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php(99): Illuminate\Foundation\Http\Kernel->sendRequestThroughRouter(Object(Illuminate\Http\Request))
#79 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php(506): Illuminate\Foundation\Http\Kernel->handle(Object(Illuminate\Http\Request))
#80 /media/sf_GitHub/Cachet/Cachet/vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php(126): Illuminate\Foundation\Testing\TestCase->call('POST', '/api/v1/subscri...', Array, Array, Array, Array)
#81 /media/sf_GitHub/Cachet/Cachet/tests/Api/SubscriberTest.php(47): Illuminate\Foundation\Testing\TestCase->post('/api/v1/subscri...', Array)
#82 [internal function]: CachetHQ\Tests\Cachet\Api\SubscriberTest->testCreateSubscriber()
#83 /media/sf_GitHub/Cachet/Cachet/vendor/phpunit/phpunit/src/Framework/TestCase.php(908): ReflectionMethod->invokeArgs(Object(CachetHQ\Tests\Cachet\Api\SubscriberTest), Array)
#84 /media/sf_GitHub/Cachet/Cachet/vendor/phpunit/phpunit/src/Framework/TestCase.php(768): PHPUnit_Framework_TestCase->runTest()
#85 /media/sf_GitHub/Cachet/Cachet/vendor/phpunit/phpunit/src/Framework/TestResult.php(612): PHPUnit_Framework_TestCase->runBare()
#86 /media/sf_GitHub/Cachet/Cachet/vendor/phpunit/phpunit/src/Framework/TestCase.php(724): PHPUnit_Framework_TestResult->run(Object(CachetHQ\Tests\Cachet\Api\SubscriberTest))
#87 /media/sf_GitHub/Cachet/Cachet/vendor/phpunit/phpunit/src/Framework/TestSuite.php(747): PHPUnit_Framework_TestCase->run(Object(PHPUnit_Framework_TestResult))
#88 /media/sf_GitHub/Cachet/Cachet/vendor/phpunit/phpunit/src/Framework/TestSuite.php(747): PHPUnit_Framework_TestSuite->run(Object(PHPUnit_Framework_TestResult))
#89 /media/sf_GitHub/Cachet/Cachet/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(440): PHPUnit_Framework_TestSuite->run(Object(PHPUnit_Framework_TestResult))
#90 /media/sf_GitHub/Cachet/Cachet/vendor/phpunit/phpunit/src/TextUI/Command.php(149): PHPUnit_TextUI_TestRunner->doRun(Object(PHPUnit_Framework_TestSuite), Array)
#91 /media/sf_GitHub/Cachet/Cachet/vendor/phpunit/phpunit/src/TextUI/Command.php(100): PHPUnit_TextUI_Command->run(Array, true)
#92 /media/sf_GitHub/Cachet/Cachet/vendor/phpunit/phpunit/phpunit(47): PHPUnit_TextUI_Command::main()
#93 {main} {"identification":{"id":"ea24b7eb-bf29-48e5-930f-29e8335e4fab"}} 
```
