### PR TITLE
[5.2] [WIP] Fixing dotenv loading

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -16,14 +16,12 @@ class DetectEnvironment
      */
     public function bootstrap(Application $app)
     {
-        if (! $app->configurationIsCached()) {
-            $this->checkForSpecificEnvironmentFile($app);
+        $this->checkForSpecificEnvironmentFile($app);
 
-            try {
-                (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
-            } catch (InvalidPathException $e) {
-                //
-            }
+        try {
+            (new Dotenv($app->environmentPath(), $app->environmentFile()))->load();
+        } catch (InvalidPathException $e) {
+            //
         }
     }
 

--- a/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
+++ b/src/Illuminate/Foundation/Bootstrap/DetectEnvironment.php
@@ -16,6 +16,10 @@ class DetectEnvironment
      */
     public function bootstrap(Application $app)
     {
+        $app->detectEnvironment(function () use ($config) {
+            return env('APP_ENV', 'production');
+        });
+
         $this->checkForSpecificEnvironmentFile($app);
 
         try {
@@ -33,11 +37,7 @@ class DetectEnvironment
      */
     protected function checkForSpecificEnvironmentFile($app)
     {
-        if (! env('APP_ENV')) {
-            return;
-        }
-
-        $file = $app->environmentFile().'.'.env('APP_ENV');
+        $file = $app->environmentFile().'.'.$app->environment();
 
         if (file_exists($app->environmentPath().'/'.$file)) {
             $app->loadEnvironmentFrom($file);

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -38,10 +38,6 @@ class LoadConfiguration
             $this->loadConfigurationFiles($app, $config);
         }
 
-        $app->detectEnvironment(function () use ($config) {
-            return $config->get('app.env', 'production');
-        });
-
         date_default_timezone_set($config['app.timezone']);
 
         mb_internal_encoding('UTF-8');


### PR DESCRIPTION
Follow-up to #13351. Please note this is very much a WIP and may have important caveats.

Important: we would lose [`app.env` config](https://github.com/laravel/laravel/commit/7ef3839fbf0ba65898ea34bf41cf23cbb3710fca). But that may be a good thing, things get mixed up because of this setting. Better use `app()->environment()`.
