### PR TITLE
[5.2] Work around lack of lastInsertId() for ODBC with PDO for MSSQL

### DIFF
--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -20,13 +20,12 @@ class SqlServerProcessor extends Processor
         $connection = $query->getConnection();
         $connection->insert($sql, $values);
         if ($connection->getConfig('odbc') === true) {
-            $result = $connection->select("SELECT CAST(COALESCE(SCOPE_IDENTITY(), @@IDENTITY) AS int) AS insertid");
-            if (!$result) {
+            $result = $connection->select('SELECT CAST(COALESCE(SCOPE_IDENTITY(), @@IDENTITY) AS int) AS insertid');
+            if (! $result) {
                 throw new Exception('Error retrieving lastInsertId');
             }
             $id = $result[0]->insertid;
-        }
-        else {
+        } else {
             $id = $connection->getPdo()->lastInsertId();
         }
 

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Database\Query\Processors;
 
-use Illuminate\Database\Query\Builder;
 use Exception;
+use Illuminate\Database\Query\Builder;
 
 class SqlServerProcessor extends Processor
 {

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Query\Processors;
 
 use Illuminate\Database\Query\Builder;
+use Exception;
 
 class SqlServerProcessor extends Processor
 {

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -17,9 +17,18 @@ class SqlServerProcessor extends Processor
      */
     public function processInsertGetId(Builder $query, $sql, $values, $sequence = null)
     {
-        $query->getConnection()->insert($sql, $values);
-
-        $id = $query->getConnection()->getPdo()->lastInsertId();
+        $connection = $query->getConnection();
+        $connection->insert($sql, $values);
+        if ($connection->getConfig('odbc') === true) {
+            $result = $connection->select("SELECT CAST(COALESCE(SCOPE_IDENTITY(), @@IDENTITY) AS int) AS insertid");
+            if (!$result) {
+                throw new Exception('Error retrieving lastInsertId');
+            }
+            $id = $result[0]->insertid;
+        }
+        else {
+            $id = $connection->getPdo()->lastInsertId();
+        }
 
         return is_numeric($id) ? (int) $id : $id;
     }


### PR DESCRIPTION
When using the ODBC driver for MSSQL an exception is thrown because the PDO driver does not implement lastInsertId().
This works around that by making an SQL call to return the id when using ODBC.
