### PR TITLE
[5.2] Fix issue #11815

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -545,9 +545,15 @@ class Builder
             return $values;
         }
 
-        $column = $this->model->getUpdatedAtColumn();
+        if (count($this->getQuery()->joins) > 0) {
+            $column = $this->model->getQualifiedUpdatedAtColumn();
+        } else {
+            $column = $this->model->getUpdatedAtColumn();
+        }
 
-        return Arr::add($values, $column, $this->model->freshTimestampString());
+        return array_merge($values, [
+            $column => $this->model->freshTimestampString()
+        ]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -552,7 +552,7 @@ class Builder
         }
 
         return array_merge($values, [
-            $column => $this->model->freshTimestampString()
+            $column => $this->model->freshTimestampString(),
         ]);
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1787,6 +1787,16 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Get the fully qualified "updated at" column.
+     *
+     * @return string
+     */
+    public function getQualifiedUpdatedAtColumn()
+    {
+        return $this->getTable().'.'.$this->getUpdatedAtColumn();
+    }
+
+    /**
      * Get a fresh timestamp for the model.
      *
      * @return \Carbon\Carbon


### PR DESCRIPTION
Timestamps are not prefixed when updating many-to-many relationship

This issue is caused by the Eloquent Builder's `addUpdatedAtColumn` method, which
does not account for relationships when retrieving the "updated at" column. Unlike
the `SoftDeletes` trait, which knows to get the qualified "deleted at" column
when deleting relationships, the Eloquent Builder's `addUpdatedAtColumn` method
simply calls the model's `getUpdatedAtColumn` method, which returns the static
constant who's value is "updated_at".

The fix for this is implementing the same methods for deleting relationships when
updated them. The `Illuminate\Database\Eloquent\Model` class receives a new
`getQualifiedUpdatedAtColumn`, which simply concatenates the model's table name
with the model's "updated at" column name. Meanwhile, the `Illuminate\Database\Eloquent\Builder`
`addUpdatedAtColumn` method checks to see if the current query has any joins. If
the query does have joins, it will call the model's `getQualifiedUpdatedAtColumn`,
otherwise it will do what it has always done, call the `getUpdatedAtColumn` method.

This finally gives us the proper "updated at" query whether we have joins or not.
However, the method returns a merged array using the `Illuminate\Support\Arr`
class, which merges the existing values with the new "updated at" column, but
due to the nature of the `Arr::set` method, breaks the join query from `table.updated_at`
to `[table => updated_at]`, breaking the subsequent query.There are two solutions
I found to this issue. The first is to modify the Query Builder `update` method to
call `Arr::dot` on the on the values passed to the method. This is not ideal, as
it reverses the `Arr::set` method which causes an unnecessary latency in time and
could also have unforseen affects. The second solution goes back to the Eloquent
Builder `update` method. Instead of using the `Arr::add` method to add the
"updated at" column, we will perform a simple `array_merge`, which does exactly
what the `Arr::add` method did when updating, but doesn't break the merge when
adding a relationship to the "updated at" column.

**When using the `Arr::add` method:**  `update `bug` inner join `bug_laravel` on `bug`.`id` = `bug_laravel`.`bug_id` set `bug`.`deleted_at` = ?, `bug` = ? where `bug_laravel`.`laravel_id` = ? and `bug`.`deleted_at` is null`
**When using `array_merge` function:** `update `bug` inner join `bug_laravel` on `bug`.`id` = `bug_laravel`.`bug_id` set `bug`.`deleted_at` = ?, `bug`.`updated_at` = ? where `bug_laravel`.`laravel_id` = ? and `bug`.`deleted_at` is null`

The first query fails, because the values returned from `Arr::add` are as follows:

```
array:2 [
  "bug.deleted_at" => "2016-05-11 18:08:12"
  "bug" => array:1 [
    "updated_at" => "2016-05-11 18:08:12"
  ]
]
```

But, using `array_merge`:

```
array:2 [
  "course.deleted_at" => "2016-05-11 18:09:39"
  "course.updated_at" => "2016-05-11 18:09:39"
]
```

This fix passes all tests, and has been tested on a working application I am currently developing.

---

Closes #11815.
