### PR TITLE
Add preseve_keys parameter to Collection::slice

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -782,11 +782,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @param  int   $offset
      * @param  int   $length
+     * @param  bool  $preserve_keys
      * @return static
      */
-    public function slice($offset, $length = null)
+    public function slice($offset, $length = null, $preserve_keys = true)
     {
-        return new static(array_slice($this->items, $offset, $length, true));
+        return new static(array_slice($this->items, $offset, $length, $preserve_keys));
     }
 
     /**

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -90,7 +90,7 @@ class RouteCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(ArrayIterator::class, $this->routeCollection->getIterator());
     }
 
-    public function testRouteCollectionCanGetIteratorWhenEMpty()
+    public function testRouteCollectionCanGetIteratorWhenEmpty()
     {
         $this->assertCount(0, $this->routeCollection);
         $this->assertInstanceOf(ArrayIterator::class, $this->routeCollection->getIterator());


### PR DESCRIPTION
Updated the definition of Collection::slice to match the helper method slice as well as php's built-in array_slice by adding third parameter to specify whether to preserve keys or no. See #13692 
