### PR TITLE
[5.2] Laravel Collection's makeVisible method should work when the 'visible' property already has values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -2136,6 +2136,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $this->hidden = array_diff($this->hidden, (array) $attributes);
 
+        if (! empty($this->visible)) {
+            $this->addVisible($attributes);
+        }
+
         return $this;
     }
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -250,9 +250,19 @@ class DatabaseEloquentCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(get_class($a->zip(['a', 'b'], ['c', 'd'])), BaseCollection::class);
         $this->assertEquals(get_class($b->flip()), BaseCollection::class);
     }
+
+    public function testMakeVisibleRemovesHiddenAndIncludesVisible()
+    {
+        $c = new Collection([new TestEloquentCollectionModel]);
+        $c = $c->makeVisible('hidden');
+
+        $this->assertEquals([], $c[0]->getHidden());
+        $this->assertEquals(['visible', 'hidden'], $c[0]->getVisible());
+    }
 }
 
 class TestEloquentCollectionModel extends Illuminate\Database\Eloquent\Model
 {
+    protected $visible = ['visible'];
     protected $hidden = ['hidden'];
 }


### PR DESCRIPTION
Closes Issue #12894 

I have chosen to add the given attributes to the visible property when it is not empty.
