### PR TITLE
[5.2] Put the payload column of jobs table to the end of insert statements.

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -270,12 +270,12 @@ class DatabaseQueue extends Queue implements QueueContract
     {
         return [
             'queue' => $queue,
-            'payload' => $payload,
             'attempts' => $attempts,
             'reserved' => 0,
             'reserved_at' => null,
             'available_at' => $availableAt,
             'created_at' => $this->getTime(),
+            'payload' => $payload,
         ];
     }
 


### PR DESCRIPTION
It was opened an [issue](https://github.com/yajra/laravel-oci8/issues/170) in laravel-oci8 because of an exception thrown when inserting in the table jobs.

> ORA-24816: Expanded non LONG bind data supplied after actual LONG or LOB column
> Cause: A Bind value of length potentially > 4000 bytes follows binding for LOB or LONG.
> **Action: Re-order the binds so that the LONG bind or LOB binds are all at the end of the bind list.**

Like is mentioned above, to solve this is simply needed to put the clob column at the end of the insert statement.

This was done in class `DatabaseQueue`, in `buildDatabaseRecord`, and then the problem is solved.
