### PR TITLE
[5.2] Removed redundant check

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -78,7 +78,7 @@ trait AuthenticatesUsers
         // If the login attempt was unsuccessful we will increment the number of attempts
         // to login and redirect the user back to the login form. Of course, when this
         // user surpasses their maximum number of attempts they will get locked out.
-        if ($throttles && ! $lockedOut) {
+        if ($throttles) {
             $this->incrementLoginAttempts($request);
         }
 


### PR DESCRIPTION
`$lockedOut` will always be `false` at the point it is placed. In another way (if `true`), the flow would have returned in the previous condition:

``` php
if ($throttles && $lockedOut = $this->hasTooManyLoginAttempts($request))
```
