### PR TITLE
[5.3] Unify join and builder syntax

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -335,30 +335,30 @@ class Builder
      */
     public function join($table, $one, $operator = null, $two = null, $type = 'inner', $where = false)
     {
+        $join = new JoinClause($type, $table, $this);
+
         // If the first "column" of the join is really a Closure instance the developer
         // is trying to build a join with a complex "on" clause containing more than
         // one condition, so we'll add the join and call a Closure with the query.
         if ($one instanceof Closure) {
-            $join = new JoinClause($type, $table);
-
             call_user_func($one, $join);
 
             $this->joins[] = $join;
 
-            $this->addBinding($join->bindings, 'join');
+            $this->addBinding($join->getBindings(), 'join');
         }
 
         // If the column is simply a string, we can assume the join simply has a basic
         // "on" clause with a single condition. So we will just build the join with
         // this simple join clauses attached to it. There is not a join callback.
         else {
-            $join = new JoinClause($type, $table);
+            $method = $where ? 'where' : 'on';
 
-            $this->joins[] = $join->on(
+            $this->joins[] = $join->$method(
                 $one, $operator, $two, 'and', $where
             );
 
-            $this->addBinding($join->bindings, 'join');
+            $this->addBinding($join->getBindings(), 'join');
         }
 
         return $this;
@@ -450,7 +450,7 @@ class Builder
             return $this->join($table, $first, $operator, $second, 'cross');
         }
 
-        $this->joins[] = new JoinClause('cross', $table);
+        $this->joins[] = new JoinClause('cross', $table, $this);
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -354,9 +354,7 @@ class Builder
         else {
             $method = $where ? 'where' : 'on';
 
-            $this->joins[] = $join->$method(
-                $one, $operator, $two, 'and', $where
-            );
+            $this->joins[] = $join->$method($one, $operator, $two);
 
             $this->addBinding($join->getBindings(), 'join');
         }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -209,8 +209,10 @@ class PostgresGrammar extends Grammar
         // all out then implode them. This should give us "where" like syntax after
         // everything has been built and then we will join it to the real wheres.
         foreach ($query->joins as $join) {
-            foreach ($join->clauses as $clause) {
-                $joinWheres[] = $this->compileJoinConstraint($clause);
+            foreach ($join->wheres as $where) {
+                $method = "where{$where['type']}";
+
+                $joinWheres[] = $where['boolean'].' '.$this->$method($query, $where);
             }
         }
 

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Query;
 
 use Closure;
-use InvalidArgumentException;
 
 class JoinClause extends Builder
 {

--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -5,7 +5,7 @@ namespace Illuminate\Database\Query;
 use Closure;
 use InvalidArgumentException;
 
-class JoinClause
+class JoinClause extends Builder
 {
     /**
      * The type of join being performed.
@@ -22,30 +22,29 @@ class JoinClause
     public $table;
 
     /**
-     * The "on" clauses for the join.
+     * The parent query builder instance.
      *
-     * @var array
+     * @var \Illuminate\Database\Query\Builder
      */
-    public $clauses = [];
-
-    /**
-     * The "on" bindings for the join.
-     *
-     * @var array
-     */
-    public $bindings = [];
+    private $parentQuery;
 
     /**
      * Create a new join clause instance.
      *
      * @param  string  $type
      * @param  string  $table
+     * @param  \Illuminate\Database\Query\Builder $parentQuery
      * @return void
      */
-    public function __construct($type, $table)
+    public function __construct($type, $table, Builder $parentQuery)
     {
         $this->type = $type;
         $this->table = $table;
+        $this->parentQuery = $parentQuery;
+
+        parent::__construct(
+            $parentQuery->connection, $parentQuery->grammar, $parentQuery->processor
+        );
     }
 
     /**
@@ -64,34 +63,17 @@ class JoinClause
      * @param  string|null  $operator
      * @param  string|null  $second
      * @param  string  $boolean
-     * @param  bool  $where
      * @return $this
      *
      * @throws \InvalidArgumentException
      */
-    public function on($first, $operator = null, $second = null, $boolean = 'and', $where = false)
+    public function on($first, $operator = null, $second = null, $boolean = 'and')
     {
         if ($first instanceof Closure) {
-            return $this->nest($first, $boolean);
+            return $this->whereNested($first, $boolean);
         }
 
-        if (func_num_args() < 3) {
-            throw new InvalidArgumentException('Not enough arguments for the on clause.');
-        }
-
-        if ($where) {
-            $this->bindings[] = $second;
-        }
-
-        if ($where && ($operator === 'in' || $operator === 'not in') && is_array($second)) {
-            $second = count($second);
-        }
-
-        $nested = false;
-
-        $this->clauses[] = compact('first', 'operator', 'second', 'boolean', 'where', 'nested');
-
-        return $this;
+        return $this->whereColumn($first, $operator, $second, $boolean);
     }
 
     /**
@@ -108,146 +90,12 @@ class JoinClause
     }
 
     /**
-     * Add an "on where" clause to the join.
+     * Get a new instance of the join clause builder.
      *
-     * @param  \Closure|string  $first
-     * @param  string|null  $operator
-     * @param  string|null  $second
-     * @param  string  $boolean
      * @return \Illuminate\Database\Query\JoinClause
      */
-    public function where($first, $operator = null, $second = null, $boolean = 'and')
+    public function newQuery()
     {
-        return $this->on($first, $operator, $second, $boolean, true);
-    }
-
-    /**
-     * Add an "or on where" clause to the join.
-     *
-     * @param  \Closure|string  $first
-     * @param  string|null  $operator
-     * @param  string|null  $second
-     * @return \Illuminate\Database\Query\JoinClause
-     */
-    public function orWhere($first, $operator = null, $second = null)
-    {
-        return $this->on($first, $operator, $second, 'or', true);
-    }
-
-    /**
-     * Add an "on where is null" clause to the join.
-     *
-     * @param  string  $column
-     * @param  string  $boolean
-     * @return \Illuminate\Database\Query\JoinClause
-     */
-    public function whereNull($column, $boolean = 'and')
-    {
-        return $this->on($column, 'is', new Expression('null'), $boolean, false);
-    }
-
-    /**
-     * Add an "or on where is null" clause to the join.
-     *
-     * @param  string  $column
-     * @return \Illuminate\Database\Query\JoinClause
-     */
-    public function orWhereNull($column)
-    {
-        return $this->whereNull($column, 'or');
-    }
-
-    /**
-     * Add an "on where is not null" clause to the join.
-     *
-     * @param  string  $column
-     * @param  string  $boolean
-     * @return \Illuminate\Database\Query\JoinClause
-     */
-    public function whereNotNull($column, $boolean = 'and')
-    {
-        return $this->on($column, 'is', new Expression('not null'), $boolean, false);
-    }
-
-    /**
-     * Add an "or on where is not null" clause to the join.
-     *
-     * @param  string  $column
-     * @return \Illuminate\Database\Query\JoinClause
-     */
-    public function orWhereNotNull($column)
-    {
-        return $this->whereNotNull($column, 'or');
-    }
-
-    /**
-     * Add an "on where in (...)" clause to the join.
-     *
-     * @param  string  $column
-     * @param  array  $values
-     * @return \Illuminate\Database\Query\JoinClause
-     */
-    public function whereIn($column, array $values)
-    {
-        return $this->on($column, 'in', $values, 'and', true);
-    }
-
-    /**
-     * Add an "on where not in (...)" clause to the join.
-     *
-     * @param  string  $column
-     * @param  array  $values
-     * @return \Illuminate\Database\Query\JoinClause
-     */
-    public function whereNotIn($column, array $values)
-    {
-        return $this->on($column, 'not in', $values, 'and', true);
-    }
-
-    /**
-     * Add an "or on where in (...)" clause to the join.
-     *
-     * @param  string  $column
-     * @param  array  $values
-     * @return \Illuminate\Database\Query\JoinClause
-     */
-    public function orWhereIn($column, array $values)
-    {
-        return $this->on($column, 'in', $values, 'or', true);
-    }
-
-    /**
-     * Add an "or on where not in (...)" clause to the join.
-     *
-     * @param  string  $column
-     * @param  array  $values
-     * @return \Illuminate\Database\Query\JoinClause
-     */
-    public function orWhereNotIn($column, array $values)
-    {
-        return $this->on($column, 'not in', $values, 'or', true);
-    }
-
-    /**
-     * Add a nested where statement to the query.
-     *
-     * @param  \Closure  $callback
-     * @param  string   $boolean
-     * @return \Illuminate\Database\Query\JoinClause
-     */
-    public function nest(Closure $callback, $boolean = 'and')
-    {
-        $join = new static($this->type, $this->table);
-
-        $callback($join);
-
-        if (count($join->clauses)) {
-            $nested = true;
-
-            $this->clauses[] = compact('nested', 'join', 'boolean');
-            $this->bindings = array_merge($this->bindings, $join->bindings);
-        }
-
-        return $this;
+        return new static($this->type, $this->table, $this->parentQuery);
     }
 }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -506,7 +506,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
         $builder = $model->where('bar', 'baz');
         $builder->whereHas('foo', function ($q) {
             $q->join('quuuux', function ($j) {
-               $j->on('quuuuux', '=', 'quuuuuux', 'and', true);
+               $j->where('quuuuux', '=', 'quuuuuux');
             });
             $q->having('bam', '>', 'qux');
         })->where('quux', 'quuux');


### PR DESCRIPTION
This is a massive cleanup of the join clause (~200 lines of production code removed). The idea is to extend the query builder and reuse its functionality instead of duplicating it. This has multiple benefits:
- no need to duplicate the logic for where clauses
- simplified join compilation (by reusing where clause compiler)
- unified syntax between join clause and query builder (i.e. "=" operator is now optional, access to additional clauses like `whereRaw`, `whereSub`, ...)

The only breaking change is the removal of `$where` boolean parameter in the `on` clause and the removal of some public `JoinClause` properties.
