### PR TITLE
[5.2] Ensures MigrationCreator::create receives $create as a boolean

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -67,10 +67,11 @@ class MigrateMakeCommand extends BaseCommand
 
         $table = $this->input->getOption('table');
 
-        $create = $this->input->getOption('create');
+        $create = $this->input->getOption('create') ?: false;
 
         if (! $table && is_string($create)) {
             $table = $create;
+            $create = true;
         }
 
         // Now we are ready to write the migration out to disk. Once we've written


### PR DESCRIPTION
Follow-up to #13409.

Previously, `$create` could also be:
- null if no `--create` argument
- a string if argument was `--create=tablename`

In both cases, `MigrationCreator::create` was receiving it as so, and the code was working because of loose typing.

<br>Refs #2528, https://github.com/laravel/framework/commit/c30a4cb7b0ae935c901be1c51307cbfff9041b50.
