### PR TITLE
[5.2] Illuminate\Http\Request::header() does not retrieve multiple values

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -518,7 +518,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function header($key = null, $default = null)
     {
-        return $this->retrieveItem('headers', $key, $default);
+        return $this->headers($key, $default, true);
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -518,7 +518,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function header($key = null, $default = null)
     {
-        return $this->headers($key, $default, true);
+        return $this->headers->get($key, $default, true);
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -518,7 +518,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function header($key = null, $default = null)
     {
-        return $this->headers->get($key, $default, true);
+        return $this->headers->get($key, $default, false);
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -334,6 +334,8 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_DO_THIS' => 'foo']);
         $this->assertEquals('foo', $request->header('do-this'));
+        $request->headers->set('do-this', ['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar'], $request->header('do-this'));
         $all = $request->header(null);
         $this->assertEquals('foo', $all['do-this'][0]);
     }


### PR DESCRIPTION
When the `Illuminate\Http\Request::header()` function accesses the HeaderBag (stored in `headers` property) it only returns the first value of a header, even when a header has multiple values.

Example:

``` php
$request = new Illuminate\Http\Request;
$request->headers->set('X-My-Header', ['foo', 'bar']);
var_dump($request->header('X-My-Header'));
```

Will output:

``` php
string(3) "foo"
```

However it should output:

``` php
array(2) {
  [0]=>
  string(3) "foo"
  [1]=>
  string(3) "bar"
}
```

When calling Symfony's `HeaderBag::get()`, the third parameter `$first` is not specified, defaulting to `true` and only returning the first item.

It looks like the third parameter was removed from Illuminate's `Request::retrieveItem()` after the `$deep` flag was deprecated in Symfony's `ParameterBag::get()` and `ServerBag::get()`, however `HeaderBag::get()` still needs that third parameter.
