### PR TITLE
Abstract connector

### DIFF
--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -7,7 +7,7 @@ use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Database\DetectsLostConnections;
 
-class Connector
+abstract class Connector
 {
     use DetectsLostConnections;
 

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -25,6 +25,14 @@ abstract class Connector
     ];
 
     /**
+     * Establish a database connection.
+     *
+     * @param  array  $config
+     * @return \PDO
+     */
+    abstract public function connect(array $config);
+
+    /**
      * Get the PDO options based on the configuration.
      *
      * @param  array  $config


### PR DESCRIPTION
I know it doesn't propose any functionality differences, but should `Illuminate\Database\Connectors\Connector` be abstract and force `connect()` to all child classes?
