### PR TITLE
[5.2] Configurable FakerGenerator locale

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -64,7 +64,9 @@ class DatabaseServiceProvider extends ServiceProvider
     protected function registerEloquentFactory()
     {
         $this->app->singleton(FakerGenerator::class, function () {
-            return FakerFactory::create();
+            return FakerFactory::create(
+                config('database.faker_locale', FakerFactory::DEFAULT_LOCALE)
+            );
         });
 
         $this->app->singleton(EloquentFactory::class, function ($app) {


### PR DESCRIPTION
Currently, to get locale-specific data from Faker (addresses, telephone numbers, etc) within model factory definitions, we need to override the binding or use another instance of FakerGenerator.

This PR combined with another on the laravel/laravel repository allows the default Faker locale to be set with ease.
