### PR TITLE
[5.3] Memcached persistent connections, SASL authentication, and custom options

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -161,7 +161,16 @@ class CacheManager implements FactoryContract
     {
         $prefix = $this->getPrefix($config);
 
-        $memcached = $this->app['memcached.connector']->connect($config['servers']);
+        $persistentConnectionId = array_get($config, 'persistent_id');
+        $customOptions = array_get($config, 'options', []);
+        $saslCredentials = array_filter(array_get($config, 'sasl', []));
+
+        $memcached = $this->app['memcached.connector']->connect(
+            $config['servers'],
+            $persistentConnectionId,
+            $customOptions,
+            $saslCredentials
+        );
 
         return $this->repository(new MemcachedStore($memcached, $prefix));
     }

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -61,7 +61,7 @@ class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $validOptions = ['OPT_NO_BLOCK' => true, 'OPT_AUTO_EJECT_HOSTS' => true];
+        $validOptions = ['OPT_NO_BLOCK' => true, 'OPT_CONNECT_TIMEOUT' => 2000];
 
         $memcached = $this->memcachedMockWithAddServer();
         $memcached->shouldReceive('setOptions')->once()->andReturn(true);
@@ -85,7 +85,7 @@ class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase
             $this->markTestSkipped('Memcached module not installed');
         }
 
-        $invalidOptions = ['OPT_NO_BLOC' => true, 'OPT_AUTO_EJECT_HOST' => true];
+        $invalidOptions = ['OPT_NO_BLOC' => true, 'OPT_CONNECT_TIMEOUT' => 2000];
 
         $memcached = m::mock('stdClass');
 

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -11,12 +11,14 @@ class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase
 
     public function testServersAreAddedCorrectly()
     {
-        $connector = $this->getMock('Illuminate\Cache\MemcachedConnector', ['getMemcached']);
-        $memcached = m::mock('stdClass');
-        $memcached->shouldReceive('addServer')->once()->with('localhost', 11211, 100);
-        $memcached->shouldReceive('getVersion')->once()->andReturn([]);
-        $connector->expects($this->once())->method('getMemcached')->will($this->returnValue($memcached));
-        $result = $connector->connect([['host' => 'localhost', 'port' => 11211, 'weight' => 100]]);
+        $memcached = $this->memcachedMockWithAddServer();
+
+        $connector = $this->connectorMock();
+        $connector->expects($this->once())
+            ->method('getMemcached')
+            ->will($this->returnValue($memcached));
+
+        $result = $this->connect($connector);
 
         $this->assertSame($result, $memcached);
     }
@@ -26,11 +28,143 @@ class CacheMemcachedConnectorTest extends PHPUnit_Framework_TestCase
      */
     public function testExceptionThrownOnBadConnection()
     {
-        $connector = $this->getMock('Illuminate\Cache\MemcachedConnector', ['getMemcached']);
+        $memcached = $this->memcachedMockWithAddServer(['255.255.255']);
+
+        $connector = $this->connectorMock();
+        $connector->expects($this->once())
+            ->method('getMemcached')
+            ->will($this->returnValue($memcached));
+
+        $this->connect($connector);
+    }
+
+    public function testServersAreAddedCorrectlyWithPersistentConnection()
+    {
+        $persistentConnectionId = 'persistent_connection_id';
+
+        $memcached = $this->memcachedMockWithAddServer();
+
+        $connector = $this->connectorMock();
+        $connector->expects($this->once())
+            ->method('getMemcached')
+            ->with($persistentConnectionId)
+            ->will($this->returnValue($memcached));
+
+        $result = $this->connect($connector, $persistentConnectionId);
+
+        $this->assertSame($result, $memcached);
+    }
+
+    public function testServersAreAddedCorrectlyWithValidOptions()
+    {
+        if (! class_exists('Memcached')) {
+            $this->markTestSkipped('Memcached module not installed');
+        }
+
+        $validOptions = ['OPT_NO_BLOCK' => true, 'OPT_AUTO_EJECT_HOSTS' => true];
+
+        $memcached = $this->memcachedMockWithAddServer();
+        $memcached->shouldReceive('setOptions')->once()->andReturn(true);
+
+        $connector = $this->connectorMock();
+        $connector->expects($this->once())
+            ->method('getMemcached')
+            ->will($this->returnValue($memcached));
+
+        $result = $this->connect($connector, false, $validOptions);
+
+        $this->assertSame($result, $memcached);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testExceptionThrownWithInvalidOptions()
+    {
+        if (! class_exists('Memcached')) {
+            $this->markTestSkipped('Memcached module not installed');
+        }
+
+        $invalidOptions = ['OPT_NO_BLOC' => true, 'OPT_AUTO_EJECT_HOST' => true];
+
         $memcached = m::mock('stdClass');
-        $memcached->shouldReceive('addServer')->once()->with('localhost', 11211, 100);
-        $memcached->shouldReceive('getVersion')->once()->andReturn(['255.255.255']);
+
+        $connector = $this->connectorMock();
+        $connector->expects($this->once())
+            ->method('getMemcached')
+            ->will($this->returnValue($memcached));
+
+        $this->connect($connector, false, $invalidOptions);
+    }
+
+    public function testServersAreAddedCorrectlyWithSaslCredentials()
+    {
+        if (! class_exists('Memcached')) {
+            $this->markTestSkipped('Memcached module not installed');
+        }
+
+        $saslCredentials = ['foo', 'bar'];
+
+        $memcached = $this->memcachedMockWithAddServer();
+        $memcached->shouldReceive('setOption')->once()->with(Memcached::OPT_BINARY_PROTOCOL, true)->andReturn(true);
+        $memcached->shouldReceive('setSaslAuthData')
+            ->once()->with($saslCredentials[0], $saslCredentials[1])
+            ->andReturn(true);
+
+        $connector = $this->connectorMock();
         $connector->expects($this->once())->method('getMemcached')->will($this->returnValue($memcached));
-        $result = $connector->connect([['host' => 'localhost', 'port' => 11211, 'weight' => 100]]);
+
+        $result = $this->connect($connector, false, [], $saslCredentials);
+
+        $this->assertSame($result, $memcached);
+    }
+
+    protected function memcachedMockWithAddServer($returnedVersion = [])
+    {
+        $memcached = m::mock('stdClass');
+        $memcached->shouldReceive('addServer')->once()->with($this->getHost(), $this->getPort(), $this->getWeight());
+        $memcached->shouldReceive('getVersion')->once()->andReturn($returnedVersion);
+        $memcached->shouldReceive('getServerList')->once()->andReturn([]);
+
+        return $memcached;
+    }
+
+    protected function connectorMock()
+    {
+        return $this->getMock('Illuminate\Cache\MemcachedConnector', ['getMemcached']);
+    }
+
+    protected function connect(
+        $connector,
+        $persistentConnectionId = false,
+        array $customOptions = [],
+        array $saslCredentials = []
+    ) {
+        return $connector->connect(
+            $this->getServers(),
+            $persistentConnectionId,
+            $customOptions,
+            $saslCredentials
+        );
+    }
+
+    protected function getServers()
+    {
+        return [['host' => $this->getHost(), 'port' => $this->getPort(), 'weight' => $this->getWeight()]];
+    }
+
+    protected function getHost()
+    {
+        return 'localhost';
+    }
+
+    protected function getPort()
+    {
+        return 11211;
+    }
+
+    protected function getWeight()
+    {
+        return 100;
     }
 }


### PR DESCRIPTION
This PR adds support for memcached persistent connections, SASL authentication, and custom options. I released [this package](https://github.com/b3it/laravel-memcached-plus) to offer these features, but I think it would be great to have them out the box with the framework!

Proposed additions to [cache configuration file](https://github.com/laravel/laravel/blob/master/config/cache.php#L50) are below. I can create a PR for these if this PR is accepted.

The following extra configuration items are available for use with a memcached store:
- `persistent_id` - [`Memcached::__construct`](http://php.net/manual/en/memcached.construct.php)
  explains how this is used
- `sasl` - used by [`Memcached::setSaslAuthData`](http://php.net/manual/en/memcached.setsaslauthdata.php)
- `options` - see [`Memcached::setOptions`](http://php.net/manual/en/memcached.setoptions.php)

These may be used in a store config like so:

```
'stores' => [
    'memcachedstorefoo' => [
        'driver'  => 'memcached',
        'persistent_id' => 'laravel_foo',
        'sasl'       => [
            env('MEMCACHED_USERNAME'),
            env('MEMCACHED_PASSWORD')
        ],
        'options'    => [
            'OPT_NO_BLOCK'         => true,
            'OPT_AUTO_EJECT_HOSTS' => true,
            'OPT_CONNECT_TIMEOUT'  => 2000,
            'OPT_POLL_TIMEOUT'     => 2000,
            'OPT_RETRY_TIMEOUT'    => 2,
        ],
        'servers' => [
            [
                'host' => '127.0.0.1', 'port' => 11211, 'weight' => 100
            ],
        ],
    ],
],
```

When defining `options` the config key should be set to the `Memcached` constant name as a string.
This avoids any issues with local environments missing ext-memcached and throwing a warning about
undefined constants. The config keys are automatically resolved into `Memcached` constants by
`MemcachedConnector` which throws a `RuntimeException` if the constant is invalid.

Tests for the new features are included, and as part of these I have extracted out some common methods used by all the `CacheMemcachedConnectorTest` tests, for example to generate the mocks etc. Happy to have feedback if this isn't the best approach.

It would be great to have any feedback on this if you have any queries or concerns.

Thanks!
