### PR TITLE
[5.3] Add exception logging to queued job attempts

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Foundation\Console\ServeCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Queue\Console\FailedTableCommand;
+use Illuminate\Queue\Console\FailedAttemptsTableCommand;
 use Illuminate\Foundation\Console\TinkerCommand;
 use Illuminate\Foundation\Console\JobMakeCommand;
 use Illuminate\Foundation\Console\AppNameCommand;
@@ -90,6 +91,7 @@ class ArtisanServiceProvider extends ServiceProvider
         'PolicyMake' => 'command.policy.make',
         'ProviderMake' => 'command.provider.make',
         'QueueFailedTable' => 'command.queue.failed-table',
+        'QueueFailedAttemptsTable' => 'command.queue.failed-attempts-table',
         'QueueTable' => 'command.queue.table',
         'RequestMake' => 'command.request.make',
         'SeederMake' => 'command.seeder.make',
@@ -377,6 +379,18 @@ class ArtisanServiceProvider extends ServiceProvider
     {
         $this->app->singleton('command.queue.failed-table', function ($app) {
             return new FailedTableCommand($app['files'], $app['composer']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerQueueFailedAttemptsTableCommand()
+    {
+        $this->app->singleton('command.queue.failed-attempts-table', function ($app) {
+            return new FailedAttemptsTableCommand($app['files'], $app['composer']);
         });
     }
 

--- a/src/Illuminate/Queue/Console/FailedAttemptsTableCommand.php
+++ b/src/Illuminate/Queue/Console/FailedAttemptsTableCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\Command;
+use Illuminate\Support\Composer;
+use Illuminate\Filesystem\Filesystem;
+
+class FailedAttemptsTableCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'queue:failed-attempts-table';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a migration for the failed job attempts database table';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * @var \Illuminate\Support\Composer
+     */
+    protected $composer;
+
+    /**
+     * Create a new failed queue jobs table command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @param  \Illuminate\Support\Composer    $composer
+     * @return void
+     */
+    public function __construct(Filesystem $files, Composer $composer)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+        $this->composer = $composer;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $table = $this->laravel['config']['queue.failed.attempts_table'];
+
+        $tableClassName = Str::studly($table);
+
+        $fullPath = $this->createBaseMigration($table);
+
+        $stub = str_replace(
+            ['{{table}}', '{{tableClassName}}'], [$table, $tableClassName], $this->files->get(__DIR__.'/stubs/failed_attempts.stub')
+        );
+
+        $this->files->put($fullPath, $stub);
+
+        $this->info('Migration created successfully!');
+
+        $this->composer->dumpAutoloads();
+    }
+
+    /**
+     * Create a base migration file for the table.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    protected function createBaseMigration($table = 'failed_job_attempts')
+    {
+        $name = 'create_'.$table.'_table';
+
+        $path = $this->laravel->databasePath().'/migrations';
+
+        return $this->laravel['migration.creator']->create($name, $path);
+    }
+}

--- a/src/Illuminate/Queue/Console/FlushFailedAttemptsCommand.php
+++ b/src/Illuminate/Queue/Console/FlushFailedAttemptsCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Console\Command;
+
+class FlushFailedAttemptsCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'queue:flush-attempts';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Flush all of the failed job attempts';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        $this->laravel['queue.attempts.failer']->flush();
+
+        $this->info('All failed job attempts were deleted successfully!');
+    }
+}

--- a/src/Illuminate/Queue/Console/stubs/failed_attempts.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_attempts.stub
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class Create{{tableClassName}}Table extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('{{table}}', function (Blueprint $table) {
+            $table->increments('id');
+            $table->text('connection');
+            $table->text('queue');
+            $table->text('message');
+            $table->longText('stack_trace');
+            $table->longText('payload');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('{{table}}');
+    }
+}

--- a/src/Illuminate/Queue/ConsoleServiceProvider.php
+++ b/src/Illuminate/Queue/ConsoleServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Console\RetryCommand;
 use Illuminate\Queue\Console\ListFailedCommand;
 use Illuminate\Queue\Console\FlushFailedCommand;
+use Illuminate\Queue\Console\FlushFailedAttemptsCommand;
 use Illuminate\Queue\Console\ForgetFailedCommand;
 
 class ConsoleServiceProvider extends ServiceProvider
@@ -40,9 +41,14 @@ class ConsoleServiceProvider extends ServiceProvider
             return new FlushFailedCommand;
         });
 
+        $this->app->singleton('command.queue.attempts.flush', function () {
+            return new FlushFailedAttemptsCommand;
+        });
+
         $this->commands(
             'command.queue.failed', 'command.queue.retry',
-            'command.queue.forget', 'command.queue.flush'
+            'command.queue.forget', 'command.queue.flush',
+            'command.queue.attempts.flush'
         );
     }
 

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobAttemptProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobAttemptProvider.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Queue\Failed;
+
+use Carbon\Carbon;
+use Illuminate\Database\ConnectionResolverInterface;
+
+class DatabaseFailedJobAttemptProvider implements FailedJobAttemptProviderInterface
+{
+    /**
+     * The connection resolver implementation.
+     *
+     * @var \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected $resolver;
+
+    /**
+     * The database connection name.
+     *
+     * @var string
+     */
+    protected $database;
+
+    /**
+     * The database table.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * Create a new database failed job provider.
+     *
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
+     * @param  string  $database
+     * @param  string  $table
+     * @return void
+     */
+    public function __construct(ConnectionResolverInterface $resolver, $database, $table)
+    {
+        $this->table = $table;
+        $this->resolver = $resolver;
+        $this->database = $database;
+    }
+
+    /**
+     * Log a failed job attempt into storage.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  string  $payload
+     * @param  Exception  $exception
+     * @return void
+     */
+    public function log($connection, $queue, $payload, $exception)
+    {
+        $failed_at = Carbon::now();
+        $message = "{$exception->getMessage()} at {$exception->getFile()} at line {$exception->getLine()}";
+        $stack_trace = $exception->getTraceAsString();
+
+        $this->getTable()->insert(compact('connection', 'queue', 'message', 'stack_trace', 'payload', 'failed_at'));
+    }
+
+    /**
+     * Flush all of the failed job attempts from storage.
+     *
+     * @return void
+     */
+    public function flush()
+    {
+        $this->getTable()->delete();
+    }
+
+    /**
+     * Get a new query builder instance for the table.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    protected function getTable()
+    {
+        return $this->resolver->connection($this->database)->table($this->table);
+    }
+}

--- a/src/Illuminate/Queue/Failed/FailedJobAttemptProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobAttemptProviderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Queue\Failed;
+
+interface FailedJobAttemptProviderInterface
+{
+    /**
+     * Log a failed job attempt into storage.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  string  $payload
+     * @param  Exception  $exception
+     * @return void
+     */
+    public function log($connection, $queue, $payload, $exception);
+
+    /**
+     * Flush all of the failed job attempts from storage.
+     *
+     * @return void
+     */
+    public function flush();
+}

--- a/src/Illuminate/Queue/Failed/NullFailedJobAttemptProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobAttemptProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Queue\Failed;
+
+class NullFailedJobAttemptProvider implements FailedJobAttemptProviderInterface
+{
+    /**
+     * Log a failed job attempt into storage.
+     *
+     * @param  string  $connection
+     * @param  string  $queue
+     * @param  string  $payload
+     * @param  Exception  $exception
+     * @return void
+     */
+    public function log($connection, $queue, $payload, $exception)
+    {
+        //
+    }
+
+    /**
+     * Flush all of the failed job attempts from storage.
+     *
+     * @return void
+     */
+    public function flush()
+    {
+        //
+    }
+}


### PR DESCRIPTION
This is a second attempt at logging exceptions whenever a job _attempt_ fails. (https://github.com/laravel/framework/pull/6486)

I think jobs should fail only if enough attempts were made unsuccessfully, as it is current behavior. As a job might fail because of different exceptions I decided to save exceptions based on job attempts.

I tried adding a list failed attempts command, but given stack traces and exception messages are so long reading the output wasn't helpful. I think people would actually read the database instead an artisan command.

This PR is related to this: https://github.com/laravel/laravel/pull/3769
Please let me know if there's something you'd like to change. I think this should be very helpful to people as it'd be to me.
