### PR TITLE
Support all input sources in $request->get()

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -338,6 +338,19 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Retrieve an input item from the request.
+     * Overridden to support all of Illuminate's input sources.
+     *
+     * @param  string  $key
+     * @param  string|array|null  $default
+     * @return string|array
+     */
+    public function get($key, $default = null)
+    {
+        return $this->input($key, $default);
+    }
+
+    /**
      * Get a subset of the items from the input data.
      *
      * @param  array|mixed  $keys


### PR DESCRIPTION
When JSON data is received, e.g. on performing a test like this:

``` php
$this->json('POST', '/url', $data);
```

the input data is currently not readable by `$request->get()` as this method is defined in `Symfony\Component\HttpFoundation\Request` while JSON input source support is added later on in `Illuminate\Http\Request`.

By simply overriding the `get()` method as proposed, all possible input parameter getters will support JSON.

FYI my use case: a vendor package is built on Symfony's Request class and as such uses `$request->get()`. Unfortunately when sending JSON, none of the input parameters are recognized at the moment.
