### PR TITLE
[5.2] removing check for $this->$key in __isset method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -3470,11 +3470,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function __isset($key)
     {
-        if (isset($this->attributes[$key]) || isset($this->relations[$key])) {
-            return true;
-        }
-
-        if (method_exists($this, $key) && $this->$key && isset($this->relations[$key])) {
+        if (isset($this->attributes[$key]) || isset($this->relations[$key]) ||
+            method_exists($this, $key)) {
             return true;
         }
 


### PR DESCRIPTION
In regards to [this comment](https://github.com/laravel/framework/commit/725496088a97b8aff45f44aa264d188eff18c8af#commitcomment-17533465) - I ran into a bug when working with models where a method that existed on the model still threw an error here because $this->$key wasn't set. It seems incorrect?
