### PR TITLE
[5.2] Explicitly use 'id' for retrieving session entry in DatabaseSessionHandler

### DIFF
--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -73,7 +73,7 @@ class DatabaseSessionHandler implements SessionHandlerInterface, ExistenceAwareI
      */
     public function read($sessionId)
     {
-        $session = (object) $this->getQuery()->find($sessionId);
+        $session = (object) $this->getQuery()->where('id', $sessionId)->first();
 
         if (isset($session->payload)) {
             $this->exists = true;


### PR DESCRIPTION
This change makes the `DatabaseSessionHandler` work properly even if the underlying database driver doesn't use 'id' as the key for `Query\Builder::find()`.

Example - `Jenssegers/Mongodb` implements the `Query\Builder::find()` method like this:

``` php
    public function find($id, $columns = [])
    {
        return $this->where('_id', '=', $this->convertKey($id))->first($columns);
    }
```

The rest of the `DatabaseSessionHandler` explicitly uses the key 'id', so it breaks and the session is never loaded properly.
