### PR TITLE
[5.2] Added missing Symfony UploadedFile class test property

### DIFF
--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -58,16 +58,18 @@ class UploadedFile extends SymfonyUploadedFile
      * Create a new file instance from a base instance.
      *
      * @param  \Symfony\Component\HttpFoundation\File\UploadedFile  $file
+     * @param  bool $test
      * @return static
      */
-    public static function createFromBase(SymfonyUploadedFile $file)
+    public static function createFromBase(SymfonyUploadedFile $file, $test)
     {
         return $file instanceof static ? $file : new static(
             $file->getPathname(),
             $file->getClientOriginalName(),
             $file->getClientMimeType(),
             $file->getClientSize(),
-            $file->getError()
+            $file->getError(),
+            $test
         );
     }
 }

--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -61,7 +61,7 @@ class UploadedFile extends SymfonyUploadedFile
      * @param  bool $test
      * @return static
      */
-    public static function createFromBase(SymfonyUploadedFile $file, $test)
+    public static function createFromBase(SymfonyUploadedFile $file, $test = false)
     {
         return $file instanceof static ? $file : new static(
             $file->getPathname(),


### PR DESCRIPTION
During development I've encountered problem where Symfony Uploaded File with test = true was omitted and ended up being false which resulted in https://github.com/symfony/http-foundation/blob/master/File/UploadedFile.php#L199 returning false and throwing https://github.com/symfony/http-foundation/blob/master/File/UploadedFile.php#L235 while testing.
