### PR TITLE
[5.2] Don't make use call when database is empty

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -23,7 +23,9 @@ class MySqlConnector extends Connector implements ConnectorInterface
         // connection's behavior, and some might be specified by the developers.
         $connection = $this->createConnection($dsn, $config, $options);
 
-        $connection->exec("use `{$config['database']}`;");
+        if (isset($config['database'])) {
+            $connection->exec("use `{$config['database']}`;");
+        }
 
         $collation = $config['collation'];
 


### PR DESCRIPTION
When database is empty, the `use` call will throw `SQLSTATE[3D000]: Invalid catalog name: 1046 No database selected`. Making a connection to a mysql server without specifying a database is useful in some cases, it shouldn't throw an error.
