### PR TITLE
[5.2] Helper function to clear routes resources 

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -64,6 +64,13 @@ class Event
     public $withoutOverlapping = false;
 
     /**
+     * Indicates if the command should run in background.
+     *
+     * @var bool
+     */
+    public $runInBackground = false;
+
+    /**
      * The array of filter callbacks.
      *
      * @var array
@@ -142,7 +149,11 @@ class Event
      */
     public function run(Container $container)
     {
-        $this->runCommandInForeground($container);
+        if (! $this->runInBackground) {
+            $this->runCommandInForeground($container);
+        } else {
+            $this->runCommandInBackground();
+        }
     }
 
     /**
@@ -160,6 +171,18 @@ class Event
         ))->run();
 
         $this->callAfterCallbacks($container);
+    }
+
+    /**
+     * Run the command in the background.
+     *
+     * @return void
+     */
+    protected function runCommandInBackground()
+    {
+        (new Process(
+            $this->buildCommand(), base_path(), null, null, null
+        ))->run();
     }
 
     /**
@@ -635,6 +658,18 @@ class Event
         return $this->skip(function () {
             return file_exists($this->mutexPath());
         });
+    }
+
+    /**
+     * State that the command should run in background.
+     *
+     * @return $this
+     */
+    public function runInBackground()
+    {
+        $this->runInBackground = true;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -596,6 +596,18 @@ class Event
     }
 
     /**
+     * State that the command should run in background.
+     *
+     * @return $this
+     */
+    public function runInBackground()
+    {
+        $this->runInBackground = true;
+
+        return $this;
+    }
+
+    /**
      * Set the timezone the date should be evaluated on.
      *
      * @param  \DateTimeZone|string  $timezone
@@ -658,18 +670,6 @@ class Event
         return $this->skip(function () {
             return file_exists($this->mutexPath());
         });
-    }
-
-    /**
-     * State that the command should run in background.
-     *
-     * @return $this
-     */
-    public function runInBackground()
-    {
-        $this->runInBackground = true;
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -365,6 +365,27 @@ if (! function_exists('class_uses_recursive')) {
     }
 }
 
+if (!function_exists("clear_routes")) {
+    /**
+     * Clear routes file
+     *
+     * @param String $remove
+     * @return mixed
+     */
+    function clear_routes($remove)
+    {
+        $path = app_path() . '/Http/routes.php';
+        $lines = file($path, FILE_IGNORE_NEW_LINES);
+        foreach ($lines as $key => $line) {
+            if (strstr($line, $remove)) {
+                unset($lines[$key]);
+            }
+        }
+        $data = implode("\n", array_values($lines));
+        return file_put_contents($path, $data);
+    }
+}
+
 if (! function_exists('collect')) {
     /**
      * Create a collection from the given value.
@@ -889,30 +910,5 @@ if (! function_exists('with')) {
     function with($object)
     {
         return $object;
-    }
-}
-
-if (!function_exists("clear_routes")) {
-    /**
-     * Clear routes file
-     *
-     * @param String $remove
-     * @return mixed
-     */
-    function clear_routes($remove)
-    {
-        $path = app_path() . '/Http/routes.php';
-
-        $lines = file($path, FILE_IGNORE_NEW_LINES);
-
-        foreach ($lines as $key => $line) {
-            if (strstr($line, $remove)) {
-                unset($lines[$key]);
-            }
-        }
-
-        $data = implode("\n", array_values($lines));
-
-        return file_put_contents($path, $data);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -365,16 +365,16 @@ if (! function_exists('class_uses_recursive')) {
     }
 }
 
-if (!function_exists("clear_routes")) {
+if (! function_exists("clear_routes")) {
     /**
-     * Clear routes file
+     * Clear routes file.
      *
-     * @param String $remove
+     * @param string $remove
      * @return mixed
      */
     function clear_routes($remove)
     {
-        $path = app_path() . '/Http/routes.php';
+        $path = app_path().'/Http/routes.php';
         $lines = file($path, FILE_IGNORE_NEW_LINES);
         foreach ($lines as $key => $line) {
             if (strstr($line, $remove)) {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -365,7 +365,7 @@ if (! function_exists('class_uses_recursive')) {
     }
 }
 
-if (! function_exists("clear_routes")) {
+if (! function_exists('clear_routes')) {
     /**
      * Clear routes file.
      *

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -382,7 +382,7 @@ if (! function_exists('clear_routes')) {
             }
         }
         $data = implode("\n", array_values($lines));
-        
+
         return file_put_contents($path, $data);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -891,3 +891,28 @@ if (! function_exists('with')) {
         return $object;
     }
 }
+
+if (!function_exists("clear_routes")) {
+    /**
+     * Clear routes file
+     *
+     * @param String $remove
+     * @return mixed
+     */
+    function clear_routes($remove)
+    {
+        $path = app_path() . '/Http/routes.php';
+
+        $lines = file($path, FILE_IGNORE_NEW_LINES);
+
+        foreach ($lines as $key => $line) {
+            if (strstr($line, $remove)) {
+                unset($lines[$key]);
+            }
+        }
+
+        $data = implode("\n", array_values($lines));
+
+        return file_put_contents($path, $data);
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -375,13 +375,17 @@ if (! function_exists('clear_routes')) {
     function clear_routes($remove)
     {
         $path = app_path().'/Http/routes.php';
+        
         $lines = file($path, FILE_IGNORE_NEW_LINES);
+        
         foreach ($lines as $key => $line) {
             if (strstr($line, $remove)) {
                 unset($lines[$key]);
             }
         }
+        
         $data = implode("\n", array_values($lines));
+        
         return file_put_contents($path, $data);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -375,15 +375,12 @@ if (! function_exists('clear_routes')) {
     function clear_routes($remove)
     {
         $path = app_path().'/Http/routes.php';
-        
         $lines = file($path, FILE_IGNORE_NEW_LINES);
-        
         foreach ($lines as $key => $line) {
             if (strstr($line, $remove)) {
                 unset($lines[$key]);
             }
         }
-        
         $data = implode("\n", array_values($lines));
         
         return file_put_contents($path, $data);


### PR DESCRIPTION
This function allows us to clear routes with specified resources.

For Example :

We want to remove **foo** resources from routes.php.

``` php
<?php

    Route::get('foo',FooController@index);
    Route::post('foo/post',FooController@store);

    Route::get('bar',BarController@index);

```

By using `clear_routes("foo")` **foo** resources will be removed.

Result :

``` php
<?php

    Route::get('bar',BarController@index);

```
