### PR TITLE
[5.3] --timeout option for queue:work command

### DIFF
--- a/src/Illuminate/Queue/Console/TimeoutException.php
+++ b/src/Illuminate/Queue/Console/TimeoutException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Exception;
+
+class TimeoutException extends Exception
+{
+}

--- a/src/Illuminate/Queue/Console/TimeoutException.php
+++ b/src/Illuminate/Queue/Console/TimeoutException.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Queue\Console;
 
-use Exception;
+use RuntimeException;
 
-class TimeoutException extends Exception
+class TimeoutException extends RuntimeException
 {
 }

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Queue\Console;
 
 use Carbon\Carbon;
+use Illuminate\Queue\MissingExtensionException;
+use Illuminate\Queue\TimeoutException;
 use Illuminate\Queue\Worker;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Job;
@@ -94,6 +96,10 @@ class WorkCommand extends Command
         $timeout = $this->option('timeout');
 
         if ($timeout > 0) {
+
+            if (!extension_loaded('pcntl')) {
+                throw new MissingExtensionException('The pcntl extension is required to use the timeout option.');
+            }
 
             declare(ticks=1);
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -97,7 +97,7 @@ class WorkCommand extends Command
 
         if ($timeout > 0) {
 
-            if (!extension_loaded('pcntl')) {
+            if (! extension_loaded('pcntl')) {
                 throw new MissingExtensionException('The pcntl extension is required to use the timeout option.');
             }
 

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -96,16 +96,15 @@ class WorkCommand extends Command
         $timeout = $this->option('timeout');
 
         if ($timeout > 0) {
+            if (extension_loaded('pcntl') && function_exists('pcntl_alarm') && function_exists('pcntl_signal')) {
+                declare(ticks=1);
 
-            if (! extension_loaded('pcntl')) {
+                pcntl_signal(SIGALRM, function () {
+                    throw new TimeoutException();
+                }, true);
+            } else {
                 throw new MissingExtensionException('The pcntl extension is required to use the timeout option.');
             }
-
-            declare(ticks=1);
-
-            pcntl_signal(SIGALRM, function () {
-                throw new TimeoutException();
-            }, true);
         }
 
         if ($daemon) {

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -95,7 +95,7 @@ class WorkCommand extends Command
 
         if ($timeout > 0) {
 
-            declare(ticks = 1);
+            declare(ticks=1);
 
             pcntl_signal(SIGALRM, function () {
                 throw new TimeoutException();

--- a/src/Illuminate/Queue/MissingExtensionException.php
+++ b/src/Illuminate/Queue/MissingExtensionException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Queue;
+
+use RuntimeException;
+
+class MissingExtensionException extends RuntimeException
+{
+
+}

--- a/src/Illuminate/Queue/MissingExtensionException.php
+++ b/src/Illuminate/Queue/MissingExtensionException.php
@@ -6,5 +6,4 @@ use RuntimeException;
 
 class MissingExtensionException extends RuntimeException
 {
-
 }

--- a/src/Illuminate/Queue/TimeoutException.php
+++ b/src/Illuminate/Queue/TimeoutException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Queue\Console;
+namespace Illuminate\Queue;
 
 use RuntimeException;
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -158,7 +158,7 @@ class Worker
                 pcntl_alarm($timeout);
             }
             try {
-                $response = $this->process(
+                return $this->process(
                     $this->manager->getName($connectionName), $job, $maxTries, $delay
                 );
             } finally {
@@ -166,8 +166,6 @@ class Worker
                     pcntl_alarm(0);
                 }
             }
-
-            return $response;
         }
 
         $this->sleep($sleep);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -154,7 +154,6 @@ class Worker
         // then immediately return back out. If there is no job on the queue
         // we will "sleep" the worker for the specified number of seconds.
         if (! is_null($job)) {
-
             if ($timeout > 0) {
                 pcntl_alarm($timeout);
             }

--- a/tests/Queue/QueueWorkCommandTest.php
+++ b/tests/Queue/QueueWorkCommandTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use Illuminate\Encryption\Encrypter;
+use Illuminate\Foundation\Application;
+use Illuminate\Queue\Console\WorkCommand;
+use Illuminate\Queue\QueueManager;
+use Illuminate\Queue\RedisQueue;
+use Illuminate\Queue\Worker;
+use Illuminate\Redis\Database;
+use Mockery\MockInterface;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class QueueWorkCommandTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MockInterface|QueueManager
+     */
+    private $manager;
+
+    /**
+     * @var RedisQueue
+     */
+    private $queue;
+
+    /**
+     * @var Database
+     */
+    private $redis;
+
+    /**
+     * @var WorkCommand
+     */
+    private $workCommand;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $laravel = new Application();
+
+        $crypt = new Encrypter('someRandomString');
+
+        $laravel->instance('encrypter', $crypt);
+
+        $this->redis = new Database([
+            'cluster' => false,
+            'default' => [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'database' => 5,
+            ],
+        ]);
+
+        $this->redis->connection()->flushdb();
+
+        $this->queue = new RedisQueue($this->redis);
+
+        $this->queue->setEncrypter($crypt);
+
+        $this->queue->setContainer($laravel);
+
+        $this->manager = Mockery::mock(QueueManager::class);
+
+        $worker = new Worker($this->manager);
+
+        $this->workCommand = new WorkCommand($worker);
+
+        $this->workCommand->setLaravel($laravel);
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        Mockery::close();
+        $this->redis->connection()->flushdb();
+    }
+
+    /**
+     * @expectedException \Illuminate\Queue\TimeoutException
+     */
+    public function testTimeoutWhenWorkingOnAnInfinitLoopJob()
+    {
+        $this->queue->push(function() {
+            while(true) {
+                sleep(10);
+            }
+        });
+
+        $this->manager->shouldReceive('connection')->once()->with(null)->andReturn($this->queue);
+        $this->manager->shouldReceive('getName')->once()->with(null)->andReturn('default');
+        $this->workCommand->run(new ArrayInput([
+            '--timeout' => 2,
+        ]), new NullOutput());
+    }
+
+    public function testNoTimeoutWhenWorkingTheJobIsFastEnough()
+    {
+        $this->queue->push(function() {
+            //do nothing!
+        });
+
+        $this->manager->shouldReceive('connection')->once()->with(null)->andReturn($this->queue);
+        $this->manager->shouldReceive('getName')->once()->with(null)->andReturn('default');
+        $this->workCommand->run(new ArrayInput([
+            '--timeout' => 200,
+        ]), new NullOutput());
+    }
+}

--- a/tests/Queue/QueueWorkCommandTest.php
+++ b/tests/Queue/QueueWorkCommandTest.php
@@ -81,8 +81,8 @@ class QueueWorkCommandTest extends PHPUnit_Framework_TestCase
      */
     public function testTimeoutWhenWorkingOnAnInfinitLoopJob()
     {
-        $this->queue->push(function() {
-            while(true) {
+        $this->queue->push(function () {
+            while (true) {
                 sleep(10);
             }
         });
@@ -96,7 +96,7 @@ class QueueWorkCommandTest extends PHPUnit_Framework_TestCase
 
     public function testNoTimeoutWhenWorkingTheJobIsFastEnough()
     {
-        $this->queue->push(function() {
+        $this->queue->push(function () {
             //do nothing!
         });
 


### PR DESCRIPTION
Lack of timeout is something I found dangerous for our workers. For me, calling set_time_limit() is not an option:

> [Warning](http://php.net/manual/en/function.set-time-limit.php): This function has no effect when PHP is running in safe mode. There is no workaround other than turning off safe mode or changing the time limit in the php.ini. 

In this PR, a solution based on alarm signal is proposed. At the moment, this is just for consideration and discussion. I will try to complete the tests and do any suggested fix or improvement.
Very thanks for your time.

Related issue: [laravel/internal](https://github.com/laravel/internals/issues/75), #13372
