### PR TITLE
[5.3] Bind CacheManager to custom driver closure.

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -284,7 +284,7 @@ class CacheManager implements FactoryContract
      */
     public function extend($driver, Closure $callback)
     {
-        $this->customCreators[$driver] = $callback;
+        $this->customCreators[$driver] = $callback->bindTo($this, $this);
 
         return $this;
     }

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Cache\CacheManager;
 use Mockery as m;
+use Illuminate\Cache\CacheManager;
 
 class CacheManagerTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Cache\CacheManager;
+use Mockery as m;
+
+class CacheManagerTest extends PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testCustomDriverClosureBoundObjectIsCacheManager()
+    {
+        $cacheManager = new CacheManager([
+            'config' => [
+                'cache.stores.' . __CLASS__ => [
+                    'driver' => __CLASS__
+                ]
+            ]
+        ]);
+        $driver       = function () {
+            return $this;
+        };
+        $cacheManager->extend(__CLASS__, $driver);
+        $this->assertEquals($cacheManager, $cacheManager->store(__CLASS__));
+    }
+}

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -14,12 +14,12 @@ class CacheManagerTest extends PHPUnit_Framework_TestCase
     {
         $cacheManager = new CacheManager([
             'config' => [
-                'cache.stores.' . __CLASS__ => [
-                    'driver' => __CLASS__
-                ]
-            ]
+                'cache.stores.'.__CLASS__ => [
+                    'driver' => __CLASS__,
+                ],
+            ],
         ]);
-        $driver       = function () {
+        $driver = function () {
             return $this;
         };
         $cacheManager->extend(__CLASS__, $driver);


### PR DESCRIPTION
This feature aims to replace a custom drivers bound object with an instance of the CacheManager. This would allow you to accomplish more advanced cache driver logic such as overloading the memcached driver to catch connection errors, and gracefully failover to the database calls, third party API calls, etc. that you would be caching.

**Example:**

``` php
$this->app->make('cache')->extend('memcached', function ($app, $config) {
    /** @var \Illuminate\Cache\CacheManager $this */
    try {
        return $this->createMemcachedDriver($config);
    } catch (\RuntimeException $re) {
        return $this->createNullDriver($config);
    }
});
```

Since I've passed the `CacheManager` as both parameters to `\Closure` [bindTo](http://php.net/manual/en/closure.bindto.php), it allows `$this` to have more than a static scope, and thus allows for access to the protected methods on `CacheManager`.

I've added a unit test for `CacheManager` that confirms `$this` is being correctly set when a custom driver is specified.

Signed-off-by: Hunter Skrasek hunter@perk.com
