### PR TITLE
[5.2] Add method to get guest middleware with guard parameter

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -303,4 +303,14 @@ trait ResetsPasswords
     {
         return property_exists($this, 'guard') ? $this->guard : null;
     }
+
+    /**
+     * Get the guest middleware for the application.
+     */
+    public function guestMiddleware()
+    {
+        $guard = $this->getGuard();
+
+        return $guard ? 'guest:'.$guard : 'guest';
+    }
 }

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -306,6 +306,8 @@ trait ResetsPasswords
 
     /**
      * Get the guest middleware for the application.
+     *
+     * @return string
      */
     public function guestMiddleware()
     {


### PR DESCRIPTION
guestMiddleware() method used to pass guard parameter if it
is set on PasswordResetController by the user.

This method required to fix issue #13383
