### PR TITLE
[5.2] More strict integer validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1031,7 +1031,7 @@ class Validator implements ValidatorContract
             return true;
         }
 
-        return is_null($value) || ctype_digit($value) && filter_var($value, FILTER_VALIDATE_INT) !== false;
+        return is_null($value) || is_numeric($value) && filter_var($value, FILTER_VALIDATE_INT) !== false;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1031,7 +1031,7 @@ class Validator implements ValidatorContract
             return true;
         }
 
-        return is_null($value) || filter_var($value, FILTER_VALIDATE_INT) !== false;
+        return is_null($value) || ctype_digit($value) && filter_var($value, FILTER_VALIDATE_INT) !== false;
     }
 
     /**


### PR DESCRIPTION
Currently the `integer` validation rule only checks if the value under validation could be filtered as integer. Checking conditions are not enough strict and successfully pass digits with leading or trailing spaces.

``` php
$request = array('test' => ' 245 ');

$v = Validator::make($request, [
    'test' => 'integer',
]);

if ($v->fails()) {
    return $this->respondBadRequest($v->errors());
}

dd($request['test']); // string ' 245 ' (length=5)
```

Validator only validates. It doesn't convert the given string into integer, so we can't be sure that the value after `integer` validation is actually integer. This patch adds more strictness to this rule.
#13630
