### PR TITLE
[5.3] Add $preserve argument.

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -730,11 +730,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Reverse items order.
      *
+     * @param  bool  $preserve
      * @return static
      */
-    public function reverse()
+    public function reverse($preserve = true)
     {
-        return new static(array_reverse($this->items, true));
+        return new static(array_reverse($this->items, $preserve));
     }
 
     /**


### PR DESCRIPTION
The reason for this edit is to allow the user to define the preservation of keys or not. A use case is within Spark itself.

In `PerformanceIndicatorsRepository::all()`, the method will need to be updated to the following come 5.3:

``` php
public function all($take = 60)
{
    return array_reverse(
        DB::table('performance_indicators')->orderBy('created_at', 'desc')->take($take)->get()->toArray()
    );
}
```

With the proposed change, the method could be changed to:

``` php
public function all($take = 60)
{
    return DB::table('performance_indicators')->orderBy('created_at', 'desc')->take($take)->get()->reverse(false);
}
```
