### PR TITLE
[5.2] Allow buildDirectory to be set as empty.

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -346,7 +346,7 @@ if (! function_exists('elixir')) {
         }
 
         if (isset($manifest[$file])) {
-            return '/'.$buildDirectory.'/'.$manifest[$file];
+            return '/'.trim($buildDirectory.'/'.$manifest[$file], '/');
         }
 
         throw new InvalidArgumentException("File {$file} not defined in asset manifest.");


### PR DESCRIPTION
In order the files to be copied in the root of public directory as stated in https://github.com/laravel/elixir/issues/66, calling elixir without a build path specified, we get //path/to/script.js which is not a valid path. 

This PR makes possible to call it that way `elixir('path/to/script.js', null)`
