### PR TITLE
[5.3] Normalize guessed ability names

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -52,6 +52,25 @@ trait AuthorizesRequests
             return [$ability, $arguments];
         }
 
-        return [debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['function'], $ability];
+        $method = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['function'];
+
+        return [$this->normalizeGuessedAbilityName($method), $ability];
+    }
+
+    /**
+     * Normalize the ability name that has been guessed from the method name.
+     *
+     * @param  string  $ability
+     * @return string
+     */
+    protected function normalizeGuessedAbilityName($ability)
+    {
+        if (method_exists($this, 'resourceAbilityMap')) {
+            $map = $this->resourceAbilityMap();
+
+            $ability = isset($map[$ability]) ? $map[$ability] : $ability;
+        }
+
+        return $ability;
     }
 }

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -3,6 +3,8 @@
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Container\Container;
 use Illuminate\Auth\Access\Response;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Auth\Access\AuthorizesResources;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
 class FoundationAuthorizesRequestsTraitTest extends PHPUnit_Framework_TestCase
@@ -67,12 +69,25 @@ class FoundationAuthorizesRequestsTraitTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($_SERVER['_test.authorizes.trait.policy']);
     }
 
+    public function test_policy_method_may_be_guessed_and_normalized()
+    {
+        unset($_SERVER['_test.authorizes.trait.policy']);
+
+        $gate = $this->getBasicGate();
+
+        $gate->policy(FoundationAuthorizesRequestTestClass::class, FoundationAuthorizesRequestTestPolicy::class);
+
+        (new FoundationTestAuthorizeTraitClass)->store(new FoundationAuthorizesRequestTestClass);
+
+        $this->assertTrue($_SERVER['_test.authorizes.trait.policy']);
+    }
+
     public function getBasicGate()
     {
-        $container = new Container;
-        Container::setInstance($container);
+        $container = Container::setInstance(new Container);
 
         $gate = new Gate($container, function () { return (object) ['id' => 1]; });
+
         $container->instance(GateContract::class, $gate);
 
         return $gate;
@@ -85,6 +100,13 @@ class FoundationAuthorizesRequestTestClass
 
 class FoundationAuthorizesRequestTestPolicy
 {
+    public function create()
+    {
+        $_SERVER['_test.authorizes.trait.policy'] = true;
+
+        return true;
+    }
+
     public function update()
     {
         $_SERVER['_test.authorizes.trait.policy'] = true;
@@ -102,5 +124,10 @@ class FoundationAuthorizesRequestTestPolicy
 
 class FoundationTestAuthorizeTraitClass
 {
-    use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+    use AuthorizesRequests, AuthorizesResources;
+
+    public function store($object)
+    {
+        $this->authorize($object);
+    }
 }


### PR DESCRIPTION
So that these two end up calling the same policy method:

``` php
public function create()
{
    $this->authorize(Post::class);

    return view('posts.create');
}

public function store()
{
    $this->authorize(Post::class);

    //
}
```

Just like `authorizeResource` works.

---

This is a breaking change that will have to be pointed out in the upgrade docs.

To opt out of it, you can either pass the ability name manually or override the `normalizeGuessedAbilityName` to simply return the ability as is.
