### PR TITLE
[5.2] Add authenticate method to the guards

### DIFF
--- a/src/Illuminate/Auth/AuthenticationException.php
+++ b/src/Illuminate/Auth/AuthenticationException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Auth;
+
+use Exception;
+
+class AuthenticationException extends Exception
+{
+    /**
+     * The guard instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Guard
+     */
+    protected $guard;
+
+    /**
+     * Create a new authentication exception.
+     *
+     * @param \Illuminate\Contracts\Auth\Guard|null  $guard
+     */
+    public function __construct($guard = null)
+    {
+        $this->guard = $guard;
+
+        parent::__construct('Unauthenticated.');
+    }
+
+    /**
+     * Get the guard instance.
+     *
+     * @return \Illuminate\Contracts\Auth\Guard|null
+     */
+    public function guard()
+    {
+        return $this->guard;
+    }
+}

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -26,6 +26,22 @@ trait GuardHelpers
     /**
      * Determine if the current user is authenticated.
      *
+     * @return \Illuminate\Contracts\Auth\Authenticatable
+     *
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    public function authenticate()
+    {
+        if (! is_null($user = $this->user())) {
+            return $user;
+        }
+
+        throw new AuthenticationException($this);
+    }
+
+    /**
+     * Determine if the current user is authenticated.
+     *
      * @return bool
      */
     public function check()

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -59,10 +59,12 @@ trait GuardHelpers
      * Set the current user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @return void
+     * @return $this
      */
     public function setUser(AuthenticatableContract $user)
     {
         $this->user = $user;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -691,13 +691,15 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * Set the current user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @return void
+     * @return $this
      */
     public function setUser(AuthenticatableContract $user)
     {
         $this->user = $user;
 
         $this->loggedOut = false;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Exceptions;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Illuminate\Http\Response;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Exception\HttpResponseException;
@@ -100,6 +101,8 @@ class Handler implements ExceptionHandlerContract
             return $e->getResponse();
         } elseif ($e instanceof ModelNotFoundException) {
             $e = new NotFoundHttpException($e->getMessage(), $e);
+        } elseif ($e instanceof AuthenticationException) {
+            return $this->unauthenticated($request, $e);
         } elseif ($e instanceof AuthorizationException) {
             $e = new HttpException(403, $e->getMessage());
         } elseif ($e instanceof ValidationException && $e->getResponse()) {
@@ -173,6 +176,22 @@ class Handler implements ExceptionHandlerContract
         $decorated = $this->decorate($handler->getContent($e), $handler->getStylesheet($e));
 
         return SymfonyResponse::create($decorated, $e->getStatusCode(), $e->getHeaders());
+    }
+
+    /**
+     * Convert an authentication exception into an unauthenticated response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Auth\AuthenticationException  $e
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function unauthenticated($request, AuthenticationException $e)
+    {
+        if ($request->ajax() || $request->wantsJson()) {
+            return response('Unauthorized.', 401);
+        } else {
+            return redirect()->guest('login');
+        }
     }
 
     /**

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -118,6 +118,25 @@ class AuthGuardTest extends PHPUnit_Framework_TestCase
         $mock->login($user);
     }
 
+    public function testAuthenticateReturnsUserWhenUserIsNotNull()
+    {
+        $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');
+        $guard = $this->getGuard()->setUser($user);
+
+        $this->assertEquals($user, $guard->authenticate());
+    }
+
+    /**
+     * @expectedException \Illuminate\Auth\AuthenticationException
+     */
+    public function testAuthenticateThrowsWhenUserIsNull()
+    {
+        $guard = $this->getGuard();
+        $guard->getSession()->shouldReceive('get')->once()->andReturn(null);
+
+        $guard->authenticate();
+    }
+
     public function testIsAuthedReturnsTrueWhenUserIsNotNull()
     {
         $user = m::mock('Illuminate\Contracts\Auth\Authenticatable');


### PR DESCRIPTION
...which will throw an exception if the user is not logged in.

~~This also updates the `Authorize` middleware with a call to `authenticate`, [so that it returns a proper 401 if the user is not logged in](https://github.com/laravel/framework/pull/13113).~~
