### PR TITLE
[5.3] Proper handeling primitive types in validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -605,6 +605,7 @@ class Validator implements ValidatorContract
         if (! $this->hasRule($attribute, ['Nullable'])) {
             return true;
         }
+
         return ! is_null($value);
     }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -569,6 +569,10 @@ class Validator implements ValidatorContract
      */
     protected function presentOrRuleIsImplicit($rule, $attribute, $value)
     {
+        if (is_string($value) && trim($value) === '') {
+            return $this->isImplicit($rule);
+        }
+
         return $this->validatePresent($attribute, $value) || $this->isImplicit($rule);
     }
 
@@ -1035,7 +1039,7 @@ class Validator implements ValidatorContract
      */
     protected function validateArray($attribute, $value)
     {
-        return $value === '' || is_array($value);
+        return is_array($value);
     }
 
     /**
@@ -1049,7 +1053,7 @@ class Validator implements ValidatorContract
     {
         $acceptable = [true, false, 0, 1, '0', '1'];
 
-        return $value === '' || in_array($value, $acceptable, true);
+        return in_array($value, $acceptable, true);
     }
 
     /**
@@ -1061,7 +1065,7 @@ class Validator implements ValidatorContract
      */
     protected function validateInteger($attribute, $value)
     {
-        return $value === '' || filter_var($value, FILTER_VALIDATE_INT) !== false;
+        return filter_var($value, FILTER_VALIDATE_INT) !== false;
     }
 
     /**
@@ -1073,7 +1077,7 @@ class Validator implements ValidatorContract
      */
     protected function validateNumeric($attribute, $value)
     {
-        return $value === '' || is_numeric($value);
+        return is_numeric($value);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -120,11 +120,11 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
     {
         $trans = $this->getRealTranslator();
 
-        $v = new Validator($trans, ['x' => ''], ['x' => 'size:10']);
+        $v = new Validator($trans, ['x' => ''], ['x' => 'size:10|array|integer|min:5']);
         $this->assertTrue($v->passes());
     }
 
-    public function testEmptyNonStringExistingAttributesAreValidated()
+    public function testEmptyExistingAttributesAreValidated()
     {
         $trans = $this->getRealTranslator();
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -116,7 +116,15 @@ class ValidationValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testEmptyExistingAttributesAreValidated()
+    public function testValidateEmptyStringsAlwaysPasses()
+    {
+        $trans = $this->getRealTranslator();
+
+        $v = new Validator($trans, ['x' => ''], ['x' => 'size:10']);
+        $this->assertTrue($v->passes());
+    }
+
+    public function testEmptyNonStringExistingAttributesAreValidated()
     {
         $trans = $this->getRealTranslator();
 


### PR DESCRIPTION
https://github.com/laravel/framework/pull/13334 was reverted in https://github.com/laravel/framework/pull/13532 due to wrong handling of empty strings.

This PR brings back the changes from #13334 and fixes the issue with empty strings, so that an empty string shall pass any rule unless it implies "required".
