### PR TITLE
[5.2] Fix for my previous PR #13237

### DIFF
--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -72,7 +72,7 @@ class SparkPostTransport extends Transport
      */
     protected function getRecipients(Swift_Mime_Message $message)
     {
-        $to = $bcc = [];
+        $to = [];
 
         if ($message->getTo()) {
             $to = array_merge($to, array_keys($message->getTo()));
@@ -83,7 +83,7 @@ class SparkPostTransport extends Transport
         }
 
         if ($message->getBcc()) {
-            $to = array_merge($bcc, array_keys($message->getBcc()));
+            $to = array_merge($to, array_keys($message->getBcc()));
         }
 
         $recipients = array_map(function ($address) {


### PR DESCRIPTION
Noticed a small issue with my previous PR #13237, that caused emails that used both the "to" header and the "bcc" header to only deliver to BCC recipients.
