### PR TITLE
[5.1] Bring back support for Carbon instances to Before and After validators

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -7,6 +7,7 @@ use DateTime;
 use Countable;
 use Exception;
 use DateTimeZone;
+use Carbon\Carbon;
 use RuntimeException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -1425,7 +1426,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(1, $parameters, 'before');
 
-        if (! is_string($value) && ! is_numeric($value)) {
+        if (! is_string($value) && ! is_numeric($value) && ! $value instanceof Carbon) {
             return false;
         }
 
@@ -1467,7 +1468,7 @@ class Validator implements ValidatorContract
     {
         $this->requireParameterCount(1, $parameters, 'after');
 
-        if (! is_string($value) && ! is_numeric($value)) {
+        if (! is_string($value) && ! is_numeric($value) && ! $value instanceof Carbon) {
             return false;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mockery as m;
+use Carbon\Carbon;
 use Illuminate\Validation\Validator;
 use Symfony\Component\HttpFoundation\File\File;
 
@@ -1359,10 +1360,22 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $v = new Validator($trans, ['x' => ['2000-01-01']], ['x' => 'Before:2012-01-01']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, ['x' => new Carbon('2000-01-01')], ['x' => 'Before:2012-01-01']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => [new Carbon('2000-01-01')]], ['x' => 'Before:2012-01-01']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, ['x' => '2012-01-01'], ['x' => 'After:2000-01-01']);
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => ['2012-01-01']], ['x' => 'After:2000-01-01']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => new Carbon('2012-01-01')], ['x' => 'After:2000-01-01']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => [new Carbon('2012-01-01')]], ['x' => 'After:2000-01-01']);
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['start' => '2012-01-01', 'ends' => '2013-01-01'], ['start' => 'After:2000-01-01', 'ends' => 'After:start']);


### PR DESCRIPTION
Prior to Laravel 5.1.32, the Before and After validation rules accepted Carbon instances and correctly validated them. In 5.1.32 the validateBefore and validateAfter methods were changed to return false if the value passed was not a string and in subsequent point released if it was not a string or a number.

In 5.1.32 the following check was added to both validateBefore and validateAfter

```
    if (! is_string($value)) {
        return false;
    }
```

They evolved to the following in 5.1.35

```
    if (! is_string($value) && ! is_numeric($value)) {
        return false;
    }
```

This PR expands the check to see if the value is also not a Carbon instance. Carbon instances are compatible with strtotime() while DateTime instances are not.

```
strtotime(new DateTime());
> PHP warning:  strtotime() expects parameter 1 to be string, object given on line 1

strtotime(new Carbon());
> 1462824036
```

I have a fair amount of code in my 5.1 project that has relied on Before and After properly validating Carbon instances. My only alternatives would be to override Laravel's validator which adds technical debt or modify a bunch of code to convert Carbon dates before validation.

Given 5.1 is an LTS, I would hope that it would continue to support validation of Carbon instances as it has for most of it's lifetime.
