### PR TITLE
[5.2] Add datetime stamp to the end of class name of migration

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -111,7 +111,7 @@ class MigrationCreator
      */
     protected function getClassName($name)
     {
-        return Str::studly($name);
+        return Str::studly($name).'_'.$this->getDatePrefix();
     }
 
     /**


### PR DESCRIPTION
Now we can make two migrations with the same name because after creating migration datetime stamp added only to the name of migration file. 
To reproduce it run:

``` console
php artisan make:migration update_users_table
Created Migration: 2016_05_24_105256_update_users_table

php artisan make:migration update_users_table
Created Migration: 2016_05_24_105749_update_users_table

php artisan migrate
  [Symfony\Component\Debug\Exception\FatalErrorException]
  Cannot redeclare class UpdateUsersTable
```

**As a result We have error because we have two class with name UpdateUsersTable.**

My code will resolve this problem.
