### PR TITLE
[5.2] Improvements for SessionGuard methods loginUsingId and onceUsingId

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -474,9 +474,13 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         $user = $this->provider->retrieveById($id);
 
-        $this->login($user, $remember);
+        if (! is_null($user)) {
+            $this->login($user, $remember);
 
-        return $user;
+            return $user;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -472,8 +472,6 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function loginUsingId($id, $remember = false)
     {
-        $this->session->set($this->getName(), $id);
-
         $this->login($user = $this->provider->retrieveById($id), $remember);
 
         return $user;

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -472,7 +472,9 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function loginUsingId($id, $remember = false)
     {
-        $this->login($user = $this->provider->retrieveById($id), $remember);
+        $user = $this->provider->retrieveById($id);
+
+        $this->login($user, $remember);
 
         return $user;
     }
@@ -485,7 +487,9 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function onceUsingId($id)
     {
-        if (! is_null($user = $this->provider->retrieveById($id))) {
+        $user = $this->provider->retrieveById($id);
+
+        if (! is_null($user)) {
             $this->setUser($user);
 
             return true;

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -249,11 +249,10 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $guard->login($user, true);
     }
 
-    public function testLoginUsingIdStoresInSessionAndLogsInWithUser()
+    public function testLoginUsingIdLogsInWithUser()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
-        $guard->getSession()->shouldReceive('set')->once()->with($guard->getName(), 10);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user = m::mock('Illuminate\Contracts\Auth\Authenticatable'));
         $guard->shouldReceive('login')->once()->with($user, false);
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -252,10 +252,10 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
     public function testLoginUsingIdStoresInSessionAndLogsInWithUser()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
-        $guard = $this->getMock('Illuminate\Auth\SessionGuard', ['login', 'user'], ['default', $provider, $session, $request]);
+        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
         $guard->getSession()->shouldReceive('set')->once()->with($guard->getName(), 10);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user = m::mock('Illuminate\Contracts\Auth\Authenticatable'));
-        $guard->expects($this->once())->method('login')->with($this->equalTo($user), $this->equalTo(false))->will($this->returnValue($user));
+        $guard->shouldReceive('login')->once()->with($user, false)->andReturn($user);
 
         $this->assertEquals($user, $guard->loginUsingId(10));
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -255,7 +255,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
         $guard->getSession()->shouldReceive('set')->once()->with($guard->getName(), 10);
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user = m::mock('Illuminate\Contracts\Auth\Authenticatable'));
-        $guard->shouldReceive('login')->once()->with($user, false)->andReturn($user);
+        $guard->shouldReceive('login')->once()->with($user, false);
 
         $this->assertEquals($user, $guard->loginUsingId(10));
     }

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -263,8 +263,12 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
 
     public function testOnceUsingIdFailure()
     {
-        $guard = $this->getGuard();
+        list($session, $provider, $request, $cookie) = $this->getMocks();
+        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
+        $guard->shouldNotReceive('setUser');
+
         $this->assertFalse($guard->onceUsingId(11));
     }
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -261,6 +261,17 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($user, $guard->loginUsingId(10));
     }
 
+    public function testLoginUsingIdFailure()
+    {
+        list($session, $provider, $request, $cookie) = $this->getMocks();
+        $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
+
+        $guard->getProvider()->shouldReceive('retrieveById')->once()->with(11)->andReturn(null);
+        $guard->shouldNotReceive('login');
+
+        $this->assertFalse($guard->loginUsingId(11));
+    }
+
     public function testOnceUsingIdFailure()
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -253,7 +253,9 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
     {
         list($session, $provider, $request, $cookie) = $this->getMocks();
         $guard = m::mock('Illuminate\Auth\SessionGuard', ['default', $provider, $session])->makePartial();
-        $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user = m::mock('Illuminate\Contracts\Auth\Authenticatable'));
+
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user);
         $guard->shouldReceive('login')->once()->with($user, false);
 
         $this->assertEquals($user, $guard->loginUsingId(10));


### PR DESCRIPTION
Follow-up to #12999.
- Remove redundant session set, as I explained in [this message](https://github.com/laravel/framework/pull/12999#issuecomment-205104562).
- If `loginUsingId` didn't find user, don't try to login and return false, instead of producing a load of errors. Note how well it is consistent with `onceUsingId`.
- Improve test coverage.
