### PR TITLE
[5.2] Change the name of a compiled view.

### DIFF
--- a/src/Illuminate/View/Compilers/Compiler.php
+++ b/src/Illuminate/View/Compilers/Compiler.php
@@ -21,16 +21,25 @@ abstract class Compiler
     protected $cachePath;
 
     /**
+     * Get the base path of the views directory.
+     *
+     * @var string
+     */
+    protected $basePath;
+
+    /**
      * Create a new compiler instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  string  $cachePath
+     * @param  string  $basePath
      * @return void
      */
-    public function __construct(Filesystem $files, $cachePath)
+    public function __construct(Filesystem $files, $cachePath, $basePath = null)
     {
         $this->files = $files;
         $this->cachePath = $cachePath;
+        $this->basePath = $basePath;
     }
 
     /**
@@ -41,6 +50,10 @@ abstract class Compiler
      */
     public function getCompiledPath($path)
     {
+        // The sha1 should not care about where the project is stored.
+        // We just get the relative path from the base path.
+        $path = str_replace_first($this->basePath, '', $path);
+
         return $this->cachePath.'/'.sha1($path).'.php';
     }
 

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -98,8 +98,8 @@ class ViewServiceProvider extends ServiceProvider
         $matches = call_user_func_array('array_intersect_assoc', $paths);
 
         $root = '/';
-        for ($i = 0; isset($matches[ $i ]); $i += 1) {
-            $root .= $matches[ $i ].'/';
+        for ($i = 0; isset($matches[$i]); $i += 1) {
+            $root .= $matches[$i].'/';
         }
 
         return $root;

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -73,13 +73,36 @@ class ViewServiceProvider extends ServiceProvider
         // instance to pass into the engine so it can compile the views properly.
         $app->singleton('blade.compiler', function ($app) {
             $cache = $app['config']['view.compiled'];
+            $base = $this->getCommonRootPath($app['config']['view.paths']);
 
-            return new BladeCompiler($app['files'], $cache);
+            return new BladeCompiler($app['files'], $cache, $base);
         });
 
         $resolver->register('blade', function () use ($app) {
             return new CompilerEngine($app['blade.compiler']);
         });
+    }
+
+    /**
+     * Get the common root from an array of paths.
+     *
+     * @param  array  $paths
+     * @return string
+     */
+    protected function getCommonRootPath(array $paths)
+    {
+        array_walk($paths, function (&$path) {
+            $path = explode('/', trim($path, '/'));
+        });
+
+        $matches = call_user_func_array('array_intersect_assoc', $paths);
+
+        $root = '/';
+        for ($i = 0; isset($matches[ $i ]); $i += 1) {
+            $root .= $matches[ $i ].'/';
+        }
+
+        return $root;
     }
 
     /**

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -35,8 +35,12 @@ class ViewBladeCompilerTest extends PHPUnit_Framework_TestCase
 
     public function testCompilePathIsProperlyCreated()
     {
-        $compiler = new BladeCompiler($this->getFiles(), __DIR__);
+        $compiler = new BladeCompiler($this->getFiles(), __DIR__, 'base_path');
         $this->assertEquals(__DIR__.'/'.sha1('foo').'.php', $compiler->getCompiledPath('foo'));
+        $this->assertEquals(
+            __DIR__.'/'.sha1('/resources/views/foo').'.php',
+            $compiler->getCompiledPath('base_path/resources/views/foo')
+        );
     }
 
     public function testCompileCompilesFileAndReturnsContents()


### PR DESCRIPTION
The name will no longer reflect the hash of the full path of the view.

This allow us to deploy applications to PaaS solutions where applications cannot write to the filesystem. It also eases debugging: the hash of the compiled views will be the same on any environment.

Tested against these configurations:

``` php
// config/view.php
'paths' => [
    realpath(base_path('resources/views')),
]
```

``` php
// config/view.php
'paths' => [
    realpath(base_path('resources/views')),
    realpath(base_path('resources/mymodule/foo')),
]
```

``` php
// config/view.php
'paths' => [
    realpath(base_path('resources/views')),
    realpath(base_path('../external/views')),
]
```
