### PR TITLE
[5.2] Fix using onlyTrashed and withTrashed with whereHas #2

### DIFF
--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -405,6 +405,31 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends PHPUnit_Framework_TestC
     /**
      * @group test
      */
+    public function testWhereHasWithNestedDeletedRelationshipAndOnlyTrashedCondition()
+    {
+        $this->createUsers();
+
+        $abigail = SoftDeletesTestUser::where('email', 'abigailotwell@gmail.com')->first();
+        $post = $abigail->posts()->create(['title' => 'First Title']);
+        $post->delete();
+
+        $users = SoftDeletesTestUser::has('posts')->get();
+        $this->assertEquals(0, count($users));
+
+        $users = SoftDeletesTestUser::whereHas('posts', function ($q) {
+            $q->onlyTrashed();
+        })->get();
+        $this->assertEquals(1, count($users));
+
+        $users = SoftDeletesTestUser::whereHas('posts', function ($q) {
+            $q->withTrashed();
+        })->get();
+        $this->assertEquals(1, count($users));
+    }
+
+    /**
+     * @group test
+     */
     public function testWhereHasWithNestedDeletedRelationship()
     {
         $this->createUsers();


### PR DESCRIPTION
This is my attempt to fix https://github.com/laravel/framework/pull/13390

What I did is:
- First we need to store an array of global scopes that were removed from the query
- If any scopes were removed from the hasQuery, we also need to remove them from the relationQuery.

@taylorotwell @themsaid 
