### PR TITLE
[5.2] Avoid chunkById to duplicate orders clause with the same column

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1418,7 +1418,6 @@ class Builder
                 }
             }
         }
-        
         return $this->where($column, '>', $lastId)
                     ->orderBy($column, 'asc')
                     ->take($perPage);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1418,6 +1418,7 @@ class Builder
                 }
             }
         }
+        
         return $this->where($column, '>', $lastId)
                     ->orderBy($column, 'asc')
                     ->take($perPage);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1410,7 +1410,6 @@ class Builder
      */
     public function forPageAfterId($perPage = 15, $lastId = 0, $column = 'id')
     {
-                
         // avoid duplicate orders
         if ($this->orders !== null) {
             foreach ($this->orders as $key => $order) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1418,7 +1418,7 @@ class Builder
                 }
             }
         }
-        
+
         return $this->where($column, '>', $lastId)
                     ->orderBy($column, 'asc')
                     ->take($perPage);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1410,6 +1410,16 @@ class Builder
      */
     public function forPageAfterId($perPage = 15, $lastId = 0, $column = 'id')
     {
+                
+        // avoid duplicate orders
+        if ($this->orders !== null) {
+            foreach ($this->orders as $key => $order) {
+                if ($order['column'] == $column) {
+                    unset($this->orders[$key]);
+                }
+            }
+        }
+        
         return $this->where($column, '>', $lastId)
                     ->orderBy($column, 'asc')
                     ->take($perPage);


### PR DESCRIPTION
When executing the method `chunkById` to work with a massive importation from a legacy database, each time the query where called to be build the `ordersBy` got duplicated.

This PR tests if the `ordersBy` clause already exists for each column, if so remove it to compile right the query.
