### PR TITLE
[5.2] Allow models to specify a timezone for $dates

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -141,13 +141,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $dates = [];
 
     /**
-     * The timezone to use when mutating dates.
-     *
-     * @var string|null
-     */
-    protected $timezone = null;
-
-    /**
      * The storage format of the model's date columns.
      *
      * @var string
@@ -258,6 +251,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @var array
      */
     public static $manyMethods = ['belongsToMany', 'morphToMany', 'morphedByMany'];
+
+    /**
+     * The timezone to use when mutating dates.
+     *
+     * @var string|null
+     */
+    protected static $timezone = null;
 
     /**
      * The name of the "created at" column.
@@ -2917,8 +2917,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $format = $this->getDateFormat();
 
         $value = $this->asDateTime($value);
-        if ($this->timezone) {
-            $value->setTimezone($this->timezone);
+        if (static::$timezone) {
+            $value->setTimezone(static::$timezone);
         }
 
         return $value->format($format);
@@ -2965,8 +2965,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // Finally, we will just assume this date is in the format used by default on
         // the database connection and use that format to create the Carbon object
         // that is returned back out to the developers after we convert it here.
-        if ($this->timezone) {
-            return Carbon::createFromFormat($this->getDateFormat(), $value, $this->timezone)
+        if (static::$timezone) {
+            return Carbon::createFromFormat($this->getDateFormat(), $value, static::$timezone)
                 ->setTimezone(date_default_timezone_get());
         } else {
             return Carbon::createFromFormat($this->getDateFormat(), $value);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -143,7 +143,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * The timezone to use when mutating dates.
      *
-     * @var string
+     * @var string|null
      */
     protected $timezone = null;
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -141,6 +141,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected $dates = [];
 
     /**
+     * The timezone to use when mutating dates.
+     *
+     * @var string
+     */
+    protected $timezone = null;
+
+    /**
      * The storage format of the model's date columns.
      *
      * @var string
@@ -2910,6 +2917,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $format = $this->getDateFormat();
 
         $value = $this->asDateTime($value);
+        if ($this->timezone) {
+            $value->setTimezone($this->timezone);
+        }
 
         return $value->format($format);
     }
@@ -2955,7 +2965,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // Finally, we will just assume this date is in the format used by default on
         // the database connection and use that format to create the Carbon object
         // that is returned back out to the developers after we convert it here.
-        return Carbon::createFromFormat($this->getDateFormat(), $value);
+        if ($this->timezone) {
+            return Carbon::createFromFormat($this->getDateFormat(), $value, $this->timezone)
+                ->setTimezone(date_default_timezone_get());
+        } else {
+            return Carbon::createFromFormat($this->getDateFormat(), $value);
+        }
     }
 
     /**


### PR DESCRIPTION
Date mutators depend on a global variable, PHP's default timezone. This can cause incorrect timestamps to be saved to and retrieved from the database if the timezone ever changes, or if two environments use a different timezone setting:

``` php
// assume: global timezone is UTC
// assume: my_timestamp column is listed in $dates or $casts

$x = App\SomeModel::find(1);
$y = $x->my_timestamp;              // perhaps 2016-01-02 03:04:05 UTC

// timezone changed (or it's a different app, or the app is running
// with different environment settings, etc.)

date_default_timezone_set('America/New_York');
$z = $x->my_timestamp;
// $z is 2016-01-02 03:04:05 EST
// this is NOT equivalent to the above UTC timestamp
```

This patch adds a `Model` property, `$timezone`. The default value is `null` and behaves exacty as it does today.

If set to a non-null value, timestamp columns listed in `$dates`, or listed in `$casts` as `"datetime"`, will be rendered in the given timezone when written to the database and to the equivalent local time when retrieved from the database:

``` php
// assume: global timezone is UTC
// assume: my_timestamp column is listed in $dates or $casts
// assume: the model's $timestamp value is set to 'UTC'

$x = App\SomeModel::find(1);
$y = $x->my_timestamp;              // perhaps 2016-01-02 03:04:05 UTC

// timezone changed
date_default_timezone_set('America/New_York');
$z = $x->my_timestamp;
// $z is 2016-01-01 22:04:05 EST
// this IS equivalent to the above UTC timestamp
```
### Relationship to Laravel's app.timezone value

It's common to set the timezone in `config/app.php` and it's unlikely that you would change it elsewhere.

However, this is not always the case when `Eloquent` is used as a standalone ORM, for example, in a legacy non-Laravel app.

The TL;DR is that timestamp values saved to the database should be deterministic, regardless of the global timezone setting or changes to the local environment.
