### PR TITLE
[5.2] Fix SparkPost doesn't send attachments

### DIFF
--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -62,7 +62,7 @@ class SparkPostTransport extends Transport
         ];
 
         if ($attachments = $message->getChildren()) {
-            $options['json']['content']['attachments'] = array_map(function($attachment) {
+            $options['json']['content']['attachments'] = array_map(function ($attachment) {
                 return [
                     'type' => $attachment->getContentType(),
                     'name' => $attachment->getFileName(),

--- a/src/Illuminate/Mail/Transport/SparkPostTransport.php
+++ b/src/Illuminate/Mail/Transport/SparkPostTransport.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Mail\Transport;
 
+use Swift_Encoding;
 use Swift_Mime_Message;
 use GuzzleHttp\ClientInterface;
 
@@ -59,6 +60,16 @@ class SparkPostTransport extends Transport
                 ],
             ],
         ];
+
+        if ($attachments = $message->getChildren()) {
+            $options['json']['content']['attachments'] = array_map(function($attachment) {
+                return [
+                    'type' => $attachment->getContentType(),
+                    'name' => $attachment->getFileName(),
+                    'data' => Swift_Encoding::getBase64Encoding()->encodeString($attachment->getBody()),
+                ];
+            }, $attachments);
+        }
 
         return $this->client->post('https://api.sparkpost.com/api/v1/transmissions', $options);
     }


### PR DESCRIPTION
Fix issue #13546.

Here SparkPost's docs on attachments:
https://github.com/SparkPost/sparkpost-api-documentation/blob/master/services/transmissions_api.md#attachment-attributes
