### PR TITLE
[5.2] Allow custom validators to be called with out function name

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -3114,7 +3114,11 @@ class Validator implements ValidatorContract
      */
     protected function callClassBasedExtension($callback, $parameters)
     {
-        list($class, $method) = explode('@', $callback);
+        if (Str::contains($callback, '@')) {
+            list($class, $method) = explode('@', $callback);
+        } else {
+            list($class, $method) = [$callback, '__invoke'];
+        }
 
         return call_user_func_array([$this->container->make($class), $method], $parameters);
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2045,6 +2045,20 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo!', $v->messages()->first('name'));
     }
 
+    public function testClassBasedCustomValidatorsUsingInvoke()
+    {
+        $trans = $this->getRealTranslator();
+        $trans->addResource('array', ['validation.foo' => 'foo!'], 'en', 'messages');
+        $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
+        $v->setContainer($container = m::mock('Illuminate\Container\Container'));
+        $v->addExtension('foo', 'Foo');
+        $container->shouldReceive('make')->once()->with('Foo')->andReturn($foo = m::mock('StdClass'));
+        $foo->shouldReceive('__invoke')->once()->andReturn(false);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('foo!', $v->messages()->first('name'));
+    }
+
     public function testCustomImplicitValidators()
     {
         $trans = $this->getRealTranslator();


### PR DESCRIPTION
This would class based custom validators to simply call the class instead of having to define a function inside the class.

`Validator::extend('postcode', PostcodeValidator::class);`
