### PR TITLE
[5.2] Adds assertion to check for soft deleted records

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -87,15 +87,15 @@ trait InteractsWithDatabase
     protected function seeInDatabaseSoftDeleted($table, array $data, $connection = null)
     {
         $database = $this->app->make('db');
-        
+
         $connection = $connection ?: $database->getDefaultConnection();
-        
+
         $count = $database->connection($connection)->table($table)->where($data)->whereNotNull('deleted_at')->count();
-        
+
         $this->assertGreaterThan(0, $count, sprintf(
             'Unable to find soft deleted row in database table [%s] that matched attributes [%s].', $table, json_encode($data)
         ));
-        
+
         return $this;
     }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -77,6 +77,26 @@ trait InteractsWithDatabase
     }
 
     /**
+     * Assert that a given where condition matches a soft deleted record.
+     *
+     * @param  string $table
+     * @param  array $data
+     * @param  string|null $connection
+     * @return $this
+     */
+    protected function seeInDatabaseSoftDeleted($table, array $data, $connection = null)
+    {
+        $database = $this->app->make('db');
+        $connection = $connection ?: $database->getDefaultConnection();
+        $count = $database->connection($connection)->table($table)->where($data)->whereNotNull('deleted_at')->count();
+        $this->assertGreaterThan(0, $count, sprintf(
+            'Unable to find soft deleted row in database table [%s] that matched attributes [%s].', $table, json_encode($data)
+        ));
+        return $this;
+    }
+
+
+    /**
      * Seed a given database connection.
      *
      * @param  string  $class

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -87,11 +87,15 @@ trait InteractsWithDatabase
     protected function seeInDatabaseSoftDeleted($table, array $data, $connection = null)
     {
         $database = $this->app->make('db');
+        
         $connection = $connection ?: $database->getDefaultConnection();
+        
         $count = $database->connection($connection)->table($table)->where($data)->whereNotNull('deleted_at')->count();
+        
         $this->assertGreaterThan(0, $count, sprintf(
             'Unable to find soft deleted row in database table [%s] that matched attributes [%s].', $table, json_encode($data)
         ));
+        
         return $this;
     }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -95,7 +95,6 @@ trait InteractsWithDatabase
         return $this;
     }
 
-
     /**
      * Seed a given database connection.
      *


### PR DESCRIPTION
Currently it doesn't seem possible to use `seeInDatabase` to check where `deleted_at` is not null. This new helper facilitates the assertion that a record has been soft deleted from the database.
