### PR TITLE
[5.2] Accept != and <> as operators while value is null

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -589,7 +589,7 @@ class Builder
     {
         $isOperator = in_array($operator, $this->operators);
 
-        return $isOperator && $operator != '=' && is_null($value);
+        return $isOperator && ! in_array($operator, ['=', '<>', '!=']) && is_null($value);
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1273,11 +1273,23 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
 
-    public function testProvidingNullOrFalseAsSecondParameterBuildsCorrectly()
+    public function testProvidingNullWithOperatorsBuildsCorrectly()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('foo', null);
         $this->assertEquals('select * from "users" where "foo" is null', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('foo', '=', null);
+        $this->assertEquals('select * from "users" where "foo" is null', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('foo', '!=', null);
+        $this->assertEquals('select * from "users" where "foo" is not null', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('foo', '<>', null);
+        $this->assertEquals('select * from "users" where "foo" is not null', $builder->toSql());
     }
 
     public function testDynamicWhere()


### PR DESCRIPTION
As noted here https://github.com/laravel/framework/issues/13314

Currently:

``` php
->where('done_at','=',null); // converted to whereNull
->where('done_at', '!=', null) // throws exception
```

This PR accepts `!=` and `<>` as operators when the value given to `where()` is `null`, allowing the conversion of `where` with these operators to have the same effect as `whereNotNull`.
