### PR TITLE
[5.2] Fix redundant MAC rehashing

### DIFF
--- a/src/Illuminate/Encryption/BaseEncrypter.php
+++ b/src/Illuminate/Encryption/BaseEncrypter.php
@@ -72,10 +72,6 @@ abstract class BaseEncrypter
      */
     protected function validMac(array $payload)
     {
-        $bytes = random_bytes(16);
-
-        $calcMac = hash_hmac('sha256', $this->hash($payload['iv'], $payload['value']), $bytes, true);
-
-        return hash_equals(hash_hmac('sha256', $payload['mac'], $bytes, true), $calcMac);
+        return hash_equals($this->hash($payload['iv'], $payload['value']), $payload['mac']);
     }
 }


### PR DESCRIPTION
The BaseEncrypter is not comparing a freshly computed MAC based on the payload to the one supplied, but instead is comparing MACs of these two values (so basically MACs of MACs). As far as I can tell this is unnecessary and also wastes 16 bytes of randomness each time something is decrypted (as well as processing power).

I removed said redundant code.
