### PR TITLE
[5.2] Added third parameter to Collection::slice to preserve keys

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -782,11 +782,12 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      *
      * @param  int   $offset
      * @param  int   $length
+     * @param  bool  $preserveKeys
      * @return static
      */
-    public function slice($offset, $length = null)
+    public function slice($offset, $length = null, $preserveKeys = true)
     {
-        return new static(array_slice($this->items, $offset, $length, true));
+        return new static(array_slice($this->items, $offset, $length, $preserveKeys));
     }
 
     /**


### PR DESCRIPTION
See #13697 

The definition of Collection::slice now matches `slice` and `array_slice`
