### PR TITLE
Support JSON input in $request->get()

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -338,6 +338,19 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Retrieve an input item from the request.
+     * Overridden to support all of Illuminate's input sources.
+     *
+     * @param  string  $key
+     * @param  string|array|null  $default
+     * @return string|array
+     */
+    public function get($key, $default = null)
+    {
+        return $this->input($key, $default);
+    }
+
+    /**
      * Get a subset of the items from the input data.
      *
      * @param  array|mixed  $keys
@@ -824,25 +837,25 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * Create an Illuminate request from a Symfony instance.
      *
-     * @param  \Symfony\Component\HttpFoundation\Request  $request
+     * @param  \Symfony\Component\HttpFoundation\Request  $baseRequest
      * @return \Illuminate\Http\Request
      */
-    public static function createFromBase(SymfonyRequest $request)
+    public static function createFromBase(SymfonyRequest $baseRequest)
     {
-        if ($request instanceof static) {
-            return $request;
+        if ($baseRequest instanceof static) {
+            return $baseRequest;
         }
 
-        $content = $request->content;
+        $request = (new static);
 
-        $request = (new static)->duplicate(
+        $request->content = $baseRequest->content;
 
-            $request->query->all(), $request->request->all(), $request->attributes->all(),
+        $request = $request->duplicate(
 
-            $request->cookies->all(), $request->files->all(), $request->server->all()
+            $baseRequest->query->all(), $baseRequest->request->all(), $baseRequest->attributes->all(),
+
+            $baseRequest->cookies->all(), $baseRequest->files->all(), $baseRequest->server->all()
         );
-
-        $request->content = $content;
 
         $request->request = $request->getInputSource();
 


### PR DESCRIPTION
Improved version of #13565 

---

When JSON data is received, e.g. on performing a test like this:

``` php
$this->json('POST', '/url', $data);
```

the input data is currently not readable by `$request->get()` as this method is defined in `Symfony\Component\HttpFoundation\Request` while JSON input source support is added later on in `Illuminate\Http\Request`.

By simply overriding the `get()` method as proposed, all possible input parameter getters will support JSON. It was necessary to modify the `createFromBase()` method slightly as well: content setting needs to happen before duplication since `get()` will be called during duplication. This would inevitably set `$json` to `null` as no content is available yet.

FYI my use case: a vendor package is built on Symfony's Request class and as such uses `$request->get()`. Unfortunately when sending JSON, none of the input parameters are recognized at the moment.
