### PR TITLE
[5.2] Return null instead of 0 for a default BelongsTo key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -163,11 +163,11 @@ class BelongsTo extends Relation
             }
         }
 
-        // If there are no keys that were not null we will just return an array with 0 in
-        // it so the query doesn't fail, but will not return any results, which should
-        // be what this developer is expecting in a case where this happens to them.
-        if (count($keys) == 0) {
-            return [0];
+        // If there are no keys that were not null we will just return an array with either
+        // null or 0 in (depending on if incrementing keys are in use) so the query wont
+        // fail and returns no results, which should be what the developer expects.
+        if (count($keys) === 0) {
+            return [$this->related->incrementing ? 0 : null];
         }
 
         return array_values(array_unique($keys));

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -89,6 +89,24 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase
         $relation->associate(1);
     }
 
+    public function testDefaultEagerConstraintsWhenIncrementing()
+    {
+        $relation = $this->getRelation();
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', [0]);
+        $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
+        $relation->addEagerConstraints($models);
+    }
+
+    public function testDefaultEagerConstraintsWhenNotIncrementing()
+    {
+        $parent = m::mock('Illuminate\Database\Eloquent\Model');
+        $parent->incrementing = false;
+        $relation = $this->getRelation();
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', [null]);
+        $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
+        $relation->addEagerConstraints($models);
+    }
+
     protected function getRelation($parent = null)
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
@@ -111,4 +129,9 @@ class EloquentBelongsToModelStub extends Illuminate\Database\Eloquent\Model
 class AnotherEloquentBelongsToModelStub extends Illuminate\Database\Eloquent\Model
 {
     public $foreign_key = 'foreign.value.two';
+}
+
+class MissingEloquentBelongsToModelStub extends Illuminate\Database\Eloquent\Model
+{
+    public $foreign_key = null;
 }

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -92,26 +92,25 @@ class DatabaseEloquentBelongsToTest extends PHPUnit_Framework_TestCase
     public function testDefaultEagerConstraintsWhenIncrementing()
     {
         $relation = $this->getRelation();
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', [0]);
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', m::mustBe([0]));
         $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }
 
     public function testDefaultEagerConstraintsWhenNotIncrementing()
     {
-        $parent = m::mock('Illuminate\Database\Eloquent\Model');
-        $parent->incrementing = false;
-        $relation = $this->getRelation();
-        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', [null]);
+        $relation = $this->getRelation(null, false);
+        $relation->getQuery()->shouldReceive('whereIn')->once()->with('relation.id', m::mustBe([null]));
         $models = [new MissingEloquentBelongsToModelStub, new MissingEloquentBelongsToModelStub];
         $relation->addEagerConstraints($models);
     }
 
-    protected function getRelation($parent = null)
+    protected function getRelation($parent = null, $incrementing = true)
     {
         $builder = m::mock('Illuminate\Database\Eloquent\Builder');
         $builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
         $related = m::mock('Illuminate\Database\Eloquent\Model');
+        $related->incrementing = $incrementing;
         $related->shouldReceive('getKeyName')->andReturn('id');
         $related->shouldReceive('getTable')->andReturn('relation');
         $builder->shouldReceive('getModel')->andReturn($related);


### PR DESCRIPTION
This is for an edge-case when using UUIDs (or any type other than `integer`, really) on postgres.

The scenario for this:
- You have model with a nullable foreign key, say `other_id`, of type `uuid`
- You grab a bunch out of the database, and every model's `other_id` is `null`
- You then attempt to lazy-load the set (or eager-load if you skip the previous point)

I'm not sure exactly how to unit-test this, as the error actually happens when you attempt to do a query like so, with `key` as a `uuid` type, and is in the database layer. Postgres is extremely pedantic about syntax (and will even reject invalid UUIDs).

``` sql
select * from table where key in (0)
```

This results in:

```
Illuminate\Database\QueryException

> SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for uuid: "0"

(SQL: select * from "table" where "table"."id" in (0))
```

I'm not exactly sure if this can be considered backwards-compatible, as it does change the query used by default, but the behaviour should be identical across all supported databases.

The rationale behind using `null` here is because it passes the initial syntax check for all types in all databases. The `0` approach is a side-effect of assuming primary keys are always integers (which can also be 0).

The only BC break possible would be if someone came to rely on a `BelongsTo` relationship with a "default" value in their database (with an ID of 0) that would always be returned.
