### PR TITLE
[5.2] Fix migration tests on windows

### DIFF
--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -20,7 +20,7 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase
         $app = new Illuminate\Foundation\Application;
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
-        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.'/migrations', null, false);
+        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', null, false);
         $composer->shouldReceive('dumpAutoloads')->once();
 
         $this->runCommand($command, ['name' => 'create_foo']);
@@ -36,7 +36,7 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase
         $app = new Illuminate\Foundation\Application;
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
-        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.'/migrations', null, false);
+        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', null, false);
 
         $this->runCommand($command, ['name' => 'create_foo']);
     }
@@ -51,7 +51,7 @@ class DatabaseMigrationMakeCommandTest extends PHPUnit_Framework_TestCase
         $app = new Illuminate\Foundation\Application;
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
-        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.'/migrations', 'users', true);
+        $creator->shouldReceive('create')->once()->with('create_foo', __DIR__.DIRECTORY_SEPARATOR.'migrations', 'users', true);
 
         $this->runCommand($command, ['name' => 'create_foo', '--create' => 'users']);
     }

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -18,7 +18,7 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.DIRECTORY_SEPARATOR.'migrations', ['pretend' => false, 'step' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -33,7 +33,7 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.DIRECTORY_SEPARATOR.'migrations', ['pretend' => false, 'step' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
         $command->expects($this->once())->method('call')->with($this->equalTo('migrate:install'), $this->equalTo(['--database' => null]));
@@ -48,7 +48,7 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => true, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.DIRECTORY_SEPARATOR.'migrations', ['pretend' => true, 'step' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -62,7 +62,7 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with('foo');
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.DIRECTORY_SEPARATOR.'migrations', ['pretend' => false, 'step' => false]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 
@@ -76,7 +76,7 @@ class DatabaseMigrationMigrateCommandTest extends PHPUnit_Framework_TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('setConnection')->once()->with(null);
-        $migrator->shouldReceive('run')->once()->with(__DIR__.'/migrations', ['pretend' => false, 'step' => true]);
+        $migrator->shouldReceive('run')->once()->with(__DIR__.DIRECTORY_SEPARATOR.'migrations', ['pretend' => false, 'step' => true]);
         $migrator->shouldReceive('getNotes')->andReturn([]);
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
 


### PR DESCRIPTION
Follow-up to #13254. A similar change _might_ be applied to a few other places (search for "/migrations").

But for now, just fixing the tests broken on windows.

ping @mnabialek
