### PR TITLE
Get local file path with Storage

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -254,7 +254,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
         $adapter = $this->driver->getAdapter();
         if ($adapter instanceof LocalAdapter) {
 
-            return ($adapter->getPathPrefix().$path);
+            return $adapter->getPathPrefix().$path;
         } else {
             throw new RuntimeException('This driver does not support retrieving URLs.');
         }

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -244,14 +244,16 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     }
 
     /**
-    * Get the local path for the given filename.
-    * @param string $path
-    * @return string
-    */
+     * Get the local path for the given filename.
+     *
+     * @param string $path
+     * @return string
+     */
     public function localPath($path)
     {
         $adapter = $this->driver->getAdapter();
         if ($adapter instanceof LocalAdapter) {
+
             return ($adapter->getPathPrefix().$path);
         } else {
             throw new RuntimeException('This driver does not support retrieving URLs.');

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -244,6 +244,23 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     }
 
     /**
+    * Get the local path for the given filename.
+    * @param string $path
+    * @return string
+    */
+    public function localPath($path)
+    {
+        $adapter = $this->driver->getAdapter();
+        if ($adapter instanceof LocalAdapter) {
+            return ($adapter->getPathPrefix().$path);
+        } else {
+            throw new RuntimeException('This driver does not support retrieving URLs.');
+        }
+    }
+
+
+
+    /**
      * Get an array of all files in a directory.
      *
      * @param  string|null  $directory


### PR DESCRIPTION
Problem:
The way Storage::disk('local')->url('filename.png') actually returns the path to the file, but it lacks the folder that was listed in the "/config/filesystem.php": eg "app" folder:
'local' => [
'driver' => 'local',
'root' => storage_path('app'),
],
As a result, we get the path: "/storage/filename.png", instead of "/storage/app/filename.png"
I tried to solve this problem - and as a result wrote this method.
