### PR TITLE
Catch the Exception when get job otherwise it will keep writing error…

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -143,17 +143,25 @@ class Worker
      */
     public function pop($connectionName, $queue = null, $delay = 0, $sleep = 3, $maxTries = 0)
     {
-        $connection = $this->manager->connection($connectionName);
+        //If we catch an exception, we will stop the queue process and throw Exception
+        try {
+            $connection = $this->manager->connection($connectionName);
 
-        $job = $this->getNextJob($connection, $queue);
+            $job = $this->getNextJob($connection, $queue);
 
-        // If we're able to pull a job off of the stack, we will process it and
-        // then immediately return back out. If there is no job on the queue
-        // we will "sleep" the worker for the specified number of seconds.
-        if (! is_null($job)) {
-            return $this->process(
-                $this->manager->getName($connectionName), $job, $maxTries, $delay
-            );
+            // If we're able to pull a job off of the stack, we will process it and
+            // then immediately return back out. If there is no job on the queue
+            // we will "sleep" the worker for the specified number of seconds.
+            if (!is_null($job)) {
+                return $this->process(
+                    $this->manager->getName($connectionName), $job, $maxTries, $delay
+                );
+            }
+        } catch (Exception $e) {
+            if ($this->exceptions) {
+                $this->exceptions->report($e);
+            }
+            $this->stop();
         }
 
         $this->sleep($sleep);


### PR DESCRIPTION
Catch the Exception when get job otherwise it will keep writing error log when some exception happen.If not catch exception, log file will become very large in a short time.
