### PR TITLE
[5.2] Merge wheres to hasQuery for withCount()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1030,6 +1030,7 @@ class Builder
                 $relation->getRelated()->newQuery(), $this
             );
 
+            $this->mergeModelDefinedRelationWheresToHasQuery($query, $relation);
             call_user_func($constraints, $query);
 
             $this->selectSub($query->getQuery(), snake_case($name).'_count');

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1030,10 +1030,10 @@ class Builder
                 $relation->getRelated()->newQuery(), $this
             );
 
-            $this->mergeModelDefinedRelationWheresToHasQuery($query, $relation);
             call_user_func($constraints, $query);
+            $this->mergeModelDefinedRelationWheresToHasQuery($query, $relation);
 
-            $this->selectSub($query->getQuery(), snake_case($name).'_count');
+            $this->selectSub($query->toBase(), snake_case($name).'_count');
         }
 
         return $this;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -481,8 +481,8 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
             $q->where('bam', '>', 'qux');
         }]);
 
-        $this->assertEquals('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "active" = ? and "bam" > ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
-        $this->assertEquals([true, 'qux'], $builder->getBindings());
+        $this->assertEquals('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertEquals(['qux', true], $builder->getBindings());
     }
 
     public function testWithCountAndContraintsAndHaving()

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -477,7 +477,7 @@ class DatabaseEloquentBuilderTest extends PHPUnit_Framework_TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->select('id')->withCount(['activeFoo' => function($q){
+        $builder = $model->select('id')->withCount(['activeFoo' => function ($q) {
             $q->where('bam', '>', 'qux');
         }]);
 


### PR DESCRIPTION
Fixes missing wheres defined on the relation when creating the subquery for a relation count, see https://github.com/laravel/framework/pull/13414#issuecomment-220069780
