### PR TITLE
[5.2] Added support for different log levels.

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
+++ b/src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php
@@ -68,7 +68,10 @@ class ConfigureLogging
      */
     protected function configureSingleHandler(Application $app, Writer $log)
     {
-        $log->useFiles($app->storagePath().'/logs/laravel.log');
+        $log->useFiles(
+            $app->storagePath().'/logs/laravel.log',
+            $app->make('config')->get('app.log_level', 'debug')
+        );
     }
 
     /**
@@ -80,9 +83,11 @@ class ConfigureLogging
      */
     protected function configureDailyHandler(Application $app, Writer $log)
     {
+        $config = $app->make('config');
         $log->useDailyFiles(
             $app->storagePath().'/logs/laravel.log',
-            $app->make('config')->get('app.log_max_files', 5)
+            $config->get('app.log_max_files', 5),
+            $config->get('app.log_level', 'debug')
         );
     }
 
@@ -95,7 +100,10 @@ class ConfigureLogging
      */
     protected function configureSyslogHandler(Application $app, Writer $log)
     {
-        $log->useSyslog('laravel');
+        $log->useSyslog(
+            'laravel',
+            $app->make('config')->get('app.log_level', 'debug')
+        );
     }
 
     /**
@@ -107,6 +115,6 @@ class ConfigureLogging
      */
     protected function configureErrorlogHandler(Application $app, Writer $log)
     {
-        $log->useErrorLog();
+        $log->useErrorLog($app->make('config')->get('app.log_level', 'debug'));
     }
 }


### PR DESCRIPTION
This adds support for different logging levels that seems to be implemented but it was missing from this file. Now we can use different logging levels. If we switch from development to production we have different amount of logging information. 

This is feature of [Monolog](https://github.com/Seldaek/monolog/blob/master/src/Monolog/Logger.php#L304) and it was added in **src/Illuminate/Log/Writer.php** but not in  **src/Illuminate/Foundation/Bootstrap/ConfigureLogging.php**

This functionality is not tested since it is part of Monolog.
