### PR TITLE
[5.1] Improvements for Auth Guard methods loginUsingId and onceUsingId

### DIFF
--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -484,8 +484,6 @@ class Guard implements GuardContract
      */
     public function loginUsingId($id, $remember = false)
     {
-        $this->session->set($this->getName(), $id);
-
         $this->login($user = $this->provider->retrieveById($id), $remember);
 
         return $user;

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -484,7 +484,9 @@ class Guard implements GuardContract
      */
     public function loginUsingId($id, $remember = false)
     {
-        $this->login($user = $this->provider->retrieveById($id), $remember);
+        $user = $this->provider->retrieveById($id);
+
+        $this->login($user, $remember);
 
         return $user;
     }
@@ -497,7 +499,9 @@ class Guard implements GuardContract
      */
     public function onceUsingId($id)
     {
-        if (! is_null($user = $this->provider->retrieveById($id))) {
+        $user = $this->provider->retrieveById($id);
+
+        if (! is_null($user)) {
             $this->setUser($user);
 
             return true;

--- a/src/Illuminate/Auth/Guard.php
+++ b/src/Illuminate/Auth/Guard.php
@@ -486,9 +486,13 @@ class Guard implements GuardContract
     {
         $user = $this->provider->retrieveById($id);
 
-        $this->login($user, $remember);
+        if (! is_null($user)) {
+            $this->login($user, $remember);
 
-        return $user;
+            return $user;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -239,10 +239,10 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
     public function testLoginUsingIdStoresInSessionAndLogsInWithUser()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = $this->getMock('Illuminate\Auth\Guard', ['login', 'user'], [$provider, $session, $request]);
+        $guard = m::mock('Illuminate\Auth\Guard', [$provider, $session, $request])->makePartial();
         $guard->getSession()->shouldReceive('set')->once()->with($guard->getName(), 10);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user = m::mock('Illuminate\Contracts\Auth\Authenticatable'));
-        $guard->expects($this->once())->method('login')->with($this->equalTo($user), $this->equalTo(false))->will($this->returnValue($user));
+        $guard->shouldReceive('login')->once()->with($user, false)->andReturn($user);
 
         $this->assertEquals($user, $guard->loginUsingId(10));
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -240,7 +240,9 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\Guard', [$provider, $session, $request])->makePartial();
-        $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user = m::mock('Illuminate\Contracts\Auth\Authenticatable'));
+
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user);
         $guard->shouldReceive('login')->once()->with($user, false);
 
         $this->assertEquals($user, $guard->loginUsingId(10));

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -236,11 +236,10 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $guard->login($user, true);
     }
 
-    public function testLoginUsingIdStoresInSessionAndLogsInWithUser()
+    public function testLoginUsingIdLogsInWithUser()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\Guard', [$provider, $session, $request])->makePartial();
-        $guard->getSession()->shouldReceive('set')->once()->with($guard->getName(), 10);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user = m::mock('Illuminate\Contracts\Auth\Authenticatable'));
         $guard->shouldReceive('login')->once()->with($user, false);
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -242,7 +242,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $guard = m::mock('Illuminate\Auth\Guard', [$provider, $session, $request])->makePartial();
         $guard->getSession()->shouldReceive('set')->once()->with($guard->getName(), 10);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user = m::mock('Illuminate\Contracts\Auth\Authenticatable'));
-        $guard->shouldReceive('login')->once()->with($user, false)->andReturn($user);
+        $guard->shouldReceive('login')->once()->with($user, false);
 
         $this->assertEquals($user, $guard->loginUsingId(10));
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -248,6 +248,17 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($user, $guard->loginUsingId(10));
     }
 
+    public function testLoginUsingIdFailure()
+    {
+        list($session, $provider, $request, $cookie) = $this->getMocks();
+        $guard = m::mock('Illuminate\Auth\Guard', [$provider, $session, $request])->makePartial();
+
+        $guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
+        $guard->shouldNotReceive('login');
+
+        $this->assertFalse($guard->loginUsingId(11));
+    }
+
     public function testOnceUsingIdFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -250,8 +250,12 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
 
     public function testOnceUsingIdFailure()
     {
-        $guard = $this->getGuard();
+        list($session, $provider, $request, $cookie) = $this->getMocks();
+        $guard = m::mock('Illuminate\Auth\Guard', [$provider, $session, $request])->makePartial();
+
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
+        $guard->shouldNotReceive('setUser');
+
         $this->assertFalse($guard->onceUsingId(11));
     }
 


### PR DESCRIPTION
Follow-up to #12999.
- Remove redundant session set, as I explained in [this message](https://github.com/laravel/framework/pull/12999#issuecomment-205104562).
- If `loginUsingId` didn't find user, don't try to login and return false, instead of producing a load of errors. Note how well it is consistent with `onceUsingId`.
- Improve test coverage.
