### PR TITLE
[5.1] Account for __isset changes in PHP 7

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3397,15 +3397,26 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
-     * Determine if an attribute exists on the model.
+     * Determine if an attribute or relation exists on the model.
      *
      * @param  string  $key
      * @return bool
      */
     public function __isset($key)
     {
-        return (isset($this->attributes[$key]) || isset($this->relations[$key])) ||
-                ($this->hasGetMutator($key) && ! is_null($this->getAttributeValue($key)));
+        if (isset($this->attributes[$key]) || isset($this->relations[$key])) {
+            return true;
+        }
+
+        if (method_exists($this, $key)) {
+            // For unloaded relations we attempt to load it in if the method exists
+            $this->$key;
+            if (isset($this->relations[$key])) {
+                return true;
+            }
+        }
+
+        return $this->hasGetMutator($key) && ! is_null($this->getAttributeValue($key));
     }
 
     /**


### PR DESCRIPTION
Update: this is a revised PR after speaking with Taylor about the intended behavior and possible solutions.

PHP 7 has fixed a bug with __isset which affects both the native isset and empty methods. This causes specific issues with checking isset or empty on relations in Eloquent. In PHP 7 checking if a property exists on an unloaded relation, for example `isset($this->relation->id)` is always returning false because unlike PHP 5.6, PHP 7 is now checking the offset of each attribute before chaining to the next one. In PHP 5.6 it would eager load the relation without checking the offset. This change brings back the intended behavior of the core Eloquent model __isset method for PHP 7 so it works like it did in PHP 5.6.

For reference, please check the following link, specifically Nikita Popov's comment (core PHP dev) - https://bugs.php.net/bug.php?id=69659
