### PR TITLE
[5.2] Fix replacing route default parameters.

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -518,8 +518,8 @@ class Route
      */
     protected function replaceDefaults(array $parameters)
     {
-        foreach ($parameters as $key => &$value) {
-            $value = isset($value) ? $value : Arr::get($this->defaults, $key);
+        foreach ($parameters as $key => $value) {
+            $parameters[$key] = isset($value) ? $value : Arr::get($this->defaults, $key);
         }
 
         foreach ($this->defaults as $key => $value) {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -277,6 +277,9 @@ class RoutingRouteTest extends PHPUnit_Framework_TestCase
         $router->get('foo/{bar?}', ['uses' => 'RouteTestControllerWithParameterStub@returnParameter'])->defaults('bar', 'foo');
         $this->assertEquals('foo', $router->dispatch(Request::create('foo', 'GET'))->getContent());
 
+        $router->get('foo/{bar?}', ['uses' => 'RouteTestControllerWithParameterStub@returnParameter'])->defaults('bar', 'foo');
+        $this->assertEquals('bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+
         $router->get('foo/{bar?}', function ($bar = '') { return $bar; })->defaults('bar', 'foo');
         $this->assertEquals('foo', $router->dispatch(Request::create('foo', 'GET'))->getContent());
     }


### PR DESCRIPTION
``` php
Route::get('foo/{bar?}')->defaults('bar', 'default');
```

If we create request `http:\\localhost\foo\bar` 
#### Before

``` php
dd(Request::route()->parameters())

// return 
[
    'bar' => 'default'
]
```
#### After

``` php
dd(Request::route()->parameters())

// return 
[
    'bar' => 'bar'
]
```
