### PR TITLE
[5.3] Account for possible starting slash for elixir asset

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -345,6 +345,8 @@ if (! function_exists('elixir')) {
             $manifestPath = $buildDirectory;
         }
 
+        $file = ltrim($file,'/');
+
         if (isset($manifest[$file])) {
             return '/'.$buildDirectory.'/'.$manifest[$file];
         }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -345,6 +345,8 @@ if (! function_exists('elixir')) {
             $manifestPath = $buildDirectory;
         }
 
+        $file = ltrim($file, '/');
+
         if (isset($manifest[$file])) {
             return '/'.$buildDirectory.'/'.$manifest[$file];
         }


### PR DESCRIPTION
Concerning the elixir() function for asset versioning:
By default the file parameter is expected to be passed without beginning slash. Otherwise an exception will be thrown.

With this small addition, the possible starting slash will be sanitized and silently ignored.
