### PR TITLE
[5.3] Fix primitive types validation passing on [] or null

### DIFF
--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -115,6 +115,53 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testEmptyExistingAttributesAreValidated()
+    {
+        $trans = $this->getRealTranslator();
+
+        $v = new Validator($trans, ['x' => ''], ['x' => 'array']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => []], ['x' => 'boolean']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => []], ['x' => 'numeric']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => []], ['x' => 'integer']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['x' => []], ['x' => 'string']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, [], ['x' => 'string', 'y' => 'numeric', 'z' => 'integer', 'a' => 'boolean', 'b' => 'array']);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testNullable()
+    {
+        $trans = $this->getRealTranslator();
+
+        $v = new Validator($trans, [
+            'x' => null, 'y' => null, 'z' => null, 'a' => null, 'b' => null,
+        ], [
+            'x' => 'string|nullable', 'y' => 'integer|nullable', 'z' => 'numeric|nullable', 'a' => 'array|nullable', 'b' => 'bool|nullable',
+        ]);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, [
+            'x' => null, 'y' => null, 'z' => null, 'a' => null, 'b' => null,
+        ], [
+            'x' => 'string', 'y' => 'integer', 'z' => 'numeric', 'a' => 'array', 'b' => 'bool',
+        ]);
+        $this->assertTrue($v->fails());
+        $this->assertEquals('validation.string', $v->messages()->get('x')[0]);
+        $this->assertEquals('validation.integer', $v->messages()->get('y')[0]);
+        $this->assertEquals('validation.numeric', $v->messages()->get('z')[0]);
+        $this->assertEquals('validation.array', $v->messages()->get('a')[0]);
+        $this->assertEquals('validation.boolean', $v->messages()->get('b')[0]);
+    }
+
     public function testProperLanguageLineIsSet()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
Following up on https://github.com/laravel/framework/pull/13279

``` php
Validator::make(['roles' => ''], ['roles' => 'array']); // passes - no change
Validator::make(['is_new' => []], ['is_new' => 'bool']); // fails - was passing before PR
Validator::make(['roles' => null], ['roles' => 'array']); // fails - was passing before PR
```

Now validation passes on empty string, but fails on empty array or null.

Also added a `nullable` modifier.

``` php
Validator::make(['middle_name' => null], ['middle_name' => 'string']); //fails

Validator::make(['middle_name' => null], ['middle_name' => 'string|nullable']); //passes
```

---

HTML Forms post an empty string if the field is not filled, so we pass `integer, numeric, bool, array` in case of empty string to eliminate confusion, but for `null` I think primitive type validation should fail if the value is `null`, also `bool, numeric, integer, string` should fail on empty array.
