### PR TITLE
[5.3] Allows configuration of cache store to use for sessions

### DIFF
--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -151,9 +151,10 @@ class SessionManager extends Manager
      */
     protected function createCacheHandler($driver)
     {
+        $store = array_get($this->app['config'], 'session.store') ?: $driver;
         $minutes = $this->app['config']['session.lifetime'];
 
-        return new CacheBasedSessionHandler(clone $this->app['cache']->driver($driver), $minutes);
+        return new CacheBasedSessionHandler(clone $this->app['cache']->store($store), $minutes);
     }
 
     /**


### PR DESCRIPTION
Allows configuration of the cache store to use for sessions, much like `session.connection` with Database sessions.

Introduces a `session.store` config option which defaults to null. When `session.store` is null then the driver name will be used as the store name which is the current behaviour.
