### PR TITLE
[5.3] Implement route binding substitution using a middleware

### DIFF
--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Routing\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Routing\Registrar;
+
+class SubstituteBindings
+{
+    /**
+     * The router instance.
+     *
+     * @var \Illuminate\Contracts\Routing\Registrar
+     */
+    protected $router;
+
+    /**
+     * Create a new bindings substitutor.
+     *
+     * @param  \Illuminate\Contracts\Routing\Registrar  $router
+     * @return void
+     */
+    public function __construct(Registrar $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $route = $request->route();
+
+        $this->router->substituteBindings($route);
+        $this->router->substituteImplicitBindings($route);
+
+        return $next($request);
+    }
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -734,7 +734,7 @@ class Router implements RegistrarContract
 
         $this->container->instance('Illuminate\Routing\Route', $route);
 
-        return $this->substituteBindings($route);
+        return $route;
     }
 
     /**
@@ -743,15 +743,13 @@ class Router implements RegistrarContract
      * @param  \Illuminate\Routing\Route  $route
      * @return \Illuminate\Routing\Route
      */
-    protected function substituteBindings($route)
+    public function substituteBindings($route)
     {
         foreach ($route->parameters() as $key => $value) {
             if (isset($this->binders[$key])) {
                 $route->setParameter($key, $this->performBinding($key, $value, $route));
             }
         }
-
-        $this->substituteImplicitBindings($route);
 
         return $route;
     }
@@ -762,7 +760,7 @@ class Router implements RegistrarContract
      * @param  \Illuminate\Routing\Route  $route
      * @return void
      */
-    protected function substituteImplicitBindings($route)
+    public function substituteImplicitBindings($route)
     {
         $parameters = $route->parameters();
 

--- a/tests/Foundation/FoundationAuthorizeMiddlewareTest.php
+++ b/tests/Foundation/FoundationAuthorizeMiddlewareTest.php
@@ -7,8 +7,10 @@ use Illuminate\Auth\Access\Gate;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Factory as Auth;
+use Illuminate\Contracts\Routing\Registrar;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Http\Middleware\Authorize;
+use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 
 class FoundationAuthorizeMiddlewareTest extends PHPUnit_Framework_TestCase
@@ -43,6 +45,8 @@ class FoundationAuthorizeMiddlewareTest extends PHPUnit_Framework_TestCase
         });
 
         $this->router = new Router(new Dispatcher, $this->container);
+
+        $this->container->singleton(Registrar::class, function () { return $this->router; });
     }
 
     public function testSimpleAbilityUnauthorized()
@@ -90,7 +94,7 @@ class FoundationAuthorizeMiddlewareTest extends PHPUnit_Framework_TestCase
         });
 
         $this->router->get('users/create', [
-            'middleware' => Authorize::class.':create,App\User',
+            'middleware' => [SubstituteBindings::class, Authorize::class.':create,App\User'],
             'uses' => function () { return 'success'; },
         ]);
 
@@ -130,7 +134,7 @@ class FoundationAuthorizeMiddlewareTest extends PHPUnit_Framework_TestCase
         });
 
         $this->router->get('posts/{post}/edit', [
-            'middleware' => Authorize::class.':edit,post',
+            'middleware' => [SubstituteBindings::class, Authorize::class.':edit,post'],
             'uses' => function () { return 'success'; },
         ]);
 
@@ -150,7 +154,7 @@ class FoundationAuthorizeMiddlewareTest extends PHPUnit_Framework_TestCase
         });
 
         $this->router->get('posts/{post}/edit', [
-            'middleware' => Authorize::class.':edit,post',
+            'middleware' => [SubstituteBindings::class, Authorize::class.':edit,post'],
             'uses' => function () { return 'success'; },
         ]);
 


### PR DESCRIPTION
Not only is this really elegant, but it also allows massive flexibility on when and how these bindings take place. It's a relatively common use case for people to want to run middlewares before the bindings take place for various reasons such as ACL, throttling, or whatever.

There is however a very minor upgrading requirement that people now need to register this new middleware.
