### PR TITLE
[5.3] Change group route namespace global scope merge style

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -375,6 +375,10 @@ class Router implements RegistrarContract
     protected static function formatUsesPrefix($new, $old)
     {
         if (isset($new['namespace'])) {
+            if (strpos($new['namespace'], '\\') === 0) {
+                return trim($new['namespace'], '\\');
+            }
+            
             return isset($old['namespace'])
                     ? trim($old['namespace'], '\\').'\\'.trim($new['namespace'], '\\')
                     : trim($new['namespace'], '\\');

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -635,6 +635,15 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
 
         $router = $this->getRouter();
         $router->group(['namespace' => 'Namespace'], function () use ($router) {
+            $router->get('foo/bar', '\\Controller@action');
+        });
+        $routes = $router->getRoutes()->getRoutes();
+        $action = $routes[0]->getAction();
+
+        $this->assertEquals('\Controller@action', $action['controller']);
+
+        $router = $this->getRouter();
+        $router->group(['namespace' => 'Namespace'], function () use ($router) {
             $router->group(['namespace' => 'Nested'], function () use ($router) {
                 $router->get('foo/bar', 'Controller@action');
             });
@@ -643,6 +652,17 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $action = $routes[0]->getAction();
 
         $this->assertEquals('Namespace\\Nested\\Controller@action', $action['controller']);
+
+        $router = $this->getRouter();
+        $router->group(['namespace' => 'Namespace'], function () use ($router) {
+            $router->group(['namespace' => '\GlobalScope'], function () use ($router) {
+                $router->get('foo/bar', 'Controller@action');
+            });
+        });
+        $routes = $router->getRoutes()->getRoutes();
+        $action = $routes[0]->getAction();
+
+        $this->assertEquals('GlobalScope\\Controller@action', $action['controller']);
 
         $router = $this->getRouter();
         $router->group(['prefix' => 'baz'], function () use ($router) {


### PR DESCRIPTION
Before  changes

``` php
Route::group(['namespace'=>'\FileManager\Controller'],function(){
   dd( Route::get('upload','UploadController@show')->getActionName());
//"App\Http\Controllers\FileManager\Controller\UploadController@show"
});
```

After

``` php
Route::group(['namespace'=>'\FileManager\Controller'],function(){
   dd( Route::get('upload','UploadController@show')->getActionName());
//"FileManager\Controller\UploadController@show"
});


Route::group(['namespace'=>'FileManager\Controller'],function(){
   dd( Route::get('upload','UploadController@show')->getActionName());
//"App\Http\Controllers\FileManager\Controller\UploadController@show"
});
```
