### PR TITLE
[5.3] Call authenticate in the Authorize middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/Authorize.php
+++ b/src/Illuminate/Foundation/Http/Middleware/Authorize.php
@@ -38,6 +38,8 @@ class Authorize
      */
     public function handle($request, Closure $next, $ability, $model = null)
     {
+        auth()->authenticate();
+
         $this->gate->authorize($ability, $this->getGateArguments($request, $model));
 
         return $next($request);

--- a/tests/Foundation/FoundationAuthorizeMiddlewareTest.php
+++ b/tests/Foundation/FoundationAuthorizeMiddlewareTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Factory as Auth;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Http\Middleware\Authorize;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
@@ -14,13 +16,25 @@ class FoundationAuthorizeMiddlewareTest extends PHPUnit_Framework_TestCase
     protected $container;
     protected $user;
 
+    public function tearDown()
+    {
+        m::close();
+    }
+
     public function setUp()
     {
         parent::setUp();
 
         $this->user = new stdClass;
 
-        $this->container = new Container;
+        Container::setInstance($this->container = new Container);
+
+        $this->container->singleton(Auth::class, function () {
+            $auth = m::mock(Auth::class);
+            $auth->shouldReceive('authenticate')->once()->andReturn(null);
+
+            return $auth;
+        });
 
         $this->container->singleton(GateContract::class, function () {
             return new Gate($this->container, function () {


### PR DESCRIPTION
We'll now call the new [`authenticate`](https://github.com/laravel/framework/pull/13651) method on the auth class, so that when no user is logged in it returns with a 401 instead of a 403.

This is taking a second stab at [this](https://github.com/laravel/framework/pull/13113), but now with a unified place to set your unauthenticated response.
