### PR TITLE
[5.2] fix using onlyTrashed and withTrashed with whereHas

### DIFF
--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -405,6 +405,31 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
     /**
      * @group test
      */
+    public function testWhereHasWithNestedDeletedRelationshipAndOnlyTrashedCondition()
+    {
+        $this->createUsers();
+
+        $abigail = SoftDeletesTestUser::where('email', 'abigailotwell@gmail.com')->first();
+        $post = $abigail->posts()->create(['title' => 'First Title']);
+        $post->delete();
+
+        $users = SoftDeletesTestUser::has('posts')->get();
+        $this->assertEquals(0, count($users));
+
+        $users = SoftDeletesTestUser::wherehas('posts', function ($q) {
+            $q->onlyTrashed();
+        })->get();
+        $this->assertEquals(1, count($users));
+
+        $users = SoftDeletesTestUser::wherehas('posts', function ($q) {
+            $q->withTrashed();
+        })->get();
+        $this->assertEquals(1, count($users));
+    }
+
+    /**
+     * @group test
+     */
     public function testWhereHasWithNestedDeletedRelationship()
     {
         $this->createUsers();


### PR DESCRIPTION
For `Post` having many `Comment` models,  `Comment` is using soft deletion:

``` php
Post::has('comments')->get(); 
// Returns a post that has comments where `comments.deleted_at IS NULL`.

Post::whereHas('comments', function($q){
    $q->withTrashed();
})->get();
// Should return posts that has comments even if soft deleted.

Post::whereHas('comments', function($q){
    $q->onlyTrashed();
})->get();
// Should return posts that has all comments soft deleted.
```

Currently case 2 & 3 aren't working, that's because the soft deletion query scope adds a `whereNull` condition on every query, this PR manages to remove this condition when needed. Here's a sample query that demonstrates case 2:

``` sql
select * from `posts` where exists (select * from `comments` where `comments`.`post_id` = `posts`.`id` and `comments`.`deleted_at` is not null and `comments`.`deleted_at` is null)
```

**NOTE** I'm not sure if that's the right way to accomplish the task, I tried to fix it with a minimal effect on the current code.
