### PR TITLE
[5.2] fix #13534 by returning an Eloquent Collection if factory count is 1

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -85,6 +85,8 @@ class FactoryBuilder
 
         if ($this->amount === 1) {
             $results->save();
+
+            return new Collection([$results]);
         } else {
             foreach ($results as $result) {
                 $result->save();


### PR DESCRIPTION
This fixes the issue in #13534 

If the factory amount is 1, the return value of `create()` is an eloquent model not an Eloquent Collection. So calling `each()` on a model will end up calling `Builder::get()` which brings all the models.
