### PR TITLE
[5.3] Divide authentification routes

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -277,15 +277,46 @@ class Router implements RegistrarContract
     public function auth()
     {
         // Authentication Routes...
+        $this->login();
+
+        // Registration Routes...
+        $this->register();
+
+        // Password Reset Routes...
+        $this->password();
+    }
+
+    /**
+     * Register login and logout routes for an application.
+     *
+     * @return void
+     */
+    public function login()
+    {
         $this->get('login', 'Auth\AuthController@showLoginForm');
         $this->post('login', 'Auth\AuthController@login');
         $this->get('logout', 'Auth\AuthController@logout');
+    }
 
-        // Registration Routes...
+    /**
+     * Register registration routes for an application.
+     *
+     * @return void
+     */
+    public function register()
+    {
         $this->get('register', 'Auth\AuthController@showRegistrationForm');
         $this->post('register', 'Auth\AuthController@register');
+    }
 
-        // Password Reset Routes...
+
+    /**
+     * Register password routes for an application.
+     *
+     * @return void
+     */
+    public function password()
+    {
         $this->get('password/reset/{token?}', 'Auth\PasswordController@showResetForm');
         $this->post('password/email', 'Auth\PasswordController@sendResetLinkEmail');
         $this->post('password/reset', 'Auth\PasswordController@reset');


### PR DESCRIPTION
I recently stumbled upon some applications where users are allowed to login but aren't allowed to register themselves. So it might be neat to easily add routes for login and logout without the registration routes. 

I simply divided the function `auth` in three methods. These methods can be called from `routes.php` to add these routes separately.
