### PR TITLE
[5.2] Add whereColumn clause

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -550,16 +550,17 @@ class Builder
      *
      * @param  array  $column
      * @param  string  $boolean
+     * @param  string  $method
      * @return $this
      */
-    protected function addArrayOfWheres($column, $boolean)
+    protected function addArrayOfWheres($column, $boolean, $method = 'where')
     {
-        return $this->whereNested(function ($query) use ($column) {
+        return $this->whereNested(function ($query) use ($column, $method) {
             foreach ($column as $key => $value) {
                 if (is_numeric($key) && is_array($value)) {
-                    call_user_func_array([$query, 'where'], $value);
+                    call_user_func_array([$query, $method], $value);
                 } else {
-                    $query->where($key, '=', $value);
+                    $query->$method($key, '=', $value);
                 }
             }
         }, $boolean);
@@ -576,6 +577,52 @@ class Builder
     public function orWhere($column, $operator = null, $value = null)
     {
         return $this->where($column, $operator, $value, 'or');
+    }
+
+    /**
+     * Add a "where" clause comparing two columns to the query.
+     *
+     * @param  string|array  $first
+     * @param  string|null  $operator
+     * @param  string|null  $second
+     * @param  string|null  $boolean
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function whereColumn($first, $operator = null, $second = null, $boolean = 'and')
+    {
+        // If the column is an array, we will assume it is an array of key-value pairs
+        // and can add them each as a where clause. We will maintain the boolean we
+        // received when the method was called and pass it into the nested where.
+        if (is_array($first)) {
+            return $this->addArrayOfWheres($first, $boolean, 'whereColumn');
+        }
+
+        // If the given operator is not found in the list of valid operators we will
+        // assume that the developer is just short-cutting the '=' operators and
+        // we will set the operators to '=' and set the values appropriately.
+        if (! in_array(strtolower($operator), $this->operators, true) &&
+            ! in_array(strtolower($operator), $this->grammar->getOperators(), true)) {
+            list($second, $operator) = [$operator, '='];
+        }
+
+        $type = 'Column';
+
+        $this->wheres[] = compact('type', 'first', 'operator', 'second', 'boolean');
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where" clause comparing two columns to the query.
+     *
+     * @param  string|array  $first
+     * @param  string|null  $operator
+     * @param  string|null  $second
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function orWhereColumn($first, $operator = null, $second = null)
+    {
+        return $this->whereColumn($first, $operator, $second, 'or');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -309,6 +309,20 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a where clause comparing two columns..
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
+     * @return string
+     */
+    protected function whereColumn(Builder $query, $where)
+    {
+        $second = $this->wrap($where['second']);
+
+        return $this->wrap($where['first']).' '.$where['operator'].' '.$second;
+    }
+
+    /**
      * Compile a "between" where clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -341,6 +341,32 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testBasicWhereColumn()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereColumn('first_name', 'last_name')->orWhereColumn('first_name', 'middle_name');
+        $this->assertEquals('select * from "users" where "first_name" = "last_name" or "first_name" = "middle_name"', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereColumn('updated_at', '>', 'created_at');
+        $this->assertEquals('select * from "users" where "updated_at" > "created_at"', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
+    public function testArrayWhereColumn()
+    {
+        $conditions = [
+            ['first_name', 'last_name'],
+            ['updated_at', '>', 'created_at']
+        ];
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereColumn($conditions);
+        $this->assertEquals('select * from "users" where ("first_name" = "last_name" and "updated_at" > "created_at")', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
     public function testUnions()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -358,7 +358,7 @@ class DatabaseQueryBuilderTest extends PHPUnit_Framework_TestCase
     {
         $conditions = [
             ['first_name', 'last_name'],
-            ['updated_at', '>', 'created_at']
+            ['updated_at', '>', 'created_at'],
         ];
 
         $builder = $this->getBuilder();


### PR DESCRIPTION
If we want to compare two columns inside a where clause, we now need to write a raw expression:

``` php
User::whereRaw('`first_name` = `last_name`');
```

But with this PR we can use a new `whereColumn` method:

``` php
User::whereColumn('first_name', 'last_name');
```

As with normal where clauses, array conditions can be passed as well:

``` php
User::whereColumn([
    ['first_name', 'last_name'],
    ['updated_at', '>', 'created_at']
]);
```
