### PR TITLE
[5.3] Typehint DateTimeInterface instead of DateTime

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2947,10 +2947,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Prepare a date for array / JSON serialization.
      *
-     * @param  \DateTime  $date
+     * @param  \DateTimeInterface  $date
      * @return string
      */
-    protected function serializeDate(DateTime $date)
+    protected function serializeDate(DateTimeInterface $date)
     {
         return $date->format($this->getDateFormat());
     }


### PR DESCRIPTION
For better customization, e.g. developers can extend and replace Carbon\Carbon with Cake\Chronos\Chronos.

Ref #13528 
