### PR TITLE
[5.3] Make SessionGuard::onceUsingId() return user instance

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -468,7 +468,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      *
      * @param  mixed  $id
      * @param  bool   $remember
-     * @return \Illuminate\Contracts\Auth\Authenticatable
+     * @return \Illuminate\Contracts\Auth\Authenticatable|false
      */
     public function loginUsingId($id, $remember = false)
     {
@@ -487,7 +487,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * Log the given user ID into the application without sessions or cookies.
      *
      * @param  mixed  $id
-     * @return bool
+     * @return \Illuminate\Contracts\Auth\Authenticatable|false
      */
     public function onceUsingId($id)
     {
@@ -496,7 +496,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         if (! is_null($user)) {
             $this->setUser($user);
 
-            return true;
+            return $user;
         }
 
         return false;

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -282,7 +282,7 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $guard->getProvider()->shouldReceive('retrieveById')->once()->with(10)->andReturn($user);
         $guard->shouldReceive('setUser')->once()->with($user);
 
-        $this->assertTrue($guard->onceUsingId(10));
+        $this->assertEquals($user, $guard->onceUsingId(10));
     }
 
     public function testOnceUsingIdFailure()


### PR DESCRIPTION
For consistency with `loginUsingId`. As `$user == true` this change shouldn't affect BC much.
