### PR TITLE
[5.2] Fix automatic scope nesting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1134,7 +1134,7 @@ class Builder
      */
     protected function shouldNestWheresForScope(QueryBuilder $query, $originalWhereCount)
     {
-        return $originalWhereCount && count($query->wheres) > $originalWhereCount;
+        return count($query->wheres) > $originalWhereCount;
     }
 
     /**

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -69,6 +69,10 @@ class DatabaseEloquentGlobalScopesTest extends PHPUnit_Framework_TestCase
     {
         $model = new EloquentClosureGlobalScopesWithOrTestModel();
 
+        $query = $model->newQuery();
+        $this->assertEquals('select "email", "password" from "table" where ("email" = ? or "email" = ?) and "active" = ? order by "name" asc', $query->toSql());
+        $this->assertEquals(['taylor@gmail.com', 'someone@else.com', 1], $query->getBindings());
+
         $query = $model->newQuery()->where('col1', 'val1')->orWhere('col2', 'val2');
         $this->assertEquals('select "email", "password" from "table" where ("col1" = ? or "col2" = ?) and ("email" = ? or "email" = ?) and "active" = ? order by "name" asc', $query->toSql());
         $this->assertEquals(['val1', 'val2', 'taylor@gmail.com', 'someone@else.com', 1], $query->getBindings());


### PR DESCRIPTION
When applying multiple global scopes, we need to nest them even if no other where clauses were added to the query. I loosened the `shouldNestWheresForScope` condition to allow for that.

Bug was reported here: https://laracasts.com/discuss/channels/general-discussion/define-multiple-global-scope-for-a-model-in-laravel
