### PR TITLE
[5.2] Fire the RouteMatched event on route:list command

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -5,7 +5,6 @@ namespace Illuminate\Foundation\Providers;
 use Illuminate\Routing\Redirector;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Routing\Events\RouteMatched;
 use Symfony\Component\HttpFoundation\Request;
 use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 
@@ -42,12 +41,10 @@ class FoundationServiceProvider extends ServiceProvider
             $resolved->validate();
         });
 
-        $this->app['events']->listen(RouteMatched::class, function () {
-            $this->app->resolving(function (FormRequest $request, $app) {
-                $this->initializeRequest($request, $app['request']);
+        $this->app->resolving(function (FormRequest $request, $app) {
+            $this->initializeRequest($request, $app['request']);
 
-                $request->setContainer($app)->setRedirector($app->make(Redirector::class));
-            });
+            $request->setContainer($app)->setRedirector($app->make(Redirector::class));
         });
     }
 


### PR DESCRIPTION
As described here https://github.com/laravel/framework/issues/13453, FormRequests wouldn't get initialised properly when being resolved from the `routes:list` command, this is because the initialisation logic only runs when the `RouteMatched` event is fired.

Check: https://github.com/laravel/framework/blob/b18c01edc8db22d29ce7500b68b6431561489bc9/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php#L45
