### PR TITLE
[5.2] Allow Request::intersect() to accept argument list

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -383,6 +383,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function intersect($keys)
     {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
         return array_filter($this->only($keys));
     }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -245,6 +245,12 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([], $request->except('age', 'name'));
     }
 
+    public function testIntersectMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => null]);
+        $this->assertEquals(['name' => 'Taylor'], $request->intersect('name', 'age', 'email'));
+    }
+
     public function testQueryMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);


### PR DESCRIPTION
Similar to `Request::only()`, `Request::except()`, `Request::exists()`, etc; this PR will allow `Request::intersect()` to accept argument list.

For example:

``` php
// Before
request()->intersect(['name', 'email', 'username']);

// This PR
request()->intersect('name', 'email', 'username');
```
