### PR TITLE
[5.2] elixir helper prepends slash to build link

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -346,7 +346,7 @@ if (! function_exists('elixir')) {
         }
 
         if (isset($manifest[$file])) {
-            return '/'.trim($buildDirectory.'/'.$manifest[$file], '/');
+            return  app(UrlGenerator::class)->to(trim($buildDirectory.'/'.$manifest[$file], '/'));
         }
 
         throw new InvalidArgumentException("File {$file} not defined in asset manifest.");


### PR DESCRIPTION
That is causing bad links when base meta is used.
