### PR TITLE
[5.2] Add relationship subquery count

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -761,6 +761,27 @@ class Builder
     {
         return $this->where($column, $operator, $value, 'or');
     }
+    
+    /**
+     * Add a relationship count select to the query.
+     *
+     * @param  string  $relation
+     * @param  string  $as
+     * @param  \Closure|null  $callback
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function selectCount($relation, $as, Closure $callback = null)
+    {
+        $relation = $this->getHasRelationQuery($relation);
+
+        $query = $relation->getRelationCountQuery($relation->getRelated()->newQuery(), $this);
+
+        if ($callback) {
+            call_user_func($callback, $query);
+        }
+
+        return $this->selectSub($query->getQuery(), $as);
+    }
 
     /**
      * Add a relationship count / exists condition to the query.

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -761,7 +761,7 @@ class Builder
     {
         return $this->where($column, $operator, $value, 'or');
     }
-    
+
     /**
      * Add a relationship count select to the query.
      *

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -455,6 +455,28 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => $builder], $builder->delete());
     }
 
+    public function testSelectCount()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->selectCount('foo', 'fooCount');
+
+        $this->assertEquals('select (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "fooCount" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+    }
+
+    public function testSelectCountWithSelectAndContraintsAndHaving()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->where('bar', 'baz')->select('*');
+        $builder->selectCount('foo', 'fooCount', function ($q) {
+            $q->where('bam', '>', 'qux');
+        })->having('fooCount', '>=', 1);
+
+        $this->assertEquals('select *, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ?) as "fooCount" from "eloquent_builder_test_model_parent_stubs" where "bar" = ? having "fooCount" >= ?', $builder->toSql());
+        $this->assertEquals(['qux', 'baz', 1], $builder->getBindings());
+    }
+
     public function testHasWithContraintsAndHavingInSubquery()
     {
         $model = new EloquentBuilderTestModelParentStub;


### PR DESCRIPTION
This uses the same subquery as the `has()` clause, but adds it to the `select`. This way the count for a relationship can be loaded in 1 query, without loading the relationship itself.

Example:

``` php
// Model with relationship
class Client extends Model {
    public function projects() {
        return $this->hasMany(Project::class);
    }
}
// Query to get the clients
$clients = Client::select('*')->selectCount('projects', 'projectCount')->get()
```

Resulting query

``` sql
select *, (select count(*) from `projects` where `projects`.`client_id` = `clients`.`id`) as `projectCount` from `clients`
```

This will add an attribute`projectCount` to each Client object. This can also be used with `->having('projectCount', '>=', 1)` to avoid using an extra `has()` subquery. And also easy ordering in the query: `->orderBy('projectCount', 'desc')`

I know this has been rejected before (#2813), but it seems that most of the 'complicated' logic has been implemented already (subquery selects and relationCountQuery).

The alternatives are:
- `$client->projects->count()` -> Needs to load all relations, even when you don't need them.
- `$client->projects()->count()` -> Needs to run 1 query per client, so not good for many rows.

Potential problem: Adding a select will stop the default select columns from being added, so an explicit `select` is needed, before doing the count select. Not sure if this needs working around.
