### PR TITLE
[5.3] [Proposal] Array values recursive.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -871,3 +871,33 @@ if (! function_exists('with')) {
         return $object;
     }
 }
+
+if (! function_exists('array_values_recursive')) {
+    /**
+     * Recursively get all values from array.
+     *
+     * @param  array  $array
+     * @param  bool   $merge  maintain array dimension
+     * @return array
+     */
+    function array_values_recursive(array $array, $merge = true)
+    {
+        $values = [];
+
+        foreach ($array as $key => $value) {
+            $values[] = is_array($value) ? array_values_recursive($value, $merge) : $value;
+        }
+
+        if (! $merge) {
+            return $values;
+        }
+
+        $valuesForMerge = function () use ($values) {
+            return array_map(function ($value) {
+                return is_array($value) ? $value : [$value];
+            }, $values);
+        };
+
+        return call_user_func_array('array_merge', $valuesForMerge());
+    }
+}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -661,6 +661,43 @@ class SupportHelpersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Mövsümov', array_pull($developer, 'surname'));
         $this->assertEquals(['firstname' => 'Ferid'], $developer);
     }
+
+    public function testArrayValuesRecursive()
+    {
+        $validations = [
+            'required',
+            'text' => 'integer',
+            'textbox' => [
+                'string' => 'limit|500',
+            ],
+            'select' => [
+                'multiselect',
+                [
+                    'apple',
+                    'banana',
+                    'selected'  => 'orange',
+                ],
+            ],
+        ];
+
+        $this->assertEquals([
+            'required',
+            'integer',
+            [
+                'limit|500',
+            ],
+            [
+                'multiselect',
+                [
+                    'apple', 'banana', 'orange',
+                ],
+            ],
+        ], array_values_recursive($validations, false));
+
+        $this->assertEquals([
+            'required', 'integer', 'limit|500', 'multiselect', 'apple', 'banana', 'orange',
+        ], array_values_recursive($validations));
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
Get array values regarless of its dimension.

Example:

``` php
$validations = [
            'required',
            'text' => 'integer',
            'textbox' => [
                'string' => 'limit|500',
            ],
            'select' => [
                'multiselect',
                [
                    'apple',
                    'banana',
                    'selected'  => 'orange',
                ],
            ],
        ];
```

Result should be

``` php
['required', 'integer', 'limit|500', 'multiselect', 'apple', 'banana', 'orange']
```

I used this in many projects and i found it useful.
