### PR TITLE
[5.2] Fix issue #12628 Scheduler no longer runs commands in background

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -64,6 +64,13 @@ class Event
     public $withoutOverlapping = false;
 
     /**
+     * Indicates if the command should run in background.
+     *
+     * @var bool
+     */
+    public $runInBackground = false;
+
+    /**
      * The array of filter callbacks.
      *
      * @var array
@@ -142,7 +149,11 @@ class Event
      */
     public function run(Container $container)
     {
-        $this->runCommandInForeground($container);
+        if (! $this->runInBackground) {
+            $this->runCommandInForeground($container);
+        } else {
+            $this->runCommandInBackground();
+        }
     }
 
     /**
@@ -160,6 +171,18 @@ class Event
         ))->run();
 
         $this->callAfterCallbacks($container);
+    }
+
+    /**
+     * Run the command in the background.
+     *
+     * @return void
+     */
+    protected function runCommandInBackground()
+    {
+        (new Process(
+            $this->buildCommand(), base_path(), null, null, null
+        ))->run();
     }
 
     /**
@@ -635,6 +658,18 @@ class Event
         return $this->skip(function () {
             return file_exists($this->mutexPath());
         });
+    }
+
+    /**
+     * State that the command should run in background.
+     *
+     * @return $this
+     */
+    public function runInBackground()
+    {
+        $this->runInBackground = true;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Fix issue #12628

The fix adds a option `runInBackground`, so for long tasks just need add `runInBackground()` like the example:

```
$schedule->command("email:customers")->runInBackground()->withoutOverlapping();
$schedule->command("email:organisations")->runInBackground()->withoutOverlapping();
$schedule->command("email:administrators")->runInBackground()->withoutOverlapping();
```
