### PR TITLE
Ref. Fix for issue #13561

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -120,7 +120,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function fullUrlWithQuery(array $query)
     {
         return count($this->query()) > 0
-                        ? $this->url().'/?'.http_build_query(array_merge($this->query(), $query))
+                        ? $this->url().'?'.http_build_query(array_merge($this->query(), $query))
                         : $this->fullUrl().'?'.http_build_query($query);
     }
 


### PR DESCRIPTION
Remove the trailing separator called in fullUrlWithQuery:

https://github.com/laravel/framework/issues/13561
