### PR TITLE
[5.2] Rearrange configuration files loading order

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -79,6 +79,13 @@ class LoadConfiguration
             $files[$nesting.basename($file->getRealPath(), '.php')] = $file->getRealPath();
         }
 
+        uksort($files, function ($prev, $next) {
+            $prev = preg_replace('/\.php$/', '', $prev);
+            $next = preg_replace('/\.php$/', '', $next);
+
+            return strcmp($prev, $next);
+        });
+
         return $files;
     }
 


### PR DESCRIPTION
There is a bug on loading configuration files when you use dots in config file names. Laravel is using "getConfigurationFiles" method to get config files in config directory, and it uses "Symfony\Component\Finder\Finder" class to do it. But files are coming in wrong order.
- app.php
- auth.php
- ...
- foo.aaa.php
- foo.php
- foo.zzz.php
- ...
- session.php
- view.php

In this case, "foo.php" is overriding "foo.aaa.php", and definations remain out of action by this way. This problem is caused by the file extension, because "aaa" is ahead of "php" and "php" is behind of "zzz" in the alphabetical order. Correct order should be as follows:
- app.php
- auth.php
- ...
- foo.php
- foo.aaa.php
- foo.zzz.php
- ...
- session.php
- view.php

By this way, "foo.aaa.php" and "foo.zzz.php" are added to configuration under "foo" in dot notation.
