### PR TITLE
[5.1] Decrement transaction count when beginTransaction errors

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -507,7 +507,7 @@ class Connection implements ConnectionInterface
         if ($this->transactions == 1) {
             try {
                 $this->pdo->beginTransaction();
-            } catch(Exception $e) {
+            } catch (Exception $e) {
                 --$this->transactions;
 
                 throw $e;

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -498,13 +498,20 @@ class Connection implements ConnectionInterface
      * Start a new database transaction.
      *
      * @return void
+     * @throws Exception
      */
     public function beginTransaction()
     {
         ++$this->transactions;
 
         if ($this->transactions == 1) {
-            $this->pdo->beginTransaction();
+            try {
+                $this->pdo->beginTransaction();
+            } catch(Exception $e) {
+                --$this->transactions;
+
+                throw $e;
+            }
         } elseif ($this->transactions > 1 && $this->queryGrammar->supportsSavepoints()) {
             $this->pdo->exec(
                 $this->queryGrammar->compileSavepoint('trans'.$this->transactions)


### PR DESCRIPTION
Currently the transactions count is incremented before attempting the `beginTransaction` call to PDO.  However, its never decremented when it fails.  This is fine in most cases as the exception would bubbe up.

However, when using the Job Worker Daemon, this exception is reported - but swallowed in order to keep the daemon running. That means subsequent attempts to use the Connection class from that worker cause `Can't swap PDO instance while within transaction.` exceptions to be thrown.

I added a couple test cases that shows that this fixes the specific issue that lead to this PR - as well as making sure existing functionality is maintained when the call succeeds.
