### PR TITLE
[5.2] Added view composer parameters.

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -78,6 +78,13 @@ class Factory implements FactoryContract
     protected $composers = [];
 
     /**
+     * View composer parameters.
+     *
+     * @var array
+     */
+    protected $composerParameters = [];
+
+    /**
      * All of the finished, captured sections.
      *
      * @var array
@@ -399,6 +406,17 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Add a view composer parameter.
+     *
+     * @param  mixed  $parameter
+     * @return void
+     */
+    public function addComposerParameter($parameter)
+    {
+        $this->composerParameters[] = $parameter;
+    }
+
+    /**
      * Add an event for a given view.
      *
      * @param  string  $view
@@ -507,7 +525,9 @@ class Factory implements FactoryContract
      */
     public function callComposer(View $view)
     {
-        $this->events->fire('composing: '.$view->getName(), [$view]);
+        $parameters = $this->composerParameters;
+        array_unshift($parameters, $view);
+        $this->events->fire('composing: '.$view->getName(), $parameters);
     }
 
     /**

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -150,6 +150,19 @@ class View implements ArrayAccess, ViewContract
     }
 
     /**
+     * Add a parameter that will be passed to associated view composers.
+     *
+     * @param  mixed  $parameter
+     * @return $this
+     */
+    public function composeWith($parameter)
+    {
+        $this->factory->addComposerParameter($parameter);
+
+        return $this;
+    }
+
+    /**
      * Get the data bound to the view instance.
      *
      * @return array


### PR DESCRIPTION
This PR allows additional parameters to be passed to view composer callbacks by way of a new **composeWith(...)** method in _Illuminate/View/View_

Controller:

``` php
class BlogController extends Controller
{
    public function article()
    {
        return view('blog.article')
            ->composeWith(Input::get('id'));
    }
}
```

View composer:

``` php
class BlogArticleViewComposer
{
    public function compose(View $view, $articleId)
    {
        $view->with('article', BlogArticle::find($articleId));
    }
}
```

Obviously this is a very simple example but it demonstrates how we can pass information to the view composer without assigning it directly to the view. The cleans up the view data and provides a clearer interface for the composer as we no longer need to check the data using code like this:

``` php
if (!isset($view->articleId)) {
    throw new Exception('...');
}
```

Hope you find this useful!
